### PR TITLE
Multimodal: Rename pydantic classes from Sample* to Image*

### DIFF
--- a/lightly_studio/src/lightly_studio/api/db_tables.py
+++ b/lightly_studio/src/lightly_studio/api/db_tables.py
@@ -16,7 +16,7 @@ from lightly_studio.models.metadata import (
     SampleMetadataTable,  # noqa: F401, required for SQLModel to work properly
 )
 from lightly_studio.models.sample import (
-    SampleTable,  # noqa: F401, required for SQLModel to work properly
+    ImageTable,  # noqa: F401, required for SQLModel to work properly
 )
 from lightly_studio.models.sample_embedding import (
     SampleEmbeddingTable,  # noqa: F401, required for SQLModel to work properly

--- a/lightly_studio/src/lightly_studio/api/routes/api/sample.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/sample.py
@@ -17,10 +17,10 @@ from lightly_studio.api.routes.api.validators import Paginated
 from lightly_studio.db_manager import SessionDep
 from lightly_studio.models.dataset import DatasetTable
 from lightly_studio.models.sample import (
-    SampleCreate,
-    SampleTable,
-    SampleView,
-    SampleViewsWithCount,
+    ImageCreate,
+    ImageTable,
+    ImageView,
+    ImageViewsWithCount,
 )
 from lightly_studio.resolvers import (
     sample_resolver,
@@ -34,11 +34,11 @@ from lightly_studio.resolvers.samples_filter import (
 samples_router = APIRouter(prefix="/datasets/{dataset_id}", tags=["samples"])
 
 
-@samples_router.post("/samples", response_model=SampleView)
+@samples_router.post("/samples", response_model=ImageView)
 def create_sample(
     session: SessionDep,
-    input_sample: SampleCreate,
-) -> SampleTable:
+    input_sample: ImageCreate,
+) -> ImageTable:
     """Create a new sample in the database."""
     return sample_resolver.create(session=session, sample=input_sample)
 
@@ -54,7 +54,7 @@ class ReadSamplesRequest(BaseModel):
     )
 
 
-@samples_router.post("/samples/list", response_model=SampleViewsWithCount)
+@samples_router.post("/samples/list", response_model=ImageViewsWithCount)
 def read_samples(
     session: SessionDep,
     dataset_id: Annotated[UUID, Path(title="Dataset Id")],
@@ -98,12 +98,12 @@ def get_sample_dimensions(
     )
 
 
-@samples_router.get("/samples/{sample_id}", response_model=SampleView)
+@samples_router.get("/samples/{sample_id}", response_model=ImageView)
 def read_sample(
     session: SessionDep,
     dataset_id: Annotated[UUID, Path(title="Dataset Id", description="The ID of the dataset")],
     sample_id: Annotated[UUID, Path(title="Sample Id")],
-) -> SampleTable:
+) -> ImageTable:
     """Retrieve a single sample from the database."""
     sample = sample_resolver.get_by_id(session=session, dataset_id=dataset_id, sample_id=sample_id)
     if not sample:
@@ -115,8 +115,8 @@ def read_sample(
 def update_sample(
     session: SessionDep,
     sample_id: Annotated[UUID, Path(title="Sample Id")],
-    sample_input: SampleCreate,
-) -> SampleTable:
+    sample_input: ImageCreate,
+) -> ImageTable:
     """Update an existing sample in the database."""
     sample = sample_resolver.update(session=session, sample_id=sample_id, sample_data=sample_input)
     if not sample:

--- a/lightly_studio/src/lightly_studio/api/routes/images.py
+++ b/lightly_studio/src/lightly_studio/api/routes/images.py
@@ -34,7 +34,7 @@ async def serve_image_by_sample_id(
         HTTPException: If the sample is not found or the file is not accessible.
     """
     # Retrieve the sample from the database.
-    sample_record = session.get(sample.SampleTable, sample_id)
+    sample_record = session.get(sample.ImageTable, sample_id)
     if not sample_record:
         raise HTTPException(
             status_code=status.HTTP_STATUS_NOT_FOUND,

--- a/lightly_studio/src/lightly_studio/core/dataset.py
+++ b/lightly_studio/src/lightly_studio/core/dataset.py
@@ -34,7 +34,7 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationType,
 )
 from lightly_studio.models.dataset import DatasetCreate, DatasetTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.resolvers import (
     dataset_resolver,
     embedding_model_resolver,
@@ -143,7 +143,7 @@ class Dataset:
     def __iter__(self) -> Iterator[Sample]:
         """Iterate over samples in the dataset."""
         for sample in self.session.exec(
-            select(SampleTable).where(SampleTable.dataset_id == self.dataset_id)
+            select(ImageTable).where(ImageTable.dataset_id == self.dataset_id)
         ):
             yield Sample(inner=sample)
 
@@ -154,7 +154,7 @@ class Dataset:
             sample_id: The UUID of the sample to retrieve.
 
         Returns:
-            A single SampleTable object.
+            A single ImageTable object.
 
         Raises:
             IndexError: If no sample is found with the given sample_id.

--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -12,7 +12,7 @@ from lightly_studio.core.dataset_query.sample_field import SampleField
 from lightly_studio.core.sample import Sample
 from lightly_studio.export.export_dataset import DatasetExport
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.resolvers import tag_resolver
 from lightly_studio.selection.select import Selection
 
@@ -135,7 +135,7 @@ class DatasetQuery:
             Iterator of Sample objects from the database.
         """
         # Build query
-        query = select(SampleTable).where(SampleTable.dataset_id == self.dataset.dataset_id)
+        query = select(ImageTable).where(ImageTable.dataset_id == self.dataset.dataset_id)
 
         # Apply filter if present
         if self.match_expression:
@@ -159,8 +159,8 @@ class DatasetQuery:
                 query = query.limit(limit)
 
         # Execute query and yield results
-        for sample_table in self.session.exec(query):
-            yield Sample(inner=sample_table)
+        for image_table in self.session.exec(query):
+            yield Sample(inner=image_table)
 
     def to_list(self) -> list[Sample]:
         """Execute the query and return the results as a list.

--- a/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
@@ -8,7 +8,7 @@ from sqlmodel.sql.expression import SelectOfScalar
 from typing_extensions import Self
 
 from lightly_studio.core.dataset_query.field import Field
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 
 
 class OrderByExpression(ABC):
@@ -23,7 +23,7 @@ class OrderByExpression(ABC):
         self.ascending = ascending
 
     @abstractmethod
-    def apply(self, query: SelectOfScalar[SampleTable]) -> SelectOfScalar[SampleTable]:
+    def apply(self, query: SelectOfScalar[ImageTable]) -> SelectOfScalar[ImageTable]:
         """Apply this ordering to a SQLModel Select query.
 
         Args:
@@ -65,7 +65,7 @@ class OrderByField(OrderByExpression):
         super().__init__()
         self.field = field
 
-    def apply(self, query: SelectOfScalar[SampleTable]) -> SelectOfScalar[SampleTable]:
+    def apply(self, query: SelectOfScalar[ImageTable]) -> SelectOfScalar[ImageTable]:
         """Apply this ordering to a SQLModel Select query.
 
         Args:

--- a/lightly_studio/src/lightly_studio/core/dataset_query/sample_field.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/sample_field.py
@@ -10,7 +10,7 @@ from lightly_studio.core.dataset_query.field import (
     StringField,
 )
 from lightly_studio.core.dataset_query.tags_expression import TagsAccessor
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 
 
 class SampleField:
@@ -20,9 +20,9 @@ class SampleField:
     used to build database queries on sample properties.
     """
 
-    file_name = StringField(col(SampleTable.file_name))
-    width = NumericalField(col(SampleTable.width))
-    height = NumericalField(col(SampleTable.height))
-    file_path_abs = StringField(col(SampleTable.file_path_abs))
-    created_at = DatetimeField(col(SampleTable.created_at))
+    file_name = StringField(col(ImageTable.file_name))
+    width = NumericalField(col(ImageTable.width))
+    height = NumericalField(col(ImageTable.height))
+    file_path_abs = StringField(col(ImageTable.file_path_abs))
+    created_at = DatetimeField(col(ImageTable.created_at))
     tags = TagsAccessor()

--- a/lightly_studio/src/lightly_studio/core/dataset_query/tags_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/tags_expression.py
@@ -8,7 +8,7 @@ from sqlalchemy import ColumnElement
 from sqlmodel import col
 
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.models.tag import TagTable
 
 
@@ -43,4 +43,4 @@ class TagsContainsExpression(MatchExpression):
         Returns:
             The SQLAlchemy expression for this field expression.
         """
-        return SampleTable.tags.any(col(TagTable.name) == self.tag_name)
+        return ImageTable.tags.any(col(TagTable.name) == self.tag_name)

--- a/lightly_studio/src/lightly_studio/core/sample.py
+++ b/lightly_studio/src/lightly_studio/core/sample.py
@@ -8,7 +8,7 @@ from typing import Any, Generic, Protocol, TypeVar, cast
 from sqlalchemy.orm import Mapped, object_session
 from sqlmodel import Session, col
 
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.resolvers import metadata_resolver, tag_resolver
 
 T = TypeVar("T")
@@ -84,21 +84,21 @@ class Sample:
     ```
     """
 
-    file_name = DBField(col(SampleTable.file_name))
-    width = DBField(col(SampleTable.width))
-    height = DBField(col(SampleTable.height))
-    dataset_id = DBField(col(SampleTable.dataset_id))
-    file_path_abs = DBField(col(SampleTable.file_path_abs))
+    file_name = DBField(col(ImageTable.file_name))
+    width = DBField(col(ImageTable.width))
+    height = DBField(col(ImageTable.height))
+    dataset_id = DBField(col(ImageTable.dataset_id))
+    file_path_abs = DBField(col(ImageTable.file_path_abs))
 
-    sample_id = DBField(col(SampleTable.sample_id))
-    created_at = DBField(col(SampleTable.created_at))
-    updated_at = DBField(col(SampleTable.updated_at))
+    sample_id = DBField(col(ImageTable.sample_id))
+    created_at = DBField(col(ImageTable.created_at))
+    updated_at = DBField(col(ImageTable.updated_at))
 
-    def __init__(self, inner: SampleTable) -> None:
+    def __init__(self, inner: ImageTable) -> None:
         """Initialize the Sample.
 
         Args:
-            inner: The SampleTable SQLAlchemy model instance.
+            inner: The ImageTable SQLAlchemy model instance.
         """
         self.inner = inner
         self._metadata = SampleMetadata(self)

--- a/lightly_studio/src/lightly_studio/dataset/loader.py
+++ b/lightly_studio/src/lightly_studio/dataset/loader.py
@@ -42,7 +42,7 @@ from lightly_studio.dataset.embedding_manager import (
 from lightly_studio.models.annotation.annotation_base import AnnotationCreate
 from lightly_studio.models.annotation_label import AnnotationLabelCreate
 from lightly_studio.models.dataset import DatasetCreate, DatasetTable
-from lightly_studio.models.sample import SampleCreate, SampleTable
+from lightly_studio.models.sample import ImageCreate, ImageTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
@@ -84,16 +84,16 @@ class DatasetLoader:
 
         annotations_to_create: list[AnnotationCreate] = []
         sample_ids: list[UUID] = []
-        samples_to_create: list[SampleCreate] = []
+        samples_to_create: list[ImageCreate] = []
         samples_image_data: list[
-            tuple[SampleCreate, ImageInstanceSegmentation | ImageObjectDetection]
+            tuple[ImageCreate, ImageInstanceSegmentation | ImageObjectDetection]
         ] = []
 
         for image_data in tqdm(input_labels.get_labels(), desc="Processing images", unit=" images"):
             image: Image = image_data.image  # type: ignore[attr-defined]
 
             typed_image_data: ImageInstanceSegmentation | ImageObjectDetection = image_data  # type: ignore[assignment]
-            sample = SampleCreate(
+            sample = ImageCreate(
                 file_name=str(image.filename),
                 file_path_abs=str(img_dir / image.filename),
                 width=image.width,
@@ -371,7 +371,7 @@ def _create_samples_from_paths(
     Yields:
         UUIDs of created sample records.
     """
-    samples_to_create: list[SampleCreate] = []
+    samples_to_create: list[ImageCreate] = []
 
     for image_path in tqdm(
         image_paths,
@@ -384,7 +384,7 @@ def _create_samples_from_paths(
         except (FileNotFoundError, PIL.UnidentifiedImageError, OSError):
             continue
 
-        sample = SampleCreate(
+        sample = ImageCreate(
             file_name=Path(image_path).name,
             file_path_abs=image_path,
             width=width,
@@ -486,8 +486,8 @@ def _process_instance_segmentation_annotations(
 
 def _process_batch_annotations(  # noqa: PLR0913
     session: Session,
-    stored_samples: list[SampleTable],
-    samples_data: list[tuple[SampleCreate, ImageInstanceSegmentation | ImageObjectDetection]],
+    stored_samples: list[ImageTable],
+    samples_data: list[tuple[ImageCreate, ImageInstanceSegmentation | ImageObjectDetection]],
     dataset_id: UUID,
     label_map: dict[int, UUID],
     annotations_to_create: list[AnnotationCreate],

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -28,7 +28,7 @@ from lightly_studio.models.annotation_label import (
     AnnotationLabelCreate,
 )
 from lightly_studio.models.classifier import EmbeddingClassifier
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
@@ -269,7 +269,7 @@ class ClassifierManager:
 
     def provide_negative_samples(
         self, session: Session, dataset_id: UUID, selected_samples: list[UUID], limit: int = 10
-    ) -> Sequence[SampleTable]:
+    ) -> Sequence[ImageTable]:
         """Provide random samples that are not in the selected samples.
 
         Args:

--- a/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
+++ b/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
@@ -29,12 +29,12 @@ if TYPE_CHECKING:
         AnnotationLabelTable,
     )
     from lightly_studio.models.sample import (
-        SampleTable,
+        ImageTable,
     )
     from lightly_studio.models.tag import TagTable
 else:
     TagTable = object
-    SampleTable = object
+    ImageTable = object
     AnnotationLabelTable = object
 
 
@@ -65,7 +65,7 @@ class AnnotationBaseTable(SQLModel, table=True):
     annotation_label: Mapped["AnnotationLabelTable"] = Relationship(
         sa_relationship_kwargs={"lazy": "select"},
     )
-    sample: Mapped[Optional["SampleTable"]] = Relationship(
+    sample: Mapped[Optional["ImageTable"]] = Relationship(
         sa_relationship_kwargs={"lazy": "select"},
     )
     tags: Mapped[List["TagTable"]] = Relationship(
@@ -116,7 +116,7 @@ class AnnotationCreate(SQLModel):
     segmentation_mask: Optional[List[int]] = None
 
 
-class AnnotationSampleView(SQLModel):
+class AnnotationImageView(SQLModel):
     """Sample class for annotation view."""
 
     file_path_abs: str
@@ -147,10 +147,10 @@ class AnnotationView(SQLModel):
     semantic_segmentation_details: Optional[SemanticSegmentationAnnotationView] = None
 
 
-class AnnotationWithSampleView(AnnotationView):
+class AnnotationWithImageView(AnnotationView):
     """Response model for bounding box annotation."""
 
-    sample: AnnotationSampleView
+    sample: AnnotationImageView
 
 
 class AnnotationViewsWithCount(BaseModel):
@@ -158,7 +158,7 @@ class AnnotationViewsWithCount(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    annotations: List[AnnotationWithSampleView] = PydanticField(..., alias="data")
+    annotations: List[AnnotationWithImageView] = PydanticField(..., alias="data")
     total_count: int
     next_cursor: Optional[int] = PydanticField(..., alias="nextCursor")
 
@@ -166,4 +166,4 @@ class AnnotationViewsWithCount(BaseModel):
 class AnnotationDetailsView(AnnotationView):
     """Representing detailed view of an annotation."""
 
-    sample: AnnotationSampleView
+    sample: AnnotationImageView

--- a/lightly_studio/src/lightly_studio/models/caption.py
+++ b/lightly_studio/src/lightly_studio/models/caption.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Mapped
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
-    from lightly_studio.models.sample import SampleTable
+    from lightly_studio.models.sample import ImageTable
 
 
 class CaptionTable(SQLModel, table=True):
@@ -24,7 +24,7 @@ class CaptionTable(SQLModel, table=True):
     dataset_id: UUID = Field(foreign_key="dataset.dataset_id")
     sample_id: UUID = Field(foreign_key="sample.sample_id")
 
-    sample: Mapped[Optional["SampleTable"]] = Relationship(
+    sample: Mapped[Optional["ImageTable"]] = Relationship(
         back_populates="captions",
         sa_relationship_kwargs={"lazy": "select"},
     )
@@ -40,7 +40,7 @@ class CaptionCreate(SQLModel):
     text: str
 
 
-class CaptionSampleView(SQLModel):
+class CaptionImageView(SQLModel):
     """Sample class for caption view."""
 
     file_path_abs: str
@@ -61,7 +61,7 @@ class CaptionView(SQLModel):
 class CaptionDetailsView(CaptionView):
     """Response model for caption."""
 
-    sample: CaptionSampleView
+    sample: CaptionImageView
 
 
 class CaptionsListView(BaseModel):

--- a/lightly_studio/src/lightly_studio/models/dataset.py
+++ b/lightly_studio/src/lightly_studio/models/dataset.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session as SQLAlchemySession
 from sqlmodel import Field, Session, SQLModel
 
 from lightly_studio.api.routes.api.validators import Paginated
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.resolvers import sample_resolver
 from lightly_studio.resolvers.samples_filter import SampleFilter
 
@@ -51,7 +51,7 @@ class DatasetTable(DatasetBase, table=True):
         filters: SampleFilter | None = None,
         text_embedding: list[float] | None = None,
         sample_ids: list[UUID] | None = None,
-    ) -> Sequence[SampleTable]:
+    ) -> Sequence[ImageTable]:
         """Retrieve samples for this dataset with optional filtering.
 
         Just passes the parameters to the sample resolver.
@@ -64,7 +64,7 @@ class DatasetTable(DatasetBase, table=True):
             sample_ids: Optional list of sample IDs to filter by.
 
         Returns:
-            A sequence of SampleTable objects.
+            A sequence of ImageTable objects.
         """
         # Get the session from the instance.
         # SQLAlchemy Session is compatible with SQLModel's Session at runtime,

--- a/lightly_studio/src/lightly_studio/models/metadata.py
+++ b/lightly_studio/src/lightly_studio/models/metadata.py
@@ -18,9 +18,9 @@ from lightly_studio.metadata.complex_metadata import (
 )
 
 if TYPE_CHECKING:
-    from lightly_studio.models.sample import SampleTable
+    from lightly_studio.models.sample import ImageTable
 else:
-    SampleTable = object
+    ImageTable = object
 
 
 TYPE_TO_NAME_MAP = {
@@ -190,7 +190,7 @@ class SampleMetadataTable(MetadataBase, table=True):
     __tablename__ = "metadata"
     sample_id: UUID = Field(foreign_key="sample.sample_id", unique=True)
 
-    sample: SampleTable = Relationship(back_populates="metadata_dict")
+    sample: ImageTable = Relationship(back_populates="metadata_dict")
 
 
 class SampleMetadataView(SQLModel):

--- a/lightly_studio/src/lightly_studio/models/sample.py
+++ b/lightly_studio/src/lightly_studio/models/sample.py
@@ -33,8 +33,8 @@ else:
     SampleMetadataView = object
 
 
-class SampleBase(SQLModel):
-    """Base class for the Sample model."""
+class ImageBase(SQLModel):
+    """Base class for the Image model."""
 
     """The name of the image file."""
     file_name: str
@@ -52,25 +52,8 @@ class SampleBase(SQLModel):
     file_path_abs: str = Field(default=None, unique=True)
 
 
-class SampleCreate(SampleBase):
-    """Sample class when inserting."""
-
-
-class SampleViewForAnnotation(SQLModel):
-    """Sample class for annotation view."""
-
-    """The name of the image file."""
-    file_path_abs: str
-    sample_id: UUID
-
-    """The width of the image in pixels."""
-    width: int
-
-    """The height of the image in pixels."""
-    height: int
-
-    created_at: datetime
-    updated_at: datetime
+class ImageCreate(ImageBase):
+    """Image class when inserting."""
 
 
 class SampleTagLinkTable(SQLModel, table=True):
@@ -82,8 +65,8 @@ class SampleTagLinkTable(SQLModel, table=True):
     tag_id: Optional[UUID] = Field(default=None, foreign_key="tag.tag_id", primary_key=True)
 
 
-class SampleTable(SampleBase, table=True):
-    """This class defines the Sample model."""
+class ImageTable(ImageBase, table=True):
+    """This class defines the Image model."""
 
     __tablename__ = "sample"
     sample_id: UUID = Field(default_factory=uuid4, primary_key=True)
@@ -159,11 +142,11 @@ TagKind = Literal[
 ]
 
 
-class SampleView(SQLModel):
-    """Sample class when retrieving."""
+class ImageView(SQLModel):
+    """Image class when retrieving."""
 
-    class SampleViewTag(SQLModel):
-        """Tag view inside Sample view."""
+    class ImageViewTag(SQLModel):
+        """Tag view inside Image view."""
 
         tag_id: UUID
         name: str
@@ -178,17 +161,17 @@ class SampleView(SQLModel):
     dataset_id: UUID
     annotations: List["AnnotationView"]
     captions: List[CaptionView] = []
-    tags: List[SampleViewTag]
+    tags: List[ImageViewTag]
     metadata_dict: Optional["SampleMetadataView"] = None
     width: int
     height: int
 
 
-class SampleViewsWithCount(BaseModel):
-    """Response model for counted samples."""
+class ImageViewsWithCount(BaseModel):
+    """Response model for counted images."""
 
     model_config = ConfigDict(populate_by_name=True)
 
-    samples: List[SampleView] = PydanticField(..., alias="data")
+    samples: List[ImageView] = PydanticField(..., alias="data")
     total_count: int
     next_cursor: Optional[int] = PydanticField(None, alias="nextCursor")

--- a/lightly_studio/src/lightly_studio/models/sample_embedding.py
+++ b/lightly_studio/src/lightly_studio/models/sample_embedding.py
@@ -9,10 +9,10 @@ from sqlalchemy import ARRAY, Float
 from sqlmodel import Column, Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
-    from lightly_studio.models.sample import SampleTable
+    from lightly_studio.models.sample import ImageTable
 
 else:
-    SampleTable = object
+    ImageTable = object
 
 
 class SampleEmbeddingBase(SQLModel):
@@ -34,4 +34,4 @@ class SampleEmbeddingTable(SampleEmbeddingBase, table=True):
     """This class defines the SampleEmbedding model."""
 
     __tablename__ = "sample_embedding"
-    sample: SampleTable = Relationship(back_populates="embeddings")
+    sample: ImageTable = Relationship(back_populates="embeddings")

--- a/lightly_studio/src/lightly_studio/models/tag.py
+++ b/lightly_studio/src/lightly_studio/models/tag.py
@@ -15,10 +15,10 @@ if TYPE_CHECKING:
     from lightly_studio.models.annotation.annotation_base import (
         AnnotationBaseTable,
     )
-    from lightly_studio.models.sample import SampleTable
+    from lightly_studio.models.sample import ImageTable
 
 else:
-    SampleTable = object
+    ImageTable = object
     TagTable = object
     AnnotationBaseTable = object
 
@@ -84,7 +84,7 @@ class TagTable(TagBase, table=True):
     )
 
     """The sample ids associated with the tag."""
-    samples: Mapped[List["SampleTable"]] = Relationship(
+    samples: Mapped[List["ImageTable"]] = Relationship(
         back_populates="tags",
         link_model=SampleTagLinkTable,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/count_annotations_by_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/count_annotations_by_dataset.py
@@ -10,7 +10,7 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationBaseTable,
 )
 from lightly_studio.models.annotation_label import AnnotationLabelTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.models.tag import TagTable
 
 
@@ -41,10 +41,10 @@ def count_annotations_by_dataset(  # noqa: PLR0913 // FIXME: refactor to use pro
             == col(AnnotationLabelTable.annotation_label_id),
         )
         .join(
-            SampleTable,
-            col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
+            ImageTable,
+            col(ImageTable.sample_id) == col(AnnotationBaseTable.sample_id),
         )
-        .where(SampleTable.dataset_id == dataset_id)
+        .where(ImageTable.dataset_id == dataset_id)
         .group_by(AnnotationLabelTable.annotation_label_name)
         .order_by(col(AnnotationLabelTable.annotation_label_name).asc())
     )
@@ -63,30 +63,30 @@ def count_annotations_by_dataset(  # noqa: PLR0913 // FIXME: refactor to use pro
             == col(AnnotationLabelTable.annotation_label_id),
         )
         .join(
-            SampleTable,
-            col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
+            ImageTable,
+            col(ImageTable.sample_id) == col(AnnotationBaseTable.sample_id),
         )
-        .where(SampleTable.dataset_id == dataset_id)
+        .where(ImageTable.dataset_id == dataset_id)
     )
 
     # Add dimension filters
     if min_width is not None:
-        filtered_query = filtered_query.where(SampleTable.width >= min_width)
+        filtered_query = filtered_query.where(ImageTable.width >= min_width)
     if max_width is not None:
-        filtered_query = filtered_query.where(SampleTable.width <= max_width)
+        filtered_query = filtered_query.where(ImageTable.width <= max_width)
     if min_height is not None:
-        filtered_query = filtered_query.where(SampleTable.height >= min_height)
+        filtered_query = filtered_query.where(ImageTable.height >= min_height)
     if max_height is not None:
-        filtered_query = filtered_query.where(SampleTable.height <= max_height)
+        filtered_query = filtered_query.where(ImageTable.height <= max_height)
 
     # Add label filter if specified
     if filtered_labels:
         filtered_query = filtered_query.where(
-            col(SampleTable.sample_id).in_(
-                select(SampleTable.sample_id)
+            col(ImageTable.sample_id).in_(
+                select(ImageTable.sample_id)
                 .join(
                     AnnotationBaseTable,
-                    col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
+                    col(ImageTable.sample_id) == col(AnnotationBaseTable.sample_id),
                 )
                 .join(
                     AnnotationLabelTable,

--- a/lightly_studio/src/lightly_studio/resolvers/annotations/annotations_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotations/annotations_filter.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from sqlmodel import col
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.models.tag import TagTable
 from lightly_studio.type_definitions import QueryType
 
@@ -67,8 +67,8 @@ class AnnotationsFilter(BaseModel):
         if self.sample_tag_ids:
             query = (
                 query.join(AnnotationBaseTable.sample)
-                .join(SampleTable.tags)
-                .where(SampleTable.tags.any(col(TagTable.tag_id).in_(self.sample_tag_ids)))
+                .join(ImageTable.tags)
+                .where(ImageTable.tags.any(col(TagTable.tag_id).in_(self.sample_tag_ids)))
                 .distinct()
             )
 

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver.py
@@ -11,7 +11,7 @@ from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.dataset import DatasetCreate, DatasetTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.models.tag import TagTable
 
 
@@ -104,7 +104,7 @@ def _build_export_query(  # noqa: C901
     dataset_id: UUID,
     include: ExportFilter | None = None,
     exclude: ExportFilter | None = None,
-) -> SelectOfScalar[SampleTable]:
+) -> SelectOfScalar[ImageTable]:
     """Build the export query based on filters.
 
     Args:
@@ -125,19 +125,19 @@ def _build_export_query(  # noqa: C901
     if include:
         if include.tag_ids:
             return (
-                select(SampleTable)
-                .where(SampleTable.dataset_id == dataset_id)
+                select(ImageTable)
+                .where(ImageTable.dataset_id == dataset_id)
                 .where(
                     or_(
                         # Samples with matching sample tags
-                        col(SampleTable.tags).any(
+                        col(ImageTable.tags).any(
                             and_(
                                 TagTable.kind == "sample",
                                 col(TagTable.tag_id).in_(include.tag_ids),
                             )
                         ),
                         # Samples with matching annotation tags
-                        col(SampleTable.annotations).any(
+                        col(ImageTable.annotations).any(
                             col(AnnotationBaseTable.tags).any(
                                 and_(
                                     TagTable.kind == "annotation",
@@ -147,28 +147,28 @@ def _build_export_query(  # noqa: C901
                         ),
                     )
                 )
-                .order_by(col(SampleTable.created_at).asc())
+                .order_by(col(ImageTable.created_at).asc())
                 .distinct()
             )
 
         # get samples by specific sample_ids
         if include.sample_ids:
             return (
-                select(SampleTable)
-                .where(SampleTable.dataset_id == dataset_id)
-                .where(col(SampleTable.sample_id).in_(include.sample_ids))
-                .order_by(col(SampleTable.created_at).asc())
+                select(ImageTable)
+                .where(ImageTable.dataset_id == dataset_id)
+                .where(col(ImageTable.sample_id).in_(include.sample_ids))
+                .order_by(col(ImageTable.created_at).asc())
                 .distinct()
             )
 
         # get samples by specific annotation_ids
         if include.annotation_ids:
             return (
-                select(SampleTable)
-                .join(SampleTable.annotations)
+                select(ImageTable)
+                .join(ImageTable.annotations)
                 .where(AnnotationBaseTable.dataset_id == dataset_id)
                 .where(col(AnnotationBaseTable.annotation_id).in_(include.annotation_ids))
-                .order_by(col(SampleTable.created_at).asc())
+                .order_by(col(ImageTable.created_at).asc())
                 .distinct()
             )
 
@@ -176,19 +176,19 @@ def _build_export_query(  # noqa: C901
     elif exclude:
         if exclude.tag_ids:
             return (
-                select(SampleTable)
-                .where(SampleTable.dataset_id == dataset_id)
+                select(ImageTable)
+                .where(ImageTable.dataset_id == dataset_id)
                 .where(
                     and_(
-                        ~col(SampleTable.tags).any(
+                        ~col(ImageTable.tags).any(
                             and_(
                                 TagTable.kind == "sample",
                                 col(TagTable.tag_id).in_(exclude.tag_ids),
                             )
                         ),
                         or_(
-                            ~col(SampleTable.annotations).any(),
-                            ~col(SampleTable.annotations).any(
+                            ~col(ImageTable.annotations).any(),
+                            ~col(ImageTable.annotations).any(
                                 col(AnnotationBaseTable.tags).any(
                                     and_(
                                         TagTable.kind == "annotation",
@@ -199,30 +199,30 @@ def _build_export_query(  # noqa: C901
                         ),
                     )
                 )
-                .order_by(col(SampleTable.created_at).asc())
+                .order_by(col(ImageTable.created_at).asc())
                 .distinct()
             )
         if exclude.sample_ids:
             return (
-                select(SampleTable)
-                .where(SampleTable.dataset_id == dataset_id)
-                .where(col(SampleTable.sample_id).notin_(exclude.sample_ids))
-                .order_by(col(SampleTable.created_at).asc())
+                select(ImageTable)
+                .where(ImageTable.dataset_id == dataset_id)
+                .where(col(ImageTable.sample_id).notin_(exclude.sample_ids))
+                .order_by(col(ImageTable.created_at).asc())
                 .distinct()
             )
         if exclude.annotation_ids:
             return (
-                select(SampleTable)
-                .where(SampleTable.dataset_id == dataset_id)
+                select(ImageTable)
+                .where(ImageTable.dataset_id == dataset_id)
                 .where(
                     or_(
-                        ~col(SampleTable.annotations).any(),
-                        ~col(SampleTable.annotations).any(
+                        ~col(ImageTable.annotations).any(),
+                        ~col(ImageTable.annotations).any(
                             col(AnnotationBaseTable.annotation_id).in_(exclude.annotation_ids)
                         ),
                     )
                 )
-                .order_by(col(SampleTable.created_at).asc())
+                .order_by(col(ImageTable.created_at).asc())
                 .distinct()
             )
 

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
@@ -125,7 +125,7 @@ def apply_metadata_filters(
             ],
             metadata_model=SampleMetadataTable,
             metadata_join_condition=SampleMetadataTable.sample_id ==
-                                    SampleTable.sample_id,
+                                    ImageTable.sample_id,
         )
         ```
     """

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
@@ -11,7 +11,7 @@ from lightly_studio.models.metadata import (
     MetadataInfoView,
     SampleMetadataTable,
 )
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 
 
 def get_all_metadata_keys_and_schema(
@@ -30,12 +30,12 @@ def get_all_metadata_keys_and_schema(
     # Query all metadata_schema dicts for samples in the dataset
     rows = session.exec(
         select(SampleMetadataTable.metadata_schema)
-        .select_from(SampleTable)
+        .select_from(ImageTable)
         .join(
             SampleMetadataTable,
-            col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
+            col(SampleMetadataTable.sample_id) == col(ImageTable.sample_id),
         )
-        .where(SampleTable.dataset_id == dataset_id)
+        .where(ImageTable.dataset_id == dataset_id)
     ).all()
     # Merge all schemas
     merged: dict[str, str] = {}
@@ -84,10 +84,10 @@ def _get_metadata_min_max_values(
             func.min(func.cast(func.json_extract(SampleMetadataTable.data, json_path), Float)),
             func.max(func.cast(func.json_extract(SampleMetadataTable.data, json_path), Float)),
         )
-        .select_from(SampleTable)
-        .join(SampleMetadataTable, col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id))
+        .select_from(ImageTable)
+        .join(SampleMetadataTable, col(SampleMetadataTable.sample_id) == col(ImageTable.sample_id))
         .where(
-            SampleTable.dataset_id == dataset_id,
+            ImageTable.dataset_id == dataset_id,
             func.json_extract(SampleMetadataTable.data, json_path).is_not(None),
         )
     )

--- a/lightly_studio/src/lightly_studio/resolvers/sample_embedding_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_embedding_resolver.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from sqlalchemy import String, cast
 from sqlmodel import Session, col, select
 
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.models.sample_embedding import (
     SampleEmbeddingCreate,
     SampleEmbeddingTable,
@@ -77,10 +77,10 @@ def get_all_by_dataset_id(
     """
     query = (
         select(SampleEmbeddingTable)
-        .join(SampleTable)
-        .where(SampleEmbeddingTable.sample_id == SampleTable.sample_id)
-        .where(SampleTable.dataset_id == dataset_id)
+        .join(ImageTable)
+        .where(SampleEmbeddingTable.sample_id == ImageTable.sample_id)
+        .where(ImageTable.dataset_id == dataset_id)
         .where(SampleEmbeddingTable.embedding_model_id == embedding_model_id)
-        .order_by(col(SampleTable.created_at).asc())
+        .order_by(col(ImageTable.created_at).asc())
     )
     return list(session.exec(query).all())

--- a/lightly_studio/src/lightly_studio/resolvers/sample_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_resolver.py
@@ -15,24 +15,24 @@ from lightly_studio.api.routes.api.validators import Paginated
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
-from lightly_studio.models.sample import SampleCreate, SampleTable
+from lightly_studio.models.sample import ImageCreate, ImageTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.models.tag import TagTable
 from lightly_studio.resolvers.samples_filter import SampleFilter
 
 
-def create(session: Session, sample: SampleCreate) -> SampleTable:
+def create(session: Session, sample: ImageCreate) -> ImageTable:
     """Create a new sample in the database."""
-    db_sample = SampleTable.model_validate(sample)
+    db_sample = ImageTable.model_validate(sample)
     session.add(db_sample)
     session.commit()
     session.refresh(db_sample)
     return db_sample
 
 
-def create_many(session: Session, samples: list[SampleCreate]) -> list[SampleTable]:
+def create_many(session: Session, samples: list[ImageCreate]) -> list[ImageTable]:
     """Create multiple samples in a single database commit."""
-    db_samples = [SampleTable.model_validate(sample) for sample in samples]
+    db_samples = [ImageTable.model_validate(sample) for sample in samples]
     session.bulk_save_objects(db_samples)
     session.commit()
     return db_samples
@@ -42,8 +42,8 @@ def filter_new_paths(session: Session, file_paths_abs: list[str]) -> tuple[list[
     """Return a) file_path_abs that do not already exist in the database and b) those that do."""
     existing_file_paths_abs = set(
         session.exec(
-            select(col(SampleTable.file_path_abs)).where(
-                col(SampleTable.file_path_abs).in_(file_paths_abs)
+            select(col(ImageTable.file_path_abs)).where(
+                col(ImageTable.file_path_abs).in_(file_paths_abs)
             )
         ).all()
     )
@@ -54,11 +54,11 @@ def filter_new_paths(session: Session, file_paths_abs: list[str]) -> tuple[list[
     )
 
 
-def get_by_id(session: Session, dataset_id: UUID, sample_id: UUID) -> SampleTable | None:
+def get_by_id(session: Session, dataset_id: UUID, sample_id: UUID) -> ImageTable | None:
     """Retrieve a single sample by ID."""
     return session.exec(
-        select(SampleTable).where(
-            SampleTable.sample_id == sample_id, SampleTable.dataset_id == dataset_id
+        select(ImageTable).where(
+            ImageTable.sample_id == sample_id, ImageTable.dataset_id == dataset_id
         )
     ).one_or_none()
 
@@ -66,17 +66,17 @@ def get_by_id(session: Session, dataset_id: UUID, sample_id: UUID) -> SampleTabl
 def count_by_dataset_id(session: Session, dataset_id: UUID) -> int:
     """Count the number of samples in a dataset."""
     return session.exec(
-        select(func.count()).select_from(SampleTable).where(SampleTable.dataset_id == dataset_id)
+        select(func.count()).select_from(ImageTable).where(ImageTable.dataset_id == dataset_id)
     ).one()
 
 
-def get_many_by_id(session: Session, sample_ids: list[UUID]) -> list[SampleTable]:
+def get_many_by_id(session: Session, sample_ids: list[UUID]) -> list[ImageTable]:
     """Retrieve multiple samples by their IDs.
 
     Output order matches the input order.
     """
     results = session.exec(
-        select(SampleTable).where(col(SampleTable.sample_id).in_(sample_ids))
+        select(ImageTable).where(col(ImageTable.sample_id).in_(sample_ids))
     ).all()
     # Return samples in the same order as the input IDs
     sample_map = {sample.sample_id: sample for sample in results}
@@ -86,7 +86,7 @@ def get_many_by_id(session: Session, sample_ids: list[UUID]) -> list[SampleTable
 class GetAllSamplesByDatasetIdResult(BaseModel):
     """Result of getting all samples."""
 
-    samples: Sequence[SampleTable]
+    samples: Sequence[ImageTable]
     total_count: int
     next_cursor: int | None = None
 
@@ -101,23 +101,23 @@ def get_all_by_dataset_id(  # noqa: PLR0913
 ) -> GetAllSamplesByDatasetIdResult:
     """Retrieve samples for a specific dataset with optional filtering."""
     samples_query = (
-        select(SampleTable)
+        select(ImageTable)
         .options(
-            selectinload(SampleTable.annotations).options(
+            selectinload(ImageTable.annotations).options(
                 joinedload(AnnotationBaseTable.annotation_label),
                 joinedload(AnnotationBaseTable.object_detection_details),
                 joinedload(AnnotationBaseTable.instance_segmentation_details),
                 joinedload(AnnotationBaseTable.semantic_segmentation_details),
             ),
-            selectinload(SampleTable.captions),
-            selectinload(SampleTable.tags),
+            selectinload(ImageTable.captions),
+            selectinload(ImageTable.tags),
             # Ignore type checker error below as it's a false positive caused by TYPE_CHECKING.
-            joinedload(SampleTable.metadata_dict),  # type: ignore[arg-type]
+            joinedload(ImageTable.metadata_dict),  # type: ignore[arg-type]
         )
-        .where(SampleTable.dataset_id == dataset_id)
+        .where(ImageTable.dataset_id == dataset_id)
     )
     total_count_query = (
-        select(func.count()).select_from(SampleTable).where(SampleTable.dataset_id == dataset_id)
+        select(func.count()).select_from(ImageTable).where(ImageTable.dataset_id == dataset_id)
     )
 
     if filters:
@@ -126,8 +126,8 @@ def get_all_by_dataset_id(  # noqa: PLR0913
 
     # TODO(Michal, 06/2025): Consider adding sample_ids to the filters.
     if sample_ids:
-        samples_query = samples_query.where(col(SampleTable.sample_id).in_(sample_ids))
-        total_count_query = total_count_query.where(col(SampleTable.sample_id).in_(sample_ids))
+        samples_query = samples_query.where(col(ImageTable.sample_id).in_(sample_ids))
+        total_count_query = total_count_query.where(col(ImageTable.sample_id).in_(sample_ids))
 
     if text_embedding:
         # Fetch the first embedding_model_id for the given dataset_id
@@ -141,7 +141,7 @@ def get_all_by_dataset_id(  # noqa: PLR0913
             samples_query = (
                 samples_query.join(
                     SampleEmbeddingTable,
-                    col(SampleTable.sample_id) == col(SampleEmbeddingTable.sample_id),
+                    col(ImageTable.sample_id) == col(SampleEmbeddingTable.sample_id),
                 )
                 .where(SampleEmbeddingTable.embedding_model_id == embedding_model_id)
                 .order_by(
@@ -153,11 +153,11 @@ def get_all_by_dataset_id(  # noqa: PLR0913
             )
             total_count_query = total_count_query.join(
                 SampleEmbeddingTable,
-                col(SampleTable.sample_id) == col(SampleEmbeddingTable.sample_id),
+                col(ImageTable.sample_id) == col(SampleEmbeddingTable.sample_id),
             ).where(SampleEmbeddingTable.embedding_model_id == embedding_model_id)
     else:
         samples_query = samples_query.order_by(
-            col(SampleTable.created_at).asc(), col(SampleTable.sample_id).asc()
+            col(ImageTable.created_at).asc(), col(ImageTable.sample_id).asc()
         )
 
     # Apply pagination if provided
@@ -186,19 +186,19 @@ def get_dimension_bounds(
     """Get min and max dimensions of samples in a dataset."""
     # Prepare the base query for dimensions
     query: Select[tuple[int | None, int | None, int | None, int | None]] = select(
-        func.min(SampleTable.width).label("min_width"),
-        func.max(SampleTable.width).label("max_width"),
-        func.min(SampleTable.height).label("min_height"),
-        func.max(SampleTable.height).label("max_height"),
+        func.min(ImageTable.width).label("min_width"),
+        func.max(ImageTable.width).label("max_width"),
+        func.min(ImageTable.height).label("min_height"),
+        func.max(ImageTable.height).label("max_height"),
     )
 
     if annotation_label_ids:
         # Subquery to filter samples matching all annotation labels
         label_filter = (
-            select(SampleTable.sample_id)
+            select(ImageTable.sample_id)
             .join(
                 AnnotationBaseTable,
-                col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
+                col(ImageTable.sample_id) == col(AnnotationBaseTable.sample_id),
             )
             .join(
                 AnnotationLabelTable,
@@ -206,26 +206,26 @@ def get_dimension_bounds(
                 == col(AnnotationLabelTable.annotation_label_id),
             )
             .where(
-                SampleTable.dataset_id == dataset_id,
+                ImageTable.dataset_id == dataset_id,
                 col(AnnotationLabelTable.annotation_label_id).in_(annotation_label_ids),
             )
-            .group_by(col(SampleTable.sample_id))
+            .group_by(col(ImageTable.sample_id))
             .having(
                 func.count(col(AnnotationLabelTable.annotation_label_id).distinct())
                 == len(annotation_label_ids)
             )
         )
         # Filter the dimension query based on the subquery
-        query = query.where(col(SampleTable.sample_id).in_(label_filter))
+        query = query.where(col(ImageTable.sample_id).in_(label_filter))
     else:
         # If no labels specified, filter dimensions
         # for all samples in the dataset
-        query = query.where(SampleTable.dataset_id == dataset_id)
+        query = query.where(ImageTable.dataset_id == dataset_id)
 
     if tag_ids:
         query = (
-            query.join(SampleTable.tags)
-            .where(SampleTable.tags.any(col(TagTable.tag_id).in_(tag_ids)))
+            query.join(ImageTable.tags)
+            .where(ImageTable.tags.any(col(TagTable.tag_id).in_(tag_ids)))
             .distinct()
         )
 
@@ -236,7 +236,7 @@ def get_dimension_bounds(
     return {key: value for key, value in result.items() if value is not None}
 
 
-def update(session: Session, sample_id: UUID, sample_data: SampleCreate) -> SampleTable | None:
+def update(session: Session, sample_id: UUID, sample_data: ImageCreate) -> ImageTable | None:
     """Update an existing sample."""
     sample = get_by_id(session=session, dataset_id=sample_data.dataset_id, sample_id=sample_id)
     if not sample:
@@ -268,7 +268,7 @@ def get_samples_excluding(
     dataset_id: UUID,
     excluded_sample_ids: list[UUID],
     limit: int | None = None,
-) -> Sequence[SampleTable]:
+) -> Sequence[ImageTable]:
     """Get random samples excluding specified sample IDs.
 
     Args:
@@ -282,9 +282,9 @@ def get_samples_excluding(
         List of samples not associated with the excluded IDs.
     """
     query = (
-        select(SampleTable)
-        .where(SampleTable.dataset_id == dataset_id)
-        .where(col(SampleTable.sample_id).not_in(excluded_sample_ids))
+        select(ImageTable)
+        .where(ImageTable.dataset_id == dataset_id)
+        .where(col(ImageTable.sample_id).not_in(excluded_sample_ids))
         .order_by(func.random())
     )
 

--- a/lightly_studio/src/lightly_studio/resolvers/samples_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/samples_filter.py
@@ -9,7 +9,7 @@ from sqlmodel import col, select
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.metadata import SampleMetadataTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.models.tag import TagTable
 from lightly_studio.resolvers.metadata_resolver.metadata_filter import (
     MetadataFilter,
@@ -38,7 +38,7 @@ class SampleFilter(BaseModel):
     def apply(self, query: QueryType) -> QueryType:
         """Apply the filters to the given query."""
         if self.sample_ids:
-            query = query.where(col(SampleTable.sample_id).in_(self.sample_ids))
+            query = query.where(col(ImageTable.sample_id).in_(self.sample_ids))
 
         # Apply dimension-based filters to the query.
         query = self._apply_dimension_filters(query)
@@ -52,18 +52,18 @@ class SampleFilter(BaseModel):
                 .where(col(AnnotationLabelTable.annotation_label_id).in_(self.annotation_label_ids))
                 .distinct()
             )
-            query = query.where(col(SampleTable.sample_id).in_(sample_ids_subquery))
+            query = query.where(col(ImageTable.sample_id).in_(sample_ids_subquery))
 
         # Apply tag filters to the query.
         if self.tag_ids:
             sample_ids_subquery = (
-                select(SampleTable.sample_id)
-                .select_from(SampleTable)
-                .join(SampleTable.tags)
+                select(ImageTable.sample_id)
+                .select_from(ImageTable)
+                .join(ImageTable.tags)
                 .where(col(TagTable.tag_id).in_(self.tag_ids))
                 .distinct()
             )
-            query = query.where(col(SampleTable.sample_id).in_(sample_ids_subquery))
+            query = query.where(col(ImageTable.sample_id).in_(sample_ids_subquery))
 
         # Apply metadata filters to the query.
         if self.metadata_filters:
@@ -71,19 +71,19 @@ class SampleFilter(BaseModel):
                 query,
                 self.metadata_filters,
                 metadata_model=SampleMetadataTable,
-                metadata_join_condition=SampleMetadataTable.sample_id == SampleTable.sample_id,
+                metadata_join_condition=SampleMetadataTable.sample_id == ImageTable.sample_id,
             )
         return query
 
     def _apply_dimension_filters(self, query: QueryType) -> QueryType:
         if self.width:
             if self.width.min is not None:
-                query = query.where(SampleTable.width >= self.width.min)
+                query = query.where(ImageTable.width >= self.width.min)
             if self.width.max is not None:
-                query = query.where(SampleTable.width <= self.width.max)
+                query = query.where(ImageTable.width <= self.width.max)
         if self.height:
             if self.height.min is not None:
-                query = query.where(SampleTable.height >= self.height.min)
+                query = query.where(ImageTable.height >= self.height.min)
             if self.height.max is not None:
-                query = query.where(SampleTable.height <= self.height.max)
+                query = query.where(ImageTable.height <= self.height.max)
         return query

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -10,7 +10,7 @@ from sqlmodel import Session, col, select
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation.links import AnnotationTagLinkTable
-from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
+from lightly_studio.models.sample import ImageTable, SampleTagLinkTable
 from lightly_studio.models.tag import TagCreate, TagTable, TagUpdate
 
 
@@ -97,8 +97,8 @@ def delete(session: Session, tag_id: UUID) -> bool:
 def add_tag_to_sample(
     session: Session,
     tag_id: UUID,
-    sample: SampleTable,
-) -> SampleTable | None:
+    sample: ImageTable,
+) -> ImageTable | None:
     """Add a tag to a sample."""
     tag = get_by_id(session=session, tag_id=tag_id)
     if not tag or not tag.tag_id:
@@ -116,8 +116,8 @@ def add_tag_to_sample(
 def remove_tag_from_sample(
     session: Session,
     tag_id: UUID,
-    sample: SampleTable,
-) -> SampleTable | None:
+    sample: ImageTable,
+) -> ImageTable | None:
     """Remove a tag from a sample."""
     tag = get_by_id(session=session, tag_id=tag_id)
     if not tag or not tag.tag_id:

--- a/lightly_studio/src/lightly_studio/type_definitions.py
+++ b/lightly_studio/src/lightly_studio/type_definitions.py
@@ -7,13 +7,13 @@ from uuid import UUID
 from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 
 # Generic query type for filters that work with both data queries and count queries
 QueryType = TypeVar(
     "QueryType",
     SelectOfScalar[AnnotationBaseTable],
-    SelectOfScalar[SampleTable],
+    SelectOfScalar[ImageTable],
     SelectOfScalar[int],
     SelectOfScalar[UUID],
 )

--- a/lightly_studio/tests/api/routes/api/annotations/test_create_annotation.py
+++ b/lightly_studio/tests/api/routes/api/annotations/test_create_annotation.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 from lightly_studio.api.routes.api.status import HTTP_STATUS_OK
 from lightly_studio.models.annotation.annotation_base import AnnotationType, AnnotationView
 from lightly_studio.models.annotation_label import AnnotationLabelTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.services import annotations_service
 from lightly_studio.services.annotations_service.create_annotation import AnnotationCreateParams
 
@@ -17,7 +17,7 @@ def test_create_annotation_object_detection(
     mocker: MockerFixture,
     dataset_id: UUID,
     test_client: TestClient,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
 ) -> None:
     expected_label = annotation_labels[0]
@@ -69,7 +69,7 @@ def test_create_annotation_instance_segmentation(
     mocker: MockerFixture,
     dataset_id: UUID,
     test_client: TestClient,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
 ) -> None:
     expected_label = annotation_labels[0]
@@ -123,7 +123,7 @@ def test_create_annotation_semantic_segmentation(
     mocker: MockerFixture,
     dataset_id: UUID,
     test_client: TestClient,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
 ) -> None:
     expected_label = annotation_labels[0]
@@ -169,7 +169,7 @@ def test_create_annotation_classification(
     mocker: MockerFixture,
     dataset_id: UUID,
     test_client: TestClient,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
 ) -> None:
     expected_label = annotation_labels[0]

--- a/lightly_studio/tests/api/routes/api/test_sample.py
+++ b/lightly_studio/tests/api/routes/api/test_sample.py
@@ -9,7 +9,7 @@ from lightly_studio.api.routes.api.status import (
 )
 from lightly_studio.api.routes.api.validators import Paginated
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.sample import SampleView
+from lightly_studio.models.sample import ImageView
 from lightly_studio.resolvers import (
     dataset_resolver,
     sample_resolver,
@@ -184,7 +184,7 @@ def test_add_tag_to_sample_calls_add_tag_to_sample(
     sample_id = uuid4()
     tag_id = uuid4()
 
-    sample = SampleView(
+    sample = ImageView(
         dataset_id=dataset_id,
         sample_id=sample_id,
         file_path_abs="/path/to/sample1.png",
@@ -225,7 +225,7 @@ def test_remove_tag_from_sample_calls_remove_tag_from_sample(
     tag_id = uuid4()
     sample_id = uuid4()
 
-    sample = SampleView(
+    sample = ImageView(
         dataset_id=dataset_id,
         sample_id=sample_id,
         file_path_abs="/path/to/sample1.png",

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -27,7 +27,7 @@ from lightly_studio.models.annotation_label import (
 from lightly_studio.models.caption import CaptionCreate, CaptionTable
 from lightly_studio.models.dataset import DatasetCreate, DatasetTable
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
-from lightly_studio.models.sample import SampleCreate, SampleTable
+from lightly_studio.models.sample import ImageCreate, ImageTable
 from lightly_studio.models.tag import TagCreate, TagTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
@@ -106,11 +106,11 @@ def embedding_model_input(dataset: DatasetTable) -> EmbeddingModelCreate:
 
 
 @pytest.fixture
-def samples(db_session: Session, dataset: DatasetTable) -> list[SampleTable]:
+def samples(db_session: Session, dataset: DatasetTable) -> list[ImageTable]:
     """Create test samples."""
     samples = []
     for i in range(10):
-        sample_input = SampleCreate(
+        sample_input = ImageCreate(
             file_name=f"test_image_{i}.jpg",
             file_path_abs=f"/test/path/test_image_{i}.jpg",
             width=640,
@@ -147,7 +147,7 @@ class AnnotationsTestData(BaseModel):
     annotation_labels: list[AnnotationLabelTable]
     datasets: list[DatasetTable]
     annotations: Sequence[AnnotationBaseTable]
-    samples: list[SampleTable]
+    samples: list[ImageTable]
 
     labeled_annotations: dict[UUID, list[AnnotationBaseTable]] = {}
 
@@ -156,14 +156,14 @@ class CaptionsTestData(BaseModel):
     """Test data for captions."""
 
     datasets: list[DatasetTable]
-    samples: list[SampleTable]
+    samples: list[ImageTable]
 
     captions: Sequence[CaptionTable]
 
 
 def create_test_base_annotation(
     db_session: Session,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_label: AnnotationLabelTable,
     annotation_type: AnnotationType = AnnotationType.OBJECT_DETECTION,
 ) -> AnnotationBaseTable:
@@ -189,7 +189,7 @@ def create_test_base_annotation(
 
 def create_test_base_annotations(
     db_session: Session,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
     annotation_type: AnnotationType = AnnotationType.OBJECT_DETECTION,
 ) -> list[AnnotationBaseTable]:
@@ -274,9 +274,9 @@ def sample_tags(
 @pytest.fixture
 def samples_assigned_with_tags(
     db_session: Session,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     sample_tags: list[TagTable],
-) -> tuple[list[SampleTable], list[TagTable]]:
+) -> tuple[list[ImageTable], list[TagTable]]:
     """Create a list of sample tags for testing."""
     taged_samples = []
 
@@ -295,9 +295,9 @@ def samples_assigned_with_tags(
 def annotations_test_data(
     db_session: Session,
     datasets: list[DatasetTable],
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
-    samples_assigned_with_tags: tuple[list[SampleTable], list[TagTable]],
+    samples_assigned_with_tags: tuple[list[ImageTable], list[TagTable]],
 ) -> AnnotationsTestData:
     """Create test data in test database."""
     annotation_types: list[AnnotationType] = [
@@ -402,7 +402,7 @@ def annotation_tags_assigned(
 def captions_test_data(
     db_session: Session,
     datasets: list[DatasetTable],
-    samples: list[SampleTable],
+    samples: list[ImageTable],
 ) -> CaptionsTestData:
     """Create test data in test database."""
     captions_to_create: list[CaptionCreate] = []

--- a/lightly_studio/tests/core/dataset_query/test_field_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_field_expression.py
@@ -14,13 +14,13 @@ from lightly_studio.core.dataset_query.field_expression import (
     StringOperator,
 )
 from lightly_studio.core.dataset_query.sample_field import SampleField
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from tests.helpers_resolvers import create_dataset, create_sample
 
 
 class TestNumericalFieldExpression:
     def test_apply__less(self) -> None:
-        query = select(SampleTable)
+        query = select(ImageTable)
 
         expr = NumericalFieldExpression(field=SampleField.height, operator="<", value=10)
 
@@ -30,7 +30,7 @@ class TestNumericalFieldExpression:
         assert "where sample.height < 10" in sql
 
     def test_apply__greater_equal(self) -> None:
-        query = select(SampleTable)
+        query = select(ImageTable)
 
         expr = NumericalFieldExpression(field=SampleField.height, operator=">=", value=100)
 
@@ -81,7 +81,7 @@ class TestNumericalFieldExpression:
         expr = NumericalFieldExpression(
             field=SampleField.height, operator=operator, value=test_value
         )
-        query = select(SampleTable).where(SampleTable.dataset_id == dataset.dataset_id)
+        query = select(ImageTable).where(ImageTable.dataset_id == dataset.dataset_id)
         result_query = query.where(expr.get())
         results = test_db.exec(result_query).all()
 
@@ -95,7 +95,7 @@ class TestNumericalFieldExpression:
 
 class TestDatetimeFieldExpression:
     def test_apply__greater_than(self) -> None:
-        query = select(SampleTable)
+        query = select(ImageTable)
         test_datetime = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
         expr = DatetimeFieldExpression(
@@ -108,7 +108,7 @@ class TestDatetimeFieldExpression:
         assert "where sample.created_at > '2023-01-01 12:00:00+00:00'" in sql
 
     def test_apply__less_than_or_equal(self) -> None:
-        query = select(SampleTable)
+        query = select(ImageTable)
         test_datetime = datetime(2024, 6, 15, 10, 30, 0, tzinfo=timezone.utc)
 
         expr = DatetimeFieldExpression(
@@ -123,7 +123,7 @@ class TestDatetimeFieldExpression:
 
 class TestStringFieldExpression:
     def test_apply__equal(self) -> None:
-        query = select(SampleTable)
+        query = select(ImageTable)
 
         expr = StringFieldExpression(field=SampleField.file_name, operator="==", value="test.jpg")
 
@@ -164,7 +164,7 @@ class TestStringFieldExpression:
         expr = StringFieldExpression(
             field=SampleField.file_name, operator=cast(StringOperator, operator), value=test_value
         )
-        query = select(SampleTable).where(SampleTable.dataset_id == dataset.dataset_id)
+        query = select(ImageTable).where(ImageTable.dataset_id == dataset.dataset_id)
         result_query = query.where(expr.get())
         results = test_db.exec(result_query).all()
 

--- a/lightly_studio/tests/core/dataset_query/test_order_by.py
+++ b/lightly_studio/tests/core/dataset_query/test_order_by.py
@@ -4,13 +4,13 @@ from sqlmodel import select
 
 from lightly_studio.core.dataset_query.order_by import OrderByField
 from lightly_studio.core.dataset_query.sample_field import SampleField
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 
 
 class TestOrderByField:
     def test_apply__default_ascending(self) -> None:
         """Test that default ordering is ascending."""
-        query = select(SampleTable)
+        query = select(ImageTable)
         order_by = OrderByField(SampleField.file_name)
 
         returned_query = order_by.apply(query)
@@ -20,7 +20,7 @@ class TestOrderByField:
 
     def test_apply__descending(self) -> None:
         """Test descending ordering via desc() method."""
-        query = select(SampleTable)
+        query = select(ImageTable)
         order_by = OrderByField(SampleField.file_name).desc()
 
         returned_query = order_by.apply(query)
@@ -30,7 +30,7 @@ class TestOrderByField:
 
     def test_apply__desc_then_asc(self) -> None:
         """Test that desc().asc() returns to ascending order."""
-        query = select(SampleTable)
+        query = select(ImageTable)
         order_by = OrderByField(SampleField.file_name).desc().asc()
 
         returned_query = order_by.apply(query)

--- a/lightly_studio/tests/core/dataset_query/test_tags_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_tags_expression.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlmodel import Session, select
 
 from lightly_studio.core.dataset_query.sample_field import SampleField
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.resolvers import tag_resolver
 from tests.helpers_resolvers import create_dataset, create_sample, create_tag
 
@@ -15,7 +15,7 @@ class TestTagsContainsExpression:
 
     def test_apply__sql(self) -> None:
         """Test that TagsContainsExpression correctly modifies the SQL query."""
-        query = select(SampleTable)
+        query = select(ImageTable)
         query = query.where(SampleField.tags.contains("car").get())
         sql = str(query.compile(compile_kwargs={"literal_binds": True}))
 
@@ -31,7 +31,7 @@ class TestTagsContainsExpression:
         tag = create_tag(session=test_db, dataset_id=dataset.dataset_id, tag_name="car")
         tag_resolver.add_tag_to_sample(session=test_db, tag_id=tag.tag_id, sample=sample)
 
-        query = select(SampleTable)
+        query = select(ImageTable)
         query = query.where(SampleField.tags.contains("vehicle").get())
         query = query.where(SampleField.tags.contains("car").get())
 

--- a/lightly_studio/tests/core/test_add_samples.py
+++ b/lightly_studio/tests/core/test_add_samples.py
@@ -13,7 +13,7 @@ from PIL import Image as PILImage
 from sqlmodel import Session
 
 from lightly_studio.core import add_samples
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.resolvers import caption_resolver, sample_resolver
 from tests.helpers_resolvers import create_dataset
 
@@ -125,7 +125,7 @@ def test_load_into_dataset_from_coco_captions(db_session: Session, tmp_path: Pat
     assert {
         (c.sample.file_name, c.text)
         for c in captions_result.captions
-        if isinstance(c.sample, SampleTable)
+        if isinstance(c.sample, ImageTable)
     } == {
         ("image1.jpg", "Caption 1 of image 1"),
         ("image1.jpg", "Caption 2 of image 1"),

--- a/lightly_studio/tests/core/test_dataset__coco_caption.py
+++ b/lightly_studio/tests/core/test_dataset__coco_caption.py
@@ -7,7 +7,7 @@ import pytest
 from PIL import Image
 
 from lightly_studio import Dataset
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.resolvers import caption_resolver
 
 
@@ -49,7 +49,7 @@ class TestDataset:
         assert {
             (c.sample.file_name, c.text)
             for c in captions_result.captions
-            if isinstance(c.sample, SampleTable)
+            if isinstance(c.sample, ImageTable)
         } == {
             ("image1.jpg", "Caption 1 of image 1"),
             ("image1.jpg", "Caption 2 of image 1"),

--- a/lightly_studio/tests/core/test_dataset__labelformat.py
+++ b/lightly_studio/tests/core/test_dataset__labelformat.py
@@ -16,7 +16,7 @@ from sqlmodel import select
 from lightly_studio import Dataset
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 
 
 class TestDataset:
@@ -48,7 +48,7 @@ class TestDataset:
         assert label_names == {"cat", "dog", "cow"}
 
         # Check sample
-        sample = session.exec(select(SampleTable)).first()
+        sample = session.exec(select(ImageTable)).first()
         assert sample is not None
         assert sample.file_name == "image.jpg"
         assert sample.width == 100

--- a/lightly_studio/tests/core/test_sample.py
+++ b/lightly_studio/tests/core/test_sample.py
@@ -13,14 +13,14 @@ from tests.helpers_resolvers import create_dataset, create_sample, create_tag
 class TestSample:
     def test_basic_fields_get(self, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)
-        sample_table = create_sample(
+        image_table = create_sample(
             session=test_db,
             dataset_id=dataset.dataset_id,
             file_path_abs="/path/to/sample1.png",
             width=640,
             height=480,
         )
-        sample = Sample(inner=sample_table)
+        sample = Sample(inner=image_table)
 
         # Test "get".
         assert sample.file_name == "sample1.png"
@@ -28,17 +28,17 @@ class TestSample:
         assert sample.height == 480
         assert sample.dataset_id == dataset.dataset_id
         assert sample.file_path_abs == "/path/to/sample1.png"
-        assert sample.sample_id == sample_table.sample_id
-        assert sample.created_at == sample_table.created_at
-        assert sample.updated_at == sample_table.updated_at
+        assert sample.sample_id == image_table.sample_id
+        assert sample.created_at == image_table.created_at
+        assert sample.updated_at == image_table.updated_at
 
     def test_basic_fields_set(self, mocker: MockerFixture, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)
-        sample_table = create_sample(
+        image_table = create_sample(
             session=test_db,
             dataset_id=dataset.dataset_id,
         )
-        sample = Sample(inner=sample_table)
+        sample = Sample(inner=image_table)
 
         # Spy on commit.
         spy_commit = mocker.spy(test_db, "commit")
@@ -49,14 +49,14 @@ class TestSample:
         sample.width = 1000
         assert spy_commit.call_count == 2
 
-        new_sample_table = sample_resolver.get_by_id(
+        new_image_table = sample_resolver.get_by_id(
             session=test_db,
             dataset_id=dataset.dataset_id,
             sample_id=sample.sample_id,
         )
-        assert new_sample_table is not None
-        assert new_sample_table.file_name == "sample1.png"
-        assert new_sample_table.width == 1000
+        assert new_image_table is not None
+        assert new_image_table.file_name == "sample1.png"
+        assert new_image_table.width == 1000
 
         # Can't set a foreign key to a non-existent id.
         with pytest.raises(IntegrityError):
@@ -64,11 +64,11 @@ class TestSample:
 
     def test_add_tag(self, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)
-        sample_table = create_sample(
+        image_table = create_sample(
             session=test_db,
             dataset_id=dataset.dataset_id,
         )
-        sample = Sample(inner=sample_table)
+        sample = Sample(inner=image_table)
 
         # Test adding a tag.
         assert [tag.name for tag in sample.inner.tags] == []
@@ -81,11 +81,11 @@ class TestSample:
 
     def test_remove_tag(self, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)
-        sample_table = create_sample(
+        image_table = create_sample(
             session=test_db,
             dataset_id=dataset.dataset_id,
         )
-        sample = Sample(inner=sample_table)
+        sample = Sample(inner=image_table)
 
         # Add some tags first
         sample.add_tag("tag1")
@@ -111,11 +111,11 @@ class TestSample:
 
     def test_tags_property_get(self, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)
-        sample_table = create_sample(
+        image_table = create_sample(
             session=test_db,
             dataset_id=dataset.dataset_id,
         )
-        sample = Sample(inner=sample_table)
+        sample = Sample(inner=image_table)
 
         # Test empty tags
         assert sample.tags == set()
@@ -127,11 +127,11 @@ class TestSample:
 
     def test_tags_property_set(self, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)
-        sample_table = create_sample(
+        image_table = create_sample(
             session=test_db,
             dataset_id=dataset.dataset_id,
         )
-        sample = Sample(inner=sample_table)
+        sample = Sample(inner=image_table)
 
         # Test setting tags from empty to multiple
         sample.tags = {"tag1", "tag2", "tag3"}
@@ -150,11 +150,11 @@ class TestSample:
 
     def test_metadata(self, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)
-        sample_table = create_sample(
+        image_table = create_sample(
             session=test_db,
             dataset_id=dataset.dataset_id,
         )
-        sample = Sample(inner=sample_table)
+        sample = Sample(inner=image_table)
 
         # Test getting from empty metadata
         assert sample.metadata["nonexistent"] is None
@@ -181,18 +181,18 @@ class TestSample:
 
     def test_metadata__schema_must_match(self, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)
-        sample_table1 = create_sample(
+        image_table1 = create_sample(
             session=test_db,
             dataset_id=dataset.dataset_id,
             file_path_abs="/path/to/sample1.png",
         )
-        sample_table2 = create_sample(
+        image_table2 = create_sample(
             session=test_db,
             dataset_id=dataset.dataset_id,
             file_path_abs="/path/to/sample2.png",
         )
-        sample1 = Sample(inner=sample_table1)
-        sample2 = Sample(inner=sample_table2)
+        sample1 = Sample(inner=image_table1)
+        sample2 = Sample(inner=image_table2)
 
         # Set the initial value to a string
         sample1.metadata["key"] = "string_value"

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -16,7 +16,7 @@ from lightly_studio.dataset.embedding_manager import (
 )
 from lightly_studio.models.dataset import DatasetTable
 from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import embedding_model_resolver
 from tests.helpers_resolvers import create_dataset
@@ -180,7 +180,7 @@ def test_embed_text_with_invalid_model(
 def test_embed_images(
     db_session: Session,
     dataset: DatasetTable,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
 ) -> None:
     """Test generating and storing image embeddings."""
     # Register model

--- a/lightly_studio/tests/dataset/test_loader__coco.py
+++ b/lightly_studio/tests/dataset/test_loader__coco.py
@@ -31,7 +31,7 @@ from lightly_studio.dataset.loader import DatasetLoader
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from tests.conftest import assert_contains_properties
 
 
@@ -150,7 +150,7 @@ class TestDatasetLoader:
         assert labels[1].annotation_label_name == "car"
 
         # Check if sample was created
-        sample = session.exec(select(SampleTable)).first()
+        sample = session.exec(select(ImageTable)).first()
         assert sample is not None
         assert sample.file_name == "test_image.jpg"
         assert sample.width == 640
@@ -212,7 +212,7 @@ class TestDatasetLoader:
         assert label_names == {"person", "car"}
 
         # Check if sample was created
-        sample = session.exec(select(SampleTable)).first()
+        sample = session.exec(select(ImageTable)).first()
         assert sample is not None
         assert sample.file_name == "test_image.jpg"
         assert sample.width == 640
@@ -295,7 +295,7 @@ class TestDatasetLoader:
         assert label_names == {"person", "car"}
 
         # Check if sample was created
-        sample = session.exec(select(SampleTable)).first()
+        sample = session.exec(select(ImageTable)).first()
         assert sample is not None
         assert sample.file_name == "test_image.jpg"
         assert sample.width == 640

--- a/lightly_studio/tests/dataset/test_loader__labelformat.py
+++ b/lightly_studio/tests/dataset/test_loader__labelformat.py
@@ -16,7 +16,7 @@ from sqlmodel import select
 from lightly_studio.dataset.loader import DatasetLoader
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 
 
 def get_input(
@@ -90,7 +90,7 @@ class TestDatasetLoader:
         assert label_names == {"cat", "dog", "cow"}
 
         # Check sample
-        sample = session.exec(select(SampleTable)).first()
+        sample = session.exec(select(ImageTable)).first()
         assert sample is not None
         assert sample.file_name == "image.jpg"
         assert sample.width == 100

--- a/lightly_studio/tests/dataset/test_loader__yolo.py
+++ b/lightly_studio/tests/dataset/test_loader__yolo.py
@@ -21,7 +21,7 @@ from lightly_studio.dataset.loader import DatasetLoader
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 
 
 @pytest.fixture
@@ -93,7 +93,7 @@ class TestDatasetLoader:
         assert labels[1].annotation_label_name == "car"
 
         # Check if sample was created
-        sample = session.exec(select(SampleTable)).first()
+        sample = session.exec(select(ImageTable)).first()
         assert sample is not None
         assert sample.file_name == "test_image.jpg"
         assert sample.width == 640
@@ -163,7 +163,7 @@ class TestDatasetLoader:
         assert labels[1].annotation_label_name == "car"
 
         # Check if sample was created
-        sample = session.exec(select(SampleTable)).first()
+        sample = session.exec(select(ImageTable)).first()
         assert sample is not None
         assert sample.file_name == "test_image.jpg"
         assert sample.width == 640

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -23,7 +23,7 @@ from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.embedding_model import (
     EmbeddingModelTable,
 )
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.models.sample_embedding import (
     SampleEmbeddingCreate,
     SampleEmbeddingTable,
@@ -206,7 +206,7 @@ class TestClassifierManager:
     def test_provide_negative_samples(
         self,
         db_session: Session,
-        samples: list[SampleTable],
+        samples: list[ImageTable],
         mocker: MockerFixture,
     ) -> None:
         """Test providing negative samples."""
@@ -659,7 +659,7 @@ class TestClassifierManager:
     def test_run_classifier(
         self,
         db_session: Session,
-        samples: list[SampleTable],
+        samples: list[ImageTable],
         mocker: MockerFixture,
         classifier: ClassifierEntry,
         embedding_model: EmbeddingModelTable,
@@ -764,7 +764,7 @@ class TestClassifierManager:
     def test_run_classifier__no_samples_in_database(
         self,
         db_session: Session,
-        samples: list[SampleTable],
+        samples: list[ImageTable],
         mocker: MockerFixture,
         classifier: ClassifierEntry,
         classifier_manager: ClassifierManager,

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -24,7 +24,7 @@ from lightly_studio.models.embedding_model import (
     EmbeddingModelCreate,
     EmbeddingModelTable,
 )
-from lightly_studio.models.sample import SampleCreate, SampleTable
+from lightly_studio.models.sample import ImageCreate, ImageTable
 from lightly_studio.models.sample_embedding import (
     SampleEmbeddingCreate,
     SampleEmbeddingTable,
@@ -85,11 +85,11 @@ def create_sample(
     file_path_abs: str = "/path/to/sample1.png",
     width: int = 1920,
     height: int = 1080,
-) -> SampleTable:
+) -> ImageTable:
     """Helper function to create a sample."""
     return sample_resolver.create(
         session=session,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs=file_path_abs,
             file_name=Path(file_path_abs).name,
@@ -118,7 +118,7 @@ def create_samples(
     db_session: Session,
     dataset_id: UUID,
     images: list[SampleImage],
-) -> list[SampleTable]:
+) -> list[ImageTable]:
     """Creates samples in the database for a given dataset.
 
     Args:
@@ -127,7 +127,7 @@ def create_samples(
         images: A list of SampleImage objects representing the samples to create.
 
     Returns:
-        A list of the created SampleTable objects.
+        A list of the created ImageTable objects.
     """
     return [
         create_sample(
@@ -293,7 +293,7 @@ def create_samples_with_embeddings(
     dataset_id: UUID,
     embedding_model_id: UUID,
     images_and_embeddings: list[tuple[SampleImage, list[float]]],
-) -> list[SampleTable]:
+) -> list[ImageTable]:
     """Creates samples with embeddings in the database.
 
     Args:
@@ -304,7 +304,7 @@ def create_samples_with_embeddings(
             SampleImage object and its corresponding embedding.
 
     Returns:
-        A list of the created SampleTable objects.
+        A list of the created ImageTable objects.
     """
     result = []
     for image, embedding in images_and_embeddings:

--- a/lightly_studio/tests/models/test_dataset.py
+++ b/lightly_studio/tests/models/test_dataset.py
@@ -1,6 +1,6 @@
 from sqlmodel import Session
 
-from lightly_studio.models.sample import SampleCreate
+from lightly_studio.models.sample import ImageCreate
 from lightly_studio.resolvers import sample_resolver, tag_resolver
 from lightly_studio.resolvers.samples_filter import SampleFilter
 from tests.helpers_resolvers import (
@@ -24,7 +24,7 @@ class TestDatasetTable:
         # Create samples.
         sample1 = sample_resolver.create(
             session=test_db,
-            sample=SampleCreate(
+            sample=ImageCreate(
                 dataset_id=dataset_id,
                 file_path_abs="/path/to/sample1.png",
                 file_name="sample1.png",
@@ -34,7 +34,7 @@ class TestDatasetTable:
         )
         _sample2 = sample_resolver.create(
             session=test_db,
-            sample=SampleCreate(
+            sample=ImageCreate(
                 dataset_id=dataset_id,
                 file_path_abs="/path/to/sample2.png",
                 file_name="sample2.png",

--- a/lightly_studio/tests/resolvers/annotations/test_annotations_base_get_all_annotations_filtering.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotations_base_get_all_annotations_filtering.py
@@ -7,7 +7,7 @@ from sqlmodel import Session
 from lightly_studio.api.routes.api.validators import Paginated
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.models.tag import TagTable
 from lightly_studio.resolvers import annotation_resolver as annotations_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import (
@@ -125,7 +125,7 @@ def test_filter_by_annotation_tag_ids(
 
 def test_filter_by_sample_tag_ids(
     db_session: Session,
-    samples_assigned_with_tags: tuple[list[SampleTable], list[TagTable]],
+    samples_assigned_with_tags: tuple[list[ImageTable], list[TagTable]],
     annotations_test_data: None,  # noqa: ARG001
 ) -> None:
     # We have 12 annotations all together

--- a/lightly_studio/tests/resolvers/test_annotation_resolver.py
+++ b/lightly_studio/tests/resolvers/test_annotation_resolver.py
@@ -12,7 +12,7 @@ from lightly_studio.models.annotation.annotation_base import (
 )
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.resolvers import annotation_resolver, tag_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
@@ -36,11 +36,11 @@ class _TestData:
     dog_annotation2: AnnotationBaseTable
     cat_annotation: AnnotationBaseTable
     dataset: DatasetTable
-    sample1: SampleTable
-    sample2: SampleTable
+    sample1: ImageTable
+    sample2: ImageTable
     mouse_annotation: AnnotationBaseTable
     dataset2: DatasetTable
-    sample_with_mouse: SampleTable
+    sample_with_mouse: ImageTable
 
 
 @pytest.fixture

--- a/lightly_studio/tests/resolvers/test_dataset_resolver.py
+++ b/lightly_studio/tests/resolvers/test_dataset_resolver.py
@@ -8,7 +8,7 @@ from sqlmodel import Session
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.dataset import DatasetCreate, DatasetTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.models.tag import TagTable
 from lightly_studio.resolvers import dataset_resolver, tag_resolver
 from lightly_studio.resolvers.dataset_resolver import ExportFilter
@@ -24,7 +24,7 @@ from tests.helpers_resolvers import (
 @dataclass
 class TestDatasetExport:
     dataset: DatasetTable
-    samples: list[SampleTable]
+    samples: list[ImageTable]
     annotations: list[AnnotationBaseTable]
     tags: dict[str, TagTable]
     samples_total: int

--- a/lightly_studio/tests/resolvers/test_sample_resolver.py
+++ b/lightly_studio/tests/resolvers/test_sample_resolver.py
@@ -5,7 +5,7 @@ from sqlmodel import Session
 
 from lightly_studio.api.routes.api.validators import Paginated
 from lightly_studio.models.annotation_label import AnnotationLabelCreate
-from lightly_studio.models.sample import SampleCreate
+from lightly_studio.models.sample import ImageCreate
 from lightly_studio.resolvers import (
     annotation_label_resolver,
     sample_resolver,
@@ -34,7 +34,7 @@ def test_create_many_samples(test_db: Session) -> None:
     dataset_id = dataset.dataset_id
 
     samples_to_create = [
-        SampleCreate(
+        ImageCreate(
             dataset_id=dataset_id,
             file_path_abs=f"/path/to/batch_sample_{i}.png",
             file_name=f"batch_sample_{i}.png",
@@ -67,7 +67,7 @@ def test_create_many__duplicated(test_db: Session) -> None:
     dataset_id = dataset.dataset_id
 
     samples_to_create_1 = [
-        SampleCreate(
+        ImageCreate(
             dataset_id=dataset_id,
             file_path_abs=f"/path/to/batch_sample_{i}.png",
             file_name=f"batch_sample_{i}.png",
@@ -79,7 +79,7 @@ def test_create_many__duplicated(test_db: Session) -> None:
 
     # we create the same samples again, such that we have duplicates but different UUIDs
     samples_to_create_2 = [
-        SampleCreate(
+        ImageCreate(
             dataset_id=dataset_id,
             file_path_abs=f"/path/to/batch_sample_{i}.png",
             file_name=f"batch_sample_{i}.png",
@@ -106,7 +106,7 @@ def test_create__duplicated(test_db: Session) -> None:
     dataset = create_dataset(session=test_db)
     dataset_id = dataset.dataset_id
 
-    sample_to_create_1 = SampleCreate(
+    sample_to_create_1 = ImageCreate(
         dataset_id=dataset_id,
         file_path_abs="/path/to/sample.png",
         file_name="sample.png",
@@ -115,7 +115,7 @@ def test_create__duplicated(test_db: Session) -> None:
     )
 
     # we create the same sample again, such that we have duplicates but different UUIDs
-    sample_to_create_2 = SampleCreate(
+    sample_to_create_2 = ImageCreate(
         dataset_id=dataset_id,
         file_path_abs="/path/to/sample.png",
         file_name="sample.png",
@@ -347,7 +347,7 @@ def test_get_all_by_dataset_id__with_annotation_filtering(
     # Create samples
     sample1 = sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample1.png",
             file_name="sample1.png",
@@ -357,7 +357,7 @@ def test_get_all_by_dataset_id__with_annotation_filtering(
     )
     sample2 = sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample2.png",
             file_name="sample2.png",
@@ -449,7 +449,7 @@ def test_get_all_by_dataset_id__with_sample_ids(
     # Create samples
     sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample1.png",
             file_name="sample1.png",
@@ -459,7 +459,7 @@ def test_get_all_by_dataset_id__with_sample_ids(
     )
     sample2 = sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample2.png",
             file_name="sample2.png",
@@ -469,7 +469,7 @@ def test_get_all_by_dataset_id__with_sample_ids(
     )
     sample3 = sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample3.png",
             file_name="sample3.png",
@@ -498,7 +498,7 @@ def test_get_dimension_bounds(
     # Create samples with different dimensions
     sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample1.png",
             file_name="small.jpg",
@@ -508,7 +508,7 @@ def test_get_dimension_bounds(
     )
     sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample2.png",
             file_name="large.jpg",
@@ -533,7 +533,7 @@ def test_get_all_by_dataset_id__with_dimension_filtering(
     # Create samples with different dimensions
     sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample1.png",
             file_name="small.jpg",
@@ -543,7 +543,7 @@ def test_get_all_by_dataset_id__with_dimension_filtering(
     )
     sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample2.png",
             file_name="medium.jpg",
@@ -553,7 +553,7 @@ def test_get_all_by_dataset_id__with_dimension_filtering(
     )
     sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample3.png",
             file_name="large.jpg",
@@ -609,7 +609,7 @@ def test_get_dimension_bounds__with_tag_filtering(
     # Create samples with different dimensions
     sample1 = sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/small.png",
             file_name="small.jpg",
@@ -619,7 +619,7 @@ def test_get_dimension_bounds__with_tag_filtering(
     )
     sample2 = sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/medium.png",
             file_name="medium.jpg",
@@ -629,7 +629,7 @@ def test_get_dimension_bounds__with_tag_filtering(
     )
     sample3 = sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/large.png",
             file_name="large.jpg",
@@ -692,7 +692,7 @@ def test_get_dimension_bounds_with_annotation_filtering(
     # Create samples with different dimensions
     sample1 = sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample1.png",
             file_name="small.jpg",
@@ -702,7 +702,7 @@ def test_get_dimension_bounds_with_annotation_filtering(
     )
     sample2 = sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample2.png",
             file_name="medium.jpg",
@@ -712,7 +712,7 @@ def test_get_dimension_bounds_with_annotation_filtering(
     )
     sample3 = sample_resolver.create(
         session=test_db,
-        sample=SampleCreate(
+        sample=ImageCreate(
             dataset_id=dataset_id,
             file_path_abs="/path/to/sample3.png",
             file_name="large.jpg",

--- a/lightly_studio/tests/resolvers/test_samples_filter.py
+++ b/lightly_studio/tests/resolvers/test_samples_filter.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import pytest
 from sqlmodel import Session, col, select
 
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.resolvers import tag_resolver
 from lightly_studio.resolvers.samples_filter import (
     FilterDimensions,
@@ -27,9 +27,7 @@ from tests.helpers_resolvers import (
 
 class TestSampleFilter:
     @pytest.fixture
-    def setup_samples_filter_test(
-        self, test_db: Session
-    ) -> tuple[list[SampleTable], UUID, Session]:
+    def setup_samples_filter_test(self, test_db: Session) -> tuple[list[ImageTable], UUID, Session]:
         """Create sample data for testing."""
         dataset = create_dataset(session=test_db)
         dataset_id = dataset.dataset_id
@@ -95,17 +93,17 @@ class TestSampleFilter:
     )
     def test_samples_filter_dimensions(
         self,
-        setup_samples_filter_test: tuple[list[SampleTable], UUID, Session],
+        setup_samples_filter_test: tuple[list[ImageTable], UUID, Session],
         width_filter: FilterDimensions | None,
         height_filter: FilterDimensions | None,
         expected_count: int,
-        expected_condition: Callable[[SampleTable], bool],
+        expected_condition: Callable[[ImageTable], bool],
     ) -> None:
         """Test SampleFilter with dimension filters."""
         samples, dataset_id, session = setup_samples_filter_test
 
         # Create the base query.
-        query = select(SampleTable)
+        query = select(ImageTable)
 
         # Create the filter.
         sample_filter = SampleFilter(
@@ -121,7 +119,7 @@ class TestSampleFilter:
         assert all(expected_condition(sample) for sample in result)
 
     def test_samples_filter_dimentions__apply_filters(
-        self, setup_samples_filter_test: tuple[list[SampleTable], UUID, Session]
+        self, setup_samples_filter_test: tuple[list[ImageTable], UUID, Session]
     ) -> None:
         """Test that apply_filters calls apply_dimensions_filters."""
         samples, dataset_id, session = setup_samples_filter_test
@@ -131,7 +129,7 @@ class TestSampleFilter:
         height_filter = FilterDimensions(min=500, max=1200)
 
         # Create the base query.
-        query = select(SampleTable)
+        query = select(ImageTable)
 
         # Create the filter.
         sample_filter = SampleFilter(
@@ -145,7 +143,7 @@ class TestSampleFilter:
 
         # Should match only samples that satisfy both width
         # and height conditions
-        def expected_condition(s: SampleTable) -> bool:
+        def expected_condition(s: ImageTable) -> bool:
             return 500 <= s.width <= 2000 and 500 <= s.height <= 1200
 
         expected_count = 2  # Based on our test data
@@ -156,7 +154,7 @@ class TestSampleFilter:
     def test_samples_filter_annotation_filters(
         self,
         test_db: Session,
-        setup_samples_filter_test: tuple[list[SampleTable], UUID, Session],
+        setup_samples_filter_test: tuple[list[ImageTable], UUID, Session],
     ) -> None:
         """Test SampleFilter with annotation label filters."""
         samples, dataset_id, session = setup_samples_filter_test
@@ -180,7 +178,7 @@ class TestSampleFilter:
         )
 
         # Create the base query.
-        query = select(SampleTable)
+        query = select(ImageTable)
 
         # Create the filter.
         sample_filter = SampleFilter(
@@ -198,7 +196,7 @@ class TestSampleFilter:
     def test_samples_filter_tag_filters(
         self,
         test_db: Session,
-        setup_samples_filter_test: tuple[list[SampleTable], UUID, Session],
+        setup_samples_filter_test: tuple[list[ImageTable], UUID, Session],
     ) -> None:
         """Test SampleFilter with tag filters."""
         samples, dataset_id, session = setup_samples_filter_test
@@ -230,7 +228,7 @@ class TestSampleFilter:
         )
 
         # Create the base query.
-        query = select(SampleTable)
+        query = select(ImageTable)
 
         # Create the filter with tag1
         sample_filter = SampleFilter(
@@ -248,7 +246,7 @@ class TestSampleFilter:
     def test_samples_filter_annotation_filters__distinct_samples_only(
         self,
         test_db: Session,
-        setup_samples_filter_test: tuple[list[SampleTable], UUID, Session],
+        setup_samples_filter_test: tuple[list[ImageTable], UUID, Session],
     ) -> None:
         """Test SampleFilter with annotation label filters.
 
@@ -279,7 +277,7 @@ class TestSampleFilter:
         )
 
         # Create the base query.
-        query = select(SampleTable)
+        query = select(ImageTable)
 
         # Create the filter to only get samples with at least one cat.
         sample_filter = SampleFilter(
@@ -297,7 +295,7 @@ class TestSampleFilter:
     def test_samples_filter_tag_filters__distinct_samples_only(
         self,
         test_db: Session,
-        setup_samples_filter_test: tuple[list[SampleTable], UUID, Session],
+        setup_samples_filter_test: tuple[list[ImageTable], UUID, Session],
     ) -> None:
         """Test SampleFilter with tag filters."""
         samples, dataset_id, session = setup_samples_filter_test
@@ -334,7 +332,7 @@ class TestSampleFilter:
             )
 
         # Create the base query.
-        query = select(SampleTable)
+        query = select(ImageTable)
 
         # Create the filter with tag1
         sample_filter = SampleFilter(
@@ -370,9 +368,9 @@ class TestSampleFilter:
             ],
         )
 
-        query = select(SampleTable).order_by(
-            col(SampleTable.created_at).asc(),
-            col(SampleTable.sample_id).asc(),
+        query = select(ImageTable).order_by(
+            col(ImageTable.created_at).asc(),
+            col(ImageTable.sample_id).asc(),
         )
         sample_filter = SampleFilter(
             sample_ids=[

--- a/lightly_studio/tests/selection/helpers_selection.py
+++ b/lightly_studio/tests/selection/helpers_selection.py
@@ -24,12 +24,12 @@ def fill_db_with_samples_and_metadata(
     """Creates a dataset and fills it with sample and metadata."""
     dataset = create_dataset(test_db)
     for i, data in enumerate(metadata):
-        sample_table = create_sample(
+        image_table = create_sample(
             session=test_db,
             dataset_id=dataset.dataset_id,
             file_path_abs=f"sample_{i}.jpg",
         )
-        sample = Sample(inner=sample_table)
+        sample = Sample(inner=image_table)
         sample.metadata[metadata_key] = data
     return dataset.dataset_id
 

--- a/lightly_studio/tests/services/annotations_service/test_create_annotation.py
+++ b/lightly_studio/tests/services/annotations_service/test_create_annotation.py
@@ -13,7 +13,7 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationType,
 )
 from lightly_studio.models.annotation_label import AnnotationLabelTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import ImageTable
 from lightly_studio.services.annotations_service.create_annotation import (
     AnnotationCreateParams,
     create_annotation,
@@ -23,7 +23,7 @@ from lightly_studio.services.annotations_service.create_annotation import (
 def test_create_annotation_object_detection(
     db_session: Session,
     dataset_id: UUID,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
 ) -> None:
     """Test to create object detection annotation."""
@@ -57,7 +57,7 @@ def test_create_annotation_object_detection(
 def test_create_annotation_instance_segmentation(
     db_session: Session,
     dataset_id: UUID,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
 ) -> None:
     """Test to create instance segmentation annotation."""
@@ -92,7 +92,7 @@ def test_create_annotation_instance_segmentation(
 def test_create_annotation_semantic_segmentation(
     db_session: Session,
     dataset_id: UUID,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
 ) -> None:
     """Test to create semantic segmentation annotation."""
@@ -119,7 +119,7 @@ def test_create_annotation_semantic_segmentation(
 def test_create_annotation_classification(
     db_session: Session,
     dataset_id: UUID,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
 ) -> None:
     """Test to create classification annotation."""
@@ -144,7 +144,7 @@ def test_create_annotation_classification(
 def test_create_annotation_failure(
     db_session: Session,
     dataset_id: UUID,
-    samples: list[SampleTable],
+    samples: list[ImageTable],
     annotation_labels: list[AnnotationLabelTable],
     mocker: MockerFixture,
 ) -> None:

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
@@ -3,7 +3,7 @@
     import { type ComponentProps } from 'svelte';
     import SampleAnnotation from '../SampleAnnotation/SampleAnnotation.svelte';
     import type { SampleImageObjectFit } from '../SampleImage/types';
-    import type { SampleView } from '$lib/api/lightly_studio_local';
+    import type { ImageView } from '$lib/api/lightly_studio_local';
 
     const {
         sample,
@@ -12,7 +12,7 @@
         sampleImageObjectFit = 'contain',
         showLabel
     }: {
-        sample: SampleView;
+        sample: ImageView;
         containerWidth: number;
         containerHeight: number;
         sampleImageObjectFit?: SampleImageObjectFit;

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetails.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetails.svelte
@@ -19,7 +19,7 @@
     import type { Dataset } from '$lib/services/types';
     import { getAnnotations } from '../SampleAnnotation/utils';
     import Spinner from '../Spinner/Spinner.svelte';
-    import type { AnnotationView, SampleView } from '$lib/api/lightly_studio_local';
+    import type { AnnotationView, ImageView } from '$lib/api/lightly_studio_local';
     import type { BoundingBox } from '$lib/types';
     import SampleDetailsAnnotation from './SampleDetailsAnnotation/SampleDetailsAnnotation.svelte';
     import ResizableRectangle from '../ResizableRectangle/ResizableRectangle.svelte';
@@ -308,7 +308,7 @@
     $effect(() => {
         setupDragBehavior();
 
-        sample.subscribe((result: QueryObserverResult<SampleView>) => {
+        sample.subscribe((result: QueryObserverResult<ImageView>) => {
             if (result.isSuccess && result.data) {
                 let annotations = getAnnotations(result.data);
 

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanel.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanel.svelte
@@ -5,7 +5,7 @@
 
     import SampleMetadata from '$lib/components/SampleMetadata/SampleMetadata.svelte';
     import SampleDetailsSidePanelAnnotation from './SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte';
-    import type { SampleView } from '$lib/api/lightly_studio_local';
+    import type { ImageView } from '$lib/api/lightly_studio_local';
     import { Button } from '$lib/components/ui';
     import { page } from '$app/state';
     import SelectList from '$lib/components/SelectList/SelectList.svelte';
@@ -15,7 +15,7 @@
     import type { ListItem } from '$lib/components/SelectList/types';
 
     type Props = {
-        sample: SampleView;
+        sample: ImageView;
         selectedAnnotationId?: string;
         onAnnotationClick: (annotationId: string) => void;
         onUpdate: () => void;

--- a/lightly_studio_view/src/lib/components/SampleMetadata/SampleMetadata.svelte
+++ b/lightly_studio_view/src/lib/components/SampleMetadata/SampleMetadata.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import Segment from '$lib/components/Segment/Segment.svelte';
     import { formatInteger, formatMetadataValue } from '$lib/utils';
-    import type { SampleView } from '$lib/api/lightly_studio_local';
+    import type { ImageView } from '$lib/api/lightly_studio_local';
 
     type MetadataDict = {
         data: Record<string, unknown>;
@@ -11,7 +11,7 @@
         sample,
         showCustomMetadata = true
     }: {
-        sample: SampleView;
+        sample: ImageView;
         showCustomMetadata?: boolean;
     } = $props();
     const sample_details = $derived([

--- a/lightly_studio_view/src/lib/components/Samples/Samples.svelte
+++ b/lightly_studio_view/src/lib/components/Samples/Samples.svelte
@@ -19,7 +19,7 @@
     } from '$lib/hooks/useSamplesInfinite/useSamplesInfinite';
     import { useScrollRestoration } from '$lib/hooks/useScrollRestoration/useScrollRestoration';
     import { useSamplesFilters } from '$lib/hooks/useSamplesFilters/useSamplesFilters';
-    import type { SampleView } from '$lib/api/lightly_studio_local';
+    import type { ImageView } from '$lib/api/lightly_studio_local';
     import { goto } from '$app/navigation';
     import _ from 'lodash';
 
@@ -135,7 +135,7 @@
 
     const { samples: infiniteSamples } = $derived(useSamplesInfinite($filterParams));
     // Derived list of samples from TanStack infinite query
-    const samples: SampleView[] = $derived(
+    const samples: ImageView[] = $derived(
         $infiniteSamples && $infiniteSamples.data
             ? $infiniteSamples.data.pages.flatMap((page) => page.data)
             : []

--- a/lightly_studio_view/src/lib/hooks/useAnnotationAdjacents/useAnnotationAdjacents.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationAdjacents/useAnnotationAdjacents.test.ts
@@ -4,7 +4,7 @@ import { useAnnotationAdjacents, UseAnnotationAdjacentsResult } from './useAnnot
 import * as sdkModule from '$lib/api/lightly_studio_local/sdk.gen';
 import type {
     AnnotationViewsWithCount,
-    AnnotationWithSampleView
+    AnnotationWithImageView
 } from '../../api/lightly_studio_local';
 
 describe('useAnnotationAdjacents', () => {
@@ -50,7 +50,7 @@ describe('useAnnotationAdjacents', () => {
         },
         instance_segmentation_details: undefined,
         semantic_segmentation_details: undefined
-    } as AnnotationWithSampleView;
+    } as AnnotationWithImageView;
 
     const mockAnnotations: AnnotationViewsWithCount = {
         data: [

--- a/lightly_studio_view/src/lib/hooks/useSampleAdjacents/useSampleAdjacents.ts
+++ b/lightly_studio_view/src/lib/hooks/useSampleAdjacents/useSampleAdjacents.ts
@@ -1,5 +1,5 @@
 import { writable, type Writable } from 'svelte/store';
-import { readSamples, type SampleView } from '$lib/api/lightly_studio_local';
+import { readSamples, type ImageView } from '$lib/api/lightly_studio_local';
 import { createMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 
@@ -19,8 +19,8 @@ type SampleAdjacentsParams = {
 
 export type SampleAdjacents = {
     isLoading: boolean;
-    sampleNext?: SampleView;
-    samplePrevious?: SampleView;
+    sampleNext?: ImageView;
+    samplePrevious?: ImageView;
     error?: string;
 };
 

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -1198,7 +1198,7 @@ export interface components {
             object_detection_details?: components["schemas"]["ObjectDetectionAnnotationView"] | null;
             instance_segmentation_details?: components["schemas"]["InstanceSegmentationAnnotationView"] | null;
             semantic_segmentation_details?: components["schemas"]["SemanticSegmentationAnnotationView"] | null;
-            sample: components["schemas"]["AnnotationSampleView"];
+            sample: components["schemas"]["AnnotationImageView"];
         };
         /**
          * AnnotationIdsBody
@@ -1210,6 +1210,30 @@ export interface components {
              * @description annotation ids to add/remove
              */
             annotation_ids?: string[] | null;
+        };
+        /**
+         * AnnotationImageView
+         * @description Sample class for annotation view.
+         */
+        AnnotationImageView: {
+            /** File Path Abs */
+            file_path_abs: string;
+            /** File Name */
+            file_name: string;
+            /**
+             * Dataset Id
+             * Format: uuid
+             */
+            dataset_id: string;
+            /**
+             * Sample Id
+             * Format: uuid
+             */
+            sample_id: string;
+            /** Width */
+            width: number;
+            /** Height */
+            height: number;
         };
         /**
          * AnnotationLabel
@@ -1241,30 +1265,6 @@ export interface components {
             annotation_label_id?: string;
             /** Created At */
             created_at?: string;
-        };
-        /**
-         * AnnotationSampleView
-         * @description Sample class for annotation view.
-         */
-        AnnotationSampleView: {
-            /** File Path Abs */
-            file_path_abs: string;
-            /** File Name */
-            file_name: string;
-            /**
-             * Dataset Id
-             * Format: uuid
-             */
-            dataset_id: string;
-            /**
-             * Sample Id
-             * Format: uuid
-             */
-            sample_id: string;
-            /** Width */
-            width: number;
-            /** Height */
-            height: number;
         };
         /**
          * AnnotationType
@@ -1325,17 +1325,17 @@ export interface components {
          */
         AnnotationViewsWithCount: {
             /** Data */
-            data: components["schemas"]["AnnotationWithSampleView"][];
+            data: components["schemas"]["AnnotationWithImageView"][];
             /** Total Count */
             total_count: number;
             /** Nextcursor */
             nextCursor: number | null;
         };
         /**
-         * AnnotationWithSampleView
+         * AnnotationWithImageView
          * @description Response model for bounding box annotation.
          */
-        AnnotationWithSampleView: {
+        AnnotationWithImageView: {
             /**
              * Sample Id
              * Format: uuid
@@ -1358,7 +1358,7 @@ export interface components {
             object_detection_details?: components["schemas"]["ObjectDetectionAnnotationView"] | null;
             instance_segmentation_details?: components["schemas"]["InstanceSegmentationAnnotationView"] | null;
             semantic_segmentation_details?: components["schemas"]["SemanticSegmentationAnnotationView"] | null;
-            sample: components["schemas"]["AnnotationSampleView"];
+            sample: components["schemas"]["AnnotationImageView"];
         };
         /** Body_load_classifier_from_buffer_api_classifiers_load_classifier_from_buffer_post */
         Body_load_classifier_from_buffer_api_classifiers_load_classifier_from_buffer_post: {
@@ -1401,13 +1401,13 @@ export interface components {
             caption_id: string;
             /** Text */
             text: string;
-            sample: components["schemas"]["CaptionSampleView"];
+            sample: components["schemas"]["CaptionImageView"];
         };
         /**
-         * CaptionSampleView
+         * CaptionImageView
          * @description Sample class for caption view.
          */
-        CaptionSampleView: {
+        CaptionImageView: {
             /** File Path Abs */
             file_path_abs: string;
             /** File Name */
@@ -1677,6 +1677,134 @@ export interface components {
             detail?: components["schemas"]["ValidationError"][];
         };
         /**
+         * ImageCreate
+         * @description Image class when inserting.
+         */
+        ImageCreate: {
+            /** File Name */
+            file_name: string;
+            /** Width */
+            width: number;
+            /** Height */
+            height: number;
+            /**
+             * Dataset Id
+             * Format: uuid
+             */
+            dataset_id?: string;
+            /** File Path Abs */
+            file_path_abs?: string;
+        };
+        /**
+         * ImageTable
+         * @description This class defines the Image model.
+         */
+        ImageTable: {
+            /** File Name */
+            file_name: string;
+            /** Width */
+            width: number;
+            /** Height */
+            height: number;
+            /**
+             * Dataset Id
+             * Format: uuid
+             */
+            dataset_id?: string;
+            /** File Path Abs */
+            file_path_abs?: string;
+            /**
+             * Sample Id
+             * Format: uuid
+             */
+            sample_id?: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at?: string;
+        };
+        /**
+         * ImageView
+         * @description Image class when retrieving.
+         */
+        ImageView: {
+            /** File Name */
+            file_name: string;
+            /** File Path Abs */
+            file_path_abs: string;
+            /**
+             * Sample Id
+             * Format: uuid
+             */
+            sample_id: string;
+            /**
+             * Dataset Id
+             * Format: uuid
+             */
+            dataset_id: string;
+            /** Annotations */
+            annotations: components["schemas"]["AnnotationView"][];
+            /**
+             * Captions
+             * @default []
+             */
+            captions: components["schemas"]["CaptionView"][];
+            /** Tags */
+            tags: components["schemas"]["ImageViewTag"][];
+            /** Metadata Dict */
+            metadata_dict?: unknown | null;
+            /** Width */
+            width: number;
+            /** Height */
+            height: number;
+        };
+        /**
+         * ImageViewTag
+         * @description Tag view inside Image view.
+         */
+        ImageViewTag: {
+            /**
+             * Tag Id
+             * Format: uuid
+             */
+            tag_id: string;
+            /** Name */
+            name: string;
+            /**
+             * Kind
+             * @enum {string}
+             */
+            kind: "sample" | "annotation";
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /**
+         * ImageViewsWithCount
+         * @description Response model for counted images.
+         */
+        ImageViewsWithCount: {
+            /** Data */
+            data: components["schemas"]["ImageView"][];
+            /** Total Count */
+            total_count: number;
+            /** Nextcursor */
+            nextCursor?: number | null;
+        };
+        /**
          * InstanceSegmentationAnnotationView
          * @description API response model for instance segmentation annotations.
          */
@@ -1823,25 +1951,6 @@ export interface components {
             pagination?: components["schemas"]["Paginated"] | null;
         };
         /**
-         * SampleCreate
-         * @description Sample class when inserting.
-         */
-        SampleCreate: {
-            /** File Name */
-            file_name: string;
-            /** Width */
-            width: number;
-            /** Height */
-            height: number;
-            /**
-             * Dataset Id
-             * Format: uuid
-             */
-            dataset_id?: string;
-            /** File Path Abs */
-            file_path_abs?: string;
-        };
-        /**
          * SampleFilter
          * @description Encapsulates filter parameters for querying samples.
          */
@@ -1867,115 +1976,6 @@ export interface components {
              * @description sample ids to add/remove
              */
             sample_ids?: string[] | null;
-        };
-        /**
-         * SampleTable
-         * @description This class defines the Sample model.
-         */
-        SampleTable: {
-            /** File Name */
-            file_name: string;
-            /** Width */
-            width: number;
-            /** Height */
-            height: number;
-            /**
-             * Dataset Id
-             * Format: uuid
-             */
-            dataset_id?: string;
-            /** File Path Abs */
-            file_path_abs?: string;
-            /**
-             * Sample Id
-             * Format: uuid
-             */
-            sample_id?: string;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at?: string;
-            /**
-             * Updated At
-             * Format: date-time
-             */
-            updated_at?: string;
-        };
-        /**
-         * SampleView
-         * @description Sample class when retrieving.
-         */
-        SampleView: {
-            /** File Name */
-            file_name: string;
-            /** File Path Abs */
-            file_path_abs: string;
-            /**
-             * Sample Id
-             * Format: uuid
-             */
-            sample_id: string;
-            /**
-             * Dataset Id
-             * Format: uuid
-             */
-            dataset_id: string;
-            /** Annotations */
-            annotations: components["schemas"]["AnnotationView"][];
-            /**
-             * Captions
-             * @default []
-             */
-            captions: components["schemas"]["CaptionView"][];
-            /** Tags */
-            tags: components["schemas"]["SampleViewTag"][];
-            /** Metadata Dict */
-            metadata_dict?: unknown | null;
-            /** Width */
-            width: number;
-            /** Height */
-            height: number;
-        };
-        /**
-         * SampleViewTag
-         * @description Tag view inside Sample view.
-         */
-        SampleViewTag: {
-            /**
-             * Tag Id
-             * Format: uuid
-             */
-            tag_id: string;
-            /** Name */
-            name: string;
-            /**
-             * Kind
-             * @enum {string}
-             */
-            kind: "sample" | "annotation";
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /**
-             * Updated At
-             * Format: date-time
-             */
-            updated_at: string;
-        };
-        /**
-         * SampleViewsWithCount
-         * @description Response model for counted samples.
-         */
-        SampleViewsWithCount: {
-            /** Data */
-            data: components["schemas"]["SampleView"][];
-            /** Total Count */
-            total_count: number;
-            /** Nextcursor */
-            nextCursor?: number | null;
         };
         /**
          * SamplesToRefineResponse
@@ -2797,7 +2797,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SampleCreate"];
+                "application/json": components["schemas"]["ImageCreate"];
             };
         };
         responses: {
@@ -2807,7 +2807,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SampleView"];
+                    "application/json": components["schemas"]["ImageView"];
                 };
             };
             /** @description Validation Error */
@@ -2842,7 +2842,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SampleViewsWithCount"];
+                    "application/json": components["schemas"]["ImageViewsWithCount"];
                 };
             };
             /** @description Validation Error */
@@ -2910,7 +2910,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SampleView"];
+                    "application/json": components["schemas"]["ImageView"];
                 };
             };
             /** @description Validation Error */
@@ -2935,7 +2935,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SampleCreate"];
+                "application/json": components["schemas"]["ImageCreate"];
             };
         };
         responses: {
@@ -2945,7 +2945,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SampleTable"];
+                    "application/json": components["schemas"]["ImageTable"];
                 };
             };
             /** @description Validation Error */

--- a/lightly_studio_view/src/lib/services/types.ts
+++ b/lightly_studio_view/src/lib/services/types.ts
@@ -1,13 +1,13 @@
 import type {
     DatasetTable,
-    SampleView,
+    ImageView,
     TagView as TagViewType,
     TagCreateBody,
     ExportFilter as ExportFilterType,
     SampleIdsBody as SampleIdsBodyType,
     AnnotationIdsBody as AnnotationIdsBodyType,
     AnnotationView,
-    AnnotationWithSampleView,
+    AnnotationWithImageView,
     ObjectDetectionAnnotationView as ObjectDetectionAnnotationViewType,
     InstanceSegmentationAnnotationView as InstanceSegmentationAnnotationViewType,
     SemanticSegmentationAnnotationView as SemanticSegmentationAnnotationViewType,
@@ -20,7 +20,7 @@ import type {
 import type { Readable } from 'svelte/store';
 
 export type Dataset = DatasetTable;
-export type Sample = SampleView;
+export type Sample = ImageView;
 export type TagView = TagViewType;
 export type TagInputBody = TagCreateBody;
 export type ExportFilter = ExportFilterType;
@@ -28,7 +28,7 @@ export type TagKind = TagCreateBody['kind'];
 export type SampleIdsBody = SampleIdsBodyType;
 export type AnnotationIdsBody = AnnotationIdsBodyType;
 export type Annotation = AnnotationView;
-export type AnnotationWithSample = AnnotationWithSampleView;
+export type AnnotationWithSample = AnnotationWithImageView;
 
 export type ObjectDetectionAnnotationView = ObjectDetectionAnnotationViewType;
 export type InstanceSegmentationAnnotationView = InstanceSegmentationAnnotationViewType;


### PR DESCRIPTION
## What has changed and why?

To be merged in a feature branch.

Used search and replace to rename:
* `class Sample*` in `lightly_studio/src/lightly_studio/models/sample.py` to `class Image*`
    * Note that captions, tags and embeddings will stay linked to a sample - did not rename those
* Renamed `sample_table` occurrences to  `image_table`

Follow-up: Change the DB table name

How to review: Please check mostly the changes in `models/` directory.

## How has it been tested?

* CI
* Manually launched the app

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
