### PR TITLE
Add docstrings to DatasetQuery

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -35,7 +35,8 @@ class DatasetQuery:
     dataset.match(...) # shorthand for dataset.query().match(...)
     ```
 
-    The object is converted to a SQL query that is lazily evaluated when iterating over it or converting it to a list.
+    The object is converted to a SQL query that is lazily evaluated when iterating over
+    it or converting it to a list.
 
     ## match() - Filtering samples
     Filtering is done via the `match()` method.


### PR DESCRIPTION
## What has changed and why?

Add better docstring to DatasetQuery
The other docstrings are updated in separate PRs.

## How has it been tested? - Screenshot

<img width="1594" height="1444" alt="image" src="https://github.com/user-attachments/assets/5f2e9b4c-6c80-42a7-87a2-54fd5fd6da92" />

[DatasetQuery - LightlyStudio Docs.pdf](https://github.com/user-attachments/files/23015317/DatasetQuery.-.LightlyStudio.Docs.pdf)