### PR TITLE
Use Dataset instead of DatasetLoader for e2e tests

### DIFF
--- a/lightly_studio/e2e-tests/index_dataset_for_end2end_ui_tests.py
+++ b/lightly_studio/e2e-tests/index_dataset_for_end2end_ui_tests.py
@@ -5,25 +5,21 @@ segmentation dataset and launch the UI application for exploration and
 visualization.
 """
 
-# We import the DatasetLoader class from the lightly_studio module
-from lightly_studio import DatasetLoader, db_manager
-from lightly_studio.api.features import lightly_studio_active_features
+from lightly_studio import AnnotationType, Dataset, db_manager, start_gui
 
 # Clean up an existing database
 db_manager.connect(cleanup_existing=True)
 
-# Create a DatasetLoader instance
-loader = DatasetLoader()
+# Create a Dataset instance
+dataset = Dataset.create()
 
 # We point to the annotations json file and the input images folder.
 # Defined dataset is processed here to be available for the UI application.
-loader.from_coco_instance_segmentations(
-    annotations_json_path="datasets/coco-128/instances_train2017.json",
-    img_dir="datasets/coco-128/images",
+dataset.add_samples_from_coco(
+    annotations_json="datasets/coco-128/instances_train2017.json",
+    images_path="datasets/coco-128/images",
+    annotation_type=AnnotationType.INSTANCE_SEGMENTATION,
 )
 
-# TODO(Horatiu, 08/2025): Current e2e tests should not use the few shot classifier implementation.
-# Without the few shot classifier feature enabled tests timeout on CI.
-lightly_studio_active_features.append("fewShotClassifierEnabled")
 # We start the UI application on port 8001
-loader.start_gui()
+start_gui()


### PR DESCRIPTION
## What has changed and why?

Use the new python interface for the e2e tests. Then we can remove the old interface.

## How has it been tested?

CI passes.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
