### PR TITLE
Adding Basic Operator Parameters

### DIFF
--- a/lightly_studio/src/lightly_studio/plugins/parameter.py
+++ b/lightly_studio/src/lightly_studio/plugins/parameter.py
@@ -43,7 +43,7 @@ class BuiltinParameter(BaseParameter, Generic[T]):
     def _validate(self, value: T) -> T:
         if isinstance(value, self._type):
             return cast(T, value)
-        raise TypeError(f"Expected value of type '{self._type.__name__}'")
+        raise TypeError(f"Expected value of type '{self._type.__name__}' but got {type(value)}'")
 
 
 class IntParameter(BuiltinParameter[int]):

--- a/lightly_studio/tests/plugins/test_paramter.py
+++ b/lightly_studio/tests/plugins/test_paramter.py
@@ -29,9 +29,9 @@ def test_builtin_parameters() -> None:
     _ = FloatParameter(name="test_float", default=42.0)
 
     # invalid default types
-    with pytest.raises(TypeError, match="Expected value of type 'int'"):
+    with pytest.raises(TypeError, match="Expected value of type 'int' but got <class 'str'>"):
         _ = IntParameter(name="test_int", default="42")
-    with pytest.raises(TypeError, match="Expected value of type 'int'"):
+    with pytest.raises(TypeError, match="Expected value of type 'int' but got <class 'float'>"):
         _ = IntParameter(name="test_int", default=42.0)
-    with pytest.raises(TypeError, match="Expected value of type 'float'"):
+    with pytest.raises(TypeError, match="Expected value of type 'float' but got <class 'int'>"):
         _ = FloatParameter(name="test_float", default=42)


### PR DESCRIPTION
## What has changed and why?

This PR adds the parameter base implementation, as well as the string, bool, int, and float version. For those, more easy solutions would have been possible. However I decided for this design, since we want to keep it flexible for more custom types as well. E.g. ClassChoiseParameter, or PathParamter, etc. Having separate classes ensures highest flexibility here.

The actual operator will be part of a follow pr.

## How has it been tested?

unit tests are in place

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
