### PR TITLE
Rename SampleImage to ImageStub

### DIFF
--- a/lightly_studio/tests/api/routes/api/test_dataset.py
+++ b/lightly_studio/tests/api/routes/api/test_dataset.py
@@ -8,7 +8,7 @@ from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_OK,
 )
 from lightly_studio.resolvers import tag_resolver
-from tests.helpers_resolvers import SampleImage, create_dataset, create_images, create_tag
+from tests.helpers_resolvers import ImageStub, create_dataset, create_images, create_tag
 
 
 def test_read_datasets(test_client: TestClient, db_session: Session) -> None:
@@ -75,9 +75,9 @@ def test_export_dataset(db_session: Session, test_client: TestClient) -> None:
         db_session=db_session,
         dataset_id=dataset_id,
         images=[
-            SampleImage(path="path/to/image0.jpg"),
-            SampleImage(path="path/to/image1.jpg"),
-            SampleImage(path="path/to/image2.jpg"),
+            ImageStub(path="path/to/image0.jpg"),
+            ImageStub(path="path/to/image1.jpg"),
+            ImageStub(path="path/to/image2.jpg"),
         ],
     )
 

--- a/lightly_studio/tests/api/routes/api/test_selection.py
+++ b/lightly_studio/tests/api/routes/api/test_selection.py
@@ -9,7 +9,7 @@ from lightly_studio.metadata import compute_typicality
 from lightly_studio.resolvers import image_resolver, tag_resolver
 from lightly_studio.resolvers.samples_filter import SampleFilter
 from tests import helpers_resolvers
-from tests.helpers_resolvers import SampleImage
+from tests.helpers_resolvers import ImageStub
 
 
 class TestDiversitySelection:
@@ -119,9 +119,9 @@ class TestDiversitySelection:
         )
 
         samples_with_embeddings = [
-            (SampleImage(path="image1.jpg"), [1.0, 0.0, 0.0]),
-            (SampleImage(path="image2.jpg"), [0.0, 1.0, 0.0]),
-            (SampleImage(path="image3.jpg"), [0.0, 1.0, 1.0]),
+            (ImageStub(path="image1.jpg"), [1.0, 0.0, 0.0]),
+            (ImageStub(path="image2.jpg"), [0.0, 1.0, 0.0]),
+            (ImageStub(path="image3.jpg"), [0.0, 1.0, 1.0]),
         ]
         helpers_resolvers.create_samples_with_embeddings(
             db_session=db_session,

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -37,7 +37,7 @@ from lightly_studio.resolvers import (
     tag_resolver,
 )
 from tests.helpers_resolvers import (
-    SampleImage,
+    ImageStub,
     create_annotation_label,
     create_dataset,
     create_image,
@@ -113,7 +113,7 @@ def samples(db_session: Session, dataset: DatasetTable) -> list[ImageTable]:
         db_session=db_session,
         dataset_id=dataset.dataset_id,
         images=[
-            SampleImage(
+            ImageStub(
                 path=f"/test/path/test_image_{i}.jpg",
                 width=640,
                 height=480,

--- a/lightly_studio/tests/core/test_dataset.py
+++ b/lightly_studio/tests/core/test_dataset.py
@@ -14,7 +14,7 @@ from lightly_studio.dataset import embedding_manager
 from lightly_studio.models.dataset import SampleType
 from lightly_studio.resolvers import image_resolver
 from tests.helpers_resolvers import (
-    SampleImage,
+    ImageStub,
     create_dataset,
     create_embedding_model,
     create_image,
@@ -139,9 +139,9 @@ class TestDataset:
         # Create a dataset and add samples to it
         dataset = Dataset.create(name="test_dataset")
         images = [
-            SampleImage(path="/path/to/image0.jpg", width=640, height=480),
-            SampleImage(path="/path/to/image1.jpg", width=640, height=480),
-            SampleImage(path="/path/to/image2.jpg", width=1024, height=768),
+            ImageStub(path="/path/to/image0.jpg", width=640, height=480),
+            ImageStub(path="/path/to/image1.jpg", width=640, height=480),
+            ImageStub(path="/path/to/image2.jpg", width=1024, height=768),
         ]
         create_images(db_session=dataset.session, dataset_id=dataset.dataset_id, images=images)
 

--- a/lightly_studio/tests/export/test_export_dataset.py
+++ b/lightly_studio/tests/export/test_export_dataset.py
@@ -12,7 +12,7 @@ from lightly_studio.models.annotation.annotation_base import AnnotationCreate, A
 from lightly_studio.models.dataset import DatasetTable
 from lightly_studio.resolvers import annotation_resolver
 from tests.helpers_resolvers import (
-    SampleImage,
+    ImageStub,
     create_annotation_label,
     create_dataset,
     create_images,
@@ -28,9 +28,9 @@ class TestDatasetExport:
         """Tests DatasetExport exporting to COCO format."""
         dataset = create_dataset(session=db_session)
         images_to_create = [
-            SampleImage(path="image0.jpg", width=100, height=100),
-            SampleImage(path="image1.jpg", width=200, height=200),
-            SampleImage(path="image2.jpg", width=300, height=300),
+            ImageStub(path="image0.jpg", width=100, height=100),
+            ImageStub(path="image1.jpg", width=200, height=200),
+            ImageStub(path="image2.jpg", width=300, height=300),
         ]
         images = create_images(
             db_session=db_session, dataset_id=dataset.dataset_id, images=images_to_create
@@ -80,7 +80,7 @@ class TestDatasetExport:
     ) -> None:
         """Tests DatasetExport exporting to COCO format."""
         dataset = create_dataset(session=db_session)
-        images = [SampleImage(path="image0.jpg", width=100, height=100)]
+        images = [ImageStub(path="image0.jpg", width=100, height=100)]
         create_images(db_session=db_session, dataset_id=dataset.dataset_id, images=images)
 
         output_json = tmp_path / "export.json"
@@ -160,8 +160,8 @@ def test_to_coco_object_detections__no_annotations(
     """Tests exporting to COCO format - no annotations."""
     dataset = create_dataset(session=db_session)
     images = [
-        SampleImage(path="img1", width=100, height=100),
-        SampleImage(path="img2", width=200, height=200),
+        ImageStub(path="img1", width=100, height=100),
+        ImageStub(path="img2", width=200, height=200),
     ]
     create_images(db_session=db_session, dataset_id=dataset.dataset_id, images=images)
 

--- a/lightly_studio/tests/export/test_lightly_studio_label_input.py
+++ b/lightly_studio/tests/export/test_lightly_studio_label_input.py
@@ -16,7 +16,7 @@ from lightly_studio.models.annotation.annotation_base import AnnotationCreate, A
 from lightly_studio.models.dataset import DatasetTable
 from lightly_studio.resolvers import annotation_resolver
 from tests.helpers_resolvers import (
-    SampleImage,
+    ImageStub,
     create_annotation_label,
     create_dataset,
     create_images,
@@ -47,8 +47,8 @@ class TestLightlyStudioLabelInput:
     ) -> None:
         dataset = create_dataset(session=db_session)
         images = [
-            SampleImage(path="img1", width=100, height=100),
-            SampleImage(path="img2", width=200, height=200),
+            ImageStub(path="img1", width=100, height=100),
+            ImageStub(path="img2", width=200, height=200),
         ]
         create_images(db_session=db_session, dataset_id=dataset.dataset_id, images=images)
         label_input = LightlyStudioObjectDetectionInput(
@@ -122,8 +122,8 @@ class TestLightlyStudioLabelInput:
     def test_get_labels__no_annotations(self, db_session: Session) -> None:
         dataset = create_dataset(session=db_session)
         images = [
-            SampleImage(path="img1", width=100, height=100),
-            SampleImage(path="img2", width=200, height=200),
+            ImageStub(path="img1", width=100, height=100),
+            ImageStub(path="img2", width=200, height=200),
         ]
         create_images(db_session=db_session, dataset_id=dataset.dataset_id, images=images)
 
@@ -149,8 +149,8 @@ class TestLightlyStudioLabelInput:
         """We currently export only object detection annotations, not instance segmentation."""
         dataset = create_dataset(session=db_session)
         images_to_create = [
-            SampleImage(path="img1", width=100, height=100),
-            SampleImage(path="img2", width=200, height=200),
+            ImageStub(path="img1", width=100, height=100),
+            ImageStub(path="img2", width=200, height=200),
         ]
         images = create_images(
             db_session=db_session, dataset_id=dataset.dataset_id, images=images_to_create

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -110,7 +110,7 @@ def create_image(
 
 
 @dataclass
-class SampleImage:
+class ImageStub:
     """Helper class to represent a sample image for testing.
 
     Attributes:
@@ -127,7 +127,7 @@ class SampleImage:
 def create_images(
     db_session: Session,
     dataset_id: UUID,
-    images: list[SampleImage],
+    images: list[ImageStub],
 ) -> list[ImageTable]:
     """Creates samples in the database for a given dataset.
 
@@ -312,7 +312,7 @@ def create_samples_with_embeddings(
     db_session: Session,
     dataset_id: UUID,
     embedding_model_id: UUID,
-    images_and_embeddings: list[tuple[SampleImage, list[float]]],
+    images_and_embeddings: list[tuple[ImageStub, list[float]]],
 ) -> list[ImageTable]:
     """Creates samples with embeddings in the database.
 

--- a/lightly_studio/tests/models/test_dataset.py
+++ b/lightly_studio/tests/models/test_dataset.py
@@ -3,7 +3,7 @@ from sqlmodel import Session
 from lightly_studio.resolvers import tag_resolver
 from lightly_studio.resolvers.samples_filter import SampleFilter
 from tests.helpers_resolvers import (
-    SampleImage,
+    ImageStub,
     create_dataset,
     create_images,
     create_tag,
@@ -27,8 +27,8 @@ class TestDatasetTable:
             db_session=test_db,
             dataset_id=dataset_id,
             images=[
-                SampleImage(path="sample1.png", width=100, height=100),
-                SampleImage(path="sample2.png", width=200, height=200),
+                ImageStub(path="sample1.png", width=100, height=100),
+                ImageStub(path="sample2.png", width=200, height=200),
             ],
         )
         image_0_id = images[0].sample_id

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
@@ -15,7 +15,7 @@ from lightly_studio.resolvers.samples_filter import (
 )
 from tests.helpers_resolvers import (
     AnnotationDetails,
-    SampleImage,
+    ImageStub,
     create_annotations,
     create_dataset,
     create_embedding_model,
@@ -138,8 +138,8 @@ def test_get_all_by_dataset_id__with_annotation_filtering(
         db_session=test_db,
         dataset_id=dataset_id,
         images=[
-            SampleImage(path="sample1.png"),
-            SampleImage(path="sample2.png"),
+            ImageStub(path="sample1.png"),
+            ImageStub(path="sample2.png"),
         ],
     )
 
@@ -228,9 +228,9 @@ def test_get_all_by_dataset_id__with_sample_ids(
         db_session=test_db,
         dataset_id=dataset_id,
         images=[
-            SampleImage(path="sample1.png"),
-            SampleImage(path="sample2.png"),
-            SampleImage(path="sample3.png"),
+            ImageStub(path="sample1.png"),
+            ImageStub(path="sample2.png"),
+            ImageStub(path="sample3.png"),
         ],
     )
     sample_ids = [images[1].sample_id, images[2].sample_id]
@@ -256,9 +256,9 @@ def test_get_all_by_dataset_id__with_dimension_filtering(
         db_session=test_db,
         dataset_id=dataset_id,
         images=[
-            SampleImage(path="small.jpg", width=100, height=200),
-            SampleImage(path="medium.jpg", width=800, height=600),
-            SampleImage(path="large.jpg", width=1920, height=1080),
+            ImageStub(path="small.jpg", width=100, height=200),
+            ImageStub(path="medium.jpg", width=800, height=600),
+            ImageStub(path="large.jpg", width=1920, height=1080),
         ],
     )
 
@@ -602,10 +602,10 @@ def test_get_all_by_dataset_id__filters_by_sample_ids(test_db: Session) -> None:
         db_session=test_db,
         dataset_id=dataset_id,
         images=[
-            SampleImage(path="sample_0.png"),
-            SampleImage(path="sample_1.png"),
-            SampleImage(path="sample_2.png"),
-            SampleImage(path="sample_3.png"),
+            ImageStub(path="sample_0.png"),
+            ImageStub(path="sample_1.png"),
+            ImageStub(path="sample_2.png"),
+            ImageStub(path="sample_3.png"),
         ],
     )
 

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_dimension_bounds.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_dimension_bounds.py
@@ -8,7 +8,7 @@ from lightly_studio.resolvers import (
 )
 from tests.helpers_resolvers import (
     AnnotationDetails,
-    SampleImage,
+    ImageStub,
     create_annotations,
     create_dataset,
     create_images,
@@ -27,8 +27,8 @@ def test_get_dimension_bounds(
         db_session=test_db,
         dataset_id=dataset_id,
         images=[
-            SampleImage(path="small.jpg", width=100, height=200),
-            SampleImage(path="large.jpg", width=1920, height=1080),
+            ImageStub(path="small.jpg", width=100, height=200),
+            ImageStub(path="large.jpg", width=1920, height=1080),
         ],
     )
 
@@ -50,9 +50,9 @@ def test_get_dimension_bounds__with_tag_filtering(
         db_session=test_db,
         dataset_id=dataset_id,
         images=[
-            SampleImage(path="small.jpg", width=100, height=200),
-            SampleImage(path="medium.jpg", width=800, height=600),
-            SampleImage(path="large.jpg", width=1920, height=1080),
+            ImageStub(path="small.jpg", width=100, height=200),
+            ImageStub(path="medium.jpg", width=800, height=600),
+            ImageStub(path="large.jpg", width=1920, height=1080),
         ],
     )
 
@@ -112,9 +112,9 @@ def test_get_dimension_bounds_with_annotation_filtering(
         db_session=test_db,
         dataset_id=dataset_id,
         images=[
-            SampleImage(path="small.jpg", width=100, height=200),
-            SampleImage(path="medium.jpg", width=500, height=600),
-            SampleImage(path="large.jpg", width=1920, height=1080),
+            ImageStub(path="small.jpg", width=100, height=200),
+            ImageStub(path="medium.jpg", width=500, height=600),
+            ImageStub(path="large.jpg", width=1920, height=1080),
         ],
     )
 

--- a/lightly_studio/tests/resolvers/test_samples_filter.py
+++ b/lightly_studio/tests/resolvers/test_samples_filter.py
@@ -15,7 +15,7 @@ from lightly_studio.resolvers.samples_filter import (
     SampleFilter,
 )
 from tests.helpers_resolvers import (
-    SampleImage,
+    ImageStub,
     create_annotation,
     create_annotation_label,
     create_dataset,
@@ -360,11 +360,11 @@ class TestSampleFilter:
             db_session=test_db,
             dataset_id=dataset_id,
             images=[
-                SampleImage(path="sample_0.png", width=300),
-                SampleImage(path="sample_1.png", width=300),
-                SampleImage(path="sample_2.png", width=100),
-                SampleImage(path="sample_3.png", width=400),
-                SampleImage(path="sample_4.png", width=500),
+                ImageStub(path="sample_0.png", width=300),
+                ImageStub(path="sample_1.png", width=300),
+                ImageStub(path="sample_2.png", width=100),
+                ImageStub(path="sample_3.png", width=400),
+                ImageStub(path="sample_4.png", width=500),
             ],
         )
 

--- a/lightly_studio/tests/resolvers/test_twodim_embedding_resolver.py
+++ b/lightly_studio/tests/resolvers/test_twodim_embedding_resolver.py
@@ -7,7 +7,7 @@ from sqlmodel import Session
 from lightly_studio.resolvers import twodim_embedding_resolver
 from tests import helpers_resolvers
 from tests.helpers_resolvers import (
-    SampleImage,
+    ImageStub,
 )
 
 
@@ -87,8 +87,8 @@ def test_get_twodim_embeddings__cache_hit(
         dataset_id=dataset.dataset_id,
         embedding_model_id=embedding_model.embedding_model_id,
         images_and_embeddings=[
-            (SampleImage(path="sample_1.jpg"), [0.1, 0.2, 0.3]),
-            (SampleImage(path="sample_2.jpg"), [0.4, 0.5, 0.6]),
+            (ImageStub(path="sample_1.jpg"), [0.1, 0.2, 0.3]),
+            (ImageStub(path="sample_2.jpg"), [0.4, 0.5, 0.6]),
         ],
     )
     calculate_spy = mocker.spy(twodim_embedding_resolver, "_calculate_2d_embeddings")


### PR DESCRIPTION
## What has changed and why?

Rename SampleImage to ImageStub. That's the name we decided to use when added an analogous class for videos.

## How has it been tested?

Just a rename.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
