### PR TITLE
Remove dataset_id from ImageCreate

### DIFF
--- a/lightly_studio/src/lightly_studio/core/add_samples.py
+++ b/lightly_studio/src/lightly_studio/core/add_samples.py
@@ -110,14 +110,13 @@ def load_into_dataset_from_paths(
             file_path_abs=image_path,
             width=width,
             height=height,
-            dataset_id=dataset_id,
         )
         samples_to_create.append(sample)
 
         # Process batch when it reaches SAMPLE_BATCH_SIZE
         if len(samples_to_create) >= SAMPLE_BATCH_SIZE:
             created_path_to_id, paths_not_inserted = _create_batch_samples(
-                session=session, samples=samples_to_create
+                session=session, dataset_id=dataset_id, samples=samples_to_create
             )
             created_sample_ids.extend(created_path_to_id.values())
             logging_context.update_example_paths(paths_not_inserted)
@@ -126,7 +125,7 @@ def load_into_dataset_from_paths(
     # Handle remaining samples
     if samples_to_create:
         created_path_to_id, paths_not_inserted = _create_batch_samples(
-            session=session, samples=samples_to_create
+            session=session, dataset_id=dataset_id, samples=samples_to_create
         )
         created_sample_ids.extend(created_path_to_id.values())
         logging_context.update_example_paths(paths_not_inserted)
@@ -176,14 +175,13 @@ def load_into_dataset_from_labelformat(
             file_path_abs=str(images_path / image.filename),
             width=image.width,
             height=image.height,
-            dataset_id=dataset_id,
         )
         samples_to_create.append(sample)
         path_to_anno_data[sample.file_path_abs] = typed_image_data
 
         if len(samples_to_create) >= SAMPLE_BATCH_SIZE:
             created_path_to_id, paths_not_inserted = _create_batch_samples(
-                session=session, samples=samples_to_create
+                session=session, dataset_id=dataset_id, samples=samples_to_create
             )
             created_sample_ids.extend(created_path_to_id.values())
             logging_context.update_example_paths(paths_not_inserted)
@@ -200,7 +198,7 @@ def load_into_dataset_from_labelformat(
 
     if samples_to_create:
         created_path_to_id, paths_not_inserted = _create_batch_samples(
-            session=session, samples=samples_to_create
+            session=session, dataset_id=dataset_id, samples=samples_to_create
         )
         created_sample_ids.extend(created_path_to_id.values())
         logging_context.update_example_paths(paths_not_inserted)
@@ -284,14 +282,13 @@ def load_into_dataset_from_coco_captions(
             file_path_abs=str(images_path / file_name_raw),
             width=width,
             height=height,
-            dataset_id=dataset_id,
         )
         samples_to_create.append(sample)
         path_to_captions[sample.file_path_abs] = captions_by_image_id.get(image_id_raw, [])
 
         if len(samples_to_create) >= SAMPLE_BATCH_SIZE:
             created_path_to_id, paths_not_inserted = _create_batch_samples(
-                session=session, samples=samples_to_create
+                session=session, dataset_id=dataset_id, samples=samples_to_create
             )
             created_sample_ids.extend(created_path_to_id.values())
             logging_context.update_example_paths(paths_not_inserted)
@@ -307,7 +304,7 @@ def load_into_dataset_from_coco_captions(
 
     if samples_to_create:
         created_path_to_id, paths_not_inserted = _create_batch_samples(
-            session=session, samples=samples_to_create
+            session=session, dataset_id=dataset_id, samples=samples_to_create
         )
         created_sample_ids.extend(created_path_to_id.values())
         logging_context.update_example_paths(paths_not_inserted)
@@ -345,12 +342,13 @@ def _log_loading_results(
 
 
 def _create_batch_samples(
-    session: Session, samples: list[ImageCreate]
+    session: Session, dataset_id: UUID, samples: list[ImageCreate]
 ) -> tuple[dict[str, UUID], list[str]]:
     """Create the batch samples.
 
     Args:
         session: The database session.
+        dataset_id: The ID of the dataset to create samples in.
         samples: The samples to create.
 
     Returns:
@@ -366,7 +364,9 @@ def _create_batch_samples(
 
     # Create only samples with new file paths
     samples_to_create = [file_path_to_sample[file_path_new] for file_path_new in file_paths_new]
-    created_sample_ids = image_resolver.create_many(session=session, samples=samples_to_create)
+    created_sample_ids = image_resolver.create_many(
+        session=session, dataset_id=dataset_id, samples=samples_to_create
+    )
 
     # Create a mapping from file path to sample ID for new samples
     file_path_new_to_sample_id = dict(zip(file_paths_new, created_sample_ids))

--- a/lightly_studio/src/lightly_studio/models/image.py
+++ b/lightly_studio/src/lightly_studio/models/image.py
@@ -38,9 +38,6 @@ class ImageBase(SQLModel):
     """The height of the image in pixels."""
     height: int
 
-    """The dataset ID to which the sample belongs."""
-    dataset_id: UUID = Field(default=None, foreign_key="dataset.dataset_id")
-
     """The dataset image path."""
     file_path_abs: str = Field(default=None)
 
@@ -63,6 +60,9 @@ class ImageTable(ImageBase, table=True):
     )
 
     sample: Mapped["SampleTable"] = Relationship()
+
+    # TODO(Michal, 11/2025): Deprecated in favor of SampleTable.dataset_id
+    dataset_id: UUID = Field(default=None, foreign_key="dataset.dataset_id")
 
 
 TagKind = Literal[

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/create_many.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/create_many.py
@@ -16,24 +16,22 @@ class ImageCreateHelper(ImageCreate):
     """Helper class to create ImageTable with sample_id."""
 
     sample_id: UUID
+    dataset_id: UUID
 
 
-def create_many(session: Session, samples: list[ImageCreate]) -> list[UUID]:
+def create_many(session: Session, dataset_id: UUID, samples: list[ImageCreate]) -> list[UUID]:
     """Create multiple samples in a single database commit.
 
     Returns the list of created sample IDs that matches the order of input samples.
     """
-    dataset_ids = {sample.dataset_id for sample in samples}
-    for dataset_id in dataset_ids:
-        dataset_resolver.check_dataset_type(
-            session=session,
-            dataset_id=dataset_id,
-            expected_type=SampleType.IMAGE,
-        )
-
+    dataset_resolver.check_dataset_type(
+        session=session,
+        dataset_id=dataset_id,
+        expected_type=SampleType.IMAGE,
+    )
     sample_ids = sample_resolver.create_many(
         session=session,
-        samples=[SampleCreate(dataset_id=sample.dataset_id) for sample in samples],
+        samples=[SampleCreate(dataset_id=dataset_id) for _ in samples],
     )
     # Bulk create ImageTable entries using the generated sample_ids.
     db_images = [
@@ -42,7 +40,7 @@ def create_many(session: Session, samples: list[ImageCreate]) -> list[UUID]:
                 file_name=sample.file_name,
                 width=sample.width,
                 height=sample.height,
-                dataset_id=sample.dataset_id,
+                dataset_id=dataset_id,
                 file_path_abs=sample.file_path_abs,
                 sample_id=sample_id,
             )

--- a/lightly_studio/tests/core/test_add_samples.py
+++ b/lightly_studio/tests/core/test_add_samples.py
@@ -141,14 +141,12 @@ def test_create_batch_samples(db_session: Session) -> None:
     # First batch: two new samples
     batch1 = [
         ImageCreate(
-            dataset_id=dataset_id,
             file_path_abs="/path/to/image_0.png",
             file_name="image_0.png",
             width=100,
             height=200,
         ),
         ImageCreate(
-            dataset_id=dataset_id,
             file_path_abs="/path/to/image_1.png",
             file_name="image_1.png",
             width=100,
@@ -156,7 +154,7 @@ def test_create_batch_samples(db_session: Session) -> None:
         ),
     ]
     new_path_to_id, existing_paths = add_samples._create_batch_samples(
-        session=db_session, samples=batch1
+        session=db_session, dataset_id=dataset_id, samples=batch1
     )
     assert len(new_path_to_id) == 2
     assert len(existing_paths) == 0
@@ -178,7 +176,6 @@ def test_create_batch_samples(db_session: Session) -> None:
     batch2 = [
         # existing - only file_path_abs matters
         ImageCreate(
-            dataset_id=dataset_id,
             file_path_abs="/path/to/image_0.png",
             file_name="xxx.png",
             width=999,
@@ -186,7 +183,6 @@ def test_create_batch_samples(db_session: Session) -> None:
         ),
         # new
         ImageCreate(
-            dataset_id=dataset_id,
             file_path_abs="/path/to/image_2.png",
             file_name="image_2.png",
             width=100,
@@ -195,7 +191,7 @@ def test_create_batch_samples(db_session: Session) -> None:
     ]
 
     new_path_to_id, existing_paths = add_samples._create_batch_samples(
-        session=db_session, samples=batch2
+        session=db_session, dataset_id=dataset_id, samples=batch2
     )
     assert len(new_path_to_id) == 1
     assert len(existing_paths) == 1

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -92,9 +92,9 @@ def create_image(
     """Helper function to create a sample."""
     sample_ids = image_resolver.create_many(
         session=session,
+        dataset_id=dataset_id,
         samples=[
             ImageCreate(
-                dataset_id=dataset_id,
                 file_path_abs=file_path_abs,
                 file_name=Path(file_path_abs).name,
                 width=width,

--- a/lightly_studio/tests/resolvers/image_resolver/test_create_many.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_create_many.py
@@ -15,14 +15,12 @@ def test_create_many_samples(test_db: Session) -> None:
     # Use out of order file names to verify that order is preserved
     samples_to_create = [
         ImageCreate(
-            dataset_id=dataset_id,
             file_path_abs="/path/to/image_1.png",
             file_name="image_1.png",
             width=100,
             height=200,
         ),
         ImageCreate(
-            dataset_id=dataset_id,
             file_path_abs="/path/to/image_0.png",
             file_name="image_0.png",
             width=300,
@@ -30,7 +28,9 @@ def test_create_many_samples(test_db: Session) -> None:
         ),
     ]
 
-    created_sample_ids = image_resolver.create_many(session=test_db, samples=samples_to_create)
+    created_sample_ids = image_resolver.create_many(
+        session=test_db, dataset_id=dataset_id, samples=samples_to_create
+    )
     retrieved_samples = image_resolver.get_all_by_dataset_id(
         session=test_db, dataset_id=dataset_id, sample_ids=created_sample_ids
     ).samples
@@ -59,9 +59,9 @@ def test_create_many__sample_type_mismatch(test_db: Session) -> None:
     with pytest.raises(ValueError, match="is having sample type 'video', expected 'image'"):
         image_resolver.create_many(
             session=test_db,
+            dataset_id=dataset.dataset_id,
             samples=[
                 ImageCreate(
-                    dataset_id=dataset.dataset_id,
                     file_path_abs="/path/to/sample1.png",
                     file_name="sample1.png",
                     width=100,


### PR DESCRIPTION
## What has changed and why?

Remove dataset_id from ImageCreate. A step towards removing dataset_id from ImageTable.

## How has it been tested?

Tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
