### PR TITLE
Fix metadata filters for infinite grid query

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
@@ -90,10 +90,6 @@ const createImagesInfiniteOptions = (params: ImagesInfiniteParams) => {
 };
 
 const buildRequestBody = (params: ImagesInfiniteParams, pageParam: number): ReadImagesRequest => {
-    const metadataFilters = params.metadata_values
-        ? createMetadataFilters(params.metadata_values)
-        : [];
-
     const baseBody: ReadImagesRequest = {
         pagination: {
             offset: pageParam,
@@ -102,7 +98,9 @@ const buildRequestBody = (params: ImagesInfiniteParams, pageParam: number): Read
         text_embedding: params.text_embedding,
         filters: {
             sample_filter: {
-                metadata_filters: metadataFilters.length > 0 ? metadataFilters : undefined
+                metadata_filters: params.metadata_values
+                    ? createMetadataFilters(params.metadata_values)
+                    : undefined
             }
         }
     };


### PR DESCRIPTION
## What has changed and why?

Make the infinite grid query use the metadata filters again. 

Previously the `sample_filter` added later was overwriting the `sample_filter` with the metadata from above. 

## How has it been tested?

Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

The bug was probably introduced by https://github.com/lightly-ai/lightly-studio/pull/151/files#r2546673483, which was merged only 2 days ago.
