### PR TITLE
Display annotations within the video frame grid view

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/frame.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/frame.py
@@ -144,15 +144,6 @@ def _build_sample_view(sample: SampleTable) -> SampleView:
     )
 
 
-def _build_frame_view(f: VideoFrameTable) -> FrameView:
-    return FrameView(
-        frame_number=f.frame_number,
-        frame_timestamp_s=f.frame_timestamp_s,
-        sample_id=f.sample_id,
-        sample=_build_sample_view(f.sample),
-    )
-
-
 def _build_video_view(video: VideoTable) -> VideoView:
     return VideoView(
         width=video.width,
@@ -163,7 +154,6 @@ def _build_video_view(video: VideoTable) -> VideoView:
         file_path_abs=video.file_path_abs,
         sample_id=video.sample_id,
         sample=_build_sample_view(video.sample),
-        frames=[_build_frame_view(f) for f in video.frames],
     )
 
 


### PR DESCRIPTION
## What has changed and why?

This PR introduces support for displaying annotations in the video frame grid view.

## How has it been tested?

- Upload a video dataset with annotations or add frame annotations.
- Go to the video frame grid view.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
