### PR TITLE
feat: release session for streaming images

### DIFF
--- a/lightly_studio/tests/api/routes/api/test_image.py
+++ b/lightly_studio/tests/api/routes/api/test_image.py
@@ -244,6 +244,5 @@ def test_serve_image_by_sample_id_releases_session_before_streaming(
 
     # Verify response
     assert response.status_code == HTTP_STATUS_OK
-    # assert response.content == image_content
     assert session_closed[0], "Session should be closed after request completes"
     assert session_get_called[0], "Session.get() should have been called during the request"

--- a/lightly_studio/tests/api/routes/api/test_image.py
+++ b/lightly_studio/tests/api/routes/api/test_image.py
@@ -198,7 +198,7 @@ def test_serve_image_by_sample_id_releases_session_before_streaming(
     # Create a mock session
     mock_session = MagicMock()
 
-    def mock_get(table: type, sample_id: str) -> ImageTable:
+    def mock_get(_: type, sample_id: str) -> ImageTable:
         session_get_called[0] = True
         # Session should still be open when get is called
         assert not session_closed[0], "Session was closed before get() was called"

--- a/lightly_studio/tests/api/routes/api/test_image.py
+++ b/lightly_studio/tests/api/routes/api/test_image.py
@@ -224,7 +224,7 @@ def test_serve_image_by_sample_id_releases_session_before_streaming(
     # Mock db_manager.session to return our context manager
     mocker.patch(
         "lightly_studio.api.routes.images.db_manager.session",
-        side_effect=lambda: mock_session_context(),
+        side_effect=mock_session_context,
     )
 
     # Mock fsspec to verify session is closed before file operations

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -1332,7 +1332,6 @@ export interface paths {
          *
          *     Args:
          *         sample_id: The ID of the sample.
-         *         session: Database session.
          *
          *     Returns:
          *         StreamingResponse with the image data.


### PR DESCRIPTION
## What has changed and why?

Session was kept during the streaming of images and that leads to hit pool limitation for sqlalchemy
```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00 (Background on this error at: https://sqlalche.me/e/20/3o7r)
```

## How has it been tested?

Nothing to test, issue reproduce by too intensive scrolling with requesting a lot of images

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
