### PR TITLE
Rename `Dataset.add_samples_from_path` to `Dataset.add_images_from_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- Renamed `Dataset.add_samples_from_path` to `Dataset.add_images_from_path`.
 - Added class balancing with a uniform or the input distribution as target. These options can be set for the `AnnotationClassBalancingStrategy`.
 - Added download_example_dataset utility function to simplify the quickstart experience by removing the need for git clone.
 - Added `tag_depth` parameter to `Dataset.add_samples_from_path` to automatically create tags from subdirectory names.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dataset_path = download_example_dataset(download_dir="dataset_examples")
 
 # Indexes the dataset, creates embeddings and stores everything in the database. Here we only load images.
 dataset = ls.Dataset.create()
-dataset.add_samples_from_path(path=f"{dataset_path}/coco_subset_128_images/images")
+dataset.add_images_from_path(path=f"{dataset_path}/coco_subset_128_images/images")
 
 # Start the UI server on localhost:8001.
 # Use env variables LIGHTLY_STUDIO_HOST and LIGHTLY_STUDIO_PORT to customize it.
@@ -82,7 +82,7 @@ Run the script with `python example_image.py`. Now you can inspect samples in th
 
 **Tagging by Folder Structure**
 
-When using `dataset.add_samples_from_path`, you can automatically assign tags based on your folder structure. The folder hierarchy is **relative to the `path` argument** you provide.
+When using `dataset.add_images_from_path`, you can automatically assign tags based on your folder structure. The folder hierarchy is **relative to the `path` argument** you provide.
 
 For example, given a folder structure where images are classified by class:
 * `my_data/`
@@ -93,7 +93,7 @@ For example, given a folder structure where images are classified by class:
 You can point `path` to the parent directory (`my_data/`) and **use `tag_depth=1` to enable** this auto-tagging. The code will then use the first-level subdirectories (`cat`, `dog`, `bird`) as tags.
 
 ```python
-dataset.add_samples_from_path(
+dataset.add_images_from_path(
     path="my_data/", 
     tag_depth=1
 )
@@ -198,11 +198,11 @@ import lightly_studio as ls
 dataset = ls.Dataset.create()
 
 # You can load data also from cloud storage
-dataset.add_samples_from_path(path="s3://my-bucket/path/to/images/")
+dataset.add_images_from_path(path="s3://my-bucket/path/to/images/")
 
 # And at any given time you can append more data (even across sources)
-dataset.add_samples_from_path(path="gcs://my-bucket-2/path/to/more-images/")
-dataset.add_samples_from_path(path="local-folder/some-data-not-in-the-cloud-yet")
+dataset.add_images_from_path(path="gcs://my-bucket-2/path/to/more-images/")
+dataset.add_images_from_path(path="local-folder/some-data-not-in-the-cloud-yet")
 
 # Load existing .db file
 dataset = ls.Dataset.load()
@@ -218,9 +218,9 @@ import lightly_studio as ls
 
 dataset = ls.Dataset.load_or_create(name="my-dataset")
 
-# Only new samples are added by `add_samples_from_path`
+# Only new samples are added by `add_images_from_path`
 for image_dir in IMAGE_DIRS:
-    dataset.add_samples_from_path(path=image_dir)
+    dataset.add_images_from_path(path=image_dir)
 
 ls.start_gui()
 ```

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -66,7 +66,7 @@ The examples below will automatically download the required example data the fir
 
     # Indexes the dataset, creates embeddings and stores everything in the database. Here we only load images.
     dataset = ls.Dataset.create()
-    dataset.add_samples_from_path(path=f"{dataset_path}/coco_subset_128_images/images")
+    dataset.add_images_from_path(path=f"{dataset_path}/coco_subset_128_images/images")
 
     # Start the UI server on port 8001. Use env variables to change port and host:
     # LIGHTLY_STUDIO_PORT=8002
@@ -80,7 +80,7 @@ The examples below will automatically download the required example data the fir
     
     **Tagging by Folder Structure**
 
-    When using `dataset.add_samples_from_path`, you can automatically assign tags based on your folder structure. The folder hierarchy is **relative to the `path` argument** you provide.
+    When using `dataset.add_images_from_path`, you can automatically assign tags based on your folder structure. The folder hierarchy is **relative to the `path` argument** you provide.
 
     For example, given a folder structure where images are classified by class:
     ```text
@@ -98,7 +98,7 @@ The examples below will automatically download the required example data the fir
     You can point `path` to the parent directory (`my_data/`) and **use `tag_depth=1` to enable** this auto-tagging. The code will then use the first-level subdirectories (`cat`, `dog`, `bird`) as tags.
 
     ```python
-    dataset.add_samples_from_path(
+    dataset.add_images_from_path(
         path="my_data/", 
         tag_depth=1
     )
@@ -273,11 +273,11 @@ import lightly_studio as ls
 dataset = ls.Dataset.create()
 
 # You can load data directly from a folder
-dataset.add_samples_from_path(path="local-folder/some-local-data")
+dataset.add_images_from_path(path="local-folder/some-local-data")
 
 # Or you can load more data at a later point (even across sources such as cloud)
-dataset.add_samples_from_path(path="local-folder/some-data-not-loaded-yet")
-dataset.add_samples_from_path(path="gcs://my-bucket-2/path/to/more-images/")
+dataset.add_images_from_path(path="local-folder/some-data-not-loaded-yet")
+dataset.add_images_from_path(path="gcs://my-bucket-2/path/to/more-images/")
 
 # You can also load a dataset from an .db file (default uses the `lightly_studio.db` file in the working directory)
 dataset = ls.Dataset.load()
@@ -310,9 +310,9 @@ IMAGE_DIRS = ["data/primary_images", "data/new_images_later"]
 # Everything persists inside lightly_studio.db automatically.
 dataset = ls.Dataset.load_or_create(name=DATASET_NAME)
 
-# Only new samples are added by `add_samples_from_path`
+# Only new samples are added by `add_images_from_path`
 for image_dir in IMAGE_DIRS:
-    dataset.add_samples_from_path(path=image_dir)
+    dataset.add_images_from_path(path=image_dir)
 
 ls.start_gui()
 ```
@@ -337,7 +337,7 @@ This installs [s3fs](https://github.com/fsspec/s3fs) (for S3), [gcsfs](https://g
 import lightly_studio as ls
 
 dataset = ls.Dataset.create(name="s3_dataset")
-dataset.add_samples_from_path(path="s3://my-bucket/images/")
+dataset.add_images_from_path(path="s3://my-bucket/images/")
 
 ls.start_gui()
 ```
@@ -347,7 +347,7 @@ The images remain in S3 and are streamed to the UI when displayed. Make sure you
 **Current Limitations:**
 
 !!! warning "Cloud Storage Limitation"
-    Cloud storage is only supported for image-only datasets using `add_samples_from_path()` or when manually indexing the data with annotations. When loading annotated datasets with `add_samples_from_coco()` or `add_samples_from_yolo()`, both images and annotation files must be stored locally for now.
+    Cloud storage is only supported for image-only datasets using `add_images_from_path()` or when manually indexing the data with annotations. When loading annotated datasets with `add_samples_from_coco()` or `add_samples_from_yolo()`, both images and annotation files must be stored locally for now.
 
 
 ### Sample
@@ -358,7 +358,7 @@ Each sample is a single data instance. The dataset stores references to all samp
 import lightly_studio as ls
 
 dataset = ls.Dataset.load_or_create(name="my_dataset")
-dataset.add_samples_from_path(path="path/to/images")
+dataset.add_images_from_path(path="path/to/images")
 
 # Iterating over the data in the dataset
 for sample in dataset:
@@ -647,7 +647,7 @@ You can choose from various and even combined selection strategies:
 
     # Load your dataset
     dataset = ls.Dataset.load_or_create()
-    dataset.add_samples_from_path(path="/path/to/image_dataset")
+    dataset.add_images_from_path(path="/path/to/image_dataset")
 
     # Select a diverse subset of 10 samples.
     dataset.query().selection().diverse(
@@ -667,7 +667,7 @@ You can choose from various and even combined selection strategies:
 
     # Load your dataset
     dataset = ls.Dataset.load_or_create()
-    dataset.add_samples_from_path(path="/path/to/image_dataset")
+    dataset.add_images_from_path(path="/path/to/image_dataset")
     # Compute and store 'typicality' metadata.
     dataset.compute_typicality_metadata(metadata_name="typicality")
 
@@ -689,7 +689,7 @@ You can choose from various and even combined selection strategies:
 
     # Load your dataset
     dataset = ls.Dataset.load_or_create()
-    dataset.add_samples_from_path(path="/path/to/image_dataset")
+    dataset.add_images_from_path(path="/path/to/image_dataset")
 
     # First, define a query set by tagging some samples.
     # For example, let's tag the first 5 samples.
@@ -751,7 +751,7 @@ You can choose from various and even combined selection strategies:
 
     # Load your dataset
     dataset = ls.Dataset.load_or_create()
-    dataset.add_samples_from_path(path="/path/to/image_dataset")
+    dataset.add_images_from_path(path="/path/to/image_dataset")
     # Compute typicality and store it as `typicality` metadata
     dataset.compute_typicality_metadata(metadata_name="typicality")
 

--- a/lightly_studio/src/lightly_studio/core/add_samples.py
+++ b/lightly_studio/src/lightly_studio/core/add_samples.py
@@ -310,7 +310,7 @@ def tag_samples_by_directory(
     if tag_depth == 0:
         return
     if tag_depth > 1:
-        raise NotImplementedError("tag_depth > 1 is not yet implemented for add_samples_from_path.")
+        raise NotImplementedError("tag_depth > 1 is not yet implemented for add_images_from_path.")
 
     input_path_abs = Path(input_path).absolute()
 

--- a/lightly_studio/src/lightly_studio/core/dataset.py
+++ b/lightly_studio/src/lightly_studio/core/dataset.py
@@ -66,7 +66,7 @@ class Dataset:
 
     Samples can be added to the dataset using various methods:
     ```python
-    dataset.add_samples_from_path(...)
+    dataset.add_images_from_path(...)
     dataset.add_samples_from_yolo(...)
     dataset.add_samples_from_coco(...)
     dataset.add_samples_from_coco_caption(...)
@@ -295,24 +295,24 @@ class Dataset:
             num_decode_threads=num_decode_threads,
         )
 
-    def add_samples_from_path(
+    def add_images_from_path(
         self,
         path: PathLike,
         allowed_extensions: Iterable[str] | None = None,
         embed: bool = True,
         tag_depth: int = 0,
     ) -> None:
-        """Adding samples from the specified path to the dataset.
+        """Adding images from the specified path to the dataset.
 
         Args:
             path: Path to the folder containing the images to add.
             allowed_extensions: An iterable container of allowed image file
                 extensions.
-            embed: If True, generate embeddings for the newly added samples.
+            embed: If True, generate embeddings for the newly added images.
             tag_depth: Defines the tagging behavior based on directory depth.
                 - `tag_depth=0` (default): No automatic tagging is performed.
                 - `tag_depth=1`: Automatically creates a tag for each
-                  sample based on its parent directory's name.
+                  image based on its parent directory's name.
 
         Raises:
             NotImplementedError: If tag_depth > 1.

--- a/lightly_studio/src/lightly_studio/core/start_gui.py
+++ b/lightly_studio/src/lightly_studio/core/start_gui.py
@@ -22,7 +22,7 @@ def _validate_has_samples() -> None:
     if not datasets:
         raise ValueError(
             "No datasets found. Please load a dataset using Dataset class methods "
-            "(e.g., add_samples_from_path(), add_samples_from_yolo(), etc.) "
+            "(e.g., add_images_from_path(), add_samples_from_yolo(), etc.) "
             "before starting the GUI."
         )
 

--- a/lightly_studio/src/lightly_studio/examples/example.py
+++ b/lightly_studio/src/lightly_studio/examples/example.py
@@ -17,7 +17,7 @@ dataset_path = env.path("EXAMPLES_DATASET_PATH", "/path/to/your/dataset")
 
 # Create a Dataset from a path
 dataset = ls.Dataset.create()
-dataset.add_samples_from_path(path=dataset_path)
+dataset.add_images_from_path(path=dataset_path)
 
 for sample in dataset:
     print(sample)

--- a/lightly_studio/src/lightly_studio/examples/example_metadata.py
+++ b/lightly_studio/src/lightly_studio/examples/example_metadata.py
@@ -40,7 +40,7 @@ def load_existing_dataset() -> tuple[ls.Dataset, list[Sample]]:
     print(" Loading existing dataset...")
 
     dataset = ls.Dataset.create()
-    dataset.add_samples_from_path(path=dataset_path)
+    dataset.add_images_from_path(path=dataset_path)
 
     # Get all samples from the dataset
     samples = dataset.query().to_list()

--- a/lightly_studio/src/lightly_studio/examples/example_selection.py
+++ b/lightly_studio/src/lightly_studio/examples/example_selection.py
@@ -17,7 +17,7 @@ dataset_path = env.path("EXAMPLES_DATASET_PATH", "/path/to/your/dataset")
 
 # Create a Dataset from a path
 dataset = ls.Dataset.create()
-dataset.add_samples_from_path(path=str(dataset_path))
+dataset.add_images_from_path(path=str(dataset_path))
 
 # Run selection via the dataset query
 dataset.query().selection().diverse(

--- a/lightly_studio/tests/core/test_add_samples.py
+++ b/lightly_studio/tests/core/test_add_samples.py
@@ -230,7 +230,7 @@ def test_tag_samples_by_directory_tag_depth_invalid(
     # We don't need a full dataset, just the function call
     with pytest.raises(
         NotImplementedError,
-        match="tag_depth > 1 is not yet implemented for add_samples_from_path",
+        match="tag_depth > 1 is not yet implemented for add_images_from_path",
     ):
         add_samples.tag_samples_by_directory(
             session=db_session,

--- a/lightly_studio/tests/core/test_dataset__path.py
+++ b/lightly_studio/tests/core/test_dataset__path.py
@@ -13,7 +13,7 @@ from tests import helpers_resolvers
 
 
 class TestDataset:
-    def test_dataset_add_samples_from_path__valid(
+    def test_dataset_add_images_from_path__valid(
         self,
         patch_dataset: None,  # noqa: ARG002
         tmp_path: Path,
@@ -30,7 +30,7 @@ class TestDataset:
         )
 
         dataset = Dataset.create(name="test_dataset")
-        dataset.add_samples_from_path(path=images_path)
+        dataset.add_images_from_path(path=images_path)
 
         samples = dataset.query().to_list()
         assert len(samples) == 4
@@ -43,7 +43,7 @@ class TestDataset:
         # Check that embeddings were created
         assert all(len(sample.inner.sample.embeddings) == 1 for sample in samples)
 
-    def test_dataset_add_samples_from_path__file_path(
+    def test_dataset_add_images_from_path__file_path(
         self,
         patch_dataset: None,  # noqa: ARG002
         tmp_path: Path,
@@ -53,9 +53,9 @@ class TestDataset:
 
         dataset = Dataset.create(name="test_dataset")
         with pytest.raises(ValueError, match="File is not an image:.*file.txt"):
-            dataset.add_samples_from_path(path=images_path)
+            dataset.add_images_from_path(path=images_path)
 
-    def test_dataset_add_samples_from_path__non_existent_dir(
+    def test_dataset_add_images_from_path__non_existent_dir(
         self,
         patch_dataset: None,  # noqa: ARG002
         tmp_path: Path,
@@ -64,9 +64,9 @@ class TestDataset:
 
         dataset = Dataset.create(name="test_dataset")
         with pytest.raises(ValueError, match="Path does not exist:.*non_existent"):
-            dataset.add_samples_from_path(path=images_path)
+            dataset.add_images_from_path(path=images_path)
 
-    def test_dataset_add_samples_from_path__empty_dir(
+    def test_dataset_add_images_from_path__empty_dir(
         self,
         patch_dataset: None,  # noqa: ARG002
         tmp_path: Path,
@@ -75,10 +75,10 @@ class TestDataset:
         images_path.mkdir()
 
         dataset = Dataset.create(name="test_dataset")
-        dataset.add_samples_from_path(path=images_path)
+        dataset.add_images_from_path(path=images_path)
         assert len(list(dataset)) == 0
 
-    def test_dataset_add_samples_from_path__corrupt_file(
+    def test_dataset_add_images_from_path__corrupt_file(
         self,
         patch_dataset: None,  # noqa: ARG002
         tmp_path: Path,
@@ -89,10 +89,10 @@ class TestDataset:
         image_path.write_text("corrupt data")
 
         dataset = Dataset.create(name="test_dataset")
-        dataset.add_samples_from_path(path=images_path)
+        dataset.add_images_from_path(path=images_path)
         assert len(list(dataset)) == 0
 
-    def test_dataset_add_samples_from_path__recursion(
+    def test_dataset_add_images_from_path__recursion(
         self,
         patch_dataset: None,  # noqa: ARG002
         tmp_path: Path,
@@ -109,10 +109,10 @@ class TestDataset:
         )
 
         dataset = Dataset.create(name="test_dataset")
-        dataset.add_samples_from_path(path=images_path / "*.*")
+        dataset.add_images_from_path(path=images_path / "*.*")
         assert len(list(dataset)) == 3
 
-    def test_dataset_add_samples_from_path__allowed_extensions(
+    def test_dataset_add_images_from_path__allowed_extensions(
         self,
         patch_dataset: None,  # noqa: ARG002
         tmp_path: Path,
@@ -129,16 +129,16 @@ class TestDataset:
         )
 
         dataset = Dataset.create(name="test_dataset")
-        dataset.add_samples_from_path(path=images_path / "**" / "*.jpg")
+        dataset.add_images_from_path(path=images_path / "**" / "*.jpg")
         assert len(list(dataset)) == 2
 
         dataset_allowed_extensions = Dataset.create(name="test_dataset_allowed_extensions")
-        dataset_allowed_extensions.add_samples_from_path(
+        dataset_allowed_extensions.add_images_from_path(
             path=images_path / "**", allowed_extensions=[".png", ".bmp"]
         )
         assert len(list(dataset_allowed_extensions)) == 2
 
-    def test_dataset_add_samples_from_path__duplication(
+    def test_dataset_add_images_from_path__duplication(
         self,
         patch_dataset: None,  # noqa: ARG002
         capsys: pytest.CaptureFixture[str],
@@ -156,7 +156,7 @@ class TestDataset:
         )
 
         dataset = Dataset.create(name="test_dataset")
-        dataset.add_samples_from_path(path=images_path)
+        dataset.add_images_from_path(path=images_path)
 
         _create_sample_images(
             [
@@ -166,14 +166,14 @@ class TestDataset:
         )
 
         # Only two are new, the other four are already in the dataset
-        dataset.add_samples_from_path(path=images_path)
+        dataset.add_images_from_path(path=images_path)
         assert len(list(dataset)) == 6
 
         captured = capsys.readouterr()
         assert "Added 2 out of 6 new samples to the dataset." in captured.out
         assert f"Examples of paths that were not added:  {images_path}" in captured.out
 
-    def test_dataset_add_samples_from_path__dont_embed(
+    def test_dataset_add_images_from_path__dont_embed(
         self,
         patch_dataset: None,  # noqa: ARG002
         tmp_path: Path,
@@ -181,21 +181,21 @@ class TestDataset:
         _create_sample_images([tmp_path / "image1.jpg"])
 
         dataset = Dataset.create(name="test_dataset")
-        dataset.add_samples_from_path(path=tmp_path, embed=False)
+        dataset.add_images_from_path(path=tmp_path, embed=False)
 
         # Check that embeddings were not created
         samples = dataset.query().to_list()
         assert len(samples) == 1
         assert len(samples[0].inner.sample.embeddings) == 0
 
-    def test_add_samples_from_path_calls_tag_samples_by_directory(
+    def test_add_images_from_path_calls_tag_samples_by_directory(
         self,
         patch_dataset: None,  # noqa: ARG002
         db_session: Session,
         tmp_path: Path,
         mocker: Mocker,
     ) -> None:
-        """Tests that Dataset.add_samples_from_path correctly calls the helper.
+        """Tests that Dataset.add_images_from_path correctly calls the helper.
 
         The add_samples.tag_samples_by_directory helper.
         """
@@ -206,7 +206,7 @@ class TestDataset:
         dataset = Dataset(dataset=dataset_table)
         dataset.session = db_session
 
-        dataset.add_samples_from_path(path=str(tmp_path), tag_depth=0, embed=False)
+        dataset.add_images_from_path(path=str(tmp_path), tag_depth=0, embed=False)
 
         spy_tagger.assert_called_once_with(
             session=db_session,

--- a/lightly_studio/tests/core/test_start_gui.py
+++ b/lightly_studio/tests/core/test_start_gui.py
@@ -27,7 +27,7 @@ def test_start_gui__with_samples(
 
     # Load the dataset using the new Dataset interface
     dataset = Dataset.create("test_dataset")
-    dataset.add_samples_from_path(path=tmp_path)
+    dataset.add_images_from_path(path=tmp_path)
 
     # Mock the server to avoid actually starting it
     # We must patch it in the start_gui module where Server was imported directly


### PR DESCRIPTION
## What has changed and why?

Rename `Dataset.add_samples_from_path` to `Dataset.add_images_from_path`.
Just renamed, no logical change.

## How has it been tested?

Current tests still work

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)
