### PR TITLE
Navigate to ImageDetail from CaptionGrid

### DIFF
--- a/lightly_studio_view/src/lib/components/Captions/Captions.svelte
+++ b/lightly_studio_view/src/lib/components/Captions/Captions.svelte
@@ -88,6 +88,8 @@
                         <CaptionsItem
                             maxHeight={`${captionSize}px`}
                             item={items[index]}
+                            datasetId={datasetId}
+                            sampleIndex={index}
                             onUpdate={refresh}
                         />
                     </div>

--- a/lightly_studio_view/src/lib/components/Captions/CaptionsItem/CaptionsItem.svelte
+++ b/lightly_studio_view/src/lib/components/Captions/CaptionsItem/CaptionsItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { goto } from '$app/navigation';
     import { toast } from 'svelte-sonner';
     import { page } from '$app/state';
     import { Card, CardContent } from '$lib/components';
@@ -8,14 +9,19 @@
     import { useSettings } from '$lib/hooks/useSettings';
     import { useDeleteCaption } from '$lib/hooks/useDeleteCaption/useDeleteCaption';
     import { useCreateCaption } from '$lib/hooks/useCreateCaption/useCreateCaption';
+    import { routeHelpers } from '$lib/routes';
 
     const {
         item,
         onUpdate,
+        datasetId,
+        sampleIndex,
         maxHeight = '100%'
     }: {
         item: SampleView;
         onUpdate: () => void;
+        datasetId: string;
+        sampleIndex: number;
         maxHeight?: string;
     } = $props();
 
@@ -52,12 +58,30 @@
             console.error('Error creating caption:', error);
         }
     };
+
+    const handleOnDoubleClick = () => {
+        goto(
+            routeHelpers.toSample({
+                sampleId: item.sample_id,
+                datasetId,
+                sampleIndex
+            })
+        );
+    };
 </script>
 
 <div style={`height: ${maxHeight}; max-height: ${maxHeight};`}>
     <Card className="h-full">
         <CardContent className="h-full flex min-h-0 flex-row items-center dark:[color-scheme:dark]">
-            <SampleImage sample={item} {objectFit} />
+            <div
+                class="sample-visual cursor-pointer"
+                ondblclick={handleOnDoubleClick}
+                aria-label="Open sample details"
+                role="button"
+                tabindex="0"
+            >
+                <SampleImage sample={item} {objectFit} />
+            </div>
             <div class="flex h-full w-full flex-1 flex-col overflow-auto px-4 py-2">
                 {#each item.captions as caption}
                     <CaptionField

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -1106,7 +1106,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/datasets/{dataset_id}/metadata/similarity": {
+    "/api/datasets/{dataset_id}/metadata/similarity/{query_tag_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1122,11 +1122,12 @@ export interface paths {
          *     Args:
          *         session: The database session.
          *         dataset: The dataset to compute similarity for.
+         *         query_tag_id: The ID of the tag to use for the query
          *         request: Request parameters including optional embedding model name
          *             and metadata field name.
          *
          *     Returns:
-         *         None (204 No Content on success).
+         *         Metadata name used for the similarity.
          *
          *     Raises:
          *         HTTPException: 404 if invalid embedding model or query tag is given.
@@ -1713,11 +1714,6 @@ export interface components {
              * @description Embedding model name (uses default if not specified)
              */
             embedding_model_name?: string | null;
-            /**
-             * Query Tag Name
-             * @description The name of the tag to use for the query
-             */
-            query_tag_name: string;
             /**
              * Metadata Name
              * @description Metadata field name (defaults to None)
@@ -4667,6 +4663,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
+                query_tag_id: string;
                 dataset_id: string;
             };
             cookie?: never;
@@ -4678,11 +4675,13 @@ export interface operations {
         };
         responses: {
             /** @description Successful Response */
-            204: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": string;
+                };
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
## What has changed and why?

Navigate to ImageDetail from CaptionGrid.

This is **not** possible to implement currently. Navigation to ImageDetail requires to know `sampleIndex` to make the prev/next buttons work properly. That's not possible - we need to change the prev/next logic not to rely on `sampleIndex`.

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)
