### PR TITLE
example to reproduce issue with hitting limit of pool

### DIFF
--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -40,6 +40,11 @@ start-e2e: build
 	@echo "Starting server for e2e tests..."
 	uv run e2e-tests/index_dataset_for_end2end_ui_tests.py
 
+.PHONY: start-coco-10k
+start-coco-10k: build
+	@echo "Starting server for e2e tests with COCO 10k dataset..."
+	uv run e2e-tests/index_coco_10k.py
+
 .PHONY: start-e2e-with-captions
 start-e2e-with-captions: build
 	@echo "Starting server for e2e tests with captions..."

--- a/lightly_studio/e2e-tests/index_coco_10k.py
+++ b/lightly_studio/e2e-tests/index_coco_10k.py
@@ -1,0 +1,25 @@
+"""End-to-end demonstration of the lightly_studio dataset loading and UI.
+
+This module provides a simple example of how to load a COCO instance
+segmentation dataset and launch the UI application for exploration and
+visualization.
+"""
+
+from lightly_studio import AnnotationType, Dataset, db_manager, start_gui
+
+# Clean up an existing database
+db_manager.connect(cleanup_existing=True)
+
+# Create a Dataset instance
+dataset = Dataset.create()
+
+# We point to the annotations json file and the input images folder.
+# Defined dataset is processed here to be available for the UI application.
+dataset.add_samples_from_coco(
+    annotations_json="datasets/coco-10k/annotations/instances_train2017.json",
+    images_path="datasets/coco-10k/images",
+    annotation_type=AnnotationType.INSTANCE_SEGMENTATION,
+)
+
+# We start the UI application on port 8001
+start_gui()


### PR DESCRIPTION
## What has changed and why?

- Fetch coco-10k dataset (you can get it from [PR](https://github.com/lightly-ai/dataset_examples/pull/10))
- Run `make start-coco-10k` and set the limit of images per row at least 7
- Scroll
- It would loading stop on some step  (check my video)

In the logs you can see
```
INFO:     ::1:57872 - "GET /api/datasets/6b2ec36a-2498-48b4-91c2-9fbf4eff6857/metadata/info HTTP/1.1" 200 OK
ERROR:asyncio:socket.accept() out of system resource
socket: <asyncio.TransportSocket fd=19, family=AddressFamily.AF_INET6, type=SocketKind.SOCK_STREAM, proto=6, laddr=('::1', 8001, 0, 0)>
Traceback (most recent call last):
  File "/Users/kondrat/.local/share/uv/python/cpython-3.8.20-macos-aarch64-none/lib/python3.8/asyncio/selector_events.py", line 164, in _accept_connection
  File "/Users/kondrat/.local/share/uv/python/cpython-3.8.20-macos-aarch64-none/lib/python3.8/socket.py", line 292, in accept
OSError: [Errno 24] Too many open files

```
or 
```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached,
```

I think it depends on where it hits the limit

UI wise it looks like:
- hitting the limit of pool connections of sql alchemy - will look like non-listing all of the items in the Grid
- Hitting the TCP connections limit (256 default for macos) looks like freesing interface because fastapi starts to timeout requests

