### PR TITLE
Introduce ImageSample.sample_table

### DIFF
--- a/lightly_studio/src/lightly_studio/export/coco_captions.py
+++ b/lightly_studio/src/lightly_studio/export/coco_captions.py
@@ -53,12 +53,12 @@ def to_coco_captions_dict(samples: Iterable[ImageSample]) -> CocoCaptionsJson:
                 "height": image.height,
             }
         )
-        for caption in image.inner.sample.captions:
+        for caption in image.captions:
             coco_annotations.append(
                 {
                     "id": annotation_id,
                     "image_id": image_id,
-                    "caption": caption.text,
+                    "caption": caption,
                 }
             )
             annotation_id += 1

--- a/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
+++ b/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
@@ -93,7 +93,7 @@ def _sample_to_image_obj_det(
             annotation=annotation,
             label_id_to_category=label_id_to_category,
         )
-        for annotation in sample.inner.sample.annotations
+        for annotation in sample.sample_table.annotations
         if annotation.annotation_type == AnnotationType.OBJECT_DETECTION
     ]
     return ImageObjectDetection(

--- a/lightly_studio/tests/core/test_dataset__coco.py
+++ b/lightly_studio/tests/core/test_dataset__coco.py
@@ -68,12 +68,12 @@ class TestDataset:
         assert len(samples) == 2
         assert {s.file_name for s in samples} == {"image1.jpg", "image2.jpg"}
         assert all(
-            len(s.inner.sample.embeddings) == 1 for s in samples
+            len(s.sample_table.embeddings) == 1 for s in samples
         )  # Embeddings should be generated
 
         # Verify the first sample and annotation
-        bbox = samples[0].inner.sample.annotations[0].object_detection_details
-        annotation = samples[0].inner.sample.annotations[0].annotation_label
+        bbox = samples[0].sample_table.annotations[0].object_detection_details
+        annotation = samples[0].sample_table.annotations[0].annotation_label
         assert isinstance(bbox, ObjectDetectionAnnotationTable)
         assert bbox.height == 200.0
         assert bbox.width == 200.0
@@ -82,8 +82,8 @@ class TestDataset:
         assert annotation.annotation_label_name == "cat"
 
         # Verify the second sample and annotation
-        bbox = samples[1].inner.sample.annotations[0].object_detection_details
-        annotation = samples[1].inner.sample.annotations[0].annotation_label
+        bbox = samples[1].sample_table.annotations[0].object_detection_details
+        annotation = samples[1].sample_table.annotations[0].annotation_label
         assert isinstance(bbox, ObjectDetectionAnnotationTable)
         assert bbox.height == 250.0
         assert bbox.width == 250.0
@@ -405,7 +405,7 @@ class TestDataset:
 
         # Check that an embedding was not created
         samples = list(dataset)
-        assert all(len(sample.inner.sample.embeddings) == 0 for sample in samples)
+        assert all(len(sample.sample_table.embeddings) == 0 for sample in samples)
 
     def test_add_samples_from_coco__tags_created_for_split(
         self,

--- a/lightly_studio/tests/core/test_dataset__coco_caption.py
+++ b/lightly_studio/tests/core/test_dataset__coco_caption.py
@@ -34,13 +34,11 @@ class TestDataset:
         assert len(samples) == 2
         assert {s.file_name for s in samples} == {"image1.jpg", "image2.jpg"}
         assert all(
-            len(s.inner.sample.embeddings) == 1 for s in samples
+            len(s.sample_table.embeddings) == 1 for s in samples
         )  # Embeddings should be generated
 
         # Assert captions
-        captions_map = {
-            s.file_name: sorted(c.text for c in s.inner.sample.captions) for s in samples
-        }
+        captions_map = {s.file_name: sorted(s.captions) for s in samples}
 
         assert captions_map == {
             "image1.jpg": ["Caption 1 of image 1", "Caption 2 of image 1"],
@@ -118,7 +116,7 @@ class TestDataset:
 
         # Check that an embedding was not created
         samples = list(dataset)
-        assert all(len(sample.inner.sample.embeddings) == 0 for sample in samples)
+        assert all(len(sample.sample_table.embeddings) == 0 for sample in samples)
 
 
 def _create_sample_images(image_paths: list[Path]) -> None:

--- a/lightly_studio/tests/core/test_dataset__labelformat.py
+++ b/lightly_studio/tests/core/test_dataset__labelformat.py
@@ -153,12 +153,12 @@ class TestDataset:
         samples = sorted(samples, key=lambda sample: sample.file_path_abs)
 
         # Verify first image and annotation
-        annotation = samples[0].inner.sample.annotations[0].annotation_label
+        annotation = samples[0].sample_table.annotations[0].annotation_label
         assert samples[0].file_name == "001.jpg"
         assert annotation.annotation_label_name == "dog"
 
         # Verify first image and annotation
-        annotation = samples[1].inner.sample.annotations[0].annotation_label
+        annotation = samples[1].sample_table.annotations[0].annotation_label
         assert samples[1].file_name == "020.jpg"
         assert annotation.annotation_label_name == "cat"
 
@@ -180,7 +180,7 @@ class TestDataset:
         # Check that an embedding was not created
         samples = dataset.query().to_list()
         assert len(samples) == 1
-        assert len(samples[0].inner.sample.embeddings) == 0
+        assert len(samples[0].sample_table.embeddings) == 0
 
 
 def _get_input(

--- a/lightly_studio/tests/core/test_dataset__path.py
+++ b/lightly_studio/tests/core/test_dataset__path.py
@@ -41,7 +41,7 @@ class TestDataset:
             "image4.jpg",
         }
         # Check that embeddings were created
-        assert all(len(sample.inner.sample.embeddings) == 1 for sample in samples)
+        assert all(len(sample.sample_table.embeddings) == 1 for sample in samples)
 
     def test_dataset_add_images_from_path__file_path(
         self,
@@ -191,7 +191,7 @@ class TestDataset:
         # Check that embeddings were not created
         samples = dataset.query().to_list()
         assert len(samples) == 1
-        assert len(samples[0].inner.sample.embeddings) == 0
+        assert len(samples[0].sample_table.embeddings) == 0
 
     def test_add_images_from_path_calls_tag_samples_by_directory(
         self,

--- a/lightly_studio/tests/core/test_dataset__yolo.py
+++ b/lightly_studio/tests/core/test_dataset__yolo.py
@@ -62,12 +62,12 @@ class TestDataset:
         assert len(samples) == 2
         assert {s.file_name for s in samples} == {"image1.jpg", "image2.jpg"}
         assert all(
-            len(s.inner.sample.embeddings) == 1 for s in samples
+            len(s.sample_table.embeddings) == 1 for s in samples
         )  # Embeddings should be generated
 
         # Verify first annotation
-        bbox = samples[0].inner.sample.annotations[0].object_detection_details
-        annotation = samples[0].inner.sample.annotations[0].annotation_label
+        bbox = samples[0].sample_table.annotations[0].object_detection_details
+        annotation = samples[0].sample_table.annotations[0].annotation_label
         assert isinstance(bbox, ObjectDetectionAnnotationTable)
         assert bbox.height == 4.0
         assert bbox.width == 4.0
@@ -76,8 +76,8 @@ class TestDataset:
         assert annotation.annotation_label_name in ("class_0", "class_1", "class_2")
 
         # Verify second annotation
-        bbox = samples[1].inner.sample.annotations[0].object_detection_details
-        annotation = samples[1].inner.sample.annotations[0].annotation_label
+        bbox = samples[1].sample_table.annotations[0].object_detection_details
+        annotation = samples[1].sample_table.annotations[0].annotation_label
         assert isinstance(bbox, ObjectDetectionAnnotationTable)
         assert bbox.height == 4.0
         assert bbox.width == 4.0
@@ -234,7 +234,7 @@ class TestDataset:
         assert len(samples) == 2
 
         for sample in samples:
-            assert len(sample.inner.sample.annotations) == 0
+            assert len(sample.sample_table.annotations) == 0
 
     # TODO(Jonas 9/25): We might want a warning here --> since no dir exists
     def test_add_samples_from_yolo__train_path_invalid(
@@ -358,7 +358,7 @@ class TestDataset:
         # No embedding should be created
         samples = list(dataset)
         assert len(samples) == 1
-        assert len(samples[0].inner.sample.embeddings) == 0
+        assert len(samples[0].sample_table.embeddings) == 0
 
 
 def _create_sample_images(image_paths: list[Path]) -> None:

--- a/lightly_studio/tests/core/test_sample.py
+++ b/lightly_studio/tests/core/test_sample.py
@@ -60,13 +60,13 @@ class TestSample:
         sample = ImageSample(inner=image_table)
 
         # Test adding a tag.
-        assert [tag.name for tag in sample.inner.sample.tags] == []
+        assert [tag.name for tag in sample.sample_table.tags] == []
         sample.add_tag("tag1")
-        assert [tag.name for tag in sample.inner.sample.tags] == ["tag1"]
+        assert [tag.name for tag in sample.sample_table.tags] == ["tag1"]
         sample.add_tag("tag2")
-        assert sorted([tag.name for tag in sample.inner.sample.tags]) == ["tag1", "tag2"]
+        assert sorted([tag.name for tag in sample.sample_table.tags]) == ["tag1", "tag2"]
         sample.add_tag("tag1")
-        assert sorted([tag.name for tag in sample.inner.sample.tags]) == ["tag1", "tag2"]
+        assert sorted([tag.name for tag in sample.sample_table.tags]) == ["tag1", "tag2"]
 
     def test_remove_tag(self, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)
@@ -79,24 +79,24 @@ class TestSample:
         # Add some tags first
         sample.add_tag("tag1")
         sample.add_tag("tag2")
-        assert sorted([tag.name for tag in sample.inner.sample.tags]) == ["tag1", "tag2"]
+        assert sorted([tag.name for tag in sample.sample_table.tags]) == ["tag1", "tag2"]
 
         # Test removing an existing, associated tag
         sample.remove_tag("tag1")
-        assert [tag.name for tag in sample.inner.sample.tags] == ["tag2"]
+        assert [tag.name for tag in sample.sample_table.tags] == ["tag2"]
 
         # Test removing a non-existent tag (should not error)
         sample.remove_tag("nonexistent")
-        assert [tag.name for tag in sample.inner.sample.tags] == ["tag2"]
+        assert [tag.name for tag in sample.sample_table.tags] == ["tag2"]
 
         # Test removing a tag that exists in database but isn't associated with sample
         create_tag(session=test_db, dataset_id=dataset.dataset_id, tag_name="unassociated")
         sample.remove_tag("unassociated")
-        assert [tag.name for tag in sample.inner.sample.tags] == ["tag2"]
+        assert [tag.name for tag in sample.sample_table.tags] == ["tag2"]
 
         # Remove the last tag
         sample.remove_tag("tag2")
-        assert [tag.name for tag in sample.inner.sample.tags] == []
+        assert [tag.name for tag in sample.sample_table.tags] == []
 
     def test_tags_property_get(self, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)
@@ -125,17 +125,17 @@ class TestSample:
         # Test setting tags from empty to multiple
         sample.tags = {"tag1", "tag2", "tag3"}
         assert sample.tags == {"tag1", "tag2", "tag3"}
-        assert sorted([tag.name for tag in sample.inner.sample.tags]) == ["tag1", "tag2", "tag3"]
+        assert sorted([tag.name for tag in sample.sample_table.tags]) == ["tag1", "tag2", "tag3"]
 
         # Test replacing existing tags with new ones
         sample.tags = {"tag2", "tag4", "tag5"}
         assert sample.tags == {"tag2", "tag4", "tag5"}
-        assert sorted([tag.name for tag in sample.inner.sample.tags]) == ["tag2", "tag4", "tag5"]
+        assert sorted([tag.name for tag in sample.sample_table.tags]) == ["tag2", "tag4", "tag5"]
 
         # Test clearing all tags
         sample.tags = set()
         assert sample.tags == set()
-        assert [tag.name for tag in sample.inner.sample.tags] == []
+        assert [tag.name for tag in sample.sample_table.tags] == []
 
     def test_metadata(self, test_db: Session) -> None:
         dataset = create_dataset(session=test_db)


### PR DESCRIPTION
## What has changed and why?
This is an important refactoring, so that we do not access `.inner.sample` directly at multiple places in the code.

* It will later allow a generalization, having a common `Sample` abstract class, e.g. shared with `VideoSample`.
* The `.inner.sample` access would not be allowed in other languages, as it goes directly to the private data.


## How has it been tested?
Existing tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
