### PR TITLE
Use non-legacy label functions for export

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -40,6 +40,7 @@ def export_dataset_annotations(
     try:
         export_dataset.to_coco_object_detections(
             session=session,
+            root_dataset_id=dataset.dataset_id,
             samples=dataset_query,
             output_json=output_path,
         )

--- a/lightly_studio/src/lightly_studio/core/dataset.py
+++ b/lightly_studio/src/lightly_studio/core/dataset.py
@@ -653,8 +653,8 @@ class Dataset(Generic[T]):
                 The dataset query to export. If None, the default query `self.query()` is used.
         """
         if query is None:
-            return DatasetExport(session=self.session, samples=self.query())
-        return DatasetExport(session=self.session, samples=query)
+            query = self.query()
+        return DatasetExport(session=self.session, root_dataset_id=self.dataset_id, samples=query)
 
 
 def _generate_embeddings_video(

--- a/lightly_studio/src/lightly_studio/export/export_dataset.py
+++ b/lightly_studio/src/lightly_studio/export/export_dataset.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Iterable
+from uuid import UUID
 
 from labelformat.formats import COCOObjectDetectionOutput
 from sqlmodel import Session
@@ -24,14 +25,16 @@ class DatasetExport:
     It allows exporting data in various formats.
     """
 
-    def __init__(self, session: Session, samples: Iterable[ImageSample]):
+    def __init__(self, session: Session, root_dataset_id: UUID, samples: Iterable[ImageSample]):
         """Initializes the DatasetExport object.
 
         Args:
             session: The database session.
+            root_dataset_id: The root dataset ID for label retrieval.
             samples: Samples to export.
         """
         self.session = session
+        self._root_dataset_id = root_dataset_id
         self.samples = samples
 
     def to_coco_object_detections(self, output_json: PathLike | None = None) -> None:
@@ -48,6 +51,7 @@ class DatasetExport:
             output_json = DEFAULT_EXPORT_FILENAME
         to_coco_object_detections(
             session=self.session,
+            root_dataset_id=self._root_dataset_id,
             samples=self.samples,
             output_json=Path(output_json),
         )
@@ -66,6 +70,7 @@ class DatasetExport:
 
 def to_coco_object_detections(
     session: Session,
+    root_dataset_id: UUID,
     samples: Iterable[ImageSample],
     output_json: Path,
 ) -> None:
@@ -76,11 +81,13 @@ def to_coco_object_detections(
 
     Args:
         session: The database session.
+        root_dataset_id: The root dataset ID for label retrieval.
         samples: The samples to export.
         output_json: The path to save the output JSON file.
     """
     export_input = LightlyStudioObjectDetectionInput(
         session=session,
+        root_dataset_id=root_dataset_id,
         samples=samples,
     )
     COCOObjectDetectionOutput(output_file=output_json).save(label_input=export_input)

--- a/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
+++ b/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
@@ -24,16 +24,21 @@ from lightly_studio.resolvers import annotation_label_resolver
 class LightlyStudioObjectDetectionInput(ObjectDetectionInput):
     """Labelformat adapter backed by dataset samples and annotations."""
 
-    def __init__(self, session: Session, samples: Iterable[ImageSample]) -> None:
+    def __init__(
+        self, session: Session, root_dataset_id: UUID, samples: Iterable[ImageSample]
+    ) -> None:
         """Initializes the LightlyStudioObjectDetectionInput.
 
         Args:
             session: The SQLModel session to use for database access. Used only in the
                 constructor to fetch the labels for the given annotation task.
+            root_dataset_id: The root dataset ID for label retrieval.
             samples: Dataset samples.
         """
         self._samples = list(samples)
-        self._label_id_to_category = _build_label_id_to_category(session=session)
+        self._label_id_to_category = _build_label_id_to_category(
+            session=session, root_dataset_id=root_dataset_id
+        )
 
     @staticmethod
     def add_cli_arguments(parser: ArgumentParser) -> None:
@@ -61,9 +66,10 @@ class LightlyStudioObjectDetectionInput(ObjectDetectionInput):
             )
 
 
-def _build_label_id_to_category(session: Session) -> dict[UUID, Category]:
-    labels = annotation_label_resolver.get_all_sorted_alphabetically_legacy(
+def _build_label_id_to_category(session: Session, root_dataset_id: UUID) -> dict[UUID, Category]:
+    labels = annotation_label_resolver.get_all_sorted_alphabetically(
         session=session,
+        root_dataset_id=root_dataset_id,
     )
     # TODO(Horatiu, 09/2025): We should get only labels that are attached to Object Detection
     # annotations.

--- a/lightly_studio/tests/export/test_export_dataset.py
+++ b/lightly_studio/tests/export/test_export_dataset.py
@@ -113,6 +113,7 @@ class TestDatasetExport:
         # Check that a default output path was used
         mock_to_coco_object_detections.assert_called_once_with(
             session=dataset.session,
+            root_dataset_id=dataset.dataset_id,
             samples=mocker.ANY,
             output_json=Path("coco_export.json"),
         )
@@ -195,6 +196,7 @@ def test_to_coco_object_detections(
     output_json = tmp_path / "task_obj_det_1.json"
     export_dataset.to_coco_object_detections(
         session=db_session,
+        root_dataset_id=dataset.dataset_id,
         samples=DatasetQuery(dataset=dataset, session=db_session),
         output_json=output_json,
     )
@@ -236,6 +238,7 @@ def test_to_coco_object_detections__no_annotations(
     output_json = tmp_path / "task_no_ann.json"
     export_dataset.to_coco_object_detections(
         session=db_session,
+        root_dataset_id=dataset.dataset_id,
         samples=DatasetQuery(dataset=dataset, session=db_session),
         output_json=output_json,
     )

--- a/lightly_studio/tests/export/test_lightly_studio_label_input.py
+++ b/lightly_studio/tests/export/test_lightly_studio_label_input.py
@@ -33,6 +33,7 @@ class TestLightlyStudioLabelInput:
 
         label_input = LightlyStudioObjectDetectionInput(
             session=db_session,
+            root_dataset_id=dataset.dataset_id,
             samples=DatasetQuery(dataset=dataset, session=db_session),
         )
         assert list(label_input.get_categories()) == [
@@ -53,6 +54,7 @@ class TestLightlyStudioLabelInput:
         create_images(db_session=db_session, dataset_id=dataset.dataset_id, images=images)
         label_input = LightlyStudioObjectDetectionInput(
             session=db_session,
+            root_dataset_id=dataset.dataset_id,
             samples=DatasetQuery(dataset=dataset, session=db_session),
         )
         assert list(label_input.get_categories()) == []
@@ -62,6 +64,7 @@ class TestLightlyStudioLabelInput:
 
         label_input = LightlyStudioObjectDetectionInput(
             session=db_session,
+            root_dataset_id=dataset.dataset_id,
             samples=DatasetQuery(dataset=dataset, session=db_session),
         )
         assert list(label_input.get_images()) == [
@@ -74,6 +77,7 @@ class TestLightlyStudioLabelInput:
         dataset = create_dataset(session=db_session)
         label_input = LightlyStudioObjectDetectionInput(
             session=db_session,
+            root_dataset_id=dataset.dataset_id,
             samples=DatasetQuery(dataset=dataset, session=db_session),
         )
         assert list(label_input.get_images()) == []
@@ -83,6 +87,7 @@ class TestLightlyStudioLabelInput:
 
         label_input = LightlyStudioObjectDetectionInput(
             session=db_session,
+            root_dataset_id=dataset.dataset_id,
             samples=DatasetQuery(dataset=dataset, session=db_session),
         )
         labels = list(label_input.get_labels())
@@ -130,6 +135,7 @@ class TestLightlyStudioLabelInput:
         # Test for task_no_ann
         label_input = LightlyStudioObjectDetectionInput(
             session=db_session,
+            root_dataset_id=dataset.dataset_id,
             samples=DatasetQuery(dataset=dataset, session=db_session),
         )
         labels = list(label_input.get_labels())
@@ -177,6 +183,7 @@ class TestLightlyStudioLabelInput:
         )
         label_input = LightlyStudioObjectDetectionInput(
             session=db_session,
+            root_dataset_id=dataset.dataset_id,
             samples=DatasetQuery(dataset=dataset, session=db_session),
         )
         labels = list(label_input.get_labels())


### PR DESCRIPTION
## What has changed and why?

On top of #317

Use non-legacy label functions for export.

## How has it been tested?

Modified tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
