### PR TITLE
Update press tag function

### DIFF
--- a/lightly_studio_view/e2e/pages/samples-page.ts
+++ b/lightly_studio_view/e2e/pages/samples-page.ts
@@ -145,9 +145,7 @@ export class SamplesPage {
     }
 
     async pressTag(tagName: string): Promise<void> {
-        await expect(this.page.getByTestId('sample-grid-item').first()).toBeVisible({
-            timeout: 10000
-        });
+        await expect(this.page.getByTestId('sample-grid-item').first()).toBeVisible();
 
         const tagLabels = this.page.getByTestId('tags-menu-label');
         const labelCount = await tagLabels.count();


### PR DESCRIPTION
## What has changed and why?

Update `pressTag` function to check the UI element instead of waiting for `/images/list` response.
There are cases when the response is available before we trigger the wait and it will fail.

## How has it been tested?

Triggered ci e2e tests several times with no failure. 
Manual tests locally. With the previous implementation it would always fail at a fresh run of the test (empty db). With the update I could not get it to fail anymore.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
