### PR TITLE
Add IPv6 detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fixed a startup problem when IPv6 is not enabled.
 
 ### Security
 

--- a/lightly_studio/tests/api/test_server.py
+++ b/lightly_studio/tests/api/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import socket as socket_module
 from socket import AF_INET, SOCK_STREAM, socket
 from unittest.mock import MagicMock, patch
 
@@ -12,7 +13,7 @@ from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_NOT_FOUND,
     HTTP_STATUS_OK,
 )
-from lightly_studio.api.server import Server
+from lightly_studio.api.server import Server, _is_ipv6_available
 
 
 def test_server_initialization() -> None:
@@ -81,3 +82,15 @@ def test__get_available_port__preferred_port_in_use() -> None:
     server = Server(host, port)
     s.close()
     assert server.port != port
+
+
+@patch("lightly_studio.api.server.socket.socket")
+def test__is_ipv6_available(mock_socket: MagicMock) -> None:
+    # Test True
+    assert _is_ipv6_available() is True
+    mock_socket.assert_called_with(socket_module.AF_INET6, socket_module.SOCK_STREAM)
+    mock_socket.return_value.__enter__.return_value.bind.assert_called_with(("::1", 0))
+
+    # Test False
+    mock_socket.return_value.__enter__.return_value.bind.side_effect = OSError
+    assert _is_ipv6_available() is False


### PR DESCRIPTION
## What has changed and why?
If IPv6 is not available, we need to translate "localhost" to a IPv4 address, otherwise uvicorn fails to start.

## How has it been tested?
Added a test. Also used `sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1` in Linux to disable IPv6 temporarily.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?
- [x] Yes
- [ ] Not needed (internal change)
