### PR TITLE
Add VideoSampleField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added notebook/Colab support and usage snippet to the docs.
 - Added image similarity search via drag-and-drop, file upload, or clipboard paste.
 - Added similarity score display for images and videos when using embedding-based search.
+- Added VideoSampleField for querying video datasets. VideoDataset.query() now works.
 
 ### Changed
 

--- a/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
@@ -2,6 +2,7 @@ from .boolean_expression import AND, NOT, OR
 from .dataset_query import DatasetQuery
 from .order_by import OrderByExpression, OrderByField
 from .sample_field import SampleField
+from .video_sample_field import VideoSampleField
 
 __all__ = [
     "AND",
@@ -11,4 +12,5 @@ __all__ = [
     "OrderByExpression",
     "OrderByField",
     "SampleField",
+    "VideoSampleField",
 ]

--- a/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from sqlmodel.sql.expression import SelectOfScalar
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 from lightly_studio.core.dataset_query.field import Field
 from lightly_studio.models.image import ImageTable
+
+T = TypeVar("T", default=ImageTable)
 
 
 class OrderByExpression(ABC):
@@ -23,7 +25,7 @@ class OrderByExpression(ABC):
         self.ascending = ascending
 
     @abstractmethod
-    def apply(self, query: SelectOfScalar[ImageTable]) -> SelectOfScalar[ImageTable]:
+    def apply(self, query: SelectOfScalar[T]) -> SelectOfScalar[T]:
         """Apply this ordering to a SQLModel Select query.
 
         Args:
@@ -65,7 +67,7 @@ class OrderByField(OrderByExpression):
         super().__init__()
         self.field = field
 
-    def apply(self, query: SelectOfScalar[ImageTable]) -> SelectOfScalar[ImageTable]:
+    def apply(self, query: SelectOfScalar[T]) -> SelectOfScalar[T]:
         """Apply this ordering to a SQLModel Select query.
 
         Args:

--- a/lightly_studio/src/lightly_studio/core/dataset_query/sample_field.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/sample_field.py
@@ -20,7 +20,7 @@ class SampleField:
     `DatasetQuery` class.
 
     ```python
-    from lightly_studio.core.dataset_query import DatasetQuery, SampleField, OrderByField
+    from lightly_studio.core.dataset_query import SampleField, OrderByField
 
     query = dataset.query()
     query.match(SampleField.tags.contains("cat"))

--- a/lightly_studio/src/lightly_studio/core/dataset_query/video_sample_field.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/video_sample_field.py
@@ -1,0 +1,40 @@
+"""Fields for querying video sample properties in the dataset query system."""
+
+from __future__ import annotations
+
+from sqlmodel import col
+
+from lightly_studio.core.dataset_query.field import (
+    NumericalField,
+    StringField,
+)
+from lightly_studio.core.dataset_query.tags_expression import TagsAccessor
+from lightly_studio.models.video import VideoTable
+
+
+class VideoSampleField:
+    """Providing access to predefined sample fields for queries.
+
+    It is used for the `query.match(...)` and `query.order_by(...)` methods of the
+    `DatasetQuery` class.
+
+    ```python
+    from lightly_studio.core.dataset_query import VideoSampleField, OrderByField
+
+    query = dataset.query()
+    query.match(VideoSampleField.tags.contains("cat"))
+    query.order_by(OrderByField(VideoSampleField.file_path_abs))
+    samples = query.to_list()
+    ```
+    """
+
+    file_name = StringField(col(VideoTable.file_name))
+    width = NumericalField(col(VideoTable.width))
+    height = NumericalField(col(VideoTable.height))
+    file_path_abs = StringField(col(VideoTable.file_path_abs))
+
+    # TODO(lukas 01/2026): make `duration_s` work too. Option[float] is not ordinal.
+    # duration_s = NumericalField(col(VideoTable.duration_s))
+    fps = NumericalField(col(VideoTable.fps))
+
+    tags = TagsAccessor()

--- a/lightly_studio/tests/core/dataset_query/test_video_dataset_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_video_dataset_query.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lightly_studio.core.dataset_query import AND
+from lightly_studio.core.dataset_query.video_sample_field import VideoSampleField
+from lightly_studio.core.video_dataset import VideoDataset
+from tests.core.test_add_videos import _create_temp_video
+
+
+class TestVideoDatasetQuery:
+    def test_dataset_add_videos_from_path__valid(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        _create_temp_video(
+            output_path=tmp_path / "test_video_1.mp4",
+            width=640,
+            height=480,
+            num_frames=30,
+            fps=2,
+        )
+        _create_temp_video(
+            output_path=tmp_path / "test_video_0.mp4",
+            width=1024,
+            height=768,
+            num_frames=30,
+            fps=3,
+        )
+
+        dataset = VideoDataset.create(name="test_dataset")
+        dataset.add_videos_from_path(path=tmp_path)
+        query = dataset.query().match(VideoSampleField.fps == 3)
+        it = iter(query)
+        assert next(it).fps == 3
+        with pytest.raises(StopIteration):
+            next(it)
+
+        query = dataset.query().match(
+            AND(VideoSampleField.width == 640, VideoSampleField.height == 480)
+        )
+        it = iter(query)
+        assert next(it).width == 640
+        with pytest.raises(StopIteration):
+            next(it)
+
+        query = dataset.query().match(VideoSampleField.file_name == "test_video_1.mp4")
+        it = iter(query)
+        assert next(it).file_name == "test_video_1.mp4"
+        with pytest.raises(StopIteration):
+            next(it)


### PR DESCRIPTION
## What has changed and why?
This makes VideoDataset.query() work now. You can call `VideoDataset.query().match(VideoSampleField.fps == 30)`

## How has it been tested?
Added a test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)
