### PR TITLE
Add basic Annotation class

### DIFF
--- a/lightly_studio/src/lightly_studio/core/annotation.py
+++ b/lightly_studio/src/lightly_studio/core/annotation.py
@@ -1,0 +1,41 @@
+"""Interface for annotations."""
+
+from typing import cast
+
+from sqlalchemy.orm import object_session
+from sqlmodel import Session, col
+
+from lightly_studio.core.db_field import DBField
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+
+
+class Annotation:
+    """Class for annotation."""
+
+    confidence = DBField(col(AnnotationBaseTable.confidence))
+    # TODO(lukas 1/2026): type should be ideally (also) encoded in Python's type system.
+    type = DBField(col(AnnotationBaseTable.annotation_type))
+    label = DBField(col(AnnotationBaseTable.annotation_label))
+
+    def __init__(self, inner: AnnotationBaseTable) -> None:
+        """Initialize the Annotation.
+
+        Args:
+            inner: The AnnotationBaseTable SQLAlchemy model instance.
+        """
+        self.inner = inner
+
+    def get_object_session(self) -> Session:
+        """Get the database session for this annotation.
+
+        Returns:
+            The SQLModel session.
+
+        Raises:
+            RuntimeError: If no active session is found.
+        """
+        session = object_session(self.inner)
+        if session is None:
+            raise RuntimeError("No active session found for the annotation")
+        # Cast from SQLAlchemy Session to SQLModel Session for mypy.
+        return cast(Session, session)

--- a/lightly_studio/src/lightly_studio/core/db_field.py
+++ b/lightly_studio/src/lightly_studio/core/db_field.py
@@ -1,0 +1,45 @@
+"""Database field descriptor."""
+
+from __future__ import annotations
+
+from typing import Any, Generic, Protocol, TypeVar
+
+from sqlalchemy.orm import Mapped
+from sqlmodel import Session
+
+T = TypeVar("T")
+
+
+class _DBFieldOwner(Protocol):
+    inner: Any
+
+    def get_object_session(self) -> Session: ...
+
+
+class DBField(Generic[T]):
+    """Descriptor for a database-backed field.
+
+    Provides interface to a SQLAlchemy model field. Setting the field
+    immediately commits to the database. The owner class must implement
+    the inner attribute and the get_object_session() method.
+    """
+
+    __slots__ = ("_sqla_descriptor",)
+    """Store the SQLAlchemy descriptor for accessing the field."""
+
+    def __init__(self, sqla_descriptor: Mapped[T]) -> None:
+        """Initialize the DBField with a SQLAlchemy descriptor."""
+        self._sqla_descriptor = sqla_descriptor
+
+    def __get__(self, obj: _DBFieldOwner | None, owner: type | None = None) -> T:
+        """Get the value of the field from the database."""
+        assert obj is not None, "DBField must be accessed via an instance, not the class"
+        # Delegate to SQLAlchemy's descriptor.
+        value: T = self._sqla_descriptor.__get__(obj.inner, type(obj.inner))
+        return value
+
+    def __set__(self, obj: _DBFieldOwner, value: T) -> None:
+        """Set the value of the field in the database. Commits the session."""
+        # Delegate to SQLAlchemy's descriptor.
+        self._sqla_descriptor.__set__(obj.inner, value)
+        obj.get_object_session().commit()

--- a/lightly_studio/src/lightly_studio/core/image_sample.py
+++ b/lightly_studio/src/lightly_studio/core/image_sample.py
@@ -2,7 +2,8 @@
 
 from sqlmodel import col
 
-from lightly_studio.core.sample import DBField, Sample
+from lightly_studio.core.db_field import DBField
+from lightly_studio.core.sample import Sample
 from lightly_studio.models.image import ImageTable
 
 

--- a/lightly_studio/src/lightly_studio/core/sample.py
+++ b/lightly_studio/src/lightly_studio/core/sample.py
@@ -4,52 +4,17 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Iterable
-from typing import Any, Generic, Protocol, TypeVar, cast
+from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy.orm import Mapped, object_session
+from sqlalchemy.orm import object_session
 from sqlmodel import Session
 
 from lightly_studio.models.caption import CaptionCreate
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.resolvers import caption_resolver, metadata_resolver, tag_resolver
 
-T = TypeVar("T")
-
-
-class _DBFieldOwner(Protocol):
-    inner: Any
-
-    def get_object_session(self) -> Session: ...
-
-
-class DBField(Generic[T]):
-    """Descriptor for a database-backed field.
-
-    Provides interface to a SQLAlchemy model field. Setting the field
-    immediately commits to the database. The owner class must implement
-    the inner attribute and the get_object_session() method.
-    """
-
-    __slots__ = ("_sqla_descriptor",)
-    """Store the SQLAlchemy descriptor for accessing the field."""
-
-    def __init__(self, sqla_descriptor: Mapped[T]) -> None:
-        """Initialize the DBField with a SQLAlchemy descriptor."""
-        self._sqla_descriptor = sqla_descriptor
-
-    def __get__(self, obj: _DBFieldOwner | None, owner: type | None = None) -> T:
-        """Get the value of the field from the database."""
-        assert obj is not None, "DBField must be accessed via an instance, not the class"
-        # Delegate to SQLAlchemy's descriptor.
-        value: T = self._sqla_descriptor.__get__(obj.inner, type(obj.inner))
-        return value
-
-    def __set__(self, obj: _DBFieldOwner, value: T) -> None:
-        """Set the value of the field in the database. Commits the session."""
-        # Delegate to SQLAlchemy's descriptor.
-        self._sqla_descriptor.__set__(obj.inner, value)
-        obj.get_object_session().commit()
+from .annotation import Annotation
 
 
 class Sample(ABC):
@@ -249,6 +214,14 @@ class Sample(ABC):
                     CaptionCreate(parent_sample_id=self.sample_id, text=text) for text in captions
                 ],
             )
+
+    @property
+    def annotations(self) -> list[Annotation]:
+        """Returns all annotations."""
+        annotations = []
+        for annotation in self.sample_table.annotations:
+            annotations.append(Annotation(inner=annotation))
+        return annotations
 
 
 class SampleMetadata:

--- a/lightly_studio/src/lightly_studio/core/video_sample.py
+++ b/lightly_studio/src/lightly_studio/core/video_sample.py
@@ -2,7 +2,8 @@
 
 from sqlmodel import col
 
-from lightly_studio.core.sample import DBField, Sample
+from lightly_studio.core.db_field import DBField
+from lightly_studio.core.sample import Sample
 from lightly_studio.models.video import VideoTable
 
 


### PR DESCRIPTION
## What has changed and why?
The class is very basic, meant to be inherited by specialized annotation classes for object detection or selection. This will come in a later commits.

## How has it been tested?
Added a test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
