### PR TITLE
feat: move users after avatar

### DIFF
--- a/lightly_studio_view/src/lib/components/NavigationMenu/NavigationMenu.svelte
+++ b/lightly_studio_view/src/lib/components/NavigationMenu/NavigationMenu.svelte
@@ -6,7 +6,7 @@
     import { SampleType, type CollectionView } from '$lib/api/lightly_studio_local';
     import MenuItem from '../MenuItem/MenuItem.svelte';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
-    import { LayoutDashboard, Users } from '@lucide/svelte';
+    import { LayoutDashboard } from '@lucide/svelte';
     import useAuth from '$lib/hooks/useAuth/useAuth';
     const {
         collection
@@ -134,17 +134,6 @@
                 icon: LayoutDashboard
             }}
         />
-        {#if user.role === 'admin'}
-            <MenuItem
-                item={{
-                    title: 'Users',
-                    id: 'users',
-                    href: '/workspace/users',
-                    isSelected: false,
-                    icon: Users
-                }}
-            />
-        {/if}
     {/if}
 
     {#each menuItems as item (item.id)}

--- a/lightly_studio_view/src/lib/components/NavigationMenu/NavigationMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/NavigationMenu/NavigationMenu.test.ts
@@ -65,55 +65,7 @@ describe('NavigationMenu', () => {
             expect(screen.getByText('Datasets')).toBeInTheDocument();
         });
 
-        it('should not render Users menu item when user is not authenticated', () => {
-            setup({ user: null });
-
-            render(NavigationMenu, { props: { collection: mockCollection } });
-
-            expect(screen.queryByText('Users')).not.toBeInTheDocument();
-        });
-
-        it('should not render Users menu item when user is authenticated but not admin', () => {
-            setup({
-                user: {
-                    role: 'viewer',
-                    email: 'viewer@example.com'
-                }
-            });
-
-            render(NavigationMenu, { props: { collection: mockCollection } });
-
-            expect(screen.queryByText('Users')).not.toBeInTheDocument();
-        });
-
-        it('should render Users menu item when user is authenticated as admin', () => {
-            setup({
-                user: {
-                    role: 'admin',
-                    email: 'admin@example.com'
-                }
-            });
-
-            render(NavigationMenu, { props: { collection: mockCollection } });
-
-            expect(screen.getByText('Users')).toBeInTheDocument();
-        });
-
-        it('should render both Datasets and Users for admin users', () => {
-            setup({
-                user: {
-                    role: 'admin',
-                    email: 'admin@example.com'
-                }
-            });
-
-            render(NavigationMenu, { props: { collection: mockCollection } });
-
-            expect(screen.getByText('Datasets')).toBeInTheDocument();
-            expect(screen.getByText('Users')).toBeInTheDocument();
-        });
-
-        it('should render only Datasets for non-admin authenticated users', () => {
+        it('should render only Datasets for authenticated users', () => {
             setup({
                 user: {
                     role: 'viewer',
@@ -124,7 +76,6 @@ describe('NavigationMenu', () => {
             render(NavigationMenu, { props: { collection: mockCollection } });
 
             expect(screen.getByText('Datasets')).toBeInTheDocument();
-            expect(screen.queryByText('Users')).not.toBeInTheDocument();
         });
     });
 
@@ -237,7 +188,6 @@ describe('NavigationMenu', () => {
             render(NavigationMenu, { props: { collection: collectionWithChildren } });
 
             expect(screen.getByText('Datasets')).toBeInTheDocument();
-            expect(screen.getByText('Users')).toBeInTheDocument();
             expect(screen.getByText('Images')).toBeInTheDocument();
             expect(screen.getByText('Videos')).toBeInTheDocument();
         });

--- a/lightly_studio_view/src/lib/components/UserAvatar/UserAvatar.svelte
+++ b/lightly_studio_view/src/lib/components/UserAvatar/UserAvatar.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
     import * as Popover from '$lib/components/ui/popover';
     import { Button } from '$lib/components/ui/button';
-    import { LogOut } from '@lucide/svelte';
+    import { LogOut, Users } from '@lucide/svelte';
     import { cn } from '$lib/utils/shadcn';
     import { useLogout } from '$lib/hooks/useLogout/useLogout';
+    import { Separator } from '../ui/separator';
+
+    const { logout } = useLogout();
 
     interface Props {
         user: {
@@ -14,7 +17,6 @@
     }
 
     let { user }: Props = $props();
-    const { logout } = useLogout();
 
     // TODO: Use name initials when names become available
     // For now, use first letter of username
@@ -39,7 +41,7 @@
     </Popover.Trigger>
 
     <Popover.Content class="w-64" align="end">
-        <div class="space-y-3">
+        <div class="flex flex-col gap-3">
             <div class="flex items-center gap-3">
                 <div
                     class="flex size-12 items-center justify-center rounded-full bg-primary text-primary-foreground"
@@ -51,13 +53,17 @@
                     <p class="text-sm text-muted-foreground">{user.username}</p>
                 </div>
             </div>
-
-            <div>
-                <Button variant="outline" class="w-full justify-start gap-2" onclick={logout}>
-                    <LogOut class="size-4" />
-                    <span>Sign out</span>
+            {#if user?.role === 'admin'}
+                <Button variant="ghost" class="w-full justify-start gap-2" href="/workspace/users">
+                    <Users class="size-4" />
+                    Users
                 </Button>
-            </div>
+            {/if}
+            <Separator />
+            <Button variant="outline" class="w-full justify-start gap-2" onclick={logout}>
+                <LogOut class="size-4" />
+                <span>Sign out</span>
+            </Button>
         </div>
     </Popover.Content>
 </Popover.Root>

--- a/lightly_studio_view/src/lib/components/UserAvatar/UserAvatar.test.ts
+++ b/lightly_studio_view/src/lib/components/UserAvatar/UserAvatar.test.ts
@@ -35,4 +35,30 @@ describe('UserAvatar', () => {
         const signOutButton = getByRole('button', { name: /sign out/i });
         expect(signOutButton).toBeTruthy();
     });
+
+    it('should render users menu item for admin user', async () => {
+        const { getByTitle, getByRole } = render(UserAvatar, { props: { user: mockUser } });
+        const avatarButton = getByTitle('admin');
+
+        await fireEvent.click(avatarButton);
+
+        const usersButton = getByRole('link', { name: /users/i });
+        expect(usersButton).toBeTruthy();
+        expect(usersButton.getAttribute('href')).toBe('/workspace/users');
+    });
+
+    it('should not render users menu item for non-admin user', async () => {
+        const nonAdminUser = {
+            username: 'user',
+            email: 'user@example.com',
+            role: 'user'
+        };
+        const { getByTitle, queryByRole } = render(UserAvatar, { props: { user: nonAdminUser } });
+        const avatarButton = getByTitle('user');
+
+        await fireEvent.click(avatarButton);
+
+        const usersButton = queryByRole('link', { name: /users/i });
+        expect(usersButton).toBeNull();
+    });
 });


### PR DESCRIPTION
## What has changed and why?

Place users menu right after avatar 
https://lightly-ai.slack.com/archives/C01KSD8EE65/p1768230279666449

## How has it been tested?

- Run app
- Emulate context with
```
sessionStorage.setItem('lightlyEnterprise', JSON.stringify({
    "settings": {showDashboard: true},
    "token": "some-token",  
    "user": {role: "admin", email: "admin@localhost", username: "fff"}
}))
```
- Check what you see users in the context menu for user

## Visual change

<img width="1425" height="1023" alt="Screenshot 2026-01-13 at 15 01 01" src="https://github.com/user-attachments/assets/6218a55a-eaa1-4706-b143-bda5afb30c28" />

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
