### PR TITLE
Clear `itemsSelectedByFilter` on tag dialog close

### DIFF
--- a/lightly_studio_view/src/lib/components/TagCreateDialog/TagCreateDialog.svelte
+++ b/lightly_studio_view/src/lib/components/TagCreateDialog/TagCreateDialog.svelte
@@ -267,6 +267,7 @@
         hasFetched = false;
         tagsEnlistedToCreate = [];
         tagsToAddItemsTo.clear();
+        itemsSelectedByFilter = null;
     };
 
     const changesToCommit = $derived(tagsToAddItemsTo.size > 0 || tagsEnlistedToCreate.length > 0);


### PR DESCRIPTION
## What has changed and why?

When closing the Tag Create dialog, the `itemsSelectedByFilter` variable was not being reset.  This PR ensures that `itemsSelectedByFilter` is cleared when the dialog is closed by setting it to `null`.

## How has it been tested?

Manual tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
