### PR TITLE
Access group components with getitem notation

### DIFF
--- a/lightly_studio/src/lightly_studio/core/group_sample.py
+++ b/lightly_studio/src/lightly_studio/core/group_sample.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.core.image_sample import ImageSample
 from lightly_studio.core.sample import Sample
+from lightly_studio.core.video_sample import VideoSample
+from lightly_studio.models.collection import SampleType
 from lightly_studio.models.group import GroupTable
+from lightly_studio.resolvers import group_resolver, image_resolver, video_resolver
 
 
 class GroupSample(Sample):
@@ -23,3 +31,47 @@ class GroupSample(Sample):
         """
         self.inner = inner
         super().__init__(sample_table=inner.sample)
+
+    def __getitem__(self, key: str) -> Sample | None:
+        """Get a component sample by its key.
+
+        Args:
+            key: The key of the component sample.
+
+        Returns:
+            The component sample if it is set, None otherwise.
+
+        Raises:
+            KeyError: If the component key is not in the group schema.
+        """
+        comp_sample_id, comp_type = group_resolver.get_group_component_with_type(
+            session=self.get_object_session(), sample_id=self.sample_id, key=key
+        )
+        if comp_sample_id is None:
+            return None
+        return _create_specific_sample_class(
+            session=self.get_object_session(), sample_id=comp_sample_id, sample_type=comp_type
+        )
+
+
+def _create_specific_sample_class(
+    session: Session, sample_id: UUID, sample_type: SampleType
+) -> Sample:
+    if sample_type == SampleType.IMAGE:
+        image_table = image_resolver.get_by_id(session=session, sample_id=sample_id)
+        if image_table is None:
+            raise ValueError(f"Image sample with id '{sample_id}' does not exist.")
+        return ImageSample(inner=image_table)
+    if sample_type == SampleType.VIDEO:
+        video_table = video_resolver.get_by_id(session=session, sample_id=sample_id)
+        if video_table is None:
+            raise ValueError(f"Video sample with id '{sample_id}' does not exist.")
+        return VideoSample(inner=video_table)
+    if sample_type == SampleType.GROUP:
+        group_table = group_resolver.get_by_id(session=session, sample_id=sample_id)
+        if group_table is None:
+            raise ValueError(f"Group sample with id '{sample_id}' does not exist.")
+        return GroupSample(inner=group_table)
+    raise NotImplementedError(
+        f"Group component of SampleType '{sample_type}' is not supported yet."
+    )

--- a/lightly_studio/tests/core/test_group_sample.py
+++ b/lightly_studio/tests/core/test_group_sample.py
@@ -1,6 +1,9 @@
+import pytest
 from sqlmodel import Session
 
 from lightly_studio.core.group_sample import GroupSample
+from lightly_studio.core.image_sample import ImageSample
+from lightly_studio.core.video_sample import VideoSample
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import collection_resolver, group_resolver
 from tests.helpers_resolvers import create_collection, create_image
@@ -47,3 +50,21 @@ class TestGroupSample:
 
         # Access properties
         assert group.sample_id == group_id
+
+        # Access component samples
+        img_sample = group["img"]
+        assert isinstance(img_sample, ImageSample)
+        assert img_sample.sample_id == image_table.sample_id
+        assert img_sample.file_name == "front_0.jpg"
+
+        vid_sample = group["vid"]
+        assert isinstance(vid_sample, VideoSample)
+        assert vid_sample.sample_id == video_table.sample_id
+        assert vid_sample.file_name == "back_0.mp4"
+
+        extra_sample = group["extra"]
+        assert extra_sample is None
+
+        # Accessing a non-existing component should raise KeyError
+        with pytest.raises(KeyError):
+            group["non_existing"]


### PR DESCRIPTION
## What has changed and why?

Access group components with getitem notation. Finishes productionisation of the GroupSample prototype.

## How has it been tested?

Expandedd test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
