### PR TITLE
Relax guidelines for final full stop in comments

### DIFF
--- a/ai_guidelines/python.md
+++ b/ai_guidelines/python.md
@@ -64,10 +64,13 @@ Use the following format: `# TODO({name}, {mm}/{yyyy}): Blah blah`
 
 ## Comments
 
-Prefer full sentences and punctuation.
+Prefer full sentences and punctuation. Final full stop can be omitted for a single sentence.
 
 ```python
-# This is a proper comment about the following lines.
+# This is a proper comment. It spans multiple sentences.
+...
+
+# Single sentences can have the final full stop omitted
 ...
 
 # we don't do this <-


### PR DESCRIPTION
## What has changed and why?

Relaxed the final full stop guideline. It does not make much readability difference, while it generates not so valuable AI PR comments.

## How has it been tested?

Not tested.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
