### PR TITLE
Deprecate AnnotationTable.tags

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -75,7 +75,6 @@ def count_annotations_by_collection(  # noqa: PLR0913 // FIXME: refactor to use 
     max_width: Annotated[int | None, Query(ge=0)] = None,
     min_height: Annotated[int | None, Query(ge=0)] = None,
     max_height: Annotated[int | None, Query(ge=0)] = None,
-    tag_ids: list[UUID] | None = None,
 ) -> list[dict[str, str | int]]:
     """Get annotation counts for a specific collection.
 
@@ -89,7 +88,6 @@ def count_annotations_by_collection(  # noqa: PLR0913 // FIXME: refactor to use 
         max_width=max_width,
         min_height=min_height,
         max_height=max_height,
-        tag_ids=tag_ids,
     )
 
     return [

--- a/lightly_studio/src/lightly_studio/api/routes/api/frame.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/frame.py
@@ -183,7 +183,10 @@ def _build_annotation_view(a: AnnotationBaseTable) -> AnnotationView:
             if a.segmentation_details
             else None
         ),
-        tags=[AnnotationView.AnnotationViewTag(tag_id=t.tag_id, name=t.name) for t in a.tags],
+        tags=[
+            AnnotationView.AnnotationViewTag(tag_id=t.tag_id, name=t.name)
+            for t in a.tags_deprecated
+        ],
         sample=_build_sample_view(a.sample),
     )
 

--- a/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
+++ b/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
@@ -76,7 +76,7 @@ class AnnotationBaseTable(SQLModel, table=True):
             "foreign_keys": "[AnnotationBaseTable.parent_sample_id]",
         },
     )
-    tags: Mapped[List["TagTable"]] = Relationship(
+    tags_deprecated: Mapped[List["TagTable"]] = Relationship(
         back_populates="annotations",
         link_model=AnnotationTagLinkTable,
     )

--- a/lightly_studio/src/lightly_studio/models/tag.py
+++ b/lightly_studio/src/lightly_studio/models/tag.py
@@ -82,6 +82,6 @@ class TagTable(TagBase, table=True):
 
     """The annotation ids associated with the tag (legacy bounding box)."""
     annotations: Mapped[List["AnnotationBaseTable"]] = Relationship(
-        back_populates="tags",
+        back_populates="tags_deprecated",
         link_model=AnnotationTagLinkTable,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/count_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/count_annotations_by_collection.py
@@ -13,7 +13,6 @@ from lightly_studio.models.annotation.annotation_base import (
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
-from lightly_studio.models.tag import TagTable
 from lightly_studio.type_definitions import QueryType
 
 
@@ -25,7 +24,6 @@ def count_annotations_by_collection(  # noqa: PLR0913 // FIXME: refactor to use 
     max_width: int | None = None,
     min_height: int | None = None,
     max_height: int | None = None,
-    tag_ids: list[UUID] | None = None,
 ) -> list[tuple[str, int, int]]:
     """Count annotations for a specific collection.
 
@@ -42,7 +40,6 @@ def count_annotations_by_collection(  # noqa: PLR0913 // FIXME: refactor to use 
         max_width=max_width,
         min_height=min_height,
         max_height=max_height,
-        tag_ids=tag_ids,
     )
     current_counts = _get_current_counts(session=session, filters=filters)
 
@@ -88,7 +85,6 @@ class _CountFilters:
     max_width: int | None
     min_height: int | None
     max_height: int | None
-    tag_ids: list[UUID] | None
 
 
 def _get_current_counts(session: Session, filters: _CountFilters) -> dict[str, int]:
@@ -138,14 +134,6 @@ def _get_current_counts(session: Session, filters: _CountFilters) -> dict[str, i
                 )
                 .where(col(AnnotationLabelTable.annotation_label_name).in_(filters.filtered_labels))
             )
-        )
-
-    # filter by tag_ids
-    if filters.tag_ids:
-        filtered_query = (
-            filtered_query.join(AnnotationBaseTable.tags)
-            .where(AnnotationBaseTable.tags.any(col(TagTable.tag_id).in_(filters.tag_ids)))
-            .distinct()
         )
 
     # Group by label name and sort

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_annotation_label.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_annotation_label.py
@@ -61,7 +61,7 @@ def update_annotation_label(
                 annotation_sample_id=annotation_copy.sample_id,
                 tag_id=tag.tag_id,
             )
-            for tag in annotation.tags
+            for tag in annotation.tags_deprecated
         ]
 
         # we need to create a new annotation details before committing

--- a/lightly_studio/src/lightly_studio/resolvers/annotations/annotations_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotations/annotations_filter.py
@@ -61,9 +61,11 @@ class AnnotationsFilter(BaseModel):
         # Filter by annotation tags
         if self.annotation_tag_ids:
             query = (
-                query.join(AnnotationBaseTable.tags)
+                query.join(AnnotationBaseTable.tags_deprecated)
                 .where(
-                    AnnotationBaseTable.tags.any(col(TagTable.tag_id).in_(self.annotation_tag_ids))
+                    AnnotationBaseTable.tags_deprecated.any(
+                        col(TagTable.tag_id).in_(self.annotation_tag_ids)
+                    )
                 )
                 .distinct()
             )

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/export.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/export.py
@@ -165,7 +165,7 @@ def _build_export_query(  # noqa: C901
                         ),
                         # Samples with matching annotation tags
                         col(SampleTable.annotations).any(
-                            col(AnnotationBaseTable.tags).any(
+                            col(AnnotationBaseTable.tags_deprecated).any(
                                 and_(
                                     TagTable.kind == "annotation",
                                     col(TagTable.tag_id).in_(include.tag_ids),
@@ -226,7 +226,7 @@ def _build_export_query(  # noqa: C901
                         or_(
                             ~col(SampleTable.annotations).any(),
                             ~col(SampleTable.annotations).any(
-                                col(AnnotationBaseTable.tags).any(
+                                col(AnnotationBaseTable.tags_deprecated).any(
                                     and_(
                                         TagTable.kind == "annotation",
                                         col(TagTable.tag_id).in_(exclude.tag_ids),

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_all_by_collection_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_all_by_collection_id.py
@@ -43,7 +43,7 @@ def _get_load_options() -> LoaderOption:
             joinedload(AnnotationBaseTable.annotation_label),
             joinedload(AnnotationBaseTable.object_detection_details),
             joinedload(AnnotationBaseTable.segmentation_details),
-            selectinload(AnnotationBaseTable.tags),
+            selectinload(AnnotationBaseTable.tags_deprecated),
         ),
     )
 

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -144,7 +144,7 @@ def add_tag_to_annotation(
     if tag.kind != "annotation":
         raise ValueError(f"Tag {tag_id} is not of kind 'annotation'")
 
-    annotation.tags.append(tag)
+    annotation.tags_deprecated.append(tag)
     session.add(annotation)
     session.commit()
     session.refresh(annotation)
@@ -157,7 +157,7 @@ def assign_tag_to_annotation(
     annotation: AnnotationBaseTable,
 ) -> AnnotationBaseTable:
     """Add a tag to a annotation."""
-    annotation.tags.append(tag)
+    annotation.tags_deprecated.append(tag)
     session.add(annotation)
     session.commit()
     session.refresh(annotation)
@@ -176,7 +176,7 @@ def remove_tag_from_annotation(
     if tag.kind != "annotation":
         raise ValueError(f"Tag {tag_id} is not of kind 'annotation'")
 
-    annotation.tags.remove(tag)
+    annotation.tags_deprecated.remove(tag)
     session.add(annotation)
     session.commit()
     session.refresh(annotation)

--- a/lightly_studio/tests/resolvers/annotations/test_annotations_filters.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotations_filters.py
@@ -96,8 +96,8 @@ def filter_test_data(
     assert annotation2
 
     # Add tags to annotations
-    annotation1.tags.append(tag1)
-    annotation2.tags.append(tag2)
+    annotation1.tags_deprecated.append(tag1)
+    annotation2.tags_deprecated.append(tag2)
     test_db.commit()
 
     return annotation1, annotation2
@@ -143,7 +143,7 @@ def test_filter_by_tag(
     annotation1, _ = filter_test_data
 
     # Test filtering by tag
-    tag_filter = AnnotationsFilter(annotation_tag_ids=[annotation1.tags[0].tag_id])
+    tag_filter = AnnotationsFilter(annotation_tag_ids=[annotation1.tags_deprecated[0].tag_id])
     filtered_annotations = annotations_resolver.get_all(
         session=test_db, filters=tag_filter
     ).annotations
@@ -175,7 +175,7 @@ def test_combined_filters(
     combined_filter = AnnotationsFilter(
         collection_ids=[annotation1.sample.collection_id],
         annotation_label_ids=[annotation1.annotation_label_id],
-        annotation_tag_ids=[annotation1.tags[0].tag_id],
+        annotation_tag_ids=[annotation1.tags_deprecated[0].tag_id],
     )
     filtered_annotations = annotations_resolver.get_all(
         session=test_db, filters=combined_filter

--- a/lightly_studio/tests/resolvers/annotations/test_annotations_update_annotation_label.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotations_update_annotation_label.py
@@ -58,7 +58,7 @@ def test_update_annotation_with_tags(
     annotation_id = annotation.sample_id
     current_annotation_label_id = annotation.annotation_label_id
     new_label = annotations_test_data.annotation_labels[1]
-    existing_tags = [tag.tag_id for tag in annotation.tags]
+    existing_tags = [tag.tag_id for tag in annotation.tags_deprecated]
 
     assert current_annotation_label_id != new_label.annotation_label_id
 
@@ -74,7 +74,7 @@ def test_update_annotation_with_tags(
 
     assert updated_annotation is not None
 
-    tags = [tag.tag_id for tag in updated_annotation.tags]
+    tags = [tag.tag_id for tag in updated_annotation.tags_deprecated]
     assert tags == existing_tags
 
 

--- a/lightly_studio/tests/resolvers/test_annotation_resolver.py
+++ b/lightly_studio/tests/resolvers/test_annotation_resolver.py
@@ -575,7 +575,7 @@ def test_add_tag_to_annotation(test_db: Session) -> None:
     # add annotaiton to tag
     tag_resolver.add_tag_to_annotation(session=test_db, tag_id=tag.tag_id, annotation=annotation)
 
-    assert annotation.tags.index(tag) == 0
+    assert annotation.tags_deprecated.index(tag) == 0
 
 
 def test_add_tag_to_annotation__ensure_correct_kind(
@@ -620,16 +620,16 @@ def test_remove_annotation_from_tag(test_db: Session) -> None:
 
     # add annotation to tag
     tag_resolver.add_tag_to_annotation(session=test_db, tag_id=tag.tag_id, annotation=annotation)
-    assert len(annotation.tags) == 1
-    assert annotation.tags.index(tag) == 0
+    assert len(annotation.tags_deprecated) == 1
+    assert annotation.tags_deprecated.index(tag) == 0
 
     # remove annotation to tag
     tag_resolver.remove_tag_from_annotation(
         session=test_db, tag_id=tag.tag_id, annotation=annotation
     )
-    assert len(annotation.tags) == 0
+    assert len(annotation.tags_deprecated) == 0
     with pytest.raises(ValueError, match="is not in list"):
-        annotation.tags.index(tag)
+        annotation.tags_deprecated.index(tag)
 
 
 def test_add_and_remove_annotation_ids_to_tag_id(
@@ -682,9 +682,9 @@ def test_add_and_remove_annotation_ids_to_tag_id(
 
     # ensure all annotations were added to the correct tags
     for i, annotation in enumerate(annotations):
-        assert tag_1 in annotation.tags
+        assert tag_1 in annotation.tags_deprecated
         if i % 2 == 1:
-            assert tag_2 in annotation.tags
+            assert tag_2 in annotation.tags_deprecated
 
     # ensure the correct number of annotations were added to each tag
     assert len(tag_1.annotations) == total_annos

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -4496,11 +4496,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
-            content: {
-                "application/json": string[] | null;
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {


### PR DESCRIPTION
## What has changed and why?

Preparation for AnnotationTagLink table removal:
* Rename AnnotationTable.tags to Deprecate AnnotationTable.tags_deprecated
* Remove unused `tag_ids` filtering param

Note: AnnotationView.tags will stay for now to limit frontend changes.

## How has it been tested?

Existing tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
