### PR TITLE
feat: introduce endpoint to fetch groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed annotation details mask editing to keep focus stable without annoying recentering after every edit and always select the shown annotation.
+- Fixed instance-segmentation brush/eraser edits occasionally being applied to the wrong sample after navigating between samples.
 
 ### Security
 

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleEraserRect/SampleEraserRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleEraserRect/SampleEraserRect.svelte
@@ -59,11 +59,13 @@
     const { createAnnotation } = useCreateAnnotation({
         collectionId
     });
-    const { finishErase } = useSegmentationMaskEraser({
-        collectionId,
-        sample,
-        refetch: annotationLabelContext.isOnAnnotationDetailsView ? undefined : refetch
-    });
+    const eraserApi = $derived.by(() =>
+        useSegmentationMaskEraser({
+            collectionId,
+            sample,
+            refetch: annotationLabelContext.isOnAnnotationDetailsView ? undefined : refetch
+        })
+    );
 
     const annotationApi = $derived.by(() => {
         if (!annotationLabelContext.annotationId) return null;
@@ -222,6 +224,6 @@
         e.currentTarget?.releasePointerCapture?.(e.pointerId);
 
         lastBrushPoint = null;
-        finishErase(workingMask, selectedAnnotation, updateAnnotation, deleteAnn);
+        eraserApi.finishErase(workingMask, selectedAnnotation, updateAnnotation, deleteAnn);
     }}
 />

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleInstanceSegmentationRect.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleInstanceSegmentationRect.test.ts
@@ -1,0 +1,140 @@
+import { fireEvent, render } from '@testing-library/svelte';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { writable } from 'svelte/store';
+import SampleInstanceSegmentationRect from './SampleInstanceSegmentationRect/SampleInstanceSegmentationRect.svelte';
+
+const {
+    mockAnnotationContext,
+    setAnnotationId,
+    setIsDrawing,
+    committedSampleIds,
+    useInstanceSegmentationBrushMock
+} = vi.hoisted(() => {
+    const context = {
+        annotationId: null as string | null,
+        isDrawing: false,
+        isOnAnnotationDetailsView: false
+    };
+
+    const setAnnotationIdMock = vi.fn((id: string | null) => {
+        context.annotationId = id;
+    });
+    const setIsDrawingMock = vi.fn((value: boolean) => {
+        context.isDrawing = value;
+    });
+
+    const sampleIds: string[] = [];
+    const brushHookMock = vi.fn((params: { sampleId: string }) => ({
+        finishBrush: vi.fn(() => {
+            sampleIds.push(params.sampleId);
+        })
+    }));
+
+    return {
+        mockAnnotationContext: context,
+        setAnnotationId: setAnnotationIdMock,
+        setIsDrawing: setIsDrawingMock,
+        committedSampleIds: sampleIds,
+        useInstanceSegmentationBrushMock: brushHookMock
+    };
+});
+
+vi.mock('$app/state', () => ({
+    page: {
+        params: {
+            dataset_id: 'dataset-1'
+        }
+    }
+}));
+
+vi.mock('$lib/components/SampleAnnotation/utils', () => ({
+    applyBrushToMask: vi.fn(),
+    decodeRLEToBinaryMask: vi.fn(),
+    getImageCoordsFromMouse: vi.fn(() => ({ x: 10, y: 12 })),
+    interpolateLineBetweenPoints: vi.fn(() => []),
+    maskToDataUrl: vi.fn(() => 'data:image/png;base64,preview'),
+    withAlpha: vi.fn(() => 'rgba(0, 0, 255, 0.25)')
+}));
+
+vi.mock(
+    '$lib/components/SampleAnnotation/SampleAnnotationSegmentationRLE/calculateBinaryMaskFromRLE/parseColor',
+    () => ({
+        default: vi.fn(() => [0, 0, 255, 255])
+    })
+);
+
+vi.mock('$lib/contexts/SampleDetailsAnnotation.svelte', () => ({
+    useAnnotationLabelContext: () => ({
+        context: mockAnnotationContext,
+        setIsDrawing,
+        setAnnotationId
+    })
+}));
+
+vi.mock('$lib/hooks/useAnnotation/useAnnotation', () => ({
+    useAnnotation: () => ({
+        updateAnnotation: vi.fn()
+    })
+}));
+
+vi.mock('$lib/hooks/useAnnotationLabels/useAnnotationLabels', () => ({
+    useAnnotationLabels: () =>
+        writable({
+            data: []
+        })
+}));
+
+vi.mock('$lib/hooks/useCollection/useCollection', () => ({
+    useCollectionWithChildren: () => ({
+        refetch: vi.fn()
+    })
+}));
+
+vi.mock('$lib/hooks/useInstanceSegmentationBrush', () => ({
+    useInstanceSegmentationBrush: useInstanceSegmentationBrushMock
+}));
+
+describe('SampleInstanceSegmentationRect', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAnnotationContext.annotationId = null;
+        mockAnnotationContext.isDrawing = false;
+        committedSampleIds.length = 0;
+    });
+
+    it('uses the latest sample id for brush commit after rerender', async () => {
+        const baseProps = {
+            collectionId: 'collection-1',
+            brushRadius: 5,
+            drawerStrokeColor: 'rgb(0, 0, 255)',
+            mousePosition: null,
+            refetch: vi.fn()
+        };
+
+        const { container, rerender } = render(SampleInstanceSegmentationRect, {
+            props: {
+                ...baseProps,
+                sampleId: 'sample-1',
+                sample: { width: 100, height: 100, annotations: [] }
+            }
+        });
+
+        await rerender({
+            ...baseProps,
+            sampleId: 'sample-2',
+            sample: { width: 100, height: 100, annotations: [] }
+        });
+
+        const drawingRect = container.querySelector('rect');
+        expect(drawingRect).not.toBeNull();
+
+        await fireEvent.pointerDown(drawingRect as SVGRectElement, {
+            pointerId: 1,
+            clientX: 20,
+            clientY: 20
+        });
+        await fireEvent.pointerUp(drawingRect as SVGRectElement, { pointerId: 1 });
+
+        expect(committedSampleIds).toEqual(['sample-2']);
+    });
+});

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleInstanceSegmentationRect/SampleInstanceSegmentationRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleInstanceSegmentationRect/SampleInstanceSegmentationRect.svelte
@@ -66,18 +66,20 @@
     const { refetch: refetchRootCollection } = $derived.by(() =>
         useCollectionWithChildren({ collectionId: datasetId })
     );
-    const { finishBrush } = useInstanceSegmentationBrush({
-        collectionId,
-        sampleId,
-        sample,
-        refetch,
-        onAnnotationCreated: () => {
-            // Only refresh root collection if there were no annotations before
-            if (sample.annotations.length === 0) {
-                refetchRootCollection();
+    const brushApi = $derived.by(() =>
+        useInstanceSegmentationBrush({
+            collectionId,
+            sampleId,
+            sample,
+            refetch,
+            onAnnotationCreated: () => {
+                // Only refresh root collection if there were no annotations before
+                if (sample.annotations.length === 0) {
+                    refetchRootCollection();
+                }
             }
-        }
-    });
+        })
+    );
 
     const {
         context: annotationLabelContext,
@@ -190,7 +192,12 @@
     onpointerup={(e) => {
         lastBrushPoint = null;
         e.currentTarget?.releasePointerCapture?.(e.pointerId);
-        finishBrush(workingMask, resolveSelectedAnnotation(), $labels.data ?? [], updateAnnotation);
+        brushApi.finishBrush(
+            workingMask,
+            resolveSelectedAnnotation(),
+            $labels.data ?? [],
+            updateAnnotation
+        );
     }}
     onpointerdown={(e) => {
         e.currentTarget?.setPointerCapture?.(e.pointerId);


### PR DESCRIPTION
## What has changed and why?

NOTE: This PR requires [groups resolver PR](https://github.com/lightly-ai/lightly-studio/pull/527/changes#diff-924e40afdb8c35c327f291a787d8c4de7e220b46633cff35aa616ebc0a85a908) and will be merged only after mentioned.


We need to get information about available groups. 
This PR introduces endpoint to fetch groups as collection, with typical for sample filters.
Initial implementation should work for filtering with tags and pagination

## How has it been tested?

By unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
