### PR TITLE
feat: return group_snapshot and sample_count information

### DIFF
--- a/lightly_studio/src/lightly_studio/models/group.py
+++ b/lightly_studio/src/lightly_studio/models/group.py
@@ -1,6 +1,6 @@
 """Group table definition."""
 
-from typing import List, Optional
+from typing import List, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -38,6 +38,9 @@ class GroupView(BaseModel):
     sample_id: UUID
     sample: SampleView
     similarity_score: Optional[float] = None
+    # First sample's image or video for display in grid
+    group_snapshot: Optional[Union["ImageView", "VideoView"]] = None
+    sample_count: int
 
 
 class GroupViewsWithCount(BaseModel):
@@ -48,3 +51,8 @@ class GroupViewsWithCount(BaseModel):
     samples: List[GroupView] = PydanticField(..., alias="data")
     total_count: int
     next_cursor: Optional[int] = PydanticField(None, alias="nextCursor")
+
+
+# Import at the bottom to avoid circular imports
+from lightly_studio.models.image import ImageView  # noqa: E402
+from lightly_studio.models.video import VideoView  # noqa: E402

--- a/lightly_studio/src/lightly_studio/models/image.py
+++ b/lightly_studio/src/lightly_studio/models/image.py
@@ -13,6 +13,7 @@ from lightly_studio.models.annotation.annotation_base import AnnotationView
 from lightly_studio.models.caption import CaptionView
 from lightly_studio.models.metadata import SampleMetadataView
 from lightly_studio.models.sample import SampleTable, SampleView
+from lightly_studio.models.sample_view_type import SampleViewType
 
 
 class ImageBase(SQLModel):
@@ -65,6 +66,7 @@ class ImageView(BaseModel):
         created_at: datetime
         updated_at: datetime
 
+    type: SampleViewType = SampleViewType.IMAGE
     file_name: str
     file_path_abs: str
     sample_id: UUID

--- a/lightly_studio/src/lightly_studio/models/sample_view_type.py
+++ b/lightly_studio/src/lightly_studio/models/sample_view_type.py
@@ -1,0 +1,10 @@
+"""This module defines the SampleViewType enum."""
+
+from enum import Enum
+
+
+class SampleViewType(str, Enum):
+    """Enum for sample view types."""
+
+    IMAGE = "image"
+    VIDEO = "video"

--- a/lightly_studio/src/lightly_studio/models/video.py
+++ b/lightly_studio/src/lightly_studio/models/video.py
@@ -10,6 +10,7 @@ from sqlmodel import Field, Relationship, SQLModel
 
 from lightly_studio.models.range import FloatRange, IntRange
 from lightly_studio.models.sample import SampleTable, SampleView
+from lightly_studio.models.sample_view_type import SampleViewType
 
 
 class VideoBase(SQLModel):
@@ -52,6 +53,7 @@ class VideoTable(VideoBase, table=True):
 class VideoView(SQLModel):
     """Video class when retrieving."""
 
+    type: SampleViewType = SampleViewType.VIDEO
     width: int
     height: int
     duration_s: Optional[float] = None

--- a/lightly_studio/src/lightly_studio/resolvers/group_resolver/get_all.py
+++ b/lightly_studio/src/lightly_studio/resolvers/group_resolver/get_all.py
@@ -122,7 +122,7 @@ def _get_group_snapshots(
     # First, try to get images for each group
     image_query = (
         select(SampleGroupLinkTable.parent_sample_id, ImageTable)
-        .join(ImageTable, ImageTable.sample_id == SampleGroupLinkTable.sample_id)
+        .join(ImageTable, ImageTable.sample_id == SampleGroupLinkTable.sample_id)  # type: ignore[arg-type]
         .join(ImageTable.sample)
         .options(
             selectinload(ImageTable.sample).options(
@@ -165,7 +165,7 @@ def _get_group_snapshots(
     if groups_without_images:
         video_query = (
             select(SampleGroupLinkTable.parent_sample_id, VideoTable)
-            .join(VideoTable, VideoTable.sample_id == SampleGroupLinkTable.sample_id)
+            .join(VideoTable, VideoTable.sample_id == SampleGroupLinkTable.sample_id)  # type: ignore[arg-type]
             .join(VideoTable.sample)
             .options(
                 selectinload(VideoTable.sample).options(
@@ -220,10 +220,10 @@ def _get_group_sample_counts(
     count_query = (
         select(
             SampleGroupLinkTable.parent_sample_id,
-            func.count(SampleGroupLinkTable.sample_id).label("sample_count"),
+            func.count(col(SampleGroupLinkTable.sample_id)).label("sample_count"),
         )
         .where(col(SampleGroupLinkTable.parent_sample_id).in_(group_sample_ids))
-        .group_by(SampleGroupLinkTable.parent_sample_id)
+        .group_by(col(SampleGroupLinkTable.parent_sample_id))
     )
 
     results = session.exec(count_query).all()

--- a/lightly_studio/src/lightly_studio/resolvers/group_resolver/get_all.py
+++ b/lightly_studio/src/lightly_studio/resolvers/group_resolver/get_all.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.interfaces import LoaderOption
 from sqlmodel import Session, col, func, select
 
 from lightly_studio.api.routes.api.validators import Paginated
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.group import GroupTable, GroupView, GroupViewsWithCount
+from lightly_studio.models.image import ImageTable, ImageView
 from lightly_studio.models.sample import SampleTable, SampleView
+from lightly_studio.models.video import VideoTable, VideoView
 from lightly_studio.resolvers.group_resolver.group_filter import GroupFilter
 
 
@@ -51,11 +56,18 @@ def get_all(
     total_count = session.exec(total_count_query).one()
     samples = session.exec(samples_query).all()
 
+    # Fetch first sample (image or video) for each group
+    group_sample_ids = [group.sample_id for group in samples]
+    group_snapshots = _get_group_snapshots(session, group_sample_ids)
+    group_sample_counts = _get_group_sample_counts(session, group_sample_ids)
+
     group_views = [
         GroupView(
             sample_id=group.sample_id,
             sample=SampleView.model_validate(group.sample),
             similarity_score=None,
+            group_snapshot=group_snapshots.get(group.sample_id),
+            sample_count=group_sample_counts.get(group.sample_id, 0),
         )
         for group in samples
     ]
@@ -85,3 +97,135 @@ def _compute_next_cursor(
     if pagination and pagination.offset + pagination.limit < total_count:
         return pagination.offset + pagination.limit
     return None
+
+
+def _get_group_snapshots(
+    session: Session,
+    group_sample_ids: list[UUID],
+) -> dict[UUID, ImageView | VideoView]:
+    """Get the first sample (image or video) for each group.
+
+    Args:
+        session: Database session for executing queries.
+        group_sample_ids: List of group sample IDs to fetch snapshots for.
+
+    Returns:
+        Dictionary mapping group sample_id to ImageView or VideoView of the first
+        sample in that group. Images are preferred over videos when both exist.
+    """
+    if not group_sample_ids:
+        return {}
+
+    # Import here to avoid circular dependency
+    from lightly_studio.models.group import SampleGroupLinkTable
+
+    # First, try to get images for each group
+    image_query = (
+        select(SampleGroupLinkTable.parent_sample_id, ImageTable)
+        .join(ImageTable, ImageTable.sample_id == SampleGroupLinkTable.sample_id)
+        .join(ImageTable.sample)
+        .options(
+            selectinload(ImageTable.sample).options(
+                joinedload(SampleTable.tags),
+                joinedload(SampleTable.metadata_dict),  # type: ignore[arg-type]
+                selectinload(SampleTable.captions),
+                selectinload(SampleTable.annotations).options(
+                    joinedload(AnnotationBaseTable.annotation_label),
+                    joinedload(AnnotationBaseTable.object_detection_details),
+                    joinedload(AnnotationBaseTable.segmentation_details),
+                ),
+            )
+        )
+        .where(col(SampleGroupLinkTable.parent_sample_id).in_(group_sample_ids))
+        .order_by(col(SampleTable.created_at).asc())
+    )
+
+    image_results = session.exec(image_query).all()
+
+    # Keep only the first image for each group
+    snapshots: dict[UUID, ImageView | VideoView] = {}
+    for parent_sample_id, image in image_results:
+        if parent_sample_id not in snapshots:
+            snapshots[parent_sample_id] = ImageView(
+                sample_id=image.sample_id,
+                file_name=image.file_name,
+                file_path_abs=image.file_path_abs,
+                width=image.width,
+                height=image.height,
+                sample=SampleView.model_validate(image.sample),
+                annotations=[],
+                tags=[],
+                metadata_dict=None,
+                captions=[],
+            )
+
+    # For groups without images, get videos
+    groups_without_images = [gid for gid in group_sample_ids if gid not in snapshots]
+
+    if groups_without_images:
+        video_query = (
+            select(SampleGroupLinkTable.parent_sample_id, VideoTable)
+            .join(VideoTable, VideoTable.sample_id == SampleGroupLinkTable.sample_id)
+            .join(VideoTable.sample)
+            .options(
+                selectinload(VideoTable.sample).options(
+                    joinedload(SampleTable.tags),
+                    joinedload(SampleTable.metadata_dict),  # type: ignore[arg-type]
+                    selectinload(SampleTable.captions),
+                )
+            )
+            .where(col(SampleGroupLinkTable.parent_sample_id).in_(groups_without_images))
+            .order_by(col(SampleTable.created_at).asc())
+        )
+
+        video_results = session.exec(video_query).all()
+
+        # Keep only the first video for each group that doesn't have an image
+        for parent_sample_id, video in video_results:
+            if parent_sample_id not in snapshots:
+                snapshots[parent_sample_id] = VideoView(
+                    sample_id=video.sample_id,
+                    file_name=video.file_name,
+                    file_path_abs=video.file_path_abs,
+                    width=video.width,
+                    height=video.height,
+                    duration_s=video.duration_s,
+                    fps=video.fps,
+                    sample=SampleView.model_validate(video.sample),
+                )
+
+    return snapshots
+
+
+def _get_group_sample_counts(
+    session: Session,
+    group_sample_ids: list[UUID],
+) -> dict[UUID, int]:
+    """Get the count of samples for each group.
+
+    Args:
+        session: Database session for executing queries.
+        group_sample_ids: List of group sample IDs to count samples for.
+
+    Returns:
+        Dictionary mapping group sample_id to the count of samples in that group.
+    """
+    if not group_sample_ids:
+        return {}
+
+    # Import here to avoid circular dependency
+    from lightly_studio.models.group import SampleGroupLinkTable
+
+    # Count samples for each group
+    count_query = (
+        select(
+            SampleGroupLinkTable.parent_sample_id,
+            func.count(SampleGroupLinkTable.sample_id).label("sample_count"),
+        )
+        .where(col(SampleGroupLinkTable.parent_sample_id).in_(group_sample_ids))
+        .group_by(SampleGroupLinkTable.parent_sample_id)
+    )
+
+    results = session.exec(count_query).all()
+
+    return dict(results)

--- a/lightly_studio/tests/resolvers/group_resolver/test_get_all.py
+++ b/lightly_studio/tests/resolvers/group_resolver/test_get_all.py
@@ -15,6 +15,7 @@ from tests.helpers_resolvers import (
     create_images,
     create_tag,
 )
+from tests.resolvers.video.helpers import VideoStub, create_videos
 
 
 def test_get_all__basic(db_session: Session) -> None:
@@ -49,6 +50,15 @@ def test_get_all__basic(db_session: Session) -> None:
     returned_ids = [s.sample_id for s in result.samples]
     assert set(returned_ids) == set(group_ids)
     assert all(s.similarity_score is None for s in result.samples)
+    # Verify group_snapshot is populated
+    assert all(s.group_snapshot is not None for s in result.samples)
+    assert all(s.group_snapshot.type == "image" for s in result.samples)
+    # Verify image details
+    first_sample_paths = {
+        s.group_snapshot.file_path_abs for s in result.samples if s.group_snapshot is not None
+    }
+    expected_paths = {img.file_path_abs for img in front_images}
+    assert first_sample_paths == expected_paths
 
 
 def test_get_all__with_pagination(db_session: Session) -> None:
@@ -81,6 +91,9 @@ def test_get_all__with_pagination(db_session: Session) -> None:
     assert len(result.samples) == 2
     assert result.total_count == 5
     assert result.next_cursor == 2
+    # Verify group_snapshots are populated
+    assert all(s.group_snapshot is not None for s in result.samples)
+    assert all(s.group_snapshot.type == "image" for s in result.samples)
 
 
 def test_get_all__with_filters(db_session: Session) -> None:
@@ -127,6 +140,9 @@ def test_get_all__with_filters(db_session: Session) -> None:
 
     assert len(result.samples) == 2
     assert result.total_count == 2
+    # Verify group_snapshots are populated
+    assert all(s.group_snapshot is not None for s in result.samples)
+    assert all(s.group_snapshot.type == "image" for s in result.samples)
 
 
 def test_get_all__empty(db_session: Session) -> None:
@@ -141,6 +157,7 @@ def test_get_all__empty(db_session: Session) -> None:
 
     assert len(result.samples) == 0
     assert result.total_count == 0
+    # Empty result should have no group_snapshots (no need to check since list is empty)
 
 
 def test_get_all__ordered_by_created_at(db_session: Session) -> None:
@@ -179,3 +196,109 @@ def test_get_all__ordered_by_created_at(db_session: Session) -> None:
     # Verify order matches creation order
     returned_ids = [s.sample_id for s in result.samples]
     assert returned_ids == group_ids
+    # Verify group_snapshots are populated
+    assert all(s.group_snapshot is not None for s in result.samples)
+    assert all(s.group_snapshot.type == "image" for s in result.samples)
+
+
+def test_get_all__with_videos(db_session: Session) -> None:
+    """Test retrieval with video samples."""
+    group_col = create_collection(session=db_session, sample_type=SampleType.GROUP)
+    components = collection_resolver.create_group_components(
+        session=db_session,
+        parent_collection_id=group_col.collection_id,
+        components=[("front", SampleType.VIDEO)],
+    )
+
+    front_video_stubs = [VideoStub(path="front_0.mp4"), VideoStub(path="front_1.mp4")]
+    front_video_ids = create_videos(
+        session=db_session,
+        collection_id=components["front"].collection_id,
+        videos=front_video_stubs,
+    )
+
+    group_ids = group_resolver.create_many(
+        session=db_session,
+        collection_id=group_col.collection_id,
+        groups=[{front_video_ids[0]}, {front_video_ids[1]}],
+    )
+
+    result = group_resolver.get_all(
+        session=db_session,
+        pagination=None,
+        filters=GroupFilter(sample_filter=SampleFilter(collection_id=group_col.collection_id)),
+    )
+
+    assert len(result.samples) == 2
+    assert result.total_count == 2
+    returned_ids = [s.sample_id for s in result.samples]
+    assert set(returned_ids) == set(group_ids)
+    # Verify group_snapshots are populated with videos
+    assert all(s.group_snapshot is not None for s in result.samples)
+    assert all(s.group_snapshot.type == "video" for s in result.samples)
+    # Verify video details - check that paths match the stubs
+    first_sample_paths = {
+        s.group_snapshot.file_path_abs for s in result.samples if s.group_snapshot is not None
+    }
+    expected_paths = {str(stub.path) for stub in front_video_stubs}
+    assert first_sample_paths == expected_paths
+
+
+def test_get_all__sample_counts(db_session: Session) -> None:
+    """Test that sample_count is correctly populated for each group."""
+    group_col = create_collection(session=db_session, sample_type=SampleType.GROUP)
+    components = collection_resolver.create_group_components(
+        session=db_session,
+        parent_collection_id=group_col.collection_id,
+        components=[
+            ("front", SampleType.IMAGE),
+            ("side", SampleType.IMAGE),
+            ("back", SampleType.IMAGE),
+        ],
+    )
+
+    # Create images for different components
+    front_images = create_images(
+        db_session=db_session,
+        collection_id=components["front"].collection_id,
+        images=[ImageStub(path=f"front_{i}.jpg") for i in range(3)],
+    )
+    side_images = create_images(
+        db_session=db_session,
+        collection_id=components["side"].collection_id,
+        images=[ImageStub(path=f"side_{i}.jpg") for i in range(3)],
+    )
+    back_images = create_images(
+        db_session=db_session,
+        collection_id=components["back"].collection_id,
+        images=[ImageStub(path=f"back_{i}.jpg") for i in range(3)],
+    )
+
+    # Create groups with different numbers of samples from different components:
+    # Group 1: 3 samples (front, side, back)
+    # Group 2: 2 samples (front, side)
+    # Group 3: 1 sample (front)
+    group_ids = group_resolver.create_many(
+        session=db_session,
+        collection_id=group_col.collection_id,
+        groups=[
+            {front_images[0].sample_id, side_images[0].sample_id, back_images[0].sample_id},
+            {front_images[1].sample_id, side_images[1].sample_id},
+            {front_images[2].sample_id},
+        ],
+    )
+
+    result = group_resolver.get_all(
+        session=db_session,
+        pagination=None,
+        filters=GroupFilter(sample_filter=SampleFilter(collection_id=group_col.collection_id)),
+    )
+
+    assert len(result.samples) == 3
+    assert result.total_count == 3
+
+    # Verify sample counts match expected values
+    sample_counts_by_id = {s.sample_id: s.sample_count for s in result.samples}
+    assert sample_counts_by_id[group_ids[0]] == 3
+    assert sample_counts_by_id[group_ids[1]] == 2
+    assert sample_counts_by_id[group_ids[2]] == 1

--- a/lightly_studio/tests/resolvers/group_resolver/test_get_all.py
+++ b/lightly_studio/tests/resolvers/group_resolver/test_get_all.py
@@ -51,8 +51,9 @@ def test_get_all__basic(db_session: Session) -> None:
     assert set(returned_ids) == set(group_ids)
     assert all(s.similarity_score is None for s in result.samples)
     # Verify group_snapshot is populated
-    assert all(s.group_snapshot is not None for s in result.samples)
-    assert all(s.group_snapshot.type == "image" for s in result.samples)
+    for sample in result.samples:
+        assert sample.group_snapshot is not None
+        assert sample.group_snapshot.type == "image"
     # Verify image details
     first_sample_paths = {
         s.group_snapshot.file_path_abs for s in result.samples if s.group_snapshot is not None
@@ -92,8 +93,9 @@ def test_get_all__with_pagination(db_session: Session) -> None:
     assert result.total_count == 5
     assert result.next_cursor == 2
     # Verify group_snapshots are populated
-    assert all(s.group_snapshot is not None for s in result.samples)
-    assert all(s.group_snapshot.type == "image" for s in result.samples)
+    for sample in result.samples:
+        assert sample.group_snapshot is not None
+        assert sample.group_snapshot.type == "image"
 
 
 def test_get_all__with_filters(db_session: Session) -> None:
@@ -141,8 +143,9 @@ def test_get_all__with_filters(db_session: Session) -> None:
     assert len(result.samples) == 2
     assert result.total_count == 2
     # Verify group_snapshots are populated
-    assert all(s.group_snapshot is not None for s in result.samples)
-    assert all(s.group_snapshot.type == "image" for s in result.samples)
+    for sample in result.samples:
+        assert sample.group_snapshot is not None
+        assert sample.group_snapshot.type == "image"
 
 
 def test_get_all__empty(db_session: Session) -> None:
@@ -197,8 +200,9 @@ def test_get_all__ordered_by_created_at(db_session: Session) -> None:
     returned_ids = [s.sample_id for s in result.samples]
     assert returned_ids == group_ids
     # Verify group_snapshots are populated
-    assert all(s.group_snapshot is not None for s in result.samples)
-    assert all(s.group_snapshot.type == "image" for s in result.samples)
+    for sample in result.samples:
+        assert sample.group_snapshot is not None
+        assert sample.group_snapshot.type == "image"
 
 
 def test_get_all__with_videos(db_session: Session) -> None:
@@ -234,8 +238,9 @@ def test_get_all__with_videos(db_session: Session) -> None:
     returned_ids = [s.sample_id for s in result.samples]
     assert set(returned_ids) == set(group_ids)
     # Verify group_snapshots are populated with videos
-    assert all(s.group_snapshot is not None for s in result.samples)
-    assert all(s.group_snapshot.type == "video" for s in result.samples)
+    for sample in result.samples:
+        assert sample.group_snapshot is not None
+        assert sample.group_snapshot.type == "video"
     # Verify video details - check that paths match the stubs
     first_sample_paths = {
         s.group_snapshot.file_path_abs for s in result.samples if s.group_snapshot is not None


### PR DESCRIPTION
## What has changed and why?

For every group we need to get group snapshot information and sample_count. 

**group snapshot**
It should provide information as image if the first component in the group is image 
It should provide information about video if the first component is video.

## How has it been tested?
By unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
