### PR TITLE
Deprecate old import style for python 3.8

### DIFF
--- a/lightly_studio/ruff.toml
+++ b/lightly_studio/ruff.toml
@@ -45,8 +45,6 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["E", "F", "W", "C90", "I", "N", "D", "UP", "B", "A", "C4", "DTZ", "T10", "PIE", "PT", "RET", "SLF", "SIM", "TID", "ARG", "PL", "RUF"]
-# TODO(Michal, 02/2026): Allows Python 3.8 typings. Remove in a follow-up PR.
-ignore = ["UP006", "UP035"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/lightly_studio/src/lightly_studio/api/app.py
+++ b/lightly_studio/src/lightly_studio/api/app.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 from sqlmodel import Session
-from typing_extensions import Annotated
 
 from lightly_studio import db_manager
 from lightly_studio.api.routes import (

--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path
 from fastapi.params import Query
 from pydantic import BaseModel
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api import annotations as annotations_module
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id

--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation_label.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation_label.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Path
 from pydantic import BaseModel
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_CREATED,

--- a/lightly_studio/src/lightly_studio/api/routes/api/annotations/create_annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotations/create_annotation.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Path
 from fastapi.params import Body
 from pydantic import BaseModel
-from typing_extensions import Annotated
 
 from lightly_studio.db_manager import SessionDep
 from lightly_studio.models.annotation.annotation_base import (

--- a/lightly_studio/src/lightly_studio/api/routes/api/caption.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/caption.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Body, HTTPException, Path
 from pydantic import BaseModel
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND
 from lightly_studio.db_manager import SessionDep

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_CONFLICT,
@@ -43,7 +42,7 @@ def get_and_validate_collection_id(
     return collection
 
 
-@collection_router.get("/collections", response_model=List[CollectionView])
+@collection_router.get("/collections", response_model=list[CollectionView])
 def read_collections(
     session: SessionDep,
     paginated: Annotated[Paginated, Query()],
@@ -64,7 +63,7 @@ def read_dataset(
 
 
 @collection_router.get(
-    "/collections/{collection_id}/hierarchy", response_model=List[CollectionView]
+    "/collections/{collection_id}/hierarchy", response_model=list[CollectionView]
 )
 def read_collection_hierarchy(
     session: SessionDep,
@@ -74,7 +73,7 @@ def read_collection_hierarchy(
     return collection_resolver.get_hierarchy(session=session, dataset_id=collection_id)
 
 
-@collection_router.get("/collections/overview", response_model=List[CollectionOverviewView])
+@collection_router.get("/collections/overview", response_model=list[CollectionOverviewView])
 def read_collections_overview(session: SessionDep) -> list[CollectionOverviewView]:
     """Retrieve collections with metadata for dashboard display."""
     return collection_resolver.get_collections_overview(session=session)

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.api.routes.api.status import (
@@ -64,7 +63,7 @@ def create_tag(
         ) from e
 
 
-@tag_router.get("/collections/{collection_id}/tags", response_model=List[TagView])
+@tag_router.get("/collections/{collection_id}/tags", response_model=list[TagView])
 def read_tags(
     session: SessionDep,
     collection: Annotated[

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -6,12 +6,12 @@ from collections.abc import Generator
 from datetime import datetime, timezone
 from pathlib import Path as PathlibPath
 from tempfile import TemporaryDirectory
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlmodel import Field
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api import collection as collection_api
 from lightly_studio.core.dataset_query.dataset_query import DatasetQuery

--- a/lightly_studio/src/lightly_studio/api/routes/api/frame.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/frame.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Path
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.validators import Paginated, PaginatedWithCursor
 from lightly_studio.db_manager import SessionDep
@@ -123,7 +122,7 @@ def get_frame_by_id(
     return _build_video_frame_view(result)
 
 
-@frame_router.post("/annotations/count", response_model=List[CountAnnotationsView])
+@frame_router.post("/annotations/count", response_model=list[CountAnnotationsView])
 def count_video_frame_annotations(
     session: SessionDep,
     video_frame_collection_id: Annotated[UUID, Path(title="Video collection Id")],

--- a/lightly_studio/src/lightly_studio/api/routes/api/group.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/group.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.validators import Paginated, PaginatedWithCursor
 from lightly_studio.db_manager import SessionDep

--- a/lightly_studio/src/lightly_studio/api/routes/api/image.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/image.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.api.routes.api.status import (

--- a/lightly_studio/src/lightly_studio/api/routes/api/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/image_embedding.py
@@ -7,12 +7,11 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from typing import List
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi import Path as FastAPIPath
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.status import HTTP_STATUS_INTERNAL_SERVER_ERROR
 from lightly_studio.dataset.embedding_manager import (
@@ -30,7 +29,7 @@ EmbeddingManagerDep = Annotated[
 
 
 @image_embedding_router.post(
-    "/image_embedding/from_file/for_collection/{collection_id}", response_model=List[float]
+    "/image_embedding/from_file/for_collection/{collection_id}", response_model=list[float]
 )
 def embed_image_from_file(
     embedding_manager: EmbeddingManagerDep,

--- a/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND
@@ -24,7 +23,7 @@ from lightly_studio.resolvers.metadata_resolver.sample.get_metadata_info import 
 metadata_router = APIRouter(prefix="/collections/{collection_id}", tags=["metadata"])
 
 
-@metadata_router.get("/metadata/info", response_model=List[MetadataInfoView])
+@metadata_router.get("/metadata/info", response_model=list[MetadataInfoView])
 def get_metadata_info(
     session: SessionDep,
     collection_id: Annotated[UUID, Path(title="collection Id")],

--- a/lightly_studio/src/lightly_studio/api/routes/api/sample.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/sample.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_CREATED,

--- a/lightly_studio/src/lightly_studio/api/routes/api/selection.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/selection.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Union
+from typing import Annotated, Union
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.db_manager import SessionDep

--- a/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/text_embedding.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -26,7 +25,7 @@ EmbeddingManagerDep = Annotated[
 
 
 @text_embedding_router.get(
-    "/text_embedding/for_collection/{collection_id}", response_model=List[float]
+    "/text_embedding/for_collection/{collection_id}", response_model=list[float]
 )
 def embed_text(
     embedding_manager: EmbeddingManagerDep,

--- a/lightly_studio/src/lightly_studio/api/routes/api/video.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/video.py
@@ -1,11 +1,10 @@
 """API routes for collection videos."""
 
-from typing import List, Optional
+from typing import Annotated, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Path
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 from lightly_studio.api.routes.api.validators import Paginated, PaginatedWithCursor
 from lightly_studio.db_manager import SessionDep
@@ -25,14 +24,14 @@ video_router = APIRouter(prefix="/collections/{collection_id}/video", tags=["vid
 class VideoFieldsBoundsBody(BaseModel):
     """The body to retrieve the fields bounds."""
 
-    annotations_frames_labels_id: Optional[List[UUID]] = None
+    annotations_frames_labels_id: Optional[list[UUID]] = None
 
 
 class ReadVideosRequest(BaseModel):
     """Request body for reading videos."""
 
     filter: Optional[VideoFilter] = Field(None, description="Filter parameters for videos")
-    text_embedding: Optional[List[float]] = Field(None, description="Text embedding to search for")
+    text_embedding: Optional[list[float]] = Field(None, description="Text embedding to search for")
 
 
 class ReadVideoCountAnnotationsRequest(BaseModel):
@@ -43,12 +42,12 @@ class ReadVideoCountAnnotationsRequest(BaseModel):
     )
 
 
-@video_router.post("/annotations/count", response_model=List[CountAnnotationsView])
+@video_router.post("/annotations/count", response_model=list[CountAnnotationsView])
 def count_video_frame_annotations_by_video_collection(
     session: SessionDep,
     collection_id: Annotated[UUID, Path(title="collection Id")],
     body: ReadVideoCountAnnotationsRequest,
-) -> List[CountAnnotationsView]:
+) -> list[CountAnnotationsView]:
     """Retrieve a list of annotations along with total count and filtered count.
 
     Args:

--- a/lightly_studio/src/lightly_studio/core/dataset.py
+++ b/lightly_studio/src/lightly_studio/core/dataset.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Generic, Iterator
+from collections.abc import Iterator
+from typing import Generic
 from uuid import UUID
 
 from typing_extensions import Self, TypeVar

--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Generic, Iterator, Type, cast
+from collections.abc import Iterator
+from typing import Generic, cast
 
 from sqlmodel import Session, select
 from sqlmodel.sql.expression import SelectOfScalar
@@ -148,7 +149,7 @@ class DatasetQuery(Generic[T]):
         if sample_class is None:
             # TODO(lukas 12/2025): Remove once we introduce ImageDatasetQuery. Right now
             # T=ImageSample is the default, so this is fine.
-            self._sample_class = cast(Type[T], ImageSample)
+            self._sample_class = cast(type[T], ImageSample)
         else:
             self._sample_class = sample_class
 

--- a/lightly_studio/src/lightly_studio/core/image/add_images.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_images.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import json
 import logging
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Literal, cast
+from typing import Literal, cast
 from uuid import UUID
 
 import fsspec

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Iterable
 from uuid import UUID
 
 import yaml

--- a/lightly_studio/src/lightly_studio/core/labelformat_helpers.py
+++ b/lightly_studio/src/lightly_studio/core/labelformat_helpers.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Literal, Protocol
+from collections.abc import Iterable
+from typing import Literal, Protocol
 from uuid import UUID
 
 from labelformat.model.binary_mask_segmentation import BinaryMaskSegmentation

--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, cast
+from typing import cast
 from uuid import UUID
 
 import av

--- a/lightly_studio/src/lightly_studio/core/video/video_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/video/video_dataset.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 from uuid import UUID
 
 from labelformat.formats import (

--- a/lightly_studio/src/lightly_studio/dataset/edge_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/edge_embedding_generator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Tuple
 from uuid import UUID
 
 import cv2
@@ -25,7 +24,7 @@ from lightly_studio.models.embedding_model import EmbeddingModelCreate
 MAX_BATCH_SIZE: int = 1
 
 
-class _ImageFileDatasetEdge(Dataset[Tuple[bytes, int, int]]):
+class _ImageFileDatasetEdge(Dataset[tuple[bytes, int, int]]):
     """Dataset wrapping image file paths for processing."""
 
     def __init__(

--- a/lightly_studio/src/lightly_studio/db_manager.py
+++ b/lightly_studio/src/lightly_studio/db_manager.py
@@ -15,16 +15,16 @@ from __future__ import annotations
 import atexit
 import logging
 import re
+from collections.abc import Generator
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
-from typing import Generator
+from typing import Annotated
 
 from fastapi import Depends
 from sqlalchemy import StaticPool, text
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, SQLModel, create_engine
-from typing_extensions import Annotated
 
 import lightly_studio.api.db_tables  # noqa: F401, required for SQLModel to work properly
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_DATABASE_URL

--- a/lightly_studio/src/lightly_studio/db_vector.py
+++ b/lightly_studio/src/lightly_studio/db_vector.py
@@ -6,7 +6,7 @@ Provides VectorType and cosine_distance that work across both DuckDB and Postgre
 
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any
 
 from sqlalchemy import ARRAY, Float
 from sqlalchemy.engine.interfaces import Dialect
@@ -16,7 +16,7 @@ from sqlalchemy.sql.functions import GenericFunction
 from sqlalchemy.types import TypeDecorator, TypeEngine
 
 
-class VectorType(TypeDecorator[List[float]]):
+class VectorType(TypeDecorator[list[float]]):
     """A dialect-aware vector column type.
 
     Returns pgvector's VECTOR() for PostgreSQL and ARRAY(Float) for DuckDB.

--- a/lightly_studio/src/lightly_studio/export/coco_captions.py
+++ b/lightly_studio/src/lightly_studio/export/coco_captions.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Iterable, TypedDict
+from collections.abc import Iterable
+from typing import TypedDict
 
 from lightly_studio.core.image.image_sample import ImageSample
 

--- a/lightly_studio/src/lightly_studio/export/export_dataset.py
+++ b/lightly_studio/src/lightly_studio/export/export_dataset.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 from uuid import UUID
 
 from labelformat.formats import COCOObjectDetectionOutput

--- a/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
+++ b/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Iterable
+from collections.abc import Iterable
 from uuid import UUID
 
 from labelformat.model.bounding_box import BoundingBox

--- a/lightly_studio/src/lightly_studio/metadata/complex_metadata.py
+++ b/lightly_studio/src/lightly_studio/metadata/complex_metadata.py
@@ -1,12 +1,12 @@
 """Complex metadata types that can be stored in JSON columns."""
 
-from typing import Any, Dict, Type
+from typing import Any
 
 from lightly_studio.metadata.gps_coordinate import GPSCoordinate
 from lightly_studio.metadata.metadata_protocol import ComplexMetadata
 
 # Registry of complex metadata types for automatic serialization/deserialization
-COMPLEX_METADATA_TYPES: Dict[str, Type[ComplexMetadata]] = {
+COMPLEX_METADATA_TYPES: dict[str, type[ComplexMetadata]] = {
     "gps_coordinate": GPSCoordinate,
 }
 

--- a/lightly_studio/src/lightly_studio/metadata/gps_coordinate.py
+++ b/lightly_studio/src/lightly_studio/metadata/gps_coordinate.py
@@ -1,7 +1,5 @@
 """GPS coordinate representation for complex metadata."""
 
-from typing import Dict
-
 
 class GPSCoordinate:
     """Represents a GPS coordinate."""
@@ -20,7 +18,7 @@ class GPSCoordinate:
         """String representation of the GPS coordinate."""
         return f"GPSCoordinate(lat={self.lat}, lon={self.lon})"
 
-    def as_dict(self) -> Dict[str, float]:
+    def as_dict(self) -> dict[str, float]:
         """Convert the GPSCoordinate to a dictionary.
 
         Returns:
@@ -29,7 +27,7 @@ class GPSCoordinate:
         return {"lat": self.lat, "lon": self.lon}
 
     @classmethod
-    def from_dict(cls, data: Dict[str, float]) -> "GPSCoordinate":
+    def from_dict(cls, data: dict[str, float]) -> "GPSCoordinate":
         """Create a GPSCoordinate from a dictionary.
 
         Args:

--- a/lightly_studio/src/lightly_studio/metadata/metadata_protocol.py
+++ b/lightly_studio/src/lightly_studio/metadata/metadata_protocol.py
@@ -1,17 +1,17 @@
 """Protocol for complex metadata types that can be stored in JSON columns."""
 
-from typing import Any, Dict, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class ComplexMetadata(Protocol):
     """Protocol for complex types that can be serialized to/from JSON."""
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         """Convert the complex metadata to a dictionary for JSON storage."""
         ...
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "ComplexMetadata":
+    def from_dict(cls, data: dict[str, Any]) -> "ComplexMetadata":
         """Create the complex metadata from a dictionary."""
         ...

--- a/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
+++ b/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
@@ -3,7 +3,7 @@
 from abc import ABC
 from datetime import datetime, timezone
 from enum import Enum
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -105,7 +105,7 @@ class AnnotationCreate(ABC, SQLModel):
     height: Optional[int] = None
 
     """ Optional properties for instance and semantic segmentation. """
-    segmentation_mask: Optional[List[int]] = None
+    segmentation_mask: Optional[list[int]] = None
 
 
 class AnnotationView(BaseModel):
@@ -134,7 +134,7 @@ class AnnotationView(BaseModel):
     object_detection_details: Optional[ObjectDetectionAnnotationView] = None
     segmentation_details: Optional[SegmentationAnnotationView] = None
 
-    tags: List[AnnotationViewTag] = []
+    tags: list[AnnotationViewTag] = []
 
     @classmethod
     def from_annotation_table(cls, annotation: "AnnotationBaseTable") -> "AnnotationView":
@@ -176,7 +176,7 @@ class AnnotationViewsWithCount(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    annotations: List[AnnotationView] = PydanticField(..., alias="data")
+    annotations: list[AnnotationView] = PydanticField(..., alias="data")
     total_count: int
     next_cursor: Optional[int] = PydanticField(..., alias="nextCursor")
 
@@ -233,7 +233,7 @@ class AnnotationWithPayloadAndCountView(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    annotations: List[AnnotationWithPayloadView] = PydanticField(..., alias="data")
+    annotations: list[AnnotationWithPayloadView] = PydanticField(..., alias="data")
     total_count: int
     next_cursor: Optional[int] = PydanticField(None, alias="nextCursor")
 
@@ -243,7 +243,7 @@ class SampleAnnotationDetailsView(BaseModel):
 
     sample_id: UUID
     collection_id: UUID
-    tags: List["TagTable"] = []
+    tags: list["TagTable"] = []
 
     @classmethod
     def from_sample_table(cls, sample: SampleTable) -> "SampleAnnotationDetailsView":

--- a/lightly_studio/src/lightly_studio/models/annotation/segmentation.py
+++ b/lightly_studio/src/lightly_studio/models/annotation/segmentation.py
@@ -4,7 +4,7 @@ Instance segmentation combines object detection and semantic segmentation,
 identifying objects and providing pixel-level masks for each instance.
 """
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 from uuid import UUID, uuid4
 
 from sqlalchemy import ARRAY, Column, Integer
@@ -41,7 +41,7 @@ class SegmentationAnnotationTable(SQLModel, table=True):
     # TODO(Kondrat 06/2025): We need to fix logic in the loader,
     # because it shouldn't be optional.
     # lightly_studio/collection/loader.py#L148
-    segmentation_mask: Optional[List[int]] = Field(
+    segmentation_mask: Optional[list[int]] = Field(
         default=None, sa_column=Column(ARRAY(Integer), nullable=True)
     )
 
@@ -53,4 +53,4 @@ class SegmentationAnnotationView(SQLModel):
     y: int
     width: int
     height: int
-    segmentation_mask: Optional[List[int]] = None
+    segmentation_mask: Optional[list[int]] = None

--- a/lightly_studio/src/lightly_studio/models/annotation_label.py
+++ b/lightly_studio/src/lightly_studio/models/annotation_label.py
@@ -1,7 +1,6 @@
 """This module defines the AnnotationLabel model for the application."""
 
 from datetime import datetime, timezone
-from typing import List
 from uuid import UUID, uuid4
 
 from sqlalchemy.orm import Mapped
@@ -44,6 +43,6 @@ class AnnotationLabelTable(AnnotationLabelBase, table=True):
         default_factory=lambda: datetime.now(timezone.utc),
         index=True,
     )
-    annotations: Mapped[List["AnnotationBaseTable"]] = Relationship(
+    annotations: Mapped[list["AnnotationBaseTable"]] = Relationship(
         back_populates="annotation_label",
     )

--- a/lightly_studio/src/lightly_studio/models/collection.py
+++ b/lightly_studio/src/lightly_studio/models/collection.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 from uuid import UUID, uuid4
 
 from sqlalchemy import UniqueConstraint
@@ -48,7 +48,7 @@ class CollectionView(CollectionBase):
     collection_id: UUID
     created_at: datetime
     updated_at: datetime
-    children: List["CollectionView"] = []
+    children: list["CollectionView"] = []
 
 
 class CollectionViewWithCount(CollectionView):
@@ -79,7 +79,7 @@ class CollectionTable(CollectionBase, table=True):
         back_populates="children",
         sa_relationship_kwargs={"remote_side": "CollectionTable.collection_id"},
     )
-    children: List["CollectionTable"] = Relationship(
+    children: list["CollectionTable"] = Relationship(
         back_populates="parent",
         sa_relationship_kwargs={"lazy": "select"},
     )

--- a/lightly_studio/src/lightly_studio/models/group.py
+++ b/lightly_studio/src/lightly_studio/models/group.py
@@ -1,6 +1,6 @@
 """Group table definition."""
 
-from typing import List, Optional
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -45,6 +45,6 @@ class GroupViewsWithCount(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    samples: List[GroupView] = PydanticField(..., alias="data")
+    samples: list[GroupView] = PydanticField(..., alias="data")
     total_count: int
     next_cursor: Optional[int] = PydanticField(None, alias="nextCursor")

--- a/lightly_studio/src/lightly_studio/models/image.py
+++ b/lightly_studio/src/lightly_studio/models/image.py
@@ -1,7 +1,7 @@
 """This module defines the User model for the application."""
 
 from datetime import datetime, timezone
-from typing import List, Literal, Optional
+from typing import Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -68,16 +68,16 @@ class ImageView(BaseModel):
     file_name: str
     file_path_abs: str
     sample_id: UUID
-    annotations: List["AnnotationView"]
+    annotations: list["AnnotationView"]
     width: int
     height: int
 
     sample: SampleView
 
     # TODO(Michal, 10/2025): Add SampleView to ImageView, don't expose these fields directly.
-    tags: List[ImageViewTag]
+    tags: list[ImageViewTag]
     metadata_dict: Optional["SampleMetadataView"] = None
-    captions: List[CaptionView] = []
+    captions: list[CaptionView] = []
     similarity_score: Optional[float] = None
 
 
@@ -86,6 +86,6 @@ class ImageViewsWithCount(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    samples: List[ImageView] = PydanticField(..., alias="data")
+    samples: list[ImageView] = PydanticField(..., alias="data")
     total_count: int
     next_cursor: Optional[int] = PydanticField(None, alias="nextCursor")

--- a/lightly_studio/src/lightly_studio/models/sample.py
+++ b/lightly_studio/src/lightly_studio/models/sample.py
@@ -1,7 +1,7 @@
 """This module defines the Sample model for the application."""
 
 from datetime import datetime, timezone
-from typing import Any, List, Optional
+from typing import Any, Optional
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict
@@ -40,19 +40,19 @@ class SampleTable(SampleBase, table=True):
         default_factory=lambda: datetime.now(timezone.utc),
     )
 
-    tags: Mapped[List["TagTable"]] = Relationship(
+    tags: Mapped[list["TagTable"]] = Relationship(
         back_populates="samples", link_model=SampleTagLinkTable
     )
-    embeddings: Mapped[List["SampleEmbeddingTable"]] = Relationship(back_populates="sample")
+    embeddings: Mapped[list["SampleEmbeddingTable"]] = Relationship(back_populates="sample")
     metadata_dict: "SampleMetadataTable" = Relationship(back_populates="sample")
-    annotations: Mapped[List["AnnotationBaseTable"]] = Relationship(
+    annotations: Mapped[list["AnnotationBaseTable"]] = Relationship(
         back_populates="parent_sample",
         sa_relationship_kwargs={
             "lazy": "select",
             "foreign_keys": "[AnnotationBaseTable.parent_sample_id]",
         },
     )
-    captions: Mapped[List["CaptionTable"]] = Relationship(
+    captions: Mapped[list["CaptionTable"]] = Relationship(
         back_populates="parent_sample",
         sa_relationship_kwargs={
             "foreign_keys": "[CaptionTable.parent_sample_id]",
@@ -117,10 +117,10 @@ class SampleView(SampleBase):
     created_at: datetime
     updated_at: datetime
 
-    tags: List["TagTable"] = []
+    tags: list["TagTable"] = []
     metadata_dict: Optional["SampleMetadataView"] = None
-    captions: List["CaptionView"] = []
-    annotations: List["AnnotationView"] = []
+    captions: list["CaptionView"] = []
+    annotations: list["AnnotationView"] = []
 
 
 class SampleViewsWithCount(BaseModel):
@@ -128,7 +128,7 @@ class SampleViewsWithCount(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    samples: List[SampleView] = PydanticField(..., alias="data")
+    samples: list[SampleView] = PydanticField(..., alias="data")
     total_count: int
     next_cursor: Optional[int] = PydanticField(None, alias="nextCursor")
 

--- a/lightly_studio/src/lightly_studio/models/tag.py
+++ b/lightly_studio/src/lightly_studio/models/tag.py
@@ -1,7 +1,7 @@
 """This module contains the Tag model and related enumerations."""
 
 from datetime import datetime, timezone
-from typing import List, Literal, Optional
+from typing import Literal, Optional
 from uuid import UUID, uuid4
 
 from sqlalchemy import UniqueConstraint
@@ -71,7 +71,7 @@ class TagTable(TagBase, table=True):
     )
 
     """The sample ids associated with the tag."""
-    samples: Mapped[List["SampleTable"]] = Relationship(
+    samples: Mapped[list["SampleTable"]] = Relationship(
         back_populates="tags",
         link_model=SampleTagLinkTable,
     )

--- a/lightly_studio/src/lightly_studio/models/video.py
+++ b/lightly_studio/src/lightly_studio/models/video.py
@@ -1,6 +1,6 @@
 """This module defines the Video and VideoFrame model for the application."""
 
-from typing import List, Optional
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -43,7 +43,7 @@ class VideoTable(VideoBase, table=True):
 
     __tablename__ = "video"
     sample_id: UUID = Field(foreign_key="sample.sample_id", primary_key=True)
-    frames: Mapped[List["VideoFrameTable"]] = Relationship(
+    frames: Mapped[list["VideoFrameTable"]] = Relationship(
         sa_relationship_kwargs={"lazy": "select"}, back_populates="video"
     )
     sample: Mapped["SampleTable"] = Relationship()
@@ -69,7 +69,7 @@ class VideoViewsWithCount(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    samples: List[VideoView] = PydanticField(..., alias="data")
+    samples: list[VideoView] = PydanticField(..., alias="data")
     total_count: int
     next_cursor: Optional[int] = PydanticField(None, alias="nextCursor")
 
@@ -134,7 +134,7 @@ class VideoFrameViewsWithCount(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    samples: List[VideoFrameView] = PydanticField(..., alias="data")
+    samples: list[VideoFrameView] = PydanticField(..., alias="data")
     total_count: int
     next_cursor: Optional[int] = PydanticField(None, alias="nextCursor")
 

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/get_by_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/get_by_ids.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 from uuid import UUID
 
 from sqlmodel import Session, col, select

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/names_by_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/names_by_ids.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 from uuid import UUID
 
 from sqlmodel import Session

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/create_group_components.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/create_group_components.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Tuple
 from uuid import UUID
 
 from sqlmodel import Session
@@ -13,7 +12,7 @@ from lightly_studio.models.collection import CollectionCreate, CollectionTable, 
 from lightly_studio.resolvers import collection_resolver
 
 # Define a type alias for group component definitions as (component_name, component_type)
-GroupComponentDefinition: TypeAlias = Tuple[str, SampleType]
+GroupComponentDefinition: TypeAlias = tuple[str, SampleType]
 
 
 def create_group_components(

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/json_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/json_utils.py
@@ -5,8 +5,6 @@ from JSON columns, dispatching to the correct syntax based on the active
 database backend (DuckDB ``json_extract()`` vs PostgreSQL ``->>``/``->``).
 """
 
-from typing import List
-
 from lightly_studio import db_manager
 from lightly_studio.db_manager import DatabaseBackend
 
@@ -72,7 +70,7 @@ def _build_pg_json_accessor(column: str, field: str, *, cast_to_float: bool = Fa
     # Split on '.' but keep bracket notation (e.g. "nested_list[0]" -> "nested_list", "[0]")
     parts = field.replace("[", ".[").split(".")
 
-    accessors: List[str] = []
+    accessors: list[str] = []
     for i, part in enumerate(parts):
         is_last = i == len(parts) - 1
         op = "->>" if is_last else "->"

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
@@ -3,7 +3,7 @@
 import contextlib
 import json
 import re
-from typing import Any, Dict, List, Literal, Protocol, Type, TypeVar
+from typing import Any, Literal, Protocol, TypeVar
 
 from pydantic import BaseModel
 from sqlalchemy import text
@@ -24,8 +24,8 @@ MetadataOperator = Literal[">", "<", "==", ">=", "<=", "!="]
 class HasMetadata(Protocol):
     """Protocol for models that have metadata."""
 
-    data: Dict[str, Any]
-    metadata_schema: Dict[str, str]
+    data: dict[str, Any]
+    metadata_schema: dict[str, str]
 
 
 class MetadataFilter(BaseModel):
@@ -95,9 +95,9 @@ def _sanitize_param_name(field: str) -> str:
 
 def apply_metadata_filters(
     query: QueryType,
-    metadata_filters: List[MetadataFilter],
+    metadata_filters: list[MetadataFilter],
     *,
-    metadata_model: Type[M],
+    metadata_model: type[M],
     metadata_join_condition: Any,
 ) -> QueryType:
     """Apply metadata filters to a query.

--- a/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
@@ -1,6 +1,6 @@
 """SampleFilter class."""
 
-from typing import List, Optional
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -20,10 +20,10 @@ class SampleFilter(BaseModel):
     """Encapsulates filter parameters for querying samples."""
 
     collection_id: Optional[UUID] = None
-    annotation_label_ids: Optional[List[UUID]] = None
-    tag_ids: Optional[List[UUID]] = None
-    metadata_filters: Optional[List[MetadataFilter]] = None
-    sample_ids: Optional[List[UUID]] = None
+    annotation_label_ids: Optional[list[UUID]] = None
+    tag_ids: Optional[list[UUID]] = None
+    metadata_filters: Optional[list[MetadataFilter]] = None
+    sample_ids: Optional[list[UUID]] = None
     has_captions: Optional[bool] = None
 
     def apply(self, query: QueryType) -> QueryType:

--- a/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/count_video_frames_annotations.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/count_video_frames_annotations.py
@@ -1,6 +1,6 @@
 """Count video frames annotations."""
 
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 from uuid import UUID
 
 from sqlmodel import Session, asc, col, func, select
@@ -22,7 +22,7 @@ def count_video_frames_annotations(
     session: Session,
     collection_id: UUID,
     filters: Optional[VideoFrameAnnotationsCounterFilter] = None,
-) -> List[CountAnnotationsView]:
+) -> list[CountAnnotationsView]:
     """Count the annotations by video frames."""
     unfiltered_query = (
         _build_base_query(collection_id=collection_id, count_column_name="total")
@@ -71,7 +71,7 @@ def count_video_frames_annotations(
     ]
 
 
-def _build_base_query(collection_id: UUID, count_column_name: str) -> Select[Tuple[Any, int]]:
+def _build_base_query(collection_id: UUID, count_column_name: str) -> Select[tuple[Any, int]]:
     return (
         select(
             col(AnnotationBaseTable.annotation_label_id).label("label_id"),

--- a/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/video_frame_annotations_counter_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/video_frame_annotations_counter_filter.py
@@ -1,6 +1,6 @@
 """Utility functions for building database queries."""
 
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 from sqlmodel import col, select
@@ -16,7 +16,7 @@ class VideoFrameAnnotationsCounterFilter(BaseModel):
     """Encapsulates filter parameters for querying video frame annotations counter."""
 
     video_filter: Optional[VideoFrameFilter] = None
-    annotations_labels: Optional[List[str]] = None
+    annotations_labels: Optional[list[str]] = None
 
     def apply(self, query: QueryType) -> QueryType:
         """Apply the filters to the given query."""

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/count_video_frame_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/count_video_frame_annotations_by_collection.py
@@ -1,6 +1,6 @@
 """Count video frame annotations by video collection."""
 
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -26,7 +26,7 @@ class CountAnnotationsView(BaseModel):
 
 def count_video_frame_annotations_by_video_collection(
     session: Session, collection_id: UUID, filters: Optional[VideoCountAnnotationsFilter] = None
-) -> List[CountAnnotationsView]:
+) -> list[CountAnnotationsView]:
     """Count the annotations by video frames."""
     unfiltered_query = (
         _build_base_query(collection_id=collection_id, count_column_name="total")
@@ -71,7 +71,7 @@ def count_video_frame_annotations_by_video_collection(
     ]
 
 
-def _build_base_query(collection_id: UUID, count_column_name: str) -> Select[Tuple[Any, int]]:
+def _build_base_query(collection_id: UUID, count_column_name: str) -> Select[tuple[Any, int]]:
     return (
         select(
             col(AnnotationBaseTable.annotation_label_id).label("label_id"),

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/video_count_annotations_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/video_count_annotations_filter.py
@@ -1,6 +1,6 @@
 """Utility functions for building database queries."""
 
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 from sqlmodel import col, select
@@ -16,7 +16,7 @@ class VideoCountAnnotationsFilter(BaseModel):
     """Encapsulates filter parameters for querying video frame annotations counter."""
 
     video_filter: Optional[VideoFilter] = None
-    video_frames_annotations_labels: Optional[List[str]] = None
+    video_frames_annotations_labels: Optional[list[str]] = None
 
     def apply(self, query: QueryType) -> QueryType:
         """Apply the filters to the given query."""

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/video_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/video_filter.py
@@ -1,6 +1,6 @@
 """Utility functions for building database queries."""
 
-from typing import List, Optional
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -21,7 +21,7 @@ class VideoFilter(BaseModel):
     height: Optional[FilterDimensions] = None
     fps: Optional[FloatRange] = None
     duration_s: Optional[FloatRange] = None
-    annotation_frames_label_ids: Optional[List[UUID]] = None
+    annotation_frames_label_ids: Optional[list[UUID]] = None
     sample_filter: Optional[SampleFilter] = None
 
     def apply(self, query: QueryType) -> QueryType:

--- a/lightly_studio/src/lightly_studio/selection/mundig.py
+++ b/lightly_studio/src/lightly_studio/selection/mundig.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 # TODO(Malte, 08/2025): About the type ignore:
 # Use pyo3 typing stubs once they are implemented.

--- a/lightly_studio/src/lightly_studio/selection/select_via_db.py
+++ b/lightly_studio/src/lightly_studio/selection/select_via_db.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 import logging
 from collections import Counter, defaultdict
-from typing import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from uuid import UUID, uuid4
 
 import numpy as np

--- a/lightly_studio/src/lightly_studio/selection/selection_config.py
+++ b/lightly_studio/src/lightly_studio/selection/selection_config.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Dict, Literal, Sequence
+from collections.abc import Sequence
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel
 
 AnnotationsClassName = str
-AnnotationClassToTarget = Dict[AnnotationsClassName, float]
+AnnotationClassToTarget = dict[AnnotationsClassName, float]
 
 
 class SelectionConfig(BaseModel):

--- a/lightly_studio/src/lightly_studio/type_definitions.py
+++ b/lightly_studio/src/lightly_studio/type_definitions.py
@@ -1,7 +1,7 @@
 """Common type definitions for the lightly_studio package."""
 
 from pathlib import Path
-from typing import Any, Tuple, TypeVar, Union
+from typing import Any, TypeVar, Union
 from uuid import UUID
 
 from sqlmodel.sql.expression import Select, SelectOfScalar
@@ -23,14 +23,14 @@ QueryType = TypeVar(
     SelectOfScalar[SampleTable],
     SelectOfScalar[SampleEmbeddingTable],
     SelectOfScalar[GroupTable],
-    Select[Tuple[VideoTable, VideoFrameTable]],
+    Select[tuple[VideoTable, VideoFrameTable]],
     SelectOfScalar[VideoFrameTable],
-    Select[Tuple[Any, int]],
-    Select[Tuple[UUID, int]],
-    Select[Tuple[AnnotationBaseTable, Any]],
-    Select[Tuple[ImageTable, float]],
-    Select[Tuple[GroupTable, float]],
-    Select[Tuple[VideoTable, VideoFrameTable, float]],
+    Select[tuple[Any, int]],
+    Select[tuple[UUID, int]],
+    Select[tuple[AnnotationBaseTable, Any]],
+    Select[tuple[ImageTable, float]],
+    Select[tuple[GroupTable, float]],
+    Select[tuple[VideoTable, VideoFrameTable, float]],
 )
 
 PathLike = Union[str, Path]

--- a/lightly_studio/src/lightly_studio/utils/video_annotations_helpers.py
+++ b/lightly_studio/src/lightly_studio/utils/video_annotations_helpers.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import json
 from argparse import ArgumentParser
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 from uuid import UUID
 
 import tqdm

--- a/lightly_studio/tests/api/routes/api/test_operator.py
+++ b/lightly_studio/tests/api/routes/api/test_operator.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Any, Generator
+from typing import Any
 from uuid import UUID
 
 import pytest

--- a/lightly_studio/tests/api/routes/api/test_text_embedding.py
+++ b/lightly_studio/tests/api/routes/api/test_text_embedding.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 from uuid import uuid4
 
 from fastapi.testclient import TestClient

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any, Generator
+from collections.abc import Generator, Sequence
+from typing import Any
 from uuid import UUID
 
 import pytest

--- a/lightly_studio/tests/core/test_labelformat_helpers.py
+++ b/lightly_studio/tests/core/test_labelformat_helpers.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 from uuid import uuid4
 
 from labelformat.model.binary_mask_segmentation import BinaryMaskSegmentation

--- a/lightly_studio/tests/dataset/test_fsspec_lister.py
+++ b/lightly_studio/tests/dataset/test_fsspec_lister.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 import boto3
 import fsspec

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 from uuid import UUID
 
 import pytest


### PR DESCRIPTION
## What has changed and why?

Deprecated old import style for python 3.8. Completely automated change by ruff.

## How has it been tested?

CI

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
