### PR TITLE
Use PaintRoller as Icon for SemSeg Labeling

### DIFF
--- a/lightly_studio_view/src/lib/components/SampleDetails/SemanticBrushToolbarButton/SemanticBrushToolbarButton.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SemanticBrushToolbarButton/SemanticBrushToolbarButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { PenTool } from '@lucide/svelte';
+    import { PaintRoller } from '@lucide/svelte';
 
     type Props = { onclick: () => void; isActive?: boolean };
 
@@ -15,7 +15,7 @@
         focus:outline-none
                 ${isActive ? 'bg-black/40' : 'hover:bg-black/20'}`}
 >
-    <PenTool
+    <PaintRoller
         class={`size-4 transition-colors ${isActive ? 'text-primary' : ''} hover:text-primary`}
     />
 </button>


### PR DESCRIPTION
## What has changed and why?

use paint roller for SemanticSegmentation laebling icon in the toolbar.

## How has it been tested?

not required

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
