### PR TITLE
feat: introduce groups_resolver.get_view_by_id

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/group_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/group_resolver/__init__.py
@@ -3,6 +3,9 @@ from lightly_studio.resolvers.group_resolver.get_all import (
     get_all,
 )
 from lightly_studio.resolvers.group_resolver.get_by_id import get_by_id
+from lightly_studio.resolvers.group_resolver.get_collection_id_by_group import (
+    get_collection_id_by_group,
+)
 from lightly_studio.resolvers.group_resolver.get_group_component_with_type import (
     get_group_component_with_type,
 )
@@ -13,13 +16,16 @@ from lightly_studio.resolvers.group_resolver.get_group_previews import get_group
 from lightly_studio.resolvers.group_resolver.get_group_sample_counts import (
     get_group_sample_counts,
 )
+from lightly_studio.resolvers.group_resolver.get_view_by_id import get_view_by_id
 
 __all__ = [
     "create_many",
     "get_all",
     "get_by_id",
+    "get_collection_id_by_group",
     "get_group_component_with_type",
     "get_group_components_as_dict",
     "get_group_previews",
     "get_group_sample_counts",
+    "get_view_by_id",
 ]

--- a/lightly_studio/src/lightly_studio/resolvers/group_resolver/get_view_by_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/group_resolver/get_view_by_id.py
@@ -1,0 +1,49 @@
+"""Implementation of get_samples_excluding function for images."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.models.group import GroupView
+from lightly_studio.models.sample import SampleView
+from lightly_studio.resolvers import group_resolver
+
+
+def get_view_by_id(session: Session, sample_id: UUID) -> GroupView:
+    """Get the view for a given sample_id.
+
+    Args:
+        session: The database session.
+        sample_id: The ID of the group to retrieve.
+
+    Returns:
+        The view for the given group.
+    """
+    group = group_resolver.get_by_id(session, sample_id)
+
+    if group is None:
+        raise ValueError(f"Group with sample_id '{sample_id}' not found.")
+
+    group_collection_id = group_resolver.get_collection_id_by_group(
+        session=session, sample_id=group.sample_id
+    )
+    if group_collection_id is None:
+        raise ValueError(f"Collection not found for group with sample_id '{sample_id}'.")
+
+    group_previews = group_resolver.get_group_previews(
+        session=session,
+        group_sample_ids=[group.sample_id],
+        group_collection_id=group_collection_id,
+    )
+    group_sample_counts = group_resolver.get_group_sample_counts(
+        session=session, group_sample_ids=[group.sample_id]
+    )
+    return GroupView(
+        sample_id=group.sample_id,
+        sample=SampleView.model_validate(group.sample),
+        similarity_score=None,
+        group_preview=group_previews.get(group.sample_id),
+        sample_count=group_sample_counts.get(group.sample_id, 0),
+    )

--- a/lightly_studio/tests/resolvers/group_resolver/test_get_view_by_id.py
+++ b/lightly_studio/tests/resolvers/group_resolver/test_get_view_by_id.py
@@ -1,0 +1,128 @@
+"""Tests for group_resolver.get_view_by_id."""
+
+from uuid import uuid4
+
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.group import GroupView
+from lightly_studio.resolvers import collection_resolver, group_resolver
+from tests.helpers_resolvers import ImageStub, create_collection, create_images
+
+
+def test_get_view_by_id_basic(db_session: Session) -> None:
+    """Test getting view for a group."""
+    # Create collections
+    group_col = create_collection(session=db_session, sample_type=SampleType.GROUP)
+    components = collection_resolver.create_group_components(
+        session=db_session,
+        parent_collection_id=group_col.collection_id,
+        components=[("front", SampleType.IMAGE)],
+    )
+
+    # Create component sample
+    front_image = create_images(
+        db_session=db_session,
+        collection_id=components["front"].collection_id,
+        images=[ImageStub(path="front_0.jpg")],
+    )[0]
+
+    # Create a group
+    group_id = group_resolver.create_many(
+        session=db_session,
+        collection_id=group_col.collection_id,
+        groups=[{front_image.sample_id}],
+    )[0]
+
+    # Call get_view_by_id
+    result = group_resolver.get_view_by_id(session=db_session, sample_id=group_id)
+
+    # Verify results
+    assert isinstance(result, GroupView)
+    assert result.sample_id == group_id
+    assert result.sample.sample_id == group_id
+    assert result.sample.collection_id == group_col.collection_id
+    assert result.sample_count == 1
+    assert result.similarity_score is None
+
+
+def test_get_view_by_id_with_multiple_components(db_session: Session) -> None:
+    """Test getting view for a group with multiple components."""
+    # Create collections
+    group_col = create_collection(session=db_session, sample_type=SampleType.GROUP)
+    components = collection_resolver.create_group_components(
+        session=db_session,
+        parent_collection_id=group_col.collection_id,
+        components=[("front", SampleType.IMAGE), ("back", SampleType.IMAGE)],
+    )
+
+    # Create component samples
+    front_image = create_images(
+        db_session=db_session,
+        collection_id=components["front"].collection_id,
+        images=[ImageStub(path="front_0.jpg")],
+    )[0]
+    back_image = create_images(
+        db_session=db_session,
+        collection_id=components["back"].collection_id,
+        images=[ImageStub(path="back_0.jpg")],
+    )[0]
+
+    # Create a group
+    group_id = group_resolver.create_many(
+        session=db_session,
+        collection_id=group_col.collection_id,
+        groups=[{front_image.sample_id, back_image.sample_id}],
+    )[0]
+
+    # Call get_view_by_id
+    result = group_resolver.get_view_by_id(session=db_session, sample_id=group_id)
+
+    # Verify results
+    assert isinstance(result, GroupView)
+    assert result.sample_id == group_id
+    assert result.sample_count == 2
+    assert result.group_preview is not None
+
+
+def test_get_view_by_id_non_existent_group(db_session: Session) -> None:
+    """Test getting view for a non-existent group raises ValueError."""
+    non_existent_id = uuid4()
+
+    with pytest.raises(ValueError, match=f"Group with sample_id '{non_existent_id}' not found"):
+        group_resolver.get_view_by_id(session=db_session, sample_id=non_existent_id)
+
+
+def test_get_view_by_id_partial_group(db_session: Session) -> None:
+    """Test getting view for a partial group (not all components present)."""
+    # Create collections
+    group_col = create_collection(session=db_session, sample_type=SampleType.GROUP)
+    components = collection_resolver.create_group_components(
+        session=db_session,
+        parent_collection_id=group_col.collection_id,
+        components=[("front", SampleType.IMAGE), ("back", SampleType.IMAGE)],
+    )
+
+    # Create only front component sample (partial group)
+    front_image = create_images(
+        db_session=db_session,
+        collection_id=components["front"].collection_id,
+        images=[ImageStub(path="front_0.jpg")],
+    )[0]
+
+    # Create a partial group
+    group_id = group_resolver.create_many(
+        session=db_session,
+        collection_id=group_col.collection_id,
+        groups=[{front_image.sample_id}],
+    )[0]
+
+    # Call get_view_by_id
+    result = group_resolver.get_view_by_id(session=db_session, sample_id=group_id)
+
+    # Verify results - sample_count should be 1 (only front component)
+    assert isinstance(result, GroupView)
+    assert result.sample_id == group_id
+    assert result.sample_count == 1
+    assert result.group_preview is not None


### PR DESCRIPTION
## What has changed and why?

This PR introduces functionality to return GroupView information

NOTE:
It requires
https://github.com/lightly-ai/lightly-studio/pull/650

## How has it been tested?

By unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
