### PR TITLE
Fix: Rename subsection from Metadata Filters to Metadata

### DIFF
--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/CombinedMetadataDimensionsFilters.svelte
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/CombinedMetadataDimensionsFilters.svelte
@@ -79,7 +79,7 @@
     });
 </script>
 
-<Segment title="Metadata Filters">
+<Segment title="Metadata">
     <div class="space-y-4">
         {#if !isVideos && !isVideoFrames}
             <!-- Dimension Filters -->


### PR DESCRIPTION
## What has changed and why?

- Simple rename from 'Metadata Filters' to 'Metadata'

Before:
<img width="594" height="598" alt="image" src="https://github.com/user-attachments/assets/79a7ac0f-ced0-480a-91d4-6dac285552b3" />

After:
<img width="630" height="607" alt="image" src="https://github.com/user-attachments/assets/02de3bfa-10d8-4fd8-87a5-3210e4b7ba7f" />


## How has it been tested?

No need for testing

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)
