### PR TITLE
Show group component names in the menu

### DIFF
--- a/lightly_studio_view/src/lib/components/NavigationMenu/utils.ts
+++ b/lightly_studio_view/src/lib/components/NavigationMenu/utils.ts
@@ -5,16 +5,17 @@ import { Image, WholeWord, Video, Frame, ComponentIcon, LayoutDashboard } from '
 import type { BreadcrumbLevel, NavigationMenuItem } from './types';
 
 export function getMenuItem(
-    sampleType: SampleType,
     pageId: string | null,
     datasetId: string,
-    collectionType: string,
-    collectionId: string
+    collectionId: string,
+    sampleType: SampleType,
+    groupComponentName?: string | null
 ): NavigationMenuItem {
+    const collectionType = sampleType.toLowerCase();
     switch (sampleType) {
         case SampleType.IMAGE:
             return {
-                title: 'Images',
+                title: groupComponentName || 'Images',
                 id: `samples-${collectionId}`,
                 href: routeHelpers.toSamples(datasetId, collectionType, collectionId),
                 isSelected: pageId === APP_ROUTES.samples || pageId === APP_ROUTES.sampleDetails,
@@ -23,7 +24,7 @@ export function getMenuItem(
 
         case SampleType.VIDEO:
             return {
-                title: 'Videos',
+                title: groupComponentName || 'Videos',
                 id: `videos-${collectionId}`,
                 href: routeHelpers.toVideos(datasetId, collectionType, collectionId),
                 isSelected: pageId === APP_ROUTES.videos || pageId === APP_ROUTES.videoDetails,
@@ -31,7 +32,7 @@ export function getMenuItem(
             };
         case SampleType.VIDEO_FRAME:
             return {
-                title: 'Frames',
+                title: groupComponentName || 'Frames',
                 id: `frames-${collectionId}`,
                 icon: Frame,
                 href: routeHelpers.toFrames(datasetId, collectionType, collectionId),
@@ -39,7 +40,7 @@ export function getMenuItem(
             };
         case SampleType.ANNOTATION:
             return {
-                title: 'Annotations',
+                title: groupComponentName || 'Annotations',
                 id: `annotations-${collectionId}`,
                 icon: ComponentIcon,
                 href: routeHelpers.toAnnotations(datasetId, collectionType, collectionId),
@@ -48,7 +49,7 @@ export function getMenuItem(
             };
         case SampleType.CAPTION:
             return {
-                title: 'Captions',
+                title: groupComponentName || 'Captions',
                 id: `captions-${collectionId}`,
                 href: routeHelpers.toCaptions(datasetId, collectionType, collectionId),
                 isSelected: pageId === APP_ROUTES.captions,
@@ -56,7 +57,7 @@ export function getMenuItem(
             };
         case SampleType.GROUP:
             return {
-                title: 'Groups',
+                title: groupComponentName || 'Groups',
                 id: 'groups',
                 href: routeHelpers.toGroups(datasetId, collectionType, collectionId),
                 isSelected: pageId === APP_ROUTES.groups,
@@ -119,7 +120,7 @@ export function buildBreadcrumbLevels(
     if (!ancestorPath) return [];
 
     const toMenuItem = (c: CollectionView): NavigationMenuItem =>
-        getMenuItem(c.sample_type, pageId, datasetId, c.sample_type.toLowerCase(), c.collection_id);
+        getMenuItem(pageId, datasetId, c.collection_id, c.sample_type, c.group_component_name);
 
     return ancestorPath.map((node, index) => {
         const siblings = index === 0 ? [rootCollection] : (ancestorPath[index - 1].children ?? []);

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -1352,8 +1352,7 @@ export interface paths {
          *
          *     Args:
          *         operator_id: The ID of the operator to execute.
-         *         collection_id: The ID of the collection to operate on.
-         *         request: The execution request containing parameters and optional context.
+         *         request: The execution request containing parameters and context.
          *         session: Database session.
          *
          *     Returns:


### PR DESCRIPTION
## What has changed and why?

Show group component names in the menu.

## How has it been tested?

Tested manually. I plan to add a test in a follow-up, after a bug with isSelected is fixed (now we highlight based on sampleType, we should highlight based on collectionId).

<img width="1117" height="238" alt="Screenshot 2026-03-05 at 10 17 40" src="https://github.com/user-attachments/assets/de4a1b8e-789a-4ddb-90e9-dd15078b88fb" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
