### PR TITLE
Add tooltips to features in annotation items in the right panel

### DIFF
--- a/lightly_studio_view/src/lib/routes.ts
+++ b/lightly_studio_view/src/lib/routes.ts
@@ -27,7 +27,9 @@ export const APP_ROUTES: Record<string, LayoutRouteId> = {
     frames: `${COLLECTION_BASE_ROUTE}/frames`,
     framesDetails: `${COLLECTION_BASE_ROUTE}/frames/[sample_id]`,
     videoDetails: `${COLLECTION_BASE_ROUTE}/videos/[sample_id]`,
-    groups: `${COLLECTION_BASE_ROUTE}/groups`
+    groups: `${COLLECTION_BASE_ROUTE}/groups`,
+    groupDetails: `${COLLECTION_BASE_ROUTE}/groups/[sampleId]`,
+    groupComponentDetails: `${COLLECTION_BASE_ROUTE}/groups/[sampleId]/[componentId]`
 };
 
 export const isSampleDetailsRoute = (routeId: string | null): boolean => {
@@ -68,6 +70,14 @@ export const isFrameDetailsRoute = (routeId: string | null): boolean => {
 
 export const isVideoDetailsRoute = (routeId: string | null): boolean => {
     return routeId ? routeId == APP_ROUTES.videoDetails : false;
+};
+
+export const isGroupDetailsRoute = (routeId: string | null): boolean => {
+    return routeId ? routeId == APP_ROUTES.groupDetails : false;
+};
+
+export const isGroupComponentDetailsRoute = (routeId: string | null): boolean => {
+    return routeId ? routeId == APP_ROUTES.groupComponentDetails : false;
 };
 
 // Route structure: /datasets/{dataset_id}/{collection_type}/{collection_id}
@@ -141,6 +151,15 @@ export const routes = {
             groupId: string
         ) => {
             return `/datasets/${datasetId}/${collectionType}/${collectionId}/groups/${groupId}`;
+        },
+        groupComponentDetails: (
+            datasetId: string,
+            collectionType: string,
+            collectionId: string,
+            groupId: string,
+            componentId: string
+        ) => {
+            return `/datasets/${datasetId}/${collectionType}/${collectionId}/groups/${groupId}/${componentId}`;
         }
     }
 };
@@ -206,5 +225,20 @@ export const routeHelpers = {
         groupId: string
     ) => {
         return routes.collection.groupDetails(datasetId, collectionType, collectionId, groupId);
+    },
+    toGroupComponentDetails: (
+        datasetId: string,
+        collectionType: string,
+        collectionId: string,
+        groupId: string,
+        componentId: string
+    ) => {
+        return routes.collection.groupComponentDetails(
+            datasetId,
+            collectionType,
+            collectionId,
+            groupId,
+            componentId
+        );
     }
 };

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -40,7 +40,9 @@
         isSamplesRoute,
         isVideoFramesRoute,
         isVideosRoute,
-        isGroupsRoute
+        isGroupsRoute,
+        isGroupDetailsRoute,
+        isGroupComponentDetailsRoute
     } from '$lib/routes';
     import { useEmbedText } from '$lib/hooks/useEmbedText/useEmbedText';
     import type { GridType } from '$lib/types';
@@ -103,6 +105,8 @@
 
     const isSamples = $derived(isSamplesRoute(page.route.id));
     const isGroups = $derived(isGroupsRoute(page.route.id));
+    const isGroupDetails = $derived(isGroupDetailsRoute(page.route.id));
+    const isGroupComponentDetails = $derived(isGroupComponentDetailsRoute(page.route.id));
     const isAnnotations = $derived(isAnnotationsRoute(page.route.id));
     const isSampleDetails = $derived(isSampleDetailsRoute(page.route.id));
     const isAnnotationDetails = $derived(isAnnotationDetailsRoute(page.route.id));
@@ -477,7 +481,7 @@
 </div>
 
 <div class="relative flex min-h-0 flex-1 flex-col">
-    {#if isSampleDetails || isAnnotationDetails}
+    {#if isSampleDetails || isAnnotationDetails || isGroupDetails || isGroupComponentDetails}
         {@render children()}
     {:else}
         <div class="flex min-h-0 flex-1 space-x-4 px-4">

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/groups/[sampleId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/groups/[sampleId]/+page.svelte
@@ -1,9 +1,52 @@
 <script lang="ts">
-    import { createSampleDetailsToolbarContext } from '$lib/contexts/SampleDetailsToolbar.svelte';
+    /**
+     * Redirect page for group detail view.
+     *
+     * This page automatically redirects to the first component's detail page within a group.
+     * When a user navigates to /groups/[sampleId], they are immediately redirected to
+     * /groups/[sampleId]/[componentId] where componentId is the sample_id of the first
+     * component in the group.
+     */
+    import { goto } from '$app/navigation';
+    import { page } from '$app/state';
+    import type { GroupComponentView } from '$lib/api/lightly_studio_local';
+    import { useGroupComponents } from '$lib/hooks/useGroupComponents/useGroupComponents';
+    import { routeHelpers } from '$lib/routes';
 
-    createSampleDetailsToolbarContext();
+    const groupId = page.params.sampleId;
+    const datasetId = page.params.dataset_id!;
+    const collectionType = page.params.collection_type!;
+    const collectionId = page.params.collection_id!;
+
+    // Fetch all components for this group
+    const { groupComponents } = useGroupComponents({ groupId });
+    const components = $derived<GroupComponentView[]>($groupComponents.data ?? []);
+
+    // Extract the sample_id of the first component to redirect to
+    const firstComponentId = $derived(
+        components.length > 0 ? components[0].details?.sample_id : null
+    );
+
+    /**
+     * Navigate to the component details page for a given component ID.
+     */
+    const navigateToComponentDetails = (componentId: string) => {
+        goto(
+            routeHelpers.toGroupComponentDetails(
+                datasetId,
+                collectionType,
+                collectionId,
+                groupId,
+                componentId
+            ),
+            { replaceState: true }
+        );
+    };
+
+    // Automatically redirect to the first component when it becomes available
+    $effect(() => {
+        if (firstComponentId) {
+            navigateToComponentDetails(firstComponentId);
+        }
+    });
 </script>
-
-<div class="flex h-full w-full space-x-4 px-4 pb-4" data-testid="sample-details">
-    <div class="h-full w-full space-y-6 rounded-[1vw] bg-card p-4">Group details</div>
-</div>

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/groups/[sampleId]/[componentId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/groups/[sampleId]/[componentId]/+page.svelte
@@ -1,0 +1,1 @@
+<div class="flex h-full gap-4 px-4 pb-4">It is coming soon!</div>


### PR DESCRIPTION
## What has changed and why?

This PR adds tooltips to the feature elements in annotation items in the right panel of the Sample Details view. These tooltips provide additional context and improve UX when users hover over feature icons.

## How has it been tested?


https://github.com/user-attachments/assets/aa09c8c9-ddb9-4231-b826-feaa6f75609b


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added descriptive tooltips to annotation item action controls (lock/unlock, show/hide, delete) for improved discoverability.

* **Improvements**
  * Enhanced tooltip positioning, caching, and responsiveness so tooltips update correctly on resize/scroll and provide more accurate, stable placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->