### PR TITLE
Introduce `DatasetTable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added DatasetTable to the database model, databases from previous versions won't work with this one.
+
 ### Deprecated
 
 ### Removed

--- a/lightly_studio/src/lightly_studio/api/db_tables.py
+++ b/lightly_studio/src/lightly_studio/api/db_tables.py
@@ -13,6 +13,9 @@ from lightly_studio.models.annotation_label import (
 from lightly_studio.models.collection import (
     CollectionTable,  # noqa: F401, required for SQLModel to work properly
 )
+from lightly_studio.models.dataset import (
+    DatasetTable,  # noqa: F401, required for SQLModel to work properly
+)
 from lightly_studio.models.embedding_model import (
     EmbeddingModelTable,  # noqa: F401, required for SQLModel to work properly
 )

--- a/lightly_studio/src/lightly_studio/models/collection.py
+++ b/lightly_studio/src/lightly_studio/models/collection.py
@@ -28,8 +28,11 @@ class CollectionBase(SQLModel):
         UniqueConstraint("name", "parent_collection_id", name="unique_collection"),
     )
     name: str = Field(index=True)
+    dataset_id: UUID = Field(index=True, foreign_key="dataset.dataset_id")
     parent_collection_id: Optional[UUID] = Field(
-        default=None, foreign_key="collection.collection_id"
+        default=None,
+        foreign_key="collection.collection_id",
+        index=True,
     )
     sample_type: SampleType
 
@@ -38,8 +41,16 @@ class CollectionBase(SQLModel):
     group_component_index: Optional[int] = None
 
 
-class CollectionCreate(CollectionBase):
+class CollectionCreate(SQLModel):
     """Collection class when inserting."""
+
+    name: str
+    parent_collection_id: Optional[UUID] = None
+    sample_type: SampleType
+
+    # Group-specific fields
+    group_component_name: Optional[str] = None
+    group_component_index: Optional[int] = None
 
 
 class CollectionView(CollectionBase):
@@ -62,6 +73,7 @@ class ComponentCollectionView(CollectionBase):
         """Create a ComponentCollectionView from a CollectionTable."""
         return cls(
             name=collection.name,
+            dataset_id=collection.dataset_id,
             parent_collection_id=collection.parent_collection_id,
             sample_type=collection.sample_type,
             group_component_name=collection.group_component_name or "",
@@ -101,3 +113,4 @@ class CollectionTable(CollectionBase, table=True):
         back_populates="parent",
         sa_relationship_kwargs={"lazy": "select"},
     )
+    # TODO(lukas, 3/2026): add a relationship to DatasetTable

--- a/lightly_studio/src/lightly_studio/models/dataset.py
+++ b/lightly_studio/src/lightly_studio/models/dataset.py
@@ -1,0 +1,14 @@
+"""This module contains the Dataset model."""
+
+from typing import Optional
+from uuid import UUID, uuid4
+
+from sqlmodel import Field, SQLModel
+
+
+class DatasetTable(SQLModel, table=True):
+    """This class defines the Dataset model."""
+
+    __tablename__ = "dataset"
+    dataset_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    root_collection_id: Optional[UUID] = Field(default=None)

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/create.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/create.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from sqlmodel import Session
 
 from lightly_studio.models.collection import CollectionCreate, CollectionTable
+from lightly_studio.models.dataset import DatasetTable
 from lightly_studio.resolvers import collection_resolver
 
 
@@ -29,8 +30,38 @@ def create(session: Session, collection: CollectionCreate) -> CollectionTable:
     )
     if existing:
         raise ValueError(f"Collection with name '{collection.name}' already exists.")
-    db_collection = CollectionTable.model_validate(collection)
+
+    db_dataset: DatasetTable | None = None
+    if collection.parent_collection_id is None:
+        # If this is the root collection, create a dataset first.
+        db_dataset = DatasetTable()
+        session.add(db_dataset)
+        session.flush([db_dataset])
+        dataset_id = db_dataset.dataset_id
+    else:
+        # Inherit dataset_id from parent collection.
+        parent = collection_resolver.get_by_id(
+            session=session, collection_id=collection.parent_collection_id
+        )
+        if parent is None:
+            raise ValueError(f"Parent collection {collection.parent_collection_id} not found")
+        # Parent exists, get_by_name checks that
+        dataset_id = parent.dataset_id
+
+    # Create the table record, adding the determined dataset_id.
+    db_collection = CollectionTable(
+        **collection.model_dump(),
+        dataset_id=dataset_id,
+    )
+
+    if db_dataset is not None:
+        # Link the dataset back to its root collection. Note that this isn't a foreign key
+        # relationship. Only the collection has a foreign key to the dataset.
+        db_dataset.root_collection_id = db_collection.collection_id
+        session.add(db_dataset)
+
     session.add(db_collection)
     session.commit()
     session.refresh(db_collection)
+
     return db_collection

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/deep_copy.py
@@ -23,6 +23,7 @@ from lightly_studio.models.annotation.segmentation import (
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.dataset import DatasetTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.group import GroupTable, SampleGroupLinkTable
 from lightly_studio.models.image import ImageTable
@@ -82,11 +83,31 @@ def deep_copy(
 
     ctx = DeepCopyContext()
 
+    # Create new dataset entry
+    new_dataset_id = uuid4()
+    db_dataset = DatasetTable(
+        dataset_id=new_dataset_id,
+        root_collection_id=None,
+    )
+    session.add(db_dataset)
+    session.flush([db_dataset])
+
     # 1. Copy collection hierarchy.
     hierarchy = collection_resolver.get_hierarchy(
         session=session, root_collection_id=root_collection_id
     )
-    root = _copy_collections(session=session, hierarchy=hierarchy, copy_name=copy_name, ctx=ctx)
+    root = _copy_collections(
+        session=session,
+        hierarchy=hierarchy,
+        copy_name=copy_name,
+        ctx=ctx,
+        new_dataset_id=new_dataset_id,
+    )
+
+    # Update dataset with root collection ID.
+    db_dataset.root_collection_id = root.collection_id
+    session.add(db_dataset)
+    session.flush([db_dataset])
 
     # 2. Copy collection-scoped entities.
     old_collection_ids = list(ctx.collection_map.keys())
@@ -126,6 +147,7 @@ def _copy_collections(
     hierarchy: list[CollectionTable],
     copy_name: str,
     ctx: DeepCopyContext,
+    new_dataset_id: UUID,
 ) -> CollectionTable:
     """Copy collection hierarchy, maintaining parent-child relationships."""
     root: CollectionTable | None = None
@@ -153,6 +175,7 @@ def _copy_collections(
             old_coll,
             {
                 "collection_id": new_id,
+                "dataset_id": new_dataset_id,
                 "name": derived_name,
                 "parent_collection_id": new_parent_id,
             },

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/delete_dataset.py
@@ -15,6 +15,7 @@ from lightly_studio.models.annotation.segmentation import SegmentationAnnotation
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.dataset import DatasetTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.group import GroupTable, SampleGroupLinkTable
 from lightly_studio.models.image import ImageTable
@@ -54,6 +55,8 @@ def delete_dataset(
         raise ValueError(f"Collection with ID {root_collection_id} not found.")
     if root.parent_collection_id is not None:
         raise ValueError("Only root collections can be deleted.")
+
+    dataset_id = root.dataset_id
 
     # Get the hierarchy and collect all IDs.
     hierarchy = collection_resolver.get_hierarchy(
@@ -105,6 +108,10 @@ def delete_dataset(
 
     # 6. Delete collections (with individual commits due to self-referential FKs).
     _delete_collections(session=session, collection_ids=collection_ids)
+
+    # 7. Delete the dataset entry itself.
+    _delete_dataset_entry(session=session, dataset_id=dataset_id)
+    session.commit()
 
 
 def _get_sample_ids(session: Session, collection_ids: list[UUID]) -> list[UUID]:
@@ -253,6 +260,13 @@ def _delete_annotation_labels(session: Session, root_collection_id: UUID) -> Non
         delete(AnnotationLabelTable).where(
             col(AnnotationLabelTable.dataset_id) == root_collection_id
         )
+    )
+
+
+def _delete_dataset_entry(session: Session, dataset_id: UUID) -> None:
+    """Delete the dataset record from DatasetTable."""
+    session.exec(  # type: ignore[call-overload]
+        delete(DatasetTable).where(col(DatasetTable.dataset_id) == dataset_id)
     )
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/get_collection_details.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/get_collection_details.py
@@ -20,6 +20,7 @@ def get_collection_details(
     )
     return CollectionViewWithCount(
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         parent_collection_id=collection.parent_collection_id,
         sample_type=collection.sample_type,
         name=collection.name,

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/table_coverage_utils.py
@@ -8,7 +8,7 @@ until they are updated to handle the new tables.
 from sqlmodel import SQLModel
 
 # Tables handled by deep_copy and delete_dataset.
-_HANDLED_TABLES_COUNT = 18
+_HANDLED_TABLES_COUNT = 19
 
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)

--- a/lightly_studio/tests/models/test_group.py
+++ b/lightly_studio/tests/models/test_group.py
@@ -44,6 +44,7 @@ def test_group_component_view_from_image_table(db_session: Session) -> None:
 
     component_collection = ComponentCollectionView(
         name=collection.name,
+        dataset_id=collection.dataset_id,
         parent_collection_id=collection.parent_collection_id,
         sample_type=collection.sample_type,
         group_component_name="front_camera",
@@ -81,6 +82,7 @@ def test_group_component_view_from_video_table(db_session: Session) -> None:
 
     component_collection = ComponentCollectionView(
         name=collection.name,
+        dataset_id=collection.dataset_id,
         parent_collection_id=collection.parent_collection_id,
         sample_type=collection.sample_type,
         group_component_name="rear_camera",

--- a/lightly_studio/tests/resolvers/collection_resolver/test_create.py
+++ b/lightly_studio/tests/resolvers/collection_resolver/test_create.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from sqlmodel import Session
 
 from lightly_studio.models.collection import CollectionCreate, SampleType
+from lightly_studio.models.dataset import DatasetTable
 from lightly_studio.resolvers import collection_resolver
 
 
@@ -13,6 +16,12 @@ def test_create(db_session: Session) -> None:
         collection=CollectionCreate(name="my_collection", sample_type=SampleType.IMAGE),
     )
     assert ds.name == "my_collection"
+    assert ds.dataset_id is not None
+
+    # Check that the dataset record was created and links to the root collection
+    db_dataset = db_session.get(DatasetTable, ds.dataset_id)
+    assert db_dataset is not None
+    assert db_dataset.root_collection_id == ds.collection_id
 
     # Creating a collection with the same name should raise an error.
     with pytest.raises(ValueError, match=r"Collection with name 'my_collection' already exists."):
@@ -100,3 +109,23 @@ def test_create__root_collections_with_same_name_fails(db_session: Session) -> N
             session=db_session,
             collection=CollectionCreate(name="root", sample_type=SampleType.IMAGE),
         )
+
+
+def test_create__with_existing_dataset_id(db_session: Session) -> None:
+    # Pre-create a dataset
+    dataset_id = uuid.uuid4()
+    db_dataset = DatasetTable(dataset_id=dataset_id)
+    db_session.add(db_dataset)
+    db_session.commit()
+
+    # `create()` should not take dataset_id, it should create one or inherit it.
+    collection = collection_resolver.create(
+        session=db_session,
+        collection=CollectionCreate(
+            name="new_root",
+            sample_type=SampleType.IMAGE,
+        ),
+    )
+
+    assert collection.dataset_id != dataset_id
+    assert collection.dataset_id is not None

--- a/lightly_studio_view/src/lib/components/NavigationMenu/utils.test.ts
+++ b/lightly_studio_view/src/lib/components/NavigationMenu/utils.test.ts
@@ -8,6 +8,7 @@ const makeCollection = (
     children?: CollectionView[]
 ): CollectionView => ({
     collection_id: id,
+    dataset_id: 'test-dataset-id',
     name: id,
     sample_type: sampleType,
     created_at: new Date(),

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -2161,6 +2161,11 @@ export interface components {
         CollectionTable: {
             /** Name */
             name: string;
+            /**
+             * Dataset Id
+             * Format: uuid
+             */
+            dataset_id: string;
             /** Parent Collection Id */
             parent_collection_id?: string | null;
             sample_type: components["schemas"]["SampleType"];
@@ -2191,6 +2196,11 @@ export interface components {
         CollectionView: {
             /** Name */
             name: string;
+            /**
+             * Dataset Id
+             * Format: uuid
+             */
+            dataset_id: string;
             /** Parent Collection Id */
             parent_collection_id?: string | null;
             sample_type: components["schemas"]["SampleType"];
@@ -2226,6 +2236,11 @@ export interface components {
         CollectionViewWithCount: {
             /** Name */
             name: string;
+            /**
+             * Dataset Id
+             * Format: uuid
+             */
+            dataset_id: string;
             /** Parent Collection Id */
             parent_collection_id?: string | null;
             sample_type: components["schemas"]["SampleType"];
@@ -2263,6 +2278,11 @@ export interface components {
         ComponentCollectionView: {
             /** Name */
             name: string;
+            /**
+             * Dataset Id
+             * Format: uuid
+             */
+            dataset_id: string;
             /** Parent Collection Id */
             parent_collection_id?: string | null;
             sample_type: components["schemas"]["SampleType"];


### PR DESCRIPTION

## What has changed and why?
Each collection now links a DatasetTable, meaning that it belongs to a dataset.

It's hard to make such a fundamental model change smaller. To make the review easier, I suggest looking only at the first commit at files:
* `lightly_studio/src/lightly_studio/resolvers/collection_resolver/create.py`
* `lightly_studio/src/lightly_studio/models/collection.py`
* `lightly_studio/src/lightly_studio/models/dataset.py`
* `lightly_studio/src/lightly_studio/resolvers/collection_resolver/get_by_name.py`

The rest follows from changes in these files, so that tests still pass.

## How has it been tested?
Mostly existing tests, I have added tests for `DatasetTable`, too.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collections are now grouped under datasets; creating a root collection auto-creates and links a dataset.
  * Deep-copy of a collection hierarchy creates a new dataset and links copied collections.
  * Deleting a collection hierarchy also removes its dataset entry.

* **Breaking Changes**
  * Database model changed; previous versions are incompatible and require migration.

* **API Updates**
  * Collection-related views/interfaces now include a dataset identifier field.

* **Tests**
  * Tests expanded to cover dataset creation, linkage, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->