### PR TITLE
Show selection order as metadata in GUI

### DIFF
--- a/lightly_studio/src/lightly_studio/selection/select_via_db.py
+++ b/lightly_studio/src/lightly_studio/selection/select_via_db.py
@@ -270,6 +270,10 @@ def select_via_database(
 
     selected_indices = mundig.run(n_samples=n_samples_to_select)
     selected_sample_ids = [input_sample_ids[i] for i in selected_indices]
+    order_key = f"{config.selection_result_tag_name}_order"
+    sample_id_to_order = {
+        sample_id: order for order, sample_id in enumerate(selected_sample_ids, start=1)
+    }
 
     datetime_str = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
     tag_description = f"Selected at {datetime_str} UTC"
@@ -284,4 +288,11 @@ def select_via_database(
     )
     tag_resolver.add_sample_ids_to_tag_id(
         session=session, tag_id=tag.tag_id, sample_ids=selected_sample_ids
+    )
+    metadata_resolver.bulk_update_metadata(
+        session=session,
+        sample_metadata=[
+            (sample_id, {order_key: order})
+            for sample_id, order in sample_id_to_order.items()
+        ],
     )

--- a/lightly_studio/tests/api/routes/api/test_selection.py
+++ b/lightly_studio/tests/api/routes/api/test_selection.py
@@ -7,7 +7,12 @@ from sqlmodel import Session
 
 from lightly_studio.metadata import compute_typicality
 from lightly_studio.models.collection import SampleType
-from lightly_studio.resolvers import image_resolver, tag_resolver, video_resolver
+from lightly_studio.resolvers import (
+    image_resolver,
+    metadata_resolver,
+    tag_resolver,
+    video_resolver,
+)
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
@@ -53,6 +58,16 @@ def test_create_combination_selection__diversity_success(
         session=db_session, collection_id=collection_id, filters=tag_filter
     )
     assert len(result.samples) == 3
+    order_key = "test_combination_selection_order"
+    order_values = {
+        metadata_resolver.get_value_for_sample(
+            session=db_session,
+            sample_id=sample.sample_id,
+            key=order_key,
+        )
+        for sample in result.samples
+    }
+    assert order_values == {1, 2, 3}
 
 
 def test_create_combination_selection__diversity_success_videos(

--- a/lightly_studio/tests/selection/test_select_via_db.py
+++ b/lightly_studio/tests/selection/test_select_via_db.py
@@ -12,6 +12,7 @@ from sqlmodel import Session
 from lightly_studio.models.tag import TagCreate
 from lightly_studio.resolvers import (
     image_resolver,
+    metadata_resolver,
     tag_resolver,
 )
 from lightly_studio.resolvers.image_filter import ImageFilter
@@ -112,6 +113,66 @@ def test_select_via_database__multi_embedding_diversity(
     expected_sample_paths = {"sample_0.jpg", "sample_19.jpg"}
     actual_sample_paths = {sample.file_path_abs for sample in samples_in_tag}
     assert actual_sample_paths == expected_sample_paths
+
+
+def test_select_via_database__stores_selection_order_metadata(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """Stores the selected sample order as integer metadata."""
+    collection_id = fill_db_with_samples_and_embeddings(
+        db_session, n_samples=4, embedding_model_names=["embedding_model_1"]
+    )
+    input_sample_ids = _all_sample_ids(db_session, collection_id)
+    metadata_resolver.set_value_for_sample(
+        session=db_session,
+        sample_id=input_sample_ids[2],
+        key="existing_key",
+        value="kept",
+    )
+    mocker.patch.object(Mundig, "run", return_value=[2, 0, 1])
+
+    selection_config = SelectionConfig(
+        collection_id=collection_id,
+        n_samples_to_select=3,
+        selection_result_tag_name="selection_1",
+        strategies=[EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1")],
+    )
+
+    select_via_database(db_session, selection_config, input_sample_ids=input_sample_ids)
+
+    order_key = "selection_1_order"
+    assert metadata_resolver.get_value_for_sample(
+        session=db_session,
+        sample_id=input_sample_ids[2],
+        key=order_key,
+    ) == 1
+    assert metadata_resolver.get_value_for_sample(
+        session=db_session,
+        sample_id=input_sample_ids[0],
+        key=order_key,
+    ) == 2
+    assert metadata_resolver.get_value_for_sample(
+        session=db_session,
+        sample_id=input_sample_ids[1],
+        key=order_key,
+    ) == 3
+    assert metadata_resolver.get_value_for_sample(
+        session=db_session,
+        sample_id=input_sample_ids[3],
+        key=order_key,
+    ) is None
+
+    metadata = metadata_resolver.get_by_sample_id(
+        session=db_session, sample_id=input_sample_ids[2]
+    )
+    assert metadata is not None
+    assert metadata.metadata_schema[order_key] == "integer"
+    assert metadata_resolver.get_value_for_sample(
+        session=db_session,
+        sample_id=input_sample_ids[2],
+        key="existing_key",
+    ) == "kept"
 
 
 def test_select_via_database__embedding_diversity__sample_filter_tags(


### PR DESCRIPTION
## What has changed and why?

When selection, save the selection order as metadata. This allows to have it in the GUI. 
It has many advantages:
- Allows to visually understand the selection process.
- Allows to solve the n_samples vs. diversity tradeoff problem. In LightlyOne, we had the `minimum_distance_stopping_condition` for it. 

## How has it been tested?

See the slider `Diverse 1000 Order` in the bottom left. Changing it changes which samples are shown. 

![image](https://github.com/user-attachments/assets/68b7884a-da01-4b78-83e8-205c27097a5b)

![image](https://github.com/user-attachments/assets/6bb9cb3a-7b03-4ee7-a588-2f53853e06c3)

