### PR TITLE
Docs v2: Add Image Dataset GUI Section

### DIFF
--- a/lightly_studio/docs/docs/dataset_setup/image_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/image_dataset.md
@@ -349,11 +349,11 @@ GUI displays only a single dataset.
 
 ## Image Dataset in the GUI
 
-Launch the GUI by calling `ls.start_gui()`. It starts a local webserver, click
+Launch the GUI by calling `ls.start_gui()`, it starts a local web server. Click
 on the link printed in the console - by default `http://localhost:8001` - to open the GUI
 in your browser.
 
-```python  title="Start the GUI"
+```python title="Start the GUI"
 import lightly_studio as ls
 ls.start_gui()
 ```
@@ -364,8 +364,8 @@ The main view shows a grid of images in your dataset. From here, you can perform
 
 - Use the left panel to filter the images by tags, annotation labels or metadata.
 - Use the search bar to do similarity search by text or an image.
-- Use the "Show Embeddings" button to explore the data in embedding space.
-- Use the "Menu" dropdown for further actions like plugins, sampling, classification, export and more.
+- Use the `Show Embeddings` button to explore the data in embedding space.
+- Use the `Menu` dropdown for further actions like plugins, sampling, classification, export and more.
 
 Refer to dedicated pages in this documentation on every feature for more details.
 


### PR DESCRIPTION
## What has changed and why?

Add Image Dataset GUI Section.

## How has it been tested?

Manually.

<img width="594" height="1272" alt="Screenshot 2026-03-17 at 14 54 51" src="https://github.com/user-attachments/assets/e498ae8d-4bed-4f88-863d-8ac89d96304d" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Image Dataset GUI Section Documentation

This PR adds documentation for using the image dataset GUI, expanding the "Image Dataset in the GUI" section with practical instructions and visual examples.

### Changes

- Added instructions for starting the GUI using `ls.start_gui()`, including the default URL and local webserver details
- Documented Grid View functionality with actionable user interactions
- Documented Detail View functionality with actionable user interactions
- Included code examples and embedded images to illustrate GUI usage
- Replaced previous placeholder content with comprehensive practical guidance

**Lines changed:** +29/-1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->