### PR TITLE
Docs v2: ImageDataset Python API

### DIFF
--- a/lightly_studio/docs/docs/dataset_setup/image_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/image_dataset.md
@@ -395,9 +395,9 @@ dataset = ls.ImageDataset.load_or_create()
 Once samples are added to the dataset, they can be iterated over, yielding `ImageSample` objects:
 
 ```python title="Iterate over dataset samples"
-for sample in dataset:
-    print(sample.file_name)
-    assert isinstance(sample, ls.ImageSample)
+for image in dataset:
+    print(image.file_name)
+    assert isinstance(image, ls.ImageSample)
 ```
 
 ### ImageSample class
@@ -469,7 +469,7 @@ iterating over it or calling `to_list()`.
 The listing below shows examples of working with queries. For details see the API reference
 for [DatasetQuery](../api/dataset_query.md#datasetquery) and [ImageSampleField](../api/dataset_query.md#imagesamplefield).
 
-```py
+```python title="Query an ImageDataset"
 from lightly_studio.core.dataset_query import AND, OR, NOT, OrderByField, ImageSampleField
 
 ###
@@ -506,6 +506,7 @@ query.add_tag("needs-review")
 # Iterate over resulting samples
 for sample in query:
     # Access the sample: see previous section
+    ...
 
 # Collect all resulting samples as list
 samples = query.to_list()


### PR DESCRIPTION
## What has changed and why?

Add documentation to manipulate an image dataset via Python.

## How has it been tested?

```
cd lightly_studio/docs
make serve
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds comprehensive Python API documentation for the `ImageDataset` and `ImageSample` classes to the image dataset setup guide.

## Changes

**File: `lightly_studio/docs/docs/dataset_setup/image_dataset.md`**

Added extensive documentation sections (lines 376-509) covering:

- **ImageDataset class**: Factory methods (`create()`, `load()`, `load_or_create()`) and iteration over `ImageSample` objects with code examples
- **ImageSample class**: Examples demonstrating access to image properties (file name, dimensions), manipulation of tags, captions, and metadata, and adding annotations
- **Querying the Dataset**: Guide to building and executing lazy queries using `DatasetQuery`, including examples of `match()`, `order_by()`, and slicing operations. Demonstrates consuming results through iteration, list conversion, and export to COCO format. Includes a GUI tip noting that similar filtering and querying can be performed in the GUI.

The documentation replaces a TODO placeholder with practical, runnable code examples for working with image datasets programmatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->