### PR TITLE
Relax duckdb version constraint to >=1.2.22

### DIFF
--- a/lightly_studio/pyproject.toml
+++ b/lightly_studio/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "annotated-types==0.7.0",
     "duckdb-engine>=0.15.0,<0.17",
-    "duckdb>=1.2.2,<1.3",
+    "duckdb>=1.2.22",
     "psycopg[binary]>=3.2.4",
     "pgvector>=0.4.0",
     "fastapi>=0.115.5",


### PR DESCRIPTION
### Motivation
- Allow newer `duckdb` releases by removing the restrictive `<1.3` upper bound and requiring at least `1.2.22` to pick up fixes/features present in later `duckdb` versions.

### Description
- Updated the `duckdb` dependency in `pyproject.toml` from `">=1.2.2,<1.3"` to `">=1.2.22"`.

### Testing
- Ran the project's automated test suite (`pytest`) and CI checks; all tests and checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc23c758e0832183dd06b52b002ee8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR relaxes the upper version constraint on the `duckdb` dependency to allow newer releases while maintaining a minimum version requirement for stability.

## Changes

- Updated `duckdb` dependency in `lightly_studio/pyproject.toml` from `>=1.2.2,<1.3` to `>=1.2.22`
  - Removes the restrictive upper bound that prevented use of duckdb versions 1.3 and later
  - Maintains a reasonable minimum version (1.2.22) to ensure compatibility with necessary fixes and features

## Impact

- **Scope**: Minimal - single dependency version constraint change
- **Code Changes**: None (configuration only)
- **Testing**: All automated tests and CI checks passed

## Rationale

The change allows projects depending on this package to use newer duckdb versions that may contain important fixes and features, while avoiding potentially incompatible earlier versions through the increased minimum version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->