### PR TITLE
feat: move out search for grid to separate component

### DIFF
--- a/lightly_studio_view/src/lib/components/GridSearch/GridSearch.svelte
+++ b/lightly_studio_view/src/lib/components/GridSearch/GridSearch.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+    import { Search, Image as ImageIcon, X } from '@lucide/svelte';
+    import Input from '$lib/components/ui/input/input.svelte';
+    import { page } from '$app/state';
+    import { toast } from 'svelte-sonner';
+    import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+    import { useEmbedText } from '$lib/hooks/useEmbedText/useEmbedText';
+
+    const { textEmbedding, setTextEmbedding } = useGlobalStorage();
+
+    const MAX_IMAGE_SIZE_MB = 50;
+    const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
+
+    let dragOver = $state(false);
+    let activeImage = $state<string | null>(null);
+    let submittedQueryText = $state('');
+    let previewUrl = $state<string | null>(null);
+    let isUploading = $state(false);
+    let query_text = $state($textEmbedding ? $textEmbedding.queryText : '');
+    let fileInput = $state<HTMLInputElement | null>(null);
+
+    function handleDragOver(e: DragEvent) {
+        e.preventDefault();
+        dragOver = true;
+    }
+
+    function handleDragLeave(e: DragEvent) {
+        e.preventDefault();
+        dragOver = false;
+    }
+
+    const setError = (errorMessage: string) => {
+        toast.error('Error', { description: errorMessage });
+    };
+
+    async function uploadImage(file: File) {
+        if (file.size > MAX_IMAGE_SIZE_BYTES) {
+            setError(`Image is too large. Maximum size is ${MAX_IMAGE_SIZE_MB}MB.`);
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('file', file);
+
+        isUploading = true;
+        try {
+            const currentCollectionId = page.params.collection_id;
+            if (!currentCollectionId) {
+                throw new Error('Collection ID is not available');
+            }
+            const response = await fetch(
+                `/api/image_embedding/from_file/for_collection/${currentCollectionId}`,
+                {
+                    method: 'POST',
+                    body: formData
+                }
+            );
+
+            if (!response.ok) {
+                throw new Error(`Error uploading image: ${response.statusText}`);
+            }
+
+            const embedding = await response.json();
+
+            // Clear text search state
+            query_text = '';
+            submittedQueryText = '';
+            activeImage = file.name;
+
+            // Create preview URL for the uploaded image
+            if (previewUrl) {
+                URL.revokeObjectURL(previewUrl);
+            }
+            previewUrl = URL.createObjectURL(file);
+
+            setTextEmbedding({
+                queryText: file.name,
+                embedding: embedding
+            });
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : 'Failed to upload image';
+            setError(message);
+        } finally {
+            isUploading = false;
+        }
+    }
+
+    async function handleDrop(e: DragEvent) {
+        e.preventDefault();
+        dragOver = false;
+        if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
+            const file = e.dataTransfer.files[0];
+            if (file.type.startsWith('image/')) {
+                await uploadImage(file);
+            } else {
+                setError('Please drop an image file.');
+            }
+        }
+    }
+
+    async function onKeyDown(event: KeyboardEvent) {
+        if (event.key === 'Enter') {
+            const trimmedQuery = query_text.trim();
+            submittedQueryText = trimmedQuery;
+        }
+    }
+
+    function clearSearch() {
+        activeImage = null;
+        query_text = '';
+        submittedQueryText = '';
+        if (previewUrl) {
+            URL.revokeObjectURL(previewUrl);
+            previewUrl = null;
+        }
+        setTextEmbedding(undefined);
+    }
+
+    async function handlePaste(e: ClipboardEvent) {
+        const clipboardData = e.clipboardData;
+        if (!clipboardData) return;
+
+        // Check clipboardData.files first (most common case)
+        if (clipboardData.files && clipboardData.files.length > 0) {
+            const file = clipboardData.files[0];
+            if (file.type.startsWith('image/')) {
+                e.preventDefault();
+                await uploadImage(file);
+                return;
+            }
+        }
+
+        // Fallback: check clipboardData.items (screenshots, images copied from web)
+        const items = clipboardData.items;
+        if (items) {
+            for (const item of items) {
+                if (item.type.startsWith('image/')) {
+                    const file = item.getAsFile();
+                    if (file) {
+                        e.preventDefault();
+                        await uploadImage(file);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    function triggerFileInput() {
+        fileInput?.click();
+    }
+
+    async function handleFileSelect(e: Event) {
+        const target = e.target as HTMLInputElement;
+        if (target.files && target.files.length > 0) {
+            await uploadImage(target.files[0]);
+        }
+        // Reset input
+        target.value = '';
+    }
+    const collectionId = $derived(page.params.collection_id!);
+
+    const embedTextQuery = $derived(
+        useEmbedText({
+            collectionId,
+            queryText: submittedQueryText,
+            embeddingModelId: null
+        })
+    );
+
+    $effect(() => {
+        if (activeImage) return;
+
+        if ($embedTextQuery.isError && $embedTextQuery.error) {
+            const queryError = $embedTextQuery.error as
+                | { error?: unknown; message?: string }
+                | Error;
+            const message = 'error' in queryError ? queryError.error : queryError.message;
+            setError(String(message));
+            return;
+        }
+
+        if (!submittedQueryText) {
+            setTextEmbedding(undefined);
+            return;
+        }
+
+        if ($embedTextQuery.isSuccess) {
+            setTextEmbedding({
+                queryText: submittedQueryText,
+                embedding: $embedTextQuery.data
+            });
+        }
+    });
+</script>
+
+<div
+    class="relative"
+    role="region"
+    aria-label="Search by image or text"
+    ondragover={handleDragOver}
+    ondragleave={handleDragLeave}
+    ondrop={handleDrop}
+>
+    <Search class="absolute left-2 top-[50%] h-4 w-4 translate-y-[-50%] text-muted-foreground" />
+    {#if activeImage || submittedQueryText}
+        <div
+            class="flex h-10 w-full items-center rounded-md border border-input bg-background px-3 py-2 pl-8 text-sm {dragOver
+                ? 'ring-2 ring-primary'
+                : ''}"
+        >
+            {#if activeImage}
+                <span class="mr-2 flex items-center gap-2 truncate text-muted-foreground">
+                    {#if previewUrl}
+                        <img
+                            src={previewUrl}
+                            alt="Search preview"
+                            class="h-6 w-6 rounded object-cover"
+                        />
+                    {:else}
+                        <ImageIcon class="h-4 w-4" />
+                    {/if}
+                    {activeImage}
+                </span>
+            {:else}
+                <button
+                    type="button"
+                    class="mr-2 min-w-0 flex-1 cursor-text truncate text-left text-muted-foreground"
+                    onclick={() => {
+                        submittedQueryText = '';
+                    }}
+                >
+                    {submittedQueryText}
+                </button>
+            {/if}
+            <button
+                class="ml-auto hover:text-foreground"
+                onclick={clearSearch}
+                title="Clear search"
+                data-testid="search-clear-button"
+            >
+                <X class="h-4 w-4" />
+            </button>
+        </div>
+    {:else}
+        <Input
+            placeholder={isUploading ? 'Uploading...' : 'Search samples by description or image'}
+            class="pl-8 pr-8 {dragOver ? 'ring-2 ring-primary' : ''}"
+            bind:value={query_text}
+            onkeydown={onKeyDown}
+            onpaste={handlePaste}
+            disabled={isUploading}
+            data-testid="text-embedding-search-input"
+        />
+        <button
+            class="absolute right-2 top-[50%] translate-y-[-50%] text-muted-foreground hover:text-foreground disabled:opacity-50"
+            onclick={triggerFileInput}
+            title="Upload image for search"
+            disabled={isUploading}
+        >
+            <ImageIcon class="h-4 w-4" />
+        </button>
+    {/if}
+    <input
+        type="file"
+        accept="image/*"
+        class="hidden"
+        bind:this={fileInput}
+        onchange={handleFileSelect}
+        disabled={isUploading}
+    />
+</div>

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -43,3 +43,4 @@ export { default as VideoPreview } from '$lib/components/VideoPreview/VideoPrevi
 export { default as VideoPlayer } from '$lib/components/VideoPlayer/VideoPlayer.svelte';
 export { default as VideoFrameDetails } from '$lib/components/VideoFrameDetails/VideoFrameDetails.svelte';
 export { default as VideoSampleMetadata } from '$lib/components/VideoSampleMetadata/VideoSampleMetadata.svelte';
+export { default as GridSearch } from '$lib/components/GridSearch/GridSearch.svelte';

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -11,19 +11,10 @@
         TagCreateDialog,
         TagsMenu
     } from '$lib/components';
-    import Input from '$lib/components/ui/input/input.svelte';
     import Separator from '$lib/components/ui/separator/separator.svelte';
-    import {
-        Search,
-        SlidersHorizontal,
-        Image as ImageIcon,
-        X,
-        ChartNetwork,
-        GripVertical
-    } from '@lucide/svelte';
+    import { SlidersHorizontal, ChartNetwork, GripVertical } from '@lucide/svelte';
     import { onDestroy, onMount } from 'svelte';
     import { get, toStore, writable } from 'svelte/store';
-    import { toast } from 'svelte-sonner';
     import { Header } from '$lib/components';
     import MenuDialogHost from '$lib/components/Header/MenuDialogHost.svelte';
 
@@ -44,7 +35,6 @@
         isGroupDetailsRoute,
         isGroupComponentDetailsRoute
     } from '$lib/routes';
-    import { useEmbedText } from '$lib/hooks/useEmbedText/useEmbedText';
     import type { GridType } from '$lib/types';
     import { useAnnotationCounts } from '$lib/hooks/useAnnotationCounts/useAnnotationCounts';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage.js';
@@ -70,11 +60,11 @@
         buildVideoAnnotationCountsFilter,
         buildVideoFrameAnnotationCountsFilter
     } from '$lib/utils/buildAnnotationCountsFilters';
+    import GridSearch from '$lib/components/GridSearch/GridSearch.svelte';
     const { data, children } = $props();
     const {
         collection,
         globalStorage: {
-            setTextEmbedding,
             textEmbedding,
             setLastGridType,
             clearSelectedSamples,
@@ -156,24 +146,6 @@
         // TODO: also remember state of tags, labels, metadata filters etc. Possible store it in pagestate
         setLastGridType(gridType);
     });
-
-    let query_text = $state($textEmbedding ? $textEmbedding.queryText : '');
-    let submittedQueryText = $state('');
-
-    const embedTextQuery = $derived(
-        useEmbedText({
-            collectionId,
-            queryText: submittedQueryText,
-            embeddingModelId: null
-        })
-    );
-
-    async function onKeyDown(event: KeyboardEvent) {
-        if (event.key === 'Enter') {
-            const trimmedQuery = query_text.trim();
-            submittedQueryText = trimmedQuery;
-        }
-    }
 
     const hasEmbeddingsQuery = $derived(useHasEmbeddings({ collectionId }));
     const hasEmbeddings = $derived(!!$hasEmbeddingsQuery.data);
@@ -312,179 +284,10 @@
         }
     };
 
-    // Error handling for text embedding search
-    const setError = (errorMessage: string) => {
-        toast.error('Error', { description: errorMessage });
-    };
-
     const totalAnnotations = $derived.by(() => {
         const countsData = $annotationCounts.data;
         if (!countsData) return 0;
         return countsData.reduce((sum, item) => sum + Number(item.total_count), 0);
-    });
-
-    const MAX_IMAGE_SIZE_MB = 50;
-    const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
-
-    let dragOver = $state(false);
-    let activeImage = $state<string | null>(null);
-    let previewUrl = $state<string | null>(null);
-    let isUploading = $state(false);
-    let fileInput = $state<HTMLInputElement | null>(null);
-
-    function handleDragOver(e: DragEvent) {
-        e.preventDefault();
-        dragOver = true;
-    }
-
-    function handleDragLeave(e: DragEvent) {
-        e.preventDefault();
-        dragOver = false;
-    }
-
-    async function handleDrop(e: DragEvent) {
-        e.preventDefault();
-        dragOver = false;
-        if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
-            const file = e.dataTransfer.files[0];
-            if (file.type.startsWith('image/')) {
-                await uploadImage(file);
-            } else {
-                setError('Please drop an image file.');
-            }
-        }
-    }
-
-    async function handlePaste(e: ClipboardEvent) {
-        const clipboardData = e.clipboardData;
-        if (!clipboardData) return;
-
-        // Check clipboardData.files first (most common case)
-        if (clipboardData.files && clipboardData.files.length > 0) {
-            const file = clipboardData.files[0];
-            if (file.type.startsWith('image/')) {
-                e.preventDefault();
-                await uploadImage(file);
-                return;
-            }
-        }
-
-        // Fallback: check clipboardData.items (screenshots, images copied from web)
-        const items = clipboardData.items;
-        if (items) {
-            for (const item of items) {
-                if (item.type.startsWith('image/')) {
-                    const file = item.getAsFile();
-                    if (file) {
-                        e.preventDefault();
-                        await uploadImage(file);
-                        return;
-                    }
-                }
-            }
-        }
-    }
-
-    async function handleFileSelect(e: Event) {
-        const target = e.target as HTMLInputElement;
-        if (target.files && target.files.length > 0) {
-            await uploadImage(target.files[0]);
-        }
-        // Reset input
-        target.value = '';
-    }
-
-    async function uploadImage(file: File) {
-        if (file.size > MAX_IMAGE_SIZE_BYTES) {
-            setError(`Image is too large. Maximum size is ${MAX_IMAGE_SIZE_MB}MB.`);
-            return;
-        }
-
-        const formData = new FormData();
-        formData.append('file', file);
-
-        isUploading = true;
-        try {
-            const currentCollectionId = page.params.collection_id;
-            if (!currentCollectionId) {
-                throw new Error('Collection ID is not available');
-            }
-            const response = await fetch(
-                `/api/image_embedding/from_file/for_collection/${currentCollectionId}`,
-                {
-                    method: 'POST',
-                    body: formData
-                }
-            );
-
-            if (!response.ok) {
-                throw new Error(`Error uploading image: ${response.statusText}`);
-            }
-
-            const embedding = await response.json();
-
-            // Clear text search state
-            query_text = '';
-            submittedQueryText = '';
-            activeImage = file.name;
-
-            // Create preview URL for the uploaded image
-            if (previewUrl) {
-                URL.revokeObjectURL(previewUrl);
-            }
-            previewUrl = URL.createObjectURL(file);
-
-            setTextEmbedding({
-                queryText: file.name,
-                embedding: embedding
-            });
-        } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : 'Failed to upload image';
-            setError(message);
-        } finally {
-            isUploading = false;
-        }
-    }
-
-    function clearSearch() {
-        activeImage = null;
-        query_text = '';
-        submittedQueryText = '';
-        if (previewUrl) {
-            URL.revokeObjectURL(previewUrl);
-            previewUrl = null;
-        }
-        setTextEmbedding(undefined);
-    }
-
-    function triggerFileInput() {
-        fileInput?.click();
-    }
-
-    // Update effect to respect activeImage
-    $effect(() => {
-        if (activeImage) return;
-
-        if ($embedTextQuery.isError && $embedTextQuery.error) {
-            const queryError = $embedTextQuery.error as
-                | { error?: unknown; message?: string }
-                | Error;
-            const message = 'error' in queryError ? queryError.error : queryError.message;
-            setError(String(message));
-            return;
-        }
-
-        if (!submittedQueryText) {
-            setTextEmbedding(undefined);
-            return;
-        }
-
-        if ($embedTextQuery.isSuccess) {
-            setTextEmbedding({
-                queryText: submittedQueryText,
-                embedding: $embedTextQuery.data
-            });
-        }
     });
 
     const showLeftSidebar = $derived(
@@ -547,90 +350,7 @@
                             <div class="my-2 flex items-center space-x-4">
                                 <div class="flex-1">
                                     {#if hasEmbeddings}
-                                        <div
-                                            class="relative"
-                                            role="region"
-                                            aria-label="Search by image or text"
-                                            ondragover={handleDragOver}
-                                            ondragleave={handleDragLeave}
-                                            ondrop={handleDrop}
-                                        >
-                                            <Search
-                                                class="absolute left-2 top-[50%] h-4 w-4 translate-y-[-50%] text-muted-foreground"
-                                            />
-                                            {#if activeImage || submittedQueryText}
-                                                <div
-                                                    class="flex h-10 w-full items-center rounded-md border border-input bg-background px-3 py-2 pl-8 text-sm {dragOver
-                                                        ? 'ring-2 ring-primary'
-                                                        : ''}"
-                                                >
-                                                    {#if activeImage}
-                                                        <span
-                                                            class="mr-2 flex items-center gap-2 truncate text-muted-foreground"
-                                                        >
-                                                            {#if previewUrl}
-                                                                <img
-                                                                    src={previewUrl}
-                                                                    alt="Search preview"
-                                                                    class="h-6 w-6 rounded object-cover"
-                                                                />
-                                                            {:else}
-                                                                <ImageIcon class="h-4 w-4" />
-                                                            {/if}
-                                                            {activeImage}
-                                                        </span>
-                                                    {:else}
-                                                        <button
-                                                            type="button"
-                                                            class="mr-2 min-w-0 flex-1 cursor-text truncate text-left text-muted-foreground"
-                                                            onclick={() => {
-                                                                submittedQueryText = '';
-                                                            }}
-                                                        >
-                                                            {submittedQueryText}
-                                                        </button>
-                                                    {/if}
-                                                    <button
-                                                        class="ml-auto hover:text-foreground"
-                                                        onclick={clearSearch}
-                                                        title="Clear search"
-                                                        data-testid="search-clear-button"
-                                                    >
-                                                        <X class="h-4 w-4" />
-                                                    </button>
-                                                </div>
-                                            {:else}
-                                                <Input
-                                                    placeholder={isUploading
-                                                        ? 'Uploading...'
-                                                        : 'Search samples by description or image'}
-                                                    class="pl-8 pr-8 {dragOver
-                                                        ? 'ring-2 ring-primary'
-                                                        : ''}"
-                                                    bind:value={query_text}
-                                                    onkeydown={onKeyDown}
-                                                    onpaste={handlePaste}
-                                                    disabled={isUploading}
-                                                    data-testid="text-embedding-search-input"
-                                                />
-                                                <button
-                                                    class="absolute right-2 top-[50%] translate-y-[-50%] text-muted-foreground hover:text-foreground disabled:opacity-50"
-                                                    onclick={triggerFileInput}
-                                                    title="Upload image for search"
-                                                    disabled={isUploading}
-                                                >
-                                                    <ImageIcon class="h-4 w-4" />
-                                                </button>
-                                            {/if}
-                                            <input
-                                                type="file"
-                                                accept="image/*"
-                                                class="hidden"
-                                                bind:this={fileInput}
-                                                onchange={handleFileSelect}
-                                                disabled={isUploading}
-                                            />
-                                        </div>
+                                        <GridSearch />
                                     {/if}
                                 </div>
 
@@ -663,90 +383,7 @@
                             <div class="flex-1">
                                 <!-- Conditional rendering for the search bar -->
                                 {#if (isSamples || isVideos) && hasEmbeddings}
-                                    <div
-                                        class="relative"
-                                        role="region"
-                                        aria-label="Search by image or text"
-                                        ondragover={handleDragOver}
-                                        ondragleave={handleDragLeave}
-                                        ondrop={handleDrop}
-                                    >
-                                        <Search
-                                            class="absolute left-2 top-[50%] h-4 w-4 translate-y-[-50%] text-muted-foreground"
-                                        />
-                                        {#if activeImage || submittedQueryText}
-                                            <div
-                                                class="flex h-10 w-full items-center rounded-md border border-input bg-background px-3 py-2 pl-8 text-sm {dragOver
-                                                    ? 'ring-2 ring-primary'
-                                                    : ''}"
-                                            >
-                                                {#if activeImage}
-                                                    <span
-                                                        class="mr-2 flex items-center gap-2 truncate text-muted-foreground"
-                                                    >
-                                                        {#if previewUrl}
-                                                            <img
-                                                                src={previewUrl}
-                                                                alt="Search preview"
-                                                                class="h-6 w-6 rounded object-cover"
-                                                            />
-                                                        {:else}
-                                                            <ImageIcon class="h-4 w-4" />
-                                                        {/if}
-                                                        {activeImage}
-                                                    </span>
-                                                {:else}
-                                                    <button
-                                                        type="button"
-                                                        class="mr-2 min-w-0 flex-1 cursor-text truncate text-left text-muted-foreground"
-                                                        onclick={() => {
-                                                            submittedQueryText = '';
-                                                        }}
-                                                    >
-                                                        {submittedQueryText}
-                                                    </button>
-                                                {/if}
-                                                <button
-                                                    class="ml-auto hover:text-foreground"
-                                                    onclick={clearSearch}
-                                                    title="Clear search"
-                                                    data-testid="search-clear-button"
-                                                >
-                                                    <X class="h-4 w-4" />
-                                                </button>
-                                            </div>
-                                        {:else}
-                                            <Input
-                                                placeholder={isUploading
-                                                    ? 'Uploading...'
-                                                    : 'Search samples by description or image'}
-                                                class="pl-8 pr-8 {dragOver
-                                                    ? 'ring-2 ring-primary'
-                                                    : ''}"
-                                                bind:value={query_text}
-                                                onkeydown={onKeyDown}
-                                                onpaste={handlePaste}
-                                                disabled={isUploading}
-                                                data-testid="text-embedding-search-input"
-                                            />
-                                            <button
-                                                class="absolute right-2 top-[50%] translate-y-[-50%] text-muted-foreground hover:text-foreground disabled:opacity-50"
-                                                onclick={triggerFileInput}
-                                                title="Upload image for search"
-                                                disabled={isUploading}
-                                            >
-                                                <ImageIcon class="h-4 w-4" />
-                                            </button>
-                                        {/if}
-                                        <input
-                                            type="file"
-                                            accept="image/*"
-                                            class="hidden"
-                                            bind:this={fileInput}
-                                            onchange={handleFileSelect}
-                                            disabled={isUploading}
-                                        />
-                                    </div>
+                                    <GridSearch />
                                 {/if}
                             </div>
 


### PR DESCRIPTION
## What has changed and why?
This PR extracts the GridSearch component from the layout to reduce the complexity of the layout and code duplication.
There are no logic changes - just moving the component to the separate file and cleaning up the code duplication.

## How has it been tested?

Ny e2e tests and visually by running `make start-e2e` and checking what search is still working after the refactoring

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
