### PR TITLE
feat: introduce ActiveSearchDisplay

### DIFF
--- a/lightly_studio_view/src/lib/components/GridSearch/ActiveSearchDisplay/ActiveSearchDisplay.svelte
+++ b/lightly_studio_view/src/lib/components/GridSearch/ActiveSearchDisplay/ActiveSearchDisplay.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+    import { Image as ImageIcon, X } from '@lucide/svelte';
+
+    interface Props {
+        activeImage: string | null;
+        submittedQueryText: string;
+        previewUrl: string | null;
+        dragOver: boolean;
+        onClearImage: () => void;
+        onClearText: () => void;
+    }
+
+    let {
+        activeImage,
+        submittedQueryText,
+        previewUrl,
+        dragOver,
+        onClearImage,
+        onClearText
+    }: Props = $props();
+</script>
+
+<div
+    class="flex h-10 w-full items-center rounded-md border border-input bg-background px-3 py-2 pl-8 text-sm {dragOver
+        ? 'ring-2 ring-primary'
+        : ''}"
+>
+    {#if activeImage}
+        <span class="mr-2 flex items-center gap-2 truncate text-muted-foreground">
+            {#if previewUrl}
+                <img src={previewUrl} alt="Search preview" class="h-6 w-6 rounded object-cover" />
+            {:else}
+                <ImageIcon class="h-4 w-4" />
+            {/if}
+            {activeImage}
+        </span>
+        <button
+            class="ml-auto hover:text-foreground"
+            onclick={onClearImage}
+            title="Clear search"
+            data-testid="search-clear-button"
+        >
+            <X class="h-4 w-4" />
+        </button>
+    {:else}
+        <button
+            type="button"
+            class="mr-2 min-w-0 flex-1 cursor-text truncate text-left text-muted-foreground"
+            onclick={onClearText}
+        >
+            {submittedQueryText}
+        </button>
+        <button
+            class="ml-auto hover:text-foreground"
+            onclick={onClearImage}
+            title="Clear search"
+            data-testid="search-clear-button"
+        >
+            <X class="h-4 w-4" />
+        </button>
+    {/if}
+</div>

--- a/lightly_studio_view/src/lib/components/GridSearch/ActiveSearchDisplay/ActiveSearchDisplay.test.ts
+++ b/lightly_studio_view/src/lib/components/GridSearch/ActiveSearchDisplay/ActiveSearchDisplay.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import ActiveSearchDisplay from './ActiveSearchDisplay.svelte';
+
+describe('ActiveSearchDisplay', () => {
+    const defaultProps = {
+        activeImage: null,
+        submittedQueryText: '',
+        previewUrl: null,
+        dragOver: false,
+        onClearImage: vi.fn(),
+        onClearText: vi.fn()
+    };
+
+    it('renders with text query', () => {
+        render(ActiveSearchDisplay, {
+            props: { ...defaultProps, submittedQueryText: 'test search query' }
+        });
+        expect(screen.getByText('test search query')).toBeInTheDocument();
+    });
+
+    it('renders with active image and filename', () => {
+        render(ActiveSearchDisplay, { props: { ...defaultProps, activeImage: 'test-image.jpg' } });
+        expect(screen.getByText('test-image.jpg')).toBeInTheDocument();
+    });
+
+    it('renders image preview when previewUrl is provided', () => {
+        render(ActiveSearchDisplay, {
+            props: {
+                ...defaultProps,
+                activeImage: 'test-image.jpg',
+                previewUrl: 'data:image/png;base64,test'
+            }
+        });
+
+        const img = screen.getByAltText('Search preview');
+        expect(img).toBeInTheDocument();
+        expect(img).toHaveAttribute('src', 'data:image/png;base64,test');
+    });
+
+    it('renders image icon when no preview is available', () => {
+        const { container } = render(ActiveSearchDisplay, {
+            props: { ...defaultProps, activeImage: 'test-image.jpg' }
+        });
+        expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('applies ring style when dragOver is true', () => {
+        const { container } = render(ActiveSearchDisplay, {
+            props: { ...defaultProps, submittedQueryText: 'test', dragOver: true }
+        });
+        expect(container.querySelector('.ring-2.ring-primary')).toBeInTheDocument();
+    });
+
+    it('calls onClearImage when clear button is clicked with image', async () => {
+        const onClearImage = vi.fn();
+        render(ActiveSearchDisplay, {
+            props: { ...defaultProps, activeImage: 'test-image.jpg', onClearImage }
+        });
+
+        await fireEvent.click(screen.getByTestId('search-clear-button'));
+        expect(onClearImage).toHaveBeenCalledOnce();
+    });
+
+    it('calls onClearText when text button is clicked', async () => {
+        const onClearText = vi.fn();
+        render(ActiveSearchDisplay, {
+            props: { ...defaultProps, submittedQueryText: 'test search', onClearText }
+        });
+
+        await fireEvent.click(screen.getByText('test search'));
+        expect(onClearText).toHaveBeenCalledOnce();
+    });
+
+    it('calls onClearImage when clear button is clicked with text query', async () => {
+        const onClearImage = vi.fn();
+        render(ActiveSearchDisplay, {
+            props: { ...defaultProps, submittedQueryText: 'test search', onClearImage }
+        });
+
+        await fireEvent.click(screen.getByTestId('search-clear-button'));
+        expect(onClearImage).toHaveBeenCalledOnce();
+    });
+
+    it('has correct accessibility attributes on clear button', () => {
+        render(ActiveSearchDisplay, { props: { ...defaultProps, activeImage: 'test-image.jpg' } });
+        expect(screen.getByTestId('search-clear-button')).toHaveAttribute('title', 'Clear search');
+    });
+});


### PR DESCRIPTION
## What has changed and why?

(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR introduces a new `ActiveSearchDisplay` Svelte component that provides an inline search status display for the GridSearch functionality. The component conditionally renders either active image information or submitted query text, with associated clear actions and visual feedback for drag-over interactions.

## Changes

### New Component: ActiveSearchDisplay.svelte
- Renders an inline search status bar with conditional display logic
- Accepts props for active image state, query text, optional preview URL, drag-over state, and clear callbacks
- Displays either:
  - Image/preview thumbnail with filename and clear button
  - Search icon placeholder when no preview URL is available
  - Submitted query text with clear button
- Applies ring highlight styling when `dragOver` is true
- Implements accessible UI with appropriate title attributes and test identifiers

**Props interface:**
- `activeImage: string | null` - Currently active image filename
- `submittedQueryText: string` - Submitted search query text
- `previewUrl: string | null` - Optional preview image URL
- `dragOver: boolean` - Drag-over state for visual feedback
- `onClearImage: () => void` - Callback for clearing active image
- `onClearText: () => void` - Callback for clearing query text

### Test Suite: ActiveSearchDisplay.test.ts
- Comprehensive test coverage validating component behavior
- Tests conditional rendering of submitted text and active image filename
- Verifies preview image rendering with correct `alt` text and `src` attributes
- Tests SVG icon display fallback when no preview URL is provided
- Validates styling behavior with drag-over state (ring CSS classes)
- Validates callback invocation on user interactions:
  - Clear button click triggers appropriate callbacks for both image and text clearing
  - Query text interactions properly invoke `onClearText` callback
- Verifies accessibility metadata (clear button title attribute)

## Impact
- **Lines changed:** +151 (-0)
- **New files:** 2 (component + tests)
- **Estimated code review effort:** Medium

This component extends the GridSearch functionality with proper state display and user interaction handling, fully covered by tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->