### PR TITLE
feat: introduce SearchINput component

### DIFF
--- a/lightly_studio_view/src/lib/components/GridSearch/SearchInput/SearchInput.svelte
+++ b/lightly_studio_view/src/lib/components/GridSearch/SearchInput/SearchInput.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+    import { Search, Image as ImageIcon } from '@lucide/svelte';
+    import Input from '$lib/components/ui/input/input.svelte';
+
+    interface Props {
+        queryText: string;
+        isUploading: boolean;
+        dragOver: boolean;
+        onkeydown: (event: KeyboardEvent) => void;
+        onpaste: (event: ClipboardEvent) => Promise<void>;
+        triggerFileInput: () => void;
+    }
+
+    let {
+        queryText = $bindable(),
+        isUploading,
+        dragOver,
+        onkeydown,
+        onpaste,
+        triggerFileInput
+    }: Props = $props();
+</script>
+
+<div class="relative">
+    <Search class="absolute left-2 top-[50%] h-4 w-4 translate-y-[-50%] text-muted-foreground" />
+    <Input
+        placeholder={isUploading ? 'Uploading...' : 'Search samples by description or image'}
+        class="pl-8 pr-8 {dragOver ? 'ring-2 ring-primary' : ''}"
+        bind:value={queryText}
+        {onkeydown}
+        {onpaste}
+        disabled={isUploading}
+        data-testid="text-embedding-search-input"
+    />
+    <button
+        class="absolute right-2 top-[50%] translate-y-[-50%] text-muted-foreground hover:text-foreground disabled:opacity-50"
+        onclick={triggerFileInput}
+        title="Upload image for search"
+        disabled={isUploading}
+    >
+        <ImageIcon class="h-4 w-4" />
+    </button>
+</div>

--- a/lightly_studio_view/src/lib/components/GridSearch/SearchInput/SearchInput.test.ts
+++ b/lightly_studio_view/src/lib/components/GridSearch/SearchInput/SearchInput.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import SearchInput from './SearchInput.svelte';
+
+describe('SearchInput', () => {
+    const defaultProps = {
+        queryText: '',
+        isUploading: false,
+        dragOver: false,
+        onkeydown: vi.fn(),
+        onpaste: vi.fn(),
+        triggerFileInput: vi.fn()
+    };
+
+    it('renders with correct placeholder when not uploading', () => {
+        render(SearchInput, { props: defaultProps });
+        expect(
+            screen.getByPlaceholderText('Search samples by description or image')
+        ).toBeInTheDocument();
+    });
+
+    it('renders with uploading placeholder when isUploading is true', () => {
+        render(SearchInput, { props: { ...defaultProps, isUploading: true } });
+        expect(screen.getByPlaceholderText('Uploading...')).toBeInTheDocument();
+    });
+
+    it('displays queryText value in input', () => {
+        render(SearchInput, { props: { ...defaultProps, queryText: 'test query' } });
+        expect(screen.getByDisplayValue('test query')).toBeInTheDocument();
+    });
+
+    it('applies ring style when dragOver is true', () => {
+        const { container } = render(SearchInput, { props: { ...defaultProps, dragOver: true } });
+        expect(container.querySelector('.ring-2.ring-primary')).toBeInTheDocument();
+    });
+
+    it('disables input when isUploading is true', () => {
+        render(SearchInput, { props: { ...defaultProps, isUploading: true } });
+        expect(screen.getByTestId('text-embedding-search-input')).toBeDisabled();
+    });
+
+    it('calls onkeydown when key is pressed', async () => {
+        const onkeydown = vi.fn();
+        render(SearchInput, { props: { ...defaultProps, onkeydown } });
+
+        await fireEvent.keyDown(screen.getByTestId('text-embedding-search-input'), {
+            key: 'Enter'
+        });
+        expect(onkeydown).toHaveBeenCalledOnce();
+    });
+
+    it('calls onpaste when content is pasted', async () => {
+        const onpaste = vi.fn();
+        render(SearchInput, { props: { ...defaultProps, onpaste } });
+
+        await fireEvent.paste(screen.getByTestId('text-embedding-search-input'));
+        expect(onpaste).toHaveBeenCalledOnce();
+    });
+
+    it('calls triggerFileInput when image icon button is clicked', async () => {
+        const triggerFileInput = vi.fn();
+        render(SearchInput, { props: { ...defaultProps, triggerFileInput } });
+
+        await fireEvent.click(screen.getByTitle('Upload image for search'));
+        expect(triggerFileInput).toHaveBeenCalledOnce();
+    });
+
+    it('disables image upload button when isUploading is true', () => {
+        render(SearchInput, { props: { ...defaultProps, isUploading: true } });
+        expect(screen.getByTitle('Upload image for search')).toBeDisabled();
+    });
+
+    it('renders both search and image icons', () => {
+        const { container } = render(SearchInput, { props: defaultProps });
+        expect(container.querySelectorAll('svg').length).toBe(2);
+    });
+
+    it('has correct testid attribute', () => {
+        render(SearchInput, { props: defaultProps });
+        expect(screen.getByTestId('text-embedding-search-input')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## What has changed and why?

(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## SearchInput Component Introduction

Added a new `SearchInput` Svelte component to support text-based search with image upload capabilities in the GridSearch feature.

### Component Implementation
The `SearchInput.svelte` component provides:
- **Two-way binding** of search query text via the `queryText` prop
- **Search input field** with a leading search icon and trailing image upload button
- **Visual feedback** for drag-over state (active ring styling)
- **Dynamic input state** management (disabled during image uploads)
- **Event handlers** for keyboard input and clipboard paste operations
- **Configurable upload trigger** through the `triggerFileInput` callback

### Props Interface
- `queryText`: string (bindable for two-way binding)
- `isUploading`: boolean (controls input disabled state and upload button availability)
- `dragOver`: boolean (applies visual ring styling to indicate drag-over state)
- `onkeydown`: KeyboardEvent handler
- `onpaste`: async ClipboardEvent handler
- `triggerFileInput`: Callback to initiate file input

### Test Coverage
Comprehensive test suite (`SearchInput.test.ts`) covering:
- Placeholder text switching based on upload state
- Query text display in input field
- Drag-over visual styling
- Input disabled state during uploads
- Keyboard and paste event handling
- Upload button click functionality and upload-state disabling
- SVG icon rendering (exactly 2 icons)
- Proper test identifiers (`data-testid`)

### Metrics
- Component: +43 lines
- Tests: +82 lines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->