### PR TITLE
feat: introduce useImageUploadHandlers

### DIFF
--- a/lightly_studio_view/src/lib/components/GridSearch/hooks/useImageUploadHandlers/useImageUploadHandlers.test.ts
+++ b/lightly_studio_view/src/lib/components/GridSearch/hooks/useImageUploadHandlers/useImageUploadHandlers.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import { useImageUploadHandlers } from './useImageUploadHandlers';
+
+// Mock DOM APIs not available in vitest environment
+class MockDataTransfer {
+    private _files: File[] = [];
+    items: { type: string; getAsFile: () => File | null }[] = [];
+
+    get files(): File[] {
+        return this._files;
+    }
+
+    set files(value: File[]) {
+        this._files = value;
+    }
+}
+
+class MockDragEvent extends Event {
+    dataTransfer: MockDataTransfer | null = null;
+
+    constructor(type: string, init?: { dataTransfer?: MockDataTransfer }) {
+        super(type);
+        this.dataTransfer = init?.dataTransfer || null;
+    }
+
+    preventDefault() {
+        // Mock implementation
+    }
+}
+
+class MockClipboardEvent extends Event {
+    clipboardData: MockDataTransfer | null = null;
+
+    constructor(type: string, init?: { clipboardData?: MockDataTransfer }) {
+        super(type);
+        this.clipboardData = init?.clipboardData || null;
+    }
+
+    preventDefault() {
+        // Mock implementation
+    }
+}
+
+describe('useImageUploadHandlers', () => {
+    let mockUploadFile: ReturnType<typeof vi.fn>;
+    let mockSetActiveImage: ReturnType<typeof vi.fn>;
+    let mockSetPreviewUrl: ReturnType<typeof vi.fn>;
+    let mockOnError: ReturnType<typeof vi.fn>;
+    let originalCreateObjectURL: typeof URL.createObjectURL;
+    let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+
+    beforeEach(() => {
+        mockUploadFile = vi.fn().mockResolvedValue(undefined);
+        mockSetActiveImage = vi.fn();
+        mockSetPreviewUrl = vi.fn();
+        mockOnError = vi.fn();
+
+        // Mock URL.createObjectURL and revokeObjectURL
+        originalCreateObjectURL = URL.createObjectURL;
+        originalRevokeObjectURL = URL.revokeObjectURL;
+        URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+        URL.revokeObjectURL = vi.fn();
+    });
+
+    afterEach(() => {
+        URL.createObjectURL = originalCreateObjectURL;
+        URL.revokeObjectURL = originalRevokeObjectURL;
+    });
+
+    it('should initialize with dragOver set to false', () => {
+        const { dragOver } = useImageUploadHandlers({
+            uploadFile: mockUploadFile,
+            setActiveImage: mockSetActiveImage,
+            setPreviewUrl: mockSetPreviewUrl,
+            onError: mockOnError
+        });
+
+        expect(get(dragOver)).toBe(false);
+    });
+
+    it('should set dragOver to true on handleDragOver', () => {
+        const { dragOver, handleDragOver } = useImageUploadHandlers({
+            uploadFile: mockUploadFile,
+            setActiveImage: mockSetActiveImage,
+            setPreviewUrl: mockSetPreviewUrl,
+            onError: mockOnError
+        });
+
+        const event = new MockDragEvent('dragover');
+        const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+        handleDragOver(event as unknown as DragEvent);
+
+        expect(get(dragOver)).toBe(true);
+        expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it('should set dragOver to false on handleDragLeave', () => {
+        const { dragOver, handleDragOver, handleDragLeave } = useImageUploadHandlers({
+            uploadFile: mockUploadFile,
+            setActiveImage: mockSetActiveImage,
+            setPreviewUrl: mockSetPreviewUrl,
+            onError: mockOnError
+        });
+
+        const dragOverEvent = new MockDragEvent('dragover');
+        handleDragOver(dragOverEvent as unknown as DragEvent);
+
+        const dragLeaveEvent = new MockDragEvent('dragleave');
+        const preventDefaultSpy = vi.spyOn(dragLeaveEvent, 'preventDefault');
+
+        handleDragLeave(dragLeaveEvent as unknown as DragEvent);
+
+        expect(get(dragOver)).toBe(false);
+        expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it('should handle drop with image file', async () => {
+        const { dragOver, handleDrop } = useImageUploadHandlers({
+            uploadFile: mockUploadFile,
+            setActiveImage: mockSetActiveImage,
+            setPreviewUrl: mockSetPreviewUrl,
+            onError: mockOnError
+        });
+
+        const file = new File(['content'], 'test.png', { type: 'image/png' });
+        const dataTransfer = new MockDataTransfer();
+        dataTransfer.files = [file];
+
+        const event = new MockDragEvent('drop', { dataTransfer });
+        const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+        await handleDrop(event as unknown as DragEvent);
+
+        expect(get(dragOver)).toBe(false);
+        expect(preventDefaultSpy).toHaveBeenCalled();
+        expect(mockSetActiveImage).toHaveBeenCalledWith('test.png');
+        expect(mockSetPreviewUrl).toHaveBeenCalledWith('blob:mock-url');
+        expect(mockUploadFile).toHaveBeenCalledWith(file);
+        expect(mockOnError).not.toHaveBeenCalled();
+    });
+
+    it('should show error when dropping non-image file', async () => {
+        const { handleDrop } = useImageUploadHandlers({
+            uploadFile: mockUploadFile,
+            setActiveImage: mockSetActiveImage,
+            setPreviewUrl: mockSetPreviewUrl,
+            onError: mockOnError
+        });
+
+        const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
+        const dataTransfer = new MockDataTransfer();
+        dataTransfer.files = [file];
+
+        const event = new MockDragEvent('drop', { dataTransfer });
+        await handleDrop(event as unknown as DragEvent);
+
+        expect(mockOnError).toHaveBeenCalledWith('Please drop an image file.');
+        expect(mockUploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should handle paste with image from clipboard files', async () => {
+        const { handlePaste } = useImageUploadHandlers({
+            uploadFile: mockUploadFile,
+            setActiveImage: mockSetActiveImage,
+            setPreviewUrl: mockSetPreviewUrl,
+            onError: mockOnError
+        });
+
+        const file = new File(['content'], 'pasted-image.png', { type: 'image/png' });
+        const dataTransfer = new MockDataTransfer();
+        dataTransfer.files = [file];
+
+        const event = new MockClipboardEvent('paste', {
+            clipboardData: dataTransfer
+        });
+        const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+        await handlePaste(event as unknown as ClipboardEvent);
+
+        expect(preventDefaultSpy).toHaveBeenCalled();
+        expect(mockSetActiveImage).toHaveBeenCalledWith('pasted-image.png');
+        expect(mockSetPreviewUrl).toHaveBeenCalledWith('blob:mock-url');
+        expect(mockUploadFile).toHaveBeenCalledWith(file);
+    });
+
+    it('should handle paste with image from clipboard items', async () => {
+        const { handlePaste } = useImageUploadHandlers({
+            uploadFile: mockUploadFile,
+            setActiveImage: mockSetActiveImage,
+            setPreviewUrl: mockSetPreviewUrl,
+            onError: mockOnError
+        });
+
+        const file = new File(['screenshot'], 'screenshot.png', { type: 'image/png' });
+
+        // Mock ClipboardEvent with items but no files
+        const mockClipboardData = {
+            files: [],
+            items: [
+                {
+                    type: 'image/png',
+                    getAsFile: () => file
+                }
+            ]
+        };
+
+        const event = {
+            clipboardData: mockClipboardData,
+            preventDefault: vi.fn()
+        } as unknown as ClipboardEvent;
+
+        await handlePaste(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(mockSetActiveImage).toHaveBeenCalledWith('screenshot.png');
+        expect(mockUploadFile).toHaveBeenCalledWith(file);
+    });
+
+    it('should not process paste event without image data', async () => {
+        const { handlePaste } = useImageUploadHandlers({
+            uploadFile: mockUploadFile,
+            setActiveImage: mockSetActiveImage,
+            setPreviewUrl: mockSetPreviewUrl,
+            onError: mockOnError
+        });
+
+        const dataTransfer = new MockDataTransfer();
+        const event = new MockClipboardEvent('paste', {
+            clipboardData: dataTransfer
+        });
+
+        await handlePaste(event as unknown as ClipboardEvent);
+
+        expect(mockUploadFile).not.toHaveBeenCalled();
+        expect(mockSetActiveImage).not.toHaveBeenCalled();
+    });
+
+    it('should handle file select from input', async () => {
+        const { handleFileSelect } = useImageUploadHandlers({
+            uploadFile: mockUploadFile,
+            setActiveImage: mockSetActiveImage,
+            setPreviewUrl: mockSetPreviewUrl,
+            onError: mockOnError
+        });
+
+        const file = new File(['content'], 'selected.jpg', { type: 'image/jpeg' });
+        const mockFiles = [file] as unknown as FileList;
+
+        const input = {
+            value: 'selected.jpg',
+            files: mockFiles
+        };
+
+        const event = { target: input } as unknown as Event;
+
+        await handleFileSelect(event);
+
+        expect(mockSetActiveImage).toHaveBeenCalledWith('selected.jpg');
+        expect(mockUploadFile).toHaveBeenCalledWith(file);
+        expect(input.value).toBe('');
+    });
+
+    it('should not upload if no file is selected', async () => {
+        const { handleFileSelect } = useImageUploadHandlers({
+            uploadFile: mockUploadFile,
+            setActiveImage: mockSetActiveImage,
+            setPreviewUrl: mockSetPreviewUrl,
+            onError: mockOnError
+        });
+
+        const input = document.createElement('input');
+        input.type = 'file';
+
+        const event = { target: input } as unknown as Event;
+
+        await handleFileSelect(event);
+
+        expect(mockUploadFile).not.toHaveBeenCalled();
+    });
+});

--- a/lightly_studio_view/src/lib/components/GridSearch/hooks/useImageUploadHandlers/useImageUploadHandlers.ts
+++ b/lightly_studio_view/src/lib/components/GridSearch/hooks/useImageUploadHandlers/useImageUploadHandlers.ts
@@ -1,0 +1,125 @@
+import { writable } from 'svelte/store';
+
+interface UseImageUploadHandlersParams {
+    /** Function to upload a file */
+    uploadFile: (file: File) => Promise<void>;
+    /** Function to handle setting active image name */
+    setActiveImage: (name: string | null) => void;
+    /** Function to set preview URL */
+    setPreviewUrl: (url: string | null) => void;
+    /** Function to show error message */
+    onError: (message: string) => void;
+}
+
+interface UseImageUploadHandlersReturn {
+    /** Whether drag is currently over the drop zone */
+    dragOver: ReturnType<typeof writable<boolean>>;
+    /** Handle drag over event */
+    handleDragOver: (e: DragEvent) => void;
+    /** Handle drag leave event */
+    handleDragLeave: (e: DragEvent) => void;
+    /** Handle drop event */
+    handleDrop: (e: DragEvent) => Promise<void>;
+    /** Handle paste event */
+    handlePaste: (e: ClipboardEvent) => Promise<void>;
+    /** Handle file selection from input */
+    handleFileSelect: (e: Event) => Promise<void>;
+}
+
+/**
+ * Hook to handle image upload interactions (drag/drop, paste, file select).
+ *
+ * @param {UseImageUploadHandlersParams} params - Configuration for upload handlers
+ * @returns {UseImageUploadHandlersReturn} Object containing drag state and event handlers
+ */
+export function useImageUploadHandlers({
+    uploadFile,
+    setActiveImage,
+    setPreviewUrl,
+    onError
+}: UseImageUploadHandlersParams): UseImageUploadHandlersReturn {
+    const dragOver = writable(false);
+
+    async function uploadImage(file: File): Promise<void> {
+        // Set active image and preview before upload
+        setActiveImage(file.name);
+
+        // Create preview URL for the uploaded image
+        const previewUrl = URL.createObjectURL(file);
+        setPreviewUrl(previewUrl);
+
+        await uploadFile(file);
+    }
+
+    function handleDragOver(e: DragEvent): void {
+        e.preventDefault();
+        dragOver.set(true);
+    }
+
+    function handleDragLeave(e: DragEvent): void {
+        e.preventDefault();
+        dragOver.set(false);
+    }
+
+    async function handleDrop(e: DragEvent): Promise<void> {
+        e.preventDefault();
+        dragOver.set(false);
+
+        if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
+            const file = e.dataTransfer.files[0];
+            if (file.type.startsWith('image/')) {
+                await uploadImage(file);
+            } else {
+                onError('Please drop an image file.');
+            }
+        }
+    }
+
+    async function handlePaste(e: ClipboardEvent): Promise<void> {
+        const clipboardData = e.clipboardData;
+        if (!clipboardData) return;
+
+        // Check clipboardData.files first (most common case)
+        if (clipboardData.files && clipboardData.files.length > 0) {
+            const file = clipboardData.files[0];
+            if (file.type.startsWith('image/')) {
+                e.preventDefault();
+                await uploadImage(file);
+                return;
+            }
+        }
+
+        // Fallback: check clipboardData.items (screenshots, images copied from web)
+        const items = clipboardData.items;
+        if (items) {
+            for (const item of items) {
+                if (item.type.startsWith('image/')) {
+                    const file = item.getAsFile();
+                    if (file) {
+                        e.preventDefault();
+                        await uploadImage(file);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    async function handleFileSelect(e: Event): Promise<void> {
+        const target = e.target as HTMLInputElement;
+        if (target.files && target.files.length > 0) {
+            await uploadImage(target.files[0]);
+        }
+        // Reset input
+        target.value = '';
+    }
+
+    return {
+        dragOver,
+        handleDragOver,
+        handleDragLeave,
+        handleDrop,
+        handlePaste,
+        handleFileSelect
+    };
+}


### PR DESCRIPTION
## What has changed and why?

(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Introduces `useImageUploadHandlers`, a new Svelte hook that manages image upload interactions through drag-and-drop, clipboard paste, and file input selection. The hook provides a unified interface for handling multiple input methods while validating file types and managing UI state.

## Key Changes

### New Hook: `useImageUploadHandlers`
Exported from `lightly_studio_view/src/lib/components/GridSearch/hooks/useImageUploadHandlers/useImageUploadHandlers.ts`

**Signature:**
```typescript
useImageUploadHandlers(params: {
  uploadFile: (file: File) => Promise<void>
  setActiveImage: (name: string | null) => void
  setPreviewUrl: (url: string | null) => void
  onError: (message: string) => void
}): {
  dragOver: Writable<boolean>
  handleDragOver: (e: DragEvent) => void
  handleDragLeave: (e: DragEvent) => void
  handleDrop: (e: DragEvent) => Promise<void>
  handlePaste: (e: ClipboardEvent) => Promise<void>
  handleFileSelect: (e: Event) => Promise<void>
}
```

**Functionality:**
- Reactive `dragOver` state tracking for visual feedback during drag operations
- **Drag-and-drop handling**: Prevents default behavior, validates dropped files by MIME type, uploads valid images, or calls error handler for invalid files
- **Clipboard paste handling**: Extracts images from `ClipboardEvent.clipboardData.files` or falls back to `clipboardData.items` when files are unavailable
- **File input handling**: Processes file selections, uploads the first selected file, and clears the input value afterward
- Image validation by MIME type prior to upload

### Comprehensive Test Coverage
Added test suite in `useImageUploadHandlers.test.ts` (+282 lines) covering:
- Reactive state transitions for `dragOver` (initial state, drag-over, drag-leave)
- Event handler behavior (preventDefault calls)
- Drop handling for both valid image files and non-image files
- Paste handling via both clipboard `files` and `items` APIs, including edge cases
- File input selection with input value reset
- Error callback invocation for invalid file types

## Code Impact

- **Lines added**: 407 total (+282 test, +125 implementation)
- **Files modified**: 2 (new hook implementation and test suite)
- **Code review effort**: Medium

<!-- end of auto-generated comment: release notes by coderabbit.ai -->