### PR TITLE
feat: introduce GridSearch component

### DIFF
--- a/lightly_studio_view/src/lib/components/GridSearch/GridSearch.svelte
+++ b/lightly_studio_view/src/lib/components/GridSearch/GridSearch.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+    import { page } from '$app/state';
+    import { toast } from 'svelte-sonner';
+    import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+    import { useEmbedText } from '$lib/hooks/useEmbedText/useEmbedText';
+    import { useFileUpload } from '$lib/hooks/useFileUpload/useFileUpload';
+    import { useImageUploadHandlers } from './hooks/useImageUploadHandlers/useImageUploadHandlers';
+    import { embedImageFromFileMutation } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+    import SearchInput from './SearchInput/SearchInput.svelte';
+    import ActiveSearchDisplay from './ActiveSearchDisplay/ActiveSearchDisplay.svelte';
+
+    const { textEmbedding, setTextEmbedding } = useGlobalStorage();
+    const MAX_IMAGE_SIZE_BYTES = 50 * 1024 * 1024; // 50MB
+
+    let activeImage = $state<string | null>(null);
+    let submittedQueryText = $state('');
+    let previewUrl = $state<string | null>(null);
+    let query_text = $state($textEmbedding ? $textEmbedding.queryText : '');
+    let fileInput = $state<HTMLInputElement | null>(null);
+
+    const collectionId = $derived(page.params.collection_id!);
+    const showError = (message: string) => toast.error('Error', { description: message });
+
+    const { isUploading, uploadFile } = useFileUpload({
+        mutationFn: embedImageFromFileMutation,
+        maxFileSize: MAX_IMAGE_SIZE_BYTES,
+        acceptedTypes: ['image/'],
+        buildMutationVariables: (file) => ({
+            body: { file },
+            path: { collection_id: collectionId }
+        }),
+        onSuccess: (embedding) => {
+            query_text = '';
+            submittedQueryText = '';
+            setTextEmbedding({ queryText: activeImage!, embedding });
+        },
+        onError: showError
+    });
+
+    const { dragOver, handleDragOver, handleDragLeave, handleDrop, handlePaste, handleFileSelect } =
+        useImageUploadHandlers({
+            uploadFile,
+            setActiveImage: (name) => (activeImage = name),
+            setPreviewUrl: (url) => {
+                if (previewUrl) URL.revokeObjectURL(previewUrl);
+                previewUrl = url;
+            },
+            onError: showError
+        });
+
+    const embedTextQuery = $derived(
+        useEmbedText({ collectionId, queryText: submittedQueryText, embeddingModelId: null })
+    );
+
+    function onKeyDown(event: KeyboardEvent) {
+        if (event.key === 'Enter') submittedQueryText = query_text.trim();
+    }
+
+    function clearSearch() {
+        activeImage = null;
+        query_text = '';
+        submittedQueryText = '';
+        if (previewUrl) {
+            URL.revokeObjectURL(previewUrl);
+            previewUrl = null;
+        }
+        setTextEmbedding(undefined);
+    }
+
+    $effect(() => {
+        if (activeImage) return;
+
+        if ($embedTextQuery.isError && $embedTextQuery.error) {
+            const queryError = $embedTextQuery.error as
+                | { error?: unknown; message?: string }
+                | Error;
+            const message = 'error' in queryError ? queryError.error : queryError.message;
+            showError(String(message));
+            return;
+        }
+
+        if (!submittedQueryText) {
+            setTextEmbedding(undefined);
+            return;
+        }
+
+        if ($embedTextQuery.isSuccess) {
+            setTextEmbedding({ queryText: submittedQueryText, embedding: $embedTextQuery.data });
+        }
+    });
+</script>
+
+<div
+    class="relative"
+    role="region"
+    aria-label="Search by image or text"
+    ondragover={handleDragOver}
+    ondragleave={handleDragLeave}
+    ondrop={handleDrop}
+>
+    {#if activeImage || submittedQueryText}
+        <ActiveSearchDisplay
+            {activeImage}
+            {submittedQueryText}
+            {previewUrl}
+            dragOver={$dragOver}
+            onClearImage={clearSearch}
+            onClearText={() => {
+                submittedQueryText = '';
+            }}
+        />
+    {:else}
+        <SearchInput
+            bind:queryText={query_text}
+            isUploading={$isUploading}
+            dragOver={$dragOver}
+            onkeydown={onKeyDown}
+            onpaste={handlePaste}
+            triggerFileInput={() => fileInput?.click()}
+        />
+    {/if}
+    <input
+        type="file"
+        accept="image/*"
+        class="hidden"
+        bind:this={fileInput}
+        onchange={handleFileSelect}
+        disabled={$isUploading}
+    />
+</div>

--- a/lightly_studio_view/src/lib/components/GridSearch/GridSearch.test.ts
+++ b/lightly_studio_view/src/lib/components/GridSearch/GridSearch.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { readable, writable } from 'svelte/store';
+import GridSearch from './GridSearch.svelte';
+
+// Mock dependencies
+vi.mock('$app/state', () => ({
+    page: {
+        params: { collection_id: 'test-collection-id' }
+    }
+}));
+
+vi.mock('svelte-sonner', () => ({
+    toast: {
+        error: vi.fn()
+    }
+}));
+
+vi.mock('$lib/hooks/useGlobalStorage', () => ({
+    useGlobalStorage: vi.fn()
+}));
+
+vi.mock('$lib/hooks/useEmbedText/useEmbedText', () => ({
+    useEmbedText: vi.fn()
+}));
+
+vi.mock('$lib/hooks/useFileUpload/useFileUpload', () => ({
+    useFileUpload: vi.fn()
+}));
+
+vi.mock('./hooks/useImageUploadHandlers/useImageUploadHandlers', () => ({
+    useImageUploadHandlers: vi.fn()
+}));
+
+vi.mock('$lib/api/lightly_studio_local/@tanstack/svelte-query.gen', () => ({
+    embedImageFromFileMutation: vi.fn()
+}));
+
+import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+import { useEmbedText } from '$lib/hooks/useEmbedText/useEmbedText';
+import { useFileUpload } from '$lib/hooks/useFileUpload/useFileUpload';
+import { useImageUploadHandlers } from './hooks/useImageUploadHandlers/useImageUploadHandlers';
+
+describe('GridSearch', () => {
+    let mockSetTextEmbedding: ReturnType<typeof vi.fn>;
+    let mockUploadFile: ReturnType<typeof vi.fn>;
+
+    const setupDefaultMocks = () => {
+        mockSetTextEmbedding = vi.fn();
+        mockUploadFile = vi.fn().mockResolvedValue(undefined);
+
+        (useGlobalStorage as ReturnType<typeof vi.fn>).mockReturnValue({
+            textEmbedding: readable(undefined),
+            setTextEmbedding: mockSetTextEmbedding
+        });
+
+        (useEmbedText as ReturnType<typeof vi.fn>).mockReturnValue(
+            readable({
+                isError: false,
+                isSuccess: false,
+                data: undefined,
+                error: undefined
+            })
+        );
+
+        (useFileUpload as ReturnType<typeof vi.fn>).mockReturnValue({
+            isUploading: readable(false),
+            uploadFile: mockUploadFile
+        });
+
+        (useImageUploadHandlers as ReturnType<typeof vi.fn>).mockReturnValue({
+            dragOver: readable(false),
+            handleDragOver: vi.fn(),
+            handleDragLeave: vi.fn(),
+            handleDrop: vi.fn(),
+            handlePaste: vi.fn(),
+            handleFileSelect: vi.fn()
+        });
+    };
+
+    beforeEach(setupDefaultMocks);
+    afterEach(() => vi.clearAllMocks());
+
+    it('renders with correct aria attributes', () => {
+        const { container } = render(GridSearch);
+
+        const region = container.querySelector('[role="region"]');
+        expect(region).toBeInTheDocument();
+        expect(region).toHaveAttribute('aria-label', 'Search by image or text');
+    });
+
+    it('shows SearchInput initially', () => {
+        render(GridSearch);
+        expect(screen.getByTestId('text-embedding-search-input')).toBeInTheDocument();
+    });
+
+    it('calls drag handlers on drag events', async () => {
+        const mockHandleDragOver = vi.fn();
+        const mockHandleDragLeave = vi.fn();
+        const mockHandleDrop = vi.fn();
+
+        (useImageUploadHandlers as ReturnType<typeof vi.fn>).mockReturnValue({
+            dragOver: readable(false),
+            handleDragOver: mockHandleDragOver,
+            handleDragLeave: mockHandleDragLeave,
+            handleDrop: mockHandleDrop,
+            handlePaste: vi.fn(),
+            handleFileSelect: vi.fn()
+        });
+
+        const { container } = render(GridSearch);
+        const region = container.querySelector('[role="region"]')!;
+
+        await fireEvent.dragOver(region);
+        expect(mockHandleDragOver).toHaveBeenCalled();
+
+        await fireEvent.dragLeave(region);
+        expect(mockHandleDragLeave).toHaveBeenCalled();
+
+        await fireEvent.drop(region);
+        expect(mockHandleDrop).toHaveBeenCalled();
+    });
+
+    it('handles paste event', async () => {
+        const mockHandlePaste = vi.fn();
+
+        (useImageUploadHandlers as ReturnType<typeof vi.fn>).mockReturnValue({
+            dragOver: readable(false),
+            handleDragOver: vi.fn(),
+            handleDragLeave: vi.fn(),
+            handleDrop: vi.fn(),
+            handlePaste: mockHandlePaste,
+            handleFileSelect: vi.fn()
+        });
+
+        render(GridSearch);
+        await fireEvent.paste(screen.getByTestId('text-embedding-search-input'));
+
+        expect(mockHandlePaste).toHaveBeenCalled();
+    });
+
+    it('renders hidden file input with correct attributes', () => {
+        const { container } = render(GridSearch);
+
+        const fileInput = container.querySelector('input[type="file"]');
+        expect(fileInput).toBeInTheDocument();
+        expect(fileInput).toHaveClass('hidden');
+        expect(fileInput).toHaveAttribute('accept', 'image/*');
+    });
+
+    it('disables file input when uploading', () => {
+        (useFileUpload as ReturnType<typeof vi.fn>).mockReturnValue({
+            isUploading: readable(true),
+            uploadFile: mockUploadFile
+        });
+
+        const { container } = render(GridSearch);
+        expect(container.querySelector('input[type="file"]')).toBeDisabled();
+    });
+
+    it('handles file select event', async () => {
+        const mockHandleFileSelect = vi.fn();
+
+        (useImageUploadHandlers as ReturnType<typeof vi.fn>).mockReturnValue({
+            dragOver: readable(false),
+            handleDragOver: vi.fn(),
+            handleDragLeave: vi.fn(),
+            handleDrop: vi.fn(),
+            handlePaste: vi.fn(),
+            handleFileSelect: mockHandleFileSelect
+        });
+
+        const { container } = render(GridSearch);
+        await fireEvent.change(container.querySelector('input[type="file"]')!);
+
+        expect(mockHandleFileSelect).toHaveBeenCalled();
+    });
+
+    it('passes drag over state to child components', () => {
+        (useImageUploadHandlers as ReturnType<typeof vi.fn>).mockReturnValue({
+            dragOver: writable(true),
+            handleDragOver: vi.fn(),
+            handleDragLeave: vi.fn(),
+            handleDrop: vi.fn(),
+            handlePaste: vi.fn(),
+            handleFileSelect: vi.fn()
+        });
+
+        const { container } = render(GridSearch);
+        expect(container.querySelector('.ring-2.ring-primary')).toBeInTheDocument();
+    });
+
+    it('passes uploading state to SearchInput', () => {
+        (useFileUpload as ReturnType<typeof vi.fn>).mockReturnValue({
+            isUploading: readable(true),
+            uploadFile: mockUploadFile
+        });
+
+        render(GridSearch);
+        const input = screen.getByPlaceholderText('Uploading...');
+        expect(input).toBeInTheDocument();
+        expect(input).toBeDisabled();
+    });
+
+    it('initializes with textEmbedding from storage', () => {
+        (useGlobalStorage as ReturnType<typeof vi.fn>).mockReturnValue({
+            textEmbedding: readable({ queryText: 'saved query', embedding: [1, 2, 3] }),
+            setTextEmbedding: mockSetTextEmbedding
+        });
+
+        render(GridSearch);
+        expect(screen.getByDisplayValue('saved query')).toBeInTheDocument();
+    });
+
+    it('configures useFileUpload with correct parameters', () => {
+        render(GridSearch);
+
+        const config = (useFileUpload as ReturnType<typeof vi.fn>).mock.calls[0][0];
+        expect(config.maxFileSize).toBe(50 * 1024 * 1024);
+        expect(config.acceptedTypes).toEqual(['image/']);
+        expect(config.onSuccess).toBeDefined();
+        expect(config.onError).toBeDefined();
+    });
+});


### PR DESCRIPTION
## What has changed and why?

(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## GridSearch Component

Introduces a new `GridSearch.svelte` component that provides combined image-and-text search functionality for collections.

### Features
- **Dual-mode search**: Supports both text query embedding and image-based search
- **Image upload methods**: Drag-and-drop, paste, and file selection with preview capability
- **Persistent state**: Integrates with global storage to maintain text queries and embedding results
- **Query execution**: Uses TanStack query hooks (`useEmbedText` and `useFileUpload` with `embedImageFromFileMutation`)
- **User interactions**: Enter key submission, keyboard shortcuts, and drag-over visual feedback
- **Error handling**: Centralized toast notifications via `svelte-sonner`
- **Route integration**: Derives `collectionId` from route parameters

### Implementation Details
- Manages component state for active uploaded image, text draft, and preview URL
- Renders either `SearchInput` (initial state) or `ActiveSearchDisplay` (when image/query active)
- Synchronizes embedding results via Svelte effects
- Implements `clearSearch` function to reset state and revoke object URLs

### Test Coverage
Comprehensive test suite (224 lines) covering:
- Accessibility and ARIA labels
- Event handlers (drag, drop, paste, file selection)
- File input configuration and behavior
- Upload state propagation
- Text embedding initialization from storage
- Hook configuration and callbacks

**Changes**: +130 lines (component) / +224 lines (tests)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->