### PR TITLE
fix: replace bare except with except Exception in tokenizer

### DIFF
--- a/lightly_studio/src/lightly_studio/vendor/perception_encoder/vision_encoder/tokenizer.py
+++ b/lightly_studio/src/lightly_studio/vendor/perception_encoder/vision_encoder/tokenizer.py
@@ -196,7 +196,7 @@ class SimpleTokenizer(object):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except Exception:` in `tokenizer.py` (line 199).

Bare `except:` catches `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` in addition to regular exceptions. This `except` clause catches a `ValueError` from `list.index()`, so `except Exception:` is the correct narrower alternative.

**Change:**
```python
# Before
                except:
                    new_word.extend(word[i:])

# After
                except Exception:
                    new_word.extend(word[i:])
```

## Testing
No behavior change for normal exceptions — style/correctness fix only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced exception handling in the vision encoder tokenizer for improved application stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->