### PR TITLE
feat: introduce scroll support in Grid

### DIFF
--- a/lightly_studio_view/src/lib/components/Grid/Grid.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.stories.svelte
@@ -11,7 +11,16 @@
     });
 </script>
 
-<Story name="Base example" args={{ itemCount: 100, onScroll: fn() }}>
+<Story
+    name="Base example"
+    args={{
+        itemCount: 100,
+        gridProps: {
+            scrollPosition: 400
+        },
+        onScroll: fn()
+    }}
+>
     {#snippet template(args)}
         <Grid {...args}>
             {#snippet gridItem({ index, style, width, height })}

--- a/lightly_studio_view/src/lib/components/Grid/Grid.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.stories.svelte
@@ -2,70 +2,48 @@
     import { defineMeta } from '@storybook/addon-svelte-csf';
     import Grid from './Grid.svelte';
     import GridItem from '../GridItem/GridItem.svelte';
+    import { fn } from 'storybook/test';
 
     const { Story } = defineMeta({
+        component: Grid,
         title: 'Components/Grid',
         tags: ['autodocs']
     });
 </script>
 
-<Story name="Base example" asChild>
-    <Grid itemCount={100} columnCount={6}>
-        {#snippet gridItem({ index, style, width, height })}
-            <GridItem {width} {height} containerProps={{ style }}>
-                <img
-                    src="https://picsum.photos/180?random={index}"
-                    alt="Placeholder {index + 1}"
-                    class="h-full w-full object-cover"
-                />
-            </GridItem>
-        {/snippet}
-    </Grid>
+<Story name="Base example" args={{ itemCount: 100, onScroll: fn() }}>
+    {#snippet template(args)}
+        <Grid {...args}>
+            {#snippet gridItem({ index, style, width, height })}
+                <GridItem {width} {height} containerProps={{ style }}>
+                    <img
+                        src="https://picsum.photos/180?random={index}"
+                        alt="Placeholder {index + 1}"
+                        class="h-full w-full object-cover"
+                    />
+                </GridItem>
+            {/snippet}
+        </Grid>
+    {/snippet}
 </Story>
 
-<Story name="With many columns" asChild>
-    <Grid itemCount={200} columnCount={10}>
-        {#snippet gridItem({ index, style, width, height })}
-            <GridItem {width} {height} containerProps={{ style }}>
-                <img
-                    src="https://picsum.photos/150?random={index + 200}"
-                    alt="Placeholder {index + 1}"
-                    class="h-full w-full object-cover"
-                />
-            </GridItem>
-        {/snippet}
-    </Grid>
-</Story>
-
-<Story name="With footer" asChild>
-    <Grid itemCount={60} columnCount={4}>
-        {#snippet gridItem({ index, style, width, height })}
-            <GridItem {width} {height} containerProps={{ style }}>
-                <img
-                    src="https://picsum.photos/190?random={index + 500}"
-                    alt="Placeholder {index + 1}"
-                    class="h-full w-full object-cover"
-                />
-            </GridItem>
-        {/snippet}
-        {#snippet footerItem()}
-            <div class="bg-gray-200 p-4 text-center text-gray-700">
-                End of grid - 60 items loaded
-            </div>
-        {/snippet}
-    </Grid>
-</Story>
-
-<Story name="Large dataset" asChild>
-    <Grid itemCount={10000} columnCount={8}>
-        {#snippet gridItem({ index, style, width, height })}
-            <GridItem {width} {height} containerProps={{ style }}>
-                <div
-                    class="flex h-full w-full items-center justify-center bg-gradient-to-br from-blue-400 to-purple-500 font-bold text-white"
-                >
-                    {index + 1}
+<Story name="With footer" args={{ itemCount: 100, onScroll: fn() }}>
+    {#snippet template(args)}
+        <Grid {...args}>
+            {#snippet gridItem({ index, style, width, height })}
+                <GridItem {width} {height} containerProps={{ style }}>
+                    <img
+                        src="https://picsum.photos/180?random={index}"
+                        alt="Placeholder {index + 1}"
+                        class="h-full w-full object-cover"
+                    />
+                </GridItem>
+            {/snippet}
+            {#snippet footerItem()}
+                <div class="bg-gray-200 p-4 text-center text-gray-700">
+                    End of grid - 60 items loaded
                 </div>
-            </GridItem>
-        {/snippet}
-    </Grid>
+            {/snippet}
+        </Grid>
+    {/snippet}
 </Story>

--- a/lightly_studio_view/src/lib/components/Grid/Grid.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.svelte
@@ -2,21 +2,25 @@
     import VirtualGrid from 'svelte-virtual/grid';
     import type { ComponentProps, Snippet } from 'svelte';
     import type { HTMLAttributes } from 'svelte/elements';
+    import Grid from 'svelte-virtual/grid';
 
     let viewport: HTMLElement | null = null;
     let clientWidth = $state(0);
     const GRID_GAP = 20;
 
     const {
-        columnCount,
+        columnCount = 4,
         itemCount,
         gridItem,
         footerItem,
         viewportProps,
-        gridProps
+        gridProps,
+        scrollToIndex,
+        scrollPosition,
+        onScroll
     }: {
         /** Number of columns in the grid */
-        columnCount: number;
+        columnCount?: number;
         /** Total number of items to display */
         itemCount: number;
         /** Snippet to render each grid item. Receives index, style, width, and height */
@@ -27,6 +31,10 @@
         viewportProps?: HTMLAttributes<HTMLDivElement>;
         /** Additional props to pass to the VirtualGrid component */
         gridProps?: Partial<ComponentProps<typeof VirtualGrid>>;
+
+        scrollToIndex?: number;
+        scrollPosition?: number;
+        onScroll?: (event: Event) => void;
     } = $props();
 
     $effect(() => {
@@ -38,6 +46,23 @@
             });
             resizeObserver.observe(viewport);
             return () => resizeObserver.disconnect();
+        }
+    });
+
+    let grid: ReturnType<typeof Grid> | undefined = $state();
+
+    $effect(() => {
+        if (grid && scrollToIndex !== undefined && itemSize > 0 && clientHeight > 0) {
+            // Use requestAnimationFrame to ensure DOM is fully updated
+            requestAnimationFrame(() => {
+                grid?.scrollToIndex(scrollToIndex);
+            });
+        }
+
+        if (grid && scrollPosition !== undefined && itemSize > 0 && clientHeight > 0) {
+            requestAnimationFrame(() => {
+                grid?.scrollToPosition(scrollPosition);
+            });
         }
     });
 
@@ -56,9 +81,11 @@
         itemHeight={itemSize + GRID_GAP}
         itemWidth={itemSize + GRID_GAP}
         height={clientHeight}
+        onscroll={onScroll}
         {itemCount}
         {columnCount}
         {...gridProps}
+        bind:this={grid}
     >
         {#snippet item({ index, style })}
             {@render gridItem({

--- a/lightly_studio_view/src/lib/components/Grid/Grid.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.svelte
@@ -2,7 +2,6 @@
     import VirtualGrid from 'svelte-virtual/grid';
     import type { ComponentProps, Snippet } from 'svelte';
     import type { HTMLAttributes } from 'svelte/elements';
-    import Grid from 'svelte-virtual/grid';
 
     let viewport: HTMLElement | null = null;
     let clientWidth = $state(0);
@@ -49,20 +48,20 @@
         }
     });
 
-    let grid: ReturnType<typeof Grid> | undefined = $state();
+    let grid: ReturnType<typeof VirtualGrid> | undefined = $state();
 
     $effect(() => {
-        if (grid && scrollToIndex !== undefined && itemSize > 0 && clientHeight > 0) {
+        if (grid && itemSize > 0 && clientHeight > 0) {
             // Use requestAnimationFrame to ensure DOM is fully updated
-            requestAnimationFrame(() => {
-                grid?.scrollToIndex(scrollToIndex);
-            });
-        }
-
-        if (grid && scrollPosition !== undefined && itemSize > 0 && clientHeight > 0) {
-            requestAnimationFrame(() => {
-                grid?.scrollToPosition(scrollPosition);
-            });
+            if (scrollToIndex !== undefined) {
+                requestAnimationFrame(() => {
+                    grid?.scrollToIndex(scrollToIndex);
+                });
+            } else if (scrollPosition !== undefined) {
+                requestAnimationFrame(() => {
+                    grid?.scrollToPosition(scrollPosition);
+                });
+            }
         }
     });
 

--- a/lightly_studio_view/src/lib/components/Grid/Grid.test.ts
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
+import { tick, type ComponentProps } from 'svelte';
 import GridTestWrapper from './GridTestWrapper.test.svelte';
 
 class MockResizeObserver {
@@ -29,7 +30,14 @@ class MockResizeObserver {
     disconnect() {}
 }
 
+type GridProps = ComponentProps<typeof GridTestWrapper>;
+
 describe('Grid', () => {
+    const defaultProps: GridProps = {
+        itemCount: 100,
+        columnCount: 3,
+        gridItem: vi.fn()
+    };
     beforeEach(() => {
         global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 
@@ -116,5 +124,77 @@ describe('Grid', () => {
             // Should be able to scroll and see grid-item-19
             expect(item19).toBeInTheDocument();
         }
+    });
+
+    it('calls onScroll callback when scrolling', async () => {
+        const onScroll = vi.fn();
+        const { container } = render(GridTestWrapper, { onScroll, ...defaultProps });
+
+        const gridScroll = container.querySelector('.grid-scroll');
+        expect(gridScroll).toBeInTheDocument();
+
+        if (gridScroll) {
+            Object.defineProperty(gridScroll, 'scrollTop', {
+                writable: true,
+                configurable: true,
+                value: 100
+            });
+
+            const scrollEvent = new Event('scroll');
+            gridScroll.dispatchEvent(scrollEvent);
+
+            await new Promise((resolve) => setTimeout(resolve, 50));
+
+            expect(onScroll).toHaveBeenCalled();
+        }
+    });
+
+    it('scrolls to index when scrollToIndex is provided', async () => {
+        vi.clearAllMocks();
+        render(GridTestWrapper, { scrollToIndex: 10, ...defaultProps });
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // scrollTo should have been called due to scrollToIndex
+        expect(Element.prototype.scrollTo).toHaveBeenCalled();
+    });
+
+    it('scrolls to position when scrollPosition is provided', async () => {
+        vi.clearAllMocks();
+        render(GridTestWrapper, { scrollPosition: 500, ...defaultProps });
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // scrollTo should have been called with the target position
+        expect(Element.prototype.scrollTo).toHaveBeenCalled();
+    });
+
+    it('calls scrollToIndex on underlying grid when scrollToIndex prop is provided', async () => {
+        vi.clearAllMocks();
+        render(GridTestWrapper, {
+            scrollToIndex: 5,
+            ...defaultProps
+        } as ComponentProps<typeof GridTestWrapper>);
+
+        await tick();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // scrollTo should have been called at least once due to scrollToIndex
+        expect(Element.prototype.scrollTo).toHaveBeenCalled();
+    });
+
+    it('calls scrollToPosition on underlying grid when scrollPosition prop is provided', async () => {
+        vi.clearAllMocks();
+        render(GridTestWrapper, {
+            itemCount: 100,
+            columnCount: 3,
+            scrollPosition: 100
+        } as ComponentProps<typeof GridTestWrapper>);
+
+        await tick();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // scrollTo should have been called at least once due to scrollPosition
+        expect(Element.prototype.scrollTo).toHaveBeenCalled();
     });
 });

--- a/lightly_studio_view/src/lib/components/Grid/GridTestWrapper.test.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/GridTestWrapper.test.svelte
@@ -2,10 +2,16 @@
     import type { ComponentProps } from 'svelte';
     import Grid from './Grid.svelte';
 
-    let { itemCount = 20, columnCount = 3 }: ComponentProps<typeof Grid> = $props();
+    let {
+        itemCount = 20,
+        columnCount = 3,
+        scrollToIndex,
+        scrollPosition,
+        onScroll
+    }: ComponentProps<typeof Grid> = $props();
 </script>
 
-<Grid {itemCount} {columnCount}>
+<Grid {itemCount} {columnCount} {scrollToIndex} {scrollPosition} {onScroll}>
     {#snippet gridItem({ index, style, width, height })}
         <div data-testid="grid-item-{index}" data-width={width} data-height={height} {style}></div>
     {/snippet}


### PR DESCRIPTION
## What has changed and why?

Added support for restoring the Grid scroll position, either by item index or by absolute scroll value.

Although the Grid component from svelte-virtual/grid exposes a scrollPosition property, it does not reliably restore the scroll state when the Grid has not been fully rendered yet. This leads to incorrect positioning on initial load.

To address this, I implemented a mechanism that ensures correct scroll restoration after the Grid has been initialized, resulting in consistent positioning regardless of render timing.

## How has it been tested?

I've added a comprehensive test and a storybook story. You can run `npm run storybook` and check what props changing changes the scrolling


https://github.com/user-attachments/assets/374e645e-e6d0-4e80-8e73-367610d32eec

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Programmatic scrolling: new scrollToIndex and scrollPosition props to navigate the grid
  * onScroll callback added
  * columnCount is now optional with default 4

* **Documentation (Storybook)**
  * Stories converted to args-driven format; simplified examples, removed two legacy stories, updated footer story to use args

* **Tests**
  * Added tests covering scroll callbacks and programmatic scrolling behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->