### PR TITLE
feat: introduce scrolling example with gridProps

### DIFF
--- a/lightly_studio_view/src/lib/components/Grid/Grid.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.stories.svelte
@@ -2,70 +2,57 @@
     import { defineMeta } from '@storybook/addon-svelte-csf';
     import Grid from './Grid.svelte';
     import GridItem from '../GridItem/GridItem.svelte';
+    import { fn } from 'storybook/test';
 
     const { Story } = defineMeta({
+        component: Grid,
         title: 'Components/Grid',
         tags: ['autodocs']
     });
 </script>
 
-<Story name="Base example" asChild>
-    <Grid itemCount={100} columnCount={6}>
-        {#snippet gridItem({ index, style, width, height })}
-            <GridItem {width} {height} containerProps={{ style }}>
-                <img
-                    src="https://picsum.photos/180?random={index}"
-                    alt="Placeholder {index + 1}"
-                    class="h-full w-full object-cover"
-                />
-            </GridItem>
-        {/snippet}
-    </Grid>
+<Story
+    name="Base example"
+    args={{
+        itemCount: 100,
+        gridProps: {
+            scrollPosition: 400,
+            onscroll: fn()
+        }
+    }}
+>
+    {#snippet template(args)}
+        <Grid {...args}>
+            {#snippet gridItem({ index, style, width, height })}
+                <GridItem {width} {height} containerProps={{ style }}>
+                    <img
+                        src="https://picsum.photos/180?random={index}"
+                        alt="Placeholder {index + 1}"
+                        class="h-full w-full object-cover"
+                    />
+                </GridItem>
+            {/snippet}
+        </Grid>
+    {/snippet}
 </Story>
 
-<Story name="With many columns" asChild>
-    <Grid itemCount={200} columnCount={10}>
-        {#snippet gridItem({ index, style, width, height })}
-            <GridItem {width} {height} containerProps={{ style }}>
-                <img
-                    src="https://picsum.photos/150?random={index + 200}"
-                    alt="Placeholder {index + 1}"
-                    class="h-full w-full object-cover"
-                />
-            </GridItem>
-        {/snippet}
-    </Grid>
-</Story>
-
-<Story name="With footer" asChild>
-    <Grid itemCount={60} columnCount={4}>
-        {#snippet gridItem({ index, style, width, height })}
-            <GridItem {width} {height} containerProps={{ style }}>
-                <img
-                    src="https://picsum.photos/190?random={index + 500}"
-                    alt="Placeholder {index + 1}"
-                    class="h-full w-full object-cover"
-                />
-            </GridItem>
-        {/snippet}
-        {#snippet footerItem()}
-            <div class="bg-gray-200 p-4 text-center text-gray-700">
-                End of grid - 60 items loaded
-            </div>
-        {/snippet}
-    </Grid>
-</Story>
-
-<Story name="Large dataset" asChild>
-    <Grid itemCount={10000} columnCount={8}>
-        {#snippet gridItem({ index, style, width, height })}
-            <GridItem {width} {height} containerProps={{ style }}>
-                <div
-                    class="flex h-full w-full items-center justify-center bg-gradient-to-br from-blue-400 to-purple-500 font-bold text-white"
-                >
-                    {index + 1}
+<Story name="With footer" args={{ itemCount: 100, onScroll: fn() }}>
+    {#snippet template(args)}
+        <Grid {...args}>
+            {#snippet gridItem({ index, style, width, height })}
+                <GridItem {width} {height} containerProps={{ style }}>
+                    <img
+                        src="https://picsum.photos/180?random={index}"
+                        alt="Placeholder {index + 1}"
+                        class="h-full w-full object-cover"
+                    />
+                </GridItem>
+            {/snippet}
+            {#snippet footerItem()}
+                <div class="bg-gray-200 p-4 text-center text-gray-700">
+                    End of grid - 60 items loaded
                 </div>
-            </GridItem>
-        {/snippet}
-    </Grid>
+            {/snippet}
+        </Grid>
+    {/snippet}
 </Story>


### PR DESCRIPTION
## What has changed and why?

Let's update the example to show how to scroll within the grid

There will be other PRs to use Grid in Samples/Annotations/etc

## How has it been tested?

Just an example in the storybook of how to scroll using gridProps using an existing component

https://github.com/user-attachments/assets/aa8dd27f-45ee-4452-9002-8dd0d088969f


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development infrastructure for component testing and documentation. Improved story configuration and testing setup to streamline the development workflow.

**Note:** This update contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->