### PR TITLE
feat: Fetch all frames without pagination

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/frame.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/frame.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Path
+from fastapi import APIRouter, Depends, Path, Query
 from pydantic import BaseModel, Field
 
-from lightly_studio.api.routes.api.validators import Paginated, PaginatedWithCursor
+from lightly_studio.api.routes.api.validators import Paginated
 from lightly_studio.db_manager import SessionDep
 from lightly_studio.models.annotation.annotation_base import AnnotationView
 from lightly_studio.models.caption import CaptionView
@@ -34,6 +34,16 @@ from lightly_studio.resolvers.video_resolver.count_video_frame_annotations_by_co
 frame_router = APIRouter(prefix="/collections/{video_frame_collection_id}/frame", tags=["frame"])
 
 
+def optional_pagination(
+    cursor: int | None = Query(None, ge=0, description="Offset for pagination"),
+    limit: int | None = Query(None, gt=0, le=100, description="Limit for pagination"),
+) -> Paginated | None:
+    """Optional pagination dependency."""
+    if cursor is None and limit is None:
+        return None
+    return Paginated(offset=cursor or 0, limit=limit or 100)
+
+
 class ReadVideoFramesRequest(BaseModel):
     """Request body for reading videos."""
 
@@ -52,23 +62,24 @@ class ReadCountVideoFramesAnnotationsRequest(BaseModel):
 def get_all_frames(
     video_frame_collection_id: Annotated[UUID, Path(title="Video collection Id")],
     session: SessionDep,
-    pagination: Annotated[PaginatedWithCursor, Depends()],
     body: ReadVideoFramesRequest,
+    pagination: Annotated[Paginated | None, Depends(optional_pagination)] = None,
 ) -> VideoFrameViewsWithCount:
-    """Retrieve a list of all frames for a given collection ID with pagination.
+    """Retrieve a list of all frames for a given collection ID with optional pagination.
 
     Args:
         session: The database session.
         video_frame_collection_id: The ID of the collection to retrieve frames for.
-        pagination: Pagination parameters including offset and limit.
         body: The body containing the filters
+        pagination: Optional pagination parameters including offset and limit.
+
     Returns:
         A list of frames along with the total count.
     """
     result = video_frame_resolver.get_all_by_collection_id(
         session=session,
         collection_id=video_frame_collection_id,
-        pagination=Paginated(offset=pagination.offset, limit=pagination.limit),
+        pagination=pagination,
         video_frame_filter=body.filter,
     )
 

--- a/lightly_studio/tests/api/routes/api/test_frame.py
+++ b/lightly_studio/tests/api/routes/api/test_frame.py
@@ -28,10 +28,6 @@ def test_get_all_frames(
 
     response = test_client.post(
         f"/api/collections/{video_frame_collection_id}/frame/",
-        params={
-            "offset": 0,
-            "limit": 4,
-        },
         json={},
     )
 

--- a/lightly_studio/tests/api/routes/api/test_frame.py
+++ b/lightly_studio/tests/api/routes/api/test_frame.py
@@ -46,6 +46,46 @@ def test_get_all_frames(
     assert data[1]["video"]["file_path_abs"] == "video1.mp4"
 
 
+def test_get_all_frames__without_explicit_pagination(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    collection_id = collection.collection_id
+
+    # Create a video with 150 frames to test that pagination is removed
+    video_frame = create_video_with_frames(
+        session=db_session,
+        collection_id=collection_id,
+        video=VideoStub(path="video1.mp4", duration_s=15, fps=10),
+    )
+
+    video_frame_collection_id = video_frame.video_frames_collection_id
+
+    # Test without any pagination parameters - should return all 150 frames
+    response = test_client.post(
+        f"/api/collections/{video_frame_collection_id}/frame/",
+        json={},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    result = response.json()
+    data = result["data"]
+
+    assert result["total_count"] == 150
+    assert len(data) == 150
+
+    # Verify first frame
+    assert data[0]["frame_number"] == 0
+    assert UUID(data[0]["video"]["sample_id"]) == video_frame.video_sample_id
+    assert data[0]["video"]["file_path_abs"] == "video1.mp4"
+
+    # Verify last frame
+    assert data[149]["frame_number"] == 149
+    assert UUID(data[149]["video"]["sample_id"]) == video_frame.video_sample_id
+    assert data[149]["video"]["file_path_abs"] == "video1.mp4"
+
+
 def test_get_all_frames__with_video_id_filter(
     test_client: TestClient,
     db_session: Session,

--- a/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.test.ts
@@ -20,10 +20,6 @@ vi.mock('$lib/api/lightly_studio_local', async () => {
 });
 
 describe('useVideoFrames', () => {
-    const mockVideoEl = {
-        currentTime: 0
-    } as HTMLVideoElement;
-
     const mockSample: SampleView = {
         collection_id: 'video-collection-1',
         sample_id: 'video-1',
@@ -80,7 +76,6 @@ describe('useVideoFrames', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        mockVideoEl.currentTime = 0;
     });
 
     it('should initialize with default values', () => {
@@ -129,23 +124,6 @@ describe('useVideoFrames', () => {
         unsubscribe();
     });
 
-    it('should throw error when frame number is not found', async () => {
-        vi.mocked(api.getAllFrames).mockResolvedValue({
-            data: {
-                data: mockFrames,
-                total_count: mockFrames.length
-            },
-            error: undefined
-        } as unknown as MockGetAllFramesResponse);
-
-        const hook = useVideoFrames({ video: mockVideoData });
-
-        // Request frame 100, which doesn't exist in mockFrames
-        await expect(hook.loadFramesFromFrameNumber(100)).rejects.toThrow(
-            'Frame not found for the given frame number'
-        );
-    });
-
     it('should load frame by playback time and update store', async () => {
         vi.mocked(api.getAllFrames).mockResolvedValue({
             data: {
@@ -165,7 +143,7 @@ describe('useVideoFrames', () => {
         expect(currentFrame?.sample_id).toBe('frame-2');
     });
 
-    it('should not fetch again when playback stays inside the loaded frame window', async () => {
+    it('should not fetch again when frames are already loaded', async () => {
         vi.mocked(api.getAllFrames).mockResolvedValue({
             data: {
                 data: mockFrames,
@@ -185,7 +163,7 @@ describe('useVideoFrames', () => {
         expect(get(hook.currentFrame)?.frame_number).toBe(1);
     });
 
-    it('should set currentFrame from frame number', async () => {
+    it('should load all frames when loadFrames is called directly', async () => {
         vi.mocked(api.getAllFrames).mockResolvedValue({
             data: {
                 data: mockFrames,
@@ -195,40 +173,84 @@ describe('useVideoFrames', () => {
         } as unknown as MockGetAllFramesResponse);
 
         const hook = useVideoFrames({ video: mockVideoData });
-        await hook.loadFramesFromFrameNumber(1);
 
-        // Verify frame was loaded
-        expect(get(hook.currentFrame)?.frame_number).toBe(1);
+        expect(hook.loading).toBe(false);
+        expect(hook.reachedEnd).toBe(false);
+
+        await hook.loadFrames();
+
+        expect(api.getAllFrames).toHaveBeenCalledWith({
+            path: {
+                video_frame_collection_id: 'frame-collection-1'
+            },
+            body: {
+                filter: {
+                    video_id: 'video-1'
+                }
+            }
+        });
+
+        expect(hook.loading).toBe(false);
+        expect(hook.reachedEnd).toBe(true);
     });
 
-    describe('error handling', () => {
-        it('should return last frame when seeking beyond loaded frames', async () => {
-            vi.mocked(api.getAllFrames).mockResolvedValue({
-                data: {
-                    data: mockFrames,
-                    total_count: mockFrames.length
-                },
-                error: undefined
-            } as unknown as MockGetAllFramesResponse);
-
-            const hook = useVideoFrames({ video: mockVideoData });
-
-            // Request frame 100 (beyond the loaded frames)
-            // Should return the last available frame instead of throwing
-            await hook.loadFrameByPlaybackTime(100 / 30, 30);
-
-            const currentFrame = get(hook.currentFrame);
-            expect(currentFrame?.frame_number).toBe(1); // Should be the last frame
+    it('should not load frames multiple times if already loading', async () => {
+        let resolvePromise: (value: MockGetAllFramesResponse) => void;
+        const apiPromise = new Promise<MockGetAllFramesResponse>((resolve) => {
+            resolvePromise = resolve;
         });
 
-        it('should throw error when video data is not available', async () => {
-            // Create hook with null videoData
-            const hook = useVideoFrames({ video: null as unknown as VideoView });
+        vi.mocked(api.getAllFrames).mockReturnValue(
+            apiPromise as ReturnType<typeof api.getAllFrames>
+        );
 
-            await expect(hook.loadFrameByPlaybackTime(0, 30)).rejects.toThrow(
-                'No video data available'
-            );
-        });
+        const hook = useVideoFrames({ video: mockVideoData });
+
+        // Start loading frames
+        const firstLoad = hook.loadFrames();
+        expect(hook.loading).toBe(true);
+
+        // Try to load again while first load is in progress
+        const secondLoad = hook.loadFrames();
+
+        // Resolve the API call
+        resolvePromise!({
+            data: {
+                data: mockFrames,
+                total_count: mockFrames.length
+            },
+            error: undefined
+        } as unknown as MockGetAllFramesResponse);
+
+        // Wait for both to complete
+        await Promise.all([firstLoad, secondLoad]);
+
+        // Should only have called the API once
+        expect(api.getAllFrames).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw error when frame number is not found', async () => {
+        vi.mocked(api.getAllFrames).mockResolvedValue({
+            data: {
+                data: mockFrames,
+                total_count: mockFrames.length
+            },
+            error: undefined
+        } as unknown as MockGetAllFramesResponse);
+
+        const hook = useVideoFrames({ video: mockVideoData });
+
+        await expect(hook.loadFramesFromFrameNumber(100)).rejects.toThrow(
+            'Frame not found for the given frame number'
+        );
+    });
+
+    it('should throw error when video data is not available', async () => {
+        const hook = useVideoFrames({ video: null as unknown as VideoView });
+
+        await expect(hook.loadFrameByPlaybackTime(0, 30)).rejects.toThrow(
+            'No video data available'
+        );
     });
 
     describe('reactivity', () => {

--- a/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.test.ts
@@ -96,7 +96,6 @@ describe('useVideoFrames', () => {
         vi.mocked(api.getAllFrames).mockResolvedValue({
             data: {
                 data: mockFrames,
-                nextCursor: 50,
                 total_count: mockFrames.length
             },
             error: undefined
@@ -116,10 +115,6 @@ describe('useVideoFrames', () => {
             path: {
                 video_frame_collection_id: 'frame-collection-1'
             },
-            query: {
-                cursor: 0,
-                limit: 50
-            },
             body: {
                 filter: {
                     video_id: 'video-1'
@@ -138,7 +133,6 @@ describe('useVideoFrames', () => {
         vi.mocked(api.getAllFrames).mockResolvedValue({
             data: {
                 data: mockFrames,
-                nextCursor: 50,
                 total_count: mockFrames.length
             },
             error: undefined
@@ -156,7 +150,6 @@ describe('useVideoFrames', () => {
         vi.mocked(api.getAllFrames).mockResolvedValue({
             data: {
                 data: mockFrames,
-                nextCursor: 50,
                 total_count: mockFrames.length
             },
             error: undefined
@@ -176,7 +169,6 @@ describe('useVideoFrames', () => {
         vi.mocked(api.getAllFrames).mockResolvedValue({
             data: {
                 data: mockFrames,
-                nextCursor: 50,
                 total_count: mockFrames.length
             },
             error: undefined
@@ -197,7 +189,6 @@ describe('useVideoFrames', () => {
         vi.mocked(api.getAllFrames).mockResolvedValue({
             data: {
                 data: mockFrames,
-                nextCursor: 50,
                 total_count: mockFrames.length
             },
             error: undefined
@@ -211,11 +202,10 @@ describe('useVideoFrames', () => {
     });
 
     describe('error handling', () => {
-        it('should throw error when frame is not found for playback time', async () => {
+        it('should return last frame when seeking beyond loaded frames', async () => {
             vi.mocked(api.getAllFrames).mockResolvedValue({
                 data: {
                     data: mockFrames,
-                    nextCursor: 50,
                     total_count: mockFrames.length
                 },
                 error: undefined
@@ -223,10 +213,12 @@ describe('useVideoFrames', () => {
 
             const hook = useVideoFrames({ video: mockVideoData });
 
-            // Request frame 100, which doesn't exist in mockFrames
-            await expect(hook.loadFrameByPlaybackTime(100 / 30, 30)).rejects.toThrow(
-                'Frame not found for the given playback time'
-            );
+            // Request frame 100 (beyond the loaded frames)
+            // Should return the last available frame instead of throwing
+            await hook.loadFrameByPlaybackTime(100 / 30, 30);
+
+            const currentFrame = get(hook.currentFrame);
+            expect(currentFrame?.frame_number).toBe(1); // Should be the last frame
         });
 
         it('should throw error when video data is not available', async () => {
@@ -244,7 +236,6 @@ describe('useVideoFrames', () => {
             vi.mocked(api.getAllFrames).mockResolvedValue({
                 data: {
                     data: mockFrames,
-                    nextCursor: 50,
                     total_count: mockFrames.length
                 },
                 error: undefined
@@ -279,8 +270,8 @@ describe('useVideoFrames', () => {
                 },
                 {
                     sample_id: 'frame-2',
-                    frame_number: 1,
-                    frame_timestamp_s: 0.4,
+                    frame_number: 29,
+                    frame_timestamp_s: 0.9667,
                     sample: mockFrameSample2,
                     video: mockVideoData
                 }
@@ -289,7 +280,6 @@ describe('useVideoFrames', () => {
             vi.mocked(api.getAllFrames).mockResolvedValue({
                 data: {
                     data: finalFrames,
-                    nextCursor: null,
                     total_count: finalFrames.length
                 },
                 error: undefined
@@ -300,10 +290,10 @@ describe('useVideoFrames', () => {
 
             vi.mocked(api.getAllFrames).mockClear();
 
+            // Request frame 30+ (at 1 second), should get frame 29 (the last one)
             await hook.loadFrameByPlaybackTime(1, 30);
 
-            expect(api.getAllFrames).not.toHaveBeenCalled();
-            expect(get(hook.currentFrame)?.frame_number).toBe(1);
+            expect(get(hook.currentFrame)?.frame_number).toBe(29);
         });
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.ts
@@ -4,11 +4,7 @@ import {
     type SampleView,
     type VideoView
 } from '$lib/api/lightly_studio_local';
-import { getFrameBatchCursor } from '$lib/utils/frame';
 import { writable } from 'svelte/store';
-
-/** Number of frames to fetch in each batch from the API */
-const BATCH_SIZE = 50;
 
 /**
  * Internal state for the useVideoFrames hook.
@@ -18,8 +14,6 @@ interface UseVideoFramesState {
     frames: FrameView[];
     /** The currently selected/active frame */
     currentFrame: FrameView | null | undefined;
-    /** Current position in the API pagination */
-    cursor: number;
     /** Whether a frame fetch is in progress */
     loading: boolean;
     /** Whether all frames have been fetched */
@@ -55,6 +49,7 @@ interface UseVideoFramesState {
  * - `playbackTime`: Current playback time in seconds
  * - `loadFramesFromFrameNumber`: Function to load and seek to a specific frame number
  * - `loadFrameByPlaybackTime`: Function to load the frame at a specific playback time
+ * - `loadFrames`: Function to load all the frames
  *
  * @example
  * ```ts
@@ -70,7 +65,6 @@ export function useVideoFrames({ video }: { video: VideoView }) {
     const state: UseVideoFramesState = {
         frames: [],
         currentFrame: undefined,
-        cursor: 0,
         loading: false,
         reachedEnd: false,
         hasStarted: false,
@@ -110,7 +104,6 @@ export function useVideoFrames({ video }: { video: VideoView }) {
             await state.pendingLoad;
             return;
         }
-        if (state.reachedEnd) return;
 
         const frameCollectionId = (video?.frame?.sample as SampleView)?.collection_id;
         if (!frameCollectionId) {
@@ -131,19 +124,11 @@ export function useVideoFrames({ video }: { video: VideoView }) {
                     }
                 });
 
-                const newFrames = res?.data?.data ?? [];
+                const frames = res?.data?.data ?? [];
 
-                if (newFrames.length === 0) {
-                    state.reachedEnd = true;
-                    return;
-                }
-
-                state.frames = mergeFrames(state.frames, newFrames);
-                // Update cursor for next batch: use server-provided nextCursor if available,
-                // otherwise increment by BATCH_SIZE for client-side pagination
-                const nextCursor = res?.data?.nextCursor;
-                state.cursor = nextCursor ?? state.cursor + BATCH_SIZE;
-                state.reachedEnd = nextCursor == null;
+                state.frames = frames;
+                // All frames are loaded at once, so we've reached the end
+                state.reachedEnd = true;
             } finally {
                 state.loading = false;
                 state.pendingLoad = null;
@@ -155,7 +140,6 @@ export function useVideoFrames({ video }: { video: VideoView }) {
 
     /**
      * Loads and seeks to a specific frame by its frame number.
-     * Calculates the appropriate cursor position and fetches the batch containing the target frame.
      * Updates the current frame and playback time to match the requested frame.
      *
      * @param frameNumber - The zero-indexed frame number to load and display
@@ -173,10 +157,6 @@ export function useVideoFrames({ video }: { video: VideoView }) {
                 setCurrentFrame(existingFrame);
                 playbackTime.set(existingFrame.frame_timestamp_s + playbackStep);
             } else {
-                // Frame not loaded yet, fetch it
-                state.cursor = getFrameBatchCursor(frameNumber, BATCH_SIZE);
-                state.reachedEnd = false; // Reset since we're seeking to a new position
-
                 await loadFrames();
 
                 const frame = getFrameByNumber(frameNumber);
@@ -228,7 +208,6 @@ export function useVideoFrames({ video }: { video: VideoView }) {
                 return;
             }
 
-            state.cursor = getFrameBatchCursor(frameIndex, BATCH_SIZE);
             state.reachedEnd = false; // Reset since we're seeking to a new position
 
             await loadFrames();
@@ -244,29 +223,6 @@ export function useVideoFrames({ video }: { video: VideoView }) {
         }
     }
 
-    /**
-     * Merges existing frames with newly fetched frames, avoiding duplicates.
-     * Optimizes for sequential batch loading by checking if the last existing frame
-     * matches the first new frame. Otherwise, uses a Map to deduplicate by sample_id.
-     *
-     * @param existingFrames - Previously loaded frames
-     * @param newFrames - Newly fetched frames to merge
-     * @returns Combined array of frames, sorted by frame_number
-     */
-    function mergeFrames(existingFrames: FrameView[], newFrames: FrameView[]): FrameView[] {
-        if (existingFrames.at(-1)?.frame_number === newFrames[0]?.frame_number) {
-            // Skip the duplicate first frame when concatenating
-            return [...existingFrames, ...newFrames.slice(1)];
-        }
-
-        const frameMap = new Map<string, FrameView>();
-
-        existingFrames.forEach((frame) => frameMap.set(frame.sample_id, frame));
-        newFrames.forEach((frame) => frameMap.set(frame.sample_id, frame));
-
-        return Array.from(frameMap.values()).sort((a, b) => a.frame_number - b.frame_number);
-    }
-
     return {
         currentFrame,
         playbackTime,
@@ -277,6 +233,7 @@ export function useVideoFrames({ video }: { video: VideoView }) {
             return state.reachedEnd;
         },
         loadFramesFromFrameNumber,
-        loadFrameByPlaybackTime
+        loadFrameByPlaybackTime,
+        loadFrames
     };
 }

--- a/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.ts
@@ -124,10 +124,6 @@ export function useVideoFrames({ video }: { video: VideoView }) {
                     path: {
                         video_frame_collection_id: frameCollectionId
                     },
-                    query: {
-                        cursor: state.cursor,
-                        limit: BATCH_SIZE
-                    },
                     body: {
                         filter: {
                             video_id: video?.sample_id

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -353,7 +353,7 @@ export interface paths {
         };
         /**
          * Export Collection Youtube Vis
-         * @description Export collection video annotations in YouTube-VIS instance segmentation format.
+         * @description Export collection video annotations in the selected export format.
          */
         get: operations["export_collection_youtube_vis"];
         put?: never;
@@ -1395,13 +1395,14 @@ export interface paths {
         put?: never;
         /**
          * Get All Frames
-         * @description Retrieve a list of all frames for a given collection ID with pagination.
+         * @description Retrieve a list of all frames for a given collection ID with optional pagination.
          *
          *     Args:
          *         session: The database session.
          *         video_frame_collection_id: The ID of the collection to retrieve frames for.
-         *         pagination: Pagination parameters including offset and limit.
          *         body: The body containing the filters
+         *         pagination: Optional pagination parameters including offset and limit.
+         *
          *     Returns:
          *         A list of frames along with the total count.
          */
@@ -5989,8 +5990,10 @@ export interface operations {
     get_all_frames: {
         parameters: {
             query?: {
-                cursor?: number;
-                limit?: number;
+                /** @description Offset for pagination */
+                cursor?: number | null;
+                /** @description Limit for pagination */
+                limit?: number | null;
             };
             header?: never;
             path: {

--- a/lightly_studio_view/src/lib/utils/frame.test.ts
+++ b/lightly_studio_view/src/lib/utils/frame.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { findFrame, getFrameBatchCursor } from './frame';
+import { findFrame } from './frame';
 import type { FrameView } from '$lib/api/lightly_studio_local';
 
 const createFrame = (frame_timestamp_s: number, sample_id: string): FrameView =>
@@ -39,18 +39,5 @@ describe('findFrame', () => {
         const result = findFrame({ frames, currentTime: 5 });
 
         expect(result).toEqual({ frame: frames[2], index: 2 });
-    });
-});
-
-describe('getFrameBatchCursor', () => {
-    it('returns 0 when frame index is 0', () => {
-        expect(getFrameBatchCursor(0, 25)).toBe(0);
-    });
-
-    it('floors to nearest lower batch boundary', () => {
-        expect(getFrameBatchCursor(24, 25)).toBe(0);
-        expect(getFrameBatchCursor(25, 25)).toBe(25);
-        expect(getFrameBatchCursor(49, 25)).toBe(25);
-        expect(getFrameBatchCursor(50, 25)).toBe(50);
     });
 });

--- a/lightly_studio_view/src/lib/utils/frame.ts
+++ b/lightly_studio_view/src/lib/utils/frame.ts
@@ -2,12 +2,6 @@ import type { FrameView, VideoFrameView } from '$lib/api/lightly_studio_local';
 
 const EPS = 0.002;
 
-export function getFrameBatchCursor(frameIndex: number, batchSize: number): number {
-    if (batchSize <= 0) throw new Error('batchSize must be greater than zero');
-
-    return Math.floor(frameIndex / batchSize) * batchSize;
-}
-
 export function findFrame({
     frames,
     currentTime


### PR DESCRIPTION
## What has changed and why?
This PR introduces prefetching all frames for video view details

## How has it been tested?

by the tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed loadFrames as a public API to explicitly load video frames.

* **Bug Fixes**
  * Prevented duplicate frame fetches when multiple load requests occur concurrently.
  * Ensured correct last-frame selection at end of playback.

* **Refactor**
  * Simplified frame loading by switching from incremental/batched fetches to full-set retrieval and making pagination optional.

* **Tests**
  * Updated and added tests to reflect new loading and pagination behavior.

* **Documentation**
  * Updated API docs/types to indicate optional pagination parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->