### PR TITLE
fix: replace bare except with except Exception in tokenizer

### DIFF
--- a/lightly_studio/src/lightly_studio/vendor/perception_encoder/vision_encoder/tokenizer.py
+++ b/lightly_studio/src/lightly_studio/vendor/perception_encoder/vision_encoder/tokenizer.py
@@ -196,7 +196,7 @@ class SimpleTokenizer(object):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except Exception:` in the BPE tokenizer's `bpe()` method.

**Why:** Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` (PEP 8 E722). Since this block handles a `ValueError` from `str.index()` (value not found), catching `Exception` is the correct scope.

**Change:**
```python
# Before
except:
    new_word.extend(word[i:])

# After
except Exception:
    new_word.extend(word[i:])
```

## Testing
No behavior change for normal operation — only prevents accidentally swallowing system-level exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved exception handling specificity in the tokenizer for enhanced reliability and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->