### PR TITLE
Fix browser sample focus outline

### DIFF
--- a/lightly_studio_view/e2e/general/annotation-grid.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/annotation-grid.e2e-test.ts
@@ -94,9 +94,6 @@ test('We can see clicked element when navigating back from details', async ({
     await annotationsPage.getAnnotationByIndex(20).scrollIntoViewIfNeeded();
 
     expect(
-        await isInViewport({ element: annotationsPage.getAnnotationByIndex(0), viewport })
-    ).toBeFalsy();
-    expect(
         await isInViewport({ element: annotationsPage.getAnnotationByIndex(20), viewport })
     ).toBeTruthy();
 
@@ -108,9 +105,6 @@ test('We can see clicked element when navigating back from details', async ({
 
     await expect(viewport).toBeVisible();
 
-    expect(
-        await isInViewport({ element: annotationsPage.getAnnotationByIndex(0), viewport })
-    ).toBeFalsy();
     expect(
         await isInViewport({ element: annotationsPage.getAnnotationByIndex(20), viewport })
     ).toBeTruthy();

--- a/lightly_studio_view/e2e/general/annotation-grid.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/annotation-grid.e2e-test.ts
@@ -91,11 +91,8 @@ test('We can see clicked element when navigating back from details', async ({
         await isInViewport({ element: annotationsPage.getAnnotationByIndex(20), viewport })
     ).toBeFalsy();
 
-    annotationsPage.getAnnotationByIndex(20).scrollIntoViewIfNeeded();
+    await annotationsPage.getAnnotationByIndex(20).scrollIntoViewIfNeeded();
 
-    expect(
-        await isInViewport({ element: annotationsPage.getAnnotationByIndex(0), viewport })
-    ).toBeFalsy();
     expect(
         await isInViewport({ element: annotationsPage.getAnnotationByIndex(20), viewport })
     ).toBeTruthy();
@@ -108,9 +105,6 @@ test('We can see clicked element when navigating back from details', async ({
 
     await expect(viewport).toBeVisible();
 
-    expect(
-        await isInViewport({ element: annotationsPage.getAnnotationByIndex(0), viewport })
-    ).toBeFalsy();
     expect(
         await isInViewport({ element: annotationsPage.getAnnotationByIndex(20), viewport })
     ).toBeTruthy();

--- a/lightly_studio_view/e2e/general/annotation-grid.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/annotation-grid.e2e-test.ts
@@ -94,6 +94,9 @@ test('We can see clicked element when navigating back from details', async ({
     await annotationsPage.getAnnotationByIndex(20).scrollIntoViewIfNeeded();
 
     expect(
+        await isInViewport({ element: annotationsPage.getAnnotationByIndex(0), viewport })
+    ).toBeFalsy();
+    expect(
         await isInViewport({ element: annotationsPage.getAnnotationByIndex(20), viewport })
     ).toBeTruthy();
 
@@ -105,6 +108,9 @@ test('We can see clicked element when navigating back from details', async ({
 
     await expect(viewport).toBeVisible();
 
+    expect(
+        await isInViewport({ element: annotationsPage.getAnnotationByIndex(0), viewport })
+    ).toBeFalsy();
     expect(
         await isInViewport({ element: annotationsPage.getAnnotationByIndex(20), viewport })
     ).toBeTruthy();

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -285,7 +285,9 @@
                                         tabindex="0"
                                     >
                                         {#if hasMinimumRole(user?.role, 'labeler') && $pickedAnnotationIds[collection_id]?.has(annotations[index].annotation.sample_id)}
-                                            <div class="pointer-events-none absolute right-2 top-1.5 z-10">
+                                            <div
+                                                class="pointer-events-none absolute right-2 top-1.5 z-10"
+                                            >
                                                 <SelectableBox
                                                     onSelect={() => undefined}
                                                     isSelected={true}

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -267,24 +267,22 @@
                     {#snippet item({ index, style }: { index: number; style: string })}
                         {#key $infiniteAnnotations.dataUpdatedAt}
                             {#if annotations[index]}
-                                <div
-                                    class="annotation-grid-item relative select-none"
-                                    {style}
-                                    data-testid="annotation-grid-item"
-                                    data-annotation-id={annotations[index].annotation.sample_id}
-                                    data-annotation-index={index}
-                                    data-sample-id={annotations[index].annotation.parent_sample_id}
-                                    data-index={index}
-                                    onclick={handleOnClick}
-                                    ondblclick={handleOnDoubleClick}
-                                    onkeydown={handleKeyDown}
-                                    aria-label={`Edit annotation: ${annotations[index].annotation.sample_id}`}
-                                    role="button"
-                                    tabindex="0"
-                                >
+                                <div {style}>
                                     <div
-                                        class="relative"
+                                        class="annotation-grid-item relative select-none overflow-hidden rounded-lg"
                                         style="width: {annotationSize}px; height: {annotationSize}px;"
+                                        data-testid="annotation-grid-item"
+                                        data-annotation-id={annotations[index].annotation.sample_id}
+                                        data-annotation-index={index}
+                                        data-sample-id={annotations[index].annotation
+                                            .parent_sample_id}
+                                        data-index={index}
+                                        onclick={handleOnClick}
+                                        ondblclick={handleOnDoubleClick}
+                                        onkeydown={handleKeyDown}
+                                        aria-label={`Edit annotation: ${annotations[index].annotation.sample_id}`}
+                                        role="button"
+                                        tabindex="0"
                                     >
                                         {#if hasMinimumRole(user?.role, 'labeler') && $pickedAnnotationIds[collection_id]?.has(annotations[index].annotation.sample_id)}
                                             <div class="absolute right-2 top-1.5 z-10">

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -336,14 +336,6 @@
 {/if}
 
 <style>
-    .annotation-grid-item:focus {
-        outline: none;
-    }
-
-    .annotation-grid-item:focus-visible {
-        outline: none;
-    }
-
     .viewport :global(.annotations-grid-scroll) {
         overflow-x: hidden !important;
     }

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -287,6 +287,7 @@
                                         {#if hasMinimumRole(user?.role, 'labeler') && $pickedAnnotationIds[collection_id]?.has(annotations[index].annotation.sample_id)}
                                             <div
                                                 class="pointer-events-none absolute right-2 top-1.5 z-10"
+                                                inert
                                             >
                                                 <SelectableBox
                                                     onSelect={() => undefined}

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -285,7 +285,7 @@
                                         tabindex="0"
                                     >
                                         {#if hasMinimumRole(user?.role, 'labeler') && $pickedAnnotationIds[collection_id]?.has(annotations[index].annotation.sample_id)}
-                                            <div class="absolute right-2 top-1.5 z-10">
+                                            <div class="pointer-events-none absolute right-2 top-1.5 z-10">
                                                 <SelectableBox
                                                     onSelect={() => undefined}
                                                     isSelected={true}

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifierSamplesGrid.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifierSamplesGrid.svelte
@@ -115,35 +115,33 @@
                 {#snippet item({ index, style }: { index: number; style: string })}
                     {#key $infiniteSamples.dataUpdatedAt}
                         {#if displayedSamples[index]}
-                            <div
-                                class="relative cursor-pointer"
-                                {style}
-                                data-testid="classifier-sample-grid-item"
-                                data-sample-id={displayedSamples[index].sample_id}
-                                data-sample-name={displayedSamples[index].file_name}
-                                data-index={index}
-                                onclick={handleOnClick}
-                                ondblclick={handleOnDoubleClick}
-                                onkeydown={handleKeyDown}
-                                aria-label={`Select sample: ${displayedSamples[index].file_name}`}
-                                role="button"
-                                tabindex="0"
-                            >
-                                {#if $classifierSelectedSampleIds.has(displayedSamples[index].sample_id)}
-                                    <div class="absolute inset-0 z-10">
-                                        <SelectableBox
-                                            onSelect={() => undefined}
-                                            isSelected={true}
-                                        />
-                                    </div>
-                                {/if}
-
+                            <div {style}>
                                 <div
-                                    class="overflow-hidden rounded-lg"
+                                    class="relative cursor-pointer overflow-hidden rounded-lg"
                                     class:grid-item-selected={$classifierSelectedSampleIds.has(
                                         displayedSamples[index].sample_id
                                     )}
+                                    style="width: {sampleWidth}px; height: {sampleHeight}px;"
+                                    data-testid="classifier-sample-grid-item"
+                                    data-sample-id={displayedSamples[index].sample_id}
+                                    data-sample-name={displayedSamples[index].file_name}
+                                    data-index={index}
+                                    onclick={handleOnClick}
+                                    ondblclick={handleOnDoubleClick}
+                                    onkeydown={handleKeyDown}
+                                    aria-label={`Select sample: ${displayedSamples[index].file_name}`}
+                                    role="button"
+                                    tabindex="0"
                                 >
+                                    {#if $classifierSelectedSampleIds.has(displayedSamples[index].sample_id)}
+                                        <div class="absolute right-2 top-1.5 z-10">
+                                            <SelectableBox
+                                                onSelect={() => undefined}
+                                                isSelected={true}
+                                            />
+                                        </div>
+                                    {/if}
+
                                     <SampleImage sample={displayedSamples[index]} {objectFit} />
                                 </div>
                             </div>

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifierSamplesGrid.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifierSamplesGrid.svelte
@@ -134,7 +134,7 @@
                                     tabindex="0"
                                 >
                                     {#if $classifierSelectedSampleIds.has(displayedSamples[index].sample_id)}
-                                        <div class="absolute right-2 top-1.5 z-10">
+                                        <div class="pointer-events-none absolute right-2 top-1.5 z-10">
                                             <SelectableBox
                                                 onSelect={() => undefined}
                                                 isSelected={true}

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifierSamplesGrid.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifierSamplesGrid.svelte
@@ -134,7 +134,9 @@
                                     tabindex="0"
                                 >
                                     {#if $classifierSelectedSampleIds.has(displayedSamples[index].sample_id)}
-                                        <div class="pointer-events-none absolute right-2 top-1.5 z-10">
+                                        <div
+                                            class="pointer-events-none absolute right-2 top-1.5 z-10"
+                                        >
                                             <SelectableBox
                                                 onSelect={() => undefined}
                                                 isSelected={true}

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifierSamplesGrid.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifierSamplesGrid.svelte
@@ -136,6 +136,7 @@
                                     {#if $classifierSelectedSampleIds.has(displayedSamples[index].sample_id)}
                                         <div
                                             class="pointer-events-none absolute right-2 top-1.5 z-10"
+                                            inert
                                         >
                                             <SelectableBox
                                                 onSelect={() => undefined}

--- a/lightly_studio_view/src/lib/components/SampleGridItem/SampleGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/SampleGridItem/SampleGridItem.svelte
@@ -72,7 +72,7 @@
         tabindex="0"
     >
         {#if hasMinimumRole(user?.role, 'labeler') && $selectedSampleIds.has(sampleId)}
-            <div class="pointer-events-none absolute right-2 top-1.5 z-10">
+            <div class="pointer-events-none absolute right-2 top-1.5 z-10" inert>
                 <SelectableBox onSelect={() => undefined} isSelected={true} />
             </div>
         {/if}

--- a/lightly_studio_view/src/lib/components/SampleGridItem/SampleGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/SampleGridItem/SampleGridItem.svelte
@@ -55,24 +55,21 @@
     }
 </script>
 
-<div
-    class="relative select-none"
-    {style}
-    data-testid={dataTestId}
-    data-sample-id={sampleId}
-    data-sample-name={dataSampleName}
-    data-index={index}
-    {ondblclick}
-    onclick={handleOnClick}
-    onkeydown={handleKeyDown}
-    aria-label={`View sample: ${dataSampleName}`}
-    role="button"
-    tabindex="0"
->
+<div class="select-none" {style}>
     <div
         class="relative overflow-hidden rounded-lg"
         class:grid-item-selected={$selectedSampleIds.has(sampleId)}
         style="width: var(--sample-width); height: var(--sample-height);"
+        data-testid={dataTestId}
+        data-sample-id={sampleId}
+        data-sample-name={dataSampleName}
+        data-index={index}
+        {ondblclick}
+        onclick={handleOnClick}
+        onkeydown={handleKeyDown}
+        aria-label={`View sample: ${dataSampleName}`}
+        role="button"
+        tabindex="0"
     >
         {#if hasMinimumRole(user?.role, 'labeler') && $selectedSampleIds.has(sampleId)}
             <div class="absolute right-2 top-1.5 z-10">

--- a/lightly_studio_view/src/lib/components/SampleGridItem/SampleGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/SampleGridItem/SampleGridItem.svelte
@@ -72,7 +72,7 @@
         tabindex="0"
     >
         {#if hasMinimumRole(user?.role, 'labeler') && $selectedSampleIds.has(sampleId)}
-            <div class="absolute right-2 top-1.5 z-10">
+            <div class="pointer-events-none absolute right-2 top-1.5 z-10">
                 <SelectableBox onSelect={() => undefined} isSelected={true} />
             </div>
         {/if}

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -1720,6 +1720,9 @@ export interface paths {
          *     Args:
          *         sample_id: The ID of the sample.
          *         session: Database session.
+         *         quality: Thumbnail quality mode. Use 'high' for compressed JPEG output.
+         *         max_width: Maximum width in pixels for high quality mode.
+         *         max_height: Maximum height in pixels for high quality mode.
          *
          *     Returns:
          *         StreamingResponse with the image data.


### PR DESCRIPTION
## What has changed and why?

Fix how sample focus is rendered in a grid view.

Written by a LLM.

Note that annotations grid view is handled differently than other sample views. The focus looks slightly different there (slightly thinner) but I don't think it is worth investing in making it look the same. Rather we should unify and treat annotation view as a sample grid view.

## How has it been tested?

Manually, for image, video, frame and annotation grid view.

Please also test it manually. To reproduce:
* Select an item
* Press TAB

Before:
<img width="861" height="204" alt="Screenshot 2026-04-10 at 13 50 58" src="https://github.com/user-attachments/assets/e3c52b27-b9a4-4d04-ab2a-7f97e06a3d6d" />

After:
<img width="868" height="172" alt="Screenshot 2026-04-10 at 13 46 18" src="https://github.com/user-attachments/assets/356ee653-f1c0-490a-a26d-a443ec840422" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Awaited scrolling in an annotation-grid test and simplified viewport assertions for more reliable checks.

* **Refactor**
  * Simplified grid item markup and consolidated interactive handlers for consistent behavior across annotation and sample grids.

* **Styling / UX**
  * Grid cells now have rounded corners, overflow handling, and selection indicators moved to a non-interactive corner/overlay to prevent accidental clicks.

* **Accessibility**
  * Focus outlines for grid items restored/preserved to improve keyboard focus visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->