### PR TITLE
feat: add test for prev/next appearance

### DIFF
--- a/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
@@ -7,7 +7,6 @@ import {
 } from '../utils';
 import * as fs from 'fs';
 import * as path from 'path';
-import { aw } from 'vitest/dist/chunks/reporters.nr4dxCkA.js';
 
 const MAX_RENDER_TIME_MS = 5000;
 const MEASUREMENT_ITERATIONS = 5;

--- a/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
@@ -88,6 +88,76 @@ test('sample details renders within 5 seconds', async ({
     expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });
 
+test('sample details renders next image within 5 seconds', async ({
+    page,
+    samplesPage,
+    sampleDetailsPage
+}) => {
+    await samplesPage.goto();
+
+    await setNetworkThrottling(page, 'Fast4G');
+
+    const result = await measureWithMedian(async () => {
+        await samplesPage.goto();
+        await samplesPage.doubleClickFirstSample();
+        await sampleDetailsPage.getSampleDetails().waitFor({ state: 'visible' });
+        await sampleDetailsPage.getNextButton().click();
+        const time = await measureElementRendering(page, sampleDetailsPage.getSampleDetails());
+        return time;
+    }, MEASUREMENT_ITERATIONS);
+
+    const passed = result.median < MAX_RENDER_TIME_MS;
+    console.log('sample-details-next-image measurements:', result);
+
+    metrics.push({
+        test: 'sample-details-next-image',
+        measurements: result.measurements,
+        median: result.median,
+        min: result.min,
+        max: result.max,
+        average: result.average,
+        passed
+    });
+    saveMetrics();
+
+    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+});
+
+test('sample details renders prev image within 5 seconds', async ({
+    page,
+    samplesPage,
+    sampleDetailsPage
+}) => {
+    await samplesPage.goto();
+
+    await setNetworkThrottling(page, 'Fast4G');
+
+    const result = await measureWithMedian(async () => {
+        await samplesPage.goto();
+        await samplesPage.getSampleByIndex(1).dblclick();
+        await sampleDetailsPage.getSampleDetails().waitFor({ state: 'visible' });
+        await sampleDetailsPage.getPrevButton().click();
+        const time = await measureElementRendering(page, sampleDetailsPage.getSampleDetails());
+        return time;
+    }, MEASUREMENT_ITERATIONS);
+
+    const passed = result.median < MAX_RENDER_TIME_MS;
+    console.log('sample-details-prev-image measurements:', result);
+
+    metrics.push({
+        test: 'sample-details-prev-image',
+        measurements: result.measurements,
+        median: result.median,
+        min: result.min,
+        max: result.max,
+        average: result.average,
+        passed
+    });
+    saveMetrics();
+
+    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+});
+
 test('annotations grid renders within 5 seconds', async ({ page, annotationsPage }) => {
     await setNetworkThrottling(page, 'Fast4G');
 

--- a/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
@@ -7,6 +7,7 @@ import {
 } from '../utils';
 import * as fs from 'fs';
 import * as path from 'path';
+import { aw } from 'vitest/dist/chunks/reporters.nr4dxCkA.js';
 
 const MAX_RENDER_TIME_MS = 5000;
 const MEASUREMENT_ITERATIONS = 5;
@@ -54,11 +55,7 @@ test('samples grid renders within 5 seconds', async ({ page, samplesPage }) => {
     expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });
 
-test('sample details renders within 5 seconds', async ({
-    page,
-    samplesPage,
-    sampleDetailsPage
-}) => {
+test('sample details renders within 5 seconds', async ({ page, samplesPage }) => {
     await samplesPage.goto();
 
     await setNetworkThrottling(page, 'Fast4G');
@@ -66,7 +63,7 @@ test('sample details renders within 5 seconds', async ({
     const result = await measureWithMedian(async () => {
         await samplesPage.goto();
         await samplesPage.doubleClickFirstSample();
-        const time = await measureElementRendering(page, sampleDetailsPage.getSampleDetails());
+        const time = await measureElementRendering(page, page.getByText('Sample 1 of 128'));
         await page.goBack();
         return time;
     }, MEASUREMENT_ITERATIONS);
@@ -100,9 +97,10 @@ test('sample details renders next image within 5 seconds', async ({
     const result = await measureWithMedian(async () => {
         await samplesPage.goto();
         await samplesPage.doubleClickFirstSample();
-        await sampleDetailsPage.getSampleDetails().waitFor({ state: 'visible' });
+
+        await page.getByText('Sample 1 of 128').waitFor();
         await sampleDetailsPage.getNextButton().click();
-        const time = await measureElementRendering(page, sampleDetailsPage.getSampleDetails());
+        const time = await measureElementRendering(page, page.getByText('Sample 2 of 128'));
         return time;
     }, MEASUREMENT_ITERATIONS);
 
@@ -135,9 +133,9 @@ test('sample details renders prev image within 5 seconds', async ({
     const result = await measureWithMedian(async () => {
         await samplesPage.goto();
         await samplesPage.getSampleByIndex(1).dblclick();
-        await sampleDetailsPage.getSampleDetails().waitFor({ state: 'visible' });
+        await page.getByText('Sample 2 of 128').waitFor({ state: 'visible' });
         await sampleDetailsPage.getPrevButton().click();
-        const time = await measureElementRendering(page, sampleDetailsPage.getSampleDetails());
+        const time = await measureElementRendering(page, page.getByText('Sample 1 of 128'));
         return time;
     }, MEASUREMENT_ITERATIONS);
 

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsBreadcrumb/AnnotationDetailsBreadcrumb.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsBreadcrumb/AnnotationDetailsBreadcrumb.svelte
@@ -79,7 +79,7 @@
         <BreadcrumbItem>
             <BreadcrumbPage class="flex items-center gap-2">
                 <SquareDashed class="h-4 w-4" />
-                <span class="max-w-[200px] truncate">
+                <span class="max-w-[200px] truncate" data-testid="annotation-details-position">
                     {#if samplePosition && totalCount}
                         Sample {samplePosition} of {totalCount}
                     {:else}

--- a/lightly_studio_view/src/lib/components/DetailsBreadcrumb/DetailsBreadcrumb.svelte
+++ b/lightly_studio_view/src/lib/components/DetailsBreadcrumb/DetailsBreadcrumb.svelte
@@ -71,7 +71,7 @@
         <BreadcrumbItem>
             <BreadcrumbPage class="flex items-center gap-2">
                 <SquareDashed class="h-4 w-4" />
-                <span class="max-w-[200px] truncate">
+                <span class="max-w-[200px] truncate" data-testid="details-position">
                     {#if index != undefined && totalCount}
                         {subsection} {index} of {totalCount}
                     {:else}

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsBreadcrumb/SampleDetailsBreadcrumb.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsBreadcrumb/SampleDetailsBreadcrumb.svelte
@@ -79,7 +79,7 @@
         <BreadcrumbItem>
             <BreadcrumbPage class="flex items-center gap-2">
                 <FileImage class="h-4 w-4" />
-                <span class="max-w-[200px] truncate">
+                <span class="max-w-[200px] truncate" data-testid="image-details-position">
                     {#if samplePosition && totalCount}
                         Sample {samplePosition} of {totalCount}
                     {:else}


### PR DESCRIPTION
## What has changed and why?

Measure prev/next appearance wit perf test

## How has it been tested?

e2e test for prev/next

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added performance tests for the sample details view that measure render times for initial load, Next and Prev image transitions, persist metrics, and assert they meet thresholds.
* **Chores**
  * Added data-testid attributes to breadcrumb elements to improve testability of sample, annotation, and details position displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->