### PR TITLE
Add AnnotationAccessor

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
@@ -1,3 +1,4 @@
+from .annotation_expression import AnnotationAccessor
 from .boolean_expression import AND, NOT, OR
 from .dataset_query import DatasetQuery
 from .image_sample_field import ImageSampleField
@@ -8,6 +9,7 @@ __all__ = [
     "AND",
     "NOT",
     "OR",
+    "AnnotationAccessor",
     "DatasetQuery",
     "ImageSampleField",
     "OrderByExpression",

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_expression.py
@@ -1,0 +1,131 @@
+"""Annotation field classes for building dataset queries on sample annotations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import ColumnElement, and_
+from sqlalchemy.orm import Mapped
+from sqlmodel import col
+
+from lightly_studio.core.dataset_query.field import ComparableField, NumericalField
+from lightly_studio.core.dataset_query.match_expression import MatchExpression
+from lightly_studio.models.annotation.annotation_base import (
+    AnnotationBaseTable,
+    AnnotationType,
+)
+from lightly_studio.models.annotation.object_detection import ObjectDetectionAnnotationTable
+from lightly_studio.models.annotation_label import AnnotationLabelTable
+from lightly_studio.models.sample import SampleTable
+
+
+# Ignore PLW1641 because `==` and `!=` create query conditions here, so these
+# classes do not need normal hash behavior.
+class ObjectDetectionNumericalField:  # noqa: PLW1641
+    """Numerical field for object detection properties."""
+
+    def __init__(self, column: Mapped[int | float]) -> None:
+        """Initialize the object detection numerical field.
+
+        Args:
+            column: The database column this field represents.
+        """
+        self.field = NumericalField(column)
+
+    def __gt__(self, other: float | int) -> ObjectDetectionMatchExpression:
+        """Create a greater-than expression."""
+        return ObjectDetectionMatchExpression(self.field.__gt__(other))
+
+    def __lt__(self, other: float | int) -> ObjectDetectionMatchExpression:
+        """Create a less-than expression."""
+        return ObjectDetectionMatchExpression(self.field.__lt__(other))
+
+    def __ge__(self, other: float | int) -> ObjectDetectionMatchExpression:
+        """Create a greater-than-or-equal expression."""
+        return ObjectDetectionMatchExpression(self.field.__ge__(other))
+
+    def __le__(self, other: float | int) -> ObjectDetectionMatchExpression:
+        """Create a less-than-or-equal expression."""
+        return ObjectDetectionMatchExpression(self.field.__le__(other))
+
+    def __eq__(self, other: Any) -> ObjectDetectionMatchExpression:  # type: ignore[override]
+        """Create an equality expression."""
+        return ObjectDetectionMatchExpression(self.field.__eq__(other))
+
+    def __ne__(self, other: Any) -> ObjectDetectionMatchExpression:  # type: ignore[override]
+        """Create a not-equal expression."""
+        return ObjectDetectionMatchExpression(self.field.__ne__(other))
+
+
+# Ignore PLW1641 because `==` and `!=` create query conditions here, so these
+# classes do not need normal hash behavior.
+class ObjectDetectionComparableField:  # noqa: PLW1641
+    """Comparable field for object detection properties."""
+
+    def __init__(
+        self,
+        column: Mapped[Any],
+    ) -> None:
+        """Initialize the object detection comparable field.
+
+        Args:
+            column: The database column this field represents.
+        """
+        self.field = ComparableField(column)
+
+    def __eq__(self, other: Any) -> ObjectDetectionMatchExpression:  # type: ignore[override]
+        """Create an equality expression."""
+        return ObjectDetectionMatchExpression(
+            criterion=self.field.__eq__(other), relationship="annotation_label"
+        )
+
+    def __ne__(self, other: Any) -> ObjectDetectionMatchExpression:  # type: ignore[override]
+        """Create a not-equal expression."""
+        return ObjectDetectionMatchExpression(
+            criterion=self.field.__ne__(other), relationship="annotation_label"
+        )
+
+
+class ObjectDetectionAccessor:
+    """Provides access to object detection query operations."""
+
+    # TODO(lukas, 4/2026): make confidence work too
+    # confidence = NumericalField(col(AnnotationBaseTable.confidence))
+    width = ObjectDetectionNumericalField(col(ObjectDetectionAnnotationTable.width))
+    height = ObjectDetectionNumericalField(col(ObjectDetectionAnnotationTable.height))
+    x = ObjectDetectionNumericalField(col(ObjectDetectionAnnotationTable.x))
+    y = ObjectDetectionNumericalField(col(ObjectDetectionAnnotationTable.y))
+    label = ObjectDetectionComparableField(
+        col(AnnotationLabelTable.annotation_label_name),
+    )
+
+
+class AnnotationAccessor:
+    """Provides access to query operations on sample annotations."""
+
+    def object_detections(self) -> ObjectDetectionAccessor:
+        """Return the accessor for querying object detection annotations."""
+        return ObjectDetectionAccessor()
+
+
+@dataclass
+class ObjectDetectionMatchExpression(MatchExpression):
+    """Expression for checking if a sample has an object detection matching a criterion."""
+
+    criterion: MatchExpression
+    # TODO(lukas, 4/2026): try using Mapped[T] as the type of relationship
+    relationship: str = "object_detection_details"
+
+    def get(self) -> ColumnElement[bool]:
+        """Get the object detection match expression."""
+        # Get the relationship property from AnnotationBaseTable
+        rel = getattr(AnnotationBaseTable, self.relationship)
+        condition = rel.has(self.criterion.get())
+
+        return SampleTable.annotations.any(
+            and_(
+                col(AnnotationBaseTable.annotation_type) == AnnotationType.OBJECT_DETECTION,
+                condition,
+            )
+        )

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_expression.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Generic, Optional
 
 from sqlalchemy import ColumnElement, and_
 from sqlalchemy.orm import Mapped
 from sqlmodel import col
+from typing_extensions import TypeVar
 
 from lightly_studio.core.dataset_query.field import ComparableField, NumericalField
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
@@ -18,6 +19,8 @@ from lightly_studio.models.annotation.annotation_base import (
 from lightly_studio.models.annotation.object_detection import ObjectDetectionAnnotationTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.sample import SampleTable
+
+T = TypeVar("T", default=Optional["ObjectDetectionAnnotationTable"])
 
 
 # Ignore PLW1641 because `==` and `!=` create query conditions here, so these
@@ -35,27 +38,45 @@ class ObjectDetectionNumericalField:  # noqa: PLW1641
 
     def __gt__(self, other: float | int) -> ObjectDetectionMatchExpression:
         """Create a greater-than expression."""
-        return ObjectDetectionMatchExpression(self.field.__gt__(other))
+        return ObjectDetectionMatchExpression(
+            criterion=self.field.__gt__(other),
+            relationship=AnnotationBaseTable.object_detection_details,
+        )
 
     def __lt__(self, other: float | int) -> ObjectDetectionMatchExpression:
         """Create a less-than expression."""
-        return ObjectDetectionMatchExpression(self.field.__lt__(other))
+        return ObjectDetectionMatchExpression(
+            self.field.__lt__(other),
+            relationship=AnnotationBaseTable.object_detection_details,
+        )
 
     def __ge__(self, other: float | int) -> ObjectDetectionMatchExpression:
         """Create a greater-than-or-equal expression."""
-        return ObjectDetectionMatchExpression(self.field.__ge__(other))
+        return ObjectDetectionMatchExpression(
+            self.field.__ge__(other),
+            relationship=AnnotationBaseTable.object_detection_details,
+        )
 
     def __le__(self, other: float | int) -> ObjectDetectionMatchExpression:
         """Create a less-than-or-equal expression."""
-        return ObjectDetectionMatchExpression(self.field.__le__(other))
+        return ObjectDetectionMatchExpression(
+            self.field.__le__(other),
+            relationship=AnnotationBaseTable.object_detection_details,
+        )
 
     def __eq__(self, other: Any) -> ObjectDetectionMatchExpression:  # type: ignore[override]
         """Create an equality expression."""
-        return ObjectDetectionMatchExpression(self.field.__eq__(other))
+        return ObjectDetectionMatchExpression(
+            self.field.__eq__(other),
+            relationship=AnnotationBaseTable.object_detection_details,
+        )
 
     def __ne__(self, other: Any) -> ObjectDetectionMatchExpression:  # type: ignore[override]
         """Create a not-equal expression."""
-        return ObjectDetectionMatchExpression(self.field.__ne__(other))
+        return ObjectDetectionMatchExpression(
+            self.field.__ne__(other),
+            relationship=AnnotationBaseTable.object_detection_details,
+        )
 
 
 # Ignore PLW1641 because `==` and `!=` create query conditions here, so these
@@ -74,16 +95,16 @@ class ObjectDetectionComparableField:  # noqa: PLW1641
         """
         self.field = ComparableField(column)
 
-    def __eq__(self, other: Any) -> ObjectDetectionMatchExpression:  # type: ignore[override]
+    def __eq__(self, other: Any) -> ObjectDetectionMatchExpression[AnnotationLabelTable]:  # type: ignore[override]
         """Create an equality expression."""
         return ObjectDetectionMatchExpression(
-            criterion=self.field.__eq__(other), relationship="annotation_label"
+            criterion=self.field.__eq__(other), relationship=AnnotationBaseTable.annotation_label
         )
 
-    def __ne__(self, other: Any) -> ObjectDetectionMatchExpression:  # type: ignore[override]
+    def __ne__(self, other: Any) -> ObjectDetectionMatchExpression[AnnotationLabelTable]:  # type: ignore[override]
         """Create a not-equal expression."""
         return ObjectDetectionMatchExpression(
-            criterion=self.field.__ne__(other), relationship="annotation_label"
+            criterion=self.field.__ne__(other), relationship=AnnotationBaseTable.annotation_label
         )
 
 
@@ -110,19 +131,15 @@ class AnnotationAccessor:
 
 
 @dataclass
-class ObjectDetectionMatchExpression(MatchExpression):
+class ObjectDetectionMatchExpression(MatchExpression, Generic[T]):
     """Expression for checking if a sample has an object detection matching a criterion."""
 
     criterion: MatchExpression
-    # TODO(lukas, 4/2026): try using Mapped[T] as the type of relationship
-    relationship: str = "object_detection_details"
+    relationship: Mapped[T]
 
     def get(self) -> ColumnElement[bool]:
         """Get the object detection match expression."""
-        # Get the relationship property from AnnotationBaseTable
-        rel = getattr(AnnotationBaseTable, self.relationship)
-        condition = rel.has(self.criterion.get())
-
+        condition = self.relationship.has(self.criterion.get())
         return SampleTable.annotations.any(
             and_(
                 col(AnnotationBaseTable.annotation_type) == AnnotationType.OBJECT_DETECTION,

--- a/lightly_studio/tests/core/dataset_query/test_annotation_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_annotation_expression.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from sqlmodel import Session, select
+
+from lightly_studio.core.dataset_query.annotation_expression import AnnotationAccessor
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.models.image import ImageTable
+from lightly_studio.models.sample import SampleTable
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
+
+
+class TestAnnotationExpressions:
+    def test_annotation_object_detections_width__sql(self) -> None:
+        query = select(ImageTable).where(
+            (AnnotationAccessor().object_detections().width <= 100).get()
+        )
+        sql = str(query.compile(compile_kwargs={"literal_binds": True}))
+        assert "EXISTS (SELECT 1" in sql
+        assert "FROM annotation_base" in sql
+        assert "FROM object_detection_annotation" in sql
+        assert "object_detection_annotation.width <= 100" in sql
+
+    def test_annotation_object_detections__filters_matching_samples(
+        self, db_session: Session
+    ) -> None:
+        collection = create_collection(session=db_session)
+        collection_id = collection.collection_id
+        image1 = create_image(
+            session=db_session, collection_id=collection_id, file_path_abs="/path/to/1.jpg"
+        )
+        image2 = create_image(
+            session=db_session, collection_id=collection_id, file_path_abs="/path/to/2.jpg"
+        )
+        label1 = create_annotation_label(
+            session=db_session, root_collection_id=collection_id, label_name="label1"
+        )
+
+        create_annotation(
+            session=db_session,
+            collection_id=collection_id,
+            sample_id=image1.sample_id,
+            annotation_label_id=label1.annotation_label_id,
+            annotation_type=AnnotationType.OBJECT_DETECTION,
+            annotation_data={"x": 0, "y": 0, "width": 150, "height": 100},
+        )
+        create_annotation(
+            session=db_session,
+            collection_id=collection_id,
+            sample_id=image2.sample_id,
+            annotation_label_id=label1.annotation_label_id,
+            annotation_type=AnnotationType.OBJECT_DETECTION,
+            annotation_data={"x": 0, "y": 0, "width": 50, "height": 100},
+        )
+
+        query = (
+            select(ImageTable)
+            .join(ImageTable.sample)
+            .where(SampleTable.collection_id == collection_id)
+            .where((AnnotationAccessor().object_detections().width > 100).get())
+            .where((AnnotationAccessor().object_detections().height == 100).get())
+        )
+        results = db_session.exec(query).all()
+        assert [image.sample_id for image in results] == [image1.sample_id]
+
+    def test_annotation_object_detections__with_other_annotations(
+        self, db_session: Session
+    ) -> None:
+        collection = create_collection(session=db_session)
+        collection_id = collection.collection_id
+        image1 = create_image(
+            session=db_session, collection_id=collection_id, file_path_abs="/path/to/1.jpg"
+        )
+        image2 = create_image(
+            session=db_session, collection_id=collection_id, file_path_abs="/path/to/2.jpg"
+        )
+        label1 = create_annotation_label(
+            session=db_session, root_collection_id=collection_id, label_name="label1"
+        )
+
+        create_annotation(
+            session=db_session,
+            collection_id=collection_id,
+            sample_id=image1.sample_id,
+            annotation_label_id=label1.annotation_label_id,
+            annotation_type=AnnotationType.OBJECT_DETECTION,
+            annotation_data={"x": 0, "y": 0, "width": 150, "height": 100},
+        )
+        create_annotation(
+            session=db_session,
+            collection_id=collection_id,
+            sample_id=image2.sample_id,
+            annotation_label_id=label1.annotation_label_id,
+            annotation_type=AnnotationType.INSTANCE_SEGMENTATION,
+            annotation_data={"segmentation_mask": [1, 2, 3, 4]},
+        )
+
+        query = (
+            select(ImageTable)
+            .join(ImageTable.sample)
+            .where(SampleTable.collection_id == collection_id)
+            .where((AnnotationAccessor().object_detections().label == "label1").get())
+        )
+        results = db_session.exec(query).all()
+        # There are two annotations with this label but only one of the right type.
+        assert [image.sample_id for image in results] == [image1.sample_id]

--- a/lightly_studio/tests/core/dataset_query/test_annotation_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_annotation_expression.py
@@ -67,6 +67,17 @@ class TestAnnotationExpressions:
         results = db_session.exec(query).all()
         assert [image.sample_id for image in results] == [image1.sample_id]
 
+        query = (
+            select(ImageTable)
+            .join(ImageTable.sample)
+            .where(SampleTable.collection_id == collection_id)
+            .where((AnnotationAccessor().object_detections().width > 100).get())
+            .where((AnnotationAccessor().object_detections().width < 100).get())
+        )
+        results = db_session.exec(query).all()
+        # Contradictory query leads to an empty result
+        assert len(results) == 0
+
     def test_annotation_object_detections__with_other_annotations(
         self, db_session: Session
     ) -> None:

--- a/lightly_studio/tests/core/dataset_query/test_tags_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_tags_expression.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlmodel import Session, select
 
-from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
+from lightly_studio.core.dataset_query.tags_expression import TagsAccessor
 from lightly_studio.models.image import ImageTable
 from lightly_studio.resolvers import tag_resolver
 from tests.helpers_resolvers import create_collection, create_image, create_tag
@@ -10,13 +10,13 @@ from tests.helpers_resolvers import create_collection, create_image, create_tag
 
 class TestTagsContainsExpression:
     def test_apply(self) -> None:
-        expr = ImageSampleField.tags.contains("car")
+        expr = TagsAccessor().contains("car")
         assert expr.tag_name == "car"
 
     def test_apply__sql(self) -> None:
         """Test that TagsContainsExpression correctly modifies the SQL query."""
         query = select(ImageTable)
-        query = query.where(ImageSampleField.tags.contains("car").get())
+        query = query.where(TagsAccessor().contains("car").get())
         sql = str(query.compile(compile_kwargs={"literal_binds": True}))
 
         # The current approach makes a subquery for the tags relationship.
@@ -32,8 +32,8 @@ class TestTagsContainsExpression:
         tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image.sample)
 
         query = select(ImageTable)
-        query = query.where(ImageSampleField.tags.contains("vehicle").get())
-        query = query.where(ImageSampleField.tags.contains("car").get())
+        query = query.where(TagsAccessor().contains("vehicle").get())
+        query = query.where(TagsAccessor().contains("car").get())
 
         # The sample has only one out of the two tags, no results are expected
         results = db_session.exec(query).all()


### PR DESCRIPTION
## What has changed and why?
It allows querying for annotations, so far only object detections are supported and only x, y, width, height and label.

## How has it been tested?
Added tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query and filter samples by object-detection annotation properties (width, height, x/y coordinates, label) via a new annotation accessor in the public API.

* **Tests**
  * Added tests validating SQL generation and runtime filtering for object-detection annotation queries.
  * Updated tag-expression tests to use the accessor-based expression pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->