### PR TITLE
Docs: Add Export page content

### DIFF
--- a/lightly_studio/docs/docs/api/dataset.md
+++ b/lightly_studio/docs/docs/api/dataset.md
@@ -11,3 +11,15 @@
 ::: lightly_studio
     options:
         members: [VideoDataset]
+
+## DatasetExport
+
+::: lightly_studio.export.export_dataset
+    options:
+        members: [DatasetExport]
+
+## VideoDatasetExport
+
+::: lightly_studio.export.export_video_dataset
+    options:
+        members: [VideoDatasetExport]

--- a/lightly_studio/docs/docs/concepts_and_tools/export.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/export.md
@@ -18,9 +18,7 @@ The following export formats are supported:
 ## Export in the GUI
 
 Open the export dialog from the `Menu` button in the top-right corner of any grid view
-and select `Export`.
-
-The dialog shows a dropdown with all available formats for the current dataset.
+and select `Export`. The dialog shows a dropdown with all available formats for the current dataset.
 
 ![Export format dropdown](https://storage.googleapis.com/lightly-public/studio/export_dialog_dropdown.png){width=80%}
 
@@ -35,14 +33,10 @@ The export includes all samples in the dataset.
 
 ### Exporting sample filenames by tag
 
-The `Image Filenames` format supports tag-based filtering. After selecting it:
+The `Image Filenames` option supports tag-based filtering. Tick `Inverse selection` to export
+samples that do not have the selected tag.
 
 ![Export filenames by tag](https://storage.googleapis.com/lightly-public/studio/export_dialog_filenames.png){width=60%}
-
-1. Pick a tag from the list of available tags.
-2. Optionally check `Inverse selection` to export all samples that do **not** have the tag.
-3. The dialog shows a live count of matching samples.
-4. Click `Download` to save the file.
 
 ## Export in Python
 

--- a/lightly_studio/docs/docs/concepts_and_tools/export.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/export.md
@@ -1,5 +1,85 @@
 # Export
 
-Export lets you save selected samples and their annotations in common formats such as COCO and YOLO. You can export an entire dataset or a filtered subset based on tags, search results, or other criteria. Exports can be triggered from the UI or through the Python API.
+Export lets you save annotations and file paths from your dataset in common formats.
+Exports can be triggered from the GUI or through the Python API. You can export an entire dataset
+or a filtered subset based on tags, or other criteria when using the Python API.
 
-More details on how to export will be added soon.
+The following export formats are supported:
+
+| Format | Content | File type |
+|---|---|---|
+| Sample Filenames | Absolute file paths of selected samples | TXT |
+| COCO Object Detection | Bounding box annotations | JSON |
+| COCO Instance Segmentation | Segmentation masks with bounding boxes | JSON |
+| COCO Captions | Image captions | JSON |
+| Pascal VOC Semantic Segmentation | Per-pixel class masks | PNG masks + class map |
+| YouTube-VIS Instance Segmentation | Video instance segmentation tracks | JSON |
+
+## Export in the GUI
+
+Open the export dialog from the `Menu` button in the top-right corner of any grid view
+and select `Export`.
+
+The dialog shows a dropdown with all available formats for the current dataset.
+
+![Export format dropdown](https://storage.googleapis.com/lightly-public/studio/export_dialog_dropdown.png){width=80%}
+
+### Exporting annotations
+
+For annotation formats (`Image Object Detections`, `Image Instance Segmentations`,
+`Image Semantic Segmentations`, `Image Captions`, `YouTube-VIS Video Instance Segmentations`),
+select the format and click `Download`. A zip file is created if the export includes multiple files.
+The export includes all samples in the dataset.
+
+![Export object detections](https://storage.googleapis.com/lightly-public/studio/export_dialog_object_detections.png){width=60%}
+
+### Exporting sample filenames by tag
+
+The `Image Filenames` format supports tag-based filtering. After selecting it:
+
+![Export filenames by tag](https://storage.googleapis.com/lightly-public/studio/export_dialog_filenames.png){width=60%}
+
+1. Pick a tag from the list of available tags.
+2. Optionally check `Inverse selection` to export all samples that do **not** have the tag.
+3. The dialog shows a live count of matching samples.
+4. Click `Download` to save the file.
+
+## Export in Python
+
+### Export a dataset
+
+Call `dataset.export()` to get an export object, then call a format-specific method on it.
+The export methods depend on the dataset type, see
+[Dataset export reference](../api/dataset.md#datasetexport)
+for details.
+
+```python
+import lightly_studio as ls
+
+# Image dataset export
+dataset = ls.ImageDataset.load()
+dataset.export().to_coco_object_detections("detections.json")
+dataset.export().to_coco_instance_segmentations("segmentations.json")
+dataset.export().to_coco_captions("captions.json")
+
+# Video dataset export
+dataset = ls.VideoDataset.load()
+dataset.export().to_youtube_vis_instance_segmentation("youtube_vis.json")
+```
+
+### Export a filtered subset
+
+Pass a `DatasetQuery` to `export()` to export only matching samples. Queries support
+filtering, ordering, and slicing — see [Search and Filter](search_and_filter.md#query-in-python)
+for the full query API.
+
+```python
+import lightly_studio as ls
+from lightly_studio.core.dataset_query import ImageSampleField
+
+dataset = ls.ImageDataset.load()
+
+# Export only samples taller than 500 pixels
+query = dataset.query().match(ImageSampleField.height > 500)
+dataset.export(query).to_coco_object_detections("tall_images.json")
+```


### PR DESCRIPTION
## What has changed and why?

Add Export page content.

I'll make a follow-up to:
- Rename DatasetExport to ImageDatasetExport
- Expose PascalVOC export via Python API

## How has it been tested?

```
cd lightly_studio/docs
make serve
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API reference sections for dataset and video-dataset export features.
  * Rewrote export guide to list supported formats (Sample Filenames TXT, COCO JSON variants, Pascal VOC segmentation, YouTube‑VIS JSON) and explain ZIP behavior.
  * Expanded GUI workflow with step-by-step export dialog, download behavior, tag-based filtering and inverse selection.
  * Added Python usage guides with examples for full-dataset and filtered exports, covering image and video workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->