### PR TITLE
Expose PascalVoc export from the Python interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a floating selection panel to grid pages.
 - Tags can be created and assigned directly from the sample and annotation detail view.
 - Tags can be created and assigned directly from the side panel in the grid view.
-- Exposed PascalVoc segmentation export from the Python interface.
+- Exposed Pascal VOC segmentation export from the Python interface.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a floating selection panel to grid pages.
 - Tags can be created and assigned directly from the sample and annotation detail view.
 - Tags can be created and assigned directly from the side panel in the grid view.
+- Exposed PascalVoc segmentation export from the Python interface.
 
 ### Changed
 

--- a/lightly_studio/docs/docs/concepts_and_tools/export.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/export.md
@@ -55,6 +55,7 @@ dataset = ls.ImageDataset.load()
 dataset.export().to_coco_object_detections("detections.json")
 dataset.export().to_coco_instance_segmentations("segmentations.json")
 dataset.export().to_coco_captions("captions.json")
+dataset.export().to_pascalvoc_instance_segmentation("pascalvoc_output_dir/")
 
 # Video dataset export
 dataset = ls.VideoDataset.load()

--- a/lightly_studio/src/lightly_studio/export/image_dataset_export.py
+++ b/lightly_studio/src/lightly_studio/export/image_dataset_export.py
@@ -91,6 +91,23 @@ class ImageDatasetExport:
             output_json=Path(output_json),
         )
 
+    def to_pascalvoc_instance_segmentation(self, output_folder: PathLike) -> None:
+        """Exports instance segmentation annotations to Pascal VOC format.
+
+        Creates a folder with per-pixel class masks (PNG) and a class map (JSON).
+
+        Args:
+            output_folder: The folder where Pascal VOC segmentation files are
+                written. The folder contains a `SegmentationClass` subfolder
+                with PNG masks and a `class_id_to_name.json` file.
+        """
+        to_pascalvoc_instance_segmentation(
+            session=self.session,
+            dataset_id=self._dataset_id,
+            samples=self.samples,
+            output_folder=Path(output_folder),
+        )
+
 
 def to_coco_object_detections(
     session: Session,
@@ -150,7 +167,8 @@ def to_pascalvoc_instance_segmentation(
 ) -> None:
     """Exports instance segmentation annotations to a Pascal VOC segmentation folder.
 
-    This function is for internal use.
+    This function is for internal use. Use
+    `Dataset.export().to_pascalvoc_instance_segmentation()` instead.
 
     Args:
         session: The database session.

--- a/lightly_studio/tests/export/test_image_dataset_export.py
+++ b/lightly_studio/tests/export/test_image_dataset_export.py
@@ -281,6 +281,44 @@ class TestImageDatasetExport:
             "annotations": [],
         }
 
+    def test_to_pascalvoc_instance_segmentation__via_class(
+        self,
+        tmp_path: Path,
+        patch_collection: None,  # noqa: ARG002
+    ) -> None:
+        dataset = ImageDataset.create(name="test_dataset")
+        create_images(
+            db_session=dataset.session,
+            collection_id=dataset.collection_id,
+            images=[ImageStub(path="image0.jpg", width=3, height=2)],
+        )
+
+        samples = list(dataset)
+        samples[0].add_annotation(
+            CreateInstanceSegmentation.from_rle_mask(
+                label="dog",
+                sample_2d=samples[0],
+                segmentation_mask=[1, 1, 4],
+            )
+        )
+
+        output_folder = tmp_path / "pascalvoc"
+        dataset.export().to_pascalvoc_instance_segmentation(
+            output_folder=output_folder,
+        )
+
+        class_map_path = output_folder / "class_id_to_name.json"
+        with class_map_path.open() as f:
+            class_map = json.load(f)
+        assert class_map == {"0": "background", "1": "dog"}
+
+        mask_path = output_folder / "SegmentationClass" / "image0.png"
+        with PILImage.open(mask_path) as mask:
+            mask_values = list(mask.getdata())
+        assert mask_values == [0, 1, 0, 0, 0, 0]
+
+    # TODO(Michal, 04/2026): The tests below test the module method, not the ImageDatasetExport
+    # class method. They should move outside of this tests class and not use patch_collection.
     def test_to_pascalvoc_instance_segmentation(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## What has changed and why?

Expose PascalVoc export from the Python interface. The backend function was implemented but not wired to the interface.

## How has it been tested?

New test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pascal VOC instance segmentation export is now available via the Python interface.

* **Documentation**
  * Added a Python example demonstrating Pascal VOC instance segmentation export.

* **Tests**
  * Added end-to-end test coverage for Pascal VOC instance segmentation export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->