### PR TITLE
Fix: Make deletion of tags in backend safe

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -87,6 +87,11 @@ def delete(session: Session, tag_id: UUID) -> bool:
     if not tag:
         return False
 
+    session.exec(
+        sqlmodel.delete(SampleTagLinkTable).where(col(SampleTagLinkTable.tag_id) == tag_id)
+    )
+    session.commit()
+
     session.delete(tag)
     session.commit()
     return True

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -90,6 +90,8 @@ def delete(session: Session, tag_id: UUID) -> bool:
     session.exec(
         sqlmodel.delete(SampleTagLinkTable).where(col(SampleTagLinkTable.tag_id) == tag_id)
     )
+    session.commit()
+
     session.delete(tag)
     session.commit()
     return True

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -90,8 +90,6 @@ def delete(session: Session, tag_id: UUID) -> bool:
     session.exec(
         sqlmodel.delete(SampleTagLinkTable).where(col(SampleTagLinkTable.tag_id) == tag_id)
     )
-    session.commit()
-
     session.delete(tag)
     session.commit()
     return True

--- a/lightly_studio/tests/api/routes/api/test_dataset_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_dataset_tag.py
@@ -4,10 +4,12 @@ from uuid import uuid4
 
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
+from sqlmodel import Session
 
 from lightly_studio.api.routes.api.status import HTTP_STATUS_OK
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.resolvers import collection_resolver, tag_resolver
+from tests.helpers_resolvers import create_collection, create_image, create_tag
 
 
 def test_read_tags__calls_get_all_by_collection_id(
@@ -39,3 +41,19 @@ def test_read_tags__calls_get_all_by_collection_id(
     mock_get_all_by_collection_id.assert_called_once_with(
         session=mocker.ANY, collection_id=collection_id, offset=0, limit=100
     )
+
+
+def test_delete_tag__deletes_tag_with_sample_links(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection = create_collection(session=db_session)
+    tag = create_tag(session=db_session, collection_id=collection.collection_id)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image.sample)
+
+    response = test_client.delete(f"/api/collections/{collection.collection_id}/tags/{tag.tag_id}")
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {"status": "deleted"}
+    assert tag_resolver.get_by_id(session=db_session, tag_id=tag.tag_id) is None

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -186,6 +186,29 @@ def test_delete_tag(db_session: Session) -> None:
     assert tag_deleted is None
 
 
+def test_delete_tag__removes_sample_links(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    tag = create_tag(session=db_session, collection_id=collection_id)
+    image_1 = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="sample1.png"
+    )
+    image_2 = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="sample2.png"
+    )
+
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_1.sample)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_2.sample)
+
+    tag_resolver.delete(session=db_session, tag_id=tag.tag_id)
+
+    tag_deleted = tag_resolver.get_by_id(session=db_session, tag_id=tag.tag_id)
+    assert tag_deleted is None
+    assert image_1.sample.tags == []
+    assert image_2.sample.tags == []
+
+
 def test_get_or_create_sample_tag_by_name(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id


### PR DESCRIPTION
## What has changed and why?

- Minor PR to make deletion of tags more safe by unlinking SampleTagLinkTable
- 
## How has it been tested?

- Updated tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tag deletion now fully removes associations with samples, preventing orphaned tag links and ensuring complete cleanup.

* **Tests**
  * Added resolver and API tests that verify tags are removed, sample link records are cleared, and the delete endpoint returns a successful deletion response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->