### PR TITLE
Add: Allow deletion of tags in frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a floating selection panel to grid pages.
 - Tags can be created and assigned directly from the sample and annotation detail view.
 - Tags can be created and assigned directly from the side panel in the grid view.
+- Tags can be deleted from the side panel in the grid view.
 - Exposed Pascal VOC segmentation export from the Python interface.
 
 ### Changed

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -143,6 +143,11 @@ def update_tag(
 @tag_router.delete("/collections/{collection_id}/tags/{tag_id}")
 def delete_tag(
     session: SessionDep,
+    # collection_id is needed for the generator
+    collection_id: Annotated[  # noqa: ARG001
+        UUID,
+        Path(title="collection Id", description="The ID of the collection"),
+    ],
     tag_id: Annotated[UUID, Path(title="Tag Id")],
 ) -> dict[str, str]:
     """Delete a tag from the database."""

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -130,6 +130,7 @@ def update_tag(
                 detail=f"Tag with id {tag_id} not found.",
             )
     except IntegrityError as e:
+        session.rollback()
         raise HTTPException(
             status_code=HTTP_STATUS_CONFLICT,
             detail=f"""

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -62,12 +62,22 @@ def update(session: Session, tag_id: UUID, tag_data: TagUpdate) -> TagTable | No
         return None
 
     update_fields = tag_data.model_dump(exclude_unset=True)
+    target_name = update_fields.get("name", tag.name)
+    target_description = update_fields.get("description", tag.description)
 
     conflicting_tag = get_by_name(
-        session=session, tag_name=tag_data.name, collection_id=tag.collection_id
+        session=session, tag_name=target_name, collection_id=tag.collection_id
     )
     if conflicting_tag and conflicting_tag.tag_id != tag_id and conflicting_tag.kind == tag.kind:
         raise IntegrityError(statement=None, params=None, orig=Exception("Tag already exists"))
+
+    if target_name == tag.name:
+        tag.description = target_description
+        tag.updated_at = datetime.now(timezone.utc)
+        session.add(tag)
+        session.commit()
+        session.refresh(tag)
+        return tag
 
     sample_ids = [
         sample_id
@@ -77,36 +87,37 @@ def update(session: Session, tag_id: UUID, tag_data: TagUpdate) -> TagTable | No
         if sample_id is not None
     ]
 
+    # DuckDB rejects updates and deletes of referenced rows in the same transaction.
+    # Commit each step so renaming a tag preserves existing sample links.
     session.exec(
         sqlmodel.delete(SampleTagLinkTable).where(col(SampleTagLinkTable.tag_id) == tag_id)
     )
+    session.commit()
 
-    # DuckDB checks unique constraints too eagerly on updates, so we recreate
-    # the tag row. We must temporarily delete the link rows first, otherwise
-    # DuckDB rejects deleting the tag row because of the foreign key.
-    # https://duckdb.org/docs/sql/indexes#over-eager-unique-constraint-checking
+    tag = get_by_id(session=session, tag_id=tag_id)
+    if not tag:
+        return None
+
     session.delete(tag)
-    session.flush()
-    session.expunge(tag)
+    session.commit()
 
     tag_updated = TagTable(
-        tag_id=tag.tag_id,
+        tag_id=tag_id,
         collection_id=tag.collection_id,
-        name=update_fields.get("name", tag.name),
-        description=update_fields.get("description", tag.description),
+        name=target_name,
+        description=target_description,
         kind=tag.kind,
         created_at=tag.created_at,
         updated_at=datetime.now(timezone.utc),
     )
-
     session.add(tag_updated)
+    session.commit()
 
     if sample_ids:
         session.add_all(
             [SampleTagLinkTable(sample_id=sample_id, tag_id=tag_id) for sample_id in sample_ids]
         )
-
-    session.commit()
+        session.commit()
 
     session.refresh(tag_updated)
     return tag_updated

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -61,6 +61,8 @@ def update(session: Session, tag_id: UUID, tag_data: TagUpdate) -> TagTable | No
     if not tag:
         return None
 
+    update_fields = tag_data.model_dump(exclude_unset=True)
+
     conflicting_tag = get_by_name(
         session=session, tag_name=tag_data.name, collection_id=tag.collection_id
     )
@@ -78,33 +80,33 @@ def update(session: Session, tag_id: UUID, tag_data: TagUpdate) -> TagTable | No
     session.exec(
         sqlmodel.delete(SampleTagLinkTable).where(col(SampleTagLinkTable.tag_id) == tag_id)
     )
-    session.commit()
 
     # DuckDB checks unique constraints too eagerly on updates, so we recreate
     # the tag row. We must temporarily delete the link rows first, otherwise
     # DuckDB rejects deleting the tag row because of the foreign key.
     # https://duckdb.org/docs/sql/indexes#over-eager-unique-constraint-checking
     session.delete(tag)
-    session.commit()
+    session.flush()
+    session.expunge(tag)
 
     tag_updated = TagTable(
         tag_id=tag.tag_id,
         collection_id=tag.collection_id,
-        name=tag_data.name,
-        description=tag_data.description,
+        name=update_fields.get("name", tag.name),
+        description=update_fields.get("description", tag.description),
         kind=tag.kind,
         created_at=tag.created_at,
         updated_at=datetime.now(timezone.utc),
     )
 
     session.add(tag_updated)
-    session.commit()
 
     if sample_ids:
-        session.bulk_save_objects(
+        session.add_all(
             [SampleTagLinkTable(sample_id=sample_id, tag_id=tag_id) for sample_id in sample_ids]
         )
-        session.commit()
+
+    session.commit()
 
     session.refresh(tag_updated)
     return tag_updated

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 import sqlmodel
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
@@ -60,23 +61,51 @@ def update(session: Session, tag_id: UUID, tag_data: TagUpdate) -> TagTable | No
     if not tag:
         return None
 
-    # due to duckdb/OLAP optimisations, update operations effecting unique
-    # constraints (e.g colums) will lead to a unique constraint violation.
-    # This is due to a update is implemented as delete+insert. The error
-    # happens only within the same session.
-    # To fix it, we can delete, commit + insert a new tag.
+    conflicting_tag = get_by_name(
+        session=session, tag_name=tag_data.name, collection_id=tag.collection_id
+    )
+    if conflicting_tag and conflicting_tag.tag_id != tag_id and conflicting_tag.kind == tag.kind:
+        raise IntegrityError(statement=None, params=None, orig=Exception("Tag already exists"))
+
+    sample_ids = [
+        sample_id
+        for sample_id in session.exec(
+            select(SampleTagLinkTable.sample_id).where(col(SampleTagLinkTable.tag_id) == tag_id)
+        ).all()
+        if sample_id is not None
+    ]
+
+    session.exec(
+        sqlmodel.delete(SampleTagLinkTable).where(col(SampleTagLinkTable.tag_id) == tag_id)
+    )
+    session.commit()
+
+    # DuckDB checks unique constraints too eagerly on updates, so we recreate
+    # the tag row. We must temporarily delete the link rows first, otherwise
+    # DuckDB rejects deleting the tag row because of the foreign key.
     # https://duckdb.org/docs/sql/indexes#over-eager-unique-constraint-checking
     session.delete(tag)
     session.commit()
 
-    # create clone of tag with updated values
-    tag_updated = TagTable.model_validate(tag)
-    tag_updated.name = tag_data.name
-    tag_updated.description = tag_data.description
-    tag_updated.updated_at = datetime.now(timezone.utc)
+    tag_updated = TagTable(
+        tag_id=tag.tag_id,
+        collection_id=tag.collection_id,
+        name=tag_data.name,
+        description=tag_data.description,
+        kind=tag.kind,
+        created_at=tag.created_at,
+        updated_at=datetime.now(timezone.utc),
+    )
 
     session.add(tag_updated)
     session.commit()
+
+    if sample_ids:
+        session.bulk_save_objects(
+            [SampleTagLinkTable(sample_id=sample_id, tag_id=tag_id) for sample_id in sample_ids]
+        )
+        session.commit()
+
     session.refresh(tag_updated)
     return tag_updated
 

--- a/lightly_studio/tests/api/routes/api/test_dataset_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_dataset_tag.py
@@ -87,6 +87,30 @@ def test_update_tag__renames_tag_with_sample_links(
     assert updated_tag.samples[0].sample_id == image.sample.sample_id
 
 
+def test_update_tag__rename_only_preserves_description(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection = create_collection(session=db_session)
+    tag = create_tag(
+        session=db_session,
+        collection_id=collection.collection_id,
+        description="existing description",
+    )
+
+    response = test_client.put(
+        f"/api/collections/{collection.collection_id}/tags/{tag.tag_id}",
+        json={"name": "renamed_tag"},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json()["name"] == "renamed_tag"
+    assert response.json()["description"] == "existing description"
+
+    updated_tag = tag_resolver.get_by_id(session=db_session, tag_id=tag.tag_id)
+    assert updated_tag is not None
+    assert updated_tag.description == "existing description"
+
+
 def test_update_tag__returns_conflict_if_name_is_already_used_by_another_tag(
     db_session: Session, test_client: TestClient
 ) -> None:

--- a/lightly_studio/tests/api/routes/api/test_dataset_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_dataset_tag.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 from sqlmodel import Session
 
-from lightly_studio.api.routes.api.status import HTTP_STATUS_OK
+from lightly_studio.api.routes.api.status import HTTP_STATUS_CONFLICT, HTTP_STATUS_OK
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.resolvers import collection_resolver, tag_resolver
 from tests.helpers_resolvers import create_collection, create_image, create_tag
@@ -57,3 +57,50 @@ def test_delete_tag__deletes_tag_with_sample_links(
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() == {"status": "deleted"}
     assert tag_resolver.get_by_id(session=db_session, tag_id=tag.tag_id) is None
+
+
+def test_update_tag__renames_tag_with_sample_links(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection = create_collection(session=db_session)
+    tag = create_tag(session=db_session, collection_id=collection.collection_id)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image.sample)
+
+    response = test_client.put(
+        f"/api/collections/{collection.collection_id}/tags/{tag.tag_id}",
+        json={
+            "name": "renamed_tag",
+            "description": tag.description,
+            "kind": tag.kind,
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json()["name"] == "renamed_tag"
+
+    updated_tag = tag_resolver.get_by_id(session=db_session, tag_id=tag.tag_id)
+    assert updated_tag is not None
+    assert updated_tag.name == "renamed_tag"
+    assert len(updated_tag.samples) == 1
+    assert updated_tag.samples[0].sample_id == image.sample.sample_id
+
+
+def test_update_tag__returns_conflict_if_name_is_already_used_by_another_tag(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection = create_collection(session=db_session)
+    tag = create_tag(session=db_session, collection_id=collection.collection_id, tag_name="tag_1")
+    create_tag(session=db_session, collection_id=collection.collection_id, tag_name="tag_2")
+
+    response = test_client.put(
+        f"/api/collections/{collection.collection_id}/tags/{tag.tag_id}",
+        json={
+            "name": "tag_2",
+            "description": tag.description,
+            "kind": tag.kind,
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CONFLICT

--- a/lightly_studio/tests/api/routes/api/test_dataset_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_dataset_tag.py
@@ -8,6 +8,7 @@ from sqlmodel import Session
 
 from lightly_studio.api.routes.api.status import HTTP_STATUS_CONFLICT, HTTP_STATUS_OK
 from lightly_studio.models.collection import CollectionTable, SampleType
+from lightly_studio.models.tag import TagCreate
 from lightly_studio.resolvers import collection_resolver, tag_resolver
 from tests.helpers_resolvers import create_collection, create_image, create_tag
 
@@ -91,10 +92,14 @@ def test_update_tag__rename_only_preserves_description(
     db_session: Session, test_client: TestClient
 ) -> None:
     collection = create_collection(session=db_session)
-    tag = create_tag(
+    tag = tag_resolver.create(
         session=db_session,
-        collection_id=collection.collection_id,
-        description="existing description",
+        tag=TagCreate(
+            collection_id=collection.collection_id,
+            name="example_tag",
+            description="existing description",
+            kind="sample",
+        ),
     )
 
     response = test_client.put(

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -109,6 +109,33 @@ def test_update_tag(db_session: Session) -> None:
     assert tag_updated.name == data_update.name
 
 
+def test_update_tag__preserves_sample_links(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    tag = create_tag(session=db_session, collection_id=collection_id)
+    image_1 = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="sample1.png"
+    )
+    image_2 = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="sample2.png"
+    )
+
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_1.sample)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_2.sample)
+
+    tag_updated = tag_resolver.update(
+        session=db_session, tag_id=tag.tag_id, tag_data=TagUpdate(name="updated_tag")
+    )
+
+    assert tag_updated is not None
+    assert tag_updated.name == "updated_tag"
+    assert tag_updated.tag_id == tag.tag_id
+    assert sorted(sample.sample_id for sample in tag_updated.samples) == sorted(
+        [image_1.sample.sample_id, image_2.sample.sample_id]
+    )
+
+
 def test_update_tag__unique_tag_name(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
@@ -125,6 +152,40 @@ def test_update_tag__unique_tag_name(db_session: Session) -> None:
             tag_data=TagUpdate(name=tag_2.name),
         )
     db_session.rollback()
+
+
+def test_update_tag__unique_tag_name__preserves_original_tag_and_links(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    tag_1 = create_tag(session=db_session, collection_id=collection_id, tag_name="example_tag_1")
+    tag_2 = create_tag(session=db_session, collection_id=collection_id, tag_name="some_other_tag")
+    image_1 = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="sample1.png"
+    )
+    image_2 = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="sample2.png"
+    )
+
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag_1.tag_id, sample=image_1.sample)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag_1.tag_id, sample=image_2.sample)
+
+    with pytest.raises(IntegrityError):
+        tag_resolver.update(
+            session=db_session,
+            tag_id=tag_1.tag_id,
+            tag_data=TagUpdate(name=tag_2.name),
+        )
+    db_session.rollback()
+
+    original_tag = tag_resolver.get_by_id(session=db_session, tag_id=tag_1.tag_id)
+    assert original_tag is not None
+    assert original_tag.name == "example_tag_1"
+    assert sorted(sample.sample_id for sample in original_tag.samples) == sorted(
+        [image_1.sample.sample_id, image_2.sample.sample_id]
+    )
 
 
 def test_update_tag__unique_tag_name__different_kind(

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -136,6 +136,28 @@ def test_update_tag__preserves_sample_links(db_session: Session) -> None:
     )
 
 
+def test_update_tag__rename_only_preserves_description(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    tag = create_tag(
+        session=db_session,
+        collection_id=collection_id,
+        tag_name="example_tag",
+        description="existing description",
+    )
+
+    tag_updated = tag_resolver.update(
+        session=db_session,
+        tag_id=tag.tag_id,
+        tag_data=TagUpdate(name="updated_tag"),
+    )
+
+    assert tag_updated is not None
+    assert tag_updated.name == "updated_tag"
+    assert tag_updated.description == "existing description"
+
+
 def test_update_tag__unique_tag_name(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -140,11 +140,14 @@ def test_update_tag__rename_only_preserves_description(db_session: Session) -> N
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    tag = create_tag(
+    tag = tag_resolver.create(
         session=db_session,
-        collection_id=collection_id,
-        tag_name="example_tag",
-        description="existing description",
+        tag=TagCreate(
+            collection_id=collection_id,
+            name="example_tag",
+            description="existing description",
+            kind="sample",
+        ),
     )
 
     tag_updated = tag_resolver.update(

--- a/lightly_studio_view/src/lib/components/SegmentTags/SegmentTags.test.ts
+++ b/lightly_studio_view/src/lib/components/SegmentTags/SegmentTags.test.ts
@@ -51,6 +51,7 @@ vi.spyOn(hooks, 'useTags').mockImplementation(() => ({
     loadTags: loadTagsMock,
     tagsSelected: writable(new Set<string>()),
     clearTagsSelected: vi.fn(),
+    clearTagSelected: vi.fn(),
     tagSelectionToggle: vi.fn(),
     isLoading: writable(false),
     error: writable(null)

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -2,11 +2,12 @@
     import { Checkbox } from '$lib/components';
     import type { GridType } from '$lib/types';
     import Segment from '$lib/components/Segment/Segment.svelte';
-    import { Tags as Tagsicon } from '@lucide/svelte';
+    import * as Popover from '$lib/components/ui/popover';
+    import { MoreHorizontal, Tags as Tagsicon, Trash2 } from '@lucide/svelte';
     import type { TagView } from '$lib/services/types';
     import { useTags } from '$lib/hooks/useTags/useTags.js';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
-    import { createTag, addSampleIdsToTagId } from '$lib/api/lightly_studio_local';
+    import { createTag, addSampleIdsToTagId, deleteTag } from '$lib/api/lightly_studio_local';
     import TagAssignInput from './TagAssignInput.svelte';
     import { toast } from 'svelte-sonner';
 
@@ -15,7 +16,7 @@
 
     const tagKind = $derived(gridType === 'annotations' ? 'annotation' : 'sample');
 
-    const { tags, tagsSelected, tagSelectionToggle, loadTags } = $derived(
+    const { tags, tagsSelected, tagSelectionToggle, loadTags, clearTagSelected } = $derived(
         useTags({ collection_id, kind: [tagKind] })
     );
 
@@ -35,6 +36,7 @@
 
     // ── Selection assignment ─────────────────────────────────────────────────────
     let assignBusy = $state(false);
+    let deletingTagId = $state<string | null>(null);
 
     async function handleAssign(name: string) {
         assignBusy = true;
@@ -77,19 +79,87 @@
             assignBusy = false;
         }
     }
+
+    async function handleDeleteTag(tag: TagView, event: MouseEvent) {
+        event.stopPropagation();
+
+        if (deletingTagId) {
+            return;
+        }
+
+        deletingTagId = tag.tag_id;
+
+        try {
+            const response = await deleteTag({
+                path: {
+                    collection_id,
+                    tag_id: tag.tag_id
+                } as never
+            });
+
+            if (response.error) {
+                toast.error('Failed to delete tag. Please try again.');
+                return;
+            }
+
+            clearTagSelected(tag.tag_id);
+            loadTags();
+            toast.success('Tag deleted successfully');
+        } catch (error) {
+            console.error('Failed to delete tag', error);
+            toast.error('Failed to delete tag. Please try again.');
+        } finally {
+            deletingTagId = null;
+        }
+    }
 </script>
 
 <Segment title="Tags" icon={Tagsicon}>
     <div class="mb-3 w-full space-y-1">
         <div class="space-y-1">
             {#each $tags as tag (tag.tag_id)}
-                <div class="flex items-center py-0.5" data-testid="tag-menu-item">
-                    <Checkbox
-                        name={tag.tag_id}
-                        isChecked={$tagsSelected.has(tag.tag_id)}
-                        label={tag.name}
-                        onCheckedChange={() => tagSelectionToggle(tag.tag_id)}
-                    />
+                <div class="flex items-center gap-2 py-0.5" data-testid="tag-menu-item">
+                    <div class="min-w-0 flex-1">
+                        <Checkbox
+                            name={tag.tag_id}
+                            isChecked={$tagsSelected.has(tag.tag_id)}
+                            label={tag.name}
+                            onCheckedChange={() => tagSelectionToggle(tag.tag_id)}
+                        />
+                    </div>
+                    <Popover.Root>
+                        <Popover.Trigger
+                            class="inline-flex size-7 shrink-0 items-center justify-center rounded-md hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+                            aria-label={`Open actions for tag ${tag.name}`}
+                            data-testid={`tag-actions-trigger-${tag.tag_id}`}
+                            disabled={deletingTagId === tag.tag_id}
+                            onclick={(event: MouseEvent) => {
+                                event.stopPropagation();
+                            }}
+                        >
+                            <MoreHorizontal />
+                        </Popover.Trigger>
+                        <Popover.Content
+                            class="w-40 p-1"
+                            align="end"
+                            onclick={(event: MouseEvent) => {
+                                event.stopPropagation();
+                            }}
+                        >
+                            <button
+                                type="button"
+                                class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-destructive hover:text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                                data-testid={`delete-tag-${tag.tag_id}`}
+                                disabled={deletingTagId !== null}
+                                onclick={(event: MouseEvent) => {
+                                    void handleDeleteTag(tag, event);
+                                }}
+                            >
+                                <Trash2 class="size-4" />
+                                {deletingTagId === tag.tag_id ? 'Deleting...' : 'Delete tag'}
+                            </button>
+                        </Popover.Content>
+                    </Popover.Root>
                 </div>
             {:else}
                 <p>No tags yet</p>

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -94,19 +94,17 @@
                 path: {
                     collection_id,
                     tag_id: tag.tag_id
-                } as never
+                }
             });
 
             if (response.error) {
-                toast.error('Failed to delete tag. Please try again.');
-                return;
+                throw new Error('Failed to delete tag.');
             }
 
             clearTagSelected(tag.tag_id);
             loadTags();
             toast.success('Tag deleted successfully');
-        } catch (error) {
-            console.error('Failed to delete tag', error);
+        } catch {
             toast.error('Failed to delete tag. Please try again.');
         } finally {
             deletingTagId = null;

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
@@ -240,7 +240,6 @@ describe('TagsMenu', () => {
 
     it('shows a toast when deleting a tag fails', async () => {
         vi.mocked(deleteTag).mockRejectedValue(new Error('network error'));
-        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
         render(TagsMenu, {
             props: {
@@ -258,7 +257,6 @@ describe('TagsMenu', () => {
 
         expect(mocks.clearTagSelected).not.toHaveBeenCalled();
         expect(mocks.loadTags).not.toHaveBeenCalled();
-        consoleErrorSpy.mockRestore();
     });
 
     it('does not toggle the checkbox when opening the tag actions menu', async () => {

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
@@ -1,4 +1,4 @@
-import { addSampleIdsToTagId, createTag } from '$lib/api/lightly_studio_local';
+import { addSampleIdsToTagId, createTag, deleteTag } from '$lib/api/lightly_studio_local';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => ({
     selectedSampleIdsByCollection: {} as Record<string, Set<string>>,
     selectedSampleAnnotationCropIds: {} as Record<string, Set<string>>,
     loadTags: vi.fn(),
-    tagSelectionToggle: vi.fn()
+    tagSelectionToggle: vi.fn(),
+    clearTagSelected: vi.fn()
 }));
 
 vi.mock('$lib/api/lightly_studio_local', async () => {
@@ -20,7 +21,8 @@ vi.mock('$lib/api/lightly_studio_local', async () => {
     return {
         ...actual,
         createTag: vi.fn(),
-        addSampleIdsToTagId: vi.fn()
+        addSampleIdsToTagId: vi.fn(),
+        deleteTag: vi.fn()
     };
 });
 
@@ -29,7 +31,8 @@ vi.mock('$lib/hooks/useTags/useTags.js', () => ({
         tags: readable(mocks.tags),
         tagsSelected: readable(mocks.tagsSelected),
         tagSelectionToggle: mocks.tagSelectionToggle,
-        loadTags: mocks.loadTags
+        loadTags: mocks.loadTags,
+        clearTagSelected: mocks.clearTagSelected
     }))
 }));
 
@@ -43,7 +46,8 @@ vi.mock('$lib/hooks/useGlobalStorage', () => ({
 
 vi.mock('svelte-sonner', () => ({
     toast: {
-        error: vi.fn()
+        error: vi.fn(),
+        success: vi.fn()
     }
 }));
 
@@ -80,6 +84,14 @@ describe('TagsMenu', () => {
                 description: 'Created Tag description',
                 created_at: new Date('2024-01-03T00:00:00.000Z'),
                 updated_at: new Date('2024-01-03T00:00:00.000Z')
+            },
+            error: undefined,
+            request: mockRequest,
+            response: mockResponse
+        });
+        vi.mocked(deleteTag).mockResolvedValue({
+            data: {
+                status: 'deleted'
             },
             error: undefined,
             request: mockRequest,
@@ -199,5 +211,66 @@ describe('TagsMenu', () => {
 
         expect(mocks.loadTags).not.toHaveBeenCalled();
         consoleErrorSpy.mockRestore();
+    });
+
+    it('deletes a tag from the sidebar actions menu', async () => {
+        render(TagsMenu, {
+            props: {
+                collection_id: 'collection-1',
+                gridType: 'samples'
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('tag-actions-trigger-tag-1'));
+        await fireEvent.click(await screen.findByTestId('delete-tag-tag-1'));
+
+        await waitFor(() => {
+            expect(deleteTag).toHaveBeenCalledWith({
+                path: {
+                    collection_id: 'collection-1',
+                    tag_id: 'tag-1'
+                }
+            });
+        });
+
+        expect(mocks.clearTagSelected).toHaveBeenCalledWith('tag-1');
+        expect(mocks.loadTags).toHaveBeenCalled();
+        expect(toast.success).toHaveBeenCalledWith('Tag deleted successfully');
+    });
+
+    it('shows a toast when deleting a tag fails', async () => {
+        vi.mocked(deleteTag).mockRejectedValue(new Error('network error'));
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        render(TagsMenu, {
+            props: {
+                collection_id: 'collection-1',
+                gridType: 'samples'
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('tag-actions-trigger-tag-1'));
+        await fireEvent.click(await screen.findByTestId('delete-tag-tag-1'));
+
+        await waitFor(() => {
+            expect(toast.error).toHaveBeenCalledWith('Failed to delete tag. Please try again.');
+        });
+
+        expect(mocks.clearTagSelected).not.toHaveBeenCalled();
+        expect(mocks.loadTags).not.toHaveBeenCalled();
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('does not toggle the checkbox when opening the tag actions menu', async () => {
+        render(TagsMenu, {
+            props: {
+                collection_id: 'collection-1',
+                gridType: 'samples'
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('tag-actions-trigger-tag-1'));
+
+        expect(mocks.tagSelectionToggle).not.toHaveBeenCalled();
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useTags/useTags.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useTags/useTags.test.ts
@@ -79,7 +79,7 @@ describe('useTags Hook', () => {
         // Mock loading state
         setup({ data: null, isLoading: true, error: null });
 
-        const { isLoading, tags } = useTags({ collection_id: '123' });
+        const { isLoading, tags } = useTags({ collection_id: 'loading-collection' });
 
         expect(get(isLoading)).toBe(true);
         expect(get(tags)).toEqual([]);
@@ -91,7 +91,7 @@ describe('useTags Hook', () => {
         // Mock error state
         vi.spyOn(lightly_studio_local, 'readTags').mockRejectedValueOnce(testError);
 
-        const { error, tags } = useTags({ collection_id: '123' });
+        const { error, tags } = useTags({ collection_id: 'error-collection' });
 
         expect(get(tags)).toEqual([]);
 
@@ -192,6 +192,19 @@ describe('useTags Hook', () => {
         expect(get(tags2Selected).has('3')).toBe(true);
     });
 
+    it('should clear a single selected tag for a collection', () => {
+        const { tagsSelected, tagSelectionToggle, clearTagSelected } = useTags({
+            collection_id: 'collection1'
+        });
+
+        tagSelectionToggle('1');
+        tagSelectionToggle('2');
+        clearTagSelected('1');
+
+        expect(get(tagsSelected).has('1')).toBe(false);
+        expect(get(tagsSelected).has('2')).toBe(true);
+    });
+
     it('should toggle tags independently across collections', () => {
         const { tagsSelected: tags1Selected, tagSelectionToggle: toggle1 } = useTags({
             collection_id: 'collection1'
@@ -215,18 +228,54 @@ describe('useTags Hook', () => {
     });
 
     it('should persist selections when creating multiple instances for same collection', () => {
-        const { tagSelectionToggle: toggle1 } = useTags({
-            collection_id: 'collection1'
+        const { tagSelectionToggle: toggle1, clearTagsSelected } = useTags({
+            collection_id: 'persist-collection'
         });
         const { tagsSelected: tags1SelectedAgain } = useTags({
-            collection_id: 'collection1'
+            collection_id: 'persist-collection'
         });
 
+        clearTagsSelected();
         toggle1('1');
         toggle1('2');
 
         expect(get(tags1SelectedAgain).has('1')).toBe(true);
         expect(get(tags1SelectedAgain).has('2')).toBe(true);
         expect(get(tags1SelectedAgain).size).toBe(2);
+    });
+
+    it('should prune stale selected tags after reloading tags', async () => {
+        const readTagsSpy = vi
+            .spyOn(lightly_studio_local, 'readTags')
+            .mockResolvedValueOnce({
+                data: mockTags,
+                error: undefined
+            })
+            .mockResolvedValueOnce({
+                data: [mockTags[0]],
+                error: undefined
+            });
+
+        const { tagsSelected, tagSelectionToggle, loadTags, clearTagsSelected, isLoading } =
+            useTags({
+                collection_id: 'prune-collection'
+            });
+
+        clearTagsSelected();
+        await waitFor(() => expect(readTagsSpy).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(get(isLoading)).toBe(false));
+        await waitFor(() => expect(get(tagsSelected).size).toBe(0));
+
+        tagSelectionToggle('1');
+        tagSelectionToggle('3');
+        expect(get(tagsSelected).size).toBe(2);
+
+        loadTags();
+
+        await waitFor(() => {
+            expect(get(tagsSelected).has('1')).toBe(true);
+            expect(get(tagsSelected).has('3')).toBe(false);
+        });
+        expect(readTagsSpy).toHaveBeenCalledTimes(2);
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useTags/useTags.ts
+++ b/lightly_studio_view/src/lib/hooks/useTags/useTags.ts
@@ -43,7 +43,7 @@ export function useTags(options: UseTagsOptions): UseTagsReturn {
                     throw new Error(JSON.stringify(response.error));
                 }
                 if (response.data) {
-                    const validTagIds = new Set(response.data.map((tag) => tag.tag_id));
+                    const validTagIds = response.data.map((tag) => tag.tag_id);
 
                     // Store tags by collection_id to prevent preloading from overwriting other collections' tags
                     tagsData.update((tagsByCollection) => ({
@@ -54,7 +54,7 @@ export function useTags(options: UseTagsOptions): UseTagsReturn {
                     tagsSelectedByCollection.update((selectedByCollection) => {
                         const selected = selectedByCollection[collection_id] ?? new Set<string>();
                         const prunedSelected = new Set(
-                            Array.from(selected).filter((tagId) => validTagIds.has(tagId))
+                            Array.from(selected).filter((tagId) => validTagIds.includes(tagId))
                         );
 
                         return {

--- a/lightly_studio_view/src/lib/hooks/useTags/useTags.ts
+++ b/lightly_studio_view/src/lib/hooks/useTags/useTags.ts
@@ -12,6 +12,7 @@ interface UseTagsReturn {
     tags: Readable<Tag[]>;
     tagsSelected: Readable<Set<string>>;
     clearTagsSelected: () => void;
+    clearTagSelected: (tagId: string) => void;
     loadTags: () => void;
     tagSelectionToggle: (tagId: string) => void;
     isLoading: Readable<boolean>;
@@ -42,11 +43,25 @@ export function useTags(options: UseTagsOptions): UseTagsReturn {
                     throw new Error(JSON.stringify(response.error));
                 }
                 if (response.data) {
+                    const validTagIds = new Set(response.data.map((tag) => tag.tag_id));
+
                     // Store tags by collection_id to prevent preloading from overwriting other collections' tags
                     tagsData.update((tagsByCollection) => ({
                         ...tagsByCollection,
                         [collection_id]: response.data ?? []
                     }));
+
+                    tagsSelectedByCollection.update((selectedByCollection) => {
+                        const selected = selectedByCollection[collection_id] ?? new Set<string>();
+                        const prunedSelected = new Set(
+                            Array.from(selected).filter((tagId) => validTagIds.has(tagId))
+                        );
+
+                        return {
+                            ...selectedByCollection,
+                            [collection_id]: prunedSelected
+                        };
+                    });
                 }
             })
             .catch((err) => {
@@ -103,12 +118,25 @@ export function useTags(options: UseTagsOptions): UseTagsReturn {
         });
     };
 
+    const clearTagSelected = (tagId: string) => {
+        tagsSelectedByCollection.update((selectedByCollection) => {
+            const selected = new Set(selectedByCollection[collection_id] ?? []);
+            selected.delete(tagId);
+
+            return {
+                ...selectedByCollection,
+                [collection_id]: selected
+            };
+        });
+    };
+
     return {
         tags: readonly(tags),
         loadTags,
         tagsSelected: readonly(tagsSelectedForCollection),
         tagSelectionToggle,
         clearTagsSelected,
+        clearTagSelected,
         isLoading: readonly(isLoading),
         error
     };


### PR DESCRIPTION
## What has changed and why?

- adds new frontend context menu to manipulate existing tags
- add menu item in tag context menu to delete tag 

https://github.com/user-attachments/assets/6bf5fba8-2b66-40be-b77d-75c4075cc74c


## How has it been tested?

- New tests for frontend and manual testing
- 
## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [X] Yes
- [ ] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-tag actions in the side-panel grid: delete tag via popover, with disabled/deleting states and cleared selection after deletion.
  * Hook API adds clearTagSelected and prunes selections after tag reloads.

* **Bug Fixes**
  * Renaming a tag preserves its linked samples.
  * Renaming to an existing name returns conflict; server rolls back on integrity errors.

* **Tests**
  * Added tests for deletion flows, selection clearing/pruning, rename preservation, and conflict handling.

* **Chore**
  * CHANGELOG updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->