### PR TITLE
Fix: Rename of tags is done properly

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -67,18 +67,22 @@ def update(session: Session, tag_id: UUID, tag_data: TagUpdate) -> TagTable | No
     if conflicting_tag and conflicting_tag.tag_id != tag_id and conflicting_tag.kind == tag.kind:
         raise IntegrityError(statement=None, params=None, orig=Exception("Tag already exists"))
 
-    sample_ids = [sample.sample_id for sample in tag.samples]
+    sample_ids = [
+        sample_id
+        for sample_id in session.exec(
+            select(SampleTagLinkTable.sample_id).where(col(SampleTagLinkTable.tag_id) == tag_id)
+        ).all()
+        if sample_id is not None
+    ]
 
     session.exec(
         sqlmodel.delete(SampleTagLinkTable).where(col(SampleTagLinkTable.tag_id) == tag_id)
     )
     session.commit()
 
-    # due to duckdb/OLAP optimisations, update operations effecting unique
-    # constraints (e.g colums) will lead to a unique constraint violation.
-    # This is due to a update is implemented as delete+insert. The error
-    # happens only within the same session.
-    # To fix it, we can delete, commit + insert a new tag.
+    # DuckDB checks unique constraints too eagerly on updates, so we recreate
+    # the tag row. We must temporarily delete the link rows first, otherwise
+    # DuckDB rejects deleting the tag row because of the foreign key.
     # https://duckdb.org/docs/sql/indexes#over-eager-unique-constraint-checking
     session.delete(tag)
     session.commit()
@@ -96,10 +100,12 @@ def update(session: Session, tag_id: UUID, tag_data: TagUpdate) -> TagTable | No
     session.add(tag_updated)
     session.commit()
 
-    for sample_id in sample_ids:
-        session.merge(SampleTagLinkTable(sample_id=sample_id, tag_id=tag_id))
+    if sample_ids:
+        session.bulk_save_objects(
+            [SampleTagLinkTable(sample_id=sample_id, tag_id=tag_id) for sample_id in sample_ids]
+        )
+        session.commit()
 
-    session.commit()
     session.refresh(tag_updated)
     return tag_updated
 

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 import sqlmodel
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
@@ -60,6 +61,19 @@ def update(session: Session, tag_id: UUID, tag_data: TagUpdate) -> TagTable | No
     if not tag:
         return None
 
+    conflicting_tag = get_by_name(
+        session=session, tag_name=tag_data.name, collection_id=tag.collection_id
+    )
+    if conflicting_tag and conflicting_tag.tag_id != tag_id and conflicting_tag.kind == tag.kind:
+        raise IntegrityError(statement=None, params=None, orig=Exception("Tag already exists"))
+
+    sample_ids = [sample.sample_id for sample in tag.samples]
+
+    session.exec(
+        sqlmodel.delete(SampleTagLinkTable).where(col(SampleTagLinkTable.tag_id) == tag_id)
+    )
+    session.commit()
+
     # due to duckdb/OLAP optimisations, update operations effecting unique
     # constraints (e.g colums) will lead to a unique constraint violation.
     # This is due to a update is implemented as delete+insert. The error
@@ -69,13 +83,22 @@ def update(session: Session, tag_id: UUID, tag_data: TagUpdate) -> TagTable | No
     session.delete(tag)
     session.commit()
 
-    # create clone of tag with updated values
-    tag_updated = TagTable.model_validate(tag)
-    tag_updated.name = tag_data.name
-    tag_updated.description = tag_data.description
-    tag_updated.updated_at = datetime.now(timezone.utc)
+    tag_updated = TagTable(
+        tag_id=tag.tag_id,
+        collection_id=tag.collection_id,
+        name=tag_data.name,
+        description=tag_data.description,
+        kind=tag.kind,
+        created_at=tag.created_at,
+        updated_at=datetime.now(timezone.utc),
+    )
 
     session.add(tag_updated)
+    session.commit()
+
+    for sample_id in sample_ids:
+        session.merge(SampleTagLinkTable(sample_id=sample_id, tag_id=tag_id))
+
     session.commit()
     session.refresh(tag_updated)
     return tag_updated

--- a/lightly_studio/tests/api/routes/api/test_dataset_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_dataset_tag.py
@@ -57,3 +57,30 @@ def test_delete_tag__deletes_tag_with_sample_links(
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() == {"status": "deleted"}
     assert tag_resolver.get_by_id(session=db_session, tag_id=tag.tag_id) is None
+
+
+def test_update_tag__renames_tag_with_sample_links(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection = create_collection(session=db_session)
+    tag = create_tag(session=db_session, collection_id=collection.collection_id)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image.sample)
+
+    response = test_client.put(
+        f"/api/collections/{collection.collection_id}/tags/{tag.tag_id}",
+        json={
+            "name": "renamed_tag",
+            "description": tag.description,
+            "kind": tag.kind,
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json()["name"] == "renamed_tag"
+
+    updated_tag = tag_resolver.get_by_id(session=db_session, tag_id=tag.tag_id)
+    assert updated_tag is not None
+    assert updated_tag.name == "renamed_tag"
+    assert [sample.sample_id for sample in updated_tag.samples] == [image.sample.sample_id]

--- a/lightly_studio/tests/api/routes/api/test_dataset_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_dataset_tag.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 from sqlmodel import Session
 
-from lightly_studio.api.routes.api.status import HTTP_STATUS_OK
+from lightly_studio.api.routes.api.status import HTTP_STATUS_CONFLICT, HTTP_STATUS_OK
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.resolvers import collection_resolver, tag_resolver
 from tests.helpers_resolvers import create_collection, create_image, create_tag
@@ -83,4 +83,24 @@ def test_update_tag__renames_tag_with_sample_links(
     updated_tag = tag_resolver.get_by_id(session=db_session, tag_id=tag.tag_id)
     assert updated_tag is not None
     assert updated_tag.name == "renamed_tag"
-    assert [sample.sample_id for sample in updated_tag.samples] == [image.sample.sample_id]
+    assert len(updated_tag.samples) == 1
+    assert updated_tag.samples[0].sample_id == image.sample.sample_id
+
+
+def test_update_tag__returns_conflict_if_name_is_already_used_by_another_tag(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection = create_collection(session=db_session)
+    tag = create_tag(session=db_session, collection_id=collection.collection_id, tag_name="tag_1")
+    create_tag(session=db_session, collection_id=collection.collection_id, tag_name="tag_2")
+
+    response = test_client.put(
+        f"/api/collections/{collection.collection_id}/tags/{tag.tag_id}",
+        json={
+            "name": "tag_2",
+            "description": tag.description,
+            "kind": tag.kind,
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CONFLICT

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -109,6 +109,33 @@ def test_update_tag(db_session: Session) -> None:
     assert tag_updated.name == data_update.name
 
 
+def test_update_tag__preserves_sample_links(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    tag = create_tag(session=db_session, collection_id=collection_id)
+    image_1 = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="sample1.png"
+    )
+    image_2 = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="sample2.png"
+    )
+
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_1.sample)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_2.sample)
+
+    tag_updated = tag_resolver.update(
+        session=db_session, tag_id=tag.tag_id, tag_data=TagUpdate(name="updated_tag")
+    )
+
+    assert tag_updated is not None
+    assert tag_updated.name == "updated_tag"
+    assert tag_updated.tag_id == tag.tag_id
+    assert sorted(sample.sample_id for sample in tag_updated.samples) == sorted(
+        [image_1.sample.sample_id, image_2.sample.sample_id]
+    )
+
+
 def test_update_tag__unique_tag_name(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -154,6 +154,40 @@ def test_update_tag__unique_tag_name(db_session: Session) -> None:
     db_session.rollback()
 
 
+def test_update_tag__unique_tag_name__preserves_original_tag_and_links(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    tag_1 = create_tag(session=db_session, collection_id=collection_id, tag_name="example_tag_1")
+    tag_2 = create_tag(session=db_session, collection_id=collection_id, tag_name="some_other_tag")
+    image_1 = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="sample1.png"
+    )
+    image_2 = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="sample2.png"
+    )
+
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag_1.tag_id, sample=image_1.sample)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag_1.tag_id, sample=image_2.sample)
+
+    with pytest.raises(IntegrityError):
+        tag_resolver.update(
+            session=db_session,
+            tag_id=tag_1.tag_id,
+            tag_data=TagUpdate(name=tag_2.name),
+        )
+    db_session.rollback()
+
+    original_tag = tag_resolver.get_by_id(session=db_session, tag_id=tag_1.tag_id)
+    assert original_tag is not None
+    assert original_tag.name == "example_tag_1"
+    assert sorted(sample.sample_id for sample in original_tag.samples) == sorted(
+        [image_1.sample.sample_id, image_2.sample.sample_id]
+    )
+
+
 def test_update_tag__unique_tag_name__different_kind(
     db_session: Session,
 ) -> None:


### PR DESCRIPTION
## What has changed and why?

- Change rename behaviour in backend. Before we were deleting + inserting a new tag. This would break the links between the tables. Now we do a proper rename. 

## How has it been tested?

- Additional tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)
