### PR TITLE
 Improve annotation canvas rendering with shared worker pooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactored annotation mask rendering to use a shared web worker pool instead of spawning one worker per canvas.
+
 ### Deprecated
 
 ### Removed

--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
@@ -3,6 +3,10 @@
     import { useCustomLabelColors, type CustomColor } from '$lib/hooks/useCustomLabelColors';
     import { getColorByLabel } from '$lib/utils';
     import type { BoundingBox } from '$lib/types';
+    import {
+        acquireMaskRendererWorker,
+        releaseMaskRendererWorker
+    } from '$lib/workers/maskRendererPool';
 
     type InstanceAnnotation = {
         annotation_type: 'segmentation_mask';
@@ -21,12 +25,14 @@
     type AnnotationCanvasAnnotation = InstanceAnnotation | ObjectDetectionAnnotation;
 
     const {
+        sampleId,
         width,
         height,
         annotations = [],
         alpha = 0.4,
         className = ''
     }: {
+        sampleId: string;
         width: number;
         height: number;
         annotations?: AnnotationCanvasAnnotation[];
@@ -41,6 +47,8 @@
     let workerReady = false;
     let hasOffscreen = false;
     let resizeObserver: ResizeObserver | null = null;
+    // Shared workers multiplex multiple canvases
+    const canvasId = sampleId;
 
     type ColorParser = (color: string) => [number, number, number, number];
 
@@ -97,12 +105,16 @@
         return [r, g, b, alphaValue];
     };
 
-    const normalizeRLE = (mask?: ArrayLike<number> | null): number[] => {
+    const toCloneableRLE = (mask?: ArrayLike<number> | null): number[] => {
         if (!mask?.length) {
             return [];
         }
 
-        // Convert to a plain number array so Worker.postMessage can structured-clone it.
+        // Ensure worker postMessage receives a plain cloneable array (no reactive proxies).
+        if (Array.isArray(mask)) {
+            return mask.slice();
+        }
+
         return Array.from(mask, (value) => Number(value) || 0);
     };
 
@@ -116,7 +128,7 @@
         for (const annotation of annotations) {
             const labelName = annotation.annotation_label_name || 'label';
 
-            const rle = normalizeRLE(annotation.segmentation_mask);
+            const rle = toCloneableRLE(annotation.segmentation_mask);
             if (rle.length) {
                 masks.push({
                     rle,
@@ -124,6 +136,7 @@
                 });
             }
 
+            // We also include boxes for instance masks when bbox details are present.
             const bbox = annotation.object_detection_details;
             if (bbox) {
                 boxes.push({
@@ -216,6 +229,7 @@
         // Include current CSS scale so the worker can keep stroke widths consistent.
         worker.postMessage({
             type: 'render',
+            canvasId,
             width,
             height,
             scaleX,
@@ -224,54 +238,79 @@
         });
     };
 
+    const handleWorkerMessage = (event: MessageEvent) => {
+        // Ignore frames produced for other canvases that share the same worker instance.
+        if (event.data?.type !== 'image' || event.data?.canvasId !== canvasId || !canvasEl) {
+            return;
+        }
+
+        const {
+            width: w,
+            height: h,
+            data,
+            boxes = [],
+            stroke = 2
+        } = event.data as {
+            canvasId: string;
+            width: number;
+            height: number;
+            data: Uint8ClampedArray;
+            boxes?: BoxPayload[];
+            stroke?: number;
+        };
+
+        const ctx = canvasEl.getContext('2d', { willReadFrequently: true });
+        if (!ctx) {
+            return;
+        }
+
+        // Worker transfers pixel buffer ownership; clone into a fresh Uint8ClampedArray for ImageData.
+        const imageData = new ImageData(new Uint8ClampedArray(data), w, h);
+        ctx.putImageData(imageData, 0, 0);
+
+        if (!boxes.length) {
+            return;
+        }
+
+        ctx.save();
+        ctx.lineWidth = stroke;
+        const clamp = (value: number, min: number, max: number) =>
+            Math.min(Math.max(value, min), max);
+
+        for (const box of boxes) {
+            ctx.strokeStyle = `rgba(${box.color[0]}, ${box.color[1]}, ${box.color[2]}, ${
+                box.color[3] / 255
+            })`;
+            const x = clamp(box.x, 0, w);
+            const y = clamp(box.y, 0, h);
+            const wBox = clamp(box.width, 0, w - x);
+            const hBox = clamp(box.height, 0, h - y);
+
+            if (wBox === 0 || hBox === 0) {
+                continue;
+            }
+
+            ctx.strokeRect(x, y, wBox, hBox);
+        }
+
+        ctx.restore();
+    };
+
     const setupWorker = () => {
         if (!canvasEl || worker) {
             return;
         }
 
-        worker = new Worker(new URL('../../workers/maskRenderer.worker.ts', import.meta.url), {
-            type: 'module'
-        });
-
-        worker.onmessage = (event: MessageEvent) => {
-            if (event.data?.type !== 'image' || !canvasEl) {
-                return;
-            }
-
-            const {
-                width: w,
-                height: h,
-                data,
-                boxes = [],
-                stroke = 2
-            } = event.data as {
-                width: number;
-                height: number;
-                data: Uint8ClampedArray;
-                boxes?: BoxPayload[];
-                stroke?: number;
-            };
-
-            const ctx = canvasEl.getContext('2d', { willReadFrequently: true });
-            if (!ctx) {
-                return;
-            }
-
-            const imageData = new ImageData(new Uint8ClampedArray(data), w, h);
-            ctx.putImageData(imageData, 0, 0);
-            drawBoxes(ctx, boxes, w, h, stroke);
-        };
+        worker = acquireMaskRendererWorker();
+        worker.addEventListener('message', handleWorkerMessage);
 
         if (canvasEl.transferControlToOffscreen) {
-            try {
-                const offscreen = canvasEl.transferControlToOffscreen();
-                worker.postMessage({ type: 'init', canvas: offscreen }, [offscreen]);
-                hasOffscreen = true;
-            } catch {
-                // The canvas may already have a 2D context; keep worker in image-data fallback mode.
-                hasOffscreen = false;
-            }
+            // Preferred path: worker draws directly into the canvas through OffscreenCanvas.
+            const offscreen = canvasEl.transferControlToOffscreen();
+            worker.postMessage({ type: 'init', canvasId, canvas: offscreen }, [offscreen]);
+            hasOffscreen = true;
         } else {
+            // Fallback path: worker sends pixel buffers back and main thread paints them.
             hasOffscreen = false;
         }
 
@@ -288,7 +327,12 @@
     });
 
     onDestroy(() => {
-        worker?.terminate();
+        if (worker) {
+            worker.postMessage({ type: 'dispose', canvasId });
+            worker.removeEventListener('message', handleWorkerMessage);
+            releaseMaskRendererWorker(worker);
+            worker = null;
+        }
         resizeObserver?.disconnect();
     });
 

--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
@@ -1,3 +1,17 @@
+<script module lang="ts">
+    let annotationCanvasInstanceCounter = 0;
+
+    const createCanvasInstanceSuffix = (): string => {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+            return crypto.randomUUID();
+        }
+
+        const fallbackSuffix = annotationCanvasInstanceCounter;
+        annotationCanvasInstanceCounter += 1;
+        return String(fallbackSuffix);
+    };
+</script>
+
 <script lang="ts">
     import { onDestroy, onMount } from 'svelte';
     import { useCustomLabelColors, type CustomColor } from '$lib/hooks/useCustomLabelColors';
@@ -48,7 +62,7 @@
     let hasOffscreen = false;
     let resizeObserver: ResizeObserver | null = null;
     // Shared workers multiplex multiple canvases
-    const canvasId = sampleId;
+    const canvasId = `${sampleId}-${createCanvasInstanceSuffix()}`;
 
     type ColorParser = (color: string) => [number, number, number, number];
 

--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.test.ts
@@ -27,12 +27,36 @@ class MockWorker {
     static instances: MockWorker[] = [];
     onmessage: ((event: MessageEvent) => void) | null = null;
     postMessage = vi.fn();
-    addEventListener = vi.fn();
-    removeEventListener = vi.fn();
+    private messageListeners = new Set<(event: MessageEvent) => void>();
+    addEventListener = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type !== 'message') {
+            return;
+        }
+
+        if (typeof listener === 'function') {
+            this.messageListeners.add(listener as (event: MessageEvent) => void);
+        }
+    });
+    removeEventListener = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type !== 'message') {
+            return;
+        }
+
+        if (typeof listener === 'function') {
+            this.messageListeners.delete(listener as (event: MessageEvent) => void);
+        }
+    });
     terminate = vi.fn();
 
     constructor() {
         MockWorker.instances.push(this);
+    }
+
+    dispatchMessage(data: unknown) {
+        const event = { data } as MessageEvent;
+        for (const listener of this.messageListeners) {
+            listener(event);
+        }
     }
 }
 
@@ -42,36 +66,51 @@ class MockResizeObserver {
     disconnect = vi.fn();
 }
 
+class MockImageData {
+    constructor(
+        public data: Uint8ClampedArray,
+        public width: number,
+        public height: number
+    ) {}
+}
+
 describe('AnnotationCanvas', () => {
-    let mockContext: Mock2dContext;
+    let canvasContexts: WeakMap<HTMLCanvasElement, Mock2dContext>;
+    const createMockContext = (): Mock2dContext => ({
+        fillStyle: 'rgba(0, 0, 0, 0)',
+        strokeStyle: 'rgba(0, 0, 0, 0)',
+        lineWidth: 1,
+        clearRect: vi.fn(),
+        fillRect: vi.fn(),
+        getImageData: vi.fn(() => ({ data: new Uint8ClampedArray([10, 20, 30, 128]) })),
+        putImageData: vi.fn(),
+        save: vi.fn(),
+        restore: vi.fn(),
+        strokeRect: vi.fn()
+    });
 
     beforeEach(() => {
         MockWorker.instances = [];
+        canvasContexts = new WeakMap<HTMLCanvasElement, Mock2dContext>();
 
-        mockContext = {
-            fillStyle: 'rgba(0, 0, 0, 0)',
-            strokeStyle: 'rgba(0, 0, 0, 0)',
-            lineWidth: 1,
-            clearRect: vi.fn(),
-            fillRect: vi.fn(),
-            getImageData: vi.fn(() => ({ data: new Uint8ClampedArray([10, 20, 30, 128]) })),
-            putImageData: vi.fn(),
-            save: vi.fn(),
-            restore: vi.fn(),
-            strokeRect: vi.fn()
-        };
-
-        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
-            (contextId: string) => {
-                if (contextId !== '2d') {
-                    return null;
-                }
-                return mockContext as unknown as CanvasRenderingContext2D;
+        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(function (
+            this: HTMLCanvasElement,
+            contextId: string
+        ) {
+            if (contextId !== '2d') {
+                return null;
             }
-        );
+
+            if (!canvasContexts.has(this)) {
+                canvasContexts.set(this, createMockContext());
+            }
+
+            return canvasContexts.get(this) as unknown as CanvasRenderingContext2D;
+        });
 
         vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
         vi.stubGlobal('ResizeObserver', MockResizeObserver as unknown as typeof ResizeObserver);
+        vi.stubGlobal('ImageData', MockImageData as unknown as typeof ImageData);
     });
 
     afterEach(() => {
@@ -85,7 +124,7 @@ describe('AnnotationCanvas', () => {
     });
 
     it('draws object-detection boxes on fallback canvas when there are no masks', async () => {
-        render(AnnotationCanvas, {
+        const { container } = render(AnnotationCanvas, {
             props: {
                 sampleId: 'sample-object-detection',
                 width: 100,
@@ -101,10 +140,14 @@ describe('AnnotationCanvas', () => {
         });
 
         await tick();
+        const canvas = container.querySelector('canvas');
+        expect(canvas).not.toBeNull();
+        const context = canvasContexts.get(canvas as HTMLCanvasElement);
+        expect(context).toBeDefined();
 
         expect(MockWorker.instances).toHaveLength(0);
-        expect(mockContext.clearRect).toHaveBeenCalledWith(0, 0, 100, 100);
-        expect(mockContext.strokeRect).toHaveBeenCalledWith(10, 21, 30, 41);
+        expect(context?.clearRect).toHaveBeenCalledWith(0, 0, 100, 100);
+        expect(context?.strokeRect).toHaveBeenCalledWith(10, 21, 30, 41);
     });
 
     it('posts a worker render message when masks are present', async () => {
@@ -131,7 +174,9 @@ describe('AnnotationCanvas', () => {
         );
         expect(workersWithRender).toHaveLength(1);
         const worker = workersWithRender[0];
-        expect(mockContext.clearRect).toHaveBeenCalledWith(0, 0, 16, 8);
+        const [canvas] = Array.from(document.querySelectorAll('canvas'));
+        const context = canvas ? canvasContexts.get(canvas as HTMLCanvasElement) : undefined;
+        expect(context?.clearRect).toHaveBeenCalledWith(0, 0, 16, 8);
         expect(worker.postMessage).toHaveBeenCalledTimes(1);
         expect(worker.postMessage).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -147,14 +192,114 @@ describe('AnnotationCanvas', () => {
     });
 
     it('clears and exits early when there are no drawable annotations', async () => {
-        render(AnnotationCanvas, {
+        const { container } = render(AnnotationCanvas, {
             props: { sampleId: 'sample-empty', width: 64, height: 32, annotations: [] }
         });
 
         await tick();
+        const canvas = container.querySelector('canvas');
+        expect(canvas).not.toBeNull();
+        const context = canvasContexts.get(canvas as HTMLCanvasElement);
+        expect(context).toBeDefined();
 
         expect(MockWorker.instances).toHaveLength(0);
-        expect(mockContext.clearRect).toHaveBeenCalledWith(0, 0, 64, 32);
-        expect(mockContext.strokeRect).not.toHaveBeenCalled();
+        expect(context?.clearRect).toHaveBeenCalledWith(0, 0, 64, 32);
+        expect(context?.strokeRect).not.toHaveBeenCalled();
+    });
+
+    it('keeps rendering isolated for two canvases with the same sampleId', async () => {
+        const first = render(AnnotationCanvas, {
+            props: {
+                sampleId: 'duplicate-sample-id',
+                width: 2,
+                height: 1,
+                annotations: [
+                    {
+                        annotation_type: 'segmentation_mask',
+                        annotation_label_name: 'road',
+                        segmentation_mask: [0, 2]
+                    }
+                ]
+            }
+        });
+
+        const second = render(AnnotationCanvas, {
+            props: {
+                sampleId: 'duplicate-sample-id',
+                width: 2,
+                height: 1,
+                annotations: [
+                    {
+                        annotation_type: 'segmentation_mask',
+                        annotation_label_name: 'car',
+                        segmentation_mask: [0, 2]
+                    }
+                ]
+            }
+        });
+
+        await tick();
+
+        expect(MockWorker.instances.length).toBeGreaterThan(0);
+        const workersWithRender = MockWorker.instances.filter((instance) =>
+            instance.postMessage.mock.calls.some(([message]) => message?.type === 'render')
+        );
+        expect(workersWithRender.length).toBeGreaterThan(0);
+
+        const renderMessages = workersWithRender
+            .flatMap((instance) => instance.postMessage.mock.calls.map(([message]) => message))
+            .filter((message) => message?.type === 'render');
+        expect(renderMessages).toHaveLength(2);
+
+        const canvasIds = [...new Set(renderMessages.map((message) => message.canvasId))];
+        expect(canvasIds).toHaveLength(2);
+
+        const firstCanvas = first.container.querySelector('canvas');
+        const secondCanvas = second.container.querySelector('canvas');
+        expect(firstCanvas).not.toBeNull();
+        expect(secondCanvas).not.toBeNull();
+
+        const firstContext = canvasContexts.get(firstCanvas as HTMLCanvasElement);
+        const secondContext = canvasContexts.get(secondCanvas as HTMLCanvasElement);
+        expect(firstContext).toBeDefined();
+        expect(secondContext).toBeDefined();
+
+        const findWorkerForCanvasId = (canvasId: string): MockWorker | undefined =>
+            workersWithRender.find((instance) =>
+                instance.postMessage.mock.calls.some(
+                    ([message]) => message?.type === 'render' && message.canvasId === canvasId
+                )
+            );
+        const firstWorker = findWorkerForCanvasId(canvasIds[0]);
+        const secondWorker = findWorkerForCanvasId(canvasIds[1]);
+        expect(firstWorker).toBeDefined();
+        expect(secondWorker).toBeDefined();
+
+        firstWorker?.dispatchMessage({
+            type: 'image',
+            canvasId: canvasIds[0],
+            width: 2,
+            height: 1,
+            data: new Uint8ClampedArray([11, 12, 13, 255, 21, 22, 23, 255]),
+            boxes: [],
+            stroke: 2
+        });
+
+        secondWorker?.dispatchMessage({
+            type: 'image',
+            canvasId: canvasIds[1],
+            width: 2,
+            height: 1,
+            data: new Uint8ClampedArray([31, 32, 33, 255, 41, 42, 43, 255]),
+            boxes: [],
+            stroke: 2
+        });
+
+        expect(firstContext?.putImageData).toHaveBeenCalledTimes(1);
+        expect(secondContext?.putImageData).toHaveBeenCalledTimes(1);
+
+        const firstImageData = firstContext?.putImageData.mock.calls[0][0] as ImageData;
+        const secondImageData = secondContext?.putImageData.mock.calls[0][0] as ImageData;
+        expect(firstImageData.data).not.toEqual(secondImageData.data);
     });
 });

--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.test.ts
@@ -79,6 +79,11 @@ describe('AnnotationCanvas', () => {
         vi.unstubAllGlobals();
     });
 
+    afterEach(async () => {
+        const { shutdownMaskRendererPool } = await import('$lib/workers/maskRendererPool');
+        shutdownMaskRendererPool();
+    });
+
     it('draws object-detection boxes on fallback canvas when there are no masks', async () => {
         render(AnnotationCanvas, {
             props: {

--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.test.ts
@@ -27,6 +27,8 @@ class MockWorker {
     static instances: MockWorker[] = [];
     onmessage: ((event: MessageEvent) => void) | null = null;
     postMessage = vi.fn();
+    addEventListener = vi.fn();
+    removeEventListener = vi.fn();
     terminate = vi.fn();
 
     constructor() {
@@ -80,6 +82,7 @@ describe('AnnotationCanvas', () => {
     it('draws object-detection boxes on fallback canvas when there are no masks', async () => {
         render(AnnotationCanvas, {
             props: {
+                sampleId: 'sample-object-detection',
                 width: 100,
                 height: 100,
                 annotations: [
@@ -102,6 +105,7 @@ describe('AnnotationCanvas', () => {
     it('posts a worker render message when masks are present', async () => {
         render(AnnotationCanvas, {
             props: {
+                sampleId: 'sample-masks',
                 width: 16,
                 height: 8,
                 annotations: [
@@ -116,8 +120,12 @@ describe('AnnotationCanvas', () => {
 
         await tick();
 
-        expect(MockWorker.instances).toHaveLength(1);
-        const worker = MockWorker.instances[0];
+        expect(MockWorker.instances.length).toBeGreaterThan(0);
+        const workersWithRender = MockWorker.instances.filter((instance) =>
+            instance.postMessage.mock.calls.some(([message]) => message?.type === 'render')
+        );
+        expect(workersWithRender).toHaveLength(1);
+        const worker = workersWithRender[0];
         expect(mockContext.clearRect).toHaveBeenCalledWith(0, 0, 16, 8);
         expect(worker.postMessage).toHaveBeenCalledTimes(1);
         expect(worker.postMessage).toHaveBeenCalledWith(
@@ -134,7 +142,9 @@ describe('AnnotationCanvas', () => {
     });
 
     it('clears and exits early when there are no drawable annotations', async () => {
-        render(AnnotationCanvas, { props: { width: 64, height: 32, annotations: [] } });
+        render(AnnotationCanvas, {
+            props: { sampleId: 'sample-empty', width: 64, height: 32, annotations: [] }
+        });
 
         await tick();
 

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
@@ -11,6 +11,7 @@
     >[number];
 
     type SampleView = {
+        sample_id: string;
         width: number;
         height: number;
         annotations: AnnotationView[];
@@ -27,6 +28,7 @@
     const { isHidden } = useHideAnnotations();
     const { showBoundingBoxesForSegmentationStore } = useSettings();
 
+    // Normalize backend annotation variants into the smaller canvas render contract.
     const mapToCanvasAnnotation = (
         annotation: SampleView['annotations'][number],
         showInstanceSegmentationBoundingBoxes: boolean
@@ -73,6 +75,7 @@
 
     let showAnnotations = $state(false);
 
+    // Delay canvas mount work until the browser is idle to reduce scroll/jank on large lists.
     const idle = window.requestIdleCallback ?? ((cb) => setTimeout(cb, 10));
 
     onMount(() => {
@@ -85,6 +88,7 @@
 {#if showAnnotations && !$isHidden && annotationsWithVisuals.length > 0}
     <div data-testid="sample-annotation-item">
         <AnnotationCanvas
+            sampleId={sample.sample_id}
             width={sample.width}
             height={sample.height}
             annotations={annotationsWithVisuals}

--- a/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationItem.svelte
+++ b/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationItem.svelte
@@ -59,8 +59,10 @@
 </script>
 
 {#if !showLabel}
+    <!-- Label-free mode uses the shared canvas renderer for better performance with many masks. -->
     <SampleAnnotations
         sample={{
+            sample_id: sample.sample_id,
             width: sampleWidth,
             height: sampleHeight,
             annotations: annotations

--- a/lightly_studio_view/src/lib/workers/maskRenderer.worker.ts
+++ b/lightly_studio_view/src/lib/workers/maskRenderer.worker.ts
@@ -10,6 +10,7 @@ import {
 
 type RenderMessage = {
     type: 'render';
+    canvasId: string;
     width: number;
     height: number;
     masks: MaskInput[];
@@ -20,19 +21,36 @@ type RenderMessage = {
 
 type InitMessage = {
     type: 'init';
+    canvasId: string;
     canvas: OffscreenCanvas;
 };
 
-type WorkerMessage = RenderMessage | InitMessage;
+type DisposeMessage = {
+    type: 'dispose';
+    canvasId: string;
+};
 
-let ctx: OffscreenCanvasRenderingContext2D | null = null;
+type WorkerMessage = RenderMessage | InitMessage | DisposeMessage;
 
-const handleRender = ({ width, height, masks, boxes, scaleX = 1, scaleY = 1 }: RenderMessage) => {
+// One worker can serve multiple canvases; each canvas keeps its own 2D context keyed by id.
+const contexts = new Map<string, OffscreenCanvasRenderingContext2D>();
+
+const handleRender = ({
+    canvasId,
+    width,
+    height,
+    masks,
+    boxes,
+    scaleX = 1,
+    scaleY = 1
+}: RenderMessage) => {
     // Render masks into a pixel buffer and overlay boxes; stroke is scaled to CSS size.
     const pixelData = renderMasks(width, height, masks);
     const stroke = computeStroke(scaleX, scaleY);
+    const ctx = contexts.get(canvasId);
 
     if (ctx) {
+        // Offscreen path: paint fully inside worker.
         const imageData = new ImageData(pixelData, width, height);
         ctx.canvas.width = width;
         ctx.canvas.height = height;
@@ -40,8 +58,8 @@ const handleRender = ({ width, height, masks, boxes, scaleX = 1, scaleY = 1 }: R
         ctx.putImageData(imageData, 0, 0);
         drawBoxesOnContext(ctx, boxes, width, height, stroke);
     } else {
-        // Fallback: send pixel data and boxes back to main thread for painting.
-        postMessage({ type: 'image', width, height, data: pixelData, boxes, stroke }, [
+        // Fallback path when no OffscreenCanvas context was registered for this canvas id.
+        postMessage({ type: 'image', canvasId, width, height, data: pixelData, boxes, stroke }, [
             pixelData.buffer
         ]);
     }
@@ -51,7 +69,17 @@ self.onmessage = (event: MessageEvent<WorkerMessage>) => {
     const message = event.data;
 
     if (message.type === 'init') {
-        ctx = message.canvas.getContext('2d', { willReadFrequently: true });
+        // Register or replace the drawing context for this canvas id.
+        const ctx = message.canvas.getContext('2d', { willReadFrequently: true });
+        if (ctx) {
+            contexts.set(message.canvasId, ctx);
+        }
+        return;
+    }
+
+    if (message.type === 'dispose') {
+        // Canvas unmounted on main thread; release its context from this worker.
+        contexts.delete(message.canvasId);
         return;
     }
 

--- a/lightly_studio_view/src/lib/workers/maskRendererUtils.ts
+++ b/lightly_studio_view/src/lib/workers/maskRendererUtils.ts
@@ -1,7 +1,5 @@
-import { decodeRLEToBinaryMask } from '$lib/components/SampleAnnotation/utils';
-
 export type MaskInput = {
-    rle: number[];
+    rle: ReadonlyArray<number>;
     color: [number, number, number, number]; // RGBA 0-255
 };
 
@@ -15,24 +13,33 @@ export type BoundingBoxInput = {
 
 export const renderMasks = (width: number, height: number, masks: MaskInput[]) => {
     const pixelData = new Uint8ClampedArray(width * height * 4);
+    const maxPixels = width * height;
 
     for (const { rle, color } of masks) {
         if (!rle?.length) {
             continue;
         }
 
-        const mask = decodeRLEToBinaryMask(rle, width, height);
+        // Decode RLE runs directly into RGBA output to avoid allocating an intermediate mask.
+        let pixelIndex = 0;
+        let value = 0;
 
-        for (let i = 0; i < mask.length; i++) {
-            if (mask[i] !== 1) {
-                continue;
+        for (let runIndex = 0; runIndex < rle.length && pixelIndex < maxPixels; runIndex++) {
+            const count = Math.max(0, Math.floor(Number(rle[runIndex]) || 0));
+            const end = Math.min(pixelIndex + count, maxPixels);
+
+            if (value === 1) {
+                for (let i = pixelIndex; i < end; i++) {
+                    const offset = i * 4;
+                    pixelData[offset] = color[0];
+                    pixelData[offset + 1] = color[1];
+                    pixelData[offset + 2] = color[2];
+                    pixelData[offset + 3] = color[3];
+                }
             }
 
-            const offset = i * 4;
-            pixelData[offset] = color[0];
-            pixelData[offset + 1] = color[1];
-            pixelData[offset + 2] = color[2];
-            pixelData[offset + 3] = color[3];
+            pixelIndex = end;
+            value = value === 0 ? 1 : 0;
         }
     }
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -67,6 +67,7 @@
     } from '$lib/utils/buildAnnotationCountsFilters';
     import EmbeddingSelectionFilterItem from '$lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte';
     import { useSelectionSummary } from '$lib/hooks';
+    import { shutdownMaskRendererPool } from '$lib/workers/maskRendererPool';
     const { data, children } = $props();
     const {
         collection,
@@ -113,6 +114,7 @@
         if (browser) {
             window.removeEventListener('keydown', handleKeyEvent);
             window.removeEventListener('keyup', handleKeyEvent);
+            shutdownMaskRendererPool();
         }
     });
 


### PR DESCRIPTION
## What has changed and why?

This PR reduces frontend memory usage in annotation-heavy views by reusing mask-rendering workers across canvases and lowering per-render allocations in the worker pipeline.

In benchmark runs, memory consumption dropped from around 1000 MB to around 200 MB.

## How has it been tested?

Unit tests + manual tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Annotation mask rendering now uses a shared web worker pool, reducing resource and memory usage across multiple canvases.
  * Instance-mask rendering now includes bounding boxes when available for clearer object-detection visualization.
  * Improved stability and isolation for concurrently rendered canvases to prevent cross-canvas rendering artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->