### PR TITLE
Add: user can rename tags in frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a floating selection panel to grid pages.
 - Tags can be created and assigned directly from the sample and annotation detail view.
 - Tags can be created and assigned directly from the side panel in the grid view.
+- Tags can be renamed directly from the side panel in the grid view.
 - Tags can be deleted from the side panel in the grid view.
 - Exposed Pascal VOC segmentation export from the Python interface.
 

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -1,13 +1,21 @@
 <script lang="ts">
+    import { tick } from 'svelte';
     import { Checkbox } from '$lib/components';
     import type { GridType } from '$lib/types';
     import Segment from '$lib/components/Segment/Segment.svelte';
+    import { Checkbox as CheckboxPrimitive } from '$lib/components/ui/checkbox';
+    import { Input } from '$lib/components/ui/input';
     import * as Popover from '$lib/components/ui/popover';
-    import { MoreHorizontal, Tags as Tagsicon, Trash2 } from '@lucide/svelte';
+    import { Check, MoreHorizontal, Pencil, Tags as Tagsicon, Trash2 } from '@lucide/svelte';
     import type { TagView } from '$lib/services/types';
     import { useTags } from '$lib/hooks/useTags/useTags.js';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
-    import { createTag, addSampleIdsToTagId, deleteTag } from '$lib/api/lightly_studio_local';
+    import {
+        createTag,
+        addSampleIdsToTagId,
+        deleteTag,
+        updateTag
+    } from '$lib/api/lightly_studio_local';
     import TagAssignInput from './TagAssignInput.svelte';
     import { toast } from 'svelte-sonner';
 
@@ -37,6 +45,21 @@
     // ── Selection assignment ─────────────────────────────────────────────────────
     let assignBusy = $state(false);
     let deletingTagId = $state<string | null>(null);
+    let editingTagId = $state<string | null>(null);
+    let renamingTagId = $state<string | null>(null);
+    let openActionsTagId = $state<string | null>(null);
+    let suppressCloseAutoFocusTagId = $state<string | null>(null);
+    let renameValue = $state('');
+    let renameInputRef = $state<HTMLInputElement | null>(null);
+
+    const editedTag = $derived($tags.find((tag: TagView) => tag.tag_id === editingTagId) ?? null);
+    const trimmedRenameValue = $derived(renameValue.trim());
+    const renameSaveDisabled = $derived(
+        !editedTag ||
+            renamingTagId !== null ||
+            trimmedRenameValue.length === 0 ||
+            trimmedRenameValue === editedTag.name
+    );
 
     async function handleAssign(name: string) {
         assignBusy = true;
@@ -110,6 +133,62 @@
             deletingTagId = null;
         }
     }
+
+    async function openRename(tag: TagView, event: MouseEvent) {
+        event.stopPropagation();
+        if (deletingTagId || renamingTagId) {
+            return;
+        }
+        suppressCloseAutoFocusTagId = tag.tag_id;
+        openActionsTagId = null;
+        editingTagId = tag.tag_id;
+        renameValue = tag.name;
+        await tick();
+        renameInputRef?.focus();
+        renameInputRef?.select();
+    }
+
+    function cancelRename(event?: MouseEvent) {
+        event?.stopPropagation();
+        editingTagId = null;
+        renameValue = '';
+    }
+
+    async function handleRename(tag: TagView, event: MouseEvent | KeyboardEvent) {
+        event.stopPropagation();
+
+        const name = renameValue.trim();
+        if (renamingTagId || name.length === 0 || name === tag.name) {
+            return;
+        }
+
+        renamingTagId = tag.tag_id;
+
+        try {
+            const response = await updateTag({
+                path: {
+                    collection_id,
+                    tag_id: tag.tag_id
+                },
+                body: {
+                    name,
+                    description: tag.description,
+                    kind: tag.kind
+                }
+            });
+
+            if (response.error) {
+                throw new Error('Failed to rename tag.');
+            }
+
+            cancelRename();
+            loadTags();
+        } catch {
+            toast.error('Failed to rename tag. Please try again.');
+        } finally {
+            renamingTagId = null;
+        }
+    }
 </script>
 
 <Segment title="Tags" icon={Tagsicon}>
@@ -118,19 +197,71 @@
             {#each $tags as tag (tag.tag_id)}
                 <div class="flex items-center gap-2 py-0.5" data-testid="tag-menu-item">
                     <div class="min-w-0 flex-1">
-                        <Checkbox
-                            name={tag.tag_id}
-                            isChecked={$tagsSelected.has(tag.tag_id)}
-                            label={tag.name}
-                            onCheckedChange={() => tagSelectionToggle(tag.tag_id)}
-                        />
+                        {#if editingTagId === tag.tag_id}
+                            <div
+                                class="flex items-center gap-2"
+                                data-testid={`rename-tag-form-${tag.tag_id}`}
+                            >
+                                <CheckboxPrimitive
+                                    checked={$tagsSelected.has(tag.tag_id)}
+                                    onCheckedChange={() => tagSelectionToggle(tag.tag_id)}
+                                    disabled={renamingTagId === tag.tag_id}
+                                />
+                                <Input
+                                    bind:ref={renameInputRef}
+                                    bind:value={renameValue}
+                                    autofocus
+                                    class="h-8 text-xs"
+                                    data-testid={`rename-tag-input-${tag.tag_id}`}
+                                    placeholder="Tag name"
+                                    disabled={renamingTagId === tag.tag_id}
+                                    onclick={(event: MouseEvent) => {
+                                        event.stopPropagation();
+                                    }}
+                                    onkeydown={(event: KeyboardEvent) => {
+                                        event.stopPropagation();
+                                        if (event.key === 'Enter') {
+                                            event.preventDefault();
+                                            void handleRename(tag, event);
+                                        }
+                                        if (event.key === 'Escape') {
+                                            event.preventDefault();
+                                            cancelRename();
+                                        }
+                                    }}
+                                />
+                                <button
+                                    type="button"
+                                    class="inline-flex size-7 shrink-0 items-center justify-center rounded-md hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+                                    data-testid={`save-tag-rename-${tag.tag_id}`}
+                                    disabled={renameSaveDisabled}
+                                    onclick={(event: MouseEvent) => {
+                                        void handleRename(tag, event);
+                                    }}
+                                >
+                                    <Check class="size-4" />
+                                </button>
+                            </div>
+                        {:else}
+                            <Checkbox
+                                name={tag.tag_id}
+                                isChecked={$tagsSelected.has(tag.tag_id)}
+                                label={tag.name}
+                                onCheckedChange={() => tagSelectionToggle(tag.tag_id)}
+                            />
+                        {/if}
                     </div>
-                    <Popover.Root>
+                    <Popover.Root
+                        open={openActionsTagId === tag.tag_id}
+                        onOpenChange={(open) => {
+                            openActionsTagId = open ? tag.tag_id : null;
+                        }}
+                    >
                         <Popover.Trigger
                             class="inline-flex size-7 shrink-0 items-center justify-center rounded-md hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
                             aria-label={`Open actions for tag ${tag.name}`}
                             data-testid={`tag-actions-trigger-${tag.tag_id}`}
-                            disabled={deletingTagId === tag.tag_id}
+                            disabled={deletingTagId === tag.tag_id || renamingTagId === tag.tag_id}
                             onclick={(event: MouseEvent) => {
                                 event.stopPropagation();
                             }}
@@ -140,15 +271,33 @@
                         <Popover.Content
                             class="w-40 p-1"
                             align="end"
+                            onCloseAutoFocus={(event) => {
+                                if (suppressCloseAutoFocusTagId === tag.tag_id) {
+                                    event.preventDefault();
+                                    suppressCloseAutoFocusTagId = null;
+                                }
+                            }}
                             onclick={(event: MouseEvent) => {
                                 event.stopPropagation();
                             }}
                         >
                             <button
                                 type="button"
+                                class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                                data-testid={`rename-tag-${tag.tag_id}`}
+                                disabled={deletingTagId !== null || renamingTagId !== null}
+                                onclick={(event: MouseEvent) => {
+                                    openRename(tag, event);
+                                }}
+                            >
+                                <Pencil class="size-4" />
+                                Rename tag
+                            </button>
+                            <button
+                                type="button"
                                 class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-destructive hover:text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                                 data-testid={`delete-tag-${tag.tag_id}`}
-                                disabled={deletingTagId !== null}
+                                disabled={deletingTagId !== null || renamingTagId !== null}
                                 onclick={(event: MouseEvent) => {
                                     void handleDeleteTag(tag, event);
                                 }}

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
@@ -311,12 +311,11 @@ describe('TagsMenu', () => {
                     kind: 'sample'
                 }
             });
+            expect(mocks.loadTags).toHaveBeenCalled();
+            expect(mocks.clearTagSelected).not.toHaveBeenCalled();
+            expect(screen.queryByTestId('rename-tag-form-tag-1')).not.toBeInTheDocument();
+            expect(toast.success).not.toHaveBeenCalled();
         });
-
-        expect(mocks.loadTags).toHaveBeenCalled();
-        expect(mocks.clearTagSelected).not.toHaveBeenCalled();
-        expect(screen.queryByTestId('rename-tag-form-tag-1')).not.toBeInTheDocument();
-        expect(toast.success).not.toHaveBeenCalled();
     });
 
     it('shows a toast when renaming a tag fails', async () => {

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
@@ -1,4 +1,9 @@
-import { addSampleIdsToTagId, createTag, deleteTag } from '$lib/api/lightly_studio_local';
+import {
+    addSampleIdsToTagId,
+    createTag,
+    deleteTag,
+    updateTag
+} from '$lib/api/lightly_studio_local';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -22,7 +27,8 @@ vi.mock('$lib/api/lightly_studio_local', async () => {
         ...actual,
         createTag: vi.fn(),
         addSampleIdsToTagId: vi.fn(),
-        deleteTag: vi.fn()
+        deleteTag: vi.fn(),
+        updateTag: vi.fn()
     };
 });
 
@@ -92,6 +98,16 @@ describe('TagsMenu', () => {
         vi.mocked(deleteTag).mockResolvedValue({
             data: {
                 status: 'deleted'
+            },
+            error: undefined,
+            request: mockRequest,
+            response: mockResponse
+        });
+        vi.mocked(updateTag).mockResolvedValue({
+            data: {
+                ...sampleTag,
+                collection_id: 'collection-1',
+                name: 'Renamed Vehicle'
             },
             error: undefined,
             request: mockRequest,
@@ -256,6 +272,75 @@ describe('TagsMenu', () => {
         });
 
         expect(mocks.clearTagSelected).not.toHaveBeenCalled();
+        expect(mocks.loadTags).not.toHaveBeenCalled();
+    });
+
+    it('renames a tag from the inline row edit via tick button', async () => {
+        render(TagsMenu, {
+            props: {
+                collection_id: 'collection-1',
+                gridType: 'samples'
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('tag-actions-trigger-tag-1'));
+        await fireEvent.click(await screen.findByTestId('rename-tag-tag-1'));
+
+        expect(await screen.findByTestId('rename-tag-form-tag-1')).toBeVisible();
+        const input = screen.getByTestId('rename-tag-input-tag-1') as HTMLInputElement;
+        expect(input).toHaveValue('Vehicle');
+        await waitFor(() => {
+            expect(document.activeElement).toBe(input);
+            expect(input.selectionStart).toBe(0);
+            expect(input.selectionEnd).toBe('Vehicle'.length);
+        });
+        expect(screen.queryByTestId('rename-tag-tag-1')).not.toBeInTheDocument();
+
+        await fireEvent.input(input, { target: { value: '  Renamed Vehicle  ' } });
+        await fireEvent.click(screen.getByTestId('save-tag-rename-tag-1'));
+
+        await waitFor(() => {
+            expect(updateTag).toHaveBeenCalledWith({
+                path: {
+                    collection_id: 'collection-1',
+                    tag_id: 'tag-1'
+                },
+                body: {
+                    name: 'Renamed Vehicle',
+                    description: 'Vehicle description',
+                    kind: 'sample'
+                }
+            });
+        });
+
+        expect(mocks.loadTags).toHaveBeenCalled();
+        expect(mocks.clearTagSelected).not.toHaveBeenCalled();
+        expect(screen.queryByTestId('rename-tag-form-tag-1')).not.toBeInTheDocument();
+        expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it('shows a toast when renaming a tag fails', async () => {
+        vi.mocked(updateTag).mockRejectedValue(new Error('network error'));
+
+        render(TagsMenu, {
+            props: {
+                collection_id: 'collection-1',
+                gridType: 'samples'
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('tag-actions-trigger-tag-1'));
+        await fireEvent.click(await screen.findByTestId('rename-tag-tag-1'));
+
+        const input = await screen.findByTestId('rename-tag-input-tag-1');
+        await fireEvent.input(input, { target: { value: 'Renamed Vehicle' } });
+        await fireEvent.click(screen.getByTestId('save-tag-rename-tag-1'));
+
+        await waitFor(() => {
+            expect(toast.error).toHaveBeenCalledWith('Failed to rename tag. Please try again.');
+        });
+
+        expect(screen.getByTestId('rename-tag-form-tag-1')).toBeVisible();
         expect(mocks.loadTags).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## What has changed and why?

- User can now rename a tag in the frontend directly
- Error is thrown (toast in frontend) when the user tries to rename to a name already existing

https://github.com/user-attachments/assets/a7a07e93-2c4b-4b54-8712-c4270172e592


## How has it been tested?

- New unit tests & manual test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-place tag renaming from the side panel with keyboard support (Enter to save, Escape to cancel)
  * "Rename tag" action in the tag context menu; actions are disabled while renaming
  * Autofocus/select when editing and validation to prevent empty/unchanged names

* **Bug Fixes**
  * Error feedback shown when a rename fails; successful renames refresh the tag list

* **Tests**
  * Added tests covering successful and failed rename flows

* **Documentation**
  * Changelog updated to note inline tag renaming
<!-- end of auto-generated comment: release notes by coderabbit.ai -->