### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/enterprise.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/enterprise.py
@@ -2,26 +2,44 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import secrets
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Header, HTTPException, status
 
 enterprise_router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @enterprise_router.put("/cloud-credentials", status_code=204, response_model=None)
-def refresh_cloud_credentials(credentials: dict[str, str]) -> None:
+def refresh_cloud_credentials(
+    credentials: dict[str, str],
+    authorization: str | None = Header(default=None),
+) -> None:
     """Receive cloud storage credentials.
 
     Sets the credentials as environment variables and clears the S3 fsspec
     instance cache so that subsequent file operations pick up the new
     credentials.
-
-    TODO Mihnea (04/2026) Security:
-     This endpoint has no authentication and accepts arbitrary env var
-     keys. This is acceptable for air-gapped on-prem (behind Docker isolation with no internet).
-     For the hosted version, this endpoint must be secured with authentication and input validation.
     """
+    expected_token = os.getenv("LIGHTLY_STUDIO_ENTERPRISE_API_TOKEN")
+    if expected_token is None:
+        logger.warning("Rejected cloud credential update: enterprise API token is not configured.")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Cloud credential updates are disabled.",
+        )
+
+    if authorization is None or not authorization.startswith("Bearer "):
+        logger.warning("Rejected cloud credential update: missing or invalid authorization header.")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+    provided_token = authorization.removeprefix("Bearer ").strip()
+    if not secrets.compare_digest(provided_token, expected_token):
+        logger.warning("Rejected cloud credential update: invalid token.")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
     os.environ.update(credentials)
 
     # We currently support only AWS - this will need to be updated once support for other providers.
@@ -30,3 +48,4 @@ def refresh_cloud_credentials(credentials: dict[str, str]) -> None:
     )
 
     S3FileSystem.clear_instance_cache()
+    logger.info("Cloud credentials updated successfully.")


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `Critical` | **File**: `lightly_studio/src/lightly_studio/api/routes/api/enterprise.py:L12`

The `/cloud-credentials` endpoint accepts client-supplied credentials and directly updates process environment variables without any authentication or authorization checks. Any caller who can reach the API can modify runtime credentials (e.g., AWS keys), potentially taking over data access, disrupting service behavior, or pivoting to other sensitive operations.

## Solution

Require strong authentication and authorization (e.g., admin-only token/JWT scope) for this endpoint. Consider disabling this route by default in non-air-gapped deployments. Add audit logging for credential update attempts and successful changes.

## Changes

- `lightly_studio/src/lightly_studio/api/routes/api/enterprise.py` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Cloud credentials endpoint now enforces Bearer token authentication, rejecting unauthorized requests to prevent unauthorized access and modification of sensitive configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->