### PR TITLE
Translate QueryExpr to MatchExpression

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -1,9 +1,13 @@
-"""Translate query-language models into dataset-query expressions."""
+"""Translate query expression models into dataset-query expressions.
+
+Uses `isinstance` checks with `assert_never` to statically check that all cases are covered.
+"""
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
-from typing import Any, Protocol, TypeVar, Union
+from typing import Protocol, TypeVar, Union
 
 from typing_extensions import assert_never
 
@@ -45,14 +49,14 @@ T_contra = TypeVar("T_contra", contravariant=True)
 Number = Union[int, float]
 
 
-class EqualityField(Protocol[T_contra]):
+class _EqualityField(Protocol[T_contra]):  # noqa: PLW1641
     """Field supporting equality comparisons that yield MatchExpression."""
 
     def __eq__(self, other: T_contra) -> MatchExpression: ...  # type: ignore[override]
     def __ne__(self, other: T_contra) -> MatchExpression: ...  # type: ignore[override]
 
 
-class OrdinalField(EqualityField[T_contra], Protocol[T_contra]):
+class _OrdinalField(_EqualityField[T_contra], Protocol[T_contra]):
     """Field supporting ordinal comparisons that yield MatchExpression."""
 
     def __lt__(self, other: T_contra) -> MatchExpression: ...
@@ -61,7 +65,7 @@ class OrdinalField(EqualityField[T_contra], Protocol[T_contra]):
     def __ge__(self, other: T_contra) -> MatchExpression: ...
 
 
-class TagsAccessor(Protocol):
+class _TagsAccessor(Protocol):
     """Tag accessor interface for dataset-query sample fields."""
 
     def contains(self, tag_name: str) -> MatchExpression: ...
@@ -71,7 +75,7 @@ class TagsAccessor(Protocol):
 # Field mappings: (table, name) → dataset-query field / accessor
 # ---------------------------------------------------------------------------
 
-_STRING_FIELDS: dict[tuple[str, str], EqualityField[str]] = {
+_STRING_FIELDS: dict[tuple[str, str], _EqualityField[str]] = {
     ("image", "file_name"): ImageSampleField.file_name,
     ("image", "file_path_abs"): ImageSampleField.file_path_abs,
     ("video", "file_name"): VideoSampleField.file_name,
@@ -81,7 +85,7 @@ _STRING_FIELDS: dict[tuple[str, str], EqualityField[str]] = {
     ("instance_segmentation", "label"): InstanceSegmentationField.label,
 }
 
-_INTEGER_FIELDS: dict[tuple[str, str], OrdinalField[int]] = {
+_INTEGER_FIELDS: dict[tuple[str, str], _OrdinalField[int]] = {
     ("image", "width"): ImageSampleField.width,
     ("image", "height"): ImageSampleField.height,
     ("video", "width"): VideoSampleField.width,
@@ -96,29 +100,30 @@ _INTEGER_FIELDS: dict[tuple[str, str], OrdinalField[int]] = {
     ("instance_segmentation", "height"): InstanceSegmentationField.height,
 }
 
-_DATETIME_FIELDS: dict[tuple[str, str], OrdinalField[datetime]] = {
+_DATETIME_FIELDS: dict[tuple[str, str], _OrdinalField[datetime]] = {
     ("image", "created_at"): ImageSampleField.created_at,
 }
 
-_ORDINAL_FLOAT_FIELDS: dict[tuple[str, str], OrdinalField[Number]] = {
+_ORDINAL_FLOAT_FIELDS: dict[tuple[str, str], _OrdinalField[Number]] = {
     ("video", "fps"): VideoSampleField.fps,
 }
 
-_EQUALITY_FLOAT_FIELDS: dict[tuple[str, str], EqualityField[Number]] = {
+_EQUALITY_FLOAT_FIELDS: dict[tuple[str, str], _EqualityField[Number]] = {
     ("video", "duration_s"): VideoSampleField.duration_s,
 }
 
-_TAGS_FIELDS: dict[tuple[str, str], TagsAccessor] = {
+_TAGS_FIELDS: dict[tuple[str, str], _TagsAccessor] = {
     ("image", "tags"): ImageSampleField.tags,
     ("video", "tags"): VideoSampleField.tags,
 }
 
 
 def _lookup(
-    mapping: dict[tuple[str, str], Any],
+    mapping: Mapping[tuple[str, str], T],
     field: FieldRef,
     kind: str,
-) -> Any:
+) -> T:
+    """Retrieve a dataset-query field / accessor with error handling."""
     key = (field.table, field.name)
     if key not in mapping:
         raise ValueError(f"Unknown {kind} field: {field.table}.{field.name}")
@@ -130,7 +135,7 @@ def _lookup(
 # ---------------------------------------------------------------------------
 
 
-def to_match_expression(expr: MatchExpr) -> MatchExpression:
+def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 C901
     """Translate a validated query-language expression to a dataset-query expression."""
     if isinstance(expr, StringExpr):
         return _apply_equality_operator(
@@ -152,24 +157,18 @@ def to_match_expression(expr: MatchExpr) -> MatchExpression:
         )
     if isinstance(expr, OrdinalFloatExpr):
         return _apply_ordinal_operator(
-            field=_lookup(
-                _ORDINAL_FLOAT_FIELDS, expr.field, "ordinal float"
-            ),
+            field=_lookup(_ORDINAL_FLOAT_FIELDS, expr.field, "ordinal float"),
             operator=expr.operator,
             value=expr.value,
         )
     if isinstance(expr, EqualityFloatExpr):
         return _apply_equality_operator(
-            field=_lookup(
-                _EQUALITY_FLOAT_FIELDS, expr.field, "equality float"
-            ),
+            field=_lookup(_EQUALITY_FLOAT_FIELDS, expr.field, "equality float"),
             operator=expr.operator,
             value=expr.value,
         )
     if isinstance(expr, TagsContainsExpr):
-        accessor: TagsAccessor = _lookup(
-            _TAGS_FIELDS, expr.field, "tags"
-        )
+        accessor: _TagsAccessor = _lookup(_TAGS_FIELDS, expr.field, "tags")
         return accessor.contains(expr.tag_name)
     if isinstance(expr, ClassificationMatchExpr):
         return ClassificationQuery.match(to_match_expression(expr.subexpr))
@@ -186,9 +185,8 @@ def to_match_expression(expr: MatchExpr) -> MatchExpression:
     assert_never(expr)
 
 
-
 def _apply_equality_operator(
-    *, field: EqualityField[T], operator: EqualityComparisonOperator, value: T
+    *, field: _EqualityField[T], operator: EqualityComparisonOperator, value: T
 ) -> MatchExpression:
     if operator is EqualityComparisonOperator.EQ:
         return field == value
@@ -198,7 +196,7 @@ def _apply_equality_operator(
 
 
 def _apply_ordinal_operator(
-    *, field: OrdinalField[T], operator: OrdinalComparisonOperator, value: T
+    *, field: _OrdinalField[T], operator: OrdinalComparisonOperator, value: T
 ) -> MatchExpression:
     if operator is OrdinalComparisonOperator.LT:
         return field < value

--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -11,6 +11,8 @@ from typing import Protocol, TypeVar, Union
 
 from typing_extensions import assert_never
 
+from lightly_studio.errors import QueryExprError
+
 from lightly_studio.core.dataset_query import (
     AND,
     NOT,
@@ -121,12 +123,18 @@ _TAGS_FIELDS: dict[tuple[str, str], _TagsAccessor] = {
 def _lookup(
     mapping: Mapping[tuple[str, str], T],
     field: FieldRef,
-    kind: str,
+    type: str,
 ) -> T:
-    """Retrieve a dataset-query field / accessor with error handling."""
+    """Retrieve a dataset-query field / accessor with error handling.
+
+    Args:
+        mapping: Mapping from (table, name) to dataset-query field / accessor.
+        field: Field reference from the query expression model.
+        type: String for error messages (e.g. "string", "ordinal float", etc.).
+    """
     key = (field.table, field.name)
     if key not in mapping:
-        raise ValueError(f"Unknown {kind} field: {field.table}.{field.name}")
+        raise QueryExprError(f"Unknown {type} field: {field.table}.{field.name}")
     return mapping[key]
 
 

--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -1,0 +1,215 @@
+"""Translate query-language models into dataset-query expressions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Protocol, TypeVar, Union
+
+from typing_extensions import assert_never
+
+from lightly_studio.core.dataset_query import (
+    AND,
+    NOT,
+    OR,
+    ClassificationField,
+    ClassificationQuery,
+    ImageSampleField,
+    InstanceSegmentationField,
+    InstanceSegmentationQuery,
+    ObjectDetectionField,
+    ObjectDetectionQuery,
+    VideoSampleField,
+)
+from lightly_studio.core.dataset_query.match_expression import MatchExpression
+from lightly_studio.models.query_expr import (
+    AndExpr,
+    ClassificationMatchExpr,
+    DatetimeExpr,
+    EqualityComparisonOperator,
+    EqualityFloatExpr,
+    FieldRef,
+    InstanceSegmentationMatchExpr,
+    IntegerExpr,
+    MatchExpr,
+    NotExpr,
+    ObjectDetectionMatchExpr,
+    OrdinalComparisonOperator,
+    OrdinalFloatExpr,
+    OrExpr,
+    StringExpr,
+    TagsContainsExpr,
+)
+
+T = TypeVar("T")
+T_contra = TypeVar("T_contra", contravariant=True)
+Number = Union[int, float]
+
+
+class EqualityField(Protocol[T_contra]):
+    """Field supporting equality comparisons that yield MatchExpression."""
+
+    def __eq__(self, other: T_contra) -> MatchExpression: ...  # type: ignore[override]
+    def __ne__(self, other: T_contra) -> MatchExpression: ...  # type: ignore[override]
+
+
+class OrdinalField(EqualityField[T_contra], Protocol[T_contra]):
+    """Field supporting ordinal comparisons that yield MatchExpression."""
+
+    def __lt__(self, other: T_contra) -> MatchExpression: ...
+    def __le__(self, other: T_contra) -> MatchExpression: ...
+    def __gt__(self, other: T_contra) -> MatchExpression: ...
+    def __ge__(self, other: T_contra) -> MatchExpression: ...
+
+
+class TagsAccessor(Protocol):
+    """Tag accessor interface for dataset-query sample fields."""
+
+    def contains(self, tag_name: str) -> MatchExpression: ...
+
+
+# ---------------------------------------------------------------------------
+# Field mappings: (table, name) → dataset-query field / accessor
+# ---------------------------------------------------------------------------
+
+_STRING_FIELDS: dict[tuple[str, str], EqualityField[str]] = {
+    ("image", "file_name"): ImageSampleField.file_name,
+    ("image", "file_path_abs"): ImageSampleField.file_path_abs,
+    ("video", "file_name"): VideoSampleField.file_name,
+    ("video", "file_path_abs"): VideoSampleField.file_path_abs,
+    ("classification", "label"): ClassificationField.label,
+    ("object_detection", "label"): ObjectDetectionField.label,
+    ("instance_segmentation", "label"): InstanceSegmentationField.label,
+}
+
+_INTEGER_FIELDS: dict[tuple[str, str], OrdinalField[int]] = {
+    ("image", "width"): ImageSampleField.width,
+    ("image", "height"): ImageSampleField.height,
+    ("video", "width"): VideoSampleField.width,
+    ("video", "height"): VideoSampleField.height,
+    ("object_detection", "x"): ObjectDetectionField.x,
+    ("object_detection", "y"): ObjectDetectionField.y,
+    ("object_detection", "width"): ObjectDetectionField.width,
+    ("object_detection", "height"): ObjectDetectionField.height,
+    ("instance_segmentation", "x"): InstanceSegmentationField.x,
+    ("instance_segmentation", "y"): InstanceSegmentationField.y,
+    ("instance_segmentation", "width"): InstanceSegmentationField.width,
+    ("instance_segmentation", "height"): InstanceSegmentationField.height,
+}
+
+_DATETIME_FIELDS: dict[tuple[str, str], OrdinalField[datetime]] = {
+    ("image", "created_at"): ImageSampleField.created_at,
+}
+
+_ORDINAL_FLOAT_FIELDS: dict[tuple[str, str], OrdinalField[Number]] = {
+    ("video", "fps"): VideoSampleField.fps,
+}
+
+_EQUALITY_FLOAT_FIELDS: dict[tuple[str, str], EqualityField[Number]] = {
+    ("video", "duration_s"): VideoSampleField.duration_s,
+}
+
+_TAGS_FIELDS: dict[tuple[str, str], TagsAccessor] = {
+    ("image", "tags"): ImageSampleField.tags,
+    ("video", "tags"): VideoSampleField.tags,
+}
+
+
+def _lookup(
+    mapping: dict[tuple[str, str], Any],
+    field: FieldRef,
+    kind: str,
+) -> Any:
+    key = (field.table, field.name)
+    if key not in mapping:
+        raise ValueError(f"Unknown {kind} field: {field.table}.{field.name}")
+    return mapping[key]
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def to_match_expression(expr: MatchExpr) -> MatchExpression:
+    """Translate a validated query-language expression to a dataset-query expression."""
+    if isinstance(expr, StringExpr):
+        return _apply_equality_operator(
+            field=_lookup(_STRING_FIELDS, expr.field, "string"),
+            operator=expr.operator,
+            value=expr.value,
+        )
+    if isinstance(expr, IntegerExpr):
+        return _apply_ordinal_operator(
+            field=_lookup(_INTEGER_FIELDS, expr.field, "integer"),
+            operator=expr.operator,
+            value=expr.value,
+        )
+    if isinstance(expr, DatetimeExpr):
+        return _apply_ordinal_operator(
+            field=_lookup(_DATETIME_FIELDS, expr.field, "datetime"),
+            operator=expr.operator,
+            value=expr.value,
+        )
+    if isinstance(expr, OrdinalFloatExpr):
+        return _apply_ordinal_operator(
+            field=_lookup(
+                _ORDINAL_FLOAT_FIELDS, expr.field, "ordinal float"
+            ),
+            operator=expr.operator,
+            value=expr.value,
+        )
+    if isinstance(expr, EqualityFloatExpr):
+        return _apply_equality_operator(
+            field=_lookup(
+                _EQUALITY_FLOAT_FIELDS, expr.field, "equality float"
+            ),
+            operator=expr.operator,
+            value=expr.value,
+        )
+    if isinstance(expr, TagsContainsExpr):
+        accessor: TagsAccessor = _lookup(
+            _TAGS_FIELDS, expr.field, "tags"
+        )
+        return accessor.contains(expr.tag_name)
+    if isinstance(expr, ClassificationMatchExpr):
+        return ClassificationQuery.match(to_match_expression(expr.subexpr))
+    if isinstance(expr, ObjectDetectionMatchExpr):
+        return ObjectDetectionQuery.match(to_match_expression(expr.subexpr))
+    if isinstance(expr, InstanceSegmentationMatchExpr):
+        return InstanceSegmentationQuery.match(to_match_expression(expr.subexpr))
+    if isinstance(expr, AndExpr):
+        return AND(*(to_match_expression(child) for child in expr.children))
+    if isinstance(expr, OrExpr):
+        return OR(*(to_match_expression(child) for child in expr.children))
+    if isinstance(expr, NotExpr):
+        return NOT(to_match_expression(expr.child))
+    assert_never(expr)
+
+
+
+def _apply_equality_operator(
+    *, field: EqualityField[T], operator: EqualityComparisonOperator, value: T
+) -> MatchExpression:
+    if operator is EqualityComparisonOperator.EQ:
+        return field == value
+    if operator is EqualityComparisonOperator.NEQ:
+        return field != value
+    assert_never(operator)
+
+
+def _apply_ordinal_operator(
+    *, field: OrdinalField[T], operator: OrdinalComparisonOperator, value: T
+) -> MatchExpression:
+    if operator is OrdinalComparisonOperator.LT:
+        return field < value
+    if operator is OrdinalComparisonOperator.LTE:
+        return field <= value
+    if operator is OrdinalComparisonOperator.GT:
+        return field > value
+    if operator is OrdinalComparisonOperator.GTE:
+        return field >= value
+    if operator is OrdinalComparisonOperator.EQ:
+        return field == value
+    if operator is OrdinalComparisonOperator.NEQ:
+        return field != value
+    assert_never(operator)

--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -11,8 +11,6 @@ from typing import Protocol, TypeVar, Union
 
 from typing_extensions import assert_never
 
-from lightly_studio.errors import QueryExprError
-
 from lightly_studio.core.dataset_query import (
     AND,
     NOT,
@@ -27,6 +25,7 @@ from lightly_studio.core.dataset_query import (
     VideoSampleField,
 )
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
+from lightly_studio.errors import QueryExprError
 from lightly_studio.models.query_expr import (
     AndExpr,
     ClassificationMatchExpr,
@@ -123,18 +122,18 @@ _TAGS_FIELDS: dict[tuple[str, str], _TagsAccessor] = {
 def _lookup(
     mapping: Mapping[tuple[str, str], T],
     field: FieldRef,
-    type: str,
+    type_: str,
 ) -> T:
     """Retrieve a dataset-query field / accessor with error handling.
 
     Args:
         mapping: Mapping from (table, name) to dataset-query field / accessor.
         field: Field reference from the query expression model.
-        type: String for error messages (e.g. "string", "ordinal float", etc.).
+        type_: String for error messages (e.g. "string", "ordinal float", etc.).
     """
     key = (field.table, field.name)
     if key not in mapping:
-        raise QueryExprError(f"Unknown {type} field: {field.table}.{field.name}")
+        raise QueryExprError(f"Unknown {type_} field: {field.table}.{field.name}")
     return mapping[key]
 
 
@@ -147,54 +146,54 @@ def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 C9
     """Translate a validated query-language expression to a dataset-query expression."""
     if isinstance(expr, StringExpr):
         return _apply_equality_operator(
-            field=_lookup(_STRING_FIELDS, expr.field, "string"),
+            field=_lookup(mapping=_STRING_FIELDS, field=expr.field, type_="string"),
             operator=expr.operator,
             value=expr.value,
         )
     if isinstance(expr, IntegerExpr):
         return _apply_ordinal_operator(
-            field=_lookup(_INTEGER_FIELDS, expr.field, "integer"),
+            field=_lookup(mapping=_INTEGER_FIELDS, field=expr.field, type_="integer"),
             operator=expr.operator,
             value=expr.value,
         )
     if isinstance(expr, DatetimeExpr):
         return _apply_ordinal_operator(
-            field=_lookup(_DATETIME_FIELDS, expr.field, "datetime"),
+            field=_lookup(mapping=_DATETIME_FIELDS, field=expr.field, type_="datetime"),
             operator=expr.operator,
             value=expr.value,
         )
     if isinstance(expr, OrdinalFloatExpr):
         return _apply_ordinal_operator(
-            field=_lookup(_ORDINAL_FLOAT_FIELDS, expr.field, "ordinal float"),
+            field=_lookup(mapping=_ORDINAL_FLOAT_FIELDS, field=expr.field, type_="ordinal float"),
             operator=expr.operator,
             value=expr.value,
         )
     if isinstance(expr, EqualityFloatExpr):
         return _apply_equality_operator(
-            field=_lookup(_EQUALITY_FLOAT_FIELDS, expr.field, "equality float"),
+            field=_lookup(mapping=_EQUALITY_FLOAT_FIELDS, field=expr.field, type_="equality float"),
             operator=expr.operator,
             value=expr.value,
         )
     if isinstance(expr, TagsContainsExpr):
-        accessor: _TagsAccessor = _lookup(_TAGS_FIELDS, expr.field, "tags")
+        accessor: _TagsAccessor = _lookup(mapping=_TAGS_FIELDS, field=expr.field, type_="tags")
         return accessor.contains(expr.tag_name)
     if isinstance(expr, ClassificationMatchExpr):
-        return ClassificationQuery.match(to_match_expression(expr.subexpr))
+        return ClassificationQuery.match(to_match_expression(expr=expr.subexpr))
     if isinstance(expr, ObjectDetectionMatchExpr):
-        return ObjectDetectionQuery.match(to_match_expression(expr.subexpr))
+        return ObjectDetectionQuery.match(to_match_expression(expr=expr.subexpr))
     if isinstance(expr, InstanceSegmentationMatchExpr):
-        return InstanceSegmentationQuery.match(to_match_expression(expr.subexpr))
+        return InstanceSegmentationQuery.match(to_match_expression(expr=expr.subexpr))
     if isinstance(expr, AndExpr):
-        return AND(*(to_match_expression(child) for child in expr.children))
+        return AND(*(to_match_expression(expr=child) for child in expr.children))
     if isinstance(expr, OrExpr):
-        return OR(*(to_match_expression(child) for child in expr.children))
+        return OR(*(to_match_expression(expr=child) for child in expr.children))
     if isinstance(expr, NotExpr):
-        return NOT(to_match_expression(expr.child))
+        return NOT(to_match_expression(expr=expr.child))
     assert_never(expr)
 
 
 def _apply_equality_operator(
-    *, field: _EqualityField[T], operator: EqualityComparisonOperator, value: T
+    field: _EqualityField[T], operator: EqualityComparisonOperator, value: T
 ) -> MatchExpression:
     if operator is EqualityComparisonOperator.EQ:
         return field == value
@@ -204,7 +203,7 @@ def _apply_equality_operator(
 
 
 def _apply_ordinal_operator(
-    *, field: _OrdinalField[T], operator: OrdinalComparisonOperator, value: T
+    field: _OrdinalField[T], operator: OrdinalComparisonOperator, value: T
 ) -> MatchExpression:
     if operator is OrdinalComparisonOperator.LT:
         return field < value

--- a/lightly_studio/src/lightly_studio/errors.py
+++ b/lightly_studio/src/lightly_studio/errors.py
@@ -3,3 +3,7 @@
 
 class TagNotFoundError(Exception):
     """Exception signaling that a tag has not been found."""
+
+
+class QueryExprError(Exception):
+    """Exception raised when a query expression cannot be translated."""

--- a/lightly_studio/tests/core/dataset_query/test_query_translation.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation.py
@@ -217,7 +217,7 @@ def test_to_match_expression__instance_segmentation_match() -> None:
     expr = InstanceSegmentationMatchExpr(subexpr=subexpr)
     sql = _to_sql(query_translation.to_match_expression(expr))
     assert "exists" in sql
-    assert "annotation_type = 'instance_segmentation'" in sql
+    assert "annotation_type = 'segmentation_mask'" in sql
     assert "annotation_label_name = 'person'" in sql
 
 

--- a/lightly_studio/tests/core/dataset_query/test_query_translation.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation.py
@@ -118,7 +118,7 @@ class TestOrdinalFloatExpr:
             value=30.0,
         )
         sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "video.fps <" in sql
+        assert "video.fps < 30.0" in sql
 
     def test_unknown_field(self) -> None:
         expr = OrdinalFloatExpr(
@@ -138,7 +138,7 @@ class TestEqualityFloatExpr:
             value=10.5,
         )
         sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "video.duration_s =" in sql
+        assert "video.duration_s = 10.5" in sql
 
     def test_neq(self) -> None:
         expr = EqualityFloatExpr(
@@ -147,7 +147,7 @@ class TestEqualityFloatExpr:
             value=0,
         )
         sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "video.duration_s !=" in sql
+        assert "video.duration_s != 0" in sql
 
     def test_unknown_field(self) -> None:
         expr = EqualityFloatExpr(

--- a/lightly_studio/tests/core/dataset_query/test_query_translation.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation.py
@@ -167,7 +167,8 @@ class TestTagsContainsExpr:
         )
         result = query_translation.to_match_expression(expr)
         sql = _to_sql(result)
-        assert "reviewed" in sql
+        assert "exists" in sql
+        assert "tag.name = 'reviewed'" in sql
 
     def test_unknown_field(self) -> None:
         expr = TagsContainsExpr(
@@ -188,7 +189,9 @@ class TestClassificationMatchExpr:
         expr = ClassificationMatchExpr(subexpr=subexpr)
         result = query_translation.to_match_expression(expr)
         sql = _to_sql(result)
-        assert "cat" in sql
+        assert "exists" in sql
+        assert "annotation_type = 'classification'" in sql
+        assert "annotation_label_name = 'cat'" in sql
 
 
 class TestObjectDetectionMatchExpr:
@@ -201,7 +204,9 @@ class TestObjectDetectionMatchExpr:
         expr = ObjectDetectionMatchExpr(subexpr=subexpr)
         result = query_translation.to_match_expression(expr)
         sql = _to_sql(result)
-        assert "50" in sql
+        assert "exists" in sql
+        assert "annotation_type = 'object_detection'" in sql
+        assert "object_detection_annotation.width > 50" in sql
 
 
 class TestInstanceSegmentationMatchExpr:
@@ -214,7 +219,9 @@ class TestInstanceSegmentationMatchExpr:
         expr = InstanceSegmentationMatchExpr(subexpr=subexpr)
         result = query_translation.to_match_expression(expr)
         sql = _to_sql(result)
-        assert "person" in sql
+        assert "exists" in sql
+        assert "annotation_type = 'instance_segmentation'" in sql
+        assert "annotation_label_name = 'person'" in sql
 
 
 class TestAndExpr:
@@ -250,8 +257,8 @@ class TestOrExpr:
         )
         expr = OrExpr(children=[child_a, child_b])
         sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "a.jpg" in sql
-        assert "b.jpg" in sql
+        assert "file_name = 'a.jpg'" in sql
+        assert "file_name = 'b.jpg'" in sql
         assert " or " in sql
 
 
@@ -296,6 +303,8 @@ def test_nested_and_or() -> None:
     )
     sql = _to_sql(query_translation.to_match_expression(and_expr))
     assert "image.height > 50" in sql
+    assert "image.width = 100" in sql
+    assert "image.width = 200" in sql
     assert " and " in sql
     assert " or " in sql
 

--- a/lightly_studio/tests/core/dataset_query/test_query_translation.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation.py
@@ -57,7 +57,6 @@ class TestStringExpr:
             query_translation.to_match_expression(expr)
 
 
-
 class TestIntegerExpr:
     @pytest.mark.parametrize(
         ("operator", "expected_op"),
@@ -70,9 +69,7 @@ class TestIntegerExpr:
             (OrdinalComparisonOperator.NEQ, "!="),
         ],
     )
-    def test_operators(
-        self, operator: OrdinalComparisonOperator, expected_op: str
-    ) -> None:
+    def test_operators(self, operator: OrdinalComparisonOperator, expected_op: str) -> None:
         expr = IntegerExpr(
             field=FieldRef(table="image", name="width"),
             operator=operator,
@@ -89,7 +86,6 @@ class TestIntegerExpr:
         )
         with pytest.raises(QueryExprError, match="Unknown integer field"):
             query_translation.to_match_expression(expr)
-
 
 
 class TestDatetimeExpr:
@@ -114,7 +110,6 @@ class TestDatetimeExpr:
             query_translation.to_match_expression(expr)
 
 
-
 class TestOrdinalFloatExpr:
     def test_lt(self) -> None:
         expr = OrdinalFloatExpr(
@@ -133,7 +128,6 @@ class TestOrdinalFloatExpr:
         )
         with pytest.raises(QueryExprError, match="Unknown ordinal float field"):
             query_translation.to_match_expression(expr)
-
 
 
 class TestEqualityFloatExpr:
@@ -165,7 +159,6 @@ class TestEqualityFloatExpr:
             query_translation.to_match_expression(expr)
 
 
-
 class TestTagsContainsExpr:
     def test_image_tags(self) -> None:
         expr = TagsContainsExpr(
@@ -183,7 +176,6 @@ class TestTagsContainsExpr:
         )
         with pytest.raises(QueryExprError, match="Unknown tags field"):
             query_translation.to_match_expression(expr)
-
 
 
 class TestClassificationMatchExpr:
@@ -223,7 +215,6 @@ class TestInstanceSegmentationMatchExpr:
         result = query_translation.to_match_expression(expr)
         sql = _to_sql(result)
         assert "person" in sql
-
 
 
 class TestAndExpr:
@@ -275,7 +266,6 @@ class TestNotExpr:
         sql = _to_sql(query_translation.to_match_expression(expr))
         # NOT(width < 100) is compiled as width >= 100 by SQLAlchemy.
         assert "image.width >= 100" in sql
-
 
 
 def test_nested_and_or() -> None:

--- a/lightly_studio/tests/core/dataset_query/test_query_translation.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation.py
@@ -28,254 +28,248 @@ from lightly_studio.models.query_expr import (
 )
 
 
-class TestStringExpr:
-    def test_eq(self) -> None:
-        expr = StringExpr(
-            field=FieldRef(table="image", name="file_name"),
-            operator=EqualityComparisonOperator.EQ,
-            value="cat.jpg",
-        )
-        sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "image.file_name = 'cat.jpg'" in sql
-
-    def test_neq(self) -> None:
-        expr = StringExpr(
-            field=FieldRef(table="image", name="file_name"),
-            operator=EqualityComparisonOperator.NEQ,
-            value="dog.jpg",
-        )
-        sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "image.file_name != 'dog.jpg'" in sql
-
-    def test_unknown_field(self) -> None:
-        expr = StringExpr(
-            field=FieldRef(table="image", name="nonexistent"),
-            operator=EqualityComparisonOperator.EQ,
-            value="x",
-        )
-        with pytest.raises(QueryExprError, match="Unknown string field"):
-            query_translation.to_match_expression(expr)
-
-
-class TestIntegerExpr:
-    @pytest.mark.parametrize(
-        ("operator", "expected_op"),
-        [
-            (OrdinalComparisonOperator.LT, "<"),
-            (OrdinalComparisonOperator.LTE, "<="),
-            (OrdinalComparisonOperator.GT, ">"),
-            (OrdinalComparisonOperator.GTE, ">="),
-            (OrdinalComparisonOperator.EQ, "="),
-            (OrdinalComparisonOperator.NEQ, "!="),
-        ],
+def test_to_match_expression__string_eq() -> None:
+    expr = StringExpr(
+        field=FieldRef(table="image", name="file_name"),
+        operator=EqualityComparisonOperator.EQ,
+        value="cat.jpg",
     )
-    def test_operators(self, operator: OrdinalComparisonOperator, expected_op: str) -> None:
-        expr = IntegerExpr(
-            field=FieldRef(table="image", name="width"),
-            operator=operator,
-            value=800,
-        )
-        sql = _to_sql(query_translation.to_match_expression(expr))
-        assert f"image.width {expected_op} 800" in sql
-
-    def test_unknown_field(self) -> None:
-        expr = IntegerExpr(
-            field=FieldRef(table="image", name="depth"),
-            operator=OrdinalComparisonOperator.EQ,
-            value=3,
-        )
-        with pytest.raises(QueryExprError, match="Unknown integer field"):
-            query_translation.to_match_expression(expr)
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "image.file_name = 'cat.jpg'" in sql
 
 
-class TestDatetimeExpr:
-    def test_gt(self) -> None:
-        dt = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
-        expr = DatetimeExpr(
-            field=FieldRef(table="image", name="created_at"),
-            operator=OrdinalComparisonOperator.GT,
-            value=dt,
-        )
-        sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "image.created_at >" in sql
-        assert "2024-01-15" in sql
-
-    def test_unknown_field(self) -> None:
-        expr = DatetimeExpr(
-            field=FieldRef(table="image", name="updated_at"),
-            operator=OrdinalComparisonOperator.EQ,
-            value=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        )
-        with pytest.raises(QueryExprError, match="Unknown datetime field"):
-            query_translation.to_match_expression(expr)
+def test_to_match_expression__string_neq() -> None:
+    expr = StringExpr(
+        field=FieldRef(table="image", name="file_name"),
+        operator=EqualityComparisonOperator.NEQ,
+        value="dog.jpg",
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "image.file_name != 'dog.jpg'" in sql
 
 
-class TestOrdinalFloatExpr:
-    def test_lt(self) -> None:
-        expr = OrdinalFloatExpr(
-            field=FieldRef(table="video", name="fps"),
-            operator=OrdinalComparisonOperator.LT,
-            value=30.0,
-        )
-        sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "video.fps < 30.0" in sql
-
-    def test_unknown_field(self) -> None:
-        expr = OrdinalFloatExpr(
-            field=FieldRef(table="video", name="bitrate"),
-            operator=OrdinalComparisonOperator.EQ,
-            value=1.0,
-        )
-        with pytest.raises(QueryExprError, match="Unknown ordinal float field"):
-            query_translation.to_match_expression(expr)
+def test_to_match_expression__string_unknown_field() -> None:
+    expr = StringExpr(
+        field=FieldRef(table="image", name="nonexistent"),
+        operator=EqualityComparisonOperator.EQ,
+        value="x",
+    )
+    with pytest.raises(QueryExprError, match="Unknown string field"):
+        query_translation.to_match_expression(expr)
 
 
-class TestEqualityFloatExpr:
-    def test_eq(self) -> None:
-        expr = EqualityFloatExpr(
-            field=FieldRef(table="video", name="duration_s"),
-            operator=EqualityComparisonOperator.EQ,
-            value=10.5,
-        )
-        sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "video.duration_s = 10.5" in sql
-
-    def test_neq(self) -> None:
-        expr = EqualityFloatExpr(
-            field=FieldRef(table="video", name="duration_s"),
-            operator=EqualityComparisonOperator.NEQ,
-            value=0,
-        )
-        sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "video.duration_s != 0" in sql
-
-    def test_unknown_field(self) -> None:
-        expr = EqualityFloatExpr(
-            field=FieldRef(table="image", name="size_mb"),
-            operator=EqualityComparisonOperator.EQ,
-            value=1.0,
-        )
-        with pytest.raises(QueryExprError, match="Unknown equality float field"):
-            query_translation.to_match_expression(expr)
+@pytest.mark.parametrize(
+    ("operator", "expected_op"),
+    [
+        (OrdinalComparisonOperator.LT, "<"),
+        (OrdinalComparisonOperator.LTE, "<="),
+        (OrdinalComparisonOperator.GT, ">"),
+        (OrdinalComparisonOperator.GTE, ">="),
+        (OrdinalComparisonOperator.EQ, "="),
+        (OrdinalComparisonOperator.NEQ, "!="),
+    ],
+)
+def test_to_match_expression__integer_operators(
+    operator: OrdinalComparisonOperator, expected_op: str
+) -> None:
+    expr = IntegerExpr(
+        field=FieldRef(table="image", name="width"),
+        operator=operator,
+        value=800,
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert f"image.width {expected_op} 800" in sql
 
 
-class TestTagsContainsExpr:
-    def test_image_tags(self) -> None:
-        expr = TagsContainsExpr(
-            field=FieldRef(table="image", name="tags"),
-            tag_name="reviewed",
-        )
-        result = query_translation.to_match_expression(expr)
-        sql = _to_sql(result)
-        assert "exists" in sql
-        assert "tag.name = 'reviewed'" in sql
-
-    def test_unknown_field(self) -> None:
-        expr = TagsContainsExpr(
-            field=FieldRef(table="image", name="labels"),
-            tag_name="x",
-        )
-        with pytest.raises(QueryExprError, match="Unknown tags field"):
-            query_translation.to_match_expression(expr)
+def test_to_match_expression__integer_unknown_field() -> None:
+    expr = IntegerExpr(
+        field=FieldRef(table="image", name="depth"),
+        operator=OrdinalComparisonOperator.EQ,
+        value=3,
+    )
+    with pytest.raises(QueryExprError, match="Unknown integer field"):
+        query_translation.to_match_expression(expr)
 
 
-class TestClassificationMatchExpr:
-    def test_wraps_subexpr(self) -> None:
-        subexpr = StringExpr(
-            field=FieldRef(table="classification", name="label"),
-            operator=EqualityComparisonOperator.EQ,
-            value="cat",
-        )
-        expr = ClassificationMatchExpr(subexpr=subexpr)
-        result = query_translation.to_match_expression(expr)
-        sql = _to_sql(result)
-        assert "exists" in sql
-        assert "annotation_type = 'classification'" in sql
-        assert "annotation_label_name = 'cat'" in sql
+def test_to_match_expression__datetime_gt() -> None:
+    dt = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    expr = DatetimeExpr(
+        field=FieldRef(table="image", name="created_at"),
+        operator=OrdinalComparisonOperator.GT,
+        value=dt,
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "image.created_at >" in sql
+    assert "2024-01-15" in sql
 
 
-class TestObjectDetectionMatchExpr:
-    def test_wraps_subexpr(self) -> None:
-        subexpr = IntegerExpr(
-            field=FieldRef(table="object_detection", name="width"),
-            operator=OrdinalComparisonOperator.GT,
-            value=50,
-        )
-        expr = ObjectDetectionMatchExpr(subexpr=subexpr)
-        result = query_translation.to_match_expression(expr)
-        sql = _to_sql(result)
-        assert "exists" in sql
-        assert "annotation_type = 'object_detection'" in sql
-        assert "object_detection_annotation.width > 50" in sql
+def test_to_match_expression__datetime_unknown_field() -> None:
+    expr = DatetimeExpr(
+        field=FieldRef(table="image", name="updated_at"),
+        operator=OrdinalComparisonOperator.EQ,
+        value=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    with pytest.raises(QueryExprError, match="Unknown datetime field"):
+        query_translation.to_match_expression(expr)
 
 
-class TestInstanceSegmentationMatchExpr:
-    def test_wraps_subexpr(self) -> None:
-        subexpr = StringExpr(
-            field=FieldRef(table="instance_segmentation", name="label"),
-            operator=EqualityComparisonOperator.EQ,
-            value="person",
-        )
-        expr = InstanceSegmentationMatchExpr(subexpr=subexpr)
-        result = query_translation.to_match_expression(expr)
-        sql = _to_sql(result)
-        assert "exists" in sql
-        assert "annotation_type = 'instance_segmentation'" in sql
-        assert "annotation_label_name = 'person'" in sql
+def test_to_match_expression__ordinal_float_lt() -> None:
+    expr = OrdinalFloatExpr(
+        field=FieldRef(table="video", name="fps"),
+        operator=OrdinalComparisonOperator.LT,
+        value=30.0,
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "video.fps < 30.0" in sql
 
 
-class TestAndExpr:
-    def test_two_children(self) -> None:
-        child_a = IntegerExpr(
-            field=FieldRef(table="image", name="width"),
-            operator=OrdinalComparisonOperator.GT,
-            value=100,
-        )
-        child_b = IntegerExpr(
-            field=FieldRef(table="image", name="height"),
-            operator=OrdinalComparisonOperator.LT,
-            value=500,
-        )
-        expr = AndExpr(children=[child_a, child_b])
-        sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "image.width > 100" in sql
-        assert "image.height < 500" in sql
-        assert " and " in sql
+def test_to_match_expression__ordinal_float_unknown_field() -> None:
+    expr = OrdinalFloatExpr(
+        field=FieldRef(table="video", name="bitrate"),
+        operator=OrdinalComparisonOperator.EQ,
+        value=1.0,
+    )
+    with pytest.raises(QueryExprError, match="Unknown ordinal float field"):
+        query_translation.to_match_expression(expr)
 
 
-class TestOrExpr:
-    def test_two_children(self) -> None:
-        child_a = StringExpr(
-            field=FieldRef(table="image", name="file_name"),
-            operator=EqualityComparisonOperator.EQ,
-            value="a.jpg",
-        )
-        child_b = StringExpr(
-            field=FieldRef(table="image", name="file_name"),
-            operator=EqualityComparisonOperator.EQ,
-            value="b.jpg",
-        )
-        expr = OrExpr(children=[child_a, child_b])
-        sql = _to_sql(query_translation.to_match_expression(expr))
-        assert "file_name = 'a.jpg'" in sql
-        assert "file_name = 'b.jpg'" in sql
-        assert " or " in sql
+def test_to_match_expression__equality_float_eq() -> None:
+    expr = EqualityFloatExpr(
+        field=FieldRef(table="video", name="duration_s"),
+        operator=EqualityComparisonOperator.EQ,
+        value=10.5,
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "video.duration_s = 10.5" in sql
 
 
-class TestNotExpr:
-    def test_negation(self) -> None:
-        child = IntegerExpr(
-            field=FieldRef(table="image", name="width"),
-            operator=OrdinalComparisonOperator.LT,
-            value=100,
-        )
-        expr = NotExpr(child=child)
-        sql = _to_sql(query_translation.to_match_expression(expr))
-        # NOT(width < 100) is compiled as width >= 100 by SQLAlchemy.
-        assert "image.width >= 100" in sql
+def test_to_match_expression__equality_float_neq() -> None:
+    expr = EqualityFloatExpr(
+        field=FieldRef(table="video", name="duration_s"),
+        operator=EqualityComparisonOperator.NEQ,
+        value=0,
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "video.duration_s != 0" in sql
 
 
-def test_nested_and_or() -> None:
+def test_to_match_expression__equality_float_unknown_field() -> None:
+    expr = EqualityFloatExpr(
+        field=FieldRef(table="image", name="size_mb"),
+        operator=EqualityComparisonOperator.EQ,
+        value=1.0,
+    )
+    with pytest.raises(QueryExprError, match="Unknown equality float field"):
+        query_translation.to_match_expression(expr)
+
+
+def test_to_match_expression__tags_contains() -> None:
+    expr = TagsContainsExpr(
+        field=FieldRef(table="image", name="tags"),
+        tag_name="reviewed",
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "exists" in sql
+    assert "tag.name = 'reviewed'" in sql
+
+
+def test_to_match_expression__tags_unknown_field() -> None:
+    expr = TagsContainsExpr(
+        field=FieldRef(table="image", name="labels"),
+        tag_name="x",
+    )
+    with pytest.raises(QueryExprError, match="Unknown tags field"):
+        query_translation.to_match_expression(expr)
+
+
+def test_to_match_expression__classification_match() -> None:
+    subexpr = StringExpr(
+        field=FieldRef(table="classification", name="label"),
+        operator=EqualityComparisonOperator.EQ,
+        value="cat",
+    )
+    expr = ClassificationMatchExpr(subexpr=subexpr)
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "exists" in sql
+    assert "annotation_type = 'classification'" in sql
+    assert "annotation_label_name = 'cat'" in sql
+
+
+def test_to_match_expression__object_detection_match() -> None:
+    subexpr = IntegerExpr(
+        field=FieldRef(table="object_detection", name="width"),
+        operator=OrdinalComparisonOperator.GT,
+        value=50,
+    )
+    expr = ObjectDetectionMatchExpr(subexpr=subexpr)
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "exists" in sql
+    assert "annotation_type = 'object_detection'" in sql
+    assert "object_detection_annotation.width > 50" in sql
+
+
+def test_to_match_expression__instance_segmentation_match() -> None:
+    subexpr = StringExpr(
+        field=FieldRef(table="instance_segmentation", name="label"),
+        operator=EqualityComparisonOperator.EQ,
+        value="person",
+    )
+    expr = InstanceSegmentationMatchExpr(subexpr=subexpr)
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "exists" in sql
+    assert "annotation_type = 'instance_segmentation'" in sql
+    assert "annotation_label_name = 'person'" in sql
+
+
+def test_to_match_expression__and() -> None:
+    child_a = IntegerExpr(
+        field=FieldRef(table="image", name="width"),
+        operator=OrdinalComparisonOperator.GT,
+        value=100,
+    )
+    child_b = IntegerExpr(
+        field=FieldRef(table="image", name="height"),
+        operator=OrdinalComparisonOperator.LT,
+        value=500,
+    )
+    expr = AndExpr(children=[child_a, child_b])
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "image.width > 100" in sql
+    assert "image.height < 500" in sql
+    assert " and " in sql
+
+
+def test_to_match_expression__or() -> None:
+    child_a = StringExpr(
+        field=FieldRef(table="image", name="file_name"),
+        operator=EqualityComparisonOperator.EQ,
+        value="a.jpg",
+    )
+    child_b = StringExpr(
+        field=FieldRef(table="image", name="file_name"),
+        operator=EqualityComparisonOperator.EQ,
+        value="b.jpg",
+    )
+    expr = OrExpr(children=[child_a, child_b])
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "file_name = 'a.jpg'" in sql
+    assert "file_name = 'b.jpg'" in sql
+    assert " or " in sql
+
+
+def test_to_match_expression__not() -> None:
+    child = IntegerExpr(
+        field=FieldRef(table="image", name="width"),
+        operator=OrdinalComparisonOperator.LT,
+        value=100,
+    )
+    expr = NotExpr(child=child)
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    # NOT(width < 100) is compiled as width >= 100 by SQLAlchemy.
+    assert "image.width >= 100" in sql
+
+
+def test_to_match_expression__nested_and_or() -> None:
     """AND containing an OR should produce correct SQL."""
     or_expr = OrExpr(
         children=[

--- a/lightly_studio/tests/core/dataset_query/test_query_translation.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation.py
@@ -1,0 +1,315 @@
+"""Tests for translating query expression models into dataset-query expressions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from lightly_studio.core.dataset_query import query_translation
+from lightly_studio.core.dataset_query.match_expression import MatchExpression
+from lightly_studio.errors import QueryExprError
+from lightly_studio.models.query_expr import (
+    AndExpr,
+    ClassificationMatchExpr,
+    DatetimeExpr,
+    EqualityComparisonOperator,
+    EqualityFloatExpr,
+    FieldRef,
+    InstanceSegmentationMatchExpr,
+    IntegerExpr,
+    NotExpr,
+    ObjectDetectionMatchExpr,
+    OrdinalComparisonOperator,
+    OrdinalFloatExpr,
+    OrExpr,
+    StringExpr,
+    TagsContainsExpr,
+)
+
+
+class TestStringExpr:
+    def test_eq(self) -> None:
+        expr = StringExpr(
+            field=FieldRef(table="image", name="file_name"),
+            operator=EqualityComparisonOperator.EQ,
+            value="cat.jpg",
+        )
+        sql = _to_sql(query_translation.to_match_expression(expr))
+        assert "image.file_name = 'cat.jpg'" in sql
+
+    def test_neq(self) -> None:
+        expr = StringExpr(
+            field=FieldRef(table="image", name="file_name"),
+            operator=EqualityComparisonOperator.NEQ,
+            value="dog.jpg",
+        )
+        sql = _to_sql(query_translation.to_match_expression(expr))
+        assert "image.file_name != 'dog.jpg'" in sql
+
+    def test_unknown_field(self) -> None:
+        expr = StringExpr(
+            field=FieldRef(table="image", name="nonexistent"),
+            operator=EqualityComparisonOperator.EQ,
+            value="x",
+        )
+        with pytest.raises(QueryExprError, match="Unknown string field"):
+            query_translation.to_match_expression(expr)
+
+
+
+class TestIntegerExpr:
+    @pytest.mark.parametrize(
+        ("operator", "expected_op"),
+        [
+            (OrdinalComparisonOperator.LT, "<"),
+            (OrdinalComparisonOperator.LTE, "<="),
+            (OrdinalComparisonOperator.GT, ">"),
+            (OrdinalComparisonOperator.GTE, ">="),
+            (OrdinalComparisonOperator.EQ, "="),
+            (OrdinalComparisonOperator.NEQ, "!="),
+        ],
+    )
+    def test_operators(
+        self, operator: OrdinalComparisonOperator, expected_op: str
+    ) -> None:
+        expr = IntegerExpr(
+            field=FieldRef(table="image", name="width"),
+            operator=operator,
+            value=800,
+        )
+        sql = _to_sql(query_translation.to_match_expression(expr))
+        assert f"image.width {expected_op} 800" in sql
+
+    def test_unknown_field(self) -> None:
+        expr = IntegerExpr(
+            field=FieldRef(table="image", name="depth"),
+            operator=OrdinalComparisonOperator.EQ,
+            value=3,
+        )
+        with pytest.raises(QueryExprError, match="Unknown integer field"):
+            query_translation.to_match_expression(expr)
+
+
+
+class TestDatetimeExpr:
+    def test_gt(self) -> None:
+        dt = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        expr = DatetimeExpr(
+            field=FieldRef(table="image", name="created_at"),
+            operator=OrdinalComparisonOperator.GT,
+            value=dt,
+        )
+        sql = _to_sql(query_translation.to_match_expression(expr))
+        assert "image.created_at >" in sql
+        assert "2024-01-15" in sql
+
+    def test_unknown_field(self) -> None:
+        expr = DatetimeExpr(
+            field=FieldRef(table="image", name="updated_at"),
+            operator=OrdinalComparisonOperator.EQ,
+            value=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        with pytest.raises(QueryExprError, match="Unknown datetime field"):
+            query_translation.to_match_expression(expr)
+
+
+
+class TestOrdinalFloatExpr:
+    def test_lt(self) -> None:
+        expr = OrdinalFloatExpr(
+            field=FieldRef(table="video", name="fps"),
+            operator=OrdinalComparisonOperator.LT,
+            value=30.0,
+        )
+        sql = _to_sql(query_translation.to_match_expression(expr))
+        assert "video.fps <" in sql
+
+    def test_unknown_field(self) -> None:
+        expr = OrdinalFloatExpr(
+            field=FieldRef(table="video", name="bitrate"),
+            operator=OrdinalComparisonOperator.EQ,
+            value=1.0,
+        )
+        with pytest.raises(QueryExprError, match="Unknown ordinal float field"):
+            query_translation.to_match_expression(expr)
+
+
+
+class TestEqualityFloatExpr:
+    def test_eq(self) -> None:
+        expr = EqualityFloatExpr(
+            field=FieldRef(table="video", name="duration_s"),
+            operator=EqualityComparisonOperator.EQ,
+            value=10.5,
+        )
+        sql = _to_sql(query_translation.to_match_expression(expr))
+        assert "video.duration_s =" in sql
+
+    def test_neq(self) -> None:
+        expr = EqualityFloatExpr(
+            field=FieldRef(table="video", name="duration_s"),
+            operator=EqualityComparisonOperator.NEQ,
+            value=0,
+        )
+        sql = _to_sql(query_translation.to_match_expression(expr))
+        assert "video.duration_s !=" in sql
+
+    def test_unknown_field(self) -> None:
+        expr = EqualityFloatExpr(
+            field=FieldRef(table="image", name="size_mb"),
+            operator=EqualityComparisonOperator.EQ,
+            value=1.0,
+        )
+        with pytest.raises(QueryExprError, match="Unknown equality float field"):
+            query_translation.to_match_expression(expr)
+
+
+
+class TestTagsContainsExpr:
+    def test_image_tags(self) -> None:
+        expr = TagsContainsExpr(
+            field=FieldRef(table="image", name="tags"),
+            tag_name="reviewed",
+        )
+        result = query_translation.to_match_expression(expr)
+        sql = _to_sql(result)
+        assert "reviewed" in sql
+
+    def test_unknown_field(self) -> None:
+        expr = TagsContainsExpr(
+            field=FieldRef(table="image", name="labels"),
+            tag_name="x",
+        )
+        with pytest.raises(QueryExprError, match="Unknown tags field"):
+            query_translation.to_match_expression(expr)
+
+
+
+class TestClassificationMatchExpr:
+    def test_wraps_subexpr(self) -> None:
+        subexpr = StringExpr(
+            field=FieldRef(table="classification", name="label"),
+            operator=EqualityComparisonOperator.EQ,
+            value="cat",
+        )
+        expr = ClassificationMatchExpr(subexpr=subexpr)
+        result = query_translation.to_match_expression(expr)
+        sql = _to_sql(result)
+        assert "cat" in sql
+
+
+class TestObjectDetectionMatchExpr:
+    def test_wraps_subexpr(self) -> None:
+        subexpr = IntegerExpr(
+            field=FieldRef(table="object_detection", name="width"),
+            operator=OrdinalComparisonOperator.GT,
+            value=50,
+        )
+        expr = ObjectDetectionMatchExpr(subexpr=subexpr)
+        result = query_translation.to_match_expression(expr)
+        sql = _to_sql(result)
+        assert "50" in sql
+
+
+class TestInstanceSegmentationMatchExpr:
+    def test_wraps_subexpr(self) -> None:
+        subexpr = StringExpr(
+            field=FieldRef(table="instance_segmentation", name="label"),
+            operator=EqualityComparisonOperator.EQ,
+            value="person",
+        )
+        expr = InstanceSegmentationMatchExpr(subexpr=subexpr)
+        result = query_translation.to_match_expression(expr)
+        sql = _to_sql(result)
+        assert "person" in sql
+
+
+
+class TestAndExpr:
+    def test_two_children(self) -> None:
+        child_a = IntegerExpr(
+            field=FieldRef(table="image", name="width"),
+            operator=OrdinalComparisonOperator.GT,
+            value=100,
+        )
+        child_b = IntegerExpr(
+            field=FieldRef(table="image", name="height"),
+            operator=OrdinalComparisonOperator.LT,
+            value=500,
+        )
+        expr = AndExpr(children=[child_a, child_b])
+        sql = _to_sql(query_translation.to_match_expression(expr))
+        assert "image.width > 100" in sql
+        assert "image.height < 500" in sql
+        assert " and " in sql
+
+
+class TestOrExpr:
+    def test_two_children(self) -> None:
+        child_a = StringExpr(
+            field=FieldRef(table="image", name="file_name"),
+            operator=EqualityComparisonOperator.EQ,
+            value="a.jpg",
+        )
+        child_b = StringExpr(
+            field=FieldRef(table="image", name="file_name"),
+            operator=EqualityComparisonOperator.EQ,
+            value="b.jpg",
+        )
+        expr = OrExpr(children=[child_a, child_b])
+        sql = _to_sql(query_translation.to_match_expression(expr))
+        assert "a.jpg" in sql
+        assert "b.jpg" in sql
+        assert " or " in sql
+
+
+class TestNotExpr:
+    def test_negation(self) -> None:
+        child = IntegerExpr(
+            field=FieldRef(table="image", name="width"),
+            operator=OrdinalComparisonOperator.LT,
+            value=100,
+        )
+        expr = NotExpr(child=child)
+        sql = _to_sql(query_translation.to_match_expression(expr))
+        # NOT(width < 100) is compiled as width >= 100 by SQLAlchemy.
+        assert "image.width >= 100" in sql
+
+
+
+def test_nested_and_or() -> None:
+    """AND containing an OR should produce correct SQL."""
+    or_expr = OrExpr(
+        children=[
+            IntegerExpr(
+                field=FieldRef(table="image", name="width"),
+                operator=OrdinalComparisonOperator.EQ,
+                value=100,
+            ),
+            IntegerExpr(
+                field=FieldRef(table="image", name="width"),
+                operator=OrdinalComparisonOperator.EQ,
+                value=200,
+            ),
+        ]
+    )
+    and_expr = AndExpr(
+        children=[
+            IntegerExpr(
+                field=FieldRef(table="image", name="height"),
+                operator=OrdinalComparisonOperator.GT,
+                value=50,
+            ),
+            or_expr,
+        ]
+    )
+    sql = _to_sql(query_translation.to_match_expression(and_expr))
+    assert "image.height > 50" in sql
+    assert " and " in sql
+    assert " or " in sql
+
+
+def _to_sql(expr: MatchExpression) -> str:
+    """Compile a MatchExpression to a lowercase SQL string for assertions."""
+    return str(expr.get().compile(compile_kwargs={"literal_binds": True})).lower()

--- a/lightly_studio/tests/models/test_query_expr.py
+++ b/lightly_studio/tests/models/test_query_expr.py
@@ -58,7 +58,7 @@ class TestQueryExpr:
                     "type": "not",
                     "child": {
                         "type": "tags_contains_expr",
-                        "field": {"table": "sample", "name": "tags"},
+                        "field": {"table": "image", "name": "tags"},
                         "tag_name": "reviewed",
                     },
                 }


### PR DESCRIPTION
## What has changed and why?

Translate QueryExpr to MatchExpression.

The diff is rather large but the bulk is declarations and tests, the logic is rather short - together 75 lines, functions `to_match_expression`, `_apply_equality_operator`, `_apply_ordinal_operator`.

## How has it been tested?

* Added unit test for translation to SQL

**Note:** There will be a follow-up PR to add tests against a DB. They will also test failures (queries that can be expressed but are invalid).

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translate validated query expressions into dataset query predicates covering fields, tags, annotations, numeric/date comparisons, and boolean composition.

* **Improvements**
  * Added a dedicated query-expression error for clearer handling of unknown or unsupported query fields/operators.

* **Tests**
  * Added comprehensive tests for expression translation, operator mappings, annotation-scoped wrappers, logical composition, and error cases; adjusted one tag-field resolution expectation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->