### PR TITLE
Add QueryExpr tests against a database

### DIFF
--- a/lightly_studio/tests/core/dataset_query/test_query_translation.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation.py
@@ -91,6 +91,16 @@ def test_to_match_expression__integer_unknown_field() -> None:
         query_translation.to_match_expression(expr)
 
 
+def test_to_match_expression__integer_wrong_type_for_valid_field() -> None:
+    expr = IntegerExpr(
+        field=FieldRef(table="classification", name="label"),
+        operator=OrdinalComparisonOperator.EQ,
+        value=3,
+    )
+    with pytest.raises(QueryExprError, match="Unknown integer field"):
+        query_translation.to_match_expression(expr)
+
+
 def test_to_match_expression__datetime_gt() -> None:
     dt = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
     expr = DatetimeExpr(

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
@@ -127,14 +127,10 @@ def test_to_match_expression__tags_contains(db_session: Session) -> None:
 def test_to_match_expression__classification_match(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     cid = dataset.collection_id
-    image1 = create_image(
-        session=db_session, collection_id=cid, file_path_abs="/path/to/cat.jpg"
-    )
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/cat.jpg")
     create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/dog.jpg")
 
-    label = create_annotation_label(
-        session=db_session, root_collection_id=cid, label_name="cat"
-    )
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="cat")
     create_annotation(
         session=db_session,
         collection_id=cid,
@@ -162,9 +158,7 @@ def test_to_match_expression__object_detection_match(db_session: Session) -> Non
     image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/1.jpg")
     image2 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/2.jpg")
 
-    label = create_annotation_label(
-        session=db_session, root_collection_id=cid, label_name="person"
-    )
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="person")
     create_annotation(
         session=db_session,
         collection_id=cid,
@@ -201,9 +195,7 @@ def test_to_match_expression__instance_segmentation_match(db_session: Session) -
     image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/1.jpg")
     create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/2.jpg")
 
-    label = create_annotation_label(
-        session=db_session, root_collection_id=cid, label_name="person"
-    )
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="person")
     create_annotation(
         session=db_session,
         collection_id=cid,

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
@@ -201,7 +201,7 @@ def test_to_match_expression__instance_segmentation_match(db_session: Session) -
         collection_id=cid,
         sample_id=image1.sample_id,
         annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.INSTANCE_SEGMENTATION,
+        annotation_type=AnnotationType.SEGMENTATION_MASK,
     )
 
     expr = InstanceSegmentationMatchExpr(

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
@@ -1,0 +1,326 @@
+"""Database integration tests for query_translation.
+
+Each test builds a query expression model, translates it via
+``query_translation.to_match_expression``, and executes it against a populated
+database through ``DatasetQuery.match``.  One representative operator per field
+type keeps the suite focused while still covering the full translation pipeline.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlmodel import Session
+
+from lightly_studio.core.dataset_query import query_translation
+from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.models.query_expr import (
+    AndExpr,
+    ClassificationMatchExpr,
+    DatetimeExpr,
+    EqualityComparisonOperator,
+    FieldRef,
+    InstanceSegmentationMatchExpr,
+    IntegerExpr,
+    NotExpr,
+    ObjectDetectionMatchExpr,
+    OrdinalComparisonOperator,
+    OrExpr,
+    StringExpr,
+    TagsContainsExpr,
+)
+from lightly_studio.resolvers import tag_resolver
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+    create_tag,
+)
+
+
+def test_to_match_expression__string_eq(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    target = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/target.jpg"
+    )
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/other.jpg")
+
+    expr = StringExpr(
+        field=FieldRef(table="image", name="file_name"),
+        operator=EqualityComparisonOperator.EQ,
+        value="target.jpg",
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [target.sample_id]
+
+
+def test_to_match_expression__integer_gt(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/small.jpg", width=100
+    )
+    big = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/big.jpg", width=800
+    )
+
+    expr = IntegerExpr(
+        field=FieldRef(table="image", name="width"),
+        operator=OrdinalComparisonOperator.GT,
+        value=500,
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [big.sample_id]
+
+
+def test_to_match_expression__datetime_gt(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    cutoff = datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+    old = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/old.jpg")
+    old.created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    db_session.add(old)
+
+    new = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/new.jpg")
+    new.created_at = datetime(2024, 12, 1, tzinfo=timezone.utc)
+    db_session.add(new)
+    db_session.commit()
+
+    expr = DatetimeExpr(
+        field=FieldRef(table="image", name="created_at"),
+        operator=OrdinalComparisonOperator.GT,
+        value=cutoff,
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [new.sample_id]
+
+
+def test_to_match_expression__tags_contains(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/1.jpg")
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/2.jpg")
+
+    tag = create_tag(session=db_session, collection_id=cid, tag_name="reviewed")
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image1.sample)
+
+    expr = TagsContainsExpr(
+        field=FieldRef(table="image", name="tags"),
+        tag_name="reviewed",
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [image1.sample_id]
+
+
+def test_to_match_expression__classification_match(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/cat.jpg"
+    )
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/dog.jpg")
+
+    label = create_annotation_label(
+        session=db_session, root_collection_id=cid, label_name="cat"
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+
+    expr = ClassificationMatchExpr(
+        subexpr=StringExpr(
+            field=FieldRef(table="classification", name="label"),
+            operator=EqualityComparisonOperator.EQ,
+            value="cat",
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [image1.sample_id]
+
+
+def test_to_match_expression__object_detection_match(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/1.jpg")
+    image2 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/2.jpg")
+
+    label = create_annotation_label(
+        session=db_session, root_collection_id=cid, label_name="person"
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_data={"x": 0, "y": 0, "width": 100, "height": 100},
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image2.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_data={"x": 0, "y": 0, "width": 10, "height": 10},
+    )
+
+    expr = ObjectDetectionMatchExpr(
+        subexpr=IntegerExpr(
+            field=FieldRef(table="object_detection", name="width"),
+            operator=OrdinalComparisonOperator.GT,
+            value=50,
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [image1.sample_id]
+
+
+def test_to_match_expression__instance_segmentation_match(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/1.jpg")
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/2.jpg")
+
+    label = create_annotation_label(
+        session=db_session, root_collection_id=cid, label_name="person"
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.INSTANCE_SEGMENTATION,
+    )
+
+    expr = InstanceSegmentationMatchExpr(
+        subexpr=StringExpr(
+            field=FieldRef(table="instance_segmentation", name="label"),
+            operator=EqualityComparisonOperator.EQ,
+            value="person",
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [image1.sample_id]
+
+
+def test_to_match_expression__and(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    create_image(
+        session=db_session,
+        collection_id=cid,
+        file_path_abs="/path/to/small_short.jpg",
+        width=100,
+        height=100,
+    )
+    target = create_image(
+        session=db_session,
+        collection_id=cid,
+        file_path_abs="/path/to/big_tall.jpg",
+        width=800,
+        height=600,
+    )
+    create_image(
+        session=db_session,
+        collection_id=cid,
+        file_path_abs="/path/to/big_short.jpg",
+        width=800,
+        height=100,
+    )
+
+    expr = AndExpr(
+        children=[
+            IntegerExpr(
+                field=FieldRef(table="image", name="width"),
+                operator=OrdinalComparisonOperator.GT,
+                value=500,
+            ),
+            IntegerExpr(
+                field=FieldRef(table="image", name="height"),
+                operator=OrdinalComparisonOperator.GT,
+                value=500,
+            ),
+        ]
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [target.sample_id]
+
+
+def test_to_match_expression__or(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    img_a = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/a.jpg")
+    img_b = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/b.jpg")
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/c.jpg")
+
+    expr = OrExpr(
+        children=[
+            StringExpr(
+                field=FieldRef(table="image", name="file_name"),
+                operator=EqualityComparisonOperator.EQ,
+                value="a.jpg",
+            ),
+            StringExpr(
+                field=FieldRef(table="image", name="file_name"),
+                operator=EqualityComparisonOperator.EQ,
+                value="b.jpg",
+            ),
+        ]
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert {r.sample_id for r in results} == {img_a.sample_id, img_b.sample_id}
+
+
+def test_to_match_expression__not(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    create_image(
+        session=db_session,
+        collection_id=cid,
+        file_path_abs="/path/to/small.jpg",
+        width=100,
+    )
+    big = create_image(
+        session=db_session,
+        collection_id=cid,
+        file_path_abs="/path/to/big.jpg",
+        width=800,
+    )
+
+    expr = NotExpr(
+        child=IntegerExpr(
+            field=FieldRef(table="image", name="width"),
+            operator=OrdinalComparisonOperator.LT,
+            value=500,
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [big.sample_id]

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__illegal.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__illegal.py
@@ -154,63 +154,6 @@ def test_to_match_expression__classification_field_inside_object_detection_match
     assert [result.sample_id for result in results] == [object_detection_image.sample_id]
 
 
-def test_to_match_expression__object_detection_field_at_top_level(
-    db_session: Session,
-) -> None:
-    """object_detection.width at the top level without ObjectDetectionMatchExpr.
-
-    Without the matcher wrapper there is no ``annotation_type`` filter.  The
-    generated SQL uses an EXISTS subquery through the .has() relationship, so
-    it does not error — but it matches annotations of *any* type whose
-    object_detection_annotation row satisfies the condition.
-    """
-    dataset = create_collection(session=db_session)
-    cid = dataset.collection_id
-    matching_image = create_image(
-        session=db_session, collection_id=cid, file_path_abs="/path/to/matching.jpg", width=800
-    )
-    nonmatching_image = create_image(
-        session=db_session, collection_id=cid, file_path_abs="/path/to/nonmatching.jpg", width=800
-    )
-    bare_image = create_image(
-        session=db_session, collection_id=cid, file_path_abs="/path/to/bare.jpg", width=800
-    )
-    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="car")
-    create_annotation(
-        session=db_session,
-        collection_id=cid,
-        sample_id=matching_image.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.OBJECT_DETECTION,
-        annotation_data={"x": 0, "y": 0, "width": 100, "height": 100},
-    )
-    create_annotation(
-        session=db_session,
-        collection_id=cid,
-        sample_id=nonmatching_image.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.OBJECT_DETECTION,
-        annotation_data={"x": 0, "y": 0, "width": 10, "height": 10},
-    )
-
-    expr = IntegerExpr(
-        field=FieldRef(table="object_detection", name="width"),
-        operator=OrdinalComparisonOperator.GT,
-        value=50,
-    )
-    match = query_translation.to_match_expression(expr)
-    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
-
-    # Wrong: once one object-detection annotation in the dataset satisfies the
-    # width filter, the top-level EXISTS subquery is not scoped to the current
-    # sample, so even the nonmatching and bare samples are returned.
-    assert [result.sample_id for result in results] == [
-        matching_image.sample_id,
-        nonmatching_image.sample_id,
-        bare_image.sample_id,
-    ]
-
-
 def test_to_match_expression__classification_label_at_top_level(
     db_session: Session,
 ) -> None:
@@ -253,7 +196,6 @@ def test_to_match_expression__classification_label_at_top_level(
         annotation_type=AnnotationType.CLASSIFICATION,
     )
 
-    # Ask for classification.label == "cat" at the top level.
     expr = StringExpr(
         field=FieldRef(table="classification", name="label"),
         operator=EqualityComparisonOperator.EQ,

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__illegal.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__illegal.py
@@ -47,14 +47,24 @@ def test_to_match_expression__image_field_inside_classification_matcher(
     """
     dataset = create_collection(session=db_session)
     cid = dataset.collection_id
-    image = create_image(
+    wide_image = create_image(
         session=db_session, collection_id=cid, file_path_abs="/path/to/wide.jpg", width=800
+    )
+    narrow_image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/narrow.jpg", width=200
     )
     label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="cat")
     create_annotation(
         session=db_session,
         collection_id=cid,
-        sample_id=image.sample_id,
+        sample_id=wide_image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=narrow_image.sample_id,
         annotation_label_id=label.annotation_label_id,
         annotation_type=AnnotationType.CLASSIFICATION,
     )
@@ -69,10 +79,10 @@ def test_to_match_expression__image_field_inside_classification_matcher(
     match = query_translation.to_match_expression(expr)
     results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
 
-    # Wrong: image.width leaks into the EXISTS subquery and is resolved from
-    # the outer scope, so the row matches even though the classification
-    # annotation has no width concept.
-    assert len(results) == 1
+    # Wrong: both samples have the same classification annotation shape, but
+    # only the wide image matches because image.width is resolved from the
+    # outer image row inside the classification subquery.
+    assert [result.sample_id for result in results] == [wide_image.sample_id]
 
 
 def test_to_match_expression__classification_field_inside_object_detection_matcher(
@@ -81,22 +91,50 @@ def test_to_match_expression__classification_field_inside_object_detection_match
     """classification.label inside ObjectDetectionMatchExpr mixes annotation contexts.
 
     The label lookup goes through AnnotationBaseTable.annotation_label
-    regardless of annotation type, but ObjectDetectionMatchExpr adds
-    ``annotation_type = 'OBJECT_DETECTION'`` which correctly rejects the
-    classification annotation.
+    regardless of the field's declared context. Wrapped in
+    ObjectDetectionMatchExpr, the same label predicate is silently evaluated
+    against object-detection annotations instead of classification ones.
     """
     dataset = create_collection(session=db_session)
     cid = dataset.collection_id
-    image = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/img.jpg")
-    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="dog")
+    classification_image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/classification.jpg"
+    )
+    object_detection_image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/object_detection.jpg"
+    )
+    other_detection_image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/other_detection.jpg"
+    )
+    dog_label = create_annotation_label(
+        session=db_session, root_collection_id=cid, label_name="dog"
+    )
+    cat_label = create_annotation_label(
+        session=db_session, root_collection_id=cid, label_name="cat"
+    )
 
-    # Create a classification annotation — NOT object detection.
     create_annotation(
         session=db_session,
         collection_id=cid,
-        sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
+        sample_id=classification_image.sample_id,
+        annotation_label_id=dog_label.annotation_label_id,
         annotation_type=AnnotationType.CLASSIFICATION,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=object_detection_image.sample_id,
+        annotation_label_id=dog_label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_data={"x": 0, "y": 0, "width": 10, "height": 10},
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=other_detection_image.sample_id,
+        annotation_label_id=cat_label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_data={"x": 0, "y": 0, "width": 10, "height": 10},
     )
 
     expr = ObjectDetectionMatchExpr(
@@ -109,9 +147,11 @@ def test_to_match_expression__classification_field_inside_object_detection_match
     match = query_translation.to_match_expression(expr)
     results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
 
-    # The ObjectDetectionMatchExpr adds ``annotation_type = 'OBJECT_DETECTION'``
-    # but the actual annotation is CLASSIFICATION, so no rows match.
-    assert len(results) == 0
+    # Wrong: the field says "classification.label", but the matcher's
+    # annotation_type filter makes it behave like a generic label predicate on
+    # object detections. The object-detection sample matches, while the actual
+    # classification sample does not.
+    assert [result.sample_id for result in results] == [object_detection_image.sample_id]
 
 
 def test_to_match_expression__object_detection_field_at_top_level(
@@ -126,21 +166,31 @@ def test_to_match_expression__object_detection_field_at_top_level(
     """
     dataset = create_collection(session=db_session)
     cid = dataset.collection_id
-    image = create_image(
-        session=db_session, collection_id=cid, file_path_abs="/path/to/img.jpg", width=800
+    matching_image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/matching.jpg", width=800
     )
-    # Second sample has no annotations at all.
-    create_image(
+    nonmatching_image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/nonmatching.jpg", width=800
+    )
+    bare_image = create_image(
         session=db_session, collection_id=cid, file_path_abs="/path/to/bare.jpg", width=800
     )
     label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="car")
     create_annotation(
         session=db_session,
         collection_id=cid,
-        sample_id=image.sample_id,
+        sample_id=matching_image.sample_id,
         annotation_label_id=label.annotation_label_id,
         annotation_type=AnnotationType.OBJECT_DETECTION,
         annotation_data={"x": 0, "y": 0, "width": 100, "height": 100},
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=nonmatching_image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_data={"x": 0, "y": 0, "width": 10, "height": 10},
     )
 
     expr = IntegerExpr(
@@ -151,10 +201,14 @@ def test_to_match_expression__object_detection_field_at_top_level(
     match = query_translation.to_match_expression(expr)
     results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
 
-    # Wrong: both samples match (2 instead of 1).  The bare sample without any
-    # annotation should not match, but the top-level EXISTS subquery is not
-    # correctly scoped to the sample, so both rows are returned.
-    assert len(results) == 2
+    # Wrong: once one object-detection annotation in the dataset satisfies the
+    # width filter, the top-level EXISTS subquery is not scoped to the current
+    # sample, so even the nonmatching and bare samples are returned.
+    assert [result.sample_id for result in results] == [
+        matching_image.sample_id,
+        nonmatching_image.sample_id,
+        bare_image.sample_id,
+    ]
 
 
 def test_to_match_expression__classification_label_at_top_level(
@@ -168,18 +222,35 @@ def test_to_match_expression__classification_label_at_top_level(
     """
     dataset = create_collection(session=db_session)
     cid = dataset.collection_id
-    image = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/img.jpg")
-    # Second sample has no annotations at all.
-    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/bare.jpg")
-    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="cat")
-    # Create an OBJECT_DETECTION annotation with label "cat".
+    object_detection_image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/object_detection.jpg"
+    )
+    classification_other_label_image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/classification_other.jpg"
+    )
+    bare_image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/bare.jpg"
+    )
+    cat_label = create_annotation_label(
+        session=db_session, root_collection_id=cid, label_name="cat"
+    )
+    dog_label = create_annotation_label(
+        session=db_session, root_collection_id=cid, label_name="dog"
+    )
     create_annotation(
         session=db_session,
         collection_id=cid,
-        sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
+        sample_id=object_detection_image.sample_id,
+        annotation_label_id=cat_label.annotation_label_id,
         annotation_type=AnnotationType.OBJECT_DETECTION,
         annotation_data={"x": 0, "y": 0, "width": 10, "height": 10},
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=classification_other_label_image.sample_id,
+        annotation_label_id=dog_label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
     )
 
     # Ask for classification.label == "cat" at the top level.
@@ -191,8 +262,11 @@ def test_to_match_expression__classification_label_at_top_level(
     match = query_translation.to_match_expression(expr)
     results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
 
-    # Wrong: both samples match (2 instead of 0).  The bare sample has no
-    # annotations at all, yet it matches because the top-level EXISTS
-    # subquery is not scoped to the sample.  The annotated sample matches
-    # because the subquery ignores annotation_type.
-    assert len(results) == 2
+    # Wrong: the top-level EXISTS subquery is not scoped to the current sample,
+    # and the predicate ignores annotation_type. A single object-detection
+    # annotation labeled "cat" makes every sample match.
+    assert [result.sample_id for result in results] == [
+        object_detection_image.sample_id,
+        classification_other_label_image.sample_id,
+        bare_image.sample_id,
+    ]

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__illegal.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__illegal.py
@@ -1,0 +1,198 @@
+"""Database tests for illegal cross-context query expressions.
+
+These queries are valid at the Pydantic model level (they parse without error)
+but are semantically wrong — for example, using an image field inside a
+classification matcher or an annotation field at the top level without a
+matcher wrapper.  The tests document the current behaviour so regressions or
+future validation improvements are caught.
+
+Illegal queries should be rejected at the user interaction layer (e.g. in the frontend
+GUI composer).
+"""
+
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from lightly_studio.core.dataset_query import query_translation
+from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.models.query_expr import (
+    ClassificationMatchExpr,
+    EqualityComparisonOperator,
+    FieldRef,
+    IntegerExpr,
+    ObjectDetectionMatchExpr,
+    OrdinalComparisonOperator,
+    StringExpr,
+)
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
+
+
+def test_to_match_expression__image_field_inside_classification_matcher(
+    db_session: Session,
+) -> None:
+    """image.width inside ClassificationMatchExpr is nonsensical.
+
+    The generated SQL nests ``image.width > 500`` inside
+    ``EXISTS (SELECT 1 FROM annotation_base WHERE ...)``.  Because the DB
+    engine resolves image.width from the outer query scope, the condition
+    evaluates on the image row rather than the annotation — silently producing
+    wrong results.
+    """
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/wide.jpg", width=800
+    )
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="cat")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+
+    expr = ClassificationMatchExpr(
+        subexpr=IntegerExpr(
+            field=FieldRef(table="image", name="width"),
+            operator=OrdinalComparisonOperator.GT,
+            value=500,
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    # Wrong: image.width leaks into the EXISTS subquery and is resolved from
+    # the outer scope, so the row matches even though the classification
+    # annotation has no width concept.
+    assert len(results) == 1
+
+
+def test_to_match_expression__classification_field_inside_object_detection_matcher(
+    db_session: Session,
+) -> None:
+    """classification.label inside ObjectDetectionMatchExpr mixes annotation contexts.
+
+    The label lookup goes through AnnotationBaseTable.annotation_label
+    regardless of annotation type, but ObjectDetectionMatchExpr adds
+    ``annotation_type = 'OBJECT_DETECTION'`` which correctly rejects the
+    classification annotation.
+    """
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/img.jpg")
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="dog")
+
+    # Create a classification annotation — NOT object detection.
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+
+    expr = ObjectDetectionMatchExpr(
+        subexpr=StringExpr(
+            field=FieldRef(table="classification", name="label"),
+            operator=EqualityComparisonOperator.EQ,
+            value="dog",
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    # The ObjectDetectionMatchExpr adds ``annotation_type = 'OBJECT_DETECTION'``
+    # but the actual annotation is CLASSIFICATION, so no rows match.
+    assert len(results) == 0
+
+
+def test_to_match_expression__object_detection_field_at_top_level(
+    db_session: Session,
+) -> None:
+    """object_detection.width at the top level without ObjectDetectionMatchExpr.
+
+    Without the matcher wrapper there is no ``annotation_type`` filter.  The
+    generated SQL uses an EXISTS subquery through the .has() relationship, so
+    it does not error — but it matches annotations of *any* type whose
+    object_detection_annotation row satisfies the condition.
+    """
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image = create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/img.jpg", width=800
+    )
+    # Second sample has no annotations at all.
+    create_image(
+        session=db_session, collection_id=cid, file_path_abs="/path/to/bare.jpg", width=800
+    )
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="car")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_data={"x": 0, "y": 0, "width": 100, "height": 100},
+    )
+
+    expr = IntegerExpr(
+        field=FieldRef(table="object_detection", name="width"),
+        operator=OrdinalComparisonOperator.GT,
+        value=50,
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    # Wrong: both samples match (2 instead of 1).  The bare sample without any
+    # annotation should not match, but the top-level EXISTS subquery is not
+    # correctly scoped to the sample, so both rows are returned.
+    assert len(results) == 2
+
+
+def test_to_match_expression__classification_label_at_top_level(
+    db_session: Session,
+) -> None:
+    """classification.label at the top level without ClassificationMatchExpr.
+
+    The ForeignComparableField generates an EXISTS through .has(), so the
+    query executes without error.  However, it matches *any* annotation whose
+    label equals the value, regardless of annotation type.
+    """
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/img.jpg")
+    # Second sample has no annotations at all.
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/bare.jpg")
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="cat")
+    # Create an OBJECT_DETECTION annotation with label "cat".
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_data={"x": 0, "y": 0, "width": 10, "height": 10},
+    )
+
+    # Ask for classification.label == "cat" at the top level.
+    expr = StringExpr(
+        field=FieldRef(table="classification", name="label"),
+        operator=EqualityComparisonOperator.EQ,
+        value="cat",
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    # Wrong: both samples match (2 instead of 0).  The bare sample has no
+    # annotations at all, yet it matches because the top-level EXISTS
+    # subquery is not scoped to the sample.  The annotated sample matches
+    # because the subquery ignores annotation_type.
+    assert len(results) == 2

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__illegal.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__illegal.py
@@ -207,8 +207,8 @@ def test_to_match_expression__classification_label_at_top_level(
     # Wrong: the top-level EXISTS subquery is not scoped to the current sample,
     # and the predicate ignores annotation_type. A single object-detection
     # annotation labeled "cat" makes every sample match.
-    assert [result.sample_id for result in results] == [
+    assert {result.sample_id for result in results} == {
         object_detection_image.sample_id,
         classification_other_label_image.sample_id,
         bare_image.sample_id,
-    ]
+    }


### PR DESCRIPTION
## What has changed and why?

Add QueryExpr tests against a database.

There are two files. The `__illegal.py` file showcases unexpected behaviour. `QueryMatch` structure is not expressive enough (by design) to prevent using some expressions in a wrong context. This responsibility is up to other parts of the system (might change in the future).

## How has it been tested?

The whole PR is just tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test verifying an integer expression against an incompatible field raises the expected error.
  * Added database-backed integration tests covering string, integer, datetime, tag, and annotation match operators and their boolean composition (AND/OR/NOT).
  * Added integration tests documenting current behavior for illegal or cross-context query expressions and their observed results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->