### PR TITLE
Add GridContainer for unified grid state rendering

### DIFF
--- a/lightly_studio_view/src/lib/components/Grid/Grid.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.svelte
@@ -6,8 +6,6 @@
 
     const GRID_GAP = 16;
 
-    const GRID_GAP = 16;
-
     let viewport: HTMLElement | null = null;
     let clientWidth = $state(0);
     let clientHeight = $state(0);

--- a/lightly_studio_view/src/lib/components/Grid/Grid.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.svelte
@@ -6,6 +6,8 @@
 
     const GRID_GAP = 16;
 
+    const GRID_GAP = 16;
+
     let viewport: HTMLElement | null = null;
     let clientWidth = $state(0);
     let clientHeight = $state(0);

--- a/lightly_studio_view/src/lib/components/GridContainer/GridContainer.stories.svelte
+++ b/lightly_studio_view/src/lib/components/GridContainer/GridContainer.stories.svelte
@@ -1,0 +1,106 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import GridContainer from './GridContainer.svelte';
+    import Grid from '../Grid/Grid.svelte';
+    import GridItem from '../GridItem/GridItem.svelte';
+
+    const { Story } = defineMeta({
+        title: 'Components/GridContainer',
+        tags: ['autodocs']
+    });
+
+    const itemCount = 60;
+    const message = {
+        loading: 'Loading samples...',
+        error: 'Failed to load samples.',
+        empty: {
+            title: 'No samples found',
+            description: 'Try adjusting your filters to see more content.'
+        }
+    };
+</script>
+
+<Story name="Loading" asChild>
+    <div class="h-[480px] w-full">
+        <GridContainer
+            status={{ loading: true, error: false, empty: false, success: false }}
+            {message}
+        />
+    </div>
+</Story>
+
+<Story name="Error" asChild>
+    <div class="h-[480px] w-full">
+        <GridContainer
+            status={{ loading: false, error: true, empty: false, success: false }}
+            {message}
+        />
+    </div>
+</Story>
+
+<Story name="Empty" asChild>
+    <div class="h-[480px] w-full">
+        <GridContainer
+            status={{ loading: false, error: false, empty: true, success: false }}
+            {message}
+        />
+    </div>
+</Story>
+
+<Story name="Success" asChild>
+    <div class="h-[480px] w-full">
+        <GridContainer
+            status={{ loading: false, error: false, empty: false, success: true }}
+            {message}
+            loader={{ loadMore: () => undefined, disabled: false, loading: false }}
+            {itemCount}
+        >
+            {#snippet children({ footer })}
+                <Grid {itemCount} columnCount={6}>
+                    {#snippet gridItem({ index, style, width, height })}
+                        <GridItem {width} {height} {style} caption={`sample-${index + 1}.jpg`}>
+                            <img
+                                src="https://picsum.photos/180?random={index}"
+                                alt="Sample {index + 1}"
+                                class="h-full w-full object-cover"
+                            />
+                        </GridItem>
+                    {/snippet}
+
+                    {#snippet footerItem()}
+                        {@render footer()}
+                    {/snippet}
+                </Grid>
+            {/snippet}
+        </GridContainer>
+    </div>
+</Story>
+
+<Story name="Success - Fetching Next Page" asChild>
+    <div class="h-[480px] w-full">
+        <GridContainer
+            status={{ loading: false, error: false, empty: false, success: true }}
+            {message}
+            loader={{ loadMore: () => undefined, disabled: true, loading: true }}
+            {itemCount}
+        >
+            {#snippet children({ footer })}
+                <Grid {itemCount} columnCount={6}>
+                    {#snippet gridItem({ index, style, width, height })}
+                        <GridItem {width} {height} {style} caption={`sample-${index + 1}.jpg`}>
+                            <img
+                                src="https://picsum.photos/180?random={index + 500}"
+                                alt="Sample {index + 1}"
+                                class="h-full w-full object-cover"
+                            />
+                        </GridItem>
+                    {/snippet}
+
+                    {#snippet footerItem()}
+                        {@render footer()}
+                    {/snippet}
+                </Grid>
+            {/snippet}
+        </GridContainer>
+    </div>
+</Story>

--- a/lightly_studio_view/src/lib/components/GridContainer/GridContainer.svelte
+++ b/lightly_studio_view/src/lib/components/GridContainer/GridContainer.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte';
+    import { LazyTrigger } from '$lib/components/LazyTrigger';
+    import Spinner from '$lib/components/Spinner/Spinner.svelte';
+
+    type GridContainerMessage = {
+        loading?: string;
+        error?: string;
+        empty?: {
+            title?: string;
+            description?: string;
+        };
+    };
+
+    type GridContainerStatus = {
+        loading: boolean;
+        error: boolean;
+        empty: boolean;
+        success: boolean;
+    };
+
+    type GridContainerLoader = {
+        loadMore?: () => void;
+        disabled?: boolean;
+        loading?: boolean;
+    };
+
+    const DEFAULT_MESSAGE = {
+        loading: 'Loading items...',
+        error: 'Something went wrong.',
+        empty: {
+            title: 'No items found',
+            description: 'There are no items to display.'
+        }
+    } as const;
+
+    let {
+        status,
+        message,
+        loader,
+        itemCount = 0,
+        children
+    }: {
+        status: GridContainerStatus;
+        message?: GridContainerMessage;
+        loader?: GridContainerLoader;
+        itemCount?: number;
+        children?: Snippet<
+            [
+                {
+                    footer: Snippet;
+                }
+            ]
+        >;
+    } = $props();
+
+    const resolvedMessage = $derived.by(() => ({
+        loading: message?.loading ?? DEFAULT_MESSAGE.loading,
+        error: message?.error ?? DEFAULT_MESSAGE.error,
+        empty: {
+            title: message?.empty?.title ?? DEFAULT_MESSAGE.empty.title,
+            description: message?.empty?.description ?? DEFAULT_MESSAGE.empty.description
+        }
+    }));
+
+    const resolvedLoader = $derived.by(() => ({
+        loadMore: loader?.loadMore ?? (() => undefined),
+        disabled: loader?.disabled ?? true,
+        loading: loader?.loading ?? false
+    }));
+</script>
+
+{#snippet footer()}
+    {#key itemCount}
+        <LazyTrigger onIntersect={resolvedLoader.loadMore} disabled={resolvedLoader.disabled} />
+    {/key}
+    {#if resolvedLoader.loading}
+        <div class="flex justify-center p-4" data-testid="grid-container-fetching-next-page">
+            <Spinner />
+        </div>
+    {/if}
+{/snippet}
+
+{#if status.loading}
+    <div class="flex h-full w-full items-center justify-center gap-2">
+        <Spinner />
+        <div>{resolvedMessage.loading}</div>
+    </div>
+{:else if status.error}
+    <div class="flex h-full w-full items-center justify-center">
+        <div class="text-center text-muted-foreground">{resolvedMessage.error}</div>
+    </div>
+{:else if status.empty}
+    <div class="flex h-full w-full items-center justify-center">
+        <div class="text-center text-muted-foreground">
+            <div class="mb-2 text-lg font-medium">{resolvedMessage.empty.title}</div>
+            <div class="text-sm">{resolvedMessage.empty.description}</div>
+        </div>
+    </div>
+{:else if status.success}
+    {@render children?.({ footer })}
+{/if}

--- a/lightly_studio_view/src/lib/components/GridContainer/GridContainer.test.ts
+++ b/lightly_studio_view/src/lib/components/GridContainer/GridContainer.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import GridContainerTestWrapper from './GridContainerTestWrapper.test.svelte';
+
+class MockIntersectionObserver {
+    callback: IntersectionObserverCallback;
+    targets: Element[] = [];
+
+    static instances: MockIntersectionObserver[] = [];
+
+    constructor(callback: IntersectionObserverCallback) {
+        this.callback = callback;
+        MockIntersectionObserver.instances.push(this);
+    }
+
+    observe(target: Element) {
+        this.targets.push(target);
+    }
+
+    unobserve() {}
+    disconnect() {}
+    takeRecords(): IntersectionObserverEntry[] {
+        return [];
+    }
+
+    trigger(isIntersecting = true) {
+        const target = this.targets[0] as Element;
+        this.callback(
+            [
+                {
+                    target,
+                    isIntersecting,
+                    intersectionRatio: isIntersecting ? 1 : 0,
+                    time: 0,
+                    boundingClientRect: {} as DOMRectReadOnly,
+                    intersectionRect: {} as DOMRectReadOnly,
+                    rootBounds: null
+                }
+            ],
+            this as unknown as IntersectionObserver
+        );
+    }
+
+    get root() {
+        return null;
+    }
+
+    get rootMargin() {
+        return '';
+    }
+
+    get thresholds() {
+        return [];
+    }
+}
+
+describe('GridContainer', () => {
+    beforeEach(() => {
+        MockIntersectionObserver.instances = [];
+        global.IntersectionObserver =
+            MockIntersectionObserver as unknown as typeof IntersectionObserver;
+    });
+
+    it('renders loading state message', () => {
+        const { container } = render(GridContainerTestWrapper, {
+            props: {
+                status: { loading: true, error: false, empty: false, success: false },
+                message: {
+                    loading: 'Loading custom text',
+                    error: 'Custom error',
+                    empty: {
+                        title: 'Custom empty title',
+                        description: 'Custom empty description'
+                    }
+                }
+            }
+        });
+
+        expect(screen.getByText('Loading custom text')).toBeInTheDocument();
+        expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    });
+
+    it('renders error state message', () => {
+        render(GridContainerTestWrapper, {
+            props: {
+                status: { loading: false, error: true, empty: false, success: false },
+                message: {
+                    loading: 'Loading custom text',
+                    error: 'Custom error',
+                    empty: {
+                        title: 'Custom empty title',
+                        description: 'Custom empty description'
+                    }
+                }
+            }
+        });
+
+        expect(screen.getByText('Custom error')).toBeInTheDocument();
+    });
+
+    it('renders empty state title and description', () => {
+        render(GridContainerTestWrapper, {
+            props: {
+                status: { loading: false, error: false, empty: true, success: false },
+                message: {
+                    loading: 'Loading custom text',
+                    error: 'Custom error',
+                    empty: {
+                        title: 'Nothing here',
+                        description: 'Try a different filter'
+                    }
+                }
+            }
+        });
+
+        expect(screen.getByText('Nothing here')).toBeInTheDocument();
+        expect(screen.getByText('Try a different filter')).toBeInTheDocument();
+    });
+
+    it('renders success content', () => {
+        render(GridContainerTestWrapper, {
+            props: {
+                status: { loading: false, error: false, empty: false, success: true }
+            }
+        });
+
+        expect(screen.getByTestId('grid-success-content')).toBeInTheDocument();
+    });
+
+    it('triggers loadMore when lazy trigger intersects', () => {
+        const onLoadMore = vi.fn();
+        render(GridContainerTestWrapper, {
+            props: {
+                status: { loading: false, error: false, empty: false, success: true },
+                loaderDisabled: false,
+                onLoadMore
+            }
+        });
+
+        expect(MockIntersectionObserver.instances).toHaveLength(1);
+
+        MockIntersectionObserver.instances[0].trigger(true);
+
+        expect(onLoadMore).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not create observer when loading more is disabled', () => {
+        render(GridContainerTestWrapper, {
+            props: {
+                status: { loading: false, error: false, empty: false, success: true },
+                loaderDisabled: true
+            }
+        });
+
+        expect(MockIntersectionObserver.instances).toHaveLength(0);
+    });
+
+    it('shows fetching next page spinner in the footer', () => {
+        render(GridContainerTestWrapper, {
+            props: {
+                status: { loading: false, error: false, empty: false, success: true },
+                loaderLoading: true
+            }
+        });
+
+        expect(screen.getByTestId('grid-container-fetching-next-page')).toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/lib/components/GridContainer/GridContainerTestWrapper.test.svelte
+++ b/lightly_studio_view/src/lib/components/GridContainer/GridContainerTestWrapper.test.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+    import GridContainer from './GridContainer.svelte';
+
+    let {
+        status = { loading: false, error: false, empty: false, success: true },
+        message = {
+            loading: 'Loading samples...',
+            error: 'Failed to load samples.',
+            empty: {
+                title: 'No samples found',
+                description: 'Try adjusting your filters.'
+            }
+        },
+        itemCount = 12,
+        loaderDisabled = false,
+        loaderLoading = false,
+        onLoadMore = () => undefined
+    }: {
+        status?: { loading: boolean; error: boolean; empty: boolean; success: boolean };
+        message?: {
+            loading: string;
+            error: string;
+            empty: {
+                title: string;
+                description: string;
+            };
+        };
+        itemCount?: number;
+        loaderDisabled?: boolean;
+        loaderLoading?: boolean;
+        onLoadMore?: () => void;
+    } = $props();
+</script>
+
+<GridContainer
+    {status}
+    {message}
+    {itemCount}
+    loader={{
+        loadMore: onLoadMore,
+        disabled: loaderDisabled,
+        loading: loaderLoading
+    }}
+>
+    {#snippet children({ footer })}
+        <div data-testid="grid-success-content">Success content</div>
+        <div data-testid="grid-footer-content">
+            {@render footer()}
+        </div>
+    {/snippet}
+</GridContainer>

--- a/lightly_studio_view/src/lib/components/GridContainer/index.ts
+++ b/lightly_studio_view/src/lib/components/GridContainer/index.ts
@@ -1,0 +1,1 @@
+export { default as GridContainer } from './GridContainer.svelte';

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -48,6 +48,7 @@ export { default as GroupsGrid } from '$lib/components/GroupsGrid/GroupsGrid.sve
 export { default as SampleGrid } from '$lib/components/SampleGrid/SampleGrid.svelte';
 export { default as SampleGridItem } from '$lib/components/SampleGridItem/SampleGridItem.svelte';
 export { default as GridItem } from '$lib/components/GridItem/GridItem.svelte';
+export { GridContainer } from '$lib/components/GridContainer';
 export { default as VideoFrameItem } from '$lib/components/VideoFrameItem/VideoFrameItem.svelte';
 export { default as SegmentTags } from '$lib/components/SegmentTags/SegmentTags.svelte';
 export { default as MetadataSegment } from '$lib/components/MetadataSegment/MetadataSegment.svelte';


### PR DESCRIPTION
## What has changed and why?

This PR introduces a reusable `GridContainer` component to keep grid visual state handling in one place.

## How has it been tested?

Unit tests + storybook.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GridContainer component for displaying item lists with support for loading, error, empty, and success states.
  * Includes lazy-loading functionality with automatic "fetch more" triggering as users scroll.
  * Displays contextual loading spinners, error messages, and customizable empty state messaging based on component state.
  * Supports customizable content rendering and footer elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->