### PR TITLE
Cosmetic fixes to langium grammar

### DIFF
--- a/lightly_studio_view/.vscode/settings.json
+++ b/lightly_studio_view/.vscode/settings.json
@@ -7,5 +7,8 @@
     "svelte.enable-ts-plugin": true,
     "[ignore]": {
         "editor.defaultFormatter": "foxundermoon.shell-format"
+    },
+    "[langium]": {
+        "editor.defaultFormatter": "langium.langium-vscode"
     }
 }

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
@@ -1,142 +1,143 @@
 grammar LightlyQuery
 
-interface Expression {}
+interface Expression {
+}
 
 interface BooleanExpression extends Expression {
-    operator: string;
-    children: Expression[];
+  operator: string;
+  children: Expression[];
 }
 
 interface NotExpression extends Expression {
-    expression: Expression;
+  expression: Expression;
 }
 
 interface ComparisonExpression extends Expression {
-    left: Expression;
-    operator: '==' | '!=' | '<' | '>' | '<=' | '>=';
-    right: Expression;
+  left: Expression;
+  operator: '==' | '!=' | '<' | '>' | '<=' | '>=';
+  right: Expression;
 }
 
 interface FunctionCall extends Expression {
-    name: string;
-    args: Expression[];
+  name: string;
+  args: Expression[];
 }
 
 interface MemberCall extends Expression {
-    receiver: string;
-    member: string;
-    args: Expression[];
+  receiver: string;
+  member: string;
+  args: Expression[];
 }
 
 interface QualifiedFieldReference extends Expression {
-    receiver: string;
-    member: string;
+  receiver: string;
+  member: string;
 }
 
 interface TagInExpression extends Expression {
-    tag_name: Expression;
+  tag_name: Expression;
 }
 
 interface FieldReference extends Expression {
-    name: string;
+  name: string;
 }
 
 interface NumberLiteral extends Expression {
-    value: number;
+  value: number;
 }
 
 interface StringLiteral extends Expression {
-    value: string;
+  value: string;
 }
 
 entry Query:
-    (expression=Sample<true>) |
+  (expression=Sample<true>) |
     ('video:' expression=Sample<false>);
 
 Sample<isImage> returns Expression:
-    SampleOr<isImage>;
+  SampleOr<isImage>;
 
 SampleOr<isImage> returns Expression:
-    SampleAnd<isImage> ({BooleanExpression.children+=current} operator='or' children+=SampleAnd<isImage> ('or' children+=SampleAnd<isImage>)*)?
+  SampleAnd<isImage> ({BooleanExpression.children+=current} operator='or' children+=SampleAnd<isImage> ('or' children+=SampleAnd<isImage>)*)?
     | {BooleanExpression} operator='or' '(' children+=Sample<isImage> (',' children+=Sample<isImage>)+ ')';
 
 SampleAnd<isImage> returns Expression:
-    SampleUnary<isImage> ({BooleanExpression.children+=current} operator='and' children+=SampleUnary<isImage> ('and' children+=SampleUnary<isImage>)*)?
+  SampleUnary<isImage> ({BooleanExpression.children+=current} operator='and' children+=SampleUnary<isImage> ('and' children+=SampleUnary<isImage>)*)?
     | {BooleanExpression} operator='and' '(' children+=Sample<isImage> (',' children+=Sample<isImage>)+ ')';
 
 SampleUnary<isImage> returns Expression:
-    '(' Sample<isImage> ')'
+  '(' Sample<isImage> ')'
     | {NotExpression} 'not' expression=SampleUnary<isImage>
     | SampleComparison<isImage>
     | TagInExpression
     | AnnotationQuery;
 
 SampleComparison<isImage> returns ComparisonExpression:
-    SampleFieldReference<isImage> {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=Literal;
+  SampleFieldReference<isImage> {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=Literal;
 
 SampleFieldReference<isImage> returns QualifiedFieldReference:
-    (<isImage> {QualifiedFieldReference} receiver=ImageSampleFieldReceiver '.' member=ImageSampleFieldName)
+  (<isImage> {QualifiedFieldReference} receiver=ImageSampleFieldReceiver '.' member=ImageSampleFieldName)
     | (<!isImage> {QualifiedFieldReference} receiver=VideoSampleFieldReceiver '.' member=VideoSampleFieldName);
 
 ObjectDetection returns Expression:
-    ObjectDetectionOr;
+  ObjectDetectionOr;
 
 ObjectDetectionOr returns Expression:
-    ObjectDetectionAnd ({BooleanExpression.children+=current} operator='or' children+=ObjectDetectionAnd ('or' children+=ObjectDetectionAnd)*)?
+  ObjectDetectionAnd ({BooleanExpression.children+=current} operator='or' children+=ObjectDetectionAnd ('or' children+=ObjectDetectionAnd)*)?
     | {BooleanExpression} operator='or' '(' children+=ObjectDetection (',' children+=ObjectDetection)+ ')';
 
 ObjectDetectionAnd returns Expression:
-    ObjectDetectionUnary ({BooleanExpression.children+=current} operator='and' children+=ObjectDetectionUnary ('and' children+=ObjectDetectionUnary)*)?
+  ObjectDetectionUnary ({BooleanExpression.children+=current} operator='and' children+=ObjectDetectionUnary ('and' children+=ObjectDetectionUnary)*)?
     | {BooleanExpression} operator='and' '(' children+=ObjectDetection (',' children+=ObjectDetection)+ ')';
 
 ObjectDetectionUnary returns Expression:
-    '(' ObjectDetection ')'
+  '(' ObjectDetection ')'
     | {NotExpression} 'not' expression=ObjectDetectionUnary
     | ObjectDetectionComparison;
 
 ObjectDetectionComparison returns ComparisonExpression:
-    ObjectDetectionFieldReference {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=Literal;
+  ObjectDetectionFieldReference {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=Literal;
 
 ObjectDetectionFieldReceiver returns string:
-    'ObjectDetection' | 'ObjectDetectionField';
+  'ObjectDetection' | 'ObjectDetectionField';
 
 ObjectDetectionFieldReference returns Expression:
-    {FieldReference} name=ObjectDetectionFieldName
+  {FieldReference} name=ObjectDetectionFieldName
     | {QualifiedFieldReference} receiver=ObjectDetectionFieldReceiver '.' member=ObjectDetectionFieldName;
 
 AnnotationQuery returns Expression:
-    {FunctionCall} name='object_detection' '(' args+=ObjectDetection ')';
+  {FunctionCall} name='object_detection' '(' args+=ObjectDetection ')';
 
 TagInExpression returns Expression:
-    {TagInExpression} 'tags.contains(' tag_name=StringLiteral ')' |
+  {TagInExpression} 'tags.contains(' tag_name=StringLiteral ')' |
     {TagInExpression} tag_name=StringLiteral 'in' 'tags';
 
 ImageSampleFieldReceiver returns string:
-    'Image' | 'ImageSampleField';
+  'Image' | 'ImageSampleField';
 
 VideoSampleFieldReceiver returns string:
-    'Video' | 'VideoSampleField';
+  'Video' | 'VideoSampleField';
 
 CommonSampleFieldName returns string:
-    'created_at';
+  'created_at';
 
 ImageSampleFieldName returns string:
-    'file_name' | 'file_path_abs' | 'height' | 'width' | CommonSampleFieldName;
+  'file_name' | 'file_path_abs' | 'height' | 'width' | CommonSampleFieldName;
 
 VideoSampleFieldName returns string:
-    'file_name' | 'file_path_abs' | 'height' | 'width' | 'duration_s' | 'fps' | CommonSampleFieldName;
+  'file_name' | 'file_path_abs' | 'height' | 'width' | 'duration_s' | 'fps' | CommonSampleFieldName;
 
 ObjectDetectionFieldName returns string:
-    'height' | 'label' | 'width' | 'x' | 'y';
+  'height' | 'label' | 'width' | 'x' | 'y';
 
 Literal returns Expression:
-    NumberLiteral | StringLiteral;
+  NumberLiteral | StringLiteral;
 
 NumberLiteral returns Expression:
-    {NumberLiteral} value=NUMBER;
+  {NumberLiteral} value=NUMBER;
 
 StringLiteral returns Expression:
-    {StringLiteral} value=STRING;
+  {StringLiteral} value=STRING;
 
 terminal NUMBER returns number: /[0-9]+(\.[0-9]*)?/;
 terminal STRING: /"([^"\\\n\r]|\\.)*"|'([^'\\\n\r]|\\.)*'/;

--- a/lightly_studio_view/src/lib/components/QueryEditor/tmp-showcase-lightly-query.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/tmp-showcase-lightly-query.ts
@@ -21,7 +21,6 @@ import {
     isTagInExpression,
     isNumberLiteral,
     isStringLiteral,
-    // isBooleanLiteral,
     isNotExpression
 } from './language/generated/ast';
 
@@ -128,7 +127,6 @@ function transformToDSLJson(node: unknown): DSLJson {
     }
     if (isNumberLiteral(node)) return node.value;
     if (isStringLiteral(node)) return unquoteStringLiteral(node.value);
-    // if (isBooleanLiteral(node)) return node.value === 'true';
 
     if (hasExpression(node)) return transformToDSLJson(node.expression);
 


### PR DESCRIPTION
## What has changed and why?
* Format grammar file
* make tmp-showcase-lightly-query.ts work again

## How has it been tested?
Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated grammar formatting and indentation for the query language.

* **Refactor**
  * Query transformation no longer explicitly converts boolean literals to boolean values; such values are now treated as generic expressions/unhandled values during transformation.

* **Chores**
  * Set the default formatter for query-language files to use the language-specific formatter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->