### PR TITLE
Add comments to the query grammar

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
@@ -143,3 +143,4 @@ terminal NUMBER returns number: /[0-9]+(\.[0-9]*)?/;
 terminal STRING: /"([^"\\\n\r]|\\.)*"|'([^'\\\n\r]|\\.)*'/;
 
 hidden terminal WS: /\s+/;
+hidden terminal SL_COMMENT: /#[^\n\r]*/;


### PR DESCRIPTION
## What has changed and why?

Add comments to the query grammar. Characters after `#` are ignored.

## How has it been tested?

`npm run storybook`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query editor now supports single-line comments using the `#` prefix for adding notes and explanations within queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->