### PR TITLE
Rename instance segmentation query to segmentation mask

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
@@ -2,12 +2,9 @@ from .boolean_expression import AND, NOT, OR
 from .classification_expression import ClassificationField, ClassificationQuery
 from .dataset_query import DatasetQuery
 from .image_sample_field import ImageSampleField
-from .instance_segmentation_expression import (
-    InstanceSegmentationField,
-    InstanceSegmentationQuery,
-)
 from .object_detection_expression import ObjectDetectionField, ObjectDetectionQuery
 from .order_by import OrderByExpression, OrderByField
+from .segmentation_mask_expression import SegmentationMaskField, SegmentationMaskQuery
 from .video_sample_field import VideoSampleField
 
 __all__ = [
@@ -18,11 +15,11 @@ __all__ = [
     "ClassificationQuery",
     "DatasetQuery",
     "ImageSampleField",
-    "InstanceSegmentationField",
-    "InstanceSegmentationQuery",
     "ObjectDetectionField",
     "ObjectDetectionQuery",
     "OrderByExpression",
     "OrderByField",
+    "SegmentationMaskField",
+    "SegmentationMaskQuery",
     "VideoSampleField",
 ]

--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -17,14 +17,14 @@ from lightly_studio.core.dataset_query.classification_expression import (
     ClassificationQuery,
 )
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
-from lightly_studio.core.dataset_query.instance_segmentation_expression import (
-    InstanceSegmentationField,
-    InstanceSegmentationQuery,
-)
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
 from lightly_studio.core.dataset_query.object_detection_expression import (
     ObjectDetectionField,
     ObjectDetectionQuery,
+)
+from lightly_studio.core.dataset_query.segmentation_mask_expression import (
+    SegmentationMaskField,
+    SegmentationMaskQuery,
 )
 from lightly_studio.core.dataset_query.video_sample_field import VideoSampleField
 from lightly_studio.errors import QueryExprError
@@ -85,7 +85,7 @@ _STRING_FIELDS: dict[tuple[str, str], _EqualityField[str]] = {
     ("video", "file_path_abs"): VideoSampleField.file_path_abs,
     ("classification", "label"): ClassificationField.label,
     ("object_detection", "label"): ObjectDetectionField.label,
-    ("segmentation_mask", "label"): InstanceSegmentationField.label,
+    ("segmentation_mask", "label"): SegmentationMaskField.label,
 }
 
 _INTEGER_FIELDS: dict[tuple[str, str], _OrdinalField[int]] = {
@@ -97,10 +97,10 @@ _INTEGER_FIELDS: dict[tuple[str, str], _OrdinalField[int]] = {
     ("object_detection", "y"): ObjectDetectionField.y,
     ("object_detection", "width"): ObjectDetectionField.width,
     ("object_detection", "height"): ObjectDetectionField.height,
-    ("segmentation_mask", "x"): InstanceSegmentationField.x,
-    ("segmentation_mask", "y"): InstanceSegmentationField.y,
-    ("segmentation_mask", "width"): InstanceSegmentationField.width,
-    ("segmentation_mask", "height"): InstanceSegmentationField.height,
+    ("segmentation_mask", "x"): SegmentationMaskField.x,
+    ("segmentation_mask", "y"): SegmentationMaskField.y,
+    ("segmentation_mask", "width"): SegmentationMaskField.width,
+    ("segmentation_mask", "height"): SegmentationMaskField.height,
 }
 
 _DATETIME_FIELDS: dict[tuple[str, str], _OrdinalField[datetime]] = {
@@ -184,7 +184,7 @@ def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 C9
     if isinstance(expr, ObjectDetectionMatchExpr):
         return ObjectDetectionQuery.match(to_match_expression(expr=expr.subexpr))
     if isinstance(expr, SegmentationMaskMatchExpr):
-        return InstanceSegmentationQuery.match(to_match_expression(expr=expr.subexpr))
+        return SegmentationMaskQuery.match(to_match_expression(expr=expr.subexpr))
     if isinstance(expr, AndExpr):
         return AND(*(to_match_expression(expr=child) for child in expr.children))
     if isinstance(expr, OrExpr):

--- a/lightly_studio/src/lightly_studio/core/dataset_query/segmentation_mask_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/segmentation_mask_expression.py
@@ -22,7 +22,7 @@ from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.sample import SampleTable
 
 
-class InstanceSegmentationField:
+class SegmentationMaskField:
     """Providing access to predefined segmentation mask fields for queries."""
 
     width = ForeignNumericalField(
@@ -47,11 +47,11 @@ class InstanceSegmentationField:
     )
 
 
-class InstanceSegmentationQuery:
+class SegmentationMaskQuery:
     """Provides access to segmentation mask query operations."""
 
     @staticmethod
-    def match(*criteria: MatchExpression) -> InstanceSegmentationMatchExpression:
+    def match(*criteria: MatchExpression) -> SegmentationMaskMatchExpression:
         """Combine multiple segmentation mask criteria into a single subquery using logical AND.
 
         Args:
@@ -60,11 +60,11 @@ class InstanceSegmentationQuery:
         Returns:
             A single match expression for satisfying all criteria.
         """
-        return InstanceSegmentationMatchExpression(criterion=AND(*criteria))
+        return SegmentationMaskMatchExpression(criterion=AND(*criteria))
 
 
 @dataclass
-class InstanceSegmentationMatchExpression(MatchExpression):
+class SegmentationMaskMatchExpression(MatchExpression):
     """Expression for checking if a sample has a segmentation mask matching a criterion."""
 
     criterion: MatchExpression

--- a/lightly_studio/tests/core/dataset_query/test_segmentation_mask_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_segmentation_mask_expression.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from sqlmodel import Session, select
 
-from lightly_studio.core.dataset_query.instance_segmentation_expression import (
-    InstanceSegmentationField,
-    InstanceSegmentationQuery,
+from lightly_studio.core.dataset_query.segmentation_mask_expression import (
+    SegmentationMaskField,
+    SegmentationMaskQuery,
 )
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.image import ImageTable
@@ -17,10 +17,10 @@ from tests.helpers_resolvers import (
 )
 
 
-class TestInstanceSegmentationExpressions:
+class TestSegmentationMaskExpressions:
     def test_annotation_segmentation_mask_width__sql(self) -> None:
         query = select(ImageTable).where(
-            InstanceSegmentationQuery.match(InstanceSegmentationField.width <= 100).get()
+            SegmentationMaskQuery.match(SegmentationMaskField.width <= 100).get()
         )
         sql = str(query.compile(compile_kwargs={"literal_binds": True}))
         assert "EXISTS (SELECT 1" in sql
@@ -71,9 +71,9 @@ class TestInstanceSegmentationExpressions:
             .join(ImageTable.sample)
             .where(SampleTable.collection_id == collection_id)
             .where(
-                InstanceSegmentationQuery.match(
-                    InstanceSegmentationField.width > 100,
-                    InstanceSegmentationField.height == 100,
+                SegmentationMaskQuery.match(
+                    SegmentationMaskField.width > 100,
+                    SegmentationMaskField.height == 100,
                 ).get()
             )
         )
@@ -116,9 +116,7 @@ class TestInstanceSegmentationExpressions:
             select(ImageTable)
             .join(ImageTable.sample)
             .where(SampleTable.collection_id == collection_id)
-            .where(
-                InstanceSegmentationQuery.match(InstanceSegmentationField.label == "label1").get()
-            )
+            .where(SegmentationMaskQuery.match(SegmentationMaskField.label == "label1").get())
         )
         results = db_session.exec(query).all()
         # There are two annotations with this label but only one of the right type.


### PR DESCRIPTION
## What has changed and why?

Rename the dataset query module for segmentation masks to align with the new segmentation mask design.

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API naming from instance-segmentation to segmentation-mask terminology across dataset query operations. Users relying on instance-segmentation-related APIs will need to update their code to use the new segmentation-mask equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->