### PR TITLE
Make hardcoded query compatible with COCO dataset

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -27,7 +27,7 @@ describe('parseLightlyQuery', () => {
         });
     });
 
-    it('returns the hardcoded object_detection stub when parsing succeeds', () => {
+    it('returns the hardcoded query stub when parsing succeeds', () => {
         const result = parseLightlyQuery(
             {
                 parse: () => ({
@@ -46,32 +46,7 @@ describe('parseLightlyQuery', () => {
                     type: 'integer_expr',
                     field: { table: 'image', name: 'width' },
                     operator: '<',
-                    value: '400'
-                }
-            }
-        });
-    });
-
-    it('returns the hardcoded object_detection stub for a valid object_detection query', () => {
-        const result = parseLightlyQuery(
-            {
-                parse: () => ({
-                    lexerErrors: [],
-                    parserErrors: [],
-                    value: {} as Query
-                })
-            },
-            'object_detection(label == "cat")'
-        );
-
-        expect(result).toEqual({
-            status: 'ok',
-            queryExpr: {
-                match_expr: {
-                    type: 'integer_expr',
-                    field: { table: 'image', name: 'width' },
-                    operator: '<',
-                    value: '400'
+                    value: 400
                 }
             }
         });

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -43,13 +43,10 @@ describe('parseLightlyQuery', () => {
             status: 'ok',
             queryExpr: {
                 match_expr: {
-                    type: 'object_detection_match_expr',
-                    subexpr: {
-                        type: 'string_expr',
-                        field: { table: 'object_detection', name: 'label' },
-                        operator: '==',
-                        value: 'cat'
-                    }
+                    type: 'integer_expr',
+                    field: { table: 'image', name: 'width' },
+                    operator: '<',
+                    value: '400'
                 }
             }
         });
@@ -71,13 +68,10 @@ describe('parseLightlyQuery', () => {
             status: 'ok',
             queryExpr: {
                 match_expr: {
-                    type: 'object_detection_match_expr',
-                    subexpr: {
-                        type: 'string_expr',
-                        field: { table: 'object_detection', name: 'label' },
-                        operator: '==',
-                        value: 'cat'
-                    }
+                    type: 'integer_expr',
+                    field: { table: 'image', name: 'width' },
+                    operator: '<',
+                    value: '400'
                 }
             }
         });

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.ts
@@ -65,7 +65,7 @@ function toQueryExpr(_parseResult: Query): QueryExpr {
             type: 'integer_expr',
             field: { table: 'image', name: 'width' },
             operator: '<',
-            value: '400'
+            value: 400
         }
     };
 }

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.ts
@@ -62,13 +62,10 @@ export function parseLightlyQuery(
 function toQueryExpr(_parseResult: Query): QueryExpr {
     return {
         match_expr: {
-            type: 'object_detection_match_expr',
-            subexpr: {
-                type: 'string_expr',
-                field: { table: 'object_detection', name: 'label' },
-                operator: '==',
-                value: 'cat'
-            }
+            type: 'integer_expr',
+            field: { table: 'image', name: 'width' },
+            operator: '<',
+            value: '400'
         }
     };
 }


### PR DESCRIPTION
## What has changed and why?

Make hardcoded query compatible with COCO dataset.

The default image dataset loads instance segmentations, not object detection. Instead, we use a query constraining height.

## How has it been tested?

CI

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures for query expression translation to reflect a revised example query stub (now using an image width threshold comparison).

* **Chores**
  * Adjusted the editor's internal query expression stub to emit a different example comparison for demonstrations and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->