### PR TITLE
Clarify image specific wording and rename isSamples

### DIFF
--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -31,7 +31,7 @@
         embeddingFilter.clearFilter();
     };
 
-    const plotFilterItemLabel = $derived(isVideos ? 'video' : 'images');
+    const plotFilterItemLabel = $derived(isVideos ? 'video' : 'image');
     const isPlotFilterApplied = $derived($isPlotFilterAppliedStore);
     const plotFilterCount = $derived($plotFilterCountStore);
     const hasPlotFilterContext = $derived((isImages || isVideos) && plotFilterCount > 0);

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -9,10 +9,10 @@
     type Props = {
         collectionIdStore: Readable<string>;
         isVideos: boolean;
-        isSamples: boolean;
+        isImages: boolean;
     };
 
-    let { collectionIdStore, isVideos, isSamples }: Props = $props();
+    let { collectionIdStore, isVideos, isImages }: Props = $props();
 
     const { setRangeSelectionForCollection } = useGlobalStorage();
 
@@ -34,7 +34,7 @@
     const plotFilterItemLabel = $derived(isVideos ? 'video' : 'sample');
     const isPlotFilterApplied = $derived($isPlotFilterAppliedStore);
     const plotFilterCount = $derived($plotFilterCountStore);
-    const hasPlotFilterContext = $derived((isSamples || isVideos) && plotFilterCount > 0);
+    const hasPlotFilterContext = $derived((isImages || isVideos) && plotFilterCount > 0);
 </script>
 
 {#if hasPlotFilterContext}

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -31,7 +31,7 @@
         embeddingFilter.clearFilter();
     };
 
-    const plotFilterItemLabel = $derived(isVideos ? 'video' : 'sample');
+    const plotFilterItemLabel = $derived(isVideos ? 'video' : 'images');
     const isPlotFilterApplied = $derived($isPlotFilterAppliedStore);
     const plotFilterCount = $derived($plotFilterCountStore);
     const hasPlotFilterContext = $derived((isImages || isVideos) && plotFilterCount > 0);

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.test.ts
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.test.ts
@@ -58,12 +58,12 @@ describe('EmbeddingSelectionFilterItem', () => {
         });
     });
 
-    it('uses image hook only and renders sample label in samples view', () => {
+    it('uses image hook only and renders sample label in images view', () => {
         render(EmbeddingSelectionFilterItem, {
             props: {
                 collectionIdStore: writable('collection-id'),
                 isVideos: false,
-                isSamples: true
+                isImages: true
             }
         });
 
@@ -79,7 +79,7 @@ describe('EmbeddingSelectionFilterItem', () => {
             props: {
                 collectionIdStore: writable('collection-id'),
                 isVideos: true,
-                isSamples: false
+                isImages: false
             }
         });
 
@@ -93,7 +93,7 @@ describe('EmbeddingSelectionFilterItem', () => {
             props: {
                 collectionIdStore: writable('collection-id'),
                 isVideos: true,
-                isSamples: false
+                isImages: false
             }
         });
 
@@ -107,7 +107,7 @@ describe('EmbeddingSelectionFilterItem', () => {
             props: {
                 collectionIdStore: writable('collection-id'),
                 isVideos: false,
-                isSamples: true
+                isImages: true
             }
         });
 
@@ -121,7 +121,7 @@ describe('EmbeddingSelectionFilterItem', () => {
             props: {
                 collectionIdStore: writable('collection-id'),
                 isVideos: false,
-                isSamples: false
+                isImages: false
             }
         });
 

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.test.ts
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.test.ts
@@ -58,7 +58,7 @@ describe('EmbeddingSelectionFilterItem', () => {
         });
     });
 
-    it('uses image hook only and renders sample label in images view', () => {
+    it('uses image hook only and renders image label in images view', () => {
         render(EmbeddingSelectionFilterItem, {
             props: {
                 collectionIdStore: writable('collection-id'),
@@ -71,7 +71,7 @@ describe('EmbeddingSelectionFilterItem', () => {
         expect(mocks.useEmbeddingFilterForVideos).not.toHaveBeenCalled();
         expect(screen.getByTestId('embedding-selection-filter-chip')).toBeInTheDocument();
         expect(screen.getByText('Embedding Plot Filter')).toBeInTheDocument();
-        expect(screen.getByText(/1\s*sample/i)).toBeInTheDocument();
+        expect(screen.getByText(/1\s*image/i)).toBeInTheDocument();
     });
 
     it('uses video hook only and renders video label in videos view', () => {

--- a/lightly_studio_view/src/lib/components/Header/Header.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Header.svelte
@@ -18,7 +18,7 @@
 
     let { collection }: { collection: CollectionView } = $props();
 
-    const isSamples = $derived(isImagesRoute(page.route.id));
+    const isImages = $derived(isImagesRoute(page.route.id));
     const isVideos = $derived(isVideosRoute(page.route.id));
     const { settingsStore } = useSettings();
 
@@ -80,7 +80,7 @@
                 {/if}
             </div>
             <div class="flex flex-auto justify-end gap-2">
-                <Menu {isSamples} {isVideos} {hasEmbeddings} {collection} {user} />
+                <Menu {isImages} {isVideos} {hasEmbeddings} {collection} {user} />
                 {#if hasMinimumRole(user?.role, 'labeler')}
                     {#if $isEditingMode}
                         <Button

--- a/lightly_studio_view/src/lib/components/Header/Menu.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Menu.svelte
@@ -21,13 +21,13 @@
     import type { LightlyEnterpriseSession } from '$lib/hooks/useAuth/getLightlyEnterpriseSession/getLightlyEnterpriseSession';
 
     let {
-        isSamples = false,
+        isImages = false,
         isVideos = false,
         hasEmbeddings = false,
         collection,
         user
     } = $props<{
-        isSamples?: boolean;
+        isImages?: boolean;
         isVideos?: boolean;
         hasEmbeddings?: boolean;
         collection: CollectionView;
@@ -50,8 +50,8 @@
         testId: string;
     };
 
-    const hasClassifier = $derived(isSamples && hasEmbeddings);
-    const hasSelection = $derived(isSamples || isVideos);
+    const hasClassifier = $derived(isImages && hasEmbeddings);
+    const hasSelection = $derived(isImages || isVideos);
     const hasExport = $derived(
         collection.sample_type == 'image' ||
             collection.sample_type == 'video' ||

--- a/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
+++ b/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
@@ -6,19 +6,19 @@
     import type { CollectionView } from '$lib/api/lightly_studio_local';
 
     let {
-        isSamples = false,
+        isImages = false,
         isVideos = false,
         hasEmbeddings = false,
         collection
     } = $props<{
-        isSamples?: boolean;
+        isImages?: boolean;
         isVideos?: boolean;
         hasEmbeddings?: boolean;
         collection: CollectionView;
     }>();
 
-    const hasClassifier = $derived(isSamples && hasEmbeddings);
-    const hasSelection = $derived(isSamples || isVideos);
+    const hasClassifier = $derived(isImages && hasEmbeddings);
+    const hasSelection = $derived(isImages || isVideos);
     const isImageCollection = $derived(collection.sample_type == 'image');
     const isVideoCollection = $derived(
         collection.sample_type == 'video' || collection.sample_type == 'video_frame'

--- a/lightly_studio_view/src/lib/components/Samples/Samples.svelte
+++ b/lightly_studio_view/src/lib/components/Samples/Samples.svelte
@@ -234,11 +234,11 @@
 
 <GridContainer
     message={{
-        loading: 'Loading samples...',
-        error: 'Error loading samples',
+        loading: 'Loading images...',
+        error: 'Error loading images',
         empty: {
-            title: 'No samples found',
-            description: "This collection doesn't contain any samples."
+            title: 'No images found',
+            description: "This collection doesn't contain any images."
         }
     }}
     status={{
@@ -278,7 +278,7 @@
                             dataIndex={index}
                             dataTestId="sample-grid-item"
                             isSelected={$selectedSampleIds.has(samples[index].sample_id)}
-                            ariaLabel={`View sample: ${samples[index].file_name}`}
+                            ariaLabel={`View image: ${samples[index].file_name}`}
                             ondblclick={() => handleOnDoubleClick(samples[index].sample_id)}
                             onSelect={(event) =>
                                 handleGridItemSelect(event, samples[index].sample_id, index)}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -118,7 +118,7 @@
         }
     });
 
-    const isSamples = $derived(isImagesRoute(page.route.id));
+    const isImages = $derived(isImagesRoute(page.route.id));
     const isGroups = $derived(isGroupsRoute(page.route.id));
     const isGroupDetails = $derived(isGroupDetailsRoute(page.route.id));
     const isAnnotations = $derived(isAnnotationsRoute(page.route.id));
@@ -135,7 +135,7 @@
         let nextGridType: GridType | null = null;
         if (isAnnotations) {
             nextGridType = 'annotations';
-        } else if (isSamples) {
+        } else if (isImages) {
             nextGridType = 'images';
         } else if (isCaptions) {
             nextGridType = 'captions';
@@ -489,13 +489,13 @@
     });
 
     const showLeftSidebar = $derived(
-        isSamples || isAnnotations || isVideos || isVideoFrames || isGroups
+        isImages || isAnnotations || isVideos || isVideoFrames || isGroups
     );
 </script>
 
 <div class="flex-none">
     <Header {collection} />
-    <MenuDialogHost {isSamples} {isVideos} {hasEmbeddings} {collection} />
+    <MenuDialogHost {isImages} {isVideos} {hasEmbeddings} {collection} />
 </div>
 
 <div class="relative flex min-h-0 flex-1 flex-col">
@@ -517,14 +517,14 @@
                                     <EmbeddingSelectionFilterItem
                                         {collectionIdStore}
                                         {isVideos}
-                                        {isSamples}
+                                        {isImages}
                                     />
                                     <LabelsMenu
                                         {annotationFilterRows}
                                         onToggleAnnotationFilter={toggleAnnotationFilterSelection}
                                     />
 
-                                    {#if isSamples || isVideos || isVideoFrames}
+                                    {#if isImages || isVideos || isVideoFrames}
                                         {#key collectionId}
                                             <CombinedMetadataDimensionsFilters
                                                 {isVideos}
@@ -539,7 +539,7 @@
                 </div>
             {/if}
 
-            {#if (isSamples || isVideos) && $showPlot}
+            {#if (isImages || isVideos) && $showPlot}
                 <!-- When plot is shown, use PaneGroup for the main content + plot -->
                 <PaneGroup direction="horizontal" class="flex-1">
                     <Pane defaultSize={50} minSize={30} class="flex">
@@ -662,10 +662,10 @@
             {:else}
                 <!-- When plot is hidden or not samples view, show normal layout -->
                 <div class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2">
-                    {#if isSamples || isAnnotations || isVideos || isGroups}
+                    {#if isImages || isAnnotations || isVideos || isGroups}
                         <GridHeader>
                             {#snippet auxControls()}
-                                {#if (isSamples || isVideos) && hasEmbeddings}
+                                {#if (isImages || isVideos) && hasEmbeddings}
                                     <Button
                                         class="flex items-center space-x-1"
                                         data-testid="toggle-plot-button"
@@ -678,7 +678,7 @@
                                     </Button>
                                 {/if}
                             {/snippet}
-                            {#if (isSamples || isVideos) && hasEmbeddings}
+                            {#if (isImages || isVideos) && hasEmbeddings}
                                 <div
                                     class="relative"
                                     role="region"


### PR DESCRIPTION
## What has changed and why?

Renamed variables from `isSamples` to `isImages` and updated a few copies.

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated terminology across the app from "samples" to "images" for clarity.
  * UI labels and status messages (loading, error, empty states) now consistently say "images."
  * Accessibility labels updated to "View image."
  * Header/menu/layout controls and embedding-related UI now respond to the images route flag, changing when embedding tools and the embedding-plot filter chip appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->