### PR TITLE
Prepare tests for frontend query parsing

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -28,10 +28,24 @@ describe('QueryExprTranslationRequest', () => {
     });
 });
 
+describe('parseLightlyQuery error handling', () => {
+    it('returns an error result when the parser reports errors', () => {
+        const parser = createParser();
+        const result = parseLightlyQuery(parser, 'invalid_query');
+
+        expect(result.status).toBe('error');
+        if (result.status !== 'error') return;
+        expect(result.errors).toHaveLength(2);
+        expect(result.errors[0].message).toMatch(/unexpected character/);
+        expect(result.errors[1].message).toMatch(
+            /Expecting: one of these possible Token sequences:/
+        );
+    });
+});
+
 describe('parseLightlyQuery', () => {
     it('example parse-translate test', () => {
         const parser = createParser();
-
         const result = parseLightlyQuery(parser, 'Image.width == 1000');
 
         expect(result).toEqual({

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -10,16 +10,15 @@ import {
     LightlyQueryGeneratedModule,
     LightlyQueryGeneratedSharedModule
 } from './generated/module.js';
-import type { Query } from './generated/ast.js';
 
 function createParser() {
     const shared = inject(
         createDefaultSharedCoreModule(EmptyFileSystem),
         LightlyQueryGeneratedSharedModule
     );
-    const LightlyQuery = inject(createDefaultCoreModule({ shared }), LightlyQueryGeneratedModule);
-    shared.ServiceRegistry.register(LightlyQuery);
-    return LightlyQuery.parser.LangiumParser;
+    const lightlyQuery = inject(createDefaultCoreModule({ shared }), LightlyQueryGeneratedModule);
+    shared.ServiceRegistry.register(lightlyQuery);
+    return lightlyQuery.parser.LangiumParser;
 }
 
 const parser = createParser();

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -5,13 +5,14 @@ import {
     createDefaultSharedCoreModule,
     inject
 } from 'langium';
+import type { LangiumParser } from 'langium';
 import { QueryExprTranslationRequest, parseLightlyQuery } from './query-expr-translation.js';
 import {
     LightlyQueryGeneratedModule,
     LightlyQueryGeneratedSharedModule
 } from './generated/module.js';
 
-function createParser() {
+function createParser(): LangiumParser {
     const shared = inject(
         createDefaultSharedCoreModule(EmptyFileSystem),
         LightlyQueryGeneratedSharedModule

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -1,6 +1,26 @@
 import { describe, it, expect } from 'vitest';
+import {
+    EmptyFileSystem,
+    createDefaultCoreModule,
+    createDefaultSharedCoreModule,
+    inject
+} from 'langium';
 import { QueryExprTranslationRequest, parseLightlyQuery } from './query-expr-translation.js';
+import {
+    LightlyQueryGeneratedModule,
+    LightlyQueryGeneratedSharedModule
+} from './generated/module.js';
 import type { Query } from './generated/ast.js';
+
+function createParser() {
+    const shared = inject(
+        createDefaultSharedCoreModule(EmptyFileSystem),
+        LightlyQueryGeneratedSharedModule
+    );
+    const LightlyQuery = inject(createDefaultCoreModule({ shared }), LightlyQueryGeneratedModule);
+    shared.ServiceRegistry.register(LightlyQuery);
+    return LightlyQuery.parser.LangiumParser;
+}
 
 describe('QueryExprTranslationRequest', () => {
     it('has the expected method name', () => {
@@ -9,35 +29,10 @@ describe('QueryExprTranslationRequest', () => {
 });
 
 describe('parseLightlyQuery', () => {
-    it('returns an error result when the parser reports errors', () => {
-        const result = parseLightlyQuery(
-            {
-                parse: () => ({
-                    lexerErrors: [],
-                    parserErrors: [{ message: 'Unexpected token', line: 3, column: 5 }],
-                    value: {} as Query
-                })
-            },
-            'invalid'
-        );
+    it('example parse-translate test', () => {
+        const parser = createParser();
 
-        expect(result).toEqual({
-            status: 'error',
-            errors: [{ message: 'Unexpected token', line: 3, column: 5 }]
-        });
-    });
-
-    it('returns the hardcoded query stub when parsing succeeds', () => {
-        const result = parseLightlyQuery(
-            {
-                parse: () => ({
-                    lexerErrors: [],
-                    parserErrors: [],
-                    value: {} as Query
-                })
-            },
-            'valid'
-        );
+        const result = parseLightlyQuery(parser, 'Image.width == 1000');
 
         expect(result).toEqual({
             status: 'ok',

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -22,6 +22,8 @@ function createParser() {
     return LightlyQuery.parser.LangiumParser;
 }
 
+const parser = createParser();
+
 describe('QueryExprTranslationRequest', () => {
     it('has the expected method name', () => {
         expect(QueryExprTranslationRequest.method).toBe('lightly-query/queryExprTranslation');
@@ -30,7 +32,6 @@ describe('QueryExprTranslationRequest', () => {
 
 describe('parseLightlyQuery error handling', () => {
     it('returns an error result when the parser reports errors', () => {
-        const parser = createParser();
         const result = parseLightlyQuery(parser, 'invalid_query');
 
         expect(result.status).toBe('error');
@@ -45,7 +46,6 @@ describe('parseLightlyQuery error handling', () => {
 
 describe('parseLightlyQuery', () => {
     it('example parse-translate test', () => {
-        const parser = createParser();
         const result = parseLightlyQuery(parser, 'Image.width == 1000');
 
         expect(result).toEqual({


### PR DESCRIPTION
## What has changed and why?

Create Langium parser in the test file so that the tests can be populated.

## How has it been tested?

CI

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced mocked parser stubs with a real parser integration in query-expression tests to improve realism.
  * Added an error-handling test that validates parsing returns error status, expects two errors, and checks their message content.
  * Updated success test to assert the translated query-expression structure for a valid query, increasing confidence in parsing and translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->