### PR TITLE
Add memory consumption performance tests

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -354,20 +354,22 @@ jobs:
           if [ -f performance-metrics.json ]; then
             echo "## 🚀 Performance Test Results" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| Test | Render Time | Status |" >> $GITHUB_STEP_SUMMARY
-            echo "|------|-------------|--------|" >> $GITHUB_STEP_SUMMARY
+            echo "| Test | Render Time | Memory Consumption | Status |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|-------------|--------------------|--------|" >> $GITHUB_STEP_SUMMARY
 
             node -e "
               const metrics = require('./performance-metrics.json');
               metrics.forEach(m => {
                 const status = m.passed ? '✅ Pass' : '❌ Fail';
                 const time = Math.round(m.median);
-                console.log(\`| \${m.test} | \${time}ms | \${status} |\`);
+                const memoryUsageMb = Math.round(m.memoryUsageMb?.median ?? m.memoryUsageMb ?? NaN);
+                const memory = Number.isNaN(memoryUsageMb) ? 'N/A' : \`\${memoryUsageMb} MB\`;
+                console.log(\`| \${m.test} | \${time}ms | \${memory} | \${status} |\`);
               });
             " >> $GITHUB_STEP_SUMMARY
 
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "_Max render time: 5000ms_" >> $GITHUB_STEP_SUMMARY
+            echo "_Max render time: 5000ms • Max memory consumption: 256 MB_" >> $GITHUB_STEP_SUMMARY
           else
             echo "⚠️ No performance metrics found" >> $GITHUB_STEP_SUMMARY
           fi

--- a/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
@@ -1,7 +1,9 @@
 import {
     expect,
     measureElementRendering,
-    measureWithMedian,
+    measureMemoryConsumption,
+    measureRenderAndMemory,
+    type MeasurementSummary,
     setNetworkThrottling,
     test
 } from '../utils';
@@ -18,6 +20,7 @@ const metrics: Array<{
     min: number;
     max: number;
     average: number;
+    memoryUsageMb: MeasurementSummary;
     passed: boolean;
 }> = [];
 
@@ -31,27 +34,30 @@ function saveMetrics() {
 test('samples grid renders within 5 seconds', async ({ page, samplesPage }) => {
     await setNetworkThrottling(page, 'Fast4G');
 
-    const result = await measureWithMedian(async () => {
+    const result = await measureRenderAndMemory(async () => {
         await page.reload();
         await samplesPage.goto();
-        return await measureElementRendering(page, samplesPage.getSampleByIndex(1));
+        const renderTimeMs = await measureElementRendering(page, samplesPage.getSampleByIndex(1));
+        const memoryUsageMb = await measureMemoryConsumption(page);
+        return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.median < MAX_RENDER_TIME_MS;
+    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
 
     console.log('samples-grid measurements:', result);
 
     metrics.push({
         test: 'samples-grid',
-        measurements: result.measurements,
-        median: result.median,
-        min: result.min,
-        max: result.max,
-        average: result.average,
+        measurements: result.renderTimeMs.measurements,
+        median: result.renderTimeMs.median,
+        min: result.renderTimeMs.min,
+        max: result.renderTimeMs.max,
+        average: result.renderTimeMs.average,
+        memoryUsageMb: result.memoryUsageMb,
         passed
     });
     saveMetrics();
-    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });
 
 test('sample details renders within 5 seconds', async ({ page, samplesPage }) => {
@@ -59,29 +65,31 @@ test('sample details renders within 5 seconds', async ({ page, samplesPage }) =>
 
     await setNetworkThrottling(page, 'Fast4G');
 
-    const result = await measureWithMedian(async () => {
+    const result = await measureRenderAndMemory(async () => {
         await samplesPage.goto();
         await samplesPage.doubleClickFirstSample();
-        const time = await measureElementRendering(page, page.getByText('Sample 1 of 128'));
+        const renderTimeMs = await measureElementRendering(page, page.getByText('Sample 1 of 128'));
+        const memoryUsageMb = await measureMemoryConsumption(page);
         await page.goBack();
-        return time;
+        return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.median < MAX_RENDER_TIME_MS;
+    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
     console.log('sample-details measurements:', result);
 
     metrics.push({
         test: 'sample-details',
-        measurements: result.measurements,
-        median: result.median,
-        min: result.min,
-        max: result.max,
-        average: result.average,
+        measurements: result.renderTimeMs.measurements,
+        median: result.renderTimeMs.median,
+        min: result.renderTimeMs.min,
+        max: result.renderTimeMs.max,
+        average: result.renderTimeMs.average,
+        memoryUsageMb: result.memoryUsageMb,
         passed
     });
     saveMetrics();
 
-    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });
 
 test('sample details renders next image within 5 seconds', async ({
@@ -93,31 +101,33 @@ test('sample details renders next image within 5 seconds', async ({
 
     await setNetworkThrottling(page, 'Fast4G');
 
-    const result = await measureWithMedian(async () => {
+    const result = await measureRenderAndMemory(async () => {
         await samplesPage.goto();
         await samplesPage.doubleClickFirstSample();
 
         await page.getByText('Sample 1 of 128').waitFor();
         await sampleDetailsPage.getNextButton().click();
-        const time = await measureElementRendering(page, page.getByText('Sample 2 of 128'));
-        return time;
+        const renderTimeMs = await measureElementRendering(page, page.getByText('Sample 2 of 128'));
+        const memoryUsageMb = await measureMemoryConsumption(page);
+        return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.median < MAX_RENDER_TIME_MS;
+    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
     console.log('sample-details-next-image measurements:', result);
 
     metrics.push({
         test: 'sample-details-next-image',
-        measurements: result.measurements,
-        median: result.median,
-        min: result.min,
-        max: result.max,
-        average: result.average,
+        measurements: result.renderTimeMs.measurements,
+        median: result.renderTimeMs.median,
+        min: result.renderTimeMs.min,
+        max: result.renderTimeMs.max,
+        average: result.renderTimeMs.average,
+        memoryUsageMb: result.memoryUsageMb,
         passed
     });
     saveMetrics();
 
-    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });
 
 test('sample details renders prev image within 5 seconds', async ({
@@ -129,55 +139,63 @@ test('sample details renders prev image within 5 seconds', async ({
 
     await setNetworkThrottling(page, 'Fast4G');
 
-    const result = await measureWithMedian(async () => {
+    const result = await measureRenderAndMemory(async () => {
         await samplesPage.goto();
         await samplesPage.getSampleByIndex(1).dblclick();
         await page.getByText('Sample 2 of 128').waitFor({ state: 'visible' });
         await sampleDetailsPage.getPrevButton().click();
-        const time = await measureElementRendering(page, page.getByText('Sample 1 of 128'));
-        return time;
+        const renderTimeMs = await measureElementRendering(page, page.getByText('Sample 1 of 128'));
+        const memoryUsageMb = await measureMemoryConsumption(page);
+        return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.median < MAX_RENDER_TIME_MS;
+    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
     console.log('sample-details-prev-image measurements:', result);
 
     metrics.push({
         test: 'sample-details-prev-image',
-        measurements: result.measurements,
-        median: result.median,
-        min: result.min,
-        max: result.max,
-        average: result.average,
+        measurements: result.renderTimeMs.measurements,
+        median: result.renderTimeMs.median,
+        min: result.renderTimeMs.min,
+        max: result.renderTimeMs.max,
+        average: result.renderTimeMs.average,
+        memoryUsageMb: result.memoryUsageMb,
         passed
     });
     saveMetrics();
 
-    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });
 
 test('annotations grid renders within 5 seconds', async ({ page, annotationsPage }) => {
     await setNetworkThrottling(page, 'Fast4G');
 
-    const result = await measureWithMedian(async () => {
+    const result = await measureRenderAndMemory(async () => {
         await page.reload();
         await annotationsPage.goto();
-        return await measureElementRendering(page, annotationsPage.getAnnotations().nth(1));
+        const renderTimeMs = await measureElementRendering(
+            page,
+            annotationsPage.getAnnotations().nth(1)
+        );
+        const memoryUsageMb = await measureMemoryConsumption(page);
+        return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.median < MAX_RENDER_TIME_MS;
+    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
 
     metrics.push({
         test: 'annotations-grid',
-        measurements: result.measurements,
-        median: result.median,
-        min: result.min,
-        max: result.max,
-        average: result.average,
+        measurements: result.renderTimeMs.measurements,
+        median: result.renderTimeMs.median,
+        min: result.renderTimeMs.min,
+        max: result.renderTimeMs.max,
+        average: result.renderTimeMs.average,
+        memoryUsageMb: result.memoryUsageMb,
         passed
     });
     saveMetrics();
 
-    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });
 
 test('annotation details renders within 5 seconds', async ({
@@ -188,27 +206,32 @@ test('annotation details renders within 5 seconds', async ({
     await annotationsPage.goto();
     await setNetworkThrottling(page, 'Fast4G');
 
-    const result = await measureWithMedian(async () => {
+    const result = await measureRenderAndMemory(async () => {
         await annotationsPage.goto();
         await annotationsPage.clickAnnotation(0);
         await annotationDetailsPage.waitForNavigation();
-        const time = await measureElementRendering(page, annotationDetailsPage.getAnnotationBox());
+        const renderTimeMs = await measureElementRendering(
+            page,
+            annotationDetailsPage.getAnnotationBox()
+        );
+        const memoryUsageMb = await measureMemoryConsumption(page);
         await page.goBack();
-        return time;
+        return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.median < MAX_RENDER_TIME_MS;
+    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
 
     metrics.push({
         test: 'annotation-details',
-        measurements: result.measurements,
-        median: result.median,
-        min: result.min,
-        max: result.max,
-        average: result.average,
+        measurements: result.renderTimeMs.measurements,
+        median: result.renderTimeMs.median,
+        min: result.renderTimeMs.min,
+        max: result.renderTimeMs.max,
+        average: result.renderTimeMs.average,
+        memoryUsageMb: result.memoryUsageMb,
         passed
     });
     saveMetrics();
 
-    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });

--- a/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
@@ -1,17 +1,21 @@
 import {
-    expect,
+    expectWithinPerformanceLimits,
+    isWithinPerformanceLimits,
     measureElementRendering,
     measureMemoryConsumption,
     measureRenderAndMemory,
-    type MeasurementSummary,
     setNetworkThrottling,
     test
 } from '../utils';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const MAX_RENDER_TIME_MS = 5000;
+const PERFORMANCE_LIMITS = {
+    maxRenderTimeMs: 5000,
+    maxMemoryUsageMb: 256
+};
 const MEASUREMENT_ITERATIONS = 5;
+type MeasurementSummary = Awaited<ReturnType<typeof measureRenderAndMemory>>['memoryUsageMb'];
 
 const metrics: Array<{
     test: string;
@@ -42,7 +46,7 @@ test('samples grid renders within 5 seconds', async ({ page, samplesPage }) => {
         return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
+    const passed = isWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 
     console.log('samples-grid measurements:', result);
 
@@ -57,7 +61,7 @@ test('samples grid renders within 5 seconds', async ({ page, samplesPage }) => {
         passed
     });
     saveMetrics();
-    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expectWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 });
 
 test('sample details renders within 5 seconds', async ({ page, samplesPage }) => {
@@ -74,7 +78,7 @@ test('sample details renders within 5 seconds', async ({ page, samplesPage }) =>
         return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
+    const passed = isWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
     console.log('sample-details measurements:', result);
 
     metrics.push({
@@ -89,7 +93,7 @@ test('sample details renders within 5 seconds', async ({ page, samplesPage }) =>
     });
     saveMetrics();
 
-    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expectWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 });
 
 test('sample details renders next image within 5 seconds', async ({
@@ -112,7 +116,7 @@ test('sample details renders next image within 5 seconds', async ({
         return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
+    const passed = isWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
     console.log('sample-details-next-image measurements:', result);
 
     metrics.push({
@@ -127,7 +131,7 @@ test('sample details renders next image within 5 seconds', async ({
     });
     saveMetrics();
 
-    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expectWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 });
 
 test('sample details renders prev image within 5 seconds', async ({
@@ -149,7 +153,7 @@ test('sample details renders prev image within 5 seconds', async ({
         return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
+    const passed = isWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
     console.log('sample-details-prev-image measurements:', result);
 
     metrics.push({
@@ -164,7 +168,7 @@ test('sample details renders prev image within 5 seconds', async ({
     });
     saveMetrics();
 
-    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expectWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 });
 
 test('annotations grid renders within 5 seconds', async ({ page, annotationsPage }) => {
@@ -181,7 +185,7 @@ test('annotations grid renders within 5 seconds', async ({ page, annotationsPage
         return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
+    const passed = isWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 
     metrics.push({
         test: 'annotations-grid',
@@ -195,7 +199,7 @@ test('annotations grid renders within 5 seconds', async ({ page, annotationsPage
     });
     saveMetrics();
 
-    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expectWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 });
 
 test('annotation details renders within 5 seconds', async ({
@@ -219,7 +223,7 @@ test('annotation details renders within 5 seconds', async ({
         return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
+    const passed = isWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 
     metrics.push({
         test: 'annotation-details',
@@ -233,5 +237,5 @@ test('annotation details renders within 5 seconds', async ({
     });
     saveMetrics();
 
-    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expectWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 });

--- a/lightly_studio_view/e2e/utils.ts
+++ b/lightly_studio_view/e2e/utils.ts
@@ -14,6 +14,30 @@ import { NETWORK_PRESETS, type NetworkPreset } from './constants';
 
 export { expect };
 
+export interface MeasurementSummary {
+    measurements: number[];
+    median: number;
+    min: number;
+    max: number;
+    average: number;
+}
+
+interface BrowserPerformanceWithMemory extends Performance {
+    memory?: {
+        usedJSHeapSize?: number;
+    };
+}
+
+interface RenderAndMemoryMeasurement {
+    renderTimeMs: number;
+    memoryUsageMb: number;
+}
+
+export interface RenderAndMemorySummary {
+    renderTimeMs: MeasurementSummary;
+    memoryUsageMb: MeasurementSummary;
+}
+
 export async function gotoFirstPage(page: Page): Promise<void> {
     await page.goto('/');
     await expect(page.getByTestId('sample-grid-item').first()).toBeVisible({ timeout: 10000 });
@@ -247,6 +271,31 @@ function calculateMedian(values: number[]): number {
     return sorted[mid];
 }
 
+export function summarizeMeasurements(measurements: number[]): MeasurementSummary {
+    return {
+        measurements,
+        median: calculateMedian(measurements),
+        min: Math.min(...measurements),
+        max: Math.max(...measurements),
+        average: measurements.reduce((a, b) => a + b, 0) / measurements.length
+    };
+}
+
+export async function measureMemoryConsumption(page: Page): Promise<number> {
+    return page.evaluate(() => {
+        const memory = (performance as BrowserPerformanceWithMemory).memory;
+        const usedJsHeapSize = memory?.usedJSHeapSize;
+
+        if (typeof usedJsHeapSize !== 'number') {
+            throw new Error(
+                'performance.memory.usedJSHeapSize is unavailable. Run this test in Chromium.'
+            );
+        }
+
+        return usedJsHeapSize / (1024 * 1024);
+    });
+}
+
 /**
  * Measures element rendering time multiple times and returns statistics including the median.
  * This provides more stable performance measurements by reducing the impact of outliers.
@@ -265,13 +314,7 @@ function calculateMedian(values: number[]): number {
 export async function measureWithMedian(
     measureFn: () => Promise<number>,
     iterations: number = 5
-): Promise<{
-    measurements: number[];
-    median: number;
-    min: number;
-    max: number;
-    average: number;
-}> {
+): Promise<MeasurementSummary> {
     const measurements: number[] = [];
 
     for (let i = 0; i < iterations; i++) {
@@ -279,12 +322,25 @@ export async function measureWithMedian(
         measurements.push(measurement);
     }
 
+    return summarizeMeasurements(measurements);
+}
+
+export async function measureRenderAndMemory(
+    measureFn: () => Promise<RenderAndMemoryMeasurement>,
+    iterations: number = 5
+): Promise<RenderAndMemorySummary> {
+    const renderMeasurements: number[] = [];
+    const memoryMeasurements: number[] = [];
+
+    for (let i = 0; i < iterations; i++) {
+        const measurement = await measureFn();
+        renderMeasurements.push(measurement.renderTimeMs);
+        memoryMeasurements.push(measurement.memoryUsageMb);
+    }
+
     return {
-        measurements,
-        median: calculateMedian(measurements),
-        min: Math.min(...measurements),
-        max: Math.max(...measurements),
-        average: measurements.reduce((a, b) => a + b, 0) / measurements.length
+        renderTimeMs: summarizeMeasurements(renderMeasurements),
+        memoryUsageMb: summarizeMeasurements(memoryMeasurements)
     };
 }
 

--- a/lightly_studio_view/e2e/utils.ts
+++ b/lightly_studio_view/e2e/utils.ts
@@ -14,14 +14,6 @@ import { NETWORK_PRESETS, type NetworkPreset } from './constants';
 
 export { expect };
 
-export interface MeasurementSummary {
-    measurements: number[];
-    median: number;
-    min: number;
-    max: number;
-    average: number;
-}
-
 interface BrowserPerformanceWithMemory extends Performance {
     memory?: {
         usedJSHeapSize?: number;
@@ -34,8 +26,13 @@ interface RenderAndMemoryMeasurement {
 }
 
 export interface RenderAndMemorySummary {
-    renderTimeMs: MeasurementSummary;
-    memoryUsageMb: MeasurementSummary;
+    renderTimeMs: ReturnType<typeof summarizeMeasurements>;
+    memoryUsageMb: ReturnType<typeof summarizeMeasurements>;
+}
+
+export interface PerformanceLimits {
+    maxRenderTimeMs: number;
+    maxMemoryUsageMb: number;
 }
 
 export async function gotoFirstPage(page: Page): Promise<void> {
@@ -281,6 +278,8 @@ export function summarizeMeasurements(measurements: number[]): MeasurementSummar
     };
 }
 
+type MeasurementSummary = ReturnType<typeof summarizeMeasurements>;
+
 export async function measureMemoryConsumption(page: Page): Promise<number> {
     return page.evaluate(() => {
         const memory = (performance as BrowserPerformanceWithMemory).memory;
@@ -342,6 +341,24 @@ export async function measureRenderAndMemory(
         renderTimeMs: summarizeMeasurements(renderMeasurements),
         memoryUsageMb: summarizeMeasurements(memoryMeasurements)
     };
+}
+
+export function isWithinPerformanceLimits(
+    result: RenderAndMemorySummary,
+    limits: PerformanceLimits
+): boolean {
+    return (
+        result.renderTimeMs.median < limits.maxRenderTimeMs &&
+        result.memoryUsageMb.median < limits.maxMemoryUsageMb
+    );
+}
+
+export function expectWithinPerformanceLimits(
+    result: RenderAndMemorySummary,
+    limits: PerformanceLimits
+): void {
+    expect(result.renderTimeMs.median).toBeLessThan(limits.maxRenderTimeMs);
+    expect(result.memoryUsageMb.median).toBeLessThan(limits.maxMemoryUsageMb);
 }
 
 /**

--- a/lightly_studio_view/e2e/videos/videos-performance.e2e-test.ts
+++ b/lightly_studio_view/e2e/videos/videos-performance.e2e-test.ts
@@ -1,7 +1,9 @@
 import {
     expect,
     measureElementRendering,
-    measureWithMedian,
+    measureMemoryConsumption,
+    measureRenderAndMemory,
+    type MeasurementSummary,
     setNetworkThrottling,
     test
 } from '../utils';
@@ -18,6 +20,7 @@ const metrics: Array<{
     min: number;
     max: number;
     average: number;
+    memoryUsageMb: MeasurementSummary;
     passed: boolean;
 }> = [];
 
@@ -31,105 +34,124 @@ function saveMetrics() {
 test('videos grid renders within 5 seconds', async ({ page, videosPage }) => {
     await setNetworkThrottling(page, 'Fast4G');
 
-    const result = await measureWithMedian(async () => {
+    const result = await measureRenderAndMemory(async () => {
         await page.reload();
         await videosPage.goto();
-        return await measureElementRendering(page, videosPage.getVideoByIndex(1));
+        const renderTimeMs = await measureElementRendering(page, videosPage.getVideoByIndex(1));
+        const memoryUsageMb = await measureMemoryConsumption(page);
+        return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.median < MAX_RENDER_TIME_MS;
+    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
 
     metrics.push({
         test: 'videos-grid',
-        measurements: result.measurements,
-        median: result.median,
-        min: result.min,
-        max: result.max,
-        average: result.average,
+        measurements: result.renderTimeMs.measurements,
+        median: result.renderTimeMs.median,
+        min: result.renderTimeMs.min,
+        max: result.renderTimeMs.max,
+        average: result.renderTimeMs.average,
+        memoryUsageMb: result.memoryUsageMb,
         passed
     });
     saveMetrics();
 
-    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });
 
 test('video frames grid renders within 5 seconds', async ({ page, videoFramesPage }) => {
     await setNetworkThrottling(page, 'Fast4G');
 
-    const result = await measureWithMedian(async () => {
+    const result = await measureRenderAndMemory(async () => {
         await page.reload();
         await videoFramesPage.goto();
-        return await measureElementRendering(page, videoFramesPage.getVideoFrameByIndex(1));
+        const renderTimeMs = await measureElementRendering(
+            page,
+            videoFramesPage.getVideoFrameByIndex(1)
+        );
+        const memoryUsageMb = await measureMemoryConsumption(page);
+        return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.median < MAX_RENDER_TIME_MS;
+    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
 
     metrics.push({
         test: 'video-frames-grid',
-        measurements: result.measurements,
-        median: result.median,
-        min: result.min,
-        max: result.max,
-        average: result.average,
+        measurements: result.renderTimeMs.measurements,
+        median: result.renderTimeMs.median,
+        min: result.renderTimeMs.min,
+        max: result.renderTimeMs.max,
+        average: result.renderTimeMs.average,
+        memoryUsageMb: result.memoryUsageMb,
         passed
     });
     saveMetrics();
 
-    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });
 
 test('video frame details renders within 5 seconds', async ({ page, videoFramesPage }) => {
     await videoFramesPage.goto();
     await setNetworkThrottling(page, 'Fast4G');
 
-    const result = await measureWithMedian(async () => {
+    const result = await measureRenderAndMemory(async () => {
         await videoFramesPage.goto();
         await videoFramesPage.doubleClickFirstVideoFrame();
-        const time = await measureElementRendering(page, videoFramesPage.getSampleDetails());
+        const renderTimeMs = await measureElementRendering(
+            page,
+            videoFramesPage.getSampleDetails()
+        );
+        const memoryUsageMb = await measureMemoryConsumption(page);
         await page.goBack();
-        return time;
+        return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.median < MAX_RENDER_TIME_MS;
+    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
 
     metrics.push({
         test: 'video-frame-details',
-        measurements: result.measurements,
-        median: result.median,
-        min: result.min,
-        max: result.max,
-        average: result.average,
+        measurements: result.renderTimeMs.measurements,
+        median: result.renderTimeMs.median,
+        min: result.renderTimeMs.min,
+        max: result.renderTimeMs.max,
+        average: result.renderTimeMs.average,
+        memoryUsageMb: result.memoryUsageMb,
         passed
     });
     saveMetrics();
 
-    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });
 
 test('video details renders within 5 seconds', async ({ page, videosPage }) => {
     await videosPage.goto();
     await setNetworkThrottling(page, 'Fast4G');
 
-    const result = await measureWithMedian(async () => {
+    const result = await measureRenderAndMemory(async () => {
         await videosPage.goto();
         await videosPage.getVideoByIndex(0).dblclick();
-        const time = await measureElementRendering(page, page.getByTestId('video-file-name'));
+        const renderTimeMs = await measureElementRendering(
+            page,
+            page.getByTestId('video-file-name')
+        );
+        const memoryUsageMb = await measureMemoryConsumption(page);
         await page.goBack();
-        return time;
+        return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.median < MAX_RENDER_TIME_MS;
+    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
 
     metrics.push({
         test: 'video-details',
-        measurements: result.measurements,
-        median: result.median,
-        min: result.min,
-        max: result.max,
-        average: result.average,
+        measurements: result.renderTimeMs.measurements,
+        median: result.renderTimeMs.median,
+        min: result.renderTimeMs.min,
+        max: result.renderTimeMs.max,
+        average: result.renderTimeMs.average,
+        memoryUsageMb: result.memoryUsageMb,
         passed
     });
     saveMetrics();
 
-    expect(result.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
 });

--- a/lightly_studio_view/e2e/videos/videos-performance.e2e-test.ts
+++ b/lightly_studio_view/e2e/videos/videos-performance.e2e-test.ts
@@ -1,17 +1,21 @@
 import {
-    expect,
+    expectWithinPerformanceLimits,
+    isWithinPerformanceLimits,
     measureElementRendering,
     measureMemoryConsumption,
     measureRenderAndMemory,
-    type MeasurementSummary,
     setNetworkThrottling,
     test
 } from '../utils';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const MAX_RENDER_TIME_MS = 5000;
+const PERFORMANCE_LIMITS = {
+    maxRenderTimeMs: 5000,
+    maxMemoryUsageMb: 256
+};
 const MEASUREMENT_ITERATIONS = 5;
+type MeasurementSummary = Awaited<ReturnType<typeof measureRenderAndMemory>>['memoryUsageMb'];
 
 const metrics: Array<{
     test: string;
@@ -42,7 +46,7 @@ test('videos grid renders within 5 seconds', async ({ page, videosPage }) => {
         return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
+    const passed = isWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 
     metrics.push({
         test: 'videos-grid',
@@ -56,7 +60,7 @@ test('videos grid renders within 5 seconds', async ({ page, videosPage }) => {
     });
     saveMetrics();
 
-    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expectWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 });
 
 test('video frames grid renders within 5 seconds', async ({ page, videoFramesPage }) => {
@@ -73,7 +77,7 @@ test('video frames grid renders within 5 seconds', async ({ page, videoFramesPag
         return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
+    const passed = isWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 
     metrics.push({
         test: 'video-frames-grid',
@@ -87,7 +91,7 @@ test('video frames grid renders within 5 seconds', async ({ page, videoFramesPag
     });
     saveMetrics();
 
-    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expectWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 });
 
 test('video frame details renders within 5 seconds', async ({ page, videoFramesPage }) => {
@@ -106,7 +110,7 @@ test('video frame details renders within 5 seconds', async ({ page, videoFramesP
         return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
+    const passed = isWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 
     metrics.push({
         test: 'video-frame-details',
@@ -120,7 +124,7 @@ test('video frame details renders within 5 seconds', async ({ page, videoFramesP
     });
     saveMetrics();
 
-    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expectWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 });
 
 test('video details renders within 5 seconds', async ({ page, videosPage }) => {
@@ -139,7 +143,7 @@ test('video details renders within 5 seconds', async ({ page, videosPage }) => {
         return { renderTimeMs, memoryUsageMb };
     }, MEASUREMENT_ITERATIONS);
 
-    const passed = result.renderTimeMs.median < MAX_RENDER_TIME_MS;
+    const passed = isWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 
     metrics.push({
         test: 'video-details',
@@ -153,5 +157,5 @@ test('video details renders within 5 seconds', async ({ page, videosPage }) => {
     });
     saveMetrics();
 
-    expect(result.renderTimeMs.median).toBeLessThan(MAX_RENDER_TIME_MS);
+    expectWithinPerformanceLimits(result, PERFORMANCE_LIMITS);
 });


### PR DESCRIPTION
## What has changed and why?

Implemented memory consumption performance tests for videos and images using Playwright, using `usedJSHeapSize` to measure the portion of the JS heap that is actively in use.

## How has it been tested?

End-to-end tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end performance benchmarking to measure both rendering time and memory usage; results now include detailed render timing stats and memory usage.
  * Updated assertions to validate combined render-time and memory limits, improving detection of performance regressions.
  * Standardized persisted metrics so performance reports include both render and memory data.

* **Chores**
  * CI summary now shows memory consumption alongside render-time in test reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->