### PR TITLE
Frontend query parsing tests

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -55,8 +55,10 @@ describe('parseLightlyQuery error handling', () => {
     });
 });
 
-// End-to-end translation tests.
-// Helper functions to construct expected QueryExpr shapes, followed by a table of tests.
+/*
+ * End-to-end translation tests.
+ * Helper functions to construct expected QueryExpr shapes followed by tests cases.
+ */
 
 type MatchExpr = QueryExpr['match_expr'];
 type OrdOp = IntegerExpr['operator'];
@@ -83,41 +85,46 @@ const dt = (table: string, name: string, operator: OrdOp, iso: string): MatchExp
     value: new Date(iso) as unknown as DatetimeExpr['value']
 });
 
-const tagsContains = (table: string, tag: string): MatchExpr => ({
-    type: 'tags_contains_expr',
-    field: { table, name: 'tags' },
-    tag_name: tag
-} satisfies TagsContainsExpr & { type: 'tags_contains_expr' });
+const tagsContains = (table: string, tag: string): MatchExpr =>
+    ({
+        type: 'tags_contains_expr',
+        field: { table, name: 'tags' },
+        tag_name: tag
+    }) satisfies TagsContainsExpr & { type: 'tags_contains_expr' };
 
-const objectDetection = (subexpr: MatchExpr): MatchExpr => ({
-    type: 'object_detection_match_expr',
-    subexpr
-} satisfies ObjectDetectionMatchExpr & { type: 'object_detection_match_expr' });
+const objectDetection = (subexpr: MatchExpr): MatchExpr =>
+    ({
+        type: 'object_detection_match_expr',
+        subexpr
+    }) satisfies ObjectDetectionMatchExpr & { type: 'object_detection_match_expr' };
 
-const and = (...children: MatchExpr[]): MatchExpr => ({
-    type: 'and',
-    children
-} satisfies AndExpr & { type: 'and' });
+const and = (...children: MatchExpr[]): MatchExpr =>
+    ({
+        type: 'and',
+        children
+    }) satisfies AndExpr & { type: 'and' };
 
-const or = (...children: MatchExpr[]): MatchExpr => ({
-    type: 'or',
-    children
-} satisfies OrExpr & { type: 'or' });
+const or = (...children: MatchExpr[]): MatchExpr =>
+    ({
+        type: 'or',
+        children
+    }) satisfies OrExpr & { type: 'or' };
 
-const not = (child: MatchExpr): MatchExpr => ({
-    type: 'not',
-    child
-} satisfies NotExpr & { type: 'not' });
+const not = (child: MatchExpr): MatchExpr =>
+    ({
+        type: 'not',
+        child
+    }) satisfies NotExpr & { type: 'not' };
 
 const query = (match_expr: MatchExpr): QueryExpr => ({ match_expr });
 
-interface TranslationCase {
+interface TranslationTestCase {
     name: string;
     source: string;
     expected: QueryExpr;
 }
 
-const TRANSLATION_CASES: TranslationCase[] = [
+const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     /* Image table fields */
     {
         name: 'image height greater than',
@@ -240,9 +247,7 @@ const TRANSLATION_CASES: TranslationCase[] = [
     {
         name: 'object detection negation',
         source: 'object_detection(NOT label == "background")',
-        expected: query(
-            objectDetection(not(str('object_detection', 'label', '==', 'background')))
-        )
+        expected: query(objectDetection(not(str('object_detection', 'label', '==', 'background'))))
     },
 
     /* Additional syntax features */
@@ -315,7 +320,7 @@ const TRANSLATION_CASES: TranslationCase[] = [
 ];
 
 describe('parseLightlyQuery translates example queries', () => {
-    it.each(TRANSLATION_CASES)('$name', ({ source, expected }) => {
+    it.each(TRANSLATION_TEST_CASES)('$name', ({ source, expected }) => {
         const result = parseLightlyQuery(parser, source);
         expect(result).toEqual({ status: 'ok', queryExpr: expected });
     });

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -13,7 +13,6 @@ import {
 } from './generated/module.js';
 import type {
     QueryExpr,
-    FieldRef,
     StringExpr,
     IntegerExpr,
     DatetimeExpr,
@@ -56,56 +55,37 @@ describe('parseLightlyQuery error handling', () => {
     });
 });
 
-// ---------------------------------------------------------------------------
-// End-to-end translation tests, driven by the real Langium parser
-// ---------------------------------------------------------------------------
-//
-// Each row defines a source query and the QueryExpr it should translate to.
-// Adding language features = appending a row; the helpers below keep each
-// expected expression to roughly one line.
-//
-// Conventions:
-//   - chained boolean operators are *flattened* into n-ary AndExpr/OrExpr
-//     (matching the Pydantic `children: list[MatchExpr]` shape on the backend)
-//   - datetime literals translate to JS `Date` instances (the typed shape of
-//     `DatetimeExpr.value`)
-//   - FieldRef tables follow the backend dispatch keys in
-//     `lightly_studio.core.dataset_query.query_translation`: `image`, `video`,
-//     `object_detection`, etc.
-//
-// These tests are intentionally failing today — they pin the target shape for
-// the upcoming AST → QueryExpr visitor.
+// End-to-end translation tests.
+// Helper functions to construct expected QueryExpr shapes, followed by a table of tests.
 
 type MatchExpr = QueryExpr['match_expr'];
 type OrdOp = IntegerExpr['operator'];
 type EqOp = StringExpr['operator'];
 
-const fieldRef = (table: string, name: string): FieldRef => ({ table, name });
-
 const int = (table: string, name: string, operator: OrdOp, value: number): MatchExpr => ({
     type: 'integer_expr',
-    field: fieldRef(table, name),
+    field: { table, name },
     operator,
     value
 });
 
 const str = (table: string, name: string, operator: EqOp, value: string): MatchExpr => ({
     type: 'string_expr',
-    field: fieldRef(table, name),
+    field: { table, name },
     operator,
     value
 });
 
 const dt = (table: string, name: string, operator: OrdOp, iso: string): MatchExpr => ({
     type: 'datetime_expr',
-    field: fieldRef(table, name),
+    field: { table, name },
     operator,
     value: new Date(iso) as unknown as DatetimeExpr['value']
 });
 
 const tagsContains = (table: string, tag: string): MatchExpr => ({
     type: 'tags_contains_expr',
-    field: fieldRef(table, 'tags'),
+    field: { table, name: 'tags' },
     tag_name: tag
 } satisfies TagsContainsExpr & { type: 'tags_contains_expr' });
 
@@ -138,6 +118,7 @@ interface TranslationCase {
 }
 
 const TRANSLATION_CASES: TranslationCase[] = [
+    /* Image table fields */
     {
         name: 'image height greater than',
         source: 'height > 400',
@@ -159,20 +140,19 @@ const TRANSLATION_CASES: TranslationCase[] = [
         expected: query(str('image', 'file_path_abs', '!=', '/datasets/cats/cat-001.jpg'))
     },
     {
-        name: 'image creation time less than',
-        source: 'created_at < "2026-01-01T00:00:00Z"',
-        expected: query(dt('image', 'created_at', '<', '2026-01-01T00:00:00Z'))
-    },
-    {
         name: 'image creation time less than or equal',
         source: 'created_at <= "2026-04-28T12:30:00+02:00"',
         expected: query(dt('image', 'created_at', '<=', '2026-04-28T12:30:00+02:00'))
     },
+
+    /* Tags expression */
     {
         name: 'tag in expression',
         source: '"training" IN tags',
         expected: query(tagsContains('image', 'training'))
     },
+
+    /* Object detection expression */
     {
         name: 'object detection label',
         source: 'object_detection(label == "cat")',
@@ -198,6 +178,8 @@ const TRANSLATION_CASES: TranslationCase[] = [
         source: 'object_detection(height <= 120)',
         expected: query(objectDetection(int('object_detection', 'height', '<=', 120)))
     },
+
+    /* Boolean operators */
     {
         name: 'boolean and',
         source: 'height > 400 AND width >= 640',
@@ -228,6 +210,8 @@ const TRANSLATION_CASES: TranslationCase[] = [
             )
         )
     },
+
+    /* Boolean operators in subexpressions */
     {
         name: 'object detection boolean expression',
         source: 'object_detection(label == "cat" AND width >= 50 AND height >= 40)',
@@ -260,6 +244,8 @@ const TRANSLATION_CASES: TranslationCase[] = [
             objectDetection(not(str('object_detection', 'label', '==', 'background')))
         )
     },
+
+    /* Additional syntax features */
     {
         name: 'single quoted string',
         source: "file_name == 'frame-0001.jpg'",
@@ -281,6 +267,8 @@ const TRANSLATION_CASES: TranslationCase[] = [
             )
         )
     },
+
+    /* Complex queries */
     {
         name: 'complex reviewed large cat image',
         source: 'height > 400 AND width >= 640 AND "reviewed" IN tags AND object_detection(label == "cat" AND width > 80 AND height > 80)',

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -53,11 +53,31 @@ describe('parseLightlyQuery error handling', () => {
             /Expecting: one of these possible Token sequences:/
         );
     });
+
+    const PARSE_FAILURE_CASES: Array<{ name: string; source: string }> = [
+        { name: 'empty input', source: '' },
+        { name: 'unknown field', source: 'x == 1' },
+        { name: 'single equals operator', source: 'height = 400' },
+        { name: 'unterminated string literal', source: 'file_name == "cat' },
+        { name: 'unmatched opening paren', source: '(height > 400' },
+        { name: 'unmatched closing paren', source: 'height > 400)' },
+        { name: 'trailing boolean operator', source: 'height > 400 AND' },
+        { name: 'missing right-hand side', source: 'height >' },
+        { name: 'string compared to int field', source: 'height == "tall"' },
+        { name: 'obj detection without arguments', source: 'object_detection()' },
+        { name: 'obj detection unknown field', source: 'object_detection(file_name == "a.jpg")' },
+        { name: 'wrong in operator use', source: '"jpg" IN file_name' },
+        { name: 'stray punctuation', source: '@@@' }
+    ];
+
+    it.each(PARSE_FAILURE_CASES)('reports errors for $name', ({ source }) => {
+        const result = parseLightlyQuery(parser, source);
+        expect(result.status).toBe('error');
+    });
 });
 
 /*
- * End-to-end translation tests.
- * Helper functions to construct expected QueryExpr shapes followed by tests cases.
+ * Helper functions to construct expected QueryExpr shapes, followed by tests cases.
  */
 
 type MatchExpr = QueryExpr['match_expr'];

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -1,6 +1,32 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+    inject,
+    EmptyFileSystem,
+    createDefaultCoreModule,
+    createDefaultSharedCoreModule
+} from 'langium';
 import { QueryExprTranslationRequest, parseLightlyQuery } from './query-expr-translation.js';
+import {
+    LightlyQueryGeneratedModule,
+    LightlyQueryGeneratedSharedModule
+} from './generated/module.js';
 import type { Query } from './generated/ast.js';
+import type {
+    QueryExpr,
+    FieldRef,
+    StringExpr,
+    IntegerExpr,
+    DatetimeExpr,
+    TagsContainsExpr,
+    ObjectDetectionMatchExpr,
+    AndExpr,
+    OrExpr,
+    NotExpr
+} from '$lib/api/lightly_studio_local';
+
+// ---------------------------------------------------------------------------
+// Mock-parser tests for the framing logic in `parseLightlyQuery`
+// ---------------------------------------------------------------------------
 
 describe('QueryExprTranslationRequest', () => {
     it('has the expected method name', () => {
@@ -8,7 +34,7 @@ describe('QueryExprTranslationRequest', () => {
     });
 });
 
-describe('parseLightlyQuery', () => {
+describe('parseLightlyQuery error path', () => {
     it('returns an error result when the parser reports errors', () => {
         const result = parseLightlyQuery(
             {
@@ -26,29 +52,296 @@ describe('parseLightlyQuery', () => {
             errors: [{ message: 'Unexpected token', line: 3, column: 5 }]
         });
     });
+});
 
-    it('returns the hardcoded query stub when parsing succeeds', () => {
-        const result = parseLightlyQuery(
-            {
-                parse: () => ({
-                    lexerErrors: [],
-                    parserErrors: [],
-                    value: {} as Query
-                })
-            },
-            'valid'
+// ---------------------------------------------------------------------------
+// End-to-end translation tests, driven by the real Langium parser
+// ---------------------------------------------------------------------------
+//
+// Each row defines a source query and the QueryExpr it should translate to.
+// Adding language features = appending a row; the helpers below keep each
+// expected expression to roughly one line.
+//
+// Conventions:
+//   - chained boolean operators are *flattened* into n-ary AndExpr/OrExpr
+//     (matching the Pydantic `children: list[MatchExpr]` shape on the backend)
+//   - datetime literals translate to JS `Date` instances (the typed shape of
+//     `DatetimeExpr.value`)
+//   - FieldRef tables follow the backend dispatch keys in
+//     `lightly_studio.core.dataset_query.query_translation`: `image`, `video`,
+//     `object_detection`, etc.
+//
+// These tests are intentionally failing today — they pin the target shape for
+// the upcoming AST → QueryExpr visitor.
+
+type MatchExpr = QueryExpr['match_expr'];
+type OrdOp = IntegerExpr['operator'];
+type EqOp = StringExpr['operator'];
+
+const fieldRef = (table: string, name: string): FieldRef => ({ table, name });
+
+const int = (table: string, name: string, operator: OrdOp, value: number): MatchExpr => ({
+    type: 'integer_expr',
+    field: fieldRef(table, name),
+    operator,
+    value
+});
+
+const str = (table: string, name: string, operator: EqOp, value: string): MatchExpr => ({
+    type: 'string_expr',
+    field: fieldRef(table, name),
+    operator,
+    value
+});
+
+const dt = (table: string, name: string, operator: OrdOp, iso: string): MatchExpr => ({
+    type: 'datetime_expr',
+    field: fieldRef(table, name),
+    operator,
+    value: new Date(iso) as unknown as DatetimeExpr['value']
+});
+
+const tagsContains = (table: string, tag: string): MatchExpr => ({
+    type: 'tags_contains_expr',
+    field: fieldRef(table, 'tags'),
+    tag_name: tag
+} satisfies TagsContainsExpr & { type: 'tags_contains_expr' });
+
+const objectDetection = (subexpr: MatchExpr): MatchExpr => ({
+    type: 'object_detection_match_expr',
+    subexpr
+} satisfies ObjectDetectionMatchExpr & { type: 'object_detection_match_expr' });
+
+const and = (...children: MatchExpr[]): MatchExpr => ({
+    type: 'and',
+    children
+} satisfies AndExpr & { type: 'and' });
+
+const or = (...children: MatchExpr[]): MatchExpr => ({
+    type: 'or',
+    children
+} satisfies OrExpr & { type: 'or' });
+
+const not = (child: MatchExpr): MatchExpr => ({
+    type: 'not',
+    child
+} satisfies NotExpr & { type: 'not' });
+
+const query = (match_expr: MatchExpr): QueryExpr => ({ match_expr });
+
+interface TranslationCase {
+    name: string;
+    source: string;
+    expected: QueryExpr;
+}
+
+const TRANSLATION_CASES: TranslationCase[] = [
+    {
+        name: 'image height greater than',
+        source: 'height > 400',
+        expected: query(int('image', 'height', '>', 400))
+    },
+    {
+        name: 'image width greater than or equal',
+        source: 'width >= 640',
+        expected: query(int('image', 'width', '>=', 640))
+    },
+    {
+        name: 'image file name equality',
+        source: 'file_name == "cat.jpg"',
+        expected: query(str('image', 'file_name', '==', 'cat.jpg'))
+    },
+    {
+        name: 'image absolute path inequality',
+        source: 'file_path_abs != "/datasets/cats/cat-001.jpg"',
+        expected: query(str('image', 'file_path_abs', '!=', '/datasets/cats/cat-001.jpg'))
+    },
+    {
+        name: 'image creation time less than',
+        source: 'created_at < "2026-01-01T00:00:00Z"',
+        expected: query(dt('image', 'created_at', '<', '2026-01-01T00:00:00Z'))
+    },
+    {
+        name: 'image creation time less than or equal',
+        source: 'created_at <= "2026-04-28T12:30:00+02:00"',
+        expected: query(dt('image', 'created_at', '<=', '2026-04-28T12:30:00+02:00'))
+    },
+    {
+        name: 'tag in expression',
+        source: '"training" IN tags',
+        expected: query(tagsContains('image', 'training'))
+    },
+    {
+        name: 'object detection label',
+        source: 'object_detection(label == "cat")',
+        expected: query(objectDetection(str('object_detection', 'label', '==', 'cat')))
+    },
+    {
+        name: 'object detection x inequality',
+        source: 'object_detection(x != 0)',
+        expected: query(objectDetection(int('object_detection', 'x', '!=', 0)))
+    },
+    {
+        name: 'object detection y less than',
+        source: 'object_detection(y < 200)',
+        expected: query(objectDetection(int('object_detection', 'y', '<', 200)))
+    },
+    {
+        name: 'object detection width greater than',
+        source: 'object_detection(width > 80)',
+        expected: query(objectDetection(int('object_detection', 'width', '>', 80)))
+    },
+    {
+        name: 'object detection height less than or equal',
+        source: 'object_detection(height <= 120)',
+        expected: query(objectDetection(int('object_detection', 'height', '<=', 120)))
+    },
+    {
+        name: 'boolean and',
+        source: 'height > 400 AND width >= 640',
+        expected: query(and(int('image', 'height', '>', 400), int('image', 'width', '>=', 640)))
+    },
+    {
+        name: 'boolean or',
+        source: 'file_name == "cat.jpg" OR file_name == "dog.jpg"',
+        expected: query(
+            or(
+                str('image', 'file_name', '==', 'cat.jpg'),
+                str('image', 'file_name', '==', 'dog.jpg')
+            )
+        )
+    },
+    {
+        name: 'boolean not',
+        source: 'NOT "rejected" IN tags',
+        expected: query(not(tagsContains('image', 'rejected')))
+    },
+    {
+        name: 'parenthesized precedence',
+        source: '(height > 400 OR width > 640) AND "reviewed" IN tags',
+        expected: query(
+            and(
+                or(int('image', 'height', '>', 400), int('image', 'width', '>', 640)),
+                tagsContains('image', 'reviewed')
+            )
+        )
+    },
+    {
+        name: 'object detection boolean expression',
+        source: 'object_detection(label == "cat" AND width >= 50 AND height >= 40)',
+        expected: query(
+            objectDetection(
+                and(
+                    str('object_detection', 'label', '==', 'cat'),
+                    int('object_detection', 'width', '>=', 50),
+                    int('object_detection', 'height', '>=', 40)
+                )
+            )
+        )
+    },
+    {
+        name: 'object detection alternatives',
+        source: 'object_detection(label == "cat" OR label == "dog")',
+        expected: query(
+            objectDetection(
+                or(
+                    str('object_detection', 'label', '==', 'cat'),
+                    str('object_detection', 'label', '==', 'dog')
+                )
+            )
+        )
+    },
+    {
+        name: 'object detection negation',
+        source: 'object_detection(NOT label == "background")',
+        expected: query(
+            objectDetection(not(str('object_detection', 'label', '==', 'background')))
+        )
+    },
+    {
+        name: 'single quoted string',
+        source: "file_name == 'frame-0001.jpg'",
+        expected: query(str('image', 'file_name', '==', 'frame-0001.jpg'))
+    },
+    {
+        name: 'trailing comment',
+        source: 'height > 400 # high resolution image',
+        expected: query(int('image', 'height', '>', 400))
+    },
+    {
+        name: 'multiline whitespace',
+        source: 'height > 400\nAND "reviewed" IN tags\nAND object_detection(label == "cat")',
+        expected: query(
+            and(
+                int('image', 'height', '>', 400),
+                tagsContains('image', 'reviewed'),
+                objectDetection(str('object_detection', 'label', '==', 'cat'))
+            )
+        )
+    },
+    {
+        name: 'complex reviewed large cat image',
+        source: 'height > 400 AND width >= 640 AND "reviewed" IN tags AND object_detection(label == "cat" AND width > 80 AND height > 80)',
+        expected: query(
+            and(
+                int('image', 'height', '>', 400),
+                int('image', 'width', '>=', 640),
+                tagsContains('image', 'reviewed'),
+                objectDetection(
+                    and(
+                        str('object_detection', 'label', '==', 'cat'),
+                        int('object_detection', 'width', '>', 80),
+                        int('object_detection', 'height', '>', 80)
+                    )
+                )
+            )
+        )
+    },
+    {
+        name: 'complex dataset curation query',
+        source: '(file_path_abs != "/datasets/archive/bad.jpg" AND created_at >= "2025-01-01T00:00:00Z") AND ("training" IN tags OR "validation" IN tags) AND object_detection((label == "cat" OR label == "dog") AND NOT (x < 5 OR y < 5))',
+        expected: query(
+            and(
+                str('image', 'file_path_abs', '!=', '/datasets/archive/bad.jpg'),
+                dt('image', 'created_at', '>=', '2025-01-01T00:00:00Z'),
+                or(tagsContains('image', 'training'), tagsContains('image', 'validation')),
+                objectDetection(
+                    and(
+                        or(
+                            str('object_detection', 'label', '==', 'cat'),
+                            str('object_detection', 'label', '==', 'dog')
+                        ),
+                        not(
+                            or(
+                                int('object_detection', 'x', '<', 5),
+                                int('object_detection', 'y', '<', 5)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+];
+
+describe('parseLightlyQuery translates example queries', () => {
+    let parser: Parameters<typeof parseLightlyQuery>[0];
+
+    beforeAll(() => {
+        const shared = inject(
+            createDefaultSharedCoreModule(EmptyFileSystem),
+            LightlyQueryGeneratedSharedModule
         );
+        const LightlyQuery = inject(
+            createDefaultCoreModule({ shared }),
+            LightlyQueryGeneratedModule
+        );
+        shared.ServiceRegistry.register(LightlyQuery);
+        parser = LightlyQuery.parser.LangiumParser;
+    });
 
-        expect(result).toEqual({
-            status: 'ok',
-            queryExpr: {
-                match_expr: {
-                    type: 'integer_expr',
-                    field: { table: 'image', name: 'width' },
-                    operator: '<',
-                    value: 400
-                }
-            }
-        });
+    it.each(TRANSLATION_CASES)('$name', ({ source, expected }) => {
+        const result = parseLightlyQuery(parser, source);
+        expect(result).toEqual({ status: 'ok', queryExpr: expected });
     });
 });

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -319,7 +319,7 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     }
 ];
 
-describe('parseLightlyQuery translates example queries', () => {
+describe.skip('parseLightlyQuery translates example queries', () => {
     it.each(TRANSLATION_TEST_CASES)('$name', ({ source, expected }) => {
         const result = parseLightlyQuery(parser, source);
         expect(result).toEqual({ status: 'ok', queryExpr: expected });


### PR DESCRIPTION
## What has changed and why?

Add frontend query parsing tests.

The tests are skipped for now, will be used for test-driven development in a follow-up.

NOTE: We focus the tests on a subset of the language:
* Only images
* Only infix syntax without table receivers

## How has it been tested?

Parsing failures fail. The positive tests will be checked in the follow-up.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
