### PR TITLE
Fix delete annotation with tag

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotation.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotation.py
@@ -13,7 +13,7 @@ from lightly_studio.models.annotation.object_detection import (
 from lightly_studio.models.annotation.segmentation import (
     SegmentationAnnotationTable,
 )
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
 from lightly_studio.resolvers import annotation_resolver
 
 
@@ -64,6 +64,13 @@ def delete_annotation(
     # Then delete the annotation's sample (created specifically for this annotation)
     # unless we're keeping it for reuse (e.g., when updating annotation label)
     if delete_sample:
+        session.exec(
+            delete(SampleTagLinkTable).where(
+                col(SampleTagLinkTable.sample_id) == annotation_sample_id
+            )
+        )
+        session.commit()
+
         annotation_sample = session.get(SampleTable, annotation_sample_id)
         if annotation_sample:
             session.delete(annotation_sample)

--- a/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
+++ b/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
@@ -1,10 +1,12 @@
 from uuid import UUID
 
 import pytest
-from sqlmodel import Session
+from sqlmodel import Session, col, select
 
+from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
 from lightly_studio.resolvers import annotation_resolver
 from tests.conftest import AnnotationsTestData
+from tests.helpers_resolvers import create_tag
 
 
 def test_delete_annotation__success(
@@ -37,3 +39,37 @@ def test_delete_annotation__raises_error_when_annotation_not_found(
     # Call the resolver and expect ValueError
     with pytest.raises(ValueError, match=f"Annotation {non_existent_annotation_id} not found"):
         annotation_resolver.delete_annotation(db_session, non_existent_annotation_id)
+
+
+def test_delete_annotation__deletes_sample_tag_links(
+    db_session: Session,
+    annotations_test_data: AnnotationsTestData,
+) -> None:
+    """Test deleting an annotation also removes tag links for its sample."""
+    annotation = annotations_test_data.annotations[0]
+    annotation_collection_id = annotation.sample.collection_id
+    tag = create_tag(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        tag_name="annotation-tag",
+        kind="annotation",
+    )
+    annotation.sample.tags.append(tag)
+    db_session.add(annotation.sample)
+    db_session.commit()
+
+    # Verify there is at least one link before deletion.
+    links_before = db_session.exec(
+        select(SampleTagLinkTable).where(col(SampleTagLinkTable.sample_id) == annotation.sample_id)
+    ).all()
+    assert links_before
+
+    annotation_resolver.delete_annotation(db_session, annotation.sample_id)
+
+    # Verify both annotation and sample-tag links were deleted.
+    assert annotation_resolver.get_by_id(db_session, annotation.sample_id) is None
+    links_after = db_session.exec(
+        select(SampleTagLinkTable).where(col(SampleTagLinkTable.sample_id) == annotation.sample_id)
+    ).all()
+    assert not links_after
+    assert db_session.get(SampleTable, annotation.sample_id) is None


### PR DESCRIPTION
## What has changed and why?

This PR fixes the delete annotation feature when a tag is already assigned. It explicitly deletes the sample tag link.

## How has it been tested?

Unit tests + manual test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced annotation deletion workflow to properly handle cleanup of tag relationships, ensuring that when annotations are deleted, all associated tag links are also removed to prevent orphaned data.

* **Tests**
  * Added test coverage to verify the annotation deletion process correctly cascades cleanup, confirming that tag relationships are properly removed along with annotation and sample records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->