### PR TITLE
Keep only the SQL Langium dialect

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
@@ -7,7 +7,7 @@
     import { useQueryEditor } from './useQueryEditor';
     import type { QueryExprTranslationResult } from './language/query-expr-translation';
 
-    const LIGHTLY_QUERY_DEFAULT_VALUE = `Image.width > 1920 AND ("reviewed" IN tags)
+    const LIGHTLY_QUERY_DEFAULT_VALUE = `width > 1920 AND ("reviewed" IN tags)
 AND object_detection(label == "car" and x > 10)`;
 
     interface QueryEditorProps {

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
@@ -23,23 +23,12 @@ interface FunctionCall extends Expression {
   args: Expression[];
 }
 
-interface MemberCall extends Expression {
-  receiver: string;
-  member: string;
-  args: Expression[];
-}
-
-interface QualifiedFieldReference extends Expression {
-  receiver: string;
+interface FieldReference extends Expression {
   member: string;
 }
 
 interface TagInExpression extends Expression {
   tag_name: Expression;
-}
-
-interface FieldReference extends Expression {
-  name: string;
 }
 
 interface NumberLiteral extends Expression {
@@ -77,22 +66,22 @@ SampleComparison<isImage> returns ComparisonExpression:
    | SampleStringFieldReference<isImage> {ComparisonExpression.left=current} operator=('==' | '!=') right=StringLiteral
    | SampleDateTimeFieldReference<isImage> {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=StringLiteral;
 
-SampleIntFieldReference<isImage> returns QualifiedFieldReference:
-  (<isImage> {QualifiedFieldReference} receiver=ImageFieldReceiver '.' member=ImageIntFieldName)
-    | (<!isImage> {QualifiedFieldReference} receiver=VideoFieldReceiver '.' member=VideoIntFieldName);
+SampleIntFieldReference<isImage> returns FieldReference:
+  (<isImage> {FieldReference} member=ImageIntFieldName)
+    | (<!isImage> {FieldReference} member=VideoIntFieldName);
 
-SampleOrdinalFloatFieldReference<isImage> returns QualifiedFieldReference:
-  (<!isImage> {QualifiedFieldReference} receiver=VideoFieldReceiver '.' member=VideoOrdinalFloatFieldName);
+SampleOrdinalFloatFieldReference<isImage> returns FieldReference:
+  (<!isImage> {FieldReference} member=VideoOrdinalFloatFieldName);
 
-SampleEqualityFloatFieldReference<isImage> returns QualifiedFieldReference:
-  (<!isImage> {QualifiedFieldReference} receiver=VideoFieldReceiver '.' member=VideoEqualityFloatFieldName);
+SampleEqualityFloatFieldReference<isImage> returns FieldReference:
+  (<!isImage> {FieldReference} member=VideoEqualityFloatFieldName);
 
-SampleStringFieldReference<isImage> returns QualifiedFieldReference:
-  (<isImage> {QualifiedFieldReference} receiver=ImageFieldReceiver '.' member=ImageStringFieldName)
-    | (<!isImage> {QualifiedFieldReference} receiver=VideoFieldReceiver '.' member=VideoStringFieldName);
+SampleStringFieldReference<isImage> returns FieldReference:
+  (<isImage> {FieldReference} member=ImageStringFieldName)
+    | (<!isImage> {FieldReference} member=VideoStringFieldName);
 
-SampleDateTimeFieldReference<isImage> returns QualifiedFieldReference:
-  (<isImage> {QualifiedFieldReference} receiver=ImageFieldReceiver '.' member=ImageDateTimeFieldName);
+SampleDateTimeFieldReference<isImage> returns FieldReference:
+  (<isImage> {FieldReference} member=ImageDateTimeFieldName);
 
 ObjectDetection returns Expression:
   ObjectDetectionOr;
@@ -111,24 +100,14 @@ ObjectDetectionUnary returns Expression:
 ObjectDetectionComparison returns ComparisonExpression:
   ObjectDetectionFieldReference {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=Literal;
 
-ObjectDetectionFieldReceiver returns string:
-  OBJECT_DETECTION_RECEIVER;
-
 ObjectDetectionFieldReference returns Expression:
-  {FieldReference} name=ObjectDetectionFieldName
-    | {QualifiedFieldReference} receiver=ObjectDetectionFieldReceiver '.' member=ObjectDetectionFieldName;
+  {FieldReference} member=ObjectDetectionFieldName;
 
 AnnotationQuery returns Expression:
   {FunctionCall} name=ANNOTATION_FUNCTION '(' args+=ObjectDetection ')';
 
 TagInExpression returns Expression:
   {TagInExpression} tag_name=StringLiteral IN TAGS_KEYWORD;
-
-ImageFieldReceiver returns string:
-  IMAGE_SAMPLE_RECEIVER;
-
-VideoFieldReceiver returns string:
-  VIDEO_SAMPLE_RECEIVER;
 
 terminal HEIGHT returns string: /\bheight\b/;
 terminal WIDTH returns string: /\bwidth\b/;
@@ -185,13 +164,10 @@ terminal NOT: /\bNOT\b/i;
 terminal IN returns string: /\bIN\b/i;
 terminal ANNOTATION_FUNCTION returns string: /\bobject_detection\b/;
 terminal TAGS_KEYWORD returns string: /\btags\b/;
-terminal IMAGE_SAMPLE_RECEIVER returns string: /\b(ImageSampleField|Image)\b/;
-terminal VIDEO_SAMPLE_RECEIVER returns string: /\b(VideoSampleField|Video)\b/;
 terminal ORDINAL_FLOAT_FIELD_NAME returns string: /\bduration_s\b/;
 terminal EQUALITY_FLOAT_FIELD_NAME returns string: /\bfps\b/;
 terminal STRING_FIELD_NAME returns string: /\b(file_name|file_path_abs)\b/;
 terminal DATE_TIME_FIELD_NAME returns string: /\bcreated_at\b/;
-terminal OBJECT_DETECTION_RECEIVER returns string: /\b(ObjectDetectionField|ObjectDetection)\b/;
 
 hidden terminal WS: /\s+/;
 hidden terminal SL_COMMENT: /#[^\n\r]*/;

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
@@ -58,12 +58,10 @@ Sample<isImage> returns Expression:
   SampleOr<isImage>;
 
 SampleOr<isImage> returns Expression:
-  SampleAnd<isImage> ({BooleanExpression.children+=current} operator=OR children+=SampleAnd<isImage> (OR children+=SampleAnd<isImage>)*)?
-    | {BooleanExpression} operator=OR '(' children+=Sample<isImage> (',' children+=Sample<isImage>)+ ')';
+  SampleAnd<isImage> ({BooleanExpression.children+=current} operator=OR children+=SampleAnd<isImage> (OR children+=SampleAnd<isImage>)*)?;
 
 SampleAnd<isImage> returns Expression:
-  SampleUnary<isImage> ({BooleanExpression.children+=current} operator=AND children+=SampleUnary<isImage> (AND children+=SampleUnary<isImage>)*)?
-    | {BooleanExpression} operator=AND '(' children+=Sample<isImage> (',' children+=Sample<isImage>)+ ')';
+  SampleUnary<isImage> ({BooleanExpression.children+=current} operator=AND children+=SampleUnary<isImage> (AND children+=SampleUnary<isImage>)*)?;
 
 SampleUnary<isImage> returns Expression:
   '(' Sample<isImage> ')'
@@ -100,12 +98,10 @@ ObjectDetection returns Expression:
   ObjectDetectionOr;
 
 ObjectDetectionOr returns Expression:
-  ObjectDetectionAnd ({BooleanExpression.children+=current} operator=OR children+=ObjectDetectionAnd (OR children+=ObjectDetectionAnd)*)?
-    | {BooleanExpression} operator=OR '(' children+=ObjectDetection (',' children+=ObjectDetection)+ ')';
+  ObjectDetectionAnd ({BooleanExpression.children+=current} operator=OR children+=ObjectDetectionAnd (OR children+=ObjectDetectionAnd)*)?;
 
 ObjectDetectionAnd returns Expression:
-  ObjectDetectionUnary ({BooleanExpression.children+=current} operator=AND children+=ObjectDetectionUnary (AND children+=ObjectDetectionUnary)*)?
-    | {BooleanExpression} operator=AND '(' children+=ObjectDetection (',' children+=ObjectDetection)+ ')';
+  ObjectDetectionUnary ({BooleanExpression.children+=current} operator=AND children+=ObjectDetectionUnary (AND children+=ObjectDetectionUnary)*)?;
 
 ObjectDetectionUnary returns Expression:
   '(' ObjectDetection ')'
@@ -126,8 +122,7 @@ AnnotationQuery returns Expression:
   {FunctionCall} name=ANNOTATION_FUNCTION '(' args+=ObjectDetection ')';
 
 TagInExpression returns Expression:
-  {TagInExpression} TAGS_CONTAINS '(' tag_name=StringLiteral ')' |
-    {TagInExpression} tag_name=StringLiteral IN TAGS_KEYWORD;
+  {TagInExpression} tag_name=StringLiteral IN TAGS_KEYWORD;
 
 ImageFieldReceiver returns string:
   IMAGE_SAMPLE_RECEIVER;
@@ -189,7 +184,6 @@ terminal OR: /\bOR\b/i;
 terminal NOT: /\bNOT\b/i;
 terminal IN returns string: /\bIN\b/i;
 terminal ANNOTATION_FUNCTION returns string: /\bobject_detection\b/;
-terminal TAGS_CONTAINS returns string: /\btags\.contains\b/;
 terminal TAGS_KEYWORD returns string: /\btags\b/;
 terminal IMAGE_SAMPLE_RECEIVER returns string: /\b(ImageSampleField|Image)\b/;
 terminal VIDEO_SAMPLE_RECEIVER returns string: /\b(VideoSampleField|Video)\b/;

--- a/lightly_studio_view/src/lib/components/QueryEditor/tmp-showcase-lightly-query.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/tmp-showcase-lightly-query.ts
@@ -16,8 +16,6 @@ import {
     isBooleanExpression,
     isComparisonExpression,
     isFunctionCall,
-    isMemberCall,
-    isQualifiedFieldReference,
     isTagInExpression,
     isNumberLiteral,
     isStringLiteral,
@@ -57,6 +55,7 @@ type DSLJson =
     | {
           kind: string;
           annotation_type?: string;
+          type?: 'image' | 'video' | 'object_detection';
           criterion?: DSLJson;
           field?: string;
           operator?: string;
@@ -76,59 +75,60 @@ function hasExpression(node: unknown): node is { expression: unknown } {
     return typeof node === 'object' && node !== null && 'expression' in node;
 }
 
-function transformToDSLJson(node: unknown): DSLJson {
+function transformToDSLJson(
+    node: unknown,
+    context: 'image' | 'video' | 'object_detection'
+): DSLJson {
     if (isBooleanExpression(node)) {
         return {
             kind: node.operator.toUpperCase(),
-            terms: node.children.map((child) => transformToDSLJson(child))
+            terms: node.children.map((child) => transformToDSLJson(child, context))
         };
     }
     if (isNotExpression(node)) {
         return {
             kind: 'NOT',
-            term: transformToDSLJson(node.expression)
+            term: transformToDSLJson(node.expression, context)
         };
     }
     if (isComparisonExpression(node)) {
         const left = node.left;
         let field = '';
-        if (isQualifiedFieldReference(left)) {
+        if (isFieldReference(left)) {
             field = left.member;
-        } else if (isMemberCall(left)) {
-            if (left.receiver === 'ObjectDetection' || left.receiver === 'ObjectDetectionField') {
-                field = left.member;
-            } else {
-                field = left.receiver || (hasName(left) ? left.name : 'unknown_field');
-            }
-        } else if (isFieldReference(left)) {
-            field = left.name;
+            // The grammar already enforces valid fields for the context.
+            // We are just forwarding the context to recursive calls.
         } else {
             field = hasName(left) ? left.name : 'unknown_field';
         }
         return {
             kind: 'COMPARISON',
+            type: context,
             field: field,
             operator: node.operator,
-            value: transformToDSLJson(node.right)
+            value: transformToDSLJson(node.right, context)
         };
     }
     if (isFunctionCall(node)) {
+        // There are only annotation function calls, so this is an annotation query.
+        assert.strictEqual(node.name, 'object_detection');
         return {
             kind: 'ANNOTATION_QUERY',
             annotation_type: node.name,
-            criterion: node.args.length > 0 ? transformToDSLJson(node.args[0]) : null
+            criterion: node.args.length > 0 ? transformToDSLJson(node.args[0], node.name) : null
         };
     }
     if (isTagInExpression(node)) {
         return {
             kind: 'TAGS_CONTAINS',
-            tag_name: transformToDSLJson(node.tag_name)
+            type: context,
+            tag_name: transformToDSLJson(node.tag_name, context)
         };
     }
     if (isNumberLiteral(node)) return node.value;
     if (isStringLiteral(node)) return unquoteStringLiteral(node.value);
 
-    if (hasExpression(node)) return transformToDSLJson(node.expression);
+    if (hasExpression(node)) return transformToDSLJson(node.expression, context);
 
     console.warn('transformToDSLJson: Unhandled node type', node);
     return null;
@@ -139,12 +139,12 @@ const services = createLightlyQueryServices().LightlyQuery;
 const parser = services.parser.LangiumParser;
 
 const queries = [
-    "(Image.width > 100 OR Image.height > 100 OR Image.created_at == '2026-04-23 12:47:18+02:00') AND object_detection(label == 'car')",
-    "'dog' in tags OR 'cat' IN tags AND Image.width > 100",
-    "'dog' in tags OR ('cat' IN tags AND Image.width >= 12)",
-    "video: NOT (Video.fps != 30.0 AND NOT 'low_res' IN tags)",
+    "(width > 100 OR height > 100 OR created_at == '2026-04-23 12:47:18+02:00') AND object_detection(label == 'car')",
+    "'dog' in tags OR 'cat' IN tags AND width > 100",
+    "'dog' in tags OR ('cat' IN tags AND width >= 12)",
+    "video: NOT (fps != 30.0 AND NOT 'low_res' IN tags)",
     "object_detection(label == 'car' AND x < 10 OR label == 'truck' AND width > 100)",
-    'object_detection(ObjectDetection.width > 50 AND ObjectDetection.height < 200)'
+    'object_detection(width > 50 AND height < 200)'
 ];
 
 const expectedOutputs = [
@@ -156,18 +156,21 @@ const expectedOutputs = [
                 terms: [
                     {
                         kind: 'COMPARISON',
+                        type: 'image',
                         field: 'width',
                         operator: '>',
                         value: 100
                     },
                     {
                         kind: 'COMPARISON',
+                        type: 'image',
                         field: 'height',
                         operator: '>',
                         value: 100
                     },
                     {
                         kind: 'COMPARISON',
+                        type: 'image',
                         field: 'created_at',
                         operator: '==',
                         value: '2026-04-23 12:47:18+02:00'
@@ -179,6 +182,7 @@ const expectedOutputs = [
                 annotation_type: 'object_detection',
                 criterion: {
                     kind: 'COMPARISON',
+                    type: 'object_detection',
                     field: 'label',
                     operator: '==',
                     value: 'car'
@@ -191,6 +195,7 @@ const expectedOutputs = [
         terms: [
             {
                 kind: 'TAGS_CONTAINS',
+                type: 'image',
                 tag_name: 'dog'
             },
             {
@@ -198,10 +203,12 @@ const expectedOutputs = [
                 terms: [
                     {
                         kind: 'TAGS_CONTAINS',
+                        type: 'image',
                         tag_name: 'cat'
                     },
                     {
                         kind: 'COMPARISON',
+                        type: 'image',
                         field: 'width',
                         operator: '>',
                         value: 100
@@ -215,6 +222,7 @@ const expectedOutputs = [
         terms: [
             {
                 kind: 'TAGS_CONTAINS',
+                type: 'image',
                 tag_name: 'dog'
             },
             {
@@ -222,10 +230,12 @@ const expectedOutputs = [
                 terms: [
                     {
                         kind: 'TAGS_CONTAINS',
+                        type: 'image',
                         tag_name: 'cat'
                     },
                     {
                         kind: 'COMPARISON',
+                        type: 'image',
                         field: 'width',
                         operator: '>=',
                         value: 12
@@ -241,6 +251,7 @@ const expectedOutputs = [
             terms: [
                 {
                     kind: 'COMPARISON',
+                    type: 'video',
                     field: 'fps',
                     operator: '!=',
                     value: 30.0
@@ -249,6 +260,7 @@ const expectedOutputs = [
                     kind: 'NOT',
                     term: {
                         kind: 'TAGS_CONTAINS',
+                        type: 'video',
                         tag_name: 'low_res'
                     }
                 }
@@ -266,12 +278,14 @@ const expectedOutputs = [
                     terms: [
                         {
                             kind: 'COMPARISON',
+                            type: 'object_detection',
                             field: 'label',
                             operator: '==',
                             value: 'car'
                         },
                         {
                             kind: 'COMPARISON',
+                            type: 'object_detection',
                             field: 'x',
                             operator: '<',
                             value: 10
@@ -283,12 +297,14 @@ const expectedOutputs = [
                     terms: [
                         {
                             kind: 'COMPARISON',
+                            type: 'object_detection',
                             field: 'label',
                             operator: '==',
                             value: 'truck'
                         },
                         {
                             kind: 'COMPARISON',
+                            type: 'object_detection',
                             field: 'width',
                             operator: '>',
                             value: 100
@@ -306,12 +322,14 @@ const expectedOutputs = [
             terms: [
                 {
                     kind: 'COMPARISON',
+                    type: 'object_detection',
                     field: 'width',
                     operator: '>',
                     value: 50
                 },
                 {
                     kind: 'COMPARISON',
+                    type: 'object_detection',
                     field: 'height',
                     operator: '<',
                     value: 200
@@ -333,7 +351,13 @@ queries.forEach((q, i) => {
         parseResult.lexerErrors.forEach((err) => console.error('Lexer Error: ' + err.message));
         parseResult.parserErrors.forEach((err) => console.error('Parser Error: ' + err.message));
     } else {
-        const json = transformToDSLJson(parseResult.value);
+        // Determine initial context
+        let initialContext: 'image' | 'video' = 'image';
+        if (q.startsWith('video:')) {
+            initialContext = 'video';
+        }
+
+        const json = transformToDSLJson(parseResult.value, initialContext);
         console.log('Emitted JSON for Backend:');
         console.log(JSON.stringify(json, null, 2));
 

--- a/lightly_studio_view/src/lib/components/QueryEditor/tmp-showcase-lightly-query.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/tmp-showcase-lightly-query.ts
@@ -140,9 +140,9 @@ const parser = services.parser.LangiumParser;
 
 const queries = [
     "(Image.width > 100 OR Image.height > 100 OR Image.created_at == '2026-04-23 12:47:18+02:00') AND object_detection(label == 'car')",
-    "tags.contains('dog') or 'cat' IN tags AND Image.width > 100",
-    "tags.contains('dog') OR AND('cat' IN tags, Image.width >= 12)",
-    "video: NOT (Video.fps != 30.0 AND NOT tags.contains('low_res'))",
+    "'dog' in tags OR 'cat' IN tags AND Image.width > 100",
+    "'dog' in tags OR ('cat' IN tags AND Image.width >= 12)",
+    "video: NOT (Video.fps != 30.0 AND NOT 'low_res' IN tags)",
     "object_detection(label == 'car' AND x < 10 OR label == 'truck' AND width > 100)",
     'object_detection(ObjectDetection.width > 50 AND ObjectDetection.height < 200)'
 ];


### PR DESCRIPTION
## What has changed and why?

* Drop functional AND/OR
* Drop Image/Video/ObjectDetection prefix
* Drop `tags.contains()`

## How has it been tested?
Using the `tmp-showcase-lightly-query.ts` script

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified query syntax: field references are unqualified and boolean expressions use a cleaner chained form.
  * Added instance segmentation match expressions into query expression types.

* **Bug Fixes**
  * Query transformation now consistently propagates context into comparisons and tag matches.

* **Documentation**
  * Tag queries standardized to the "X IN tags" form; annotation view text updated to reference instance segmentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->