### PR TITLE
Add classification annotation to the grammar

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
@@ -103,8 +103,29 @@ ObjectDetectionComparison returns ComparisonExpression:
 ObjectDetectionFieldReference returns Expression:
   {FieldReference} member=ObjectDetectionFieldName;
 
+Classification returns Expression:
+  ClassificationOr;
+
+ClassificationOr returns Expression:
+  ClassificationAnd ({BooleanExpression.children+=current} operator=OR children+=ClassificationAnd (OR children+=ClassificationAnd)*)?;
+
+ClassificationAnd returns Expression:
+  ClassificationUnary ({BooleanExpression.children+=current} operator=AND children+=ClassificationUnary (AND children+=ClassificationUnary)*)?;
+
+ClassificationUnary returns Expression:
+  '(' Classification ')'
+    | {NotExpression} NOT expression=ClassificationUnary
+    | ClassificationComparison;
+
+ClassificationComparison returns ComparisonExpression:
+  ClassificationFieldReference {ComparisonExpression.left=current} operator=('==' | '!=') right=StringLiteral;
+
+ClassificationFieldReference returns Expression:
+  {FieldReference} member=LABEL;
+
 AnnotationQuery returns Expression:
-  {FunctionCall} name=ANNOTATION_FUNCTION '(' args+=ObjectDetection ')';
+  {FunctionCall} name=OBJECT_DETECTION_FUNCTION '(' args+=ObjectDetection ')'
+  | {FunctionCall} name=CLASSIFICATION_FUNCTION '(' args+=Classification ')';
 
 TagInExpression returns Expression:
   {TagInExpression} tag_name=StringLiteral IN TAGS_KEYWORD;
@@ -162,7 +183,8 @@ terminal AND: /\bAND\b/i;
 terminal OR: /\bOR\b/i;
 terminal NOT: /\bNOT\b/i;
 terminal IN returns string: /\bIN\b/i;
-terminal ANNOTATION_FUNCTION returns string: /\bobject_detection\b/;
+terminal OBJECT_DETECTION_FUNCTION returns string: /\bobject_detection\b/;
+terminal CLASSIFICATION_FUNCTION returns string: /\bclassification\b/;
 terminal TAGS_KEYWORD returns string: /\btags\b/;
 terminal ORDINAL_FLOAT_FIELD_NAME returns string: /\bduration_s\b/;
 terminal EQUALITY_FLOAT_FIELD_NAME returns string: /\bfps\b/;

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -18,6 +18,7 @@ import type {
     DatetimeExpr,
     TagsContainsExpr,
     ObjectDetectionMatchExpr,
+    ClassificationMatchExpr,
     AndExpr,
     OrExpr,
     NotExpr
@@ -60,6 +61,7 @@ describe('parseLightlyQuery error handling', () => {
         { name: 'string compared to int field', source: 'height == "tall"' },
         { name: 'obj detection without arguments', source: 'object_detection()' },
         { name: 'obj detection unknown field', source: 'object_detection(file_name == "a.jpg")' },
+        { name: 'classification unknown field', source: 'classification(x == 0)' },
         { name: 'wrong in operator use', source: '"jpg" IN file_name' },
         { name: 'stray punctuation', source: '@@@' }
     ];
@@ -111,6 +113,12 @@ const objectDetection = (subexpr: MatchExpr): MatchExpr =>
         type: 'object_detection_match_expr',
         subexpr
     }) satisfies ObjectDetectionMatchExpr & { type: 'object_detection_match_expr' };
+
+const classification = (subexpr: MatchExpr): MatchExpr =>
+    ({
+        type: 'classification_match_expr',
+        subexpr
+    }) satisfies ClassificationMatchExpr & { type: 'classification_match_expr' };
 
 const and = (...children: MatchExpr[]): MatchExpr =>
     ({
@@ -198,6 +206,13 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
         name: 'object detection height less than or equal',
         source: 'object_detection(height <= 120)',
         expected: query(objectDetection(int('object_detection', 'height', '<=', 120)))
+    },
+
+    /* Classification expression */
+    {
+        name: 'classification label',
+        source: 'classification(label == "cat")',
+        expected: query(classification(str('classification', 'label', '==', 'cat')))
     },
 
     /* Boolean operators */


### PR DESCRIPTION
## What has changed and why?
We're missing an option to filter classification annotations in the query grammar.

## How has it been tested?
Added tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Classification-based query expressions now supported in the query editor, enabling complex queries using boolean logic operators (AND, OR, NOT) and parentheses for grouping
  * Classification label fields can be compared using equality (==) and inequality (!=) operators

* **Tests**
  * Added test coverage for classification match expressions and invalid expression handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->