### PR TITLE
Improve tif image support

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/images.py
+++ b/lightly_studio/src/lightly_studio/api/routes/images.py
@@ -164,6 +164,7 @@ def _get_content_type(file_path: str) -> str:
         ".gif": "image/gif",
         ".webp": "image/webp",
         ".bmp": "image/bmp",
+        ".tif": "image/tiff",
         ".tiff": "image/tiff",
         ".mov": "video/quicktime",
         ".mp4": "video/mp4",

--- a/lightly_studio/src/lightly_studio/dataset/fsspec_lister.py
+++ b/lightly_studio/src/lightly_studio/dataset/fsspec_lister.py
@@ -31,6 +31,7 @@ IMAGE_EXTENSIONS = {
     ".gif",
     ".webp",
     ".bmp",
+    ".tif",
     ".tiff",
 }
 

--- a/lightly_studio/tests/core/image/test_image_dataset__path.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__path.py
@@ -24,6 +24,8 @@ class TestDataset:
                 images_path / "image1.jpg",
                 images_path / "image2.png",
                 images_path / "image3.BMP",
+                images_path / "image4.tif",
+                images_path / "image5.TIFF",
                 images_path / "subfolder" / "image4.jpg",
             ]
         )
@@ -32,11 +34,13 @@ class TestDataset:
         dataset.add_images_from_path(path=images_path)
 
         samples = dataset.query().to_list()
-        assert len(samples) == 4
+        assert len(samples) == 6
         assert {s.file_name for s in samples} == {
             "image1.jpg",
             "image2.png",
             "image3.BMP",
+            "image4.tif",
+            "image5.TIFF",
             "image4.jpg",
         }
         # Check that embeddings were created

--- a/lightly_studio/tests/core/image/test_image_dataset__path.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__path.py
@@ -26,7 +26,7 @@ class TestDataset:
                 images_path / "image3.BMP",
                 images_path / "image4.tif",
                 images_path / "image5.TIFF",
-                images_path / "subfolder" / "image4.jpg",
+                images_path / "subfolder" / "image6.jpg",
             ]
         )
 
@@ -41,7 +41,7 @@ class TestDataset:
             "image3.BMP",
             "image4.tif",
             "image5.TIFF",
-            "image4.jpg",
+            "image6.jpg",
         }
         # Check that embeddings were created
         assert all(len(sample.sample_table.embeddings) == 1 for sample in samples)


### PR DESCRIPTION
## What has changed and why?

Added `.tif` support alongside the existing TIFF image handling so path-based image dataset loading discovers both `.tif` and `.tiff` files. The image media endpoint also maps `.tif` responses to `image/tiff`.

## How has it been tested?

- Added tests for .tif and .tiff

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recognize `.tif` files as TIFF images so they are handled consistently with `.tiff` files.

* **Tests**
  * Expanded test coverage to include `.tif` files and updated expectations to reflect discovery and processing of additional TIFF inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->