### PR TITLE
Temporarily disable E2E tests that are timing out

### DIFF
--- a/lightly_studio_view/e2e/general/sample-details/brush-tool-keyboard-navigation.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/sample-details/brush-tool-keyboard-navigation.e2e-test.ts
@@ -58,7 +58,7 @@ const assertBrushIsVisuallySelected = async (page: Page) => {
     );
 };
 
-test('brush stays effective across keyboard navigation while creating masks on 3 samples', async ({
+test.skip('brush stays effective across keyboard navigation while creating masks on 3 samples', async ({
     page,
     samplesPage,
     sampleDetailsPage

--- a/lightly_studio_view/e2e/general/select-all.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/select-all.e2e-test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from '../utils';
 import { cocoDataset } from './fixtures';
 
-test('select all images with label filter via keyboard shortcut', async ({ page, samplesPage }) => {
+test.skip('select all images with label filter via keyboard shortcut', async ({
+    page,
+    samplesPage
+}) => {
     // Apply a label filter to reduce the visible samples
     await samplesPage.clickLabel(cocoDataset.labels.dog.name);
     const filteredCount = await samplesPage.getSamples().count();


### PR DESCRIPTION
## What has changed and why?
These tests are timing out since the evening of April 29.

## How has it been tested?
Just by eye-balling the CI runs

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Disabled E2E test for brush tool keyboard navigation functionality across samples while creating masks as the feature undergoes refinement
  * Disabled E2E test for selecting all filtered images using keyboard shortcut functionality, pending further development
  * All test code and assertions remain intact for future re-enablement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->