### PR TITLE
Add: Tooltip to guide user to select images in grid view

### DIFF
--- a/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
@@ -73,28 +73,34 @@
     }
 </script>
 
+{#snippet tagInput()}
+    <div class="w-full">
+        <Input
+            type="text"
+            placeholder="Assign tag to selection"
+            bind:value={searchQuery}
+            onkeydown={handleKeydown}
+            oninput={handleInput}
+            onfocus={handleFocus}
+            onblur={handleBlur}
+            class="h-8 text-xs disabled:opacity-60"
+            disabled={busy}
+        />
+    </div>
+{/snippet}
+
 <div class="relative pt-2">
-    <Tooltip
-        content={showSelectionHint
-            ? 'Select items in the grid, then assign or create a tag here.'
-            : ''}
-        position="right"
-        triggerClass="block w-full"
-    >
-        <div class="w-full">
-            <Input
-                type="text"
-                placeholder="Assign tag to selection"
-                bind:value={searchQuery}
-                onkeydown={handleKeydown}
-                oninput={handleInput}
-                onfocus={handleFocus}
-                onblur={handleBlur}
-                class="h-8 text-xs disabled:opacity-60"
-                disabled={busy}
-            />
-        </div>
-    </Tooltip>
+    {#if showSelectionHint}
+        <Tooltip
+            content="Select items in the grid, then assign or create a tag here."
+            position="right"
+            triggerClass="block w-full"
+        >
+            {@render tagInput()}
+        </Tooltip>
+    {:else}
+        {@render tagInput()}
+    {/if}
     {#if showDropdown && (filteredOptions.length > 0 || (trimmedSearchQuery && !hasExactMatch))}
         <div
             class="absolute left-0 top-full z-50 mt-1 max-h-44 w-full overflow-auto rounded-md border bg-popover shadow-md"

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
     import { Input } from '$lib/components/ui/input/index.js';
+    import { Tooltip } from '$lib/components/ui/tooltip';
     import type { TagView } from '$lib/services/types';
 
     interface Props {
         options: TagView[];
         busy: boolean;
+        showSelectionHint?: boolean;
         onSelect: (name: string) => void;
     }
 
-    let { options, busy, onSelect }: Props = $props();
+    let { options, busy, showSelectionHint = false, onSelect }: Props = $props();
 
     let searchQuery = $state('');
     let showDropdown = $state(false);
@@ -72,17 +74,27 @@
 </script>
 
 <div class="relative pt-2">
-    <Input
-        type="text"
-        placeholder="Assign tag to selection"
-        bind:value={searchQuery}
-        onkeydown={handleKeydown}
-        oninput={handleInput}
-        onfocus={handleFocus}
-        onblur={handleBlur}
-        class="h-8 text-xs disabled:opacity-60"
-        disabled={busy}
-    />
+    <Tooltip
+        content={showSelectionHint
+            ? 'Select items in the grid, then assign or create a tag here.'
+            : ''}
+        position="right"
+        triggerClass="block w-full"
+    >
+        <div class="w-full">
+            <Input
+                type="text"
+                placeholder="Assign tag to selection"
+                bind:value={searchQuery}
+                onkeydown={handleKeydown}
+                oninput={handleInput}
+                onfocus={handleFocus}
+                onblur={handleBlur}
+                class="h-8 text-xs disabled:opacity-60"
+                disabled={busy}
+            />
+        </div>
+    </Tooltip>
     {#if showDropdown && (filteredOptions.length > 0 || (trimmedSearchQuery && !hasExactMatch))}
         <div
             class="absolute left-0 top-full z-50 mt-1 max-h-44 w-full overflow-auto rounded-md border bg-popover shadow-md"

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -206,6 +206,7 @@
         <TagAssignInput
             options={$tags}
             busy={assignBusy || !hasSelection}
+            showSelectionHint={!hasSelection}
             onSelect={handleAssign}
         />
     </div>

--- a/lightly_studio_view/src/lib/components/ui/tooltip/tooltip.svelte
+++ b/lightly_studio_view/src/lib/components/ui/tooltip/tooltip.svelte
@@ -8,11 +8,13 @@
         content,
         position = 'top',
         class: className,
+        triggerClass,
         children
     }: {
         content: string;
         position?: 'top' | 'bottom' | 'left' | 'right';
         class?: string;
+        triggerClass?: string;
         children: Snippet;
     } = $props();
 
@@ -86,7 +88,7 @@
 </script>
 
 <div
-    class="relative inline-block"
+    class={cn('relative inline-block', triggerClass)}
     onmouseenter={showTooltipHandler}
     onmouseleave={hideTooltipHandler}
     onfocusin={showTooltipHandler}


### PR DESCRIPTION
## What has changed and why?

- Adds a simple tooltip in the frontend to tell the user that tags can only be created once one or more items are selected. This tooltip only appears when there are no items selected.

<img width="698" height="349" alt="image" src="https://github.com/user-attachments/assets/9f1b1069-bf8d-49f9-a4f8-d5ef45019f66" />

## How has it been tested?

- No breaking changes. Tested manually in frontend.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contextual guidance hints display during tag assignment when no selection is active, helping users understand available actions.
  * Tag-assignment input can optionally show a tooltip-based selection hint that appears alongside the input.
  * Tooltip trigger can accept a custom trigger class to improve styling and positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->