### PR TITLE
Add segmentation mask annotation to the grammar

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
@@ -127,9 +127,34 @@ ClassificationComparison returns ComparisonExpression:
 ClassificationFieldReference returns Expression:
   {FieldReference} member=LABEL;
 
+SegmentationMask returns Expression:
+  SegmentationMaskOr;
+
+SegmentationMaskOr returns Expression:
+  SegmentationMaskAnd ({BooleanExpression.children+=current} operator=OR children+=SegmentationMaskAnd (OR children+=SegmentationMaskAnd)*)?;
+
+SegmentationMaskAnd returns Expression:
+  SegmentationMaskUnary ({BooleanExpression.children+=current} operator=AND children+=SegmentationMaskUnary (AND children+=SegmentationMaskUnary)*)?;
+
+SegmentationMaskUnary returns Expression:
+  '(' SegmentationMask ')'
+    | {NotExpression} NOT expression=SegmentationMaskUnary
+    | SegmentationMaskComparison;
+
+SegmentationMaskComparison returns ComparisonExpression:
+  SegmentationMaskIntFieldReference {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=IntLiteral
+   | SegmentationMaskStringFieldReference {ComparisonExpression.left=current} operator=('==' | '!=') right=StringLiteral;
+
+SegmentationMaskIntFieldReference returns FieldReference:
+  {FieldReference} member=SegmentationMaskIntFieldName;
+
+SegmentationMaskStringFieldReference returns FieldReference:
+  {FieldReference} member=SegmentationMaskStringFieldName;
+
 AnnotationQuery returns Expression:
   {FunctionCall} name=OBJECT_DETECTION_FUNCTION '(' args+=ObjectDetection ')'
-  | {FunctionCall} name=CLASSIFICATION_FUNCTION '(' args+=Classification ')';
+  | {FunctionCall} name=CLASSIFICATION_FUNCTION '(' args+=Classification ')'
+  | {FunctionCall} name=SEGMENTATION_MASK_FUNCTION '(' args+=SegmentationMask ')';
 
 TagInExpression returns Expression:
   {TagInExpression} tag_name=StringLiteral IN TAGS_KEYWORD;
@@ -167,6 +192,12 @@ ObjectDetectionIntFieldName returns string:
 ObjectDetectionStringFieldName returns string:
   LABEL;
 
+SegmentationMaskIntFieldName returns string:
+  HEIGHT | WIDTH | X_COORD | Y_COORD;
+
+SegmentationMaskStringFieldName returns string:
+  LABEL;
+
 NumericLiteral returns Expression:
   IntLiteral | FloatLiteral;
 
@@ -189,6 +220,7 @@ terminal NOT: /\bNOT\b/i;
 terminal IN returns string: /\bIN\b/i;
 terminal OBJECT_DETECTION_FUNCTION returns string: /\bobject_detection\b/;
 terminal CLASSIFICATION_FUNCTION returns string: /\bclassification\b/;
+terminal SEGMENTATION_MASK_FUNCTION returns string: /\bsegmentation_mask\b/;
 terminal TAGS_KEYWORD returns string: /\btags\b/;
 terminal ORDINAL_FLOAT_FIELD_NAME returns string: /\bduration_s\b/;
 terminal EQUALITY_FLOAT_FIELD_NAME returns string: /\bfps\b/;

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -19,6 +19,7 @@ import type {
     TagsContainsExpr,
     ObjectDetectionMatchExpr,
     ClassificationMatchExpr,
+    SegmentationMaskMatchExpr,
     AndExpr,
     OrExpr,
     NotExpr
@@ -61,6 +62,11 @@ describe('parseLightlyQuery error handling', () => {
         { name: 'string compared to int field', source: 'height == "tall"' },
         { name: 'obj detection without arguments', source: 'object_detection()' },
         { name: 'obj detection unknown field', source: 'object_detection(file_name == "a.jpg")' },
+        { name: 'segmentation without arguments', source: 'segmentation_mask()' },
+        {
+            name: 'segmentation unknown field',
+            source: 'segmentation_mask(file_name == "a.jpg")'
+        },
         { name: 'classification unknown field', source: 'classification(x == 0)' },
         { name: 'wrong in operator use', source: '"jpg" IN file_name' },
         { name: 'stray punctuation', source: '@@@' }
@@ -128,6 +134,12 @@ const classification = (subexpr: MatchExpr): MatchExpr =>
         type: 'classification_match_expr',
         subexpr
     }) satisfies ClassificationMatchExpr & { type: 'classification_match_expr' };
+
+const segmentationMask = (subexpr: MatchExpr): MatchExpr =>
+    ({
+        type: 'segmentation_mask_match_expr',
+        subexpr
+    }) satisfies SegmentationMaskMatchExpr & { type: 'segmentation_mask_match_expr' };
 
 const and = (...children: MatchExpr[]): MatchExpr =>
     ({
@@ -223,6 +235,21 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
         source: 'classification(label == "cat")',
         expected: query(classification(str('classification', 'label', '==', 'cat')))
     },
+    {
+        name: 'segmentation label',
+        source: 'segmentation_mask(label == "cat")',
+        expected: query(segmentationMask(str('segmentation_mask', 'label', '==', 'cat')))
+    },
+    {
+        name: 'segmentation x inequality',
+        source: 'segmentation_mask(x != 0)',
+        expected: query(segmentationMask(int('segmentation_mask', 'x', '!=', 0)))
+    },
+    {
+        name: 'segmentation width greater than',
+        source: 'segmentation_mask(width > 80)',
+        expected: query(segmentationMask(int('segmentation_mask', 'width', '>', 80)))
+    },
 
     /* Boolean operators */
     {
@@ -287,6 +314,19 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
         source: 'object_detection(NOT label == "background")',
         expected: query(objectDetection(not(str('object_detection', 'label', '==', 'background'))))
     },
+    {
+        name: 'segmentation boolean expression',
+        source: 'segmentation_mask(label == "cat" AND width >= 50 AND height >= 40)',
+        expected: query(
+            segmentationMask(
+                and(
+                    str('segmentation_mask', 'label', '==', 'cat'),
+                    int('segmentation_mask', 'width', '>=', 50),
+                    int('segmentation_mask', 'height', '>=', 40)
+                )
+            )
+        )
+    },
 
     /* Additional syntax features */
     {
@@ -332,6 +372,24 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
                         str('object_detection', 'label', '==', 'cat'),
                         int('object_detection', 'width', '>', 80),
                         int('object_detection', 'height', '>', 80)
+                    )
+                )
+            )
+        )
+    },
+    {
+        name: 'complex reviewed large cat segmentation image',
+        source: 'height > 400 AND width >= 640 AND "reviewed" IN tags AND segmentation_mask(label == "cat" AND width > 80 AND height > 80)',
+        expected: query(
+            and(
+                int('image', 'height', '>', 400),
+                int('image', 'width', '>=', 640),
+                tagsContains('image', 'reviewed'),
+                segmentationMask(
+                    and(
+                        str('segmentation_mask', 'label', '==', 'cat'),
+                        int('segmentation_mask', 'width', '>', 80),
+                        int('segmentation_mask', 'height', '>', 80)
                     )
                 )
             )

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -378,24 +378,6 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
         )
     },
     {
-        name: 'complex reviewed large cat segmentation image',
-        source: 'height > 400 AND width >= 640 AND "reviewed" IN tags AND segmentation_mask(label == "cat" AND width > 80 AND height > 80)',
-        expected: query(
-            and(
-                int('image', 'height', '>', 400),
-                int('image', 'width', '>=', 640),
-                tagsContains('image', 'reviewed'),
-                segmentationMask(
-                    and(
-                        str('segmentation_mask', 'label', '==', 'cat'),
-                        int('segmentation_mask', 'width', '>', 80),
-                        int('segmentation_mask', 'height', '>', 80)
-                    )
-                )
-            )
-        )
-    },
-    {
         name: 'complex dataset curation query',
         source: '(file_path_abs != "/datasets/archive/bad.jpg" AND created_at >= "2025-01-01T00:00:00Z") AND ("training" IN tags OR "validation" IN tags) AND object_detection((label == "cat" OR label == "dog") AND NOT (x < 5 OR y < 5))',
         expected: query(

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.ts
@@ -14,6 +14,8 @@ import {
     isNumberLiteral,
     isObjectDetectionIntFieldName,
     isObjectDetectionStringFieldName,
+    isSegmentationMaskIntFieldName,
+    isSegmentationMaskStringFieldName,
     isStringLiteral,
     isTagInExpression,
     isVideoEqualityFloatFieldName,
@@ -35,7 +37,7 @@ export type QueryExprTranslationResult =
     | { status: 'ok'; queryExpr: QueryExpr }
     | { status: 'error'; errors: QueryParseError[] };
 
-type QueryScope = 'image' | 'video' | 'object_detection' | 'classification';
+type QueryScope = 'image' | 'video' | 'object_detection' | 'classification' | 'segmentation_mask';
 
 interface TranslationParser {
     parse: (value: string) => {
@@ -122,10 +124,7 @@ function visit(expr: Expression, table: QueryScope): QueryExpr['match_expr'] {
     }
     if (isFunctionCall(expr)) {
         const subTable = getFunctionScope(expr.name);
-        const type =
-            subTable === 'object_detection'
-                ? 'object_detection_match_expr'
-                : 'classification_match_expr';
+        const type = toAnnotationMatchExprType(subTable);
         return {
             type,
             subexpr: visit(expr.args[0], subTable)
@@ -177,6 +176,16 @@ function visitComparisonExpression(
                 break;
             case 'object_detection':
                 if (isObjectDetectionStringFieldName(fieldName)) {
+                    return {
+                        type: 'string_expr',
+                        field: { table, name: fieldName },
+                        operator: toEqualityComparisonOperator(expr.operator),
+                        value: right.value
+                    };
+                }
+                break;
+            case 'segmentation_mask':
+                if (isSegmentationMaskStringFieldName(fieldName)) {
                     return {
                         type: 'string_expr',
                         field: { table, name: fieldName },
@@ -244,7 +253,18 @@ function visitComparisonExpression(
                     };
                 }
                 break;
+            case 'segmentation_mask':
+                if (isSegmentationMaskIntFieldName(fieldName)) {
+                    return {
+                        type: 'integer_expr',
+                        field: { table, name: fieldName },
+                        operator: expr.operator,
+                        value: right.value
+                    };
+                }
+                break;
             case 'classification':
+                // This is a placeholder in case a field is added later. The code throws later.
                 break;
         }
     }
@@ -258,12 +278,28 @@ function getRootScope(parseResult: Query): Extract<QueryScope, 'image' | 'video'
 
 function getFunctionScope(
     name: string
-): Extract<QueryScope, 'object_detection' | 'classification'> {
-    if (name === 'object_detection' || name === 'classification') {
+): Extract<QueryScope, 'object_detection' | 'classification' | 'segmentation_mask'> {
+    if (name === 'object_detection' || name === 'classification' || name === 'segmentation_mask') {
         return name;
     }
 
     throw new Error(`Unsupported function: ${name}`);
+}
+
+function toAnnotationMatchExprType(
+    scope: Extract<QueryScope, 'object_detection' | 'classification' | 'segmentation_mask'>
+): Extract<
+    QueryExpr['match_expr']['type'],
+    'object_detection_match_expr' | 'classification_match_expr' | 'segmentation_mask_match_expr'
+> {
+    switch (scope) {
+        case 'object_detection':
+            return 'object_detection_match_expr';
+        case 'classification':
+            return 'classification_match_expr';
+        case 'segmentation_mask':
+            return 'segmentation_mask_match_expr';
+    }
 }
 
 function toBooleanExprType(operator: string): 'and' | 'or' {


### PR DESCRIPTION
## What has changed and why?
Add segmentation mask Langium grammar, almost identical to object detection grammar.

## How has it been tested?
Added tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query Editor now supports segmentation_mask() queries with field comparisons, boolean composition (AND/OR) and unary operators (NOT/parentheses)
  * Enables filtering by segmentation mask properties (string/int fields and comparisons) and integrates segmentation_mask() into query translation

* **Tests**
  * Added tests covering segmentation_mask() scenarios: unknown-field errors, string/int comparisons, boolean expressions and complex queries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->