### PR TITLE
Add: Image search drag and drop from grid view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added drag-and-drop from the image grid into the image search area.
 - Added API endpoints to fetch only sample IDs with optional filters for images, video frames, and annotations (used by the select-all keyboard shortcut).
 - Added `Cmd+A` / `Ctrl+A` keyboard shortcut to select all samples matching the current filters in grid views (images, videos, video frames, annotations).
 

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.constants.ts
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.constants.ts
@@ -1,4 +1,7 @@
 export const GRID_IMAGE_SEARCH_DROP_EVENT = 'lightly:grid-image-search-drop';
+export const GRID_IMAGE_SEARCH_DROP_TARGET_SELECTOR = '[data-grid-search-drop-target]';
+export const DRAG_START_THRESHOLD_PX = 8;
+export const DRAG_PREVIEW_OFFSET_PX = 14;
 
 export type GridItemDragData = {
     url: string;

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.constants.ts
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.constants.ts
@@ -1,0 +1,6 @@
+export const GRID_IMAGE_SEARCH_DROP_EVENT = 'lightly:grid-image-search-drop';
+
+export type GridItemDragData = {
+    url: string;
+    fileName: string;
+};

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-    import { onDestroy } from 'svelte';
     import type { Snippet } from 'svelte';
     import GridItemTag from './GridItemTag.svelte';
-    import { GRID_IMAGE_SEARCH_DROP_EVENT, type GridItemDragData } from './GridItem.constants';
-    const GRID_IMAGE_SEARCH_DROP_TARGET_SELECTOR = '[data-grid-search-drop-target]';
-    const DRAG_START_THRESHOLD_PX = 8;
-    const DRAG_PREVIEW_OFFSET_PX = 14;
+    import { DRAG_PREVIEW_OFFSET_PX, type GridItemDragData } from './GridItem.constants';
+    import { useGridItemDrag } from '$lib/hooks/useGridItemDrag/useGridItemDrag.svelte';
 
     let {
         children,
@@ -39,11 +36,7 @@
         ondblclick?: (event: MouseEvent) => void;
     } = $props();
 
-    let suppressNextClick = false;
-    let pointerStart: { x: number; y: number; id: number } | null = null;
-    let capturedPointerElement: HTMLElement | null = null;
-    let isPointerDragging = $state(false);
-    let dragPreview = $state<{ x: number; y: number } | null>(null);
+    const drag = useGridItemDrag(() => dragData);
 
     function formatSize(value: string | number): string {
         return typeof value === 'number' ? `${value}px` : value;
@@ -51,8 +44,8 @@
 
     function handleOnClick(event: MouseEvent) {
         if (!onSelect) return;
-        if (suppressNextClick) {
-            suppressNextClick = false;
+        if (drag.suppressNextClick) {
+            drag.suppressNextClick = false;
             event.preventDefault();
             return;
         }
@@ -66,121 +59,6 @@
         event.preventDefault();
         onSelect(event);
     }
-
-    function suppressNextSelectionClick() {
-        suppressNextClick = true;
-        setTimeout(() => {
-            suppressNextClick = false;
-        }, 100);
-    }
-
-    function getPointerDistance(event: PointerEvent): number {
-        if (!pointerStart) {
-            return 0;
-        }
-        return Math.hypot(event.clientX - pointerStart.x, event.clientY - pointerStart.y);
-    }
-
-    function getPointerTarget(event: PointerEvent): HTMLElement | null {
-        return event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
-    }
-
-    function getSearchDropTarget(event: PointerEvent): Element | null {
-        return (
-            document
-                .elementFromPoint(event.clientX, event.clientY)
-                ?.closest(GRID_IMAGE_SEARCH_DROP_TARGET_SELECTOR) ?? null
-        );
-    }
-
-    function setBodyDraggingCursor(isDragging: boolean) {
-        document.body.style.cursor = isDragging ? 'grabbing' : '';
-    }
-
-    function updateDragPreview(event: PointerEvent) {
-        dragPreview = { x: event.clientX, y: event.clientY };
-    }
-
-    function releaseCapturedPointer(pointerId = pointerStart?.id) {
-        if (capturedPointerElement && pointerId != null) {
-            try {
-                if (capturedPointerElement.hasPointerCapture?.(pointerId)) {
-                    capturedPointerElement.releasePointerCapture(pointerId);
-                }
-            } catch {
-                // Pointer capture may already be gone when cleanup races browser events.
-            }
-        }
-        capturedPointerElement = null;
-    }
-
-    function stopDragging() {
-        releaseCapturedPointer();
-        pointerStart = null;
-        isPointerDragging = false;
-        dragPreview = null;
-        setBodyDraggingCursor(false);
-    }
-
-    function handlePointerDown(event: PointerEvent) {
-        if (!dragData || event.button !== 0) {
-            return;
-        }
-        pointerStart = { x: event.clientX, y: event.clientY, id: event.pointerId };
-        isPointerDragging = false;
-        capturedPointerElement = getPointerTarget(event);
-        capturedPointerElement?.setPointerCapture?.(event.pointerId);
-    }
-
-    function handlePointerMove(event: PointerEvent) {
-        if (!dragData || !pointerStart || pointerStart.id !== event.pointerId) {
-            return;
-        }
-        if (!isPointerDragging && getPointerDistance(event) < DRAG_START_THRESHOLD_PX) {
-            return;
-        }
-        if (!isPointerDragging) {
-            isPointerDragging = true;
-            suppressNextSelectionClick();
-            setBodyDraggingCursor(true);
-        }
-        updateDragPreview(event);
-    }
-
-    function handlePointerUp(event: PointerEvent) {
-        if (!dragData || !pointerStart || pointerStart.id !== event.pointerId) {
-            stopDragging();
-            return;
-        }
-
-        const dropTarget = isPointerDragging ? getSearchDropTarget(event) : null;
-
-        if (isPointerDragging) {
-            suppressNextSelectionClick();
-        }
-
-        stopDragging();
-
-        if (dropTarget) {
-            window.dispatchEvent(
-                new CustomEvent<GridItemDragData>(GRID_IMAGE_SEARCH_DROP_EVENT, {
-                    detail: dragData
-                })
-            );
-        }
-    }
-
-    function handlePointerCancel() {
-        stopDragging();
-    }
-
-    function handleLostPointerCapture() {
-        stopDragging();
-    }
-
-    onDestroy(() => {
-        stopDragging();
-    });
 </script>
 
 <div class="select-none" {style}>
@@ -192,15 +70,15 @@
         data-sample-name={dataSampleName}
         data-index={dataIndex}
         draggable="false"
-        class:cursor-grab={dragData && !isPointerDragging}
-        class:cursor-grabbing={isPointerDragging}
+        class:cursor-grab={dragData && !drag.isPointerDragging}
+        class:cursor-grabbing={drag.isPointerDragging}
         {ondblclick}
         onclick={handleOnClick}
-        onpointerdown={handlePointerDown}
-        onpointermove={handlePointerMove}
-        onpointerup={handlePointerUp}
-        onpointercancel={handlePointerCancel}
-        onlostpointercapture={handleLostPointerCapture}
+        onpointerdown={drag.handlePointerDown}
+        onpointermove={drag.handlePointerMove}
+        onpointerup={drag.handlePointerUp}
+        onpointercancel={drag.handlePointerCancel}
+        onlostpointercapture={drag.handleLostPointerCapture}
         onkeydown={handleKeyDown}
         aria-label={ariaLabel}
         role="button"
@@ -225,10 +103,10 @@
     </div>
 </div>
 
-{#if dragData && dragPreview}
+{#if dragData && drag.dragPreview}
     <div
         class="pointer-events-none fixed z-50 h-20 w-20 overflow-hidden rounded-md border border-primary/60 bg-background opacity-80 shadow-xl ring-2 ring-primary/30"
-        style="left: {dragPreview.x + DRAG_PREVIEW_OFFSET_PX}px; top: {dragPreview.y +
+        style="left: {drag.dragPreview.x + DRAG_PREVIEW_OFFSET_PX}px; top: {drag.dragPreview.y +
             DRAG_PREVIEW_OFFSET_PX}px;"
         data-testid="grid-item-drag-preview"
     >

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
@@ -2,10 +2,7 @@
     import { onDestroy } from 'svelte';
     import type { Snippet } from 'svelte';
     import GridItemTag from './GridItemTag.svelte';
-    import {
-        GRID_IMAGE_SEARCH_DROP_EVENT,
-        type GridItemDragData
-    } from './GridItem.constants';
+    import { GRID_IMAGE_SEARCH_DROP_EVENT, type GridItemDragData } from './GridItem.constants';
     const GRID_IMAGE_SEARCH_DROP_TARGET_SELECTOR = '[data-grid-search-drop-target]';
     const DRAG_START_THRESHOLD_PX = 8;
     const DRAG_PREVIEW_OFFSET_PX = 14;

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onDestroy, onMount } from 'svelte';
     import type { Snippet } from 'svelte';
     import GridItemTag from './GridItemTag.svelte';
 
@@ -7,8 +8,12 @@
         fileName: string;
     };
 
-    const GRID_ITEM_DRAG_MIME_TYPE = 'application/vnd.lightly-studio.grid-image+json';
+    const GRID_IMAGE_SEARCH_DROP_EVENT = 'lightly:grid-image-search-drop';
+    const GRID_IMAGE_SEARCH_DRAG_STATE_EVENT = 'lightly:grid-image-search-drag-state';
+    const GRID_IMAGE_SEARCH_DROP_TARGET_SELECTOR = '[data-grid-search-drop-target]';
     const DRAG_START_THRESHOLD_PX = 8;
+    const DRAG_PREVIEW_OFFSET_PX = 14;
+    const DRAG_INACTIVITY_TIMEOUT_MS = 8000;
 
     let {
         children,
@@ -43,7 +48,12 @@
     } = $props();
 
     let suppressNextClick = false;
-    let pointerStart: { x: number; y: number } | null = null;
+    let pointerStart: { x: number; y: number; id: number } | null = null;
+    let capturedPointerElement: HTMLElement | null = null;
+    let dragCleanupTimeout: number | null = null;
+    let isPointerDragging = $state(false);
+    let isOverSearchDropTarget = $state(false);
+    let dragPreview = $state<{ x: number; y: number } | null>(null);
 
     function formatSize(value: string | number): string {
         return typeof value === 'number' ? `${value}px` : value;
@@ -74,28 +84,186 @@
         }, 100);
     }
 
-    function handleDragStart(event: DragEvent) {
-        if (!dragData || !event.dataTransfer) {
-            event.preventDefault();
+    function getPointerDistance(event: PointerEvent): number {
+        if (!pointerStart) {
+            return 0;
+        }
+        return Math.hypot(event.clientX - pointerStart.x, event.clientY - pointerStart.y);
+    }
+
+    function getPointerTarget(event: PointerEvent): HTMLElement | null {
+        return event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    }
+
+    function getSearchDropTarget(event: PointerEvent): Element | null {
+        return (
+            document
+                .elementFromPoint(event.clientX, event.clientY)
+                ?.closest(GRID_IMAGE_SEARCH_DROP_TARGET_SELECTOR) ?? null
+        );
+    }
+
+    function setBodyDraggingCursor(isDragging: boolean) {
+        document.body.style.cursor = isDragging ? 'grabbing' : '';
+    }
+
+    function clearDragCleanupTimeout() {
+        if (dragCleanupTimeout) {
+            window.clearTimeout(dragCleanupTimeout);
+            dragCleanupTimeout = null;
+        }
+    }
+
+    function scheduleDragCleanupTimeout() {
+        clearDragCleanupTimeout();
+        dragCleanupTimeout = window.setTimeout(() => {
+            stopDragging();
+        }, DRAG_INACTIVITY_TIMEOUT_MS);
+    }
+
+    function dispatchDragState(event: PointerEvent | null) {
+        const isOverDropTarget = event ? Boolean(getSearchDropTarget(event)) : false;
+        if (isOverSearchDropTarget === isOverDropTarget && event) {
             return;
         }
 
-        if (pointerStart && event.clientX != null && event.clientY != null) {
-            const deltaX = event.clientX - pointerStart.x;
-            const deltaY = event.clientY - pointerStart.y;
-            const distance = Math.hypot(deltaX, deltaY);
-            if (distance < DRAG_START_THRESHOLD_PX) {
-                event.preventDefault();
-                return;
+        isOverSearchDropTarget = isOverDropTarget;
+        window.dispatchEvent(
+            new CustomEvent(GRID_IMAGE_SEARCH_DRAG_STATE_EVENT, {
+                detail: {
+                    active: Boolean(event),
+                    overDropTarget: isOverDropTarget
+                }
+            })
+        );
+    }
+
+    function updateDragPreview(event: PointerEvent) {
+        dragPreview = { x: event.clientX, y: event.clientY };
+        dispatchDragState(event);
+        scheduleDragCleanupTimeout();
+    }
+
+    function releaseCapturedPointer(pointerId = pointerStart?.id) {
+        if (capturedPointerElement && pointerId != null) {
+            try {
+                if (capturedPointerElement.hasPointerCapture?.(pointerId)) {
+                    capturedPointerElement.releasePointerCapture(pointerId);
+                }
+            } catch {
+                // Pointer capture may already be gone when cleanup races browser events.
             }
         }
-
-        suppressNextSelectionClick();
-        event.dataTransfer.effectAllowed = 'copy';
-        event.dataTransfer.setData(GRID_ITEM_DRAG_MIME_TYPE, JSON.stringify(dragData));
-        event.dataTransfer.setData('text/uri-list', dragData.url);
-        event.dataTransfer.setData('text/plain', dragData.url);
+        capturedPointerElement = null;
     }
+
+    function stopDragging() {
+        clearDragCleanupTimeout();
+        releaseCapturedPointer();
+        pointerStart = null;
+        isPointerDragging = false;
+        dragPreview = null;
+        setBodyDraggingCursor(false);
+        dispatchDragState(null);
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+        if (!dragData || event.button !== 0) {
+            return;
+        }
+        pointerStart = { x: event.clientX, y: event.clientY, id: event.pointerId };
+        isPointerDragging = false;
+        capturedPointerElement = getPointerTarget(event);
+        capturedPointerElement?.setPointerCapture?.(event.pointerId);
+    }
+
+    function handlePointerMove(event: PointerEvent) {
+        if (!dragData || !pointerStart || pointerStart.id !== event.pointerId) {
+            return;
+        }
+        if (isPointerDragging || getPointerDistance(event) < DRAG_START_THRESHOLD_PX) {
+            if (isPointerDragging) {
+                updateDragPreview(event);
+            }
+            return;
+        }
+
+        isPointerDragging = true;
+        suppressNextSelectionClick();
+        setBodyDraggingCursor(true);
+        updateDragPreview(event);
+    }
+
+    function handlePointerUp(event: PointerEvent) {
+        if (!dragData || !pointerStart || pointerStart.id !== event.pointerId) {
+            stopDragging();
+            return;
+        }
+
+        const dropTarget = isPointerDragging ? getSearchDropTarget(event) : null;
+
+        if (isPointerDragging) {
+            suppressNextSelectionClick();
+        }
+
+        stopDragging();
+
+        if (dropTarget) {
+            window.dispatchEvent(
+                new CustomEvent<GridItemDragData>(GRID_IMAGE_SEARCH_DROP_EVENT, {
+                    detail: dragData
+                })
+            );
+        }
+    }
+
+    function handlePointerCancel() {
+        stopDragging();
+    }
+
+    function handleLostPointerCapture() {
+        stopDragging();
+    }
+
+    function handleWindowPointerEnd(event: PointerEvent) {
+        if (!pointerStart || pointerStart.id !== event.pointerId) {
+            return;
+        }
+        stopDragging();
+    }
+
+    function handleWindowBlur() {
+        stopDragging();
+    }
+
+    function handleVisibilityChange() {
+        if (document.visibilityState === 'hidden') {
+            stopDragging();
+        }
+    }
+
+    function handleWindowKeyDown(event: KeyboardEvent) {
+        if (event.key === 'Escape') {
+            stopDragging();
+        }
+    }
+
+    onMount(() => {
+        window.addEventListener('pointerup', handleWindowPointerEnd);
+        window.addEventListener('pointercancel', handleWindowPointerEnd);
+        window.addEventListener('blur', handleWindowBlur);
+        window.addEventListener('keydown', handleWindowKeyDown);
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+    });
+
+    onDestroy(() => {
+        window.removeEventListener('pointerup', handleWindowPointerEnd);
+        window.removeEventListener('pointercancel', handleWindowPointerEnd);
+        window.removeEventListener('blur', handleWindowBlur);
+        window.removeEventListener('keydown', handleWindowKeyDown);
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+        stopDragging();
+    });
 </script>
 
 <div class="select-none" {style}>
@@ -106,17 +274,16 @@
         data-testid={dataTestId}
         data-sample-name={dataSampleName}
         data-index={dataIndex}
-        draggable={dragData ? 'true' : 'false'}
+        draggable="false"
+        class:cursor-grab={dragData && !isPointerDragging}
+        class:cursor-grabbing={isPointerDragging}
         {ondblclick}
         onclick={handleOnClick}
-        onmousedown={(event) => {
-            pointerStart = { x: event.clientX, y: event.clientY };
-        }}
-        ondragstart={handleDragStart}
-        ondragend={() => {
-            suppressNextSelectionClick();
-            pointerStart = null;
-        }}
+        onpointerdown={handlePointerDown}
+        onpointermove={handlePointerMove}
+        onpointerup={handlePointerUp}
+        onpointercancel={handlePointerCancel}
+        onlostpointercapture={handleLostPointerCapture}
         onkeydown={handleKeyDown}
         aria-label={ariaLabel}
         role="button"
@@ -140,3 +307,16 @@
         {/if}
     </div>
 </div>
+
+{#if dragData && dragPreview}
+    <div
+        class="pointer-events-none fixed z-50 h-20 w-20 overflow-hidden rounded-md border border-primary/60 bg-background shadow-xl ring-2 ring-primary/30"
+        class:opacity-90={isOverSearchDropTarget}
+        class:opacity-70={!isOverSearchDropTarget}
+        style="left: {dragPreview.x + DRAG_PREVIEW_OFFSET_PX}px; top: {dragPreview.y +
+            DRAG_PREVIEW_OFFSET_PX}px;"
+        data-testid="grid-item-drag-preview"
+    >
+        <img src={dragData.url} alt="" class="h-full w-full object-cover" draggable="false" />
+    </div>
+{/if}

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
@@ -2,13 +2,10 @@
     import { onDestroy } from 'svelte';
     import type { Snippet } from 'svelte';
     import GridItemTag from './GridItemTag.svelte';
-
-    export type GridItemDragData = {
-        url: string;
-        fileName: string;
-    };
-
-    const GRID_IMAGE_SEARCH_DROP_EVENT = 'lightly:grid-image-search-drop';
+    import {
+        GRID_IMAGE_SEARCH_DROP_EVENT,
+        type GridItemDragData
+    } from './GridItem.constants';
     const GRID_IMAGE_SEARCH_DROP_TARGET_SELECTOR = '[data-grid-search-drop-target]';
     const DRAG_START_THRESHOLD_PX = 8;
     const DRAG_PREVIEW_OFFSET_PX = 14;
@@ -75,7 +72,7 @@
 
     function suppressNextSelectionClick() {
         suppressNextClick = true;
-        window.setTimeout(() => {
+        setTimeout(() => {
             suppressNextClick = false;
         }, 100);
     }
@@ -142,16 +139,14 @@
         if (!dragData || !pointerStart || pointerStart.id !== event.pointerId) {
             return;
         }
-        if (isPointerDragging || getPointerDistance(event) < DRAG_START_THRESHOLD_PX) {
-            if (isPointerDragging) {
-                updateDragPreview(event);
-            }
+        if (!isPointerDragging && getPointerDistance(event) < DRAG_START_THRESHOLD_PX) {
             return;
         }
-
-        isPointerDragging = true;
-        suppressNextSelectionClick();
-        setBodyDraggingCursor(true);
+        if (!isPointerDragging) {
+            isPointerDragging = true;
+            suppressNextSelectionClick();
+            setBodyDraggingCursor(true);
+        }
         updateDragPreview(event);
     }
 

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onDestroy, onMount } from 'svelte';
+    import { onDestroy } from 'svelte';
     import type { Snippet } from 'svelte';
     import GridItemTag from './GridItemTag.svelte';
 
@@ -9,11 +9,9 @@
     };
 
     const GRID_IMAGE_SEARCH_DROP_EVENT = 'lightly:grid-image-search-drop';
-    const GRID_IMAGE_SEARCH_DRAG_STATE_EVENT = 'lightly:grid-image-search-drag-state';
     const GRID_IMAGE_SEARCH_DROP_TARGET_SELECTOR = '[data-grid-search-drop-target]';
     const DRAG_START_THRESHOLD_PX = 8;
     const DRAG_PREVIEW_OFFSET_PX = 14;
-    const DRAG_INACTIVITY_TIMEOUT_MS = 8000;
 
     let {
         children,
@@ -50,9 +48,7 @@
     let suppressNextClick = false;
     let pointerStart: { x: number; y: number; id: number } | null = null;
     let capturedPointerElement: HTMLElement | null = null;
-    let dragCleanupTimeout: number | null = null;
     let isPointerDragging = $state(false);
-    let isOverSearchDropTarget = $state(false);
     let dragPreview = $state<{ x: number; y: number } | null>(null);
 
     function formatSize(value: string | number): string {
@@ -107,41 +103,8 @@
         document.body.style.cursor = isDragging ? 'grabbing' : '';
     }
 
-    function clearDragCleanupTimeout() {
-        if (dragCleanupTimeout) {
-            window.clearTimeout(dragCleanupTimeout);
-            dragCleanupTimeout = null;
-        }
-    }
-
-    function scheduleDragCleanupTimeout() {
-        clearDragCleanupTimeout();
-        dragCleanupTimeout = window.setTimeout(() => {
-            stopDragging();
-        }, DRAG_INACTIVITY_TIMEOUT_MS);
-    }
-
-    function dispatchDragState(event: PointerEvent | null) {
-        const isOverDropTarget = event ? Boolean(getSearchDropTarget(event)) : false;
-        if (isOverSearchDropTarget === isOverDropTarget && event) {
-            return;
-        }
-
-        isOverSearchDropTarget = isOverDropTarget;
-        window.dispatchEvent(
-            new CustomEvent(GRID_IMAGE_SEARCH_DRAG_STATE_EVENT, {
-                detail: {
-                    active: Boolean(event),
-                    overDropTarget: isOverDropTarget
-                }
-            })
-        );
-    }
-
     function updateDragPreview(event: PointerEvent) {
         dragPreview = { x: event.clientX, y: event.clientY };
-        dispatchDragState(event);
-        scheduleDragCleanupTimeout();
     }
 
     function releaseCapturedPointer(pointerId = pointerStart?.id) {
@@ -158,13 +121,11 @@
     }
 
     function stopDragging() {
-        clearDragCleanupTimeout();
         releaseCapturedPointer();
         pointerStart = null;
         isPointerDragging = false;
         dragPreview = null;
         setBodyDraggingCursor(false);
-        dispatchDragState(null);
     }
 
     function handlePointerDown(event: PointerEvent) {
@@ -225,43 +186,7 @@
         stopDragging();
     }
 
-    function handleWindowPointerEnd(event: PointerEvent) {
-        if (!pointerStart || pointerStart.id !== event.pointerId) {
-            return;
-        }
-        stopDragging();
-    }
-
-    function handleWindowBlur() {
-        stopDragging();
-    }
-
-    function handleVisibilityChange() {
-        if (document.visibilityState === 'hidden') {
-            stopDragging();
-        }
-    }
-
-    function handleWindowKeyDown(event: KeyboardEvent) {
-        if (event.key === 'Escape') {
-            stopDragging();
-        }
-    }
-
-    onMount(() => {
-        window.addEventListener('pointerup', handleWindowPointerEnd);
-        window.addEventListener('pointercancel', handleWindowPointerEnd);
-        window.addEventListener('blur', handleWindowBlur);
-        window.addEventListener('keydown', handleWindowKeyDown);
-        document.addEventListener('visibilitychange', handleVisibilityChange);
-    });
-
     onDestroy(() => {
-        window.removeEventListener('pointerup', handleWindowPointerEnd);
-        window.removeEventListener('pointercancel', handleWindowPointerEnd);
-        window.removeEventListener('blur', handleWindowBlur);
-        window.removeEventListener('keydown', handleWindowKeyDown);
-        document.removeEventListener('visibilitychange', handleVisibilityChange);
         stopDragging();
     });
 </script>
@@ -310,9 +235,7 @@
 
 {#if dragData && dragPreview}
     <div
-        class="pointer-events-none fixed z-50 h-20 w-20 overflow-hidden rounded-md border border-primary/60 bg-background shadow-xl ring-2 ring-primary/30"
-        class:opacity-90={isOverSearchDropTarget}
-        class:opacity-70={!isOverSearchDropTarget}
+        class="pointer-events-none fixed z-50 h-20 w-20 overflow-hidden rounded-md border border-primary/60 bg-background opacity-80 shadow-xl ring-2 ring-primary/30"
         style="left: {dragPreview.x + DRAG_PREVIEW_OFFSET_PX}px; top: {dragPreview.y +
             DRAG_PREVIEW_OFFSET_PX}px;"
         data-testid="grid-item-drag-preview"

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.svelte
@@ -2,6 +2,14 @@
     import type { Snippet } from 'svelte';
     import GridItemTag from './GridItemTag.svelte';
 
+    export type GridItemDragData = {
+        url: string;
+        fileName: string;
+    };
+
+    const GRID_ITEM_DRAG_MIME_TYPE = 'application/vnd.lightly-studio.grid-image+json';
+    const DRAG_START_THRESHOLD_PX = 8;
+
     let {
         children,
         width = 300,
@@ -14,6 +22,7 @@
         caption,
         dataSampleName,
         dataIndex,
+        dragData,
         onSelect,
         ondblclick
     }: {
@@ -28,9 +37,13 @@
         caption?: string;
         dataSampleName?: string;
         dataIndex?: number;
+        dragData?: GridItemDragData;
         onSelect?: (event: MouseEvent | KeyboardEvent) => void;
         ondblclick?: (event: MouseEvent) => void;
     } = $props();
+
+    let suppressNextClick = false;
+    let pointerStart: { x: number; y: number } | null = null;
 
     function formatSize(value: string | number): string {
         return typeof value === 'number' ? `${value}px` : value;
@@ -38,6 +51,11 @@
 
     function handleOnClick(event: MouseEvent) {
         if (!onSelect) return;
+        if (suppressNextClick) {
+            suppressNextClick = false;
+            event.preventDefault();
+            return;
+        }
         event.preventDefault();
         onSelect(event);
     }
@@ -47,6 +65,36 @@
         if (event.key !== 'Enter' && event.key !== ' ') return;
         event.preventDefault();
         onSelect(event);
+    }
+
+    function suppressNextSelectionClick() {
+        suppressNextClick = true;
+        window.setTimeout(() => {
+            suppressNextClick = false;
+        }, 100);
+    }
+
+    function handleDragStart(event: DragEvent) {
+        if (!dragData || !event.dataTransfer) {
+            event.preventDefault();
+            return;
+        }
+
+        if (pointerStart && event.clientX != null && event.clientY != null) {
+            const deltaX = event.clientX - pointerStart.x;
+            const deltaY = event.clientY - pointerStart.y;
+            const distance = Math.hypot(deltaX, deltaY);
+            if (distance < DRAG_START_THRESHOLD_PX) {
+                event.preventDefault();
+                return;
+            }
+        }
+
+        suppressNextSelectionClick();
+        event.dataTransfer.effectAllowed = 'copy';
+        event.dataTransfer.setData(GRID_ITEM_DRAG_MIME_TYPE, JSON.stringify(dragData));
+        event.dataTransfer.setData('text/uri-list', dragData.url);
+        event.dataTransfer.setData('text/plain', dragData.url);
     }
 </script>
 
@@ -58,8 +106,17 @@
         data-testid={dataTestId}
         data-sample-name={dataSampleName}
         data-index={dataIndex}
+        draggable={dragData ? 'true' : 'false'}
         {ondblclick}
         onclick={handleOnClick}
+        onmousedown={(event) => {
+            pointerStart = { x: event.clientX, y: event.clientY };
+        }}
+        ondragstart={handleDragStart}
+        ondragend={() => {
+            suppressNextSelectionClick();
+            pointerStart = null;
+        }}
         onkeydown={handleKeyDown}
         aria-label={ariaLabel}
         role="button"

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.test.ts
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.test.ts
@@ -80,9 +80,7 @@ describe('GridItem', () => {
     it('drops draggable grid items on the search target after threshold movement', async () => {
         const onSelect = vi.fn();
         const onGridImageSearchDrop = vi.fn();
-        const onGridImageSearchDragState = vi.fn();
         window.addEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
-        window.addEventListener('lightly:grid-image-search-drag-state', onGridImageSearchDragState);
         render(GridItemTestWrapper, {
             props: {
                 ...defaultProps,
@@ -107,11 +105,6 @@ describe('GridItem', () => {
         expect(screen.getByTestId('grid-item-drag-preview')).toBeInTheDocument();
         expect(gridItem).toHaveClass('cursor-grabbing');
         expect(document.body.style.cursor).toBe('grabbing');
-        expect(onGridImageSearchDragState).toHaveBeenLastCalledWith(
-            expect.objectContaining({
-                detail: { active: true, overDropTarget: true }
-            })
-        );
 
         await fireEvent(gridItem, createPointerEvent('pointerup', { clientX: 30, clientY: 10 }));
         await fireEvent.click(gridItem);
@@ -126,10 +119,6 @@ describe('GridItem', () => {
         expect(onSelect).not.toHaveBeenCalled();
 
         window.removeEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
-        window.removeEventListener(
-            'lightly:grid-image-search-drag-state',
-            onGridImageSearchDragState
-        );
         vi.restoreAllMocks();
     });
 
@@ -249,56 +238,6 @@ describe('GridItem', () => {
         expect(screen.getByTestId('grid-item-drag-preview')).toBeInTheDocument();
 
         await fireEvent(gridItem, new Event('lostpointercapture', { bubbles: true }));
-
-        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
-        expect(document.body.style.cursor).toBe('');
-    });
-
-    it('cleans up drag feedback on window pointerup if the item misses pointerup', async () => {
-        render(GridItemTestWrapper, {
-            props: {
-                ...defaultProps,
-                dragData: {
-                    url: '/api/images/sample/sample-1',
-                    fileName: 'sample-1.jpg'
-                }
-            }
-        });
-
-        const gridItem = screen.getByTestId('grid-item');
-        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
-        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
-
-        expect(screen.getByTestId('grid-item-drag-preview')).toBeInTheDocument();
-
-        await fireEvent(window, createPointerEvent('pointerup', { clientX: 30, clientY: 10 }));
-
-        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
-        expect(document.body.style.cursor).toBe('');
-    });
-
-    it('cleans up drag feedback on window blur and Escape', async () => {
-        render(GridItemTestWrapper, {
-            props: {
-                ...defaultProps,
-                dragData: {
-                    url: '/api/images/sample/sample-1',
-                    fileName: 'sample-1.jpg'
-                }
-            }
-        });
-
-        const gridItem = screen.getByTestId('grid-item');
-        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
-        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
-        await fireEvent(window, new Event('blur'));
-
-        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
-        expect(document.body.style.cursor).toBe('');
-
-        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
-        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
-        await fireEvent.keyDown(window, { key: 'Escape' });
 
         expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
         expect(document.body.style.cursor).toBe('');

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.test.ts
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.test.ts
@@ -7,6 +7,20 @@ describe('GridItem', () => {
         content: 'Sample content'
     };
 
+    function createPointerEvent(
+        type: string,
+        options: { button?: number; pointerId?: number; clientX: number; clientY: number }
+    ): Event {
+        const event = new Event(type, { bubbles: true }) as PointerEvent;
+        Object.defineProperties(event, {
+            button: { value: options.button ?? 0 },
+            pointerId: { value: options.pointerId ?? 1 },
+            clientX: { value: options.clientX },
+            clientY: { value: options.clientY }
+        });
+        return event;
+    }
+
     it('renders with default dimensions and content', () => {
         render(GridItemTestWrapper, { props: defaultProps });
 
@@ -63,9 +77,12 @@ describe('GridItem', () => {
         expect(ondblclick).toHaveBeenCalledTimes(1);
     });
 
-    it('adds drag data for draggable grid items', async () => {
+    it('drops draggable grid items on the search target after threshold movement', async () => {
         const onSelect = vi.fn();
-        const setData = vi.fn();
+        const onGridImageSearchDrop = vi.fn();
+        const onGridImageSearchDragState = vi.fn();
+        window.addEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
+        window.addEventListener('lightly:grid-image-search-drag-state', onGridImageSearchDragState);
         render(GridItemTestWrapper, {
             props: {
                 ...defaultProps,
@@ -78,29 +95,77 @@ describe('GridItem', () => {
         });
 
         const gridItem = screen.getByTestId('grid-item');
-        await fireEvent.dragStart(gridItem, {
-            dataTransfer: {
-                effectAllowed: 'move',
-                setData
-            }
+        const searchTarget = document.createElement('div');
+        searchTarget.setAttribute('data-grid-search-drop-target', '');
+        Object.defineProperty(document, 'elementFromPoint', {
+            configurable: true,
+            value: vi.fn(() => searchTarget)
         });
-        await fireEvent.click(gridItem);
 
-        expect(setData).toHaveBeenCalledWith(
-            'application/vnd.lightly-studio.grid-image+json',
-            JSON.stringify({
-                url: '/api/images/sample/sample-1',
-                fileName: 'sample-1.jpg'
+        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
+        expect(screen.getByTestId('grid-item-drag-preview')).toBeInTheDocument();
+        expect(gridItem).toHaveClass('cursor-grabbing');
+        expect(document.body.style.cursor).toBe('grabbing');
+        expect(onGridImageSearchDragState).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                detail: { active: true, overDropTarget: true }
             })
         );
-        expect(setData).toHaveBeenCalledWith('text/uri-list', '/api/images/sample/sample-1');
-        expect(setData).toHaveBeenCalledWith('text/plain', '/api/images/sample/sample-1');
+
+        await fireEvent(gridItem, createPointerEvent('pointerup', { clientX: 30, clientY: 10 }));
+        await fireEvent.click(gridItem);
+
+        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
+        expect(document.body.style.cursor).toBe('');
+        expect(onGridImageSearchDrop).toHaveBeenCalledOnce();
+        expect(onGridImageSearchDrop.mock.calls[0][0].detail).toEqual({
+            url: '/api/images/sample/sample-1',
+            fileName: 'sample-1.jpg'
+        });
         expect(onSelect).not.toHaveBeenCalled();
+
+        window.removeEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
+        window.removeEventListener(
+            'lightly:grid-image-search-drag-state',
+            onGridImageSearchDragState
+        );
+        vi.restoreAllMocks();
+    });
+
+    it('does not drop draggable grid items away from the search target', async () => {
+        const onGridImageSearchDrop = vi.fn();
+        window.addEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
+        render(GridItemTestWrapper, {
+            props: {
+                ...defaultProps,
+                dragData: {
+                    url: '/api/images/sample/sample-1',
+                    fileName: 'sample-1.jpg'
+                }
+            }
+        });
+
+        const gridItem = screen.getByTestId('grid-item');
+        Object.defineProperty(document, 'elementFromPoint', {
+            configurable: true,
+            value: vi.fn(() => document.createElement('div'))
+        });
+
+        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
+        await fireEvent(gridItem, createPointerEvent('pointerup', { clientX: 30, clientY: 10 }));
+
+        expect(onGridImageSearchDrop).not.toHaveBeenCalled();
+
+        window.removeEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
+        vi.restoreAllMocks();
     });
 
     it('keeps small pointer movements selectable on draggable grid items', async () => {
         const onSelect = vi.fn();
-        const setData = vi.fn();
+        const onGridImageSearchDrop = vi.fn();
+        window.addEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
         render(GridItemTestWrapper, {
             props: {
                 ...defaultProps,
@@ -113,26 +178,130 @@ describe('GridItem', () => {
         });
 
         const gridItem = screen.getByTestId('grid-item');
-        await fireEvent(
-            gridItem,
-            new MouseEvent('mousedown', { bubbles: true, clientX: 10, clientY: 10 })
-        );
-        const dragStartEvent = new Event('dragstart') as DragEvent;
-        Object.defineProperties(dragStartEvent, {
-            clientX: { value: 13 },
-            clientY: { value: 12 },
-            dataTransfer: {
-                value: {
-                    effectAllowed: 'move',
-                    setData
+        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 13, clientY: 12 }));
+        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
+        await fireEvent(gridItem, createPointerEvent('pointerup', { clientX: 13, clientY: 12 }));
+        await fireEvent.click(gridItem);
+
+        expect(onGridImageSearchDrop).not.toHaveBeenCalled();
+        expect(onSelect).toHaveBeenCalledOnce();
+
+        window.removeEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
+    });
+
+    it('prevents native browser dragging for draggable grid items', () => {
+        render(GridItemTestWrapper, {
+            props: {
+                ...defaultProps,
+                dragData: {
+                    url: '/api/images/sample/sample-1',
+                    fileName: 'sample-1.jpg'
                 }
             }
         });
-        await fireEvent(gridItem, dragStartEvent);
-        await fireEvent.click(gridItem);
 
-        expect(setData).not.toHaveBeenCalled();
-        expect(onSelect).toHaveBeenCalledOnce();
+        expect(screen.getByTestId('grid-item')).toHaveAttribute('draggable', 'false');
+    });
+
+    it('cleans up drag feedback on pointer cancel', async () => {
+        render(GridItemTestWrapper, {
+            props: {
+                ...defaultProps,
+                dragData: {
+                    url: '/api/images/sample/sample-1',
+                    fileName: 'sample-1.jpg'
+                }
+            }
+        });
+
+        const gridItem = screen.getByTestId('grid-item');
+        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
+
+        expect(screen.getByTestId('grid-item-drag-preview')).toBeInTheDocument();
+        expect(document.body.style.cursor).toBe('grabbing');
+
+        await fireEvent(
+            gridItem,
+            createPointerEvent('pointercancel', { clientX: 30, clientY: 10 })
+        );
+
+        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
+        expect(document.body.style.cursor).toBe('');
+    });
+
+    it('cleans up drag feedback when pointer capture is lost', async () => {
+        render(GridItemTestWrapper, {
+            props: {
+                ...defaultProps,
+                dragData: {
+                    url: '/api/images/sample/sample-1',
+                    fileName: 'sample-1.jpg'
+                }
+            }
+        });
+
+        const gridItem = screen.getByTestId('grid-item');
+        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
+
+        expect(screen.getByTestId('grid-item-drag-preview')).toBeInTheDocument();
+
+        await fireEvent(gridItem, new Event('lostpointercapture', { bubbles: true }));
+
+        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
+        expect(document.body.style.cursor).toBe('');
+    });
+
+    it('cleans up drag feedback on window pointerup if the item misses pointerup', async () => {
+        render(GridItemTestWrapper, {
+            props: {
+                ...defaultProps,
+                dragData: {
+                    url: '/api/images/sample/sample-1',
+                    fileName: 'sample-1.jpg'
+                }
+            }
+        });
+
+        const gridItem = screen.getByTestId('grid-item');
+        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
+
+        expect(screen.getByTestId('grid-item-drag-preview')).toBeInTheDocument();
+
+        await fireEvent(window, createPointerEvent('pointerup', { clientX: 30, clientY: 10 }));
+
+        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
+        expect(document.body.style.cursor).toBe('');
+    });
+
+    it('cleans up drag feedback on window blur and Escape', async () => {
+        render(GridItemTestWrapper, {
+            props: {
+                ...defaultProps,
+                dragData: {
+                    url: '/api/images/sample/sample-1',
+                    fileName: 'sample-1.jpg'
+                }
+            }
+        });
+
+        const gridItem = screen.getByTestId('grid-item');
+        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
+        await fireEvent(window, new Event('blur'));
+
+        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
+        expect(document.body.style.cursor).toBe('');
+
+        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
+        await fireEvent.keyDown(window, { key: 'Escape' });
+
+        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
+        expect(document.body.style.cursor).toBe('');
     });
 
     it('applies selected style and renders selectable tag', () => {

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.test.ts
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.test.ts
@@ -103,6 +103,7 @@ describe('GridItem', () => {
         await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
         await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
         expect(screen.getByTestId('grid-item-drag-preview')).toBeInTheDocument();
+        expect(gridItem).toHaveAttribute('draggable', 'false');
         expect(gridItem).toHaveClass('cursor-grabbing');
         expect(document.body.style.cursor).toBe('grabbing');
 
@@ -120,127 +121,6 @@ describe('GridItem', () => {
 
         window.removeEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
         vi.restoreAllMocks();
-    });
-
-    it('does not drop draggable grid items away from the search target', async () => {
-        const onGridImageSearchDrop = vi.fn();
-        window.addEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
-        render(GridItemTestWrapper, {
-            props: {
-                ...defaultProps,
-                dragData: {
-                    url: '/api/images/sample/sample-1',
-                    fileName: 'sample-1.jpg'
-                }
-            }
-        });
-
-        const gridItem = screen.getByTestId('grid-item');
-        Object.defineProperty(document, 'elementFromPoint', {
-            configurable: true,
-            value: vi.fn(() => document.createElement('div'))
-        });
-
-        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
-        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
-        await fireEvent(gridItem, createPointerEvent('pointerup', { clientX: 30, clientY: 10 }));
-
-        expect(onGridImageSearchDrop).not.toHaveBeenCalled();
-
-        window.removeEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
-        vi.restoreAllMocks();
-    });
-
-    it('keeps small pointer movements selectable on draggable grid items', async () => {
-        const onSelect = vi.fn();
-        const onGridImageSearchDrop = vi.fn();
-        window.addEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
-        render(GridItemTestWrapper, {
-            props: {
-                ...defaultProps,
-                dragData: {
-                    url: '/api/images/sample/sample-1',
-                    fileName: 'sample-1.jpg'
-                },
-                onSelect
-            }
-        });
-
-        const gridItem = screen.getByTestId('grid-item');
-        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
-        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 13, clientY: 12 }));
-        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
-        await fireEvent(gridItem, createPointerEvent('pointerup', { clientX: 13, clientY: 12 }));
-        await fireEvent.click(gridItem);
-
-        expect(onGridImageSearchDrop).not.toHaveBeenCalled();
-        expect(onSelect).toHaveBeenCalledOnce();
-
-        window.removeEventListener('lightly:grid-image-search-drop', onGridImageSearchDrop);
-    });
-
-    it('prevents native browser dragging for draggable grid items', () => {
-        render(GridItemTestWrapper, {
-            props: {
-                ...defaultProps,
-                dragData: {
-                    url: '/api/images/sample/sample-1',
-                    fileName: 'sample-1.jpg'
-                }
-            }
-        });
-
-        expect(screen.getByTestId('grid-item')).toHaveAttribute('draggable', 'false');
-    });
-
-    it('cleans up drag feedback on pointer cancel', async () => {
-        render(GridItemTestWrapper, {
-            props: {
-                ...defaultProps,
-                dragData: {
-                    url: '/api/images/sample/sample-1',
-                    fileName: 'sample-1.jpg'
-                }
-            }
-        });
-
-        const gridItem = screen.getByTestId('grid-item');
-        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
-        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
-
-        expect(screen.getByTestId('grid-item-drag-preview')).toBeInTheDocument();
-        expect(document.body.style.cursor).toBe('grabbing');
-
-        await fireEvent(
-            gridItem,
-            createPointerEvent('pointercancel', { clientX: 30, clientY: 10 })
-        );
-
-        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
-        expect(document.body.style.cursor).toBe('');
-    });
-
-    it('cleans up drag feedback when pointer capture is lost', async () => {
-        render(GridItemTestWrapper, {
-            props: {
-                ...defaultProps,
-                dragData: {
-                    url: '/api/images/sample/sample-1',
-                    fileName: 'sample-1.jpg'
-                }
-            }
-        });
-
-        const gridItem = screen.getByTestId('grid-item');
-        await fireEvent(gridItem, createPointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
-        await fireEvent(gridItem, createPointerEvent('pointermove', { clientX: 30, clientY: 10 }));
-
-        expect(screen.getByTestId('grid-item-drag-preview')).toBeInTheDocument();
-
-        await fireEvent(gridItem, new Event('lostpointercapture', { bubbles: true }));
-
-        expect(screen.queryByTestId('grid-item-drag-preview')).not.toBeInTheDocument();
-        expect(document.body.style.cursor).toBe('');
     });
 
     it('applies selected style and renders selectable tag', () => {

--- a/lightly_studio_view/src/lib/components/GridItem/GridItem.test.ts
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItem.test.ts
@@ -63,6 +63,78 @@ describe('GridItem', () => {
         expect(ondblclick).toHaveBeenCalledTimes(1);
     });
 
+    it('adds drag data for draggable grid items', async () => {
+        const onSelect = vi.fn();
+        const setData = vi.fn();
+        render(GridItemTestWrapper, {
+            props: {
+                ...defaultProps,
+                dragData: {
+                    url: '/api/images/sample/sample-1',
+                    fileName: 'sample-1.jpg'
+                },
+                onSelect
+            }
+        });
+
+        const gridItem = screen.getByTestId('grid-item');
+        await fireEvent.dragStart(gridItem, {
+            dataTransfer: {
+                effectAllowed: 'move',
+                setData
+            }
+        });
+        await fireEvent.click(gridItem);
+
+        expect(setData).toHaveBeenCalledWith(
+            'application/vnd.lightly-studio.grid-image+json',
+            JSON.stringify({
+                url: '/api/images/sample/sample-1',
+                fileName: 'sample-1.jpg'
+            })
+        );
+        expect(setData).toHaveBeenCalledWith('text/uri-list', '/api/images/sample/sample-1');
+        expect(setData).toHaveBeenCalledWith('text/plain', '/api/images/sample/sample-1');
+        expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('keeps small pointer movements selectable on draggable grid items', async () => {
+        const onSelect = vi.fn();
+        const setData = vi.fn();
+        render(GridItemTestWrapper, {
+            props: {
+                ...defaultProps,
+                dragData: {
+                    url: '/api/images/sample/sample-1',
+                    fileName: 'sample-1.jpg'
+                },
+                onSelect
+            }
+        });
+
+        const gridItem = screen.getByTestId('grid-item');
+        await fireEvent(
+            gridItem,
+            new MouseEvent('mousedown', { bubbles: true, clientX: 10, clientY: 10 })
+        );
+        const dragStartEvent = new Event('dragstart') as DragEvent;
+        Object.defineProperties(dragStartEvent, {
+            clientX: { value: 13 },
+            clientY: { value: 12 },
+            dataTransfer: {
+                value: {
+                    effectAllowed: 'move',
+                    setData
+                }
+            }
+        });
+        await fireEvent(gridItem, dragStartEvent);
+        await fireEvent.click(gridItem);
+
+        expect(setData).not.toHaveBeenCalled();
+        expect(onSelect).toHaveBeenCalledOnce();
+    });
+
     it('applies selected style and renders selectable tag', () => {
         render(GridItemTestWrapper, {
             props: {

--- a/lightly_studio_view/src/lib/components/GridItem/GridItemTestWrapper.test.svelte
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItemTestWrapper.test.svelte
@@ -13,6 +13,7 @@
         caption,
         dataSampleName,
         dataIndex,
+        dragData,
         onSelect,
         ondblclick
     }: {
@@ -27,6 +28,10 @@
         caption?: string;
         dataSampleName?: string;
         dataIndex?: number;
+        dragData?: {
+            url: string;
+            fileName: string;
+        };
         onSelect?: (event: MouseEvent | KeyboardEvent) => void;
         ondblclick?: (event: MouseEvent) => void;
     } = $props();
@@ -43,6 +48,7 @@
     {caption}
     {dataSampleName}
     {dataIndex}
+    {dragData}
     {onSelect}
     {ondblclick}
 >

--- a/lightly_studio_view/src/lib/components/GridItem/index.ts
+++ b/lightly_studio_view/src/lib/components/GridItem/index.ts
@@ -1,1 +1,2 @@
 export { default as GridItem } from './GridItem.svelte';
+export { GRID_IMAGE_SEARCH_DROP_EVENT, type GridItemDragData } from './GridItem.constants';

--- a/lightly_studio_view/src/lib/components/Images/Images.svelte
+++ b/lightly_studio_view/src/lib/components/Images/Images.svelte
@@ -21,6 +21,7 @@
     import { GridContainer } from '../GridContainer';
     import { Grid } from '../Grid';
     import { GridItem } from '../GridItem';
+    import { getGridImageURL } from '$lib/utils';
     import { selectRangeByAnchor } from '$lib/utils/selectRangeByAnchor';
     import { page } from '$app/state';
     import SampleImageGridItem from '../SampleImageGridItem/SampleImageGridItem.svelte';
@@ -284,6 +285,13 @@
                             dataTestId="sample-grid-item"
                             isSelected={$selectedSampleIds.has(samples[index].sample_id)}
                             ariaLabel={`View image: ${samples[index].file_name}`}
+                            dragData={{
+                                url: getGridImageURL({
+                                    sampleId: samples[index].sample_id,
+                                    quality: 'raw'
+                                }),
+                                fileName: samples[index].file_name
+                            }}
                             ondblclick={() => handleOnDoubleClick(samples[index].sample_id)}
                             onSelect={(event) =>
                                 handleGridItemSelect(event, samples[index].sample_id, index)}

--- a/lightly_studio_view/src/lib/components/SampleImage/index.svelte
+++ b/lightly_studio_view/src/lib/components/SampleImage/index.svelte
@@ -73,6 +73,7 @@
     style="--object-fit: {objectFit}"
     {width}
     {height}
+    draggable="false"
     loading="lazy"
 />
 

--- a/lightly_studio_view/src/lib/hooks/useGridItemDrag/useGridItemDrag.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useGridItemDrag/useGridItemDrag.svelte.ts
@@ -1,0 +1,144 @@
+import { onDestroy } from 'svelte';
+import {
+    GRID_IMAGE_SEARCH_DROP_EVENT,
+    GRID_IMAGE_SEARCH_DROP_TARGET_SELECTOR,
+    DRAG_START_THRESHOLD_PX,
+    type GridItemDragData
+} from '$lib/components/GridItem/GridItem.constants';
+
+export function useGridItemDrag(getDragData: () => GridItemDragData | undefined) {
+    let suppressNextClick = $state(false);
+    let pointerStart: { x: number; y: number; id: number } | null = null;
+    let capturedPointerElement: HTMLElement | null = null;
+    let isPointerDragging = $state(false);
+    let dragPreview = $state<{ x: number; y: number } | null>(null);
+
+    function suppressNextSelectionClick() {
+        suppressNextClick = true;
+        setTimeout(() => {
+            suppressNextClick = false;
+        }, 100);
+    }
+
+    function getPointerDistance(event: PointerEvent): number {
+        if (!pointerStart) return 0;
+        return Math.hypot(event.clientX - pointerStart.x, event.clientY - pointerStart.y);
+    }
+
+    function getPointerTarget(event: PointerEvent): HTMLElement | null {
+        return event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    }
+
+    function getSearchDropTarget(event: PointerEvent): Element | null {
+        return (
+            document
+                .elementFromPoint(event.clientX, event.clientY)
+                ?.closest(GRID_IMAGE_SEARCH_DROP_TARGET_SELECTOR) ?? null
+        );
+    }
+
+    function setBodyDraggingCursor(isDragging: boolean) {
+        document.body.style.cursor = isDragging ? 'grabbing' : '';
+    }
+
+    function updateDragPreview(event: PointerEvent) {
+        dragPreview = { x: event.clientX, y: event.clientY };
+    }
+
+    function releaseCapturedPointer(pointerId = pointerStart?.id) {
+        if (capturedPointerElement && pointerId != null) {
+            try {
+                if (capturedPointerElement.hasPointerCapture?.(pointerId)) {
+                    capturedPointerElement.releasePointerCapture(pointerId);
+                }
+            } catch {
+                // Pointer capture may already be gone when cleanup races browser events.
+            }
+        }
+        capturedPointerElement = null;
+    }
+
+    function stopDragging() {
+        releaseCapturedPointer();
+        pointerStart = null;
+        isPointerDragging = false;
+        dragPreview = null;
+        setBodyDraggingCursor(false);
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+        const dragData = getDragData();
+        if (!dragData || event.button !== 0) return;
+        pointerStart = { x: event.clientX, y: event.clientY, id: event.pointerId };
+        isPointerDragging = false;
+        capturedPointerElement = getPointerTarget(event);
+        capturedPointerElement?.setPointerCapture?.(event.pointerId);
+    }
+
+    function handlePointerMove(event: PointerEvent) {
+        if (!getDragData() || !pointerStart || pointerStart.id !== event.pointerId) return;
+        if (!isPointerDragging && getPointerDistance(event) < DRAG_START_THRESHOLD_PX) return;
+        if (!isPointerDragging) {
+            isPointerDragging = true;
+            suppressNextSelectionClick();
+            setBodyDraggingCursor(true);
+        }
+        updateDragPreview(event);
+    }
+
+    function handlePointerUp(event: PointerEvent) {
+        const dragData = getDragData();
+        if (!dragData || !pointerStart || pointerStart.id !== event.pointerId) {
+            stopDragging();
+            return;
+        }
+
+        const dropTarget = isPointerDragging ? getSearchDropTarget(event) : null;
+
+        if (isPointerDragging) {
+            suppressNextSelectionClick();
+        }
+
+        stopDragging();
+
+        if (dropTarget) {
+            window.dispatchEvent(
+                new CustomEvent<GridItemDragData>(GRID_IMAGE_SEARCH_DROP_EVENT, {
+                    detail: dragData
+                })
+            );
+        }
+    }
+
+    function handlePointerCancel() {
+        stopDragging();
+    }
+
+    function handleLostPointerCapture() {
+        stopDragging();
+    }
+
+    onDestroy(() => {
+        stopDragging();
+    });
+
+    return {
+        get isPointerDragging() {
+            return isPointerDragging;
+        },
+        get dragPreview() {
+            return dragPreview;
+        },
+        get suppressNextClick() {
+            return suppressNextClick;
+        },
+        set suppressNextClick(v: boolean) {
+            suppressNextClick = v;
+        },
+        handlePointerDown,
+        handlePointerMove,
+        handlePointerUp,
+        handlePointerCancel,
+        handleLostPointerCapture
+    };
+}

--- a/lightly_studio_view/src/lib/hooks/useGridItemDrag/useGridItemDrag.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useGridItemDrag/useGridItemDrag.test.ts
@@ -1,0 +1,95 @@
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GRID_IMAGE_SEARCH_DROP_EVENT } from '$lib/components/GridItem/GridItem.constants';
+import UseGridItemDragTestWrapper from './useGridItemDragTestWrapper.test.svelte';
+
+const dragData = { url: '/api/images/sample/1', fileName: 'sample.jpg' };
+
+function ptr(
+    type: string,
+    options: { clientX: number; clientY: number; pointerId?: number; button?: number }
+): Event {
+    const event = new Event(type, { bubbles: true }) as PointerEvent;
+    Object.defineProperties(event, {
+        button: { value: options.button ?? 0 },
+        pointerId: { value: options.pointerId ?? 1 },
+        clientX: { value: options.clientX },
+        clientY: { value: options.clientY }
+    });
+    return event;
+}
+
+beforeEach(() => {
+    Object.defineProperty(document, 'elementFromPoint', {
+        configurable: true,
+        value: vi.fn(() => null)
+    });
+});
+
+afterEach(() => {
+    document.body.style.cursor = '';
+    vi.restoreAllMocks();
+});
+
+describe('useGridItemDrag', () => {
+    it('keeps pointer movement below the drag threshold idle', async () => {
+        const onDrop = vi.fn();
+        window.addEventListener(GRID_IMAGE_SEARCH_DROP_EVENT, onDrop);
+
+        render(UseGridItemDragTestWrapper, { props: { dragData } });
+        const host = screen.getByTestId('drag-host');
+        const dropTarget = document.createElement('div');
+        dropTarget.setAttribute('data-grid-search-drop-target', '');
+        vi.mocked(document.elementFromPoint).mockReturnValue(dropTarget);
+
+        await fireEvent(host, ptr('pointerdown', { clientX: 0, clientY: 0 }));
+        await fireEvent(host, ptr('pointermove', { clientX: 3, clientY: 4 }));
+        await fireEvent(host, ptr('pointerup', { clientX: 3, clientY: 4 }));
+
+        expect(screen.queryByTestId('is-dragging')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('drag-preview')).not.toBeInTheDocument();
+        expect(document.body.style.cursor).toBe('');
+        expect(onDrop).not.toHaveBeenCalled();
+
+        window.removeEventListener(GRID_IMAGE_SEARCH_DROP_EVENT, onDrop);
+    });
+
+    it('starts dragging after threshold movement and resets on pointer up', async () => {
+        render(UseGridItemDragTestWrapper, { props: { dragData } });
+        const host = screen.getByTestId('drag-host');
+
+        await fireEvent(host, ptr('pointerdown', { clientX: 10, clientY: 10 }));
+        await fireEvent(host, ptr('pointermove', { clientX: 20, clientY: 10 }));
+
+        expect(screen.getByTestId('is-dragging')).toBeInTheDocument();
+        expect(screen.getByTestId('drag-preview')).toBeInTheDocument();
+        expect(document.body.style.cursor).toBe('grabbing');
+
+        await fireEvent(host, ptr('pointerup', { clientX: 20, clientY: 10 }));
+
+        expect(screen.queryByTestId('is-dragging')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('drag-preview')).not.toBeInTheDocument();
+        expect(document.body.style.cursor).toBe('');
+    });
+
+    it('dispatches drop data when released over a drop target', async () => {
+        const onDrop = vi.fn();
+        window.addEventListener(GRID_IMAGE_SEARCH_DROP_EVENT, onDrop);
+
+        render(UseGridItemDragTestWrapper, { props: { dragData } });
+        const host = screen.getByTestId('drag-host');
+
+        const dropTarget = document.createElement('div');
+        dropTarget.setAttribute('data-grid-search-drop-target', '');
+        vi.mocked(document.elementFromPoint).mockReturnValue(dropTarget);
+
+        await fireEvent(host, ptr('pointerdown', { clientX: 0, clientY: 0 }));
+        await fireEvent(host, ptr('pointermove', { clientX: 20, clientY: 0 }));
+        await fireEvent(host, ptr('pointerup', { clientX: 20, clientY: 0 }));
+
+        expect(onDrop).toHaveBeenCalledOnce();
+        expect(onDrop.mock.calls[0][0].detail).toEqual(dragData);
+
+        window.removeEventListener(GRID_IMAGE_SEARCH_DROP_EVENT, onDrop);
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useGridItemDrag/useGridItemDragTestWrapper.test.svelte
+++ b/lightly_studio_view/src/lib/hooks/useGridItemDrag/useGridItemDragTestWrapper.test.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import type { GridItemDragData } from '$lib/components/GridItem/GridItem.constants';
+    import { useGridItemDrag } from './useGridItemDrag.svelte';
+
+    let { dragData }: { dragData?: GridItemDragData } = $props();
+
+    const drag = useGridItemDrag(() => dragData);
+</script>
+
+<div
+    data-testid="drag-host"
+    onpointerdown={drag.handlePointerDown}
+    onpointermove={drag.handlePointerMove}
+    onpointerup={drag.handlePointerUp}
+    onpointercancel={drag.handlePointerCancel}
+    onlostpointercapture={drag.handleLostPointerCapture}
+    role="button"
+    tabindex="0"
+>
+    {#if drag.isPointerDragging}
+        <div data-testid="is-dragging"></div>
+    {/if}
+    {#if drag.dragPreview}
+        <div data-testid="drag-preview"></div>
+    {/if}
+</div>

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -141,10 +141,6 @@
             window.addEventListener('keyup', handleKeyEvent);
             window.addEventListener('keydown', handleSelectAllKeydown);
             window.addEventListener(GRID_IMAGE_SEARCH_DROP_EVENT, handleGridImageSearchDrop);
-            window.addEventListener(
-                GRID_IMAGE_SEARCH_DRAG_STATE_EVENT,
-                handleGridImageSearchDragState
-            );
         }
     });
 
@@ -154,10 +150,6 @@
             window.removeEventListener('keyup', handleKeyEvent);
             window.removeEventListener('keydown', handleSelectAllKeydown);
             window.removeEventListener(GRID_IMAGE_SEARCH_DROP_EVENT, handleGridImageSearchDrop);
-            window.removeEventListener(
-                GRID_IMAGE_SEARCH_DRAG_STATE_EVENT,
-                handleGridImageSearchDragState
-            );
             shutdownMaskRendererPool();
         }
     });
@@ -335,9 +327,7 @@
 
     const MAX_IMAGE_SIZE_MB = 50;
     const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
-    const GRID_IMAGE_DRAG_MIME_TYPE = 'application/vnd.lightly-studio.grid-image+json';
     const GRID_IMAGE_SEARCH_DROP_EVENT = 'lightly:grid-image-search-drop';
-    const GRID_IMAGE_SEARCH_DRAG_STATE_EVENT = 'lightly:grid-image-search-drag-state';
 
     type GridImageDragData = {
         url?: string;
@@ -364,12 +354,6 @@
         e.preventDefault();
         dragOver = false;
 
-        const gridImageFile = await getDroppedGridImageFile(e.dataTransfer);
-        if (gridImageFile) {
-            await uploadImage(gridImageFile);
-            return;
-        }
-
         if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
             const file = e.dataTransfer.files[0];
             if (file.type.startsWith('image/')) {
@@ -377,24 +361,6 @@
             } else {
                 setError('Please drop an image file.');
             }
-        }
-    }
-
-    async function getDroppedGridImageFile(
-        dataTransfer: DataTransfer | null
-    ): Promise<File | null> {
-        const dragData = dataTransfer?.getData(GRID_IMAGE_DRAG_MIME_TYPE);
-        if (!dragData) {
-            return null;
-        }
-
-        try {
-            return await getGridImageFile(JSON.parse(dragData) as GridImageDragData);
-        } catch (err: unknown) {
-            const message =
-                err instanceof Error ? err.message : 'Failed to load dragged image for search';
-            setError(message);
-            return null;
         }
     }
 
@@ -425,13 +391,6 @@
                 err instanceof Error ? err.message : 'Failed to load dragged image for search';
             setError(message);
         }
-    }
-
-    function handleGridImageSearchDragState(event: Event) {
-        dragOver = Boolean(
-            (event as CustomEvent<{ active?: boolean; overDropTarget?: boolean }>).detail
-                ?.overDropTarget
-        );
     }
 
     async function handlePaste(e: ClipboardEvent) {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -73,10 +73,7 @@
     import { isInputElement } from '$lib/utils';
     import { shutdownMaskRendererPool } from '$lib/workers/maskRendererPool';
     import { embedImageFromFile } from '$lib/api/lightly_studio_local';
-    import {
-        GRID_IMAGE_SEARCH_DROP_EVENT,
-        type GridItemDragData
-    } from '$lib/components/GridItem';
+    import { GRID_IMAGE_SEARCH_DROP_EVENT, type GridItemDragData } from '$lib/components/GridItem';
     const { data, children } = $props();
     const {
         collection,

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -72,6 +72,7 @@
     import { useSelectAll } from '$lib/hooks/useSelectAll/useSelectAll';
     import { isInputElement } from '$lib/utils';
     import { shutdownMaskRendererPool } from '$lib/workers/maskRendererPool';
+    import { embedImageFromFile } from '$lib/api/lightly_studio_local';
     const { data, children } = $props();
     const {
         collection,
@@ -139,6 +140,11 @@
             window.addEventListener('keydown', handleKeyEvent);
             window.addEventListener('keyup', handleKeyEvent);
             window.addEventListener('keydown', handleSelectAllKeydown);
+            window.addEventListener(GRID_IMAGE_SEARCH_DROP_EVENT, handleGridImageSearchDrop);
+            window.addEventListener(
+                GRID_IMAGE_SEARCH_DRAG_STATE_EVENT,
+                handleGridImageSearchDragState
+            );
         }
     });
 
@@ -147,6 +153,11 @@
             window.removeEventListener('keydown', handleKeyEvent);
             window.removeEventListener('keyup', handleKeyEvent);
             window.removeEventListener('keydown', handleSelectAllKeydown);
+            window.removeEventListener(GRID_IMAGE_SEARCH_DROP_EVENT, handleGridImageSearchDrop);
+            window.removeEventListener(
+                GRID_IMAGE_SEARCH_DRAG_STATE_EVENT,
+                handleGridImageSearchDragState
+            );
             shutdownMaskRendererPool();
         }
     });
@@ -325,6 +336,13 @@
     const MAX_IMAGE_SIZE_MB = 50;
     const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
     const GRID_IMAGE_DRAG_MIME_TYPE = 'application/vnd.lightly-studio.grid-image+json';
+    const GRID_IMAGE_SEARCH_DROP_EVENT = 'lightly:grid-image-search-drop';
+    const GRID_IMAGE_SEARCH_DRAG_STATE_EVENT = 'lightly:grid-image-search-drag-state';
+
+    type GridImageDragData = {
+        url?: string;
+        fileName?: string;
+    };
 
     let dragOver = $state(false);
     let activeImage = $state<string | null>(null);
@@ -371,25 +389,49 @@
         }
 
         try {
-            const parsedDragData = JSON.parse(dragData) as { url?: string; fileName?: string };
-            if (!parsedDragData.url) {
-                return null;
-            }
-
-            const response = await fetch(parsedDragData.url);
-            if (!response.ok) {
-                throw new Error(`Failed to fetch dragged image: ${response.statusText}`);
-            }
-
-            const blob = await response.blob();
-            const fileName = parsedDragData.fileName || 'grid-image';
-            return new File([blob], fileName, { type: blob.type || 'image/jpeg' });
+            return await getGridImageFile(JSON.parse(dragData) as GridImageDragData);
         } catch (err: unknown) {
             const message =
                 err instanceof Error ? err.message : 'Failed to load dragged image for search';
             setError(message);
             return null;
         }
+    }
+
+    async function getGridImageFile(dragData: GridImageDragData): Promise<File | null> {
+        if (!dragData.url) {
+            return null;
+        }
+
+        const response = await fetch(dragData.url);
+        if (!response.ok) {
+            throw new Error(`Failed to fetch dragged image: ${response.statusText}`);
+        }
+
+        const blob = await response.blob();
+        const fileName = dragData.fileName || 'grid-image';
+        return new File([blob], fileName, { type: blob.type || 'image/jpeg' });
+    }
+
+    async function handleGridImageSearchDrop(event: Event) {
+        const dragData = (event as CustomEvent<GridImageDragData>).detail;
+        try {
+            const file = await getGridImageFile(dragData);
+            if (file) {
+                await uploadImage(file);
+            }
+        } catch (err: unknown) {
+            const message =
+                err instanceof Error ? err.message : 'Failed to load dragged image for search';
+            setError(message);
+        }
+    }
+
+    function handleGridImageSearchDragState(event: Event) {
+        dragOver = Boolean(
+            (event as CustomEvent<{ active?: boolean; overDropTarget?: boolean }>).detail
+                ?.overDropTarget
+        );
     }
 
     async function handlePaste(e: ClipboardEvent) {
@@ -437,28 +479,22 @@
             return;
         }
 
-        const formData = new FormData();
-        formData.append('file', file);
-
         isUploading = true;
         try {
             const currentCollectionId = page.params.collection_id;
             if (!currentCollectionId) {
                 throw new Error('Collection ID is not available');
             }
-            const response = await fetch(
-                `/api/image_embedding/from_file/for_collection/${currentCollectionId}`,
-                {
-                    method: 'POST',
-                    body: formData
-                }
-            );
 
-            if (!response.ok) {
-                throw new Error(`Error uploading image: ${response.statusText}`);
+            const response = await embedImageFromFile({
+                path: { collection_id: currentCollectionId },
+                body: { file }
+            });
+
+            if (response.error) {
+                throw new Error('Error uploading image');
             }
-
-            const embedding = await response.json();
+            const embedding = response.data;
 
             // Clear text search state
             query_text = '';
@@ -623,6 +659,7 @@
                                             class="relative"
                                             role="region"
                                             aria-label="Search by image or text"
+                                            data-grid-search-drop-target
                                             ondragover={handleDragOver}
                                             ondragleave={handleDragLeave}
                                             ondrop={handleDrop}
@@ -753,6 +790,7 @@
                                     class="relative"
                                     role="region"
                                     aria-label="Search by image or text"
+                                    data-grid-search-drop-target
                                     ondragover={handleDragOver}
                                     ondragleave={handleDragLeave}
                                     ondrop={handleDrop}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -594,13 +594,12 @@
                             class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4"
                         >
                             <GridHeader>
-                                <div class="flex-1">
+                                <div class="flex-1" data-grid-search-drop-target>
                                     {#if hasEmbeddings}
                                         <div
                                             class="relative"
                                             role="region"
                                             aria-label="Search by image or text"
-                                            data-grid-search-drop-target
                                             ondragover={handleDragOver}
                                             ondragleave={handleDragLeave}
                                             ondrop={handleDrop}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -73,6 +73,10 @@
     import { isInputElement } from '$lib/utils';
     import { shutdownMaskRendererPool } from '$lib/workers/maskRendererPool';
     import { embedImageFromFile } from '$lib/api/lightly_studio_local';
+    import {
+        GRID_IMAGE_SEARCH_DROP_EVENT,
+        type GridItemDragData
+    } from '$lib/components/GridItem';
     const { data, children } = $props();
     const {
         collection,
@@ -327,12 +331,6 @@
 
     const MAX_IMAGE_SIZE_MB = 50;
     const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
-    const GRID_IMAGE_SEARCH_DROP_EVENT = 'lightly:grid-image-search-drop';
-
-    type GridImageDragData = {
-        url?: string;
-        fileName?: string;
-    };
 
     let dragOver = $state(false);
     let activeImage = $state<string | null>(null);
@@ -364,28 +362,15 @@
         }
     }
 
-    async function getGridImageFile(dragData: GridImageDragData): Promise<File | null> {
-        if (!dragData.url) {
-            return null;
-        }
-
-        const response = await fetch(dragData.url);
-        if (!response.ok) {
-            throw new Error(`Failed to fetch dragged image: ${response.statusText}`);
-        }
-
-        const blob = await response.blob();
-        const fileName = dragData.fileName || 'grid-image';
-        return new File([blob], fileName, { type: blob.type || 'image/jpeg' });
-    }
-
     async function handleGridImageSearchDrop(event: Event) {
-        const dragData = (event as CustomEvent<GridImageDragData>).detail;
+        const { url, fileName } = (event as CustomEvent<GridItemDragData>).detail;
         try {
-            const file = await getGridImageFile(dragData);
-            if (file) {
-                await uploadImage(file);
+            const response = await fetch(url);
+            if (!response.ok) {
+                throw new Error(`Failed to fetch dragged image: ${response.statusText}`);
             }
+            const blob = await response.blob();
+            await uploadImage(new File([blob], fileName, { type: blob.type || 'image/jpeg' }));
         } catch (err: unknown) {
             const message =
                 err instanceof Error ? err.message : 'Failed to load dragged image for search';

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -324,6 +324,7 @@
 
     const MAX_IMAGE_SIZE_MB = 50;
     const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
+    const GRID_IMAGE_DRAG_MIME_TYPE = 'application/vnd.lightly-studio.grid-image+json';
 
     let dragOver = $state(false);
     let activeImage = $state<string | null>(null);
@@ -344,6 +345,13 @@
     async function handleDrop(e: DragEvent) {
         e.preventDefault();
         dragOver = false;
+
+        const gridImageFile = await getDroppedGridImageFile(e.dataTransfer);
+        if (gridImageFile) {
+            await uploadImage(gridImageFile);
+            return;
+        }
+
         if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
             const file = e.dataTransfer.files[0];
             if (file.type.startsWith('image/')) {
@@ -351,6 +359,36 @@
             } else {
                 setError('Please drop an image file.');
             }
+        }
+    }
+
+    async function getDroppedGridImageFile(
+        dataTransfer: DataTransfer | null
+    ): Promise<File | null> {
+        const dragData = dataTransfer?.getData(GRID_IMAGE_DRAG_MIME_TYPE);
+        if (!dragData) {
+            return null;
+        }
+
+        try {
+            const parsedDragData = JSON.parse(dragData) as { url?: string; fileName?: string };
+            if (!parsedDragData.url) {
+                return null;
+            }
+
+            const response = await fetch(parsedDragData.url);
+            if (!response.ok) {
+                throw new Error(`Failed to fetch dragged image: ${response.statusText}`);
+            }
+
+            const blob = await response.blob();
+            const fileName = parsedDragData.fileName || 'grid-image';
+            return new File([blob], fileName, { type: blob.type || 'image/jpeg' });
+        } catch (err: unknown) {
+            const message =
+                err instanceof Error ? err.message : 'Failed to load dragged image for search';
+            setError(message);
+            return null;
         }
     }
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
@@ -17,6 +17,7 @@
     import { selectRangeByAnchor } from '$lib/utils/selectRangeByAnchor';
     import { onMount } from 'svelte';
     import { useScrollRestoration } from '$lib/hooks/useScrollRestoration/useScrollRestoration';
+    import { getGridFrameURL } from '$lib/utils';
 
     const collectionId = $derived($page.params.collection_id!);
     const { tagsSelected } = $derived.by(() =>
@@ -217,6 +218,15 @@
                                 dataTestId="video-grid-item"
                                 isSelected={$selectedSampleIds.has(items[index].sample_id)}
                                 ariaLabel={`View sample: ${items[index].file_name}`}
+                                dragData={items[index].frame
+                                    ? {
+                                          url: getGridFrameURL({
+                                              sampleId: items[index].frame.sample_id,
+                                              quality: 'raw'
+                                          }),
+                                          fileName: `${items[index].file_name}.jpg`
+                                      }
+                                    : undefined}
                                 onSelect={(event) =>
                                     handleGridItemSelect(event, items[index].sample_id, index)}
                             >

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
@@ -17,7 +17,6 @@
     import { selectRangeByAnchor } from '$lib/utils/selectRangeByAnchor';
     import { onMount } from 'svelte';
     import { useScrollRestoration } from '$lib/hooks/useScrollRestoration/useScrollRestoration';
-    import { getGridFrameURL } from '$lib/utils';
 
     const collectionId = $derived($page.params.collection_id!);
     const { tagsSelected } = $derived.by(() =>
@@ -218,15 +217,6 @@
                                 dataTestId="video-grid-item"
                                 isSelected={$selectedSampleIds.has(items[index].sample_id)}
                                 ariaLabel={`View sample: ${items[index].file_name}`}
-                                dragData={items[index].frame
-                                    ? {
-                                          url: getGridFrameURL({
-                                              sampleId: items[index].frame.sample_id,
-                                              quality: 'raw'
-                                          }),
-                                          fileName: `${items[index].file_name}.jpg`
-                                      }
-                                    : undefined}
                                 onSelect={(event) =>
                                     handleGridItemSelect(event, items[index].sample_id, index)}
                             >


### PR DESCRIPTION
## What has changed and why?

- Adds support for doing drag and drop directly from the grid view to perform similarity search. Simply drag any image from the grid to the search bar
- Slight UX tweaks. Minor accidential drags (just a few pixels) are no longer registered as drag and drop

> Note: This workflow does not work for videos, annotations, frames but only for images.

https://github.com/user-attachments/assets/a498b515-891a-4d42-b1ae-51ba35214446



## How has it been tested?

- New tests & manual testing

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [X] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop: drag images from the grid (with live preview) into the image search area to initiate a search/upload
  * Select-all shortcut: Cmd+A / Ctrl+A selects all samples matching current grid filters
  * New API endpoints: fetch sample IDs with optional filters (images, video frames, annotations)

* **UX Improvements**
  * Prevents native browser image dragging for a smoother custom drag experience

* **Refactor**
  * Annotation rendering now uses a shared worker pool for better performance and lower resource use
<!-- end of auto-generated comment: release notes by coderabbit.ai -->