### PR TITLE
Add: button to select all items based on active filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added drag-and-drop from the image grid into the image search area.
+- Added a select-all button to select all grid items matching the active filters.
 - Added API endpoints to fetch only sample IDs with optional filters for images, video frames, and annotations (used by the select-all keyboard shortcut).
 - Added `Cmd+A` / `Ctrl+A` keyboard shortcut to select all samples matching the current filters in grid views (images, videos, video frames, annotations).
 

--- a/lightly_studio_view/src/lib/components/GridHeader/GridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/GridHeader/GridHeader.svelte
@@ -5,10 +5,16 @@
     interface GridHeaderProps {
         showImageSizeControl?: boolean;
         children?: Snippet;
+        selectionControls?: Snippet;
         auxControls?: Snippet;
     }
 
-    let { showImageSizeControl = true, children, auxControls }: GridHeaderProps = $props();
+    let {
+        showImageSizeControl = true,
+        children,
+        selectionControls,
+        auxControls
+    }: GridHeaderProps = $props();
 </script>
 
 <div class="my-2 flex items-center space-x-4">
@@ -16,6 +22,7 @@
         {@render children?.()}
     </div>
 
+    {@render selectionControls?.()}
     {#if showImageSizeControl}
         <ImageSizeControl />
     {/if}

--- a/lightly_studio_view/src/lib/components/GridHeader/GridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/GridHeader/GridHeader.test.ts
@@ -54,6 +54,16 @@ describe('GridHeader', () => {
         expect(container.textContent).toContain('Aux Controls');
     });
 
+    it('renders selectionControls snippet when provided', () => {
+        const { container } = render(GridHeaderTest, {
+            props: {
+                testCase: 'with-selection-controls'
+            }
+        });
+
+        expect(container.textContent).toContain('Selection Controls');
+    });
+
     it('renders all elements together when provided', () => {
         const { container } = render(GridHeaderTest, {
             props: {
@@ -62,6 +72,7 @@ describe('GridHeader', () => {
         });
 
         expect(container.textContent).toContain('Main Content');
+        expect(container.textContent).toContain('Selection Controls');
         expect(container.textContent).toContain('Extra Controls');
         expect(screen.getByLabelText('Zoom out')).toBeInTheDocument();
     });

--- a/lightly_studio_view/src/lib/components/GridHeader/GridHeaderTest.test.svelte
+++ b/lightly_studio_view/src/lib/components/GridHeader/GridHeaderTest.test.svelte
@@ -15,9 +15,19 @@
             Aux Controls
         {/snippet}
     </GridHeader>
+{:else if testCase === 'with-selection-controls'}
+    <GridHeader>
+        Main Content
+        {#snippet selectionControls()}
+            Selection Controls
+        {/snippet}
+    </GridHeader>
 {:else if testCase === 'all-elements'}
     <GridHeader showImageSizeControl={true}>
         Main Content
+        {#snippet selectionControls()}
+            Selection Controls
+        {/snippet}
         {#snippet auxControls()}
             Extra Controls
         {/snippet}

--- a/lightly_studio_view/src/lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte
+++ b/lightly_studio_view/src/lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+    import { SquareCheck } from '@lucide/svelte';
+    import Button from '../ui/button/button.svelte';
+
+    const { onclick }: { onclick: () => Promise<void> } = $props();
+</script>
+
+<Button
+    class="h-8 shrink-0 gap-1.5 px-2 text-diffuse-foreground hover:bg-background hover:text-foreground"
+    data-testid="select-all-button"
+    variant="ghost"
+    aria-label="Select all"
+    title="Select all"
+    {onclick}
+>
+    <SquareCheck class="size-4" />
+    <span>Select all</span>
+</Button>

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -19,7 +19,7 @@
         X,
         ChartNetwork,
         GripVertical,
-        ListChecks
+        SquareCheck
     } from '@lucide/svelte';
     import { onDestroy, onMount } from 'svelte';
     import { toStore } from 'svelte/store';
@@ -599,14 +599,14 @@
                                 {#snippet selectionControls()}
                                     {#if canSelectAll}
                                         <Button
-                                            class="flex shrink-0 items-center space-x-1"
+                                            class="h-8 shrink-0 gap-1.5 px-2 text-diffuse-foreground hover:bg-background hover:text-foreground"
                                             data-testid="select-all-button"
                                             variant="ghost"
-                                            aria-label="Select all samples"
-                                            title="Select all samples"
+                                            aria-label="Select all"
+                                            title="Select all"
                                             onclick={selectAllHandle.handleSelectAll}
                                         >
-                                            <ListChecks class="size-4" />
+                                            <SquareCheck class="size-4" />
                                             <span>Select all</span>
                                         </Button>
                                     {/if}
@@ -731,14 +731,14 @@
                             {#snippet selectionControls()}
                                 {#if canSelectAll}
                                     <Button
-                                        class="flex shrink-0 items-center space-x-1"
+                                        class="h-8 shrink-0 gap-1.5 px-2 text-diffuse-foreground hover:bg-background hover:text-foreground"
                                         data-testid="select-all-button"
                                         variant="ghost"
-                                        aria-label="Select all samples"
-                                        title="Select all samples"
+                                        aria-label="Select all"
+                                        title="Select all"
                                         onclick={selectAllHandle.handleSelectAll}
                                     >
-                                        <ListChecks class="size-4" />
+                                        <SquareCheck class="size-4" />
                                         <span>Select all</span>
                                     </Button>
                                 {/if}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -18,7 +18,8 @@
         Image as ImageIcon,
         X,
         ChartNetwork,
-        GripVertical
+        GripVertical,
+        ListChecks
     } from '@lucide/svelte';
     import { onDestroy, onMount } from 'svelte';
     import { toStore } from 'svelte/store';
@@ -116,6 +117,7 @@
     const isVideos = $derived(isVideosRoute(page.route.id));
     const isVideoFrames = $derived(isVideoFramesRoute(page.route.id));
     const isVideoDetails = $derived(isVideoDetailsRoute(page.route.id));
+    const canSelectAll = $derived(isImages || isVideos || isVideoFrames || isAnnotations);
 
     let gridType = $state<GridType>('images');
     let lastCollectionId: string | null = null;
@@ -579,6 +581,21 @@
                             class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4"
                         >
                             <GridHeader>
+                                {#snippet selectionControls()}
+                                    {#if canSelectAll}
+                                        <Button
+                                            class="flex shrink-0 items-center space-x-1"
+                                            data-testid="select-all-button"
+                                            variant="ghost"
+                                            aria-label="Select all samples"
+                                            title="Select all samples"
+                                            onclick={selectAllHandle.handleSelectAll}
+                                        >
+                                            <ListChecks class="size-4" />
+                                            <span>Select all</span>
+                                        </Button>
+                                    {/if}
+                                {/snippet}
                                 <div class="flex-1">
                                     {#if hasEmbeddings}
                                         <div
@@ -696,6 +713,21 @@
                 <div class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2">
                     {#if isImages || isAnnotations || isVideos || isGroups}
                         <GridHeader>
+                            {#snippet selectionControls()}
+                                {#if canSelectAll}
+                                    <Button
+                                        class="flex shrink-0 items-center space-x-1"
+                                        data-testid="select-all-button"
+                                        variant="ghost"
+                                        aria-label="Select all samples"
+                                        title="Select all samples"
+                                        onclick={selectAllHandle.handleSelectAll}
+                                    >
+                                        <ListChecks class="size-4" />
+                                        <span>Select all</span>
+                                    </Button>
+                                {/if}
+                            {/snippet}
                             {#snippet auxControls()}
                                 {#if (isImages || isVideos) && hasEmbeddings}
                                     <Button

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -726,7 +726,7 @@
             {:else}
                 <!-- When plot is hidden or not samples view, show normal layout -->
                 <div class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2">
-                    {#if isImages || isAnnotations || isVideos || isGroups}
+                    {#if isImages || isAnnotations || isVideos || isVideoFrames || isGroups}
                         <GridHeader>
                             {#snippet selectionControls()}
                                 {#if canSelectAll}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -9,6 +9,7 @@
         SelectionPill,
         TagsMenu
     } from '$lib/components';
+    import GridHeaderSelectAllButton from '$lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte';
     import QueryEditorPanel from '$lib/components/QueryEditorPanel/QueryEditorPanel.svelte';
     import Input from '$lib/components/ui/input/input.svelte';
     import Separator from '$lib/components/ui/separator/separator.svelte';
@@ -18,8 +19,7 @@
         Image as ImageIcon,
         X,
         ChartNetwork,
-        GripVertical,
-        SquareCheck
+        GripVertical
     } from '@lucide/svelte';
     import { onDestroy, onMount } from 'svelte';
     import { toStore } from 'svelte/store';
@@ -598,17 +598,9 @@
                             <GridHeader>
                                 {#snippet selectionControls()}
                                     {#if canSelectAll}
-                                        <Button
-                                            class="h-8 shrink-0 gap-1.5 px-2 text-diffuse-foreground hover:bg-background hover:text-foreground"
-                                            data-testid="select-all-button"
-                                            variant="ghost"
-                                            aria-label="Select all"
-                                            title="Select all"
+                                        <GridHeaderSelectAllButton
                                             onclick={selectAllHandle.handleSelectAll}
-                                        >
-                                            <SquareCheck class="size-4" />
-                                            <span>Select all</span>
-                                        </Button>
+                                        />
                                     {/if}
                                 {/snippet}
                                 <div class="flex-1" data-grid-search-drop-target>
@@ -730,17 +722,9 @@
                         <GridHeader>
                             {#snippet selectionControls()}
                                 {#if canSelectAll}
-                                    <Button
-                                        class="h-8 shrink-0 gap-1.5 px-2 text-diffuse-foreground hover:bg-background hover:text-foreground"
-                                        data-testid="select-all-button"
-                                        variant="ghost"
-                                        aria-label="Select all"
-                                        title="Select all"
+                                    <GridHeaderSelectAllButton
                                         onclick={selectAllHandle.handleSelectAll}
-                                    >
-                                        <SquareCheck class="size-4" />
-                                        <span>Select all</span>
-                                    </Button>
+                                    />
                                 {/if}
                             {/snippet}
                             {#snippet auxControls()}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
@@ -13,7 +13,7 @@
     import { isEqual, omit } from 'lodash-es';
     import { page } from '$app/state';
     import type { VideoFrameFilterParams } from '$lib/hooks/useFramesFilter/frameFilter';
-    import { GridHeader, Separator, VideoFrameItem } from '$lib/components';
+    import { VideoFrameItem } from '$lib/components';
     import { GridContainer } from '$lib/components/GridContainer';
     import { Grid } from '$lib/components/Grid';
     import { GridItem } from '$lib/components/GridItem';
@@ -142,9 +142,6 @@
 </script>
 
 <div class="flex flex-1 flex-col space-y-4">
-    <GridHeader />
-    <Separator class="mb-4 bg-border-hard" />
-
     <GridContainer
         itemCount={items.length}
         message={{


### PR DESCRIPTION
## What has changed and why?

- Adds a button next to the semantic search bar to "select all" (works for images, annotations, videos, frames)
- FYI: We reuse the select all hook introduced in #1045 which makes this PR very simple

https://github.com/user-attachments/assets/a5d1b7de-5016-475f-9422-e01afc037d71


## How has it been tested?

- New tests and manual testing (for all views: images, annotations, videos, frames)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [X] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Select all" button in the grid header to quickly select all items matching active filters, available on image, video, video-frame, and annotation views for faster bulk operations.
  * Added drag-and-drop from the image grid into the image search area so you can start searches by dropping images directly into the search UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->