### PR TITLE
Fix: backend stops after 10k requests

### DIFF
--- a/lightly_studio/src/lightly_studio/api/server.py
+++ b/lightly_studio/src/lightly_studio/api/server.py
@@ -54,7 +54,6 @@ class Server:
             http="h11",
             # https://uvicorn.dev/settings/#resource-limits
             limit_concurrency=100,  # Max concurrent connections
-            limit_max_requests=10000,  # Max requests before worker restart
             # https://uvicorn.dev/settings/#timeouts
             timeout_keep_alive=5,  # Keep-alive timeout in seconds
             timeout_graceful_shutdown=30,  # Graceful shutdown timeout


### PR DESCRIPTION
## What has changed and why?

- We remove the `limit-max-requests` parameter from the config. Before it was set to 10k which resulted in the backend stopping after serving 10k requests. The 10k option is not default in uvicorn (default is None = no limit). Not sure why we added this in the first place.

## How has it been tested?

- N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server configuration to improve request handling capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->