### PR TITLE
feat: handle onClear for text input search

### DIFF
--- a/lightly_studio_view/src/lib/components/CollectionSearch/CollectionSearch.svelte
+++ b/lightly_studio_view/src/lib/components/CollectionSearch/CollectionSearch.svelte
@@ -106,6 +106,7 @@
                 onkeydown: onKeyDown,
                 onpaste: handlePaste
             }}
+            onClear={handleClear}
             onUploadClick={triggerFileInput}
         />
     {/if}

--- a/lightly_studio_view/src/lib/components/CollectionSearch/SearchInput/CollectionSearchInput.svelte
+++ b/lightly_studio_view/src/lib/components/CollectionSearch/SearchInput/CollectionSearchInput.svelte
@@ -24,6 +24,7 @@
         onUploadClick: () => void;
         /** Disables the entire input when true. */
         disabled?: boolean;
+        onClear?: () => void;
     }
 
     let {
@@ -31,10 +32,15 @@
         inputProps,
         disabled = false,
         showOutline = false,
-        onUploadClick
+        onUploadClick,
+        onClear
     }: Props = $props();
 
     const isDisabled = $derived(Boolean(disabled || inputProps?.disabled));
+    const handleClear = () => {
+        value = '';
+        onClear?.();
+    };
 </script>
 
 <div class="relative">
@@ -50,7 +56,7 @@
     {#if value}
         <button
             class="absolute right-8 top-[50%] translate-y-[-50%] text-muted-foreground hover:text-foreground"
-            onclick={() => (value = '')}
+            onclick={handleClear}
             title="Clear search"
             data-testid="search-clear-button"
             type="button"

--- a/lightly_studio_view/src/lib/components/CollectionSearch/SearchInput/CollectionSearchInput.svelte
+++ b/lightly_studio_view/src/lib/components/CollectionSearch/SearchInput/CollectionSearchInput.svelte
@@ -24,6 +24,7 @@
         onUploadClick: () => void;
         /** Disables the entire input when true. */
         disabled?: boolean;
+        /** Called when the clear (×) button is clicked to reset the search value. */
         onClear?: () => void;
     }
 

--- a/lightly_studio_view/src/lib/components/CollectionSearch/SearchInput/CollectionSearchInput.test.ts
+++ b/lightly_studio_view/src/lib/components/CollectionSearch/SearchInput/CollectionSearchInput.test.ts
@@ -31,15 +31,17 @@ describe('CollectionSearchInput', () => {
         expect(clearButton).toBeInTheDocument();
     });
 
-    it('updates value, clears it, and calls upload handler', async () => {
+    it('updates value, clears it, and calls upload and clear handlers', async () => {
         const onUploadClick = vi.fn();
+        const onClear = vi.fn();
 
         render(CollectionSearchInput, {
             props: {
                 value: 'cat',
                 inputProps: { disabled: false, onkeydown: vi.fn(), onpaste: vi.fn() },
                 showOutline: false,
-                onUploadClick
+                onUploadClick,
+                onClear
             }
         });
 
@@ -52,7 +54,25 @@ describe('CollectionSearchInput', () => {
         await fireEvent.click(screen.getByTitle('Upload image for search'));
 
         expect(input.value).toBe('');
+        expect(onClear).toHaveBeenCalledOnce();
         expect(onUploadClick).toHaveBeenCalledOnce();
+    });
+
+    it('does not throw when clear is clicked without an onClear handler', async () => {
+        render(CollectionSearchInput, {
+            props: {
+                value: 'cat',
+                inputProps: { disabled: false, onkeydown: vi.fn(), onpaste: vi.fn() },
+                showOutline: false,
+                onUploadClick: vi.fn()
+            }
+        });
+
+        const input = screen.getByTestId('text-embedding-search-input') as HTMLInputElement;
+
+        await fireEvent.click(screen.getByTestId('search-clear-button'));
+
+        expect(input.value).toBe('');
     });
 
     it('applies disabled state consistently when provided via inputProps', () => {


### PR DESCRIPTION
## What has changed and why?

Thos PR introduces proper onClear handling for onCleat event from text inpit

## How has it been tested?

By unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for collection search clear functionality, validating callback invocation and safe behavior when no callback is provided.

* **Refactor**
  * Collection search input now supports an optional clear callback, allowing parent components to respond when users clear the search field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->