### PR TITLE
Fix docs tooltip for segmentation_mask

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/language/detectScopeAt.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/detectScopeAt.test.ts
@@ -24,6 +24,12 @@ describe('detectScopeAt', () => {
         expect(detectScopeAt(text, offset)).toBe('classification');
     });
 
+    it('returns segmentation_mask scope inside segmentation_mask(...)', () => {
+        const text = 'segmentation_mask(label == "road" AND width > 10)';
+        const offset = text.indexOf('width') + 2;
+        expect(detectScopeAt(text, offset)).toBe('segmentation_mask');
+    });
+
     it('falls back to outer scope after nested expression closes', () => {
         const text = 'object_detection(label == "cat") AND width > 10';
         const offset = text.lastIndexOf('width') + 2;

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/detectScopeAt.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/detectScopeAt.ts
@@ -11,10 +11,14 @@ export function detectScopeAt(text: string, offset: number): Scope {
     const upTo = text.slice(0, offset).replace(/"([^"\\]|\\.)*"|'([^'\\]|\\.)*'/g, '""');
     type Frame = Scope | 'paren';
     const stack: Frame[] = [];
-    const re = /\b(object_detection|classification)\s*\(|\(|\)/g;
+    const re = /\b(object_detection|classification|segmentation_mask)\s*\(|\(|\)/g;
     let match: RegExpExecArray | null;
     while ((match = re.exec(upTo))) {
-        if (match[1] === 'object_detection' || match[1] === 'classification') {
+        if (
+            match[1] === 'object_detection' ||
+            match[1] === 'classification' ||
+            match[1] === 'segmentation_mask'
+        ) {
             stack.push(match[1]);
         } else if (match[0] === '(') {
             stack.push('paren');
@@ -25,7 +29,13 @@ export function detectScopeAt(text: string, offset: number): Scope {
 
     for (let i = stack.length - 1; i >= 0; i--) {
         const frame = stack[i];
-        if (frame === 'object_detection' || frame === 'classification') return frame;
+        if (
+            frame === 'object_detection' ||
+            frame === 'classification' ||
+            frame === 'segmentation_mask'
+        ) {
+            return frame;
+        }
     }
     if (/^\s*video:/i.test(text)) return 'video';
     return 'image';

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query-schema.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query-schema.ts
@@ -5,6 +5,7 @@
  *  - top-level: image fields, or video fields when the query starts with `video:`
  *  - inside `object_detection(...)`: object detection fields
  *  - inside `classification(...)`: classification fields
+ *  - inside `segmentation_mask(...)`: segmentation mask fields
  *
  * Mirroring the field tables here lets the Monaco hover and completion
  * providers attach human-friendly documentation without re-parsing the
@@ -73,6 +74,19 @@ export const SCOPES: Record<Scope, ScopeDoc> = {
         fields: [
             { name: 'label', type: 'string', description: 'Class label of the classification.' }
         ]
+    },
+    segmentation_mask: {
+        scope: 'segmentation_mask',
+        title: 'SegmentationMask',
+        description:
+            'Segmentation mask annotation on an image. Used inside `segmentation_mask(...)`.',
+        fields: [
+            { name: 'label', type: 'string', description: 'Class label of the segmentation mask.' },
+            { name: 'x', type: 'int', description: 'Top-left X coordinate of the mask bounds.' },
+            { name: 'y', type: 'int', description: 'Top-left Y coordinate of the mask bounds.' },
+            { name: 'width', type: 'int', description: 'Mask width in pixels.' },
+            { name: 'height', type: 'int', description: 'Mask height in pixels.' }
+        ]
     }
 };
 
@@ -100,6 +114,11 @@ export const TOP_LEVEL_KEYWORDS: KeywordDoc[] = [
         name: 'classification',
         description: 'Filter on the image classification annotation.',
         insertText: 'classification(${1:label == "..."})'
+    },
+    {
+        name: 'segmentation_mask',
+        description: 'Filter on segmentation mask annotations inside an image.',
+        insertText: 'segmentation_mask(${1:label == "..."})'
     }
 ];
 

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/types.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/types.ts
@@ -5,12 +5,13 @@
  *  - top-level: image fields, or video fields when the query starts with `video:`
  *  - inside `object_detection(...)`: object detection fields
  *  - inside `classification(...)`: classification fields
+ *  - inside `segmentation_mask(...)`: segmentation mask fields
  *
  * Mirroring the field tables here lets the Monaco hover and completion
  * providers attach human-friendly documentation without re-parsing the
  * grammar at runtime. Keep both in sync when the grammar changes. */
 
-export type Scope = 'image' | 'video' | 'object_detection' | 'classification';
+export type Scope = 'image' | 'video' | 'object_detection' | 'classification' | 'segmentation_mask';
 
 export interface FieldDoc {
     name: string;

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/completionAdapter/completionAdapterBuildSchemaCompletions.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/completionAdapter/completionAdapterBuildSchemaCompletions.test.ts
@@ -18,6 +18,7 @@ describe('buildSchemaCompletions', () => {
         expect(labels).toContain('width');
         expect(labels).toContain('video:');
         expect(labels).toContain('object_detection');
+        expect(labels).toContain('segmentation_mask');
     });
 
     it('omits `video:` keyword in video scope', async () => {
@@ -29,5 +30,17 @@ describe('buildSchemaCompletions', () => {
         const labels = items.map((i) => i.label);
         expect(labels).toContain('fps');
         expect(labels).not.toContain('video:');
+    });
+
+    it('includes segmentation mask fields in segmentation_mask scope', async () => {
+        const { buildSchemaCompletions } = await import(
+            './completionAdapterBuildSchemaCompletions'
+        );
+        const range = { startLineNumber: 1, endLineNumber: 1, startColumn: 1, endColumn: 1 };
+        const items = buildSchemaCompletions('segmentation_mask', range as never);
+        const labels = items.map((i) => i.label);
+        expect(labels).toContain('label');
+        expect(labels).toContain('width');
+        expect(labels).toContain('height');
     });
 });

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/useSyntaxCompletion.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/useSyntaxCompletion.test.ts
@@ -435,6 +435,21 @@ describe('useSyntaxCompletion', () => {
         });
     });
 
+    it('resolves field scope from cursor context (segmentation_mask)', async () => {
+        const { provideCompletionItems } = await loadAndAttach([
+            { label: 'label', kind: LspCompletionItemKind.Field }
+        ]);
+        const result = await provideCompletionItems(
+            makeModel('segmentation_mask(label == "road" AND width > 10)') as never,
+            { lineNumber: 1, column: 41 } as never
+        );
+
+        expect(result.suggestions[0].detail).toBe('(field) SegmentationMask.label: string');
+        expect(result.suggestions[0].documentation).toEqual({
+            value: 'Class label of the segmentation mask.'
+        });
+    });
+
     it('leaves unknown labels untouched when neither LSP nor schema provides documentation', async () => {
         const { provideCompletionItems } = await loadAndAttach([
             { label: 'totally_unknown', kind: LspCompletionItemKind.Text }


### PR DESCRIPTION
## What has changed and why?
#1060 added `segmentation_mask` to the grammar, we need docs tooltips for it.

## How has it been tested?
Added tests, also tested in storybook.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added segmentation_mask scope to the Query Editor so you can filter/query segmentation masks by label, x, y, width, and height.

* **Tests**
  * Added and expanded unit tests and completion/syntax tests to validate segmentation_mask field suggestions and behavior in the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->