### PR TITLE
feat: design prototype for model evaluation

### DIFF
--- a/lightly_studio_view/src/lib/components/ModelComparisonFilter/ModelComparisonFilter.stories.svelte
+++ b/lightly_studio_view/src/lib/components/ModelComparisonFilter/ModelComparisonFilter.stories.svelte
@@ -3,14 +3,7 @@
 
     const { Story } = defineMeta({
         title: 'Prototypes/ModelComparisonFilter',
-        tags: ['autodocs'],
-        argTypes: {
-            imageCount: {
-                control: { type: 'select' },
-                options: [12, 24, 48, 100],
-                description: 'Number of images in the grid'
-            }
-        }
+        tags: ['autodocs']
     });
 </script>
 
@@ -20,78 +13,86 @@
     import Segment from '$lib/components/Segment/Segment.svelte';
     import { Checkbox } from '$lib/components/ui/checkbox/index.js';
     import { Label } from '$lib/components/ui/label/index.js';
+    import { Tooltip } from '$lib/components/ui/tooltip';
+    import { Slider } from '$lib/components/ui/slider';
 
     // ── Types ────────────────────────────────────────────────────────────────
 
-    type ModelDef = {
-        id: string;
-        name: string;
-        color: string;
-        enabled: boolean;
-    };
+    type ModelDef = { id: string; name: string; color: string; enabled: boolean };
+    type LabelDef = { name: string; enabled: boolean };
+    type BBox = { x: number; y: number; w: number; h: number; label: string; modelId: string; confidence: number };
+    type ImageData = { index: number; width: number; height: number; bboxes: BBox[] };
 
-    type LabelDef = {
-        name: string;
-        enabled: boolean;
-    };
-
-    type BBox = {
-        /** Normalised 0–1 coordinates relative to image size */
-        x: number;
-        y: number;
-        w: number;
-        h: number;
-        label: string;
-        modelId: string;
-    };
-
-    // ── Fake data generation ─────────────────────────────────────────────────
+    // ── Fake data ────────────────────────────────────────────────────────────
 
     const ALL_LABELS = ['cat', 'dog', 'car', 'person', 'bicycle'];
-
     const MODEL_DEFS: ModelDef[] = [
         { id: 'ground_truth', name: 'ground_truth', color: '#22c55e', enabled: true },
         { id: 'yolo_v8', name: 'yolo_v8', color: '#3b82f6', enabled: true },
         { id: 'predictions_a', name: 'predictions_a', color: '#f97316', enabled: false }
     ];
 
-    /** Seeded-ish pseudo-random so images look consistent on re-render */
     function seededRand(seed: number): number {
         const x = Math.sin(seed + 1) * 10000;
         return x - Math.floor(x);
     }
 
-    function generateBBoxes(imageIndex: number): BBox[] {
-        const boxes: BBox[] = [];
-        const modelIds = ['ground_truth', 'yolo_v8', 'predictions_a'];
+    function generateImage(imageIndex: number): ImageData {
         let seed = imageIndex * 97;
+        const width = Math.round(seededRand(seed++) * 3800 + 200);
+        const height = Math.round(seededRand(seed++) * 3800 + 200);
+        const bboxes: BBox[] = [];
 
-        for (const modelId of modelIds) {
+        for (const modelId of MODEL_DEFS.map((m) => m.id)) {
             const boxCount = Math.floor(seededRand(seed++) * 3) + 1;
             for (let b = 0; b < boxCount; b++) {
-                const x = seededRand(seed++) * 0.5;
-                const y = seededRand(seed++) * 0.5;
-                const w = seededRand(seed++) * 0.35 + 0.1;
-                const h = seededRand(seed++) * 0.35 + 0.1;
-                const labelIdx = Math.floor(seededRand(seed++) * ALL_LABELS.length);
-                boxes.push({ x, y, w, h, label: ALL_LABELS[labelIdx], modelId });
+                bboxes.push({
+                    x: seededRand(seed++) * 0.5,
+                    y: seededRand(seed++) * 0.5,
+                    w: seededRand(seed++) * 0.35 + 0.1,
+                    h: seededRand(seed++) * 0.35 + 0.1,
+                    label: ALL_LABELS[Math.floor(seededRand(seed++) * ALL_LABELS.length)],
+                    confidence: Math.round(seededRand(seed++) * 100) / 100,
+                    modelId
+                });
             }
         }
-        return boxes;
+
+        return { index: imageIndex, width, height, bboxes };
     }
 
-    // ── Reactive state ───────────────────────────────────────────────────────
+    const TOTAL_IMAGES = 48;
+    const ALL_IMAGES: ImageData[] = Array.from({ length: TOTAL_IMAGES }, (_, i) => generateImage(i));
 
-    let imageCount = $state(24);
-    const columnCount = 5;
+    // ── Reactive state ───────────────────────────────────────────────────────
 
     let models: ModelDef[] = $state(MODEL_DEFS.map((m) => ({ ...m })));
     let labelDefs: LabelDef[] = $state(ALL_LABELS.map((name) => ({ name, enabled: true })));
 
+    let widthRange = $state([0, 4000]);
+    let heightRange = $state([0, 4000]);
+
+    let confidenceThresholds = $state<Record<string, number>>(
+        Object.fromEntries(MODEL_DEFS.map((m) => [m.id, 0]))
+    );
+
     const enabledModelIds = $derived(new Set(models.filter((m) => m.enabled).map((m) => m.id)));
     const enabledLabels = $derived(new Set(labelDefs.filter((l) => l.enabled).map((l) => l.name)));
-
     const modelColorMap = $derived(Object.fromEntries(models.map((m) => [m.id, m.color])));
+
+    const colorByLabel = $derived(enabledModelIds.size === 1);
+
+    const LABEL_COLORS: Record<string, string> = {
+        cat: '#f43f5e',
+        dog: '#f97316',
+        car: '#eab308',
+        person: '#22c55e',
+        bicycle: '#6366f1'
+    };
+
+    function bboxColor(modelId: string, label: string): string {
+        return colorByLabel ? (LABEL_COLORS[label] ?? '#ffffff') : (modelColorMap[modelId] ?? '#ffffff');
+    }
 
     function toggleModel(id: string) {
         models = models.map((m) => (m.id === id ? { ...m, enabled: !m.enabled } : m));
@@ -101,31 +102,142 @@
         labelDefs = labelDefs.map((l) => (l.name === name ? { ...l, enabled: !l.enabled } : l));
     }
 
-    /** Derive visible images: only include images that have at least one visible annotation */
-    const allImages = $derived(
-        Array.from({ length: imageCount }, (_, i) => ({
-            index: i,
-            bboxes: generateBBoxes(i)
-        }))
-    );
-
     const visibleImages = $derived(
-        allImages.filter((img) =>
-            img.bboxes.some((b) => enabledModelIds.has(b.modelId) && enabledLabels.has(b.label))
-        )
+        ALL_IMAGES.filter((img) => {
+            if (img.width < widthRange[0] || img.width > widthRange[1]) return false;
+            if (img.height < heightRange[0] || img.height > heightRange[1]) return false;
+            return img.bboxes.some(
+                (b) =>
+                    enabledModelIds.has(b.modelId) &&
+                    enabledLabels.has(b.label) &&
+                    b.confidence >= (confidenceThresholds[b.modelId] ?? 0)
+            );
+        })
     );
 
     const visibleCount = $derived(visibleImages.length);
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
-    /** Returns hex with opacity as rgba string for CSS border */
     function hexToRgba(hex: string, alpha: number): string {
         const r = parseInt(hex.slice(1, 3), 16);
         const g = parseInt(hex.slice(3, 5), 16);
         const b = parseInt(hex.slice(5, 7), 16);
         return `rgba(${r}, ${g}, ${b}, ${alpha})`;
     }
+
+    function computeIoU(a: BBox, b: BBox): number {
+        const ax2 = a.x + a.w, ay2 = a.y + a.h;
+        const bx2 = b.x + b.w, by2 = b.y + b.h;
+        const ix1 = Math.max(a.x, b.x), iy1 = Math.max(a.y, b.y);
+        const ix2 = Math.min(ax2, bx2), iy2 = Math.min(ay2, by2);
+        const iw = Math.max(0, ix2 - ix1), ih = Math.max(0, iy2 - iy1);
+        const intersection = iw * ih;
+        const union = a.w * a.h + b.w * b.h - intersection;
+        return union > 0 ? intersection / union : 0;
+    }
+
+    const IOU_THRESHOLD = 0.5;
+
+    // ── Aggregation stats ────────────────────────────────────────────────────
+
+    type ClassStat = { count: number; confidenceSum: number };
+
+    type ModelStats = {
+        modelId: string;
+        annotationCount: number;
+        coverageCount: number;
+        classStats: Record<string, ClassStat>;
+        topLabel: string;
+        avgConfidence: number;
+        avgBoxArea: number;
+        precision?: number;
+        recall?: number;
+        avgIoU?: number;
+    };
+
+    const GT_MODEL_ID = 'ground_truth';
+
+    const modelStats = $derived(
+        models
+            .filter((m) => enabledModelIds.has(m.id))
+            .map((m): ModelStats => {
+                let annotationCount = 0;
+                let coverageCount = 0;
+                let confidenceSum = 0;
+                let boxAreaSum = 0;
+                const classStats: Record<string, ClassStat> = {};
+
+                // For precision/recall vs ground truth
+                let tp = 0, fp = 0, fn = 0, iouSum = 0;
+                const computeVsGt = m.id !== GT_MODEL_ID && enabledModelIds.has(GT_MODEL_ID);
+
+                for (const img of visibleImages) {
+                    const threshold = confidenceThresholds[m.id] ?? 0;
+                    const boxes = img.bboxes.filter(
+                        (b) => b.modelId === m.id && enabledLabels.has(b.label) && b.confidence >= threshold
+                    );
+
+                    if (boxes.length > 0) {
+                        coverageCount++;
+                        annotationCount += boxes.length;
+                        for (const b of boxes) {
+                            confidenceSum += b.confidence;
+                            boxAreaSum += b.w * b.h;
+                            const cs = classStats[b.label] ?? { count: 0, confidenceSum: 0 };
+                            cs.count++;
+                            cs.confidenceSum += b.confidence;
+                            classStats[b.label] = cs;
+                        }
+                    }
+
+                    if (computeVsGt) {
+                        const gtBoxes = img.bboxes.filter(
+                            (b) => b.modelId === GT_MODEL_ID && enabledLabels.has(b.label)
+                        );
+                        const matched = new Set<number>();
+                        for (const pred of boxes) {
+                            let bestIoU = 0, bestIdx = -1;
+                            gtBoxes.forEach((gt, i) => {
+                                if (matched.has(i) || gt.label !== pred.label) return;
+                                const iou = computeIoU(pred, gt);
+                                if (iou > bestIoU) { bestIoU = iou; bestIdx = i; }
+                            });
+                            if (bestIoU >= IOU_THRESHOLD && bestIdx >= 0) {
+                                tp++;
+                                iouSum += bestIoU;
+                                matched.add(bestIdx);
+                            } else {
+                                fp++;
+                            }
+                        }
+                        fn += gtBoxes.length - matched.size;
+                    }
+                }
+
+                const topLabel = Object.entries(classStats).sort((a, b) => b[1].count - a[1].count)[0]?.[0] ?? '—';
+                const avgConfidence = annotationCount > 0 ? confidenceSum / annotationCount : 0;
+                const avgBoxArea = annotationCount > 0 ? boxAreaSum / annotationCount : 0;
+
+                return {
+                    modelId: m.id,
+                    annotationCount,
+                    coverageCount,
+                    classStats,
+                    topLabel,
+                    avgConfidence,
+                    avgBoxArea,
+                    ...(computeVsGt && {
+                        precision: tp + fp > 0 ? tp / (tp + fp) : 0,
+                        recall: tp + fn > 0 ? tp / (tp + fn) : 0,
+                        avgIoU: tp > 0 ? iouSum / tp : 0
+                    })
+                };
+            })
+    );
+
+    const DIM_MAX = 4000;
+    const columnCount = 5;
 </script>
 
 <Story name="Comparison View" asChild>
@@ -134,35 +246,55 @@
         <aside
             class="flex w-60 shrink-0 flex-col gap-4 overflow-y-auto border-r border-border px-3 py-4"
         >
-            <hr class="border-border" />
-
             <!-- Models -->
             <Segment title="Models">
                 <div class="space-y-2">
                     {#each models as model (model.id)}
-                        <div class="flex items-center space-x-2" title={model.name}>
-                            <Checkbox
-                                id={`model-${model.id}`}
-                                checked={model.enabled}
-                                aria-labelledby={`model-${model.id}-label`}
-                                onCheckedChange={() => toggleModel(model.id)}
-                            />
-                            <Label
-                                id={`model-${model.id}-label`}
-                                for={`model-${model.id}`}
-                                class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap"
-                            >
-                                <!-- Color swatch -->
-                                <span
-                                    class="inline-block h-3 w-3 shrink-0 rounded-sm border"
-                                    style="background-color: {hexToRgba(
-                                        model.color,
-                                        0.35
-                                    )}; border-color: {model.color};"
-                                ></span>
-                                <span class="flex-1 truncate text-sm font-normal">{model.name}</span
+                        <div class="space-y-1" title={model.name}>
+                            <div class="flex items-center space-x-2">
+                                <Checkbox
+                                    id={`model-${model.id}`}
+                                    checked={model.enabled}
+                                    aria-labelledby={`model-${model.id}-label`}
+                                    onCheckedChange={() => toggleModel(model.id)}
+                                />
+                                <Label
+                                    id={`model-${model.id}-label`}
+                                    for={`model-${model.id}`}
+                                    class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap"
                                 >
-                            </Label>
+                                    <span
+                                        class="inline-block h-3 w-3 shrink-0 rounded-sm border"
+                                        style="background-color: {hexToRgba(model.color, 0.35)}; border-color: {model.color};"
+                                    ></span>
+                                    <span class="flex-1 truncate text-sm font-normal">{model.name}</span>
+                                </Label>
+                            </div>
+                            {#if model.enabled}
+                                <div class="flex items-center gap-2 pl-6 text-xs text-muted-foreground">
+                                    <Tooltip content="Only show annotations from this model with confidence ≥ this value" position="right">
+                                        <span class="cursor-help underline decoration-dotted">Confidence</span>
+                                    </Tooltip>
+                                    <input
+                                        type="range"
+                                        min="0"
+                                        max="1"
+                                        step="0.05"
+                                        value={confidenceThresholds[model.id]}
+                                        oninput={(e) => {
+                                            confidenceThresholds = {
+                                                ...confidenceThresholds,
+                                                [model.id]: parseFloat((e.target as HTMLInputElement).value)
+                                            };
+                                        }}
+                                        class="min-w-0 flex-1 accent-primary"
+                                        style="accent-color: {model.color};"
+                                    />
+                                    <span class="w-7 shrink-0 text-right tabular-nums">
+                                        {confidenceThresholds[model.id].toFixed(2)}
+                                    </span>
+                                </div>
+                            {/if}
                         </div>
                     {/each}
                 </div>
@@ -182,44 +314,59 @@
                             <Label
                                 id={`label-${lbl.name}-label`}
                                 for={`label-${lbl.name}`}
-                                class="flex min-w-0 flex-1 cursor-pointer items-center text-nowrap"
+                                class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap"
                             >
+                                {#if colorByLabel}
+                                    <span
+                                        class="inline-block h-3 w-3 shrink-0 rounded-sm border transition-colors"
+                                        style="background-color: {hexToRgba(LABEL_COLORS[lbl.name] ?? '#ffffff', 0.35)}; border-color: {LABEL_COLORS[lbl.name] ?? '#ffffff'};"
+                                    ></span>
+                                {/if}
                                 <span class="flex-1 truncate text-sm font-normal">{lbl.name}</span>
                             </Label>
                         </div>
                     {/each}
                 </div>
             </Segment>
+
+            <!-- Dimensions filter -->
+            <Segment title="Dimensions">
+                <div class="space-y-3 text-xs">
+                    <div class="space-y-2">
+                        <div class="flex items-center justify-between text-muted-foreground">
+                            <span>Width</span>
+                            <span class="tabular-nums">{widthRange[0]} – {widthRange[1]} px</span>
+                        </div>
+                        <Slider
+                            min={0}
+                            max={DIM_MAX}
+                            step={100}
+                            bind:value={widthRange}
+                        />
+                    </div>
+                    <div class="space-y-2">
+                        <div class="flex items-center justify-between text-muted-foreground">
+                            <span>Height</span>
+                            <span class="tabular-nums">{heightRange[0]} – {heightRange[1]} px</span>
+                        </div>
+                        <Slider
+                            min={0}
+                            max={DIM_MAX}
+                            step={100}
+                            bind:value={heightRange}
+                        />
+                    </div>
+                </div>
+            </Segment>
         </aside>
 
-        <!-- ── Main grid area ────────────────────────────────────────────── -->
+        <!-- ── Main area ─────────────────────────────────────────────────── -->
         <div class="flex min-w-0 flex-1 flex-col">
             <!-- Header bar -->
             <div
                 class="flex items-center gap-3 border-b border-border px-4 py-2 text-sm text-muted-foreground"
             >
-                <span>{visibleCount} of {imageCount} images</span>
-                <!-- Model legend pills -->
-                <div class="ml-auto flex gap-2">
-                    {#each models.filter((m) => m.enabled) as model (model.id)}
-                        <span
-                            class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium"
-                            style="background-color: {hexToRgba(
-                                model.color,
-                                0.15
-                            )}; color: {model.color}; border: 1px solid {hexToRgba(
-                                model.color,
-                                0.4
-                            )};"
-                        >
-                            <span
-                                class="inline-block h-2 w-2 rounded-full"
-                                style="background-color: {model.color};"
-                            ></span>
-                            {model.name}
-                        </span>
-                    {/each}
-                </div>
+                <span>{visibleCount} of {TOTAL_IMAGES} images</span>
             </div>
 
             <!-- Grid -->
@@ -230,25 +377,27 @@
                     </div>
                 {:else}
                     <Grid itemCount={visibleCount} {columnCount}>
-                        {#snippet gridItem({ index, style, width, height })}
+                        {#snippet gridItem({ index, style, width, height }: { index: number; style: string; width: number; height: number })}
                             {@const img = visibleImages[index]}
                             <GridItem {width} {height} {style} tag={false}>
-                                <!-- Image thumbnail via picsum (seeded by original index) -->
                                 <img
-                                    src="https://picsum.photos/{Math.round(width)}/{Math.round(
-                                        height
-                                    )}?random={img.index}"
+                                    src="https://picsum.photos/{Math.round(width)}/{Math.round(height)}?random={img.index}"
                                     alt="Sample {img.index + 1}"
                                     class="h-full w-full object-cover"
                                     loading="lazy"
                                 />
+                                <!-- Dimension badge -->
+                                <span
+                                    class="pointer-events-none absolute bottom-1 right-1 z-10 rounded bg-black/50 px-1 py-0.5 text-[9px] tabular-nums text-white"
+                                >
+                                    {img.width}×{img.height}
+                                </span>
 
-                                <!-- Annotation bbox overlays (CSS, no canvas worker needed) -->
+                                <!-- Bbox overlays -->
                                 <div class="pointer-events-none absolute inset-0">
                                     {#each img.bboxes as bbox}
-                                        {#if enabledModelIds.has(bbox.modelId) && enabledLabels.has(bbox.label)}
-                                            {@const color =
-                                                modelColorMap[bbox.modelId] ?? '#ffffff'}
+                                        {#if enabledModelIds.has(bbox.modelId) && enabledLabels.has(bbox.label) && bbox.confidence >= (confidenceThresholds[bbox.modelId] ?? 0)}
+                                            {@const color = bboxColor(bbox.modelId, bbox.label)}
                                             <div
                                                 class="absolute"
                                                 style="
@@ -257,18 +406,14 @@
                                                     width: {bbox.w * 100}%;
                                                     height: {bbox.h * 100}%;
                                                     border: 2px solid {color};
-                                                    box-shadow: inset 0 0 0 1px {hexToRgba(
-                                                    color,
-                                                    0.25
-                                                )};
+                                                    box-shadow: inset 0 0 0 1px {hexToRgba(color, 0.25)};
                                                 "
                                             >
-                                                <!-- Label chip -->
                                                 <span
                                                     class="absolute left-0 top-0 translate-y-[-100%] px-1 py-0.5 text-[9px] font-semibold leading-tight text-white"
                                                     style="background-color: {color};"
                                                 >
-                                                    {bbox.label}
+                                                    {bbox.label} {bbox.confidence.toFixed(2)}
                                                 </span>
                                             </div>
                                         {/if}
@@ -280,5 +425,124 @@
                 {/if}
             </div>
         </div>
+
+        <!-- ── Stats sidebar ─────────────────────────────────────────────── -->
+        <aside
+            class="flex w-52 shrink-0 flex-col gap-0 overflow-y-auto border-l border-border px-3 py-4"
+        >
+            <p class="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Stats
+            </p>
+            {#each modelStats as stat}
+                {@const model = models.find((m) => m.id === stat.modelId)!}
+                {@const maxCount = Math.max(...modelStats.map((s) => s.annotationCount), 1)}
+                <div class="mb-4 space-y-2">
+                    <!-- Model name -->
+                    <div class="flex items-center gap-1.5">
+                        <span
+                            class="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+                            style="background-color: {model.color};"
+                        ></span>
+                        <span class="truncate text-xs font-semibold">{model.name}</span>
+                    </div>
+
+                    <!-- Key numbers -->
+                    <div class="grid grid-cols-2 gap-x-2 gap-y-0.5 text-xs">
+                        <span class="text-muted-foreground">Annotations</span>
+                        <span class="text-right tabular-nums font-medium">{stat.annotationCount}</span>
+
+                        <Tooltip content="% of filtered images that have at least one annotation from this model" position="left">
+                            <span class="cursor-help text-muted-foreground underline decoration-dotted">Coverage</span>
+                        </Tooltip>
+                        <span class="text-right tabular-nums font-medium">
+                            {visibleCount > 0 ? Math.round((stat.coverageCount / visibleCount) * 100) : 0}%
+                        </span>
+
+                        <Tooltip content="The class this model annotates most often in the filtered image set" position="left">
+                            <span class="cursor-help text-muted-foreground underline decoration-dotted">Top class</span>
+                        </Tooltip>
+                        <span class="text-right font-medium">{stat.topLabel}</span>
+
+                        <Tooltip content="Mean confidence score across all visible annotations from this model" position="left">
+                            <span class="cursor-help text-muted-foreground underline decoration-dotted">Avg conf.</span>
+                        </Tooltip>
+                        <span class="text-right tabular-nums font-medium">{stat.avgConfidence.toFixed(2)}</span>
+
+                        <Tooltip content="Average bounding box area as % of image area — higher means larger predictions" position="left">
+                            <span class="cursor-help text-muted-foreground underline decoration-dotted">Avg box</span>
+                        </Tooltip>
+                        <span class="text-right tabular-nums font-medium">{(stat.avgBoxArea * 100).toFixed(1)}%</span>
+                    </div>
+
+                    <!-- Overall annotation bar -->
+                    <div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                        <div
+                            class="h-full rounded-full transition-all"
+                            style="width: {(stat.annotationCount / maxCount) * 100}%; background-color: {model.color};"
+                        ></div>
+                    </div>
+
+                    <!-- Precision / Recall / IoU vs ground_truth -->
+                    {#if stat.precision !== undefined}
+                        <div class="space-y-1">
+                            <p class="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                                vs ground_truth
+                            </p>
+                            <div class="grid grid-cols-2 gap-x-2 gap-y-0.5 text-xs">
+                                <Tooltip content="TP / (TP + FP) — fraction of predictions that match a ground truth box (IoU ≥ 0.5, same class)" position="left">
+                                    <span class="cursor-help text-muted-foreground underline decoration-dotted">Precision</span>
+                                </Tooltip>
+                                <span class="text-right tabular-nums font-medium">{stat.precision.toFixed(2)}</span>
+
+                                <Tooltip content="TP / (TP + FN) — fraction of ground truth boxes that were found by this model" position="left">
+                                    <span class="cursor-help text-muted-foreground underline decoration-dotted">Recall</span>
+                                </Tooltip>
+                                <span class="text-right tabular-nums font-medium">{stat.recall!.toFixed(2)}</span>
+
+                                <Tooltip content="Average Intersection over Union for matched prediction–ground truth pairs" position="left">
+                                    <span class="cursor-help text-muted-foreground underline decoration-dotted">Avg IoU</span>
+                                </Tooltip>
+                                <span class="text-right tabular-nums font-medium">{stat.avgIoU!.toFixed(2)}</span>
+                            </div>
+                        </div>
+                    {/if}
+
+                    <!-- Per-class breakdown with avg confidence -->
+                    <div class="space-y-1">
+                        <p class="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">By class</p>
+                        {#each ALL_LABELS as lbl}
+                            {@const cs = stat.classStats[lbl]}
+                            {@const count = cs?.count ?? 0}
+                            {@const avgConf = cs ? cs.confidenceSum / cs.count : 0}
+                            {@const maxClassCount = Math.max(
+                                ...modelStats.map((s) => s.classStats[lbl]?.count ?? 0),
+                                1
+                            )}
+                            {#if count > 0}
+                                <div class="space-y-0.5 text-xs">
+                                    <div class="flex items-center justify-between">
+                                        <span class="truncate text-muted-foreground">{lbl}</span>
+                                        <Tooltip content="{count} annotation{count !== 1 ? 's' : ''} · avg confidence {avgConf.toFixed(2)}" position="left">
+                                            <span class="cursor-help tabular-nums text-muted-foreground underline decoration-dotted">{count} · {avgConf.toFixed(2)}</span>
+                                        </Tooltip>
+                                    </div>
+                                    <div class="h-1 w-full overflow-hidden rounded-full bg-muted">
+                                        <div
+                                            class="h-full rounded-full transition-all"
+                                            style="width: {(count / maxClassCount) * 100}%; background-color: {hexToRgba(model.color, 0.7)};"
+                                        ></div>
+                                    </div>
+                                </div>
+                            {/if}
+                        {/each}
+                    </div>
+
+                    <hr class="border-border" />
+                </div>
+            {/each}
+            {#if modelStats.length === 0}
+                <p class="text-xs text-muted-foreground">No models enabled.</p>
+            {/if}
+        </aside>
     </div>
 </Story>

--- a/lightly_studio_view/src/lib/components/ModelComparisonFilter/ModelComparisonFilter.stories.svelte
+++ b/lightly_studio_view/src/lib/components/ModelComparisonFilter/ModelComparisonFilter.stories.svelte
@@ -13,14 +13,21 @@
     import Segment from '$lib/components/Segment/Segment.svelte';
     import { Checkbox } from '$lib/components/ui/checkbox/index.js';
     import { Label } from '$lib/components/ui/label/index.js';
-    import { Tooltip } from '$lib/components/ui/tooltip';
     import { Slider } from '$lib/components/ui/slider';
 
     // ── Types ────────────────────────────────────────────────────────────────
 
     type ModelDef = { id: string; name: string; color: string; enabled: boolean };
     type LabelDef = { name: string; enabled: boolean };
-    type BBox = { x: number; y: number; w: number; h: number; label: string; modelId: string; confidence: number };
+    type BBox = {
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+        label: string;
+        modelId: string;
+        confidence: number;
+    };
     type ImageData = { index: number; width: number; height: number; bboxes: BBox[] };
 
     // ── Fake data ────────────────────────────────────────────────────────────
@@ -62,7 +69,9 @@
     }
 
     const TOTAL_IMAGES = 48;
-    const ALL_IMAGES: ImageData[] = Array.from({ length: TOTAL_IMAGES }, (_, i) => generateImage(i));
+    const ALL_IMAGES: ImageData[] = Array.from({ length: TOTAL_IMAGES }, (_, i) =>
+        generateImage(i)
+    );
 
     // ── Reactive state ───────────────────────────────────────────────────────
 
@@ -71,10 +80,6 @@
 
     let widthRange = $state([0, 4000]);
     let heightRange = $state([0, 4000]);
-
-    let confidenceThresholds = $state<Record<string, number>>(
-        Object.fromEntries(MODEL_DEFS.map((m) => [m.id, 0]))
-    );
 
     const enabledModelIds = $derived(new Set(models.filter((m) => m.enabled).map((m) => m.id)));
     const enabledLabels = $derived(new Set(labelDefs.filter((l) => l.enabled).map((l) => l.name)));
@@ -91,7 +96,9 @@
     };
 
     function bboxColor(modelId: string, label: string): string {
-        return colorByLabel ? (LABEL_COLORS[label] ?? '#ffffff') : (modelColorMap[modelId] ?? '#ffffff');
+        return colorByLabel
+            ? (LABEL_COLORS[label] ?? '#ffffff')
+            : (modelColorMap[modelId] ?? '#ffffff');
     }
 
     function toggleModel(id: string) {
@@ -109,13 +116,24 @@
             return img.bboxes.some(
                 (b) =>
                     enabledModelIds.has(b.modelId) &&
-                    enabledLabels.has(b.label) &&
-                    b.confidence >= (confidenceThresholds[b.modelId] ?? 0)
+                    enabledLabels.has(b.label)
             );
         })
     );
 
     const visibleCount = $derived(visibleImages.length);
+
+    // Per-label: how many visible images have ≥1 annotation of that label from any enabled collection
+    const labelImageCounts = $derived(
+        Object.fromEntries(
+            ALL_LABELS.map((lbl) => [
+                lbl,
+                visibleImages.filter((img) =>
+                    img.bboxes.some((b) => enabledModelIds.has(b.modelId) && b.label === lbl)
+                ).length
+            ])
+        )
+    );
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -126,115 +144,6 @@
         return `rgba(${r}, ${g}, ${b}, ${alpha})`;
     }
 
-    function computeIoU(a: BBox, b: BBox): number {
-        const ax2 = a.x + a.w, ay2 = a.y + a.h;
-        const bx2 = b.x + b.w, by2 = b.y + b.h;
-        const ix1 = Math.max(a.x, b.x), iy1 = Math.max(a.y, b.y);
-        const ix2 = Math.min(ax2, bx2), iy2 = Math.min(ay2, by2);
-        const iw = Math.max(0, ix2 - ix1), ih = Math.max(0, iy2 - iy1);
-        const intersection = iw * ih;
-        const union = a.w * a.h + b.w * b.h - intersection;
-        return union > 0 ? intersection / union : 0;
-    }
-
-    const IOU_THRESHOLD = 0.5;
-
-    // ── Aggregation stats ────────────────────────────────────────────────────
-
-    type ClassStat = { count: number; confidenceSum: number };
-
-    type ModelStats = {
-        modelId: string;
-        annotationCount: number;
-        coverageCount: number;
-        classStats: Record<string, ClassStat>;
-        topLabel: string;
-        avgConfidence: number;
-        avgBoxArea: number;
-        precision?: number;
-        recall?: number;
-        avgIoU?: number;
-    };
-
-    const GT_MODEL_ID = 'ground_truth';
-
-    const modelStats = $derived(
-        models
-            .filter((m) => enabledModelIds.has(m.id))
-            .map((m): ModelStats => {
-                let annotationCount = 0;
-                let coverageCount = 0;
-                let confidenceSum = 0;
-                let boxAreaSum = 0;
-                const classStats: Record<string, ClassStat> = {};
-
-                // For precision/recall vs ground truth
-                let tp = 0, fp = 0, fn = 0, iouSum = 0;
-                const computeVsGt = m.id !== GT_MODEL_ID && enabledModelIds.has(GT_MODEL_ID);
-
-                for (const img of visibleImages) {
-                    const threshold = confidenceThresholds[m.id] ?? 0;
-                    const boxes = img.bboxes.filter(
-                        (b) => b.modelId === m.id && enabledLabels.has(b.label) && b.confidence >= threshold
-                    );
-
-                    if (boxes.length > 0) {
-                        coverageCount++;
-                        annotationCount += boxes.length;
-                        for (const b of boxes) {
-                            confidenceSum += b.confidence;
-                            boxAreaSum += b.w * b.h;
-                            const cs = classStats[b.label] ?? { count: 0, confidenceSum: 0 };
-                            cs.count++;
-                            cs.confidenceSum += b.confidence;
-                            classStats[b.label] = cs;
-                        }
-                    }
-
-                    if (computeVsGt) {
-                        const gtBoxes = img.bboxes.filter(
-                            (b) => b.modelId === GT_MODEL_ID && enabledLabels.has(b.label)
-                        );
-                        const matched = new Set<number>();
-                        for (const pred of boxes) {
-                            let bestIoU = 0, bestIdx = -1;
-                            gtBoxes.forEach((gt, i) => {
-                                if (matched.has(i) || gt.label !== pred.label) return;
-                                const iou = computeIoU(pred, gt);
-                                if (iou > bestIoU) { bestIoU = iou; bestIdx = i; }
-                            });
-                            if (bestIoU >= IOU_THRESHOLD && bestIdx >= 0) {
-                                tp++;
-                                iouSum += bestIoU;
-                                matched.add(bestIdx);
-                            } else {
-                                fp++;
-                            }
-                        }
-                        fn += gtBoxes.length - matched.size;
-                    }
-                }
-
-                const topLabel = Object.entries(classStats).sort((a, b) => b[1].count - a[1].count)[0]?.[0] ?? '—';
-                const avgConfidence = annotationCount > 0 ? confidenceSum / annotationCount : 0;
-                const avgBoxArea = annotationCount > 0 ? boxAreaSum / annotationCount : 0;
-
-                return {
-                    modelId: m.id,
-                    annotationCount,
-                    coverageCount,
-                    classStats,
-                    topLabel,
-                    avgConfidence,
-                    avgBoxArea,
-                    ...(computeVsGt && {
-                        precision: tp + fp > 0 ? tp / (tp + fp) : 0,
-                        recall: tp + fn > 0 ? tp / (tp + fn) : 0,
-                        avgIoU: tp > 0 ? iouSum / tp : 0
-                    })
-                };
-            })
-    );
 
     const DIM_MAX = 4000;
     const columnCount = 5;
@@ -244,10 +153,10 @@
     <div class="flex h-screen w-full overflow-hidden bg-background text-foreground">
         <!-- ── Sidebar ───────────────────────────────────────────────────── -->
         <aside
-            class="flex w-60 shrink-0 flex-col gap-4 overflow-y-auto border-r border-border px-3 py-4"
+            class="w-90 flex shrink-0 flex-col gap-4 overflow-y-auto border-r border-border px-3 py-4"
         >
-            <!-- Models -->
-            <Segment title="Models">
+            <!-- Annotation Collections -->
+            <Segment title="Annotation Collections">
                 <div class="space-y-2">
                     {#each models as model (model.id)}
                         <div class="space-y-1" title={model.name}>
@@ -265,36 +174,16 @@
                                 >
                                     <span
                                         class="inline-block h-3 w-3 shrink-0 rounded-sm border"
-                                        style="background-color: {hexToRgba(model.color, 0.35)}; border-color: {model.color};"
+                                        style="background-color: {hexToRgba(
+                                            model.color,
+                                            0.35
+                                        )}; border-color: {model.color};"
                                     ></span>
-                                    <span class="flex-1 truncate text-sm font-normal">{model.name}</span>
+                                    <span class="flex-1 truncate text-sm font-normal"
+                                        >{model.name}</span
+                                    >
                                 </Label>
                             </div>
-                            {#if model.enabled}
-                                <div class="flex items-center gap-2 pl-6 text-xs text-muted-foreground">
-                                    <Tooltip content="Only show annotations from this model with confidence ≥ this value" position="right">
-                                        <span class="cursor-help underline decoration-dotted">Confidence</span>
-                                    </Tooltip>
-                                    <input
-                                        type="range"
-                                        min="0"
-                                        max="1"
-                                        step="0.05"
-                                        value={confidenceThresholds[model.id]}
-                                        oninput={(e) => {
-                                            confidenceThresholds = {
-                                                ...confidenceThresholds,
-                                                [model.id]: parseFloat((e.target as HTMLInputElement).value)
-                                            };
-                                        }}
-                                        class="min-w-0 flex-1 accent-primary"
-                                        style="accent-color: {model.color};"
-                                    />
-                                    <span class="w-7 shrink-0 text-right tabular-nums">
-                                        {confidenceThresholds[model.id].toFixed(2)}
-                                    </span>
-                                </div>
-                            {/if}
                         </div>
                     {/each}
                 </div>
@@ -319,10 +208,18 @@
                                 {#if colorByLabel}
                                     <span
                                         class="inline-block h-3 w-3 shrink-0 rounded-sm border transition-colors"
-                                        style="background-color: {hexToRgba(LABEL_COLORS[lbl.name] ?? '#ffffff', 0.35)}; border-color: {LABEL_COLORS[lbl.name] ?? '#ffffff'};"
+                                        style="background-color: {hexToRgba(
+                                            LABEL_COLORS[lbl.name] ?? '#ffffff',
+                                            0.35
+                                        )}; border-color: {LABEL_COLORS[lbl.name] ?? '#ffffff'};"
                                     ></span>
                                 {/if}
                                 <span class="flex-1 truncate text-sm font-normal">{lbl.name}</span>
+                                {#if labelImageCounts[lbl.name]}
+                                    <span class="shrink-0 text-xs text-muted-foreground tabular-nums">
+                                        {labelImageCounts[lbl.name]}
+                                    </span>
+                                {/if}
                             </Label>
                         </div>
                     {/each}
@@ -337,24 +234,14 @@
                             <span>Width</span>
                             <span class="tabular-nums">{widthRange[0]} – {widthRange[1]} px</span>
                         </div>
-                        <Slider
-                            min={0}
-                            max={DIM_MAX}
-                            step={100}
-                            bind:value={widthRange}
-                        />
+                        <Slider min={0} max={DIM_MAX} step={100} bind:value={widthRange} />
                     </div>
                     <div class="space-y-2">
                         <div class="flex items-center justify-between text-muted-foreground">
                             <span>Height</span>
                             <span class="tabular-nums">{heightRange[0]} – {heightRange[1]} px</span>
                         </div>
-                        <Slider
-                            min={0}
-                            max={DIM_MAX}
-                            step={100}
-                            bind:value={heightRange}
-                        />
+                        <Slider min={0} max={DIM_MAX} step={100} bind:value={heightRange} />
                     </div>
                 </div>
             </Segment>
@@ -377,11 +264,23 @@
                     </div>
                 {:else}
                     <Grid itemCount={visibleCount} {columnCount}>
-                        {#snippet gridItem({ index, style, width, height }: { index: number; style: string; width: number; height: number })}
+                        {#snippet gridItem({
+                            index,
+                            style,
+                            width,
+                            height
+                        }: {
+                            index: number;
+                            style: string;
+                            width: number;
+                            height: number;
+                        })}
                             {@const img = visibleImages[index]}
                             <GridItem {width} {height} {style} tag={false}>
                                 <img
-                                    src="https://picsum.photos/{Math.round(width)}/{Math.round(height)}?random={img.index}"
+                                    src="https://picsum.photos/{Math.round(width)}/{Math.round(
+                                        height
+                                    )}?random={img.index}"
                                     alt="Sample {img.index + 1}"
                                     class="h-full w-full object-cover"
                                     loading="lazy"
@@ -396,7 +295,7 @@
                                 <!-- Bbox overlays -->
                                 <div class="pointer-events-none absolute inset-0">
                                     {#each img.bboxes as bbox}
-                                        {#if enabledModelIds.has(bbox.modelId) && enabledLabels.has(bbox.label) && bbox.confidence >= (confidenceThresholds[bbox.modelId] ?? 0)}
+                                        {#if enabledModelIds.has(bbox.modelId) && enabledLabels.has(bbox.label)}
                                             {@const color = bboxColor(bbox.modelId, bbox.label)}
                                             <div
                                                 class="absolute"
@@ -406,14 +305,18 @@
                                                     width: {bbox.w * 100}%;
                                                     height: {bbox.h * 100}%;
                                                     border: 2px solid {color};
-                                                    box-shadow: inset 0 0 0 1px {hexToRgba(color, 0.25)};
+                                                    box-shadow: inset 0 0 0 1px {hexToRgba(
+                                                    color,
+                                                    0.25
+                                                )};
                                                 "
                                             >
                                                 <span
                                                     class="absolute left-0 top-0 translate-y-[-100%] px-1 py-0.5 text-[9px] font-semibold leading-tight text-white"
                                                     style="background-color: {color};"
                                                 >
-                                                    {bbox.label} {bbox.confidence.toFixed(2)}
+                                                    {bbox.label}
+                                                    {bbox.confidence.toFixed(2)}
                                                 </span>
                                             </div>
                                         {/if}
@@ -426,123 +329,5 @@
             </div>
         </div>
 
-        <!-- ── Stats sidebar ─────────────────────────────────────────────── -->
-        <aside
-            class="flex w-52 shrink-0 flex-col gap-0 overflow-y-auto border-l border-border px-3 py-4"
-        >
-            <p class="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Stats
-            </p>
-            {#each modelStats as stat}
-                {@const model = models.find((m) => m.id === stat.modelId)!}
-                {@const maxCount = Math.max(...modelStats.map((s) => s.annotationCount), 1)}
-                <div class="mb-4 space-y-2">
-                    <!-- Model name -->
-                    <div class="flex items-center gap-1.5">
-                        <span
-                            class="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
-                            style="background-color: {model.color};"
-                        ></span>
-                        <span class="truncate text-xs font-semibold">{model.name}</span>
-                    </div>
-
-                    <!-- Key numbers -->
-                    <div class="grid grid-cols-2 gap-x-2 gap-y-0.5 text-xs">
-                        <span class="text-muted-foreground">Annotations</span>
-                        <span class="text-right tabular-nums font-medium">{stat.annotationCount}</span>
-
-                        <Tooltip content="% of filtered images that have at least one annotation from this model" position="left">
-                            <span class="cursor-help text-muted-foreground underline decoration-dotted">Coverage</span>
-                        </Tooltip>
-                        <span class="text-right tabular-nums font-medium">
-                            {visibleCount > 0 ? Math.round((stat.coverageCount / visibleCount) * 100) : 0}%
-                        </span>
-
-                        <Tooltip content="The class this model annotates most often in the filtered image set" position="left">
-                            <span class="cursor-help text-muted-foreground underline decoration-dotted">Top class</span>
-                        </Tooltip>
-                        <span class="text-right font-medium">{stat.topLabel}</span>
-
-                        <Tooltip content="Mean confidence score across all visible annotations from this model" position="left">
-                            <span class="cursor-help text-muted-foreground underline decoration-dotted">Avg conf.</span>
-                        </Tooltip>
-                        <span class="text-right tabular-nums font-medium">{stat.avgConfidence.toFixed(2)}</span>
-
-                        <Tooltip content="Average bounding box area as % of image area — higher means larger predictions" position="left">
-                            <span class="cursor-help text-muted-foreground underline decoration-dotted">Avg box</span>
-                        </Tooltip>
-                        <span class="text-right tabular-nums font-medium">{(stat.avgBoxArea * 100).toFixed(1)}%</span>
-                    </div>
-
-                    <!-- Overall annotation bar -->
-                    <div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-                        <div
-                            class="h-full rounded-full transition-all"
-                            style="width: {(stat.annotationCount / maxCount) * 100}%; background-color: {model.color};"
-                        ></div>
-                    </div>
-
-                    <!-- Precision / Recall / IoU vs ground_truth -->
-                    {#if stat.precision !== undefined}
-                        <div class="space-y-1">
-                            <p class="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                                vs ground_truth
-                            </p>
-                            <div class="grid grid-cols-2 gap-x-2 gap-y-0.5 text-xs">
-                                <Tooltip content="TP / (TP + FP) — fraction of predictions that match a ground truth box (IoU ≥ 0.5, same class)" position="left">
-                                    <span class="cursor-help text-muted-foreground underline decoration-dotted">Precision</span>
-                                </Tooltip>
-                                <span class="text-right tabular-nums font-medium">{stat.precision.toFixed(2)}</span>
-
-                                <Tooltip content="TP / (TP + FN) — fraction of ground truth boxes that were found by this model" position="left">
-                                    <span class="cursor-help text-muted-foreground underline decoration-dotted">Recall</span>
-                                </Tooltip>
-                                <span class="text-right tabular-nums font-medium">{stat.recall!.toFixed(2)}</span>
-
-                                <Tooltip content="Average Intersection over Union for matched prediction–ground truth pairs" position="left">
-                                    <span class="cursor-help text-muted-foreground underline decoration-dotted">Avg IoU</span>
-                                </Tooltip>
-                                <span class="text-right tabular-nums font-medium">{stat.avgIoU!.toFixed(2)}</span>
-                            </div>
-                        </div>
-                    {/if}
-
-                    <!-- Per-class breakdown with avg confidence -->
-                    <div class="space-y-1">
-                        <p class="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">By class</p>
-                        {#each ALL_LABELS as lbl}
-                            {@const cs = stat.classStats[lbl]}
-                            {@const count = cs?.count ?? 0}
-                            {@const avgConf = cs ? cs.confidenceSum / cs.count : 0}
-                            {@const maxClassCount = Math.max(
-                                ...modelStats.map((s) => s.classStats[lbl]?.count ?? 0),
-                                1
-                            )}
-                            {#if count > 0}
-                                <div class="space-y-0.5 text-xs">
-                                    <div class="flex items-center justify-between">
-                                        <span class="truncate text-muted-foreground">{lbl}</span>
-                                        <Tooltip content="{count} annotation{count !== 1 ? 's' : ''} · avg confidence {avgConf.toFixed(2)}" position="left">
-                                            <span class="cursor-help tabular-nums text-muted-foreground underline decoration-dotted">{count} · {avgConf.toFixed(2)}</span>
-                                        </Tooltip>
-                                    </div>
-                                    <div class="h-1 w-full overflow-hidden rounded-full bg-muted">
-                                        <div
-                                            class="h-full rounded-full transition-all"
-                                            style="width: {(count / maxClassCount) * 100}%; background-color: {hexToRgba(model.color, 0.7)};"
-                                        ></div>
-                                    </div>
-                                </div>
-                            {/if}
-                        {/each}
-                    </div>
-
-                    <hr class="border-border" />
-                </div>
-            {/each}
-            {#if modelStats.length === 0}
-                <p class="text-xs text-muted-foreground">No models enabled.</p>
-            {/if}
-        </aside>
     </div>
 </Story>

--- a/lightly_studio_view/src/lib/components/ModelComparisonFilter/ModelComparisonFilter.stories.svelte
+++ b/lightly_studio_view/src/lib/components/ModelComparisonFilter/ModelComparisonFilter.stories.svelte
@@ -1,0 +1,284 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+
+    const { Story } = defineMeta({
+        title: 'Prototypes/ModelComparisonFilter',
+        tags: ['autodocs'],
+        argTypes: {
+            imageCount: {
+                control: { type: 'select' },
+                options: [12, 24, 48, 100],
+                description: 'Number of images in the grid'
+            }
+        }
+    });
+</script>
+
+<script lang="ts">
+    import Grid from '$lib/components/Grid/Grid.svelte';
+    import GridItem from '$lib/components/GridItem/GridItem.svelte';
+    import Segment from '$lib/components/Segment/Segment.svelte';
+    import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+    import { Label } from '$lib/components/ui/label/index.js';
+
+    // ── Types ────────────────────────────────────────────────────────────────
+
+    type ModelDef = {
+        id: string;
+        name: string;
+        color: string;
+        enabled: boolean;
+    };
+
+    type LabelDef = {
+        name: string;
+        enabled: boolean;
+    };
+
+    type BBox = {
+        /** Normalised 0–1 coordinates relative to image size */
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+        label: string;
+        modelId: string;
+    };
+
+    // ── Fake data generation ─────────────────────────────────────────────────
+
+    const ALL_LABELS = ['cat', 'dog', 'car', 'person', 'bicycle'];
+
+    const MODEL_DEFS: ModelDef[] = [
+        { id: 'ground_truth', name: 'ground_truth', color: '#22c55e', enabled: true },
+        { id: 'yolo_v8', name: 'yolo_v8', color: '#3b82f6', enabled: true },
+        { id: 'predictions_a', name: 'predictions_a', color: '#f97316', enabled: false }
+    ];
+
+    /** Seeded-ish pseudo-random so images look consistent on re-render */
+    function seededRand(seed: number): number {
+        const x = Math.sin(seed + 1) * 10000;
+        return x - Math.floor(x);
+    }
+
+    function generateBBoxes(imageIndex: number): BBox[] {
+        const boxes: BBox[] = [];
+        const modelIds = ['ground_truth', 'yolo_v8', 'predictions_a'];
+        let seed = imageIndex * 97;
+
+        for (const modelId of modelIds) {
+            const boxCount = Math.floor(seededRand(seed++) * 3) + 1;
+            for (let b = 0; b < boxCount; b++) {
+                const x = seededRand(seed++) * 0.5;
+                const y = seededRand(seed++) * 0.5;
+                const w = seededRand(seed++) * 0.35 + 0.1;
+                const h = seededRand(seed++) * 0.35 + 0.1;
+                const labelIdx = Math.floor(seededRand(seed++) * ALL_LABELS.length);
+                boxes.push({ x, y, w, h, label: ALL_LABELS[labelIdx], modelId });
+            }
+        }
+        return boxes;
+    }
+
+    // ── Reactive state ───────────────────────────────────────────────────────
+
+    let imageCount = $state(24);
+    const columnCount = 5;
+
+    let models: ModelDef[] = $state(MODEL_DEFS.map((m) => ({ ...m })));
+    let labelDefs: LabelDef[] = $state(ALL_LABELS.map((name) => ({ name, enabled: true })));
+
+    const enabledModelIds = $derived(new Set(models.filter((m) => m.enabled).map((m) => m.id)));
+    const enabledLabels = $derived(new Set(labelDefs.filter((l) => l.enabled).map((l) => l.name)));
+
+    const modelColorMap = $derived(Object.fromEntries(models.map((m) => [m.id, m.color])));
+
+    function toggleModel(id: string) {
+        models = models.map((m) => (m.id === id ? { ...m, enabled: !m.enabled } : m));
+    }
+
+    function toggleLabel(name: string) {
+        labelDefs = labelDefs.map((l) => (l.name === name ? { ...l, enabled: !l.enabled } : l));
+    }
+
+    /** Derive visible images: only include images that have at least one visible annotation */
+    const allImages = $derived(
+        Array.from({ length: imageCount }, (_, i) => ({
+            index: i,
+            bboxes: generateBBoxes(i)
+        }))
+    );
+
+    const visibleImages = $derived(
+        allImages.filter((img) =>
+            img.bboxes.some((b) => enabledModelIds.has(b.modelId) && enabledLabels.has(b.label))
+        )
+    );
+
+    const visibleCount = $derived(visibleImages.length);
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /** Returns hex with opacity as rgba string for CSS border */
+    function hexToRgba(hex: string, alpha: number): string {
+        const r = parseInt(hex.slice(1, 3), 16);
+        const g = parseInt(hex.slice(3, 5), 16);
+        const b = parseInt(hex.slice(5, 7), 16);
+        return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+</script>
+
+<Story name="Comparison View" asChild>
+    <div class="flex h-screen w-full overflow-hidden bg-background text-foreground">
+        <!-- ── Sidebar ───────────────────────────────────────────────────── -->
+        <aside
+            class="flex w-60 shrink-0 flex-col gap-4 overflow-y-auto border-r border-border px-3 py-4"
+        >
+            <hr class="border-border" />
+
+            <!-- Models -->
+            <Segment title="Models">
+                <div class="space-y-2">
+                    {#each models as model (model.id)}
+                        <div class="flex items-center space-x-2" title={model.name}>
+                            <Checkbox
+                                id={`model-${model.id}`}
+                                checked={model.enabled}
+                                aria-labelledby={`model-${model.id}-label`}
+                                onCheckedChange={() => toggleModel(model.id)}
+                            />
+                            <Label
+                                id={`model-${model.id}-label`}
+                                for={`model-${model.id}`}
+                                class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap"
+                            >
+                                <!-- Color swatch -->
+                                <span
+                                    class="inline-block h-3 w-3 shrink-0 rounded-sm border"
+                                    style="background-color: {hexToRgba(
+                                        model.color,
+                                        0.35
+                                    )}; border-color: {model.color};"
+                                ></span>
+                                <span class="flex-1 truncate text-sm font-normal">{model.name}</span
+                                >
+                            </Label>
+                        </div>
+                    {/each}
+                </div>
+            </Segment>
+
+            <!-- Labels -->
+            <Segment title="Labels">
+                <div class="space-y-2">
+                    {#each labelDefs as lbl (lbl.name)}
+                        <div class="flex items-center space-x-2" title={lbl.name}>
+                            <Checkbox
+                                id={`label-${lbl.name}`}
+                                checked={lbl.enabled}
+                                aria-labelledby={`label-${lbl.name}-label`}
+                                onCheckedChange={() => toggleLabel(lbl.name)}
+                            />
+                            <Label
+                                id={`label-${lbl.name}-label`}
+                                for={`label-${lbl.name}`}
+                                class="flex min-w-0 flex-1 cursor-pointer items-center text-nowrap"
+                            >
+                                <span class="flex-1 truncate text-sm font-normal">{lbl.name}</span>
+                            </Label>
+                        </div>
+                    {/each}
+                </div>
+            </Segment>
+        </aside>
+
+        <!-- ── Main grid area ────────────────────────────────────────────── -->
+        <div class="flex min-w-0 flex-1 flex-col">
+            <!-- Header bar -->
+            <div
+                class="flex items-center gap-3 border-b border-border px-4 py-2 text-sm text-muted-foreground"
+            >
+                <span>{visibleCount} of {imageCount} images</span>
+                <!-- Model legend pills -->
+                <div class="ml-auto flex gap-2">
+                    {#each models.filter((m) => m.enabled) as model (model.id)}
+                        <span
+                            class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium"
+                            style="background-color: {hexToRgba(
+                                model.color,
+                                0.15
+                            )}; color: {model.color}; border: 1px solid {hexToRgba(
+                                model.color,
+                                0.4
+                            )};"
+                        >
+                            <span
+                                class="inline-block h-2 w-2 rounded-full"
+                                style="background-color: {model.color};"
+                            ></span>
+                            {model.name}
+                        </span>
+                    {/each}
+                </div>
+            </div>
+
+            <!-- Grid -->
+            <div class="min-h-0 flex-1">
+                {#if visibleCount === 0}
+                    <div class="flex h-full items-center justify-center text-muted-foreground">
+                        No images match the current filters.
+                    </div>
+                {:else}
+                    <Grid itemCount={visibleCount} {columnCount}>
+                        {#snippet gridItem({ index, style, width, height })}
+                            {@const img = visibleImages[index]}
+                            <GridItem {width} {height} {style} tag={false}>
+                                <!-- Image thumbnail via picsum (seeded by original index) -->
+                                <img
+                                    src="https://picsum.photos/{Math.round(width)}/{Math.round(
+                                        height
+                                    )}?random={img.index}"
+                                    alt="Sample {img.index + 1}"
+                                    class="h-full w-full object-cover"
+                                    loading="lazy"
+                                />
+
+                                <!-- Annotation bbox overlays (CSS, no canvas worker needed) -->
+                                <div class="pointer-events-none absolute inset-0">
+                                    {#each img.bboxes as bbox}
+                                        {#if enabledModelIds.has(bbox.modelId) && enabledLabels.has(bbox.label)}
+                                            {@const color =
+                                                modelColorMap[bbox.modelId] ?? '#ffffff'}
+                                            <div
+                                                class="absolute"
+                                                style="
+                                                    left: {bbox.x * 100}%;
+                                                    top: {bbox.y * 100}%;
+                                                    width: {bbox.w * 100}%;
+                                                    height: {bbox.h * 100}%;
+                                                    border: 2px solid {color};
+                                                    box-shadow: inset 0 0 0 1px {hexToRgba(
+                                                    color,
+                                                    0.25
+                                                )};
+                                                "
+                                            >
+                                                <!-- Label chip -->
+                                                <span
+                                                    class="absolute left-0 top-0 translate-y-[-100%] px-1 py-0.5 text-[9px] font-semibold leading-tight text-white"
+                                                    style="background-color: {color};"
+                                                >
+                                                    {bbox.label}
+                                                </span>
+                                            </div>
+                                        {/if}
+                                    {/each}
+                                </div>
+                            </GridItem>
+                        {/snippet}
+                    </Grid>
+                {/if}
+            </div>
+        </div>
+    </div>
+</Story>

--- a/lightly_studio_view/src/lib/components/ModelComparisonFilter/PROPOSAL.md
+++ b/lightly_studio_view/src/lib/components/ModelComparisonFilter/PROPOSAL.md
@@ -60,12 +60,6 @@ colorByLabel: boolean;
 labelColors: Record<string, string>; // label_name → hex
 ```
 
-#### `DimensionFilter` (or `useDimensions` hook)
-
-Replace two single `<input type="range">` sliders with the existing `Slider` component (bits-ui, supports dual handles via `value: [min, max]`).
-
----
-
 ### New hooks
 
 #### `useAnnotationCollections`

--- a/lightly_studio_view/src/lib/components/ModelComparisonFilter/PROPOSAL.md
+++ b/lightly_studio_view/src/lib/components/ModelComparisonFilter/PROPOSAL.md
@@ -1,0 +1,298 @@
+# Annotation Collection Comparison — Implementation Proposal
+
+Validated by the Storybook prototype at `Prototypes/ModelComparisonFilter`.
+
+---
+
+## Overview
+
+Two independent concerns:
+
+1. **Filtering** — which images to show in the grid (fast, drives pagination)
+2. **Stats** — per-collection aggregations for the visible set (can be slow, loads separately)
+
+Keeping them as separate API calls lets the grid render immediately while stats catch up asynchronously.
+
+---
+
+## Frontend Components
+
+### New components
+
+#### `ModelsMenu`
+
+Mirrors the existing `LabelsMenu` but for annotation collections.
+
+```typescript
+type Props = {
+    collections: AnnotationCollectionView[];
+    enabledCollectionIds: Set<string>;
+    confidenceThresholds: Record<string, number>;      // collectionId → 0–1
+    onToggleCollection: (collectionId: string) => void;
+    onConfidenceChange: (collectionId: string, value: number) => void;
+};
+```
+
+Renders per collection: checkbox, color swatch, name, and (when enabled) a confidence threshold slider. Color is assigned deterministically from collection id, same as the existing label color algorithm.
+
+---
+
+#### `AnnotationCollectionStatsPanel`
+
+Right sidebar. Receives pre-fetched stats and renders one card per enabled collection.
+
+```typescript
+type Props = {
+    stats: AnnotationCollectionStatsView[];
+    comparisonStats: AnnotationComparisonView[];   // empty when <2 collections enabled
+    visibleImageCount: number;
+    isLoading: boolean;
+};
+```
+
+Each card shows:
+- Annotation count, coverage %, avg confidence, avg box area
+- Per-class breakdown: count + avg confidence + relative bar
+- `vs ground_truth` section (precision, recall, avg IoU) — rendered only when a GT collection is enabled and this collection is not GT
+
+---
+
+### Modified components
+
+#### `LabelsMenu`
+
+Remove the `current_count / total_count` counters from each label row. They were the only per-label stats surface in the UI; with the `AnnotationCollectionStatsPanel` covering per-class breakdowns (count, avg confidence, relative bar) there is no need to duplicate this in the filter sidebar. The counters also create visual noise that makes the label list harder to scan.
+
+The `current_count` and `total_count` fields can be dropped from the `Annotation` type passed to the component, and the `formatInteger` import removed.
+
+Additionally, add `colorByLabel` prop. When true, renders a color swatch next to each label using the label's assigned color. Color switches automatically: label-colors when exactly one collection is enabled, collection-colors otherwise — no manual toggle needed.
+
+```typescript
+// add to existing props
+colorByLabel: boolean;
+labelColors: Record<string, string>;  // label_name → hex
+```
+
+#### `DimensionFilter` (or `useDimensions` hook)
+
+Replace two single `<input type="range">` sliders with the existing `Slider` component (bits-ui, supports dual handles via `value: [min, max]`).
+
+---
+
+### New hooks
+
+#### `useAnnotationCollections`
+
+Fetches the list of annotation collections available in the current dataset. Used to populate `ModelsMenu`.
+
+```typescript
+function useAnnotationCollections(datasetId: string): {
+    collections: Readable<AnnotationCollectionView[]>;
+};
+```
+
+#### `useAnnotationCollectionStats`
+
+Separate query from image fetching. Fires after the filter is stable (debounced ~300 ms). Returns per-collection aggregations for the current filter state.
+
+```typescript
+function useAnnotationCollectionStats(params: {
+    collectionId: string;
+    filter: ImageFilter;
+    enabledCollectionIds: string[];
+    confidenceThresholds: Record<string, number>;
+    gtCollectionId: string | null;
+    iouThreshold: number;
+}): {
+    stats: Readable<AnnotationCollectionStatsView[]>;
+    comparisonStats: Readable<AnnotationComparisonView[]>;
+    isLoading: Readable<boolean>;
+};
+```
+
+#### `useAnnotationsFilter` (extend existing)
+
+Add `collectionIds` and per-collection `confidenceThresholds` to the existing hook and to `AnnotationsFilter`.
+
+---
+
+## Backend Endpoints
+
+### Extend existing
+
+**`POST /collections/{collection_id}/images`**
+
+Extend `AnnotationsFilter` with two new fields:
+
+```python
+class AnnotationsFilter(BaseModel):
+    # existing fields ...
+    collection_ids: list[str] | None = None
+    min_confidence: float | None = None   # applied per-collection using per-collection thresholds
+```
+
+For per-collection confidence thresholds, extend to:
+
+```python
+class CollectionConfidenceThreshold(BaseModel):
+    collection_id: str
+    min_confidence: float
+
+class AnnotationsFilter(BaseModel):
+    # existing fields ...
+    collection_ids: list[str] | None = None
+    confidence_thresholds: list[CollectionConfidenceThreshold] | None = None
+```
+
+---
+
+### New: annotation collection stats
+
+**`POST /collections/{collection_id}/annotation-collection-stats`**
+
+Returns per-collection aggregations for the filtered image set. Intentionally separate from the image list endpoint so the grid can render before stats are ready.
+
+Request body: same `ImageFilter` as the images endpoint, plus which collections to aggregate.
+
+```python
+class AnnotationCollectionStatsRequest(BaseModel):
+    image_filter: ImageFilter
+    collection_ids: list[str]
+    confidence_thresholds: list[CollectionConfidenceThreshold] = []
+```
+
+Response:
+
+```python
+class ClassStatView(BaseModel):
+    label_name: str
+    count: int
+    avg_confidence: float
+
+class AnnotationCollectionStatsView(BaseModel):
+    collection_id: str
+    annotation_count: int
+    image_coverage: float          # fraction of filtered images with ≥1 annotation
+    avg_confidence: float
+    avg_box_area: float            # mean normalised bbox area (w×h, 0–1)
+    class_stats: list[ClassStatView]
+```
+
+---
+
+### New: precision / recall / IoU comparison
+
+**`POST /collections/{collection_id}/annotation-comparison`**
+
+Computes TP/FP/FN by matching prediction boxes against a ground-truth collection using IoU ≥ threshold and same label. Expensive — called only when a GT collection is explicitly set. Client should show a loading state.
+
+```python
+class AnnotationComparisonRequest(BaseModel):
+    image_filter: ImageFilter
+    prediction_collection_ids: list[str]
+    gt_collection_id: str
+    iou_threshold: float = 0.5
+    confidence_thresholds: list[CollectionConfidenceThreshold] = []
+
+class AnnotationComparisonView(BaseModel):
+    collection_id: str
+    gt_collection_id: str
+    iou_threshold: float
+    precision: float
+    recall: float
+    avg_iou: float                 # mean IoU over matched pairs only
+    true_positives: int
+    false_positives: int
+    false_negatives: int
+```
+
+---
+
+## Data flow
+
+```
+User changes filter
+    │
+    ├─► POST /images  (immediate, drives grid pagination)
+    │
+    └─► POST /annotation-collection-stats  (debounced 300ms, drives stats panel)
+            │
+            └─► POST /annotation-comparison  (only when GT collection enabled)
+```
+
+---
+
+## URL Routing Refactor
+
+### Problem
+
+The current URL structure embeds `collection_type` as a path segment:
+
+```
+/datasets/{dataset_id}/{collection_type}/{collection_id}/{view}
+```
+
+This produces redundant and confusing URLs where the type and the view repeat the same word:
+
+```
+/datasets/c8dd3828/image/c8dd3828/images       ← "image" + "images"
+/datasets/c8dd3828/video/abc123/videos         ← "video" + "videos"
+```
+
+`collection_type` also leaks an internal data model concept that has no meaning to the user.
+
+### Proposed structure
+
+```
+/datasets/{dataset_id}/collections/{collection_id}/{view}
+```
+
+Examples:
+
+| Before | After |
+|--------|-------|
+| `/datasets/c8dd3828/image/c8dd3828/images` | `/datasets/c8dd3828/collections/c8dd3828/images` |
+| `/datasets/c8dd3828/image/c8dd3828/images/sample-id` | `/datasets/c8dd3828/collections/c8dd3828/images/sample-id` |
+| `/datasets/c8dd3828/video/abc123/videos` | `/datasets/c8dd3828/collections/abc123/videos` |
+| `/datasets/c8dd3828/video/abc123/frames` | `/datasets/c8dd3828/collections/abc123/frames` |
+| `/datasets/c8dd3828/image/abc123/annotations` | `/datasets/c8dd3828/collections/abc123/annotations` |
+
+The static segment `collections/` keeps the hierarchy unambiguous and leaves room for other dataset-level routes (e.g. `/datasets/{id}/settings`).
+
+### What changes
+
+- **SvelteKit routes** — rename the `[collection_type]` directory to the static segment `collections`
+- **`routes.ts`** — remove `collectionType` parameter from all route helpers; callers no longer need to pass it
+- **`APP_ROUTES`** — update the `COLLECTION_BASE_ROUTE` constant
+- **All call sites** — drop the `collectionType` argument; this is the bulk of the migration
+
+### What does not change
+
+- `collection_id` and all view segments (`/images`, `/videos`, `/frames`, `/annotations`, `/captions`, `/groups`) are identical
+- The available views per collection are determined by the collection's media type fetched from the API, not from the URL — no logic change required
+- Backend is entirely unaffected
+
+### Future improvement: human-readable slugs
+
+Currently collection identifiers in the URL are UUIDs, making links opaque:
+
+```
+/datasets/c8dd3828/collections/f3a91b44/images
+```
+
+A follow-up could introduce a slug derived from the collection name:
+
+```
+/datasets/c8dd3828/collections/ground-truth-v2/images
+```
+
+This requires slugs to be unique per dataset and stable after rename. Can be done as a separate step after the structural refactor above.
+
+---
+
+## Open questions
+
+1. **Color assignment** — should collection colors be user-customisable and persisted (like label colors today), or always auto-assigned?
+2. **GT collection designation** — explicit UI toggle ("set as ground truth") or inferred from collection name/type?
+3. **Confidence threshold scope** — per-collection (more flexible) vs. global single threshold (simpler UI)?
+4. **Stats caching** — stats queries can be expensive on large datasets; should results be cached server-side by filter hash?

--- a/lightly_studio_view/src/lib/components/ModelComparisonFilter/PROPOSAL.md
+++ b/lightly_studio_view/src/lib/components/ModelComparisonFilter/PROPOSAL.md
@@ -6,12 +6,14 @@ Validated by the Storybook prototype at `Prototypes/ModelComparisonFilter`.
 
 ## Overview
 
-Two independent concerns:
+This scope focuses on **filtering only** (which images to show in the grid and how overlays are colored).
 
-1. **Filtering** — which images to show in the grid (fast, drives pagination)
-2. **Stats** — per-collection aggregations for the visible set (can be slow, loads separately)
+Out of scope for now:
 
-Keeping them as separate API calls lets the grid render immediately while stats catch up asynchronously.
+- Stats panel
+- Backend stats/comparison endpoints and related hooks
+
+The UI should keep the existing Labels menu behavior (including counters), but counters must account for the currently selected annotation collections.
 
 ---
 
@@ -19,7 +21,7 @@ Keeping them as separate API calls lets the grid render immediately while stats 
 
 ### New components
 
-#### `ModelsMenu`
+#### `AnnotationCollectionsMenu`
 
 Mirrors the existing `LabelsMenu` but for annotation collections.
 
@@ -27,7 +29,7 @@ Mirrors the existing `LabelsMenu` but for annotation collections.
 type Props = {
     collections: AnnotationCollectionView[];
     enabledCollectionIds: Set<string>;
-    confidenceThresholds: Record<string, number>;      // collectionId → 0–1
+    confidenceThresholds: Record<string, number>; // collectionId → 0–1
     onToggleCollection: (collectionId: string) => void;
     onConfidenceChange: (collectionId: string, value: number) => void;
 };
@@ -37,40 +39,25 @@ Renders per collection: checkbox, color swatch, name, and (when enabled) a confi
 
 ---
 
-#### `AnnotationCollectionStatsPanel`
-
-Right sidebar. Receives pre-fetched stats and renders one card per enabled collection.
-
-```typescript
-type Props = {
-    stats: AnnotationCollectionStatsView[];
-    comparisonStats: AnnotationComparisonView[];   // empty when <2 collections enabled
-    visibleImageCount: number;
-    isLoading: boolean;
-};
-```
-
-Each card shows:
-- Annotation count, coverage %, avg confidence, avg box area
-- Per-class breakdown: count + avg confidence + relative bar
-- `vs ground_truth` section (precision, recall, avg IoU) — rendered only when a GT collection is enabled and this collection is not GT
-
----
-
 ### Modified components
 
 #### `LabelsMenu`
 
-Remove the `current_count / total_count` counters from each label row. They were the only per-label stats surface in the UI; with the `AnnotationCollectionStatsPanel` covering per-class breakdowns (count, avg confidence, relative bar) there is no need to duplicate this in the filter sidebar. The counters also create visual noise that makes the label list harder to scan.
+Keep the existing label counters (`current_count / total_count`) in each label row.
 
-The `current_count` and `total_count` fields can be dropped from the `Annotation` type passed to the component, and the `formatInteger` import removed.
+Required adjustment:
+
+- Counter values must be computed from annotations belonging to **enabled/selected collections only** (instead of a single implicit source).
+- Label rows should still render correctly when multiple collections are enabled.
+
+No stats-panel replacement is needed in this iteration; label counters remain the only per-label quantitative signal in the sidebar.
 
 Additionally, add `colorByLabel` prop. When true, renders a color swatch next to each label using the label's assigned color. Color switches automatically: label-colors when exactly one collection is enabled, collection-colors otherwise — no manual toggle needed.
 
 ```typescript
 // add to existing props
 colorByLabel: boolean;
-labelColors: Record<string, string>;  // label_name → hex
+labelColors: Record<string, string>; // label_name → hex
 ```
 
 #### `DimensionFilter` (or `useDimensions` hook)
@@ -83,7 +70,7 @@ Replace two single `<input type="range">` sliders with the existing `Slider` com
 
 #### `useAnnotationCollections`
 
-Fetches the list of annotation collections available in the current dataset. Used to populate `ModelsMenu`.
+Fetches the list of annotation collections available in the current dataset. Used to populate `AnnotationCollectionsMenu`.
 
 ```typescript
 function useAnnotationCollections(datasetId: string): {
@@ -91,28 +78,11 @@ function useAnnotationCollections(datasetId: string): {
 };
 ```
 
-#### `useAnnotationCollectionStats`
-
-Separate query from image fetching. Fires after the filter is stable (debounced ~300 ms). Returns per-collection aggregations for the current filter state.
-
-```typescript
-function useAnnotationCollectionStats(params: {
-    collectionId: string;
-    filter: ImageFilter;
-    enabledCollectionIds: string[];
-    confidenceThresholds: Record<string, number>;
-    gtCollectionId: string | null;
-    iouThreshold: number;
-}): {
-    stats: Readable<AnnotationCollectionStatsView[]>;
-    comparisonStats: Readable<AnnotationComparisonView[]>;
-    isLoading: Readable<boolean>;
-};
-```
-
 #### `useAnnotationsFilter` (extend existing)
 
-Add `collectionIds` and per-collection `confidenceThresholds` to the existing hook and to `AnnotationsFilter`.
+Add `collectionIds` and `labelNames` to the existing hook and to `AnnotationsFilter`.
+
+Also update the label counter derivation used by `LabelsMenu` so counts are aggregated across selected collections.
 
 ---
 
@@ -122,88 +92,13 @@ Add `collectionIds` and per-collection `confidenceThresholds` to the existing ho
 
 **`POST /collections/{collection_id}/images`**
 
-Extend `AnnotationsFilter` with two new fields:
+Extend `AnnotationsFilter` with collection filtering and `label_names`.
 
 ```python
 class AnnotationsFilter(BaseModel):
     # existing fields ...
     collection_ids: list[str] | None = None
-    min_confidence: float | None = None   # applied per-collection using per-collection thresholds
-```
-
-For per-collection confidence thresholds, extend to:
-
-```python
-class CollectionConfidenceThreshold(BaseModel):
-    collection_id: str
-    min_confidence: float
-
-class AnnotationsFilter(BaseModel):
-    # existing fields ...
-    collection_ids: list[str] | None = None
-    confidence_thresholds: list[CollectionConfidenceThreshold] | None = None
-```
-
----
-
-### New: annotation collection stats
-
-**`POST /collections/{collection_id}/annotation-collection-stats`**
-
-Returns per-collection aggregations for the filtered image set. Intentionally separate from the image list endpoint so the grid can render before stats are ready.
-
-Request body: same `ImageFilter` as the images endpoint, plus which collections to aggregate.
-
-```python
-class AnnotationCollectionStatsRequest(BaseModel):
-    image_filter: ImageFilter
-    collection_ids: list[str]
-    confidence_thresholds: list[CollectionConfidenceThreshold] = []
-```
-
-Response:
-
-```python
-class ClassStatView(BaseModel):
-    label_name: str
-    count: int
-    avg_confidence: float
-
-class AnnotationCollectionStatsView(BaseModel):
-    collection_id: str
-    annotation_count: int
-    image_coverage: float          # fraction of filtered images with ≥1 annotation
-    avg_confidence: float
-    avg_box_area: float            # mean normalised bbox area (w×h, 0–1)
-    class_stats: list[ClassStatView]
-```
-
----
-
-### New: precision / recall / IoU comparison
-
-**`POST /collections/{collection_id}/annotation-comparison`**
-
-Computes TP/FP/FN by matching prediction boxes against a ground-truth collection using IoU ≥ threshold and same label. Expensive — called only when a GT collection is explicitly set. Client should show a loading state.
-
-```python
-class AnnotationComparisonRequest(BaseModel):
-    image_filter: ImageFilter
-    prediction_collection_ids: list[str]
-    gt_collection_id: str
-    iou_threshold: float = 0.5
-    confidence_thresholds: list[CollectionConfidenceThreshold] = []
-
-class AnnotationComparisonView(BaseModel):
-    collection_id: str
-    gt_collection_id: str
-    iou_threshold: float
-    precision: float
-    recall: float
-    avg_iou: float                 # mean IoU over matched pairs only
-    true_positives: int
-    false_positives: int
-    false_negatives: int
+    label_names: list[str] | None = None
 ```
 
 ---
@@ -213,86 +108,22 @@ class AnnotationComparisonView(BaseModel):
 ```
 User changes filter
     │
-    ├─► POST /images  (immediate, drives grid pagination)
-    │
-    └─► POST /annotation-collection-stats  (debounced 300ms, drives stats panel)
-            │
-            └─► POST /annotation-comparison  (only when GT collection enabled)
+    └─► POST /images  (immediate, drives grid pagination and label counters)
 ```
 
 ---
 
-## URL Routing Refactor
+## Proposed tasks
 
-### Problem
-
-The current URL structure embeds `collection_type` as a path segment:
-
-```
-/datasets/{dataset_id}/{collection_type}/{collection_id}/{view}
-```
-
-This produces redundant and confusing URLs where the type and the view repeat the same word:
-
-```
-/datasets/c8dd3828/image/c8dd3828/images       ← "image" + "images"
-/datasets/c8dd3828/video/abc123/videos         ← "video" + "videos"
-```
-
-`collection_type` also leaks an internal data model concept that has no meaning to the user.
-
-### Proposed structure
-
-```
-/datasets/{dataset_id}/collections/{collection_id}/{view}
-```
-
-Examples:
-
-| Before | After |
-|--------|-------|
-| `/datasets/c8dd3828/image/c8dd3828/images` | `/datasets/c8dd3828/collections/c8dd3828/images` |
-| `/datasets/c8dd3828/image/c8dd3828/images/sample-id` | `/datasets/c8dd3828/collections/c8dd3828/images/sample-id` |
-| `/datasets/c8dd3828/video/abc123/videos` | `/datasets/c8dd3828/collections/abc123/videos` |
-| `/datasets/c8dd3828/video/abc123/frames` | `/datasets/c8dd3828/collections/abc123/frames` |
-| `/datasets/c8dd3828/image/abc123/annotations` | `/datasets/c8dd3828/collections/abc123/annotations` |
-
-The static segment `collections/` keeps the hierarchy unambiguous and leaves room for other dataset-level routes (e.g. `/datasets/{id}/settings`).
-
-### What changes
-
-- **SvelteKit routes** — rename the `[collection_type]` directory to the static segment `collections`
-- **`routes.ts`** — remove `collectionType` parameter from all route helpers; callers no longer need to pass it
-- **`APP_ROUTES`** — update the `COLLECTION_BASE_ROUTE` constant
-- **All call sites** — drop the `collectionType` argument; this is the bulk of the migration
-
-### What does not change
-
-- `collection_id` and all view segments (`/images`, `/videos`, `/frames`, `/annotations`, `/captions`, `/groups`) are identical
-- The available views per collection are determined by the collection's media type fetched from the API, not from the URL — no logic change required
-- Backend is entirely unaffected
-
-### Future improvement: human-readable slugs
-
-Currently collection identifiers in the URL are UUIDs, making links opaque:
-
-```
-/datasets/c8dd3828/collections/f3a91b44/images
-```
-
-A follow-up could introduce a slug derived from the collection name:
-
-```
-/datasets/c8dd3828/collections/ground-truth-v2/images
-```
-
-This requires slugs to be unique per dataset and stable after rename. Can be done as a separate step after the structural refactor above.
-
----
-
-## Open questions
-
-1. **Color assignment** — should collection colors be user-customisable and persisted (like label colors today), or always auto-assigned?
-2. **GT collection designation** — explicit UI toggle ("set as ground truth") or inferred from collection name/type?
-3. **Confidence threshold scope** — per-collection (more flexible) vs. global single threshold (simpler UI)?
-4. **Stats caching** — stats queries can be expensive on large datasets; should results be cached server-side by filter hash?
+1. Define `AnnotationCollectionsMenu` component API and integrate it into the comparison sidebar.
+2. Implement annotation-collection fetching (`useAnnotationCollections`) and wire loading/error states.
+3. Extend frontend filter state to include selected `collectionIds` and selected `labelNames`.
+4. Update `useAnnotationsFilter` output mapping so it produces `AnnotationsFilter` with `collection_ids` and `label_names`.
+5. Keep `LabelsMenu` counters and update counter derivation to aggregate over selected collections only.
+6. Add `colorByLabel` and `labelColors` support in `LabelsMenu` and connect color mode switching logic.
+7. Extend backend `AnnotationsFilter` schema with `collection_ids` and `label_names`.
+8. Update image-list query logic to apply both collection and label-name filters.
+9. Add or adjust backend tests for `collection_ids` + `label_names` filtering behavior.
+10. Add or adjust frontend tests for `useAnnotationsFilter` mapping (`collectionIds`/`labelNames` -> `AnnotationsFilter`).
+11. Add or adjust frontend tests for `LabelsMenu` counters with multiple selected collections.
+12. Add or adjust frontend tests for sidebar interactions (collection + label toggles) affecting grid results.


### PR DESCRIPTION
## Summary
Design and prototype for annotation collection comparison (US-1, US-2, US-3).

### Storybook prototype — Prototypes/ModelComparisonFilter
A fully interactive prototype (ModelComparisonFilter.stories.svelte) that validates the proposed UX before implementation. It covers all three user stories:

US-1 — filter the image grid to images that have at least one annotation from a specific collection (model)
US-2 — filter by collection + class simultaneously
US-3 — enable multiple collections, each rendered in a distinct color, to visually compare model outputs side by side

<img width="2784" height="1348" alt="image" src="https://github.com/user-attachments/assets/5a8f1a3d-00d3-4523-bcea-a01bf097893a" />


### What the prototype includes:

Left sidebar — Models section with per-collection checkboxes, color swatches. Labels section with checkboxes. Image grid — CSS bounding box overlays colored by collection. Label chips show class name + confidence score. Grid filters reactively as controls change.
Auto color mode — when exactly one collection is enabled, boxes switch from collection-colors to label-colors automatically; label swatches appear in the sidebar to match.

### Implementation proposal — PROPOSAL.md
Documents the full implementation plan including:
New frontend components (ModelsMenu) and modifications to LabelsMenu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive Model Comparison prototype in Storybook: two-panel UI with sidebar controls, image grid with dimension badges, colored bounding-box overlays, per-model/per-label stats, deterministic sample data, and filters for model, label, width, height, plus toggles for visibility.

* **Documentation**
  * Proposal for annotation-collection comparison: UI behavior, filtering APIs, color rules, data flow, and frontend/backend integration notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->