### PR TITLE
Add public ImageDataset.add_annotations_from_*** methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `ImageDataset.add_annotations_from_coco`, `add_annotations_from_yolo`, and `add_annotations_from_labelformat` methods to attach named annotation collections to images already in the dataset. Re-using the same `name` appends; a new `name` creates a new collection. Enables ingesting ground truth and predictions from multiple sources side-by-side.
 - Added drag-and-drop from the image grid into the image search area.
 - Added a select-all button to select all grid items matching the active filters.
 - Added API endpoints to fetch only sample IDs with optional filters for images, video frames, and annotations (used by the select-all keyboard shortcut).

--- a/lightly_studio/docs/docs/dataset_setup/image_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/image_dataset.md
@@ -324,51 +324,6 @@ standard formats. See [API reference](../api/dataset.md#lightly_studio.ImageData
 Moreover, you can write an adapter to load images with annotations from a custom format, see the
 [TODO](../todo) for details. -->
 
-### Adding Annotations to Existing Images
-
-The `add_samples_from_*` methods above load images and annotations together. When images
-are already in the dataset, the `add_annotations_from_*` family attaches additional
-annotations without re-loading images. This is useful when ingesting predictions from
-multiple sources — for example ground truth alongside predictions from one or more models —
-so each source can be queried and compared independently.
-
-Each call stores its annotations under a named annotation collection. Re-running with the
-same `name` appends to that collection; a new `name` creates a new collection.
-
-```python title="Attach annotations from multiple sources"
-import lightly_studio as ls
-
-dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
-images_path = f"{dataset_path}/coco_subset_128_images/images"
-
-# Load images once.
-dataset = ls.ImageDataset.create()
-dataset.add_images_from_path(path=images_path)
-
-# Attach ground truth.
-dataset.add_annotations_from_coco(
-    annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
-    images_root=images_path,
-    name="ground_truth",
-)
-
-# Attach predictions from a model (paths are illustrative).
-dataset.add_annotations_from_coco(
-    annotations_json="/path/to/model_A_predictions.json",
-    images_root=images_path,
-    name="model_A",
-)
-```
-
-The available methods mirror the loading family:
-
-- `add_annotations_from_labelformat(input_labels, images_root, name)` — generic entrypoint, accepts any `labelformat` input object.
-- `add_annotations_from_coco(annotations_json, images_root, name, annotation_type=...)` — supports `OBJECT_DETECTION` and `SEGMENTATION_MASK`.
-- `add_annotations_from_yolo(data_yaml, name, input_split=None)` — when `input_split` is `None`, all splits in the yaml are loaded.
-
-Images are matched to annotations by their absolute path under `images_root`. If an annotation
-references an image not in the dataset, it is skipped and a single warning is logged at the end
-of the call summarising the skipped count and the first few unmatched paths.
 
 ### From a Pre-Existing Dataset
 
@@ -395,6 +350,40 @@ GUI displays only a single dataset.
     Therefore you can safely use them in a single script with `load_or_create()`,
     adding and embedding the images will be skipped on subsequent calls.
 
+### Adding Annotations to Existing Images
+
+When images are already in the dataset, the `add_annotations_from_*` methods attach
+annotations without re-loading the images. Each call stores its annotations under a named
+collection, so multiple sources (e.g. ground truth and model predictions) can be queried
+and compared independently. Re-running with the same `name` appends to that collection;
+a new `name` creates a new collection.
+
+```python title="Attach annotations from multiple sources"
+import lightly_studio as ls
+
+dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
+images_path = f"{dataset_path}/coco_subset_128_images/images"
+
+# Load images once.
+dataset = ls.ImageDataset.create()
+dataset.add_images_from_path(path=images_path)
+
+# Attach ground truth.
+dataset.add_annotations_from_coco(
+    annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
+    images_root=images_path,
+    name="ground_truth",
+)
+
+# Attach predictions from a model (paths are illustrative).
+dataset.add_annotations_from_coco(
+    annotations_json="/path/to/model_A_predictions.json",
+    images_root=images_path,
+    name="model_A",
+)
+```
+
+See the [API reference](../api/dataset.md#lightly_studio.ImageDataset) for `add_annotations_from_coco`, `add_annotations_from_yolo`, and `add_annotations_from_labelformat`.
 
 ## Image Dataset in the GUI
 

--- a/lightly_studio/docs/docs/dataset_setup/image_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/image_dataset.md
@@ -324,7 +324,6 @@ standard formats. See [API reference](../api/dataset.md#lightly_studio.ImageData
 Moreover, you can write an adapter to load images with annotations from a custom format, see the
 [TODO](../todo) for details. -->
 
-
 ### From a Pre-Existing Dataset
 
 Once a dataset is populated, the data is stored in a database. It can be loaded later as follows

--- a/lightly_studio/docs/docs/dataset_setup/image_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/image_dataset.md
@@ -324,6 +324,52 @@ standard formats. See [API reference](../api/dataset.md#lightly_studio.ImageData
 Moreover, you can write an adapter to load images with annotations from a custom format, see the
 [TODO](../todo) for details. -->
 
+### Adding Annotations to Existing Images
+
+The `add_samples_from_*` methods above load images and annotations together. When images
+are already in the dataset, the `add_annotations_from_*` family attaches additional
+annotations without re-loading images. This is useful when ingesting predictions from
+multiple sources — for example ground truth alongside predictions from one or more models —
+so each source can be queried and compared independently.
+
+Each call stores its annotations under a named annotation collection. Re-running with the
+same `name` appends to that collection; a new `name` creates a new collection.
+
+```python title="Attach annotations from multiple sources"
+import lightly_studio as ls
+
+dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
+images_path = f"{dataset_path}/coco_subset_128_images/images"
+
+# Load images once.
+dataset = ls.ImageDataset.create()
+dataset.add_images_from_path(path=images_path)
+
+# Attach ground truth.
+dataset.add_annotations_from_coco(
+    annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
+    images_root=images_path,
+    name="ground_truth",
+)
+
+# Attach predictions from a model (paths are illustrative).
+dataset.add_annotations_from_coco(
+    annotations_json="/path/to/model_A_predictions.json",
+    images_root=images_path,
+    name="model_A",
+)
+```
+
+The available methods mirror the loading family:
+
+- `add_annotations_from_labelformat(input_labels, images_root, name)` — generic entrypoint, accepts any `labelformat` input object.
+- `add_annotations_from_coco(annotations_json, images_root, name, annotation_type=...)` — supports `OBJECT_DETECTION` and `SEGMENTATION_MASK`.
+- `add_annotations_from_yolo(data_yaml, name, input_split=None)` — when `input_split` is `None`, all splits in the yaml are loaded.
+
+Images are matched to annotations by their absolute path under `images_root`. If an annotation
+references an image not in the dataset, it is skipped and a single warning is logged at the end
+of the call summarising the skipped count and the first few unmatched paths.
+
 ### From a Pre-Existing Dataset
 
 Once a dataset is populated, the data is stored in a database. It can be loaded later as follows

--- a/lightly_studio/src/lightly_studio/core/image/add_annotations.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_annotations.py
@@ -8,6 +8,12 @@ from pathlib import Path
 from uuid import UUID
 
 import fsspec
+import yaml
+from labelformat.formats import (
+    COCOInstanceSegmentationInput,
+    COCOObjectDetectionInput,
+    YOLOv8ObjectDetectionInput,
+)
 from labelformat.model.instance_segmentation import (
     ImageInstanceSegmentation,
     InstanceSegmentationInput,
@@ -20,7 +26,7 @@ from sqlmodel import Session
 from tqdm import tqdm
 
 from lightly_studio.core import labelformat_helpers
-from lightly_studio.models.annotation.annotation_base import AnnotationCreate
+from lightly_studio.models.annotation.annotation_base import AnnotationCreate, AnnotationType
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import (
     annotation_collection_coverage_resolver,
@@ -32,6 +38,7 @@ from lightly_studio.type_definitions import PathLike
 
 # Constants
 SAMPLE_BATCH_SIZE = 32  # Number of samples to process in a single batch
+ALLOWED_YOLO_SPLITS = {"train", "val", "test", "minival"}
 
 
 def add_annotations_from_labelformat(  # noqa: PLR0913
@@ -200,3 +207,78 @@ def _process_annotation_batch(  # noqa: PLR0913
         )
 
     return missing_paths
+
+
+def add_annotations_from_coco(  # noqa: PLR0913
+    session: Session,
+    root_collection_id: UUID,
+    annotations_json: PathLike,
+    images_root: PathLike,
+    collection_name: str,
+    annotation_type: AnnotationType = AnnotationType.OBJECT_DETECTION,
+) -> list[str]:
+    """Build the COCO labelformat input and add annotations.
+
+    Returns the file paths from the input that had no matching sample in the dataset.
+    """
+    label_input: COCOObjectDetectionInput | COCOInstanceSegmentationInput
+    if annotation_type == AnnotationType.OBJECT_DETECTION:
+        label_input = COCOObjectDetectionInput(input_file=annotations_json)
+    elif annotation_type == AnnotationType.SEGMENTATION_MASK:
+        label_input = COCOInstanceSegmentationInput(input_file=annotations_json)
+    else:
+        raise ValueError(f"Invalid annotation type: {annotation_type}")
+    return add_annotations_from_labelformat(
+        session=session,
+        root_collection_id=root_collection_id,
+        input_labels=label_input,
+        images_root=images_root,
+        collection_name=collection_name,
+    )
+
+
+def add_annotations_from_yolo(
+    session: Session,
+    root_collection_id: UUID,
+    data_yaml: PathLike,
+    collection_name: str,
+    input_split: str | None = None,
+) -> list[str]:
+    """Build YOLO labelformat input(s) per split and add annotations.
+
+    When ``input_split`` is ``None``, all splits present in the yaml are processed.
+    Returns the concatenated file paths from all splits that had no matching sample.
+    """
+    data_yaml_path = Path(data_yaml).absolute()
+    splits = resolve_yolo_splits(data_yaml=data_yaml_path, input_split=input_split)
+    missing: list[str] = []
+    for split in splits:
+        label_input = YOLOv8ObjectDetectionInput(input_file=data_yaml_path, input_split=split)
+        missing += add_annotations_from_labelformat(
+            session=session,
+            root_collection_id=root_collection_id,
+            input_labels=label_input,
+            images_root=label_input._images_dir(),  # noqa: SLF001
+            collection_name=collection_name,
+        )
+    return missing
+
+
+def resolve_yolo_splits(data_yaml: Path, input_split: str | None) -> list[str]:
+    """Determine which YOLO splits to process for the given config."""
+    if input_split is not None:
+        if input_split not in ALLOWED_YOLO_SPLITS:
+            raise ValueError(
+                f"Split '{input_split}' not found in config file '{data_yaml}'. "
+                f"Allowed splits: {sorted(ALLOWED_YOLO_SPLITS)}"
+            )
+        return [input_split]
+
+    with data_yaml.open() as f:
+        config = yaml.safe_load(f)
+
+    config_keys = config.keys() if isinstance(config, dict) else []
+    splits = [key for key in config_keys if key in ALLOWED_YOLO_SPLITS]
+    if not splits:
+        raise ValueError(f"No splits found in config file '{data_yaml}'")
+    return splits

--- a/lightly_studio/src/lightly_studio/core/image/add_annotations.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_annotations.py
@@ -9,11 +9,6 @@ from uuid import UUID
 
 import fsspec
 import yaml
-from labelformat.formats import (
-    COCOInstanceSegmentationInput,
-    COCOObjectDetectionInput,
-    YOLOv8ObjectDetectionInput,
-)
 from labelformat.model.instance_segmentation import (
     ImageInstanceSegmentation,
     InstanceSegmentationInput,
@@ -26,7 +21,7 @@ from sqlmodel import Session
 from tqdm import tqdm
 
 from lightly_studio.core import labelformat_helpers
-from lightly_studio.models.annotation.annotation_base import AnnotationCreate, AnnotationType
+from lightly_studio.models.annotation.annotation_base import AnnotationCreate
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import (
     annotation_collection_coverage_resolver,
@@ -122,6 +117,26 @@ def normalize_images_root(images_root: PathLike) -> str:
     return images_root_str
 
 
+def resolve_yolo_splits(data_yaml: Path, input_split: str | None) -> list[str]:
+    """Determine which YOLO splits to process for the given config."""
+    if input_split is not None:
+        if input_split not in ALLOWED_YOLO_SPLITS:
+            raise ValueError(
+                f"Split '{input_split}' not found in config file '{data_yaml}'. "
+                f"Allowed splits: {sorted(ALLOWED_YOLO_SPLITS)}"
+            )
+        return [input_split]
+
+    with data_yaml.open() as f:
+        config = yaml.safe_load(f)
+
+    config_keys = config.keys() if isinstance(config, dict) else []
+    splits = [key for key in config_keys if key in ALLOWED_YOLO_SPLITS]
+    if not splits:
+        raise ValueError(f"No splits found in config file '{data_yaml}'")
+    return splits
+
+
 def _process_annotation_batch(  # noqa: PLR0913
     session: Session,
     root_collection_id: UUID,
@@ -207,78 +222,3 @@ def _process_annotation_batch(  # noqa: PLR0913
         )
 
     return missing_paths
-
-
-def add_annotations_from_coco(  # noqa: PLR0913
-    session: Session,
-    root_collection_id: UUID,
-    annotations_json: PathLike,
-    images_root: PathLike,
-    collection_name: str,
-    annotation_type: AnnotationType = AnnotationType.OBJECT_DETECTION,
-) -> list[str]:
-    """Build the COCO labelformat input and add annotations.
-
-    Returns the file paths from the input that had no matching sample in the dataset.
-    """
-    label_input: COCOObjectDetectionInput | COCOInstanceSegmentationInput
-    if annotation_type == AnnotationType.OBJECT_DETECTION:
-        label_input = COCOObjectDetectionInput(input_file=annotations_json)
-    elif annotation_type == AnnotationType.SEGMENTATION_MASK:
-        label_input = COCOInstanceSegmentationInput(input_file=annotations_json)
-    else:
-        raise ValueError(f"Invalid annotation type: {annotation_type}")
-    return add_annotations_from_labelformat(
-        session=session,
-        root_collection_id=root_collection_id,
-        input_labels=label_input,
-        images_root=images_root,
-        collection_name=collection_name,
-    )
-
-
-def add_annotations_from_yolo(
-    session: Session,
-    root_collection_id: UUID,
-    data_yaml: PathLike,
-    collection_name: str,
-    input_split: str | None = None,
-) -> list[str]:
-    """Build YOLO labelformat input(s) per split and add annotations.
-
-    When ``input_split`` is ``None``, all splits present in the yaml are processed.
-    Returns the concatenated file paths from all splits that had no matching sample.
-    """
-    data_yaml_path = Path(data_yaml).absolute()
-    splits = resolve_yolo_splits(data_yaml=data_yaml_path, input_split=input_split)
-    missing: list[str] = []
-    for split in splits:
-        label_input = YOLOv8ObjectDetectionInput(input_file=data_yaml_path, input_split=split)
-        missing += add_annotations_from_labelformat(
-            session=session,
-            root_collection_id=root_collection_id,
-            input_labels=label_input,
-            images_root=label_input._images_dir(),  # noqa: SLF001
-            collection_name=collection_name,
-        )
-    return missing
-
-
-def resolve_yolo_splits(data_yaml: Path, input_split: str | None) -> list[str]:
-    """Determine which YOLO splits to process for the given config."""
-    if input_split is not None:
-        if input_split not in ALLOWED_YOLO_SPLITS:
-            raise ValueError(
-                f"Split '{input_split}' not found in config file '{data_yaml}'. "
-                f"Allowed splits: {sorted(ALLOWED_YOLO_SPLITS)}"
-            )
-        return [input_split]
-
-    with data_yaml.open() as f:
-        config = yaml.safe_load(f)
-
-    config_keys = config.keys() if isinstance(config, dict) else []
-    splits = [key for key in config_keys if key in ALLOWED_YOLO_SPLITS]
-    if not splits:
-        raise ValueError(f"No splits found in config file '{data_yaml}'")
-    return splits

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -219,15 +219,16 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             name: Name of the annotation collection.
             annotation_type: ``OBJECT_DETECTION`` or ``SEGMENTATION_MASK``.
         """
-        missing = add_annotations.add_annotations_from_coco(
-            session=self.session,
-            root_collection_id=self.collection_id,
-            annotations_json=annotations_json,
-            images_root=images_root,
-            collection_name=name,
-            annotation_type=annotation_type,
+        label_input: COCOObjectDetectionInput | COCOInstanceSegmentationInput
+        if annotation_type == AnnotationType.OBJECT_DETECTION:
+            label_input = COCOObjectDetectionInput(input_file=annotations_json)
+        elif annotation_type == AnnotationType.SEGMENTATION_MASK:
+            label_input = COCOInstanceSegmentationInput(input_file=annotations_json)
+        else:
+            raise ValueError(f"Invalid annotation type: {annotation_type}")
+        self.add_annotations_from_labelformat(
+            input_labels=label_input, images_root=images_root, name=name
         )
-        _log_missing_images(name=name, missing_paths=missing)
 
     def add_annotations_from_yolo(
         self,
@@ -242,13 +243,19 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             name: Name of the annotation collection.
             input_split: Specific split (e.g. ``"train"``). ``None`` loads all splits.
         """
-        missing = add_annotations.add_annotations_from_yolo(
-            session=self.session,
-            root_collection_id=self.collection_id,
-            data_yaml=data_yaml,
-            collection_name=name,
-            input_split=input_split,
-        )
+        data_yaml = Path(data_yaml).absolute()
+        missing: list[str] = []
+        for split in add_annotations.resolve_yolo_splits(
+            data_yaml=data_yaml, input_split=input_split
+        ):
+            label_input = YOLOv8ObjectDetectionInput(input_file=data_yaml, input_split=split)
+            missing += add_annotations.add_annotations_from_labelformat(
+                session=self.session,
+                root_collection_id=self.collection_id,
+                input_labels=label_input,
+                images_root=label_input._images_dir(),  # noqa: SLF001
+                collection_name=name,
+            )
         _log_missing_images(name=name, missing_paths=missing)
 
     def add_samples_from_labelformat(

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from uuid import UUID
 
 import fsspec
-import yaml
 from fsspec.implementations.local import LocalFileSystem
 from labelformat.formats import (
     COCOInstanceSegmentationInput,
@@ -27,7 +26,7 @@ from sqlmodel import Session
 
 from lightly_studio.core.dataset import BaseSampleDataset
 from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
-from lightly_studio.core.image import add_images
+from lightly_studio.core.image import add_annotations, add_images
 from lightly_studio.core.image.image_sample import ImageSample
 from lightly_studio.dataset import fsspec_lister
 from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
@@ -41,8 +40,6 @@ from lightly_studio.resolvers import (
 from lightly_studio.type_definitions import PathLike
 
 logger = logging.getLogger(__name__)
-
-ALLOWED_YOLO_SPLITS = {"train", "val", "test", "minival"}
 
 
 class ImageDataset(BaseSampleDataset[ImageSample]):
@@ -181,6 +178,79 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
                 sample_ids=created_sample_ids,
             )
 
+    def add_annotations_from_labelformat(
+        self,
+        input_labels: ObjectDetectionInput | InstanceSegmentationInput,
+        images_root: PathLike,
+        name: str,
+    ) -> None:
+        """Attach annotations from a labelformat input to images already in the dataset.
+
+        Images are matched by relative path under ``images_root``. Annotations are grouped
+        under an annotation collection identified by ``name``; reusing the same name
+        appends to that collection.
+
+        Args:
+            input_labels: Labelformat input object (e.g. ``COCOObjectDetectionInput``).
+            images_root: Root path used to construct absolute image paths for matching.
+            name: Name of the annotation collection.
+        """
+        missing = add_annotations.add_annotations_from_labelformat(
+            session=self.session,
+            root_collection_id=self.collection_id,
+            input_labels=input_labels,
+            images_root=images_root,
+            collection_name=name,
+        )
+        _log_missing_images(name=name, missing_paths=missing)
+
+    def add_annotations_from_coco(
+        self,
+        annotations_json: PathLike,
+        images_root: PathLike,
+        name: str,
+        annotation_type: AnnotationType = AnnotationType.OBJECT_DETECTION,
+    ) -> None:
+        """Attach COCO annotations to images already in the dataset.
+
+        Args:
+            annotations_json: Path to the COCO annotations JSON file.
+            images_root: Root path used for matching image filenames.
+            name: Name of the annotation collection.
+            annotation_type: ``OBJECT_DETECTION`` or ``SEGMENTATION_MASK``.
+        """
+        missing = add_annotations.add_annotations_from_coco(
+            session=self.session,
+            root_collection_id=self.collection_id,
+            annotations_json=annotations_json,
+            images_root=images_root,
+            collection_name=name,
+            annotation_type=annotation_type,
+        )
+        _log_missing_images(name=name, missing_paths=missing)
+
+    def add_annotations_from_yolo(
+        self,
+        data_yaml: PathLike,
+        name: str,
+        input_split: str | None = None,
+    ) -> None:
+        """Attach YOLO annotations to images already in the dataset.
+
+        Args:
+            data_yaml: Path to the YOLO ``data.yaml`` file.
+            name: Name of the annotation collection.
+            input_split: Specific split (e.g. ``"train"``). ``None`` loads all splits.
+        """
+        missing = add_annotations.add_annotations_from_yolo(
+            session=self.session,
+            root_collection_id=self.collection_id,
+            data_yaml=data_yaml,
+            collection_name=name,
+            input_split=input_split,
+        )
+        _log_missing_images(name=name, missing_paths=missing)
+
     def add_samples_from_labelformat(
         self,
         input_labels: ObjectDetectionInput | InstanceSegmentationInput,
@@ -234,7 +304,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             raise FileNotFoundError(f"YOLO data yaml file not found: '{data_yaml}'")
 
         # Determine which splits to process
-        splits_to_process = _resolve_yolo_splits(data_yaml=data_yaml, input_split=input_split)
+        splits_to_process = add_annotations.resolve_yolo_splits(
+            data_yaml=data_yaml, input_split=input_split
+        )
 
         all_created_sample_ids = []
 
@@ -524,21 +596,15 @@ def _generate_embeddings_image(
     )
 
 
-def _resolve_yolo_splits(data_yaml: Path, input_split: str | None) -> list[str]:
-    """Determine which YOLO splits to process for the given config."""
-    if input_split is not None:
-        if input_split not in ALLOWED_YOLO_SPLITS:
-            raise ValueError(
-                f"Split '{input_split}' not found in config file '{data_yaml}'. "
-                f"Allowed splits: {sorted(ALLOWED_YOLO_SPLITS)}"
-            )
-        return [input_split]
-
-    with data_yaml.open() as f:
-        config = yaml.safe_load(f)
-
-    config_keys = config.keys() if isinstance(config, dict) else []
-    splits = [key for key in config_keys if key in ALLOWED_YOLO_SPLITS]
-    if not splits:
-        raise ValueError(f"No splits found in config file '{data_yaml}'")
-    return splits
+def _log_missing_images(name: str, missing_paths: list[str]) -> None:
+    """Emit a single warning summarising images skipped due to no DB match."""
+    if not missing_paths:
+        return
+    logger.warning(
+        "Annotation collection '%s': skipped %d annotation(s) because no matching "
+        "image was found in the dataset. First %d unmatched path(s): %s",
+        name,
+        len(missing_paths),
+        min(5, len(missing_paths)),
+        missing_paths[:5],
+    )

--- a/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
@@ -47,9 +47,7 @@ def _create_sample_images(image_paths: list[Path]) -> None:
         Image.new("RGB", (10, 10)).save(image_path)
 
 
-def _setup_dataset_with_images(
-    tmp_path: Path, file_names: list[str]
-) -> tuple[ImageDataset, Path]:
+def _setup_dataset_with_images(tmp_path: Path, file_names: list[str]) -> tuple[ImageDataset, Path]:
     images_path = tmp_path / "images"
     images_path.mkdir()
     _create_sample_images([images_path / fn for fn in file_names])
@@ -64,9 +62,7 @@ class TestDataset:
         patch_collection: None,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
-        dataset, images_path = _setup_dataset_with_images(
-            tmp_path, ["image1.jpg", "image2.jpg"]
-        )
+        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg", "image2.jpg"])
         annotations_path = tmp_path / "annotations.json"
         annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg", "image2.jpg"])))
 
@@ -101,9 +97,7 @@ class TestDataset:
         patch_collection: None,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
-        dataset, images_path = _setup_dataset_with_images(
-            tmp_path, ["image1.jpg", "image2.jpg"]
-        )
+        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg", "image2.jpg"])
         first_path = tmp_path / "first.json"
         first_path.write_text(json.dumps(_coco_dict_with(["image1.jpg"])))
         second_path = tmp_path / "second.json"
@@ -163,9 +157,7 @@ class TestDataset:
     ) -> None:
         dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
         annotations_path = tmp_path / "annotations.json"
-        annotations_path.write_text(
-            json.dumps(_coco_dict_with(["image1.jpg", "missing.jpg"]))
-        )
+        annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg", "missing.jpg"])))
 
         with caplog.at_level(logging.WARNING):
             dataset.add_annotations_from_coco(
@@ -228,9 +220,7 @@ class TestDataset:
 
         dataset = ImageDataset.create(name="test_dataset")
         dataset.add_images_from_path(path=images_path, embed=False)
-        dataset.add_annotations_from_yolo(
-            data_yaml=yaml_path, name="model_A", input_split="train"
-        )
+        dataset.add_annotations_from_yolo(data_yaml=yaml_path, name="model_A", input_split="train")
 
         result = annotation_resolver.get_all_by_collection_name(
             session=dataset.session,
@@ -238,4 +228,3 @@ class TestDataset:
             parent_collection_id=dataset.collection_id,
         )
         assert len(result.annotations) == 2
-

--- a/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
@@ -75,8 +75,31 @@ def _setup_dataset_with_images(
     return dataset, images_path
 
 
-class TestAddAnnotationsFromCoco:
-    def test__appends_to_existing_images(
+class TestDataset:
+    def test_add_annotations_from_labelformat__generic_wrapper(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg"])))
+        label_input = COCOObjectDetectionInput(input_file=annotations_path)
+
+        dataset.add_annotations_from_labelformat(
+            input_labels=label_input,
+            images_root=images_path,
+            name="gt",
+        )
+
+        result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="gt",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(result.annotations) == 1
+
+    def test_add_annotations_from_coco__appends_to_existing_images(
         self,
         patch_collection: None,  # noqa: ARG002
         tmp_path: Path,
@@ -113,7 +136,7 @@ class TestAddAnnotationsFromCoco:
         )
         assert covered == {s.sample_id for s in dataset}
 
-    def test__same_name_appends(
+    def test_add_annotations_from_coco__same_name_appends(
         self,
         patch_collection: None,  # noqa: ARG002
         tmp_path: Path,
@@ -140,7 +163,7 @@ class TestAddAnnotationsFromCoco:
         )
         assert len(result.annotations) == 2
 
-    def test__different_names_separate_collections(
+    def test_add_annotations_from_coco__different_names_separate_collections(
         self,
         patch_collection: None,  # noqa: ARG002
         tmp_path: Path,
@@ -172,7 +195,7 @@ class TestAddAnnotationsFromCoco:
         model_ids = {a.sample_id for a in model_result.annotations}
         assert gt_ids.isdisjoint(model_ids)
 
-    def test__warns_on_missing_images(
+    def test_add_annotations_from_coco__warns_on_missing_images(
         self,
         patch_collection: None,  # noqa: ARG002
         tmp_path: Path,
@@ -202,7 +225,30 @@ class TestAddAnnotationsFromCoco:
         )
         assert len(result.annotations) == 1
 
-    def test__missing_json_raises(
+    def test_add_annotations_from_coco__segmentation_mask_annotation_type(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg"])))
+
+        dataset.add_annotations_from_coco(
+            annotations_json=annotations_path,
+            images_root=images_path,
+            name="seg",
+            annotation_type=AnnotationType.SEGMENTATION_MASK,
+        )
+
+        result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="seg",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(result.annotations) == 1
+
+    def test_add_annotations_from_coco__missing_json_raises(
         self,
         patch_collection: None,  # noqa: ARG002
         tmp_path: Path,
@@ -215,9 +261,7 @@ class TestAddAnnotationsFromCoco:
                 annotations_json=annotations_path, images_root=images_path, name="gt"
             )
 
-
-class TestAddAnnotationsFromYolo:
-    def test__loads_split_annotations(
+    def test_add_annotations_from_yolo__loads_split_annotations(
         self,
         patch_collection: None,  # noqa: ARG002
         tmp_path: Path,
@@ -246,7 +290,7 @@ class TestAddAnnotationsFromYolo:
         )
         assert len(result.annotations) == 2
 
-    def test__missing_yaml_raises(
+    def test_add_annotations_from_yolo__missing_yaml_raises(
         self,
         patch_collection: None,  # noqa: ARG002
         tmp_path: Path,
@@ -258,51 +302,3 @@ class TestAddAnnotationsFromYolo:
             dataset.add_annotations_from_yolo(
                 data_yaml=yaml_path, name="model_A", input_split="train"
             )
-
-
-class TestAddAnnotationsFromLabelformat:
-    def test__generic_wrapper(
-        self,
-        patch_collection: None,  # noqa: ARG002
-        tmp_path: Path,
-    ) -> None:
-        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
-        annotations_path = tmp_path / "annotations.json"
-        annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg"])))
-        label_input = COCOObjectDetectionInput(input_file=annotations_path)
-
-        dataset.add_annotations_from_labelformat(
-            input_labels=label_input,
-            images_root=images_path,
-            name="gt",
-        )
-
-        result = annotation_resolver.get_all_by_collection_name(
-            session=dataset.session,
-            collection_name="gt",
-            parent_collection_id=dataset.collection_id,
-        )
-        assert len(result.annotations) == 1
-
-    def test__segmentation_mask_annotation_type(
-        self,
-        patch_collection: None,  # noqa: ARG002
-        tmp_path: Path,
-    ) -> None:
-        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
-        annotations_path = tmp_path / "annotations.json"
-        annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg"])))
-
-        dataset.add_annotations_from_coco(
-            annotations_json=annotations_path,
-            images_root=images_path,
-            name="seg",
-            annotation_type=AnnotationType.SEGMENTATION_MASK,
-        )
-
-        result = annotation_resolver.get_all_by_collection_name(
-            session=dataset.session,
-            collection_name="seg",
-            parent_collection_id=dataset.collection_id,
-        )
-        assert len(result.annotations) == 1

--- a/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from random import choice
 from typing import Any
 
 import pytest
@@ -42,25 +41,10 @@ def _coco_dict_with(file_names: list[str]) -> dict[str, Any]:
     }
 
 
-def _yolo_yaml_dict() -> dict[str, Any]:
-    return {
-        "train": "../train/images",
-        "val": "../val/images",
-        "nc": 1,
-        "names": ["class_0"],
-    }
-
-
 def _create_sample_images(image_paths: list[Path]) -> None:
     for image_path in image_paths:
         image_path.parent.mkdir(parents=True, exist_ok=True)
         Image.new("RGB", (10, 10)).save(image_path)
-
-
-def _create_yolo_labels(label_paths: list[Path]) -> None:
-    for label_path in label_paths:
-        label_path.parent.mkdir(parents=True, exist_ok=True)
-        label_path.write_text(f"{choice([0])} 0.5 0.5 0.4 0.4\n")
 
 
 def _setup_dataset_with_images(
@@ -230,15 +214,17 @@ class TestDataset:
         tmp_path: Path,
     ) -> None:
         yaml_path = tmp_path / "data.yaml"
-        yaml_path.write_text(yaml.dump(_yolo_yaml_dict()))
+        yaml_path.write_text(
+            yaml.dump(
+                {"train": "../train/images", "val": "../val/images", "nc": 1, "names": ["class_0"]}
+            )
+        )
         images_path = tmp_path / "train" / "images"
         labels_path = tmp_path / "train" / "labels"
-        _create_sample_images(
-            [images_path / "image1.jpg", images_path / "image2.jpg"]
-        )
-        _create_yolo_labels(
-            [labels_path / "image1.txt", labels_path / "image2.txt"]
-        )
+        labels_path.mkdir(parents=True, exist_ok=True)
+        _create_sample_images([images_path / "image1.jpg", images_path / "image2.jpg"])
+        for fn in ("image1.txt", "image2.txt"):
+            (labels_path / fn).write_text("0 0.5 0.5 0.4 0.4\n")
 
         dataset = ImageDataset.create(name="test_dataset")
         dataset.add_images_from_path(path=images_path, embed=False)

--- a/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from random import choice
+from typing import Any
+
+import pytest
+import yaml
+from labelformat.formats import COCOObjectDetectionInput
+from PIL import Image
+
+from lightly_studio import ImageDataset
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.models.collection import SampleType
+from lightly_studio.resolvers import (
+    annotation_collection_coverage_resolver,
+    annotation_resolver,
+    collection_resolver,
+)
+
+
+def _coco_dict_with(file_names: list[str]) -> dict[str, Any]:
+    return {
+        "images": [
+            {"id": i + 1, "file_name": fn, "width": 640, "height": 480}
+            for i, fn in enumerate(file_names)
+        ],
+        "annotations": [
+            {
+                "id": i + 1,
+                "image_id": i + 1,
+                "category_id": 1,
+                "bbox": [10, 10, 20, 20],
+                "area": 400,
+                "iscrowd": 0,
+                "segmentation": [[10, 10, 10, 30, 30, 30]],
+            }
+            for i in range(len(file_names))
+        ],
+        "categories": [{"id": 1, "name": "cat"}],
+    }
+
+
+def _yolo_yaml_dict() -> dict[str, Any]:
+    return {
+        "train": "../train/images",
+        "val": "../val/images",
+        "nc": 1,
+        "names": ["class_0"],
+    }
+
+
+def _create_sample_images(image_paths: list[Path]) -> None:
+    for image_path in image_paths:
+        image_path.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("RGB", (10, 10)).save(image_path)
+
+
+def _create_yolo_labels(label_paths: list[Path]) -> None:
+    for label_path in label_paths:
+        label_path.parent.mkdir(parents=True, exist_ok=True)
+        label_path.write_text(f"{choice([0])} 0.5 0.5 0.4 0.4\n")
+
+
+def _setup_dataset_with_images(
+    tmp_path: Path, file_names: list[str]
+) -> tuple[ImageDataset, Path]:
+    images_path = tmp_path / "images"
+    images_path.mkdir()
+    _create_sample_images([images_path / fn for fn in file_names])
+    dataset = ImageDataset.create(name="test_dataset")
+    dataset.add_images_from_path(path=images_path, embed=False)
+    return dataset, images_path
+
+
+class TestAddAnnotationsFromCoco:
+    def test__appends_to_existing_images(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        dataset, images_path = _setup_dataset_with_images(
+            tmp_path, ["image1.jpg", "image2.jpg"]
+        )
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg", "image2.jpg"])))
+
+        dataset.add_annotations_from_coco(
+            annotations_json=annotations_path,
+            images_root=images_path,
+            name="ground_truth",
+        )
+
+        result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="ground_truth",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(result.annotations) == 2
+
+        cov_id = collection_resolver.get_or_create_child_collection(
+            session=dataset.session,
+            collection_id=dataset.collection_id,
+            sample_type=SampleType.ANNOTATION,
+            name="ground_truth",
+        )
+        covered = set(
+            annotation_collection_coverage_resolver.list_by_collection_id(
+                session=dataset.session, annotation_collection_id=cov_id
+            )
+        )
+        assert covered == {s.sample_id for s in dataset}
+
+    def test__same_name_appends(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        dataset, images_path = _setup_dataset_with_images(
+            tmp_path, ["image1.jpg", "image2.jpg"]
+        )
+        first_path = tmp_path / "first.json"
+        first_path.write_text(json.dumps(_coco_dict_with(["image1.jpg"])))
+        second_path = tmp_path / "second.json"
+        second_path.write_text(json.dumps(_coco_dict_with(["image2.jpg"])))
+
+        dataset.add_annotations_from_coco(
+            annotations_json=first_path, images_root=images_path, name="gt"
+        )
+        dataset.add_annotations_from_coco(
+            annotations_json=second_path, images_root=images_path, name="gt"
+        )
+
+        result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="gt",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(result.annotations) == 2
+
+    def test__different_names_separate_collections(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg"])))
+
+        dataset.add_annotations_from_coco(
+            annotations_json=annotations_path, images_root=images_path, name="gt"
+        )
+        dataset.add_annotations_from_coco(
+            annotations_json=annotations_path, images_root=images_path, name="model_A"
+        )
+
+        gt_result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="gt",
+            parent_collection_id=dataset.collection_id,
+        )
+        model_result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="model_A",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(gt_result.annotations) == 1
+        assert len(model_result.annotations) == 1
+        gt_ids = {a.sample_id for a in gt_result.annotations}
+        model_ids = {a.sample_id for a in model_result.annotations}
+        assert gt_ids.isdisjoint(model_ids)
+
+    def test__warns_on_missing_images(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(
+            json.dumps(_coco_dict_with(["image1.jpg", "missing.jpg"]))
+        )
+
+        with caplog.at_level(logging.WARNING):
+            dataset.add_annotations_from_coco(
+                annotations_json=annotations_path, images_root=images_path, name="gt"
+            )
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "skipped 1 annotation" in r.getMessage() and "missing.jpg" in r.getMessage()
+            for r in warnings
+        )
+
+        result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="gt",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(result.annotations) == 1
+
+    def test__missing_json_raises(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
+        annotations_path = tmp_path / "does_not_exist.json"
+
+        with pytest.raises(FileNotFoundError):
+            dataset.add_annotations_from_coco(
+                annotations_json=annotations_path, images_root=images_path, name="gt"
+            )
+
+
+class TestAddAnnotationsFromYolo:
+    def test__loads_split_annotations(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        yaml_path = tmp_path / "data.yaml"
+        yaml_path.write_text(yaml.dump(_yolo_yaml_dict()))
+        images_path = tmp_path / "train" / "images"
+        labels_path = tmp_path / "train" / "labels"
+        _create_sample_images(
+            [images_path / "image1.jpg", images_path / "image2.jpg"]
+        )
+        _create_yolo_labels(
+            [labels_path / "image1.txt", labels_path / "image2.txt"]
+        )
+
+        dataset = ImageDataset.create(name="test_dataset")
+        dataset.add_images_from_path(path=images_path, embed=False)
+        dataset.add_annotations_from_yolo(
+            data_yaml=yaml_path, name="model_A", input_split="train"
+        )
+
+        result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="model_A",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(result.annotations) == 2
+
+    def test__missing_yaml_raises(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        dataset, _ = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
+        yaml_path = tmp_path / "does_not_exist.yaml"
+
+        with pytest.raises(FileNotFoundError):
+            dataset.add_annotations_from_yolo(
+                data_yaml=yaml_path, name="model_A", input_split="train"
+            )
+
+
+class TestAddAnnotationsFromLabelformat:
+    def test__generic_wrapper(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg"])))
+        label_input = COCOObjectDetectionInput(input_file=annotations_path)
+
+        dataset.add_annotations_from_labelformat(
+            input_labels=label_input,
+            images_root=images_path,
+            name="gt",
+        )
+
+        result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="gt",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(result.annotations) == 1
+
+    def test__segmentation_mask_annotation_type(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg"])))
+
+        dataset.add_annotations_from_coco(
+            annotations_json=annotations_path,
+            images_root=images_path,
+            name="seg",
+            annotation_type=AnnotationType.SEGMENTATION_MASK,
+        )
+
+        result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="seg",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(result.annotations) == 1

--- a/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import pytest
 import yaml
-from labelformat.formats import COCOObjectDetectionInput
 from PIL import Image
 
 from lightly_studio import ImageDataset
@@ -76,29 +75,6 @@ def _setup_dataset_with_images(
 
 
 class TestDataset:
-    def test_add_annotations_from_labelformat__generic_wrapper(
-        self,
-        patch_collection: None,  # noqa: ARG002
-        tmp_path: Path,
-    ) -> None:
-        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
-        annotations_path = tmp_path / "annotations.json"
-        annotations_path.write_text(json.dumps(_coco_dict_with(["image1.jpg"])))
-        label_input = COCOObjectDetectionInput(input_file=annotations_path)
-
-        dataset.add_annotations_from_labelformat(
-            input_labels=label_input,
-            images_root=images_path,
-            name="gt",
-        )
-
-        result = annotation_resolver.get_all_by_collection_name(
-            session=dataset.session,
-            collection_name="gt",
-            parent_collection_id=dataset.collection_id,
-        )
-        assert len(result.annotations) == 1
-
     def test_add_annotations_from_coco__appends_to_existing_images(
         self,
         patch_collection: None,  # noqa: ARG002
@@ -248,19 +224,6 @@ class TestDataset:
         )
         assert len(result.annotations) == 1
 
-    def test_add_annotations_from_coco__missing_json_raises(
-        self,
-        patch_collection: None,  # noqa: ARG002
-        tmp_path: Path,
-    ) -> None:
-        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
-        annotations_path = tmp_path / "does_not_exist.json"
-
-        with pytest.raises(FileNotFoundError):
-            dataset.add_annotations_from_coco(
-                annotations_json=annotations_path, images_root=images_path, name="gt"
-            )
-
     def test_add_annotations_from_yolo__loads_split_annotations(
         self,
         patch_collection: None,  # noqa: ARG002
@@ -290,15 +253,3 @@ class TestDataset:
         )
         assert len(result.annotations) == 2
 
-    def test_add_annotations_from_yolo__missing_yaml_raises(
-        self,
-        patch_collection: None,  # noqa: ARG002
-        tmp_path: Path,
-    ) -> None:
-        dataset, _ = _setup_dataset_with_images(tmp_path, ["image1.jpg"])
-        yaml_path = tmp_path / "does_not_exist.yaml"
-
-        with pytest.raises(FileNotFoundError):
-            dataset.add_annotations_from_yolo(
-                data_yaml=yaml_path, name="model_A", input_split="train"
-            )


### PR DESCRIPTION
## What has changed and why?

Adds the public ImageDataset methods `add_annotations_from_labelformat`, `add_annotations_from_coco` and `add_annotations_from_yolo`. 

Moves resolve_yolo_splits from `image_dataset.py to` `add_annotations.py`

## How has it been tested?

Unittests

## Not done

- Does not add `add_annotations_from_***` for pascal voc, lightly. coco captions, as that would just bloat it but rarely be used.
- Does not add `add_annotations_from_***` for videos.
- Does not update examples, will be done once it works end-2-end.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attach annotations to images already in a dataset without re-importing
  * Support for COCO, YOLO, and labelformat annotations; named collections let you append or separate annotations

* **Documentation**
  * New guide covering how to add annotations to existing images with examples and matching rules

* **Tests**
  * Added tests validating annotation import behaviors, collection naming, missing-image warnings, segmentation masks, and YOLO split imports

* **Changelog**
  * Documented the new annotation helpers in the Unreleased changelog section
<!-- end of auto-generated comment: release notes by coderabbit.ai -->