### PR TITLE
Add endpoint read_annotation_collections

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -10,6 +10,7 @@ from fastapi.params import Query
 from pydantic import BaseModel, Field
 
 from lightly_studio.api.routes.api import annotations as annotations_module
+from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND
 from lightly_studio.api.routes.api.validators import Paginated, PaginatedWithCursor
 from lightly_studio.db_manager import SessionDep
@@ -20,7 +21,8 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationViewsWithCount,
     AnnotationWithPayloadAndCountView,
 )
-from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.models.collection import CollectionTable, CollectionView
+from lightly_studio.resolvers import annotation_resolver, collection_resolver
 from lightly_studio.resolvers.annotation_resolver.get_all import (
     GetAllAnnotationsResult,
 )
@@ -35,6 +37,25 @@ from lightly_studio.services.annotations_service.update_annotation import (
 
 annotations_router = APIRouter(prefix="/collections/{collection_id}", tags=["annotations"])
 annotations_router.include_router(annotations_module.create_annotation_router)
+
+
+@annotations_router.get(
+    "/annotation_collections",
+    response_model=list[CollectionView],
+)
+def read_annotation_collections(
+    session: SessionDep,
+    collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(get_and_validate_collection_id),
+    ],
+) -> list[CollectionTable]:
+    """List annotation collections under the given parent collection."""
+    return collection_resolver.get_annotation_collections(
+        session=session,
+        parent_collection_id=collection.collection_id,
+    )
 
 
 class AnnotationQueryParamsModel(BaseModel):

--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -21,7 +21,7 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationViewsWithCount,
     AnnotationWithPayloadAndCountView,
 )
-from lightly_studio.models.collection import CollectionTable, CollectionView
+from lightly_studio.models.collection import AnnotationCollectionView, CollectionTable
 from lightly_studio.resolvers import annotation_resolver, collection_resolver
 from lightly_studio.resolvers.annotation_resolver.get_all import (
     GetAllAnnotationsResult,
@@ -41,7 +41,7 @@ annotations_router.include_router(annotations_module.create_annotation_router)
 
 @annotations_router.get(
     "/annotation_collections",
-    response_model=list[CollectionView],
+    response_model=list[AnnotationCollectionView],
 )
 def read_annotation_collections(
     session: SessionDep,

--- a/lightly_studio/src/lightly_studio/models/collection.py
+++ b/lightly_studio/src/lightly_studio/models/collection.py
@@ -106,3 +106,10 @@ class CollectionOverviewView(SQLModel):
     sample_type: SampleType
     created_at: datetime
     total_sample_count: int
+
+
+class AnnotationCollectionView(SQLModel):
+    """Slim collection view used for the annotation collections menu."""
+
+    collection_id: UUID
+    name: str

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/__init__.py
@@ -13,6 +13,9 @@ from lightly_studio.resolvers.collection_resolver.export import (
     get_filtered_samples_count,
 )
 from lightly_studio.resolvers.collection_resolver.get_all import get_all
+from lightly_studio.resolvers.collection_resolver.get_annotation_collections import (
+    get_annotation_collections,
+)
 from lightly_studio.resolvers.collection_resolver.get_by_id import get_by_id
 from lightly_studio.resolvers.collection_resolver.get_by_name import get_by_name
 from lightly_studio.resolvers.collection_resolver.get_collection import (
@@ -45,6 +48,7 @@ __all__ = [
     "delete",
     "export",
     "get_all",
+    "get_annotation_collections",
     "get_by_id",
     "get_by_name",
     "get_collection_details",

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/get_annotation_collections.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/get_annotation_collections.py
@@ -1,0 +1,34 @@
+"""Implementation of the get annotation collections resolver function."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+
+from lightly_studio.models.collection import CollectionTable, SampleType
+
+
+def get_annotation_collections(
+    session: Session,
+    parent_collection_id: UUID,
+) -> list[CollectionTable]:
+    """Retrieves all annotation collections under a given parent collection.
+
+    Args:
+        session:
+            The database session to use.
+        parent_collection_id:
+            The UUID of the parent collection.
+
+    Returns:
+        Annotation collections that are direct children of the parent
+        collection, ordered by creation time ascending.
+    """
+    statement = (
+        select(CollectionTable)
+        .where(col(CollectionTable.parent_collection_id) == parent_collection_id)
+        .where(CollectionTable.sample_type == SampleType.ANNOTATION)
+        .order_by(col(CollectionTable.created_at).asc())
+    )
+    return list(session.exec(statement).all())

--- a/lightly_studio/tests/api/routes/api/test_annotation.py
+++ b/lightly_studio/tests/api/routes/api/test_annotation.py
@@ -313,13 +313,9 @@ def test_read_annotation_collections(
     )
 
     assert response.status_code == HTTP_STATUS_OK
-    body = response.json()
-    assert len(body) == 1
-    item = body[0]
-    assert UUID(item["collection_id"]) == expected_annotation_collection.collection_id
-    assert UUID(item["parent_collection_id"]) == parent_collection.collection_id
-    assert item["sample_type"] == SampleType.ANNOTATION.value
-    assert item["name"] == expected_annotation_collection.name
-    # CollectionView shape — sanity check the documented fields are present.
-    assert "dataset_id" in item
-    assert "created_at" in item
+    assert response.json() == [
+        {
+            "collection_id": str(expected_annotation_collection.collection_id),
+            "name": expected_annotation_collection.name,
+        }
+    ]

--- a/lightly_studio/tests/api/routes/api/test_annotation.py
+++ b/lightly_studio/tests/api/routes/api/test_annotation.py
@@ -298,3 +298,28 @@ def test_get_annotation_sample_ids(
 
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() == [str(annotation.sample_id)]
+
+
+def test_read_annotation_collections(
+    test_client: TestClient,
+    annotations_test_data: AnnotationsTestData,
+) -> None:
+    parent_collection = annotations_test_data.collections[0]
+    expected_annotation_collection = parent_collection.children[0]
+    assert expected_annotation_collection.sample_type == SampleType.ANNOTATION
+
+    response = test_client.get(
+        f"/api/collections/{parent_collection.collection_id!s}/annotation_collections",
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    body = response.json()
+    assert len(body) == 1
+    item = body[0]
+    assert UUID(item["collection_id"]) == expected_annotation_collection.collection_id
+    assert UUID(item["parent_collection_id"]) == parent_collection.collection_id
+    assert item["sample_type"] == SampleType.ANNOTATION.value
+    assert item["name"] == expected_annotation_collection.name
+    # CollectionView shape — sanity check the documented fields are present.
+    assert "dataset_id" in item
+    assert "created_at" in item

--- a/lightly_studio/tests/resolvers/collection_resolver/test_get_annotation_collections.py
+++ b/lightly_studio/tests/resolvers/collection_resolver/test_get_annotation_collections.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.resolvers import collection_resolver
+from tests.helpers_resolvers import create_collection
+
+
+def test_get_annotation_collections__success(db_session: Session) -> None:
+    parent = create_collection(session=db_session)
+    annotation_child_1 = create_collection(
+        session=db_session,
+        collection_name="ann_1",
+        parent_collection_id=parent.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    annotation_child_2 = create_collection(
+        session=db_session,
+        collection_name="ann_2",
+        parent_collection_id=parent.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    create_collection(
+        session=db_session,
+        collection_name="image_child",
+        parent_collection_id=parent.collection_id,
+        sample_type=SampleType.IMAGE,
+    )
+
+    result = collection_resolver.get_annotation_collections(
+        session=db_session, parent_collection_id=parent.collection_id
+    )
+
+    assert [c.collection_id for c in result] == [
+        annotation_child_1.collection_id,
+        annotation_child_2.collection_id,
+    ]
+
+
+def test_get_annotation_collections__only_direct_children(db_session: Session) -> None:
+    parent = create_collection(session=db_session)
+    annotation_child = create_collection(
+        session=db_session,
+        collection_name="ann_child",
+        parent_collection_id=parent.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    # Annotation grandchild — must not be returned when querying the root parent.
+    create_collection(
+        session=db_session,
+        collection_name="ann_grandchild",
+        parent_collection_id=annotation_child.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    result = collection_resolver.get_annotation_collections(
+        session=db_session, parent_collection_id=parent.collection_id
+    )
+
+    assert [c.collection_id for c in result] == [annotation_child.collection_id]


### PR DESCRIPTION
## What has changed and why?

Adds `GET /api/collections/{collection_id}/annotation_collections`, which lists every direct child collection of the given parent whose `sample_type == ANNOTATION`. The frontend menu uses it to discover available annotation collections (id + name) under the user's current collection.

The implementation mirrors the existing `read_annotation_labels` pattern but scopes the lookup by `parent_collection_id` rather than `dataset_id`, and reuses the existing `CollectionView` response model so no new model is introduced.

## How has it been tested?

new unittests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New API endpoint available to retrieve annotation collections under a specified parent collection, with results ordered by creation date.

* **Tests**
  * Added test coverage for the annotation collections endpoint, including validation of collection filtering and retrieval of direct children in collection hierarchies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->