### PR TITLE
feat: introduce MenuItem component for SideMenu

### DIFF
--- a/lightly_studio_view/src/lib/components/SideMenu/MenuItem/MenuItem.stories.svelte
+++ b/lightly_studio_view/src/lib/components/SideMenu/MenuItem/MenuItem.stories.svelte
@@ -1,0 +1,25 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import MenuItem from './MenuItem.svelte';
+    import { fn } from 'storybook/test';
+
+    const { Story } = defineMeta({
+        title: 'Components/SideMenu/MenuItem',
+        component: MenuItem,
+        tags: ['autodocs'],
+        argTypes: {
+            name: { control: 'text' },
+            checked: { control: 'boolean' },
+            showColorMarker: { control: 'boolean', defaultValue: false }
+        }
+    });
+</script>
+
+<Story
+    name="Default"
+    args={{
+        name: 'Example Label',
+        checked: false,
+        onCheckedChange: fn()
+    }}
+/>

--- a/lightly_studio_view/src/lib/components/SideMenu/MenuItem/MenuItem.svelte
+++ b/lightly_studio_view/src/lib/components/SideMenu/MenuItem/MenuItem.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+    import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+    import { Label } from '$lib/components/ui/label/index.js';
+    import type { ComponentProps } from 'svelte';
+    import { ColorMarker } from '../';
+    import { Typography } from '$lib/components';
+
+    interface Props {
+        /** Label text displayed in the menu item; also used as the `title` attribute and checkbox `id`. */
+        name: string;
+        /** Controls the checkbox checked state. */
+        checked: boolean;
+        /** When `true`, renders a color swatch before the label text. */
+        showColorMarker?: boolean;
+        /** Callback fired when the checkbox is toggled. */
+        onCheckedChange: ComponentProps<typeof Checkbox>['onCheckedChange'];
+    }
+
+    let { name, checked, showColorMarker, onCheckedChange }: Props = $props();
+</script>
+
+<div class="space-y-1" title={name}>
+    <div class="width-full flex items-center space-x-2">
+        <Checkbox
+            id={`menu-item-${name}`}
+            {checked}
+            aria-labelledby={`menu-item-${name}-label`}
+            {onCheckedChange}
+        />
+        <Label
+            id={`menu-item-${name}-label`}
+            for={`menu-item-${name}`}
+            class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
+            {#if showColorMarker}
+                <ColorMarker label={name} markerProps={{ 'data-testid': `color-marker-${name}` }} />
+            {/if}
+            <Typography variant="body1" className="flex-1 truncate">
+                {name}
+            </Typography>
+        </Label>
+    </div>
+</div>

--- a/lightly_studio_view/src/lib/components/SideMenu/MenuItem/MenuItem.svelte
+++ b/lightly_studio_view/src/lib/components/SideMenu/MenuItem/MenuItem.svelte
@@ -17,19 +17,21 @@
     }
 
     let { name, checked, showColorMarker, onCheckedChange }: Props = $props();
+
+    const nameId = $derived(name.replace(/[^a-zA-Z0-9]/g, '-'));
 </script>
 
 <div class="space-y-1" title={name}>
-    <div class="width-full flex items-center space-x-2">
+    <div class="flex w-full items-center space-x-2">
         <Checkbox
-            id={`menu-item-${name}`}
+            id={`menu-item-${nameId}`}
             {checked}
-            aria-labelledby={`menu-item-${name}-label`}
+            aria-labelledby={`menu-item-${nameId}-label`}
             {onCheckedChange}
         />
         <Label
-            id={`menu-item-${name}-label`}
-            for={`menu-item-${name}`}
+            id={`menu-item-${nameId}-label`}
+            for={`menu-item-${nameId}`}
             class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
         >
             {#if showColorMarker}

--- a/lightly_studio_view/src/lib/components/SideMenu/MenuItem/MenuItem.test.ts
+++ b/lightly_studio_view/src/lib/components/SideMenu/MenuItem/MenuItem.test.ts
@@ -1,0 +1,57 @@
+import MenuItem from './MenuItem.svelte';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('MenuItem', () => {
+    const props = {
+        name: 'test-label',
+        checked: false,
+        onCheckedChange: vi.fn()
+    };
+
+    it('renders the item name', () => {
+        render(MenuItem, props);
+
+        expect(screen.getByText(props.name)).toBeInTheDocument();
+    });
+
+    it('renders a checkbox', () => {
+        render(MenuItem, props);
+
+        expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    });
+
+    it('reflects checked state', () => {
+        render(MenuItem, { ...props, checked: true });
+
+        expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('calls onCheckedChange when checkbox is clicked', async () => {
+        const onCheckedChange = vi.fn();
+        render(MenuItem, { ...props, onCheckedChange });
+
+        await userEvent.click(screen.getByRole('checkbox'));
+
+        expect(onCheckedChange).toHaveBeenCalledOnce();
+    });
+
+    it('sets title attribute to item name', () => {
+        render(MenuItem, props);
+
+        expect(screen.getByTitle(props.name)).toBeInTheDocument();
+    });
+
+    it('does not render color marker by default', () => {
+        render(MenuItem, props);
+
+        expect(screen.queryByTestId('color-marker-test-label')).not.toBeInTheDocument();
+    });
+
+    it('renders color marker when showColorMarker is true', () => {
+        render(MenuItem, { ...props, showColorMarker: true });
+
+        expect(screen.queryByTestId('color-marker-test-label')).toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/lib/components/SideMenu/index.ts
+++ b/lightly_studio_view/src/lib/components/SideMenu/index.ts
@@ -1,1 +1,2 @@
 export { default as ColorMarker } from './ColorMarker/ColorMarker.svelte';
+export { default as MenuItem } from './MenuItem/MenuItem.svelte';


### PR DESCRIPTION
## What has changed and why?

Introduce component to render menu item for the menu

## How has it been tested?

It will be used to create menu for collection annotations
<img width="1290" height="1366" alt="Screenshot 2026-05-08 at 17 58 59" src="https://github.com/user-attachments/assets/b2ed6b71-17e8-43c7-8f8b-77a0369b3fc0" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a MenuItem component for the side menu with checkbox selection, accessible labeling, truncating labels, and optional color marker.

* **Documentation**
  * Added a Storybook entry demonstrating the MenuItem with configurable props and a default example.

* **Tests**
  * Added tests verifying rendering, checked state behavior, click handling, title attribute, and optional color-marker rendering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1085)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->