### PR TITLE
Add sample/dataset string representation

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset.py
+++ b/lightly_studio/src/lightly_studio/core/dataset.py
@@ -21,6 +21,7 @@ from lightly_studio.resolvers import (
     collection_resolver,
     embedding_model_resolver,
     metadata_resolver,
+    sample_resolver,
     tag_resolver,
 )
 
@@ -138,6 +139,36 @@ class Dataset(Generic[T], ABC):
             ValueError: If slice contains unsupported features or conflicts with existing slice.
         """
         return self.query()[key]
+
+    def __str__(self) -> str:
+        """Return a human-readable summary of the dataset."""
+        n_samples = sample_resolver.count_by_collection_id(
+            session=self.session, collection_id=self.collection_id
+        )
+        tags = sorted(
+            t.name
+            for t in tag_resolver.get_all_by_collection_id(
+                session=self.session, collection_id=self.collection_id
+            )
+        )
+        metadata_keys = sorted(
+            info.name
+            for info in metadata_resolver.get_all_metadata_keys_and_schema(
+                session=self.session, collection_id=self.collection_id
+            )
+        )
+        return (
+            f"{type(self).__name__}(name={self.name!r})\n"
+            f"  id:        {self.dataset_id}\n"
+            f"  type:      {self.sample_type().value}\n"
+            f"  n_samples: {n_samples}\n"
+            f"  tags:      {tags}\n"
+            f"  metadata:  {metadata_keys}"
+        )
+
+    def __repr__(self) -> str:
+        """Return a string representation."""
+        return self.__str__()
 
     def compute_typicality_metadata(
         self,

--- a/lightly_studio/src/lightly_studio/core/image/image_sample.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_sample.py
@@ -42,6 +42,13 @@ class ImageSample(Sample):
         self.inner = inner
         super().__init__(sample_table=inner.sample)
 
+    def __str__(self) -> str:
+        base = super().__str__()
+        return f"{base}\n  file:     {self.file_name}\n  path:     {self.file_path_abs}"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
     @property
     def width(self) -> int:
         """Image width in pixels."""

--- a/lightly_studio/src/lightly_studio/core/sample.py
+++ b/lightly_studio/src/lightly_studio/core/sample.py
@@ -308,6 +308,17 @@ class Sample(ABC):
             annotation_id=annotation_id,
         )
 
+    def __str__(self) -> str:
+        """Return a human-readable summary of the sample."""
+        metadata_dict = self._sample_table.metadata_dict
+        metadata_keys = sorted(metadata_dict.metadata_schema.keys()) if metadata_dict else []
+        tags = sorted(self.tags)
+        return f"{type(self).__name__}(id={self.sample_id})\n  tags:     {tags}\n  metadata: {metadata_keys}"
+
+    def __repr__(self) -> str:
+        """Return a string representation."""
+        return self.__str__()
+
 
 class SampleMetadata:
     """Dictionary-like interface for sample metadata."""

--- a/lightly_studio/src/lightly_studio/core/video/video_sample.py
+++ b/lightly_studio/src/lightly_studio/core/video/video_sample.py
@@ -35,6 +35,13 @@ class VideoSample(Sample):
     fps = DBField(col(VideoTable.fps))
     """Video FPS"""
 
+    def __str__(self) -> str:
+        base = super().__str__()
+        return f"{base}\n  file:     {self.file_name}\n  path:     {self.file_path_abs}"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
     def __init__(self, inner: VideoTable) -> None:
         """Initialize the Sample.
 

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/__init__.py
@@ -2,6 +2,7 @@
 
 from lightly_studio.resolvers.metadata_resolver.sample import (
     bulk_update_metadata,
+    get_all_metadata_keys_and_schema,
     get_by_sample_id,
     get_value_for_sample,
     set_value_for_sample,
@@ -9,6 +10,7 @@ from lightly_studio.resolvers.metadata_resolver.sample import (
 
 __all__ = [
     "bulk_update_metadata",
+    "get_all_metadata_keys_and_schema",
     "get_by_sample_id",
     "get_value_for_sample",
     "set_value_for_sample",

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/__init__.py
@@ -6,6 +6,9 @@ from .bulk_update_metadata import (
 from .get_by_sample_id import (
     get_by_sample_id,
 )
+from .get_metadata_info import (
+    get_all_metadata_keys_and_schema,
+)
 from .get_value_for_sample import (
     get_value_for_sample,
 )
@@ -15,6 +18,7 @@ from .set_value_for_sample import (
 
 __all__ = [
     "bulk_update_metadata",
+    "get_all_metadata_keys_and_schema",
     "get_by_sample_id",
     "get_value_for_sample",
     "set_value_for_sample",

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -633,6 +633,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/collections/{collection_id}/annotation_collections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read Annotation Collections
+         * @description List annotation collections under the given parent collection.
+         */
+        get: operations["read_annotation_collections"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/collections/{collection_id}/annotations/sample_ids": {
         parameters: {
             query?: never;
@@ -1963,6 +1983,19 @@ export interface components {
             parent_sample_id: string;
             /** Object Track Id */
             object_track_id?: string | null;
+        };
+        /**
+         * AnnotationCollectionView
+         * @description Slim collection view used for the annotation collections menu.
+         */
+        AnnotationCollectionView: {
+            /**
+             * Collection Id
+             * Format: uuid
+             */
+            collection_id: string;
+            /** Name */
+            name: string;
         };
         /**
          * AnnotationCreateInput
@@ -5256,6 +5289,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnnotationView"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_annotation_collections: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnnotationCollectionView"][];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## What has changed and why?
- in dataset exploration tasks (notebooks/with an agent), it's really helpful to get some upfront information about an objects content.
- this PR adds a basic string representation to the dataset class and the different sample classes
- currently it has to run a query, which might not be desirable, but otherwise the information is a bit limited

## How has it been tested?
- only locally, lmk if unit test required

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

will add if change is good

- [ ] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint to list annotation collections within a parent collection.

* **Improvements**
  * Enhanced string representations for datasets, samples, and related objects to include metadata and file information for improved visibility during development and debugging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1086)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->