### PR TITLE
Extract shortcut settings config and ShortcutSettingRow component

### DIFF
--- a/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
@@ -26,7 +26,7 @@
     let isSaving = $state(false);
 
     const initialFormState = createSettingsDialogFormState($settingsStore);
-    let shortcutState = $state(initialFormState.shortcutSettings);
+    let shortcuts = $state(initialFormState.shortcutSettings);
     let gridViewRendering: RenderingMode = $state(initialFormState.gridViewRendering);
     let gridViewThumbnailQuality: ThumbnailQualityMode = $state(
         initialFormState.gridViewThumbnailQuality
@@ -43,7 +43,7 @@
     $effect(() => {
         if ($settingsStore && $isLoadedStore && !initialized) {
             const formState = createSettingsDialogFormState($settingsStore);
-            shortcutState = formState.shortcutSettings;
+            shortcuts = formState.shortcutSettings;
             gridViewRendering = formState.gridViewRendering;
             gridViewThumbnailQuality = formState.gridViewThumbnailQuality;
             showAnnotationTextLabels = formState.showAnnotationTextLabels;
@@ -85,7 +85,7 @@
         try {
             await saveSettings(
                 createSettingsSavePayload({
-                    shortcutSettings: shortcutState,
+                    shortcutSettings: shortcuts,
                     gridViewRendering,
                     gridViewThumbnailQuality,
                     showAnnotationTextLabels,
@@ -115,7 +115,7 @@
         event.preventDefault();
         event.stopPropagation();
 
-        shortcutState[recordingShortcut] = normalizeShortcutKey(event);
+        shortcuts[recordingShortcut] = normalizeShortcutKey(event);
 
         // Stop recording
         recordingShortcut = null;
@@ -146,7 +146,7 @@
                             <ShortcutSettingRow
                                 id={setting.id}
                                 label={setting.label}
-                                value={shortcutState[setting.key]}
+                                value={shortcuts[setting.key]}
                                 isRecording={recordingShortcut === setting.key}
                                 onStartRecording={() => startRecording(setting.key)}
                             />

--- a/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
@@ -11,9 +11,11 @@
         createSettingsSavePayload,
         normalizeShortcutKey
     } from './settingsDialogState';
+    import { shortcutSettings, staticShortcuts } from './settingsDialogConfig';
+    import type { ShortcutSettingKey } from './settingsDialogConfig';
+    import ShortcutSettingRow from './ShortcutSettingRow/ShortcutSettingRow.svelte';
 
     type SettingsDialogFormState = ReturnType<typeof createSettingsDialogFormState>;
-    type ShortcutSettingKey = keyof SettingsDialogFormState['shortcutSettings'];
     type RenderingMode = SettingsDialogFormState['gridViewRendering'];
     type ThumbnailQualityMode = SettingsDialogFormState['gridViewThumbnailQuality'];
 
@@ -24,7 +26,7 @@
     let isSaving = $state(false);
 
     const initialFormState = createSettingsDialogFormState($settingsStore);
-    let shortcutSettings = $state(initialFormState.shortcutSettings);
+    let shortcutState = $state(initialFormState.shortcutSettings);
     let gridViewRendering: RenderingMode = $state(initialFormState.gridViewRendering);
     let gridViewThumbnailQuality: ThumbnailQualityMode = $state(
         initialFormState.gridViewThumbnailQuality
@@ -41,7 +43,7 @@
     $effect(() => {
         if ($settingsStore && $isLoadedStore && !initialized) {
             const formState = createSettingsDialogFormState($settingsStore);
-            shortcutSettings = formState.shortcutSettings;
+            shortcutState = formState.shortcutSettings;
             gridViewRendering = formState.gridViewRendering;
             gridViewThumbnailQuality = formState.gridViewThumbnailQuality;
             showAnnotationTextLabels = formState.showAnnotationTextLabels;
@@ -83,7 +85,7 @@
         try {
             await saveSettings(
                 createSettingsSavePayload({
-                    shortcutSettings,
+                    shortcutSettings: shortcutState,
                     gridViewRendering,
                     gridViewThumbnailQuality,
                     showAnnotationTextLabels,
@@ -113,7 +115,7 @@
         event.preventDefault();
         event.stopPropagation();
 
-        shortcutSettings[recordingShortcut] = normalizeShortcutKey(event);
+        shortcutState[recordingShortcut] = normalizeShortcutKey(event);
 
         // Stop recording
         recordingShortcut = null;
@@ -140,200 +142,24 @@
                     <!-- Keyboard Shortcuts -->
                     <div class="space-y-4">
                         <h3 class="text-lg font-medium text-foreground">Keyboard Shortcuts</h3>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="hide-annotations" class="text-right text-foreground">
-                                Hide Annotations
-                            </Label>
-                            <button
-                                id="hide-annotations"
-                                type="button"
-                                class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-                                onclick={(e) => {
-                                    e.preventDefault();
-                                    startRecording('hideAnnotations');
-                                }}
-                            >
-                                {#if recordingShortcut === 'hideAnnotations'}
-                                    <span class="italic opacity-70">Press a key...</span>
-                                {:else}
-                                    <span>{shortcutSettings.hideAnnotations}</span>
-                                {/if}
-                            </button>
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="go-back" class="text-right text-foreground">Go Back</Label>
-                            <button
-                                id="go-back"
-                                type="button"
-                                class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-                                onclick={(e) => {
-                                    e.preventDefault();
-                                    startRecording('goBack');
-                                }}
-                            >
-                                {#if recordingShortcut === 'goBack'}
-                                    <span class="italic opacity-70">Press a key...</span>
-                                {:else}
-                                    <span>{shortcutSettings.goBack}</span>
-                                {/if}
-                            </button>
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="toggle-edit-mode" class="text-right text-foreground">
-                                Toggle Edit Mode
-                            </Label>
-                            <button
-                                id="toggle-edit-mode"
-                                type="button"
-                                class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-                                onclick={(e) => {
-                                    e.preventDefault();
-                                    startRecording('toggleEditMode');
-                                }}
-                            >
-                                {#if recordingShortcut === 'toggleEditMode'}
-                                    <span class="italic opacity-70">Press a key...</span>
-                                {:else}
-                                    <span>{shortcutSettings.toggleEditMode}</span>
-                                {/if}
-                            </button>
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="toggle-edit-mode" class="text-right text-foreground">
-                                Toolbar selection
-                            </Label>
-                            <button
-                                id="toggle-edit-mode"
-                                type="button"
-                                class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-                                onclick={(e) => {
-                                    e.preventDefault();
-                                    startRecording('keyToolbarSelection');
-                                }}
-                            >
-                                {#if recordingShortcut === 'keyToolbarSelection'}
-                                    <span class="italic opacity-70">Press a key...</span>
-                                {:else}
-                                    <span>{shortcutSettings.keyToolbarSelection}</span>
-                                {/if}
-                            </button>
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="toggle-edit-mode" class="text-right text-foreground">
-                                Toolbar drag
-                            </Label>
-                            <button
-                                id="toggle-edit-mode"
-                                type="button"
-                                class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-                                onclick={(e) => {
-                                    e.preventDefault();
-                                    startRecording('keyToolbarDrag');
-                                }}
-                            >
-                                {#if recordingShortcut === 'keyToolbarDrag'}
-                                    <span class="italic opacity-70">Press a key...</span>
-                                {:else}
-                                    <span>{shortcutSettings.keyToolbarDrag}</span>
-                                {/if}
-                            </button>
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="toggle-edit-mode" class="text-right text-foreground">
-                                Toolbar bounding box
-                            </Label>
-                            <button
-                                id="toggle-edit-mode"
-                                type="button"
-                                class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-                                onclick={(e) => {
-                                    e.preventDefault();
-                                    startRecording('keyToolbarBoundingBox');
-                                }}
-                            >
-                                {#if recordingShortcut === 'keyToolbarBoundingBox'}
-                                    <span class="italic opacity-70">Press a key...</span>
-                                {:else}
-                                    <span>{shortcutSettings.keyToolbarBoundingBox}</span>
-                                {/if}
-                            </button>
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label
-                                for="toggle-toolbar-segmentation-mask"
-                                class="text-right text-foreground"
-                            >
-                                Toolbar segmentation mask
-                            </Label>
-                            <button
-                                id="toggle-toolbar-segmentation-mask"
-                                type="button"
-                                class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-                                onclick={(e) => {
-                                    e.preventDefault();
-                                    startRecording('keyToolbarSegmentationMask');
-                                }}
-                            >
-                                {#if recordingShortcut === 'keyToolbarSegmentationMask'}
-                                    <span class="italic opacity-70">Press a key...</span>
-                                {:else}
-                                    <span>{shortcutSettings.keyToolbarSegmentationMask}</span>
-                                {/if}
-                            </button>
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="toolbar-brush-mode" class="text-right text-foreground">
-                                Toolbar brush mode
-                            </Label>
-                            <button
-                                id="toolbar-brush-mode"
-                                type="button"
-                                class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-                                onclick={(e) => {
-                                    e.preventDefault();
-                                    startRecording('keyToolbarBrush');
-                                }}
-                            >
-                                {#if recordingShortcut === 'keyToolbarBrush'}
-                                    <span class="italic opacity-70">Press a key...</span>
-                                {:else}
-                                    <span>{shortcutSettings.keyToolbarBrush}</span>
-                                {/if}
-                            </button>
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="toolbar-eraser-mode" class="text-right text-foreground">
-                                Toolbar eraser mode
-                            </Label>
-                            <button
-                                id="toolbar-eraser-mode"
-                                type="button"
-                                class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-                                onclick={(e) => {
-                                    e.preventDefault();
-                                    startRecording('keyToolbarEraser');
-                                }}
-                            >
-                                {#if recordingShortcut === 'keyToolbarEraser'}
-                                    <span class="italic opacity-70">Press a key...</span>
-                                {:else}
-                                    <span>{shortcutSettings.keyToolbarEraser}</span>
-                                {/if}
-                            </button>
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="change-brush-size" class="text-right text-foreground">
-                                Change brush size
-                            </Label>
-                            <button
-                                id="change-brush-size"
-                                type="button"
+                        {#each shortcutSettings as setting (setting.id)}
+                            <ShortcutSettingRow
+                                id={setting.id}
+                                label={setting.label}
+                                value={shortcutState[setting.key]}
+                                isRecording={recordingShortcut === setting.key}
+                                onStartRecording={() => startRecording(setting.key)}
+                            />
+                        {/each}
+                        {#each staticShortcuts as setting (setting.id)}
+                            <ShortcutSettingRow
+                                id={setting.id}
+                                label={setting.label}
+                                value={setting.displayValue}
+                                isRecording={false}
                                 disabled
-                                class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-                            >
-                                <span>Alt + scroll</span>
-                            </button>
-                        </div>
+                            />
+                        {/each}
                     </div>
 
                     <!-- Grid View Settings -->

--- a/lightly_studio_view/src/lib/components/Settings/SettingsDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/Settings/SettingsDialog.test.ts
@@ -256,6 +256,29 @@ describe('SettingsDialog', () => {
         );
     });
 
+    it('should have unique IDs for all shortcut controls', async () => {
+        render(SettingsDialog);
+        await openDialog();
+
+        const ids = [
+            'hide-annotations',
+            'go-back',
+            'toggle-edit-mode',
+            'toolbar-selection',
+            'toolbar-drag',
+            'toolbar-bounding-box',
+            'toolbar-segmentation-mask',
+            'toolbar-brush-mode',
+            'toolbar-eraser-mode',
+            'change-brush-size'
+        ];
+
+        for (const id of ids) {
+            const elements = document.querySelectorAll(`#${id}`);
+            expect(elements.length, `Expected exactly one element with id="${id}"`).toBe(1);
+        }
+    });
+
     it('should save settings when form is submitted', async () => {
         render(SettingsDialog);
 
@@ -263,8 +286,9 @@ describe('SettingsDialog', () => {
         await openDialog();
 
         // 1. Change keyboard shortcut
-        const hideAnnotationsButton = screen.getByText('v');
-        await fireEvent.click(hideAnnotationsButton);
+        const hideAnnotationsButton = document.getElementById('hide-annotations');
+        expect(hideAnnotationsButton).not.toBeNull();
+        await fireEvent.click(hideAnnotationsButton!);
         await fireEvent.keyDown(window, { key: 'x' });
 
         // 2. Skip the dropdown interaction and directly test the effect of saving

--- a/lightly_studio_view/src/lib/components/Settings/ShortcutSettingRow/ShortcutSettingRow.svelte
+++ b/lightly_studio_view/src/lib/components/Settings/ShortcutSettingRow/ShortcutSettingRow.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+    import { Label } from '$lib/components/ui/label';
+
+    interface Props {
+        id: string;
+        label: string;
+        value: string;
+        isRecording: boolean;
+        disabled?: boolean;
+        onStartRecording?: () => void;
+    }
+
+    const { id, label, value, isRecording, disabled = false, onStartRecording }: Props = $props();
+</script>
+
+<div class="grid grid-cols-2 items-center gap-4">
+    <Label for={id} class="text-right text-foreground">
+        {label}
+    </Label>
+    <button
+        {id}
+        type="button"
+        {disabled}
+        class="rounded-md border border-input bg-background p-2 text-left text-foreground"
+        onclick={(e) => {
+            e.preventDefault();
+            onStartRecording?.();
+        }}
+    >
+        {#if isRecording}
+            <span class="italic opacity-70">Press a key...</span>
+        {:else}
+            <span>{value}</span>
+        {/if}
+    </button>
+</div>

--- a/lightly_studio_view/src/lib/components/Settings/ShortcutSettingRow/ShortcutSettingRow.svelte
+++ b/lightly_studio_view/src/lib/components/Settings/ShortcutSettingRow/ShortcutSettingRow.svelte
@@ -22,10 +22,7 @@
         type="button"
         {disabled}
         class="rounded-md border border-input bg-background p-2 text-left text-foreground"
-        onclick={(e) => {
-            e.preventDefault();
-            onStartRecording?.();
-        }}
+        onclick={() => onStartRecording?.()}
     >
         {#if isRecording}
             <span class="italic opacity-70">Press a key...</span>

--- a/lightly_studio_view/src/lib/components/Settings/ShortcutSettingRow/ShortcutSettingRow.test.ts
+++ b/lightly_studio_view/src/lib/components/Settings/ShortcutSettingRow/ShortcutSettingRow.test.ts
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import ShortcutSettingRow from './ShortcutSettingRow.svelte';
+
+describe('ShortcutSettingRow', () => {
+    it('should render label and current value', () => {
+        render(ShortcutSettingRow, {
+            props: { id: 'test-key', label: 'Test Shortcut', value: 'v', isRecording: false }
+        });
+
+        expect(screen.getByText('Test Shortcut')).toBeInTheDocument();
+        expect(screen.getByText('v')).toBeInTheDocument();
+    });
+
+    it('should show "Press a key..." when recording', () => {
+        render(ShortcutSettingRow, {
+            props: { id: 'test-key', label: 'Test Shortcut', value: 'v', isRecording: true }
+        });
+
+        expect(screen.getByText('Press a key...')).toBeInTheDocument();
+        expect(screen.queryByText('v')).not.toBeInTheDocument();
+    });
+
+    it('should call onStartRecording when clicked', async () => {
+        const onStartRecording = vi.fn();
+        render(ShortcutSettingRow, {
+            props: {
+                id: 'test-key',
+                label: 'Test Shortcut',
+                value: 'v',
+                isRecording: false,
+                onStartRecording
+            }
+        });
+
+        await fireEvent.click(screen.getByRole('button'));
+        expect(onStartRecording).toHaveBeenCalledOnce();
+    });
+
+    it('should render as disabled when disabled prop is set', () => {
+        render(ShortcutSettingRow, {
+            props: {
+                id: 'test-key',
+                label: 'Test Shortcut',
+                value: 'Alt + scroll',
+                isRecording: false,
+                disabled: true
+            }
+        });
+
+        expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('should associate label with button via id', () => {
+        render(ShortcutSettingRow, {
+            props: { id: 'my-shortcut', label: 'My Shortcut', value: 'x', isRecording: false }
+        });
+
+        const button = document.getElementById('my-shortcut');
+        expect(button).not.toBeNull();
+        expect(button?.tagName.toLowerCase()).toBe('button');
+    });
+});

--- a/lightly_studio_view/src/lib/components/Settings/settingsDialogConfig.ts
+++ b/lightly_studio_view/src/lib/components/Settings/settingsDialogConfig.ts
@@ -1,0 +1,56 @@
+/**
+ * Configuration for the shortcut settings rows displayed in SettingsDialog.
+ *
+ * Each entry maps a unique HTML id and user-visible label to a key in the
+ * SettingsDialogShortcutState managed by settingsDialogState.ts.
+ */
+
+/** Keys of the shortcut state object that can be recorded by the user. */
+export type ShortcutSettingKey =
+    | 'hideAnnotations'
+    | 'goBack'
+    | 'toggleEditMode'
+    | 'keyToolbarSelection'
+    | 'keyToolbarDrag'
+    | 'keyToolbarBoundingBox'
+    | 'keyToolbarSegmentationMask'
+    | 'keyToolbarBrush'
+    | 'keyToolbarEraser';
+
+export interface ShortcutSettingConfig {
+    /** Unique HTML id for the control (used by label `for`). */
+    id: string;
+    /** User-visible label text. */
+    label: string;
+    /** Key into SettingsDialogShortcutState. */
+    key: ShortcutSettingKey;
+}
+
+export interface StaticShortcutConfig {
+    id: string;
+    label: string;
+    /** Static display value (not recordable). */
+    displayValue: string;
+}
+
+/** Recordable shortcut rows shown in the Keyboard Shortcuts section. */
+export const shortcutSettings: readonly ShortcutSettingConfig[] = [
+    { id: 'hide-annotations', label: 'Hide Annotations', key: 'hideAnnotations' },
+    { id: 'go-back', label: 'Go Back', key: 'goBack' },
+    { id: 'toggle-edit-mode', label: 'Toggle Edit Mode', key: 'toggleEditMode' },
+    { id: 'toolbar-selection', label: 'Toolbar selection', key: 'keyToolbarSelection' },
+    { id: 'toolbar-drag', label: 'Toolbar drag', key: 'keyToolbarDrag' },
+    { id: 'toolbar-bounding-box', label: 'Toolbar bounding box', key: 'keyToolbarBoundingBox' },
+    {
+        id: 'toolbar-segmentation-mask',
+        label: 'Toolbar segmentation mask',
+        key: 'keyToolbarSegmentationMask'
+    },
+    { id: 'toolbar-brush-mode', label: 'Toolbar brush mode', key: 'keyToolbarBrush' },
+    { id: 'toolbar-eraser-mode', label: 'Toolbar eraser mode', key: 'keyToolbarEraser' }
+] as const;
+
+/** Non-recordable shortcut rows (static display only). */
+export const staticShortcuts: readonly StaticShortcutConfig[] = [
+    { id: 'change-brush-size', label: 'Change brush size', displayValue: 'Alt + scroll' }
+] as const;


### PR DESCRIPTION
## What has changed and why?

Part 2 of the settings refactor.

Extracts the repeated shortcut row markup in `SettingsDialog.svelte` into a typed config array and a reusable component, as part of the settings dialog refactor (step 2).

- Create `settingsDialogConfig.ts` with typed `shortcutSettings` and `staticShortcuts` arrays, giving every shortcut a unique stable HTML ID
- Extract `ShortcutSettingRow.svelte` with explicit props (`id`, `label`, `value`, `isRecording`, `disabled`, `onStartRecording`)
- Replace ~180 lines of duplicated shortcut markup with `{#each}` loops over the config arrays
- Fix 5 shortcut rows that previously shared `id="toggle-edit-mode"` — all 10 rows now have distinct IDs

## How has it been tested?

- Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Settings dialog keyboard shortcut UI rewritten to be configuration-driven and simplified for maintainability.
  * Shortcut recording now syncs and persists normalized key values with the form state.

* **New Features**
  * Added modular shortcut row component and a config-driven list separating editable and static/display-only shortcuts.

* **Tests**
  * Added/updated tests to cover shortcut rows, recording interactions, unique element ids, save flow, and dialog closing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1089)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->