### PR TITLE
Extract SettingsFieldRow layout component

### DIFF
--- a/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
@@ -12,8 +12,8 @@
     } from './settingsDialogState';
     import { shortcutSettings, staticShortcuts } from './settingsDialogConfig';
     import type { ShortcutSettingKey } from './settingsDialogConfig';
-    import ShortcutSettingRow from './ShortcutSettingRow/ShortcutSettingRow.svelte';
-    import SettingsFieldRow from './SettingsFieldRow/SettingsFieldRow.svelte';
+    import { ShortcutSettingRow } from './ShortcutSettingRow';
+    import { SettingsFieldRow } from './SettingsFieldRow';
 
     type SettingsDialogFormState = ReturnType<typeof createSettingsDialogFormState>;
     type RenderingMode = SettingsDialogFormState['gridViewRendering'];

--- a/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { Button } from '$lib/components/ui/button';
     import * as Dialog from '$lib/components/ui/dialog';
-    import { Label } from '$lib/components/ui/label';
     import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
     import { Switch } from '$lib/components/ui/switch';
     import { useSettings } from '$lib/hooks/useSettings';
@@ -14,6 +13,7 @@
     import { shortcutSettings, staticShortcuts } from './settingsDialogConfig';
     import type { ShortcutSettingKey } from './settingsDialogConfig';
     import ShortcutSettingRow from './ShortcutSettingRow/ShortcutSettingRow.svelte';
+    import SettingsFieldRow from './SettingsFieldRow/SettingsFieldRow.svelte';
 
     type SettingsDialogFormState = ReturnType<typeof createSettingsDialogFormState>;
     type RenderingMode = SettingsDialogFormState['gridViewRendering'];
@@ -165,10 +165,7 @@
                     <!-- Grid View Settings -->
                     <div class="space-y-4">
                         <h3 class="text-lg font-medium text-foreground">Display Settings</h3>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="grid-view-rendering" class="text-right text-foreground">
-                                Grid View Rendering
-                            </Label>
+                        <SettingsFieldRow id="grid-view-rendering" label="Grid View Rendering">
                             <div class="relative">
                                 <Select
                                     type="single"
@@ -184,24 +181,21 @@
                                     </SelectContent>
                                 </Select>
                             </div>
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label for="show-sample-filenames" class="text-right text-foreground">
-                                Show filenames in grid view
-                            </Label>
+                        </SettingsFieldRow>
+                        <SettingsFieldRow
+                            id="show-sample-filenames"
+                            label="Show filenames in grid view"
+                        >
                             <Switch
                                 id="show-sample-filenames"
                                 bind:checked={showSampleFilenames}
                                 disabled={isSaving}
                             />
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label
-                                for="grid-view-thumbnail-quality"
-                                class="text-right text-foreground"
-                            >
-                                Thumbnail Quality in Grid View
-                            </Label>
+                        </SettingsFieldRow>
+                        <SettingsFieldRow
+                            id="grid-view-thumbnail-quality"
+                            label="Thumbnail Quality in Grid View"
+                        >
                             <div class="relative">
                                 <Select
                                     type="single"
@@ -217,38 +211,32 @@
                                     </SelectContent>
                                 </Select>
                             </div>
-                        </div>
+                        </SettingsFieldRow>
                     </div>
 
-                    <!-- Annotation Text Labels Setting -->
+                    <!-- Annotation Settings -->
                     <div class="space-y-4">
                         <h3 class="text-lg font-medium text-foreground">Annotation Settings</h3>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label
-                                for="show-bounding-boxes-for-segmentation"
-                                class="text-right text-foreground"
-                            >
-                                Show Bounding Boxes for Segmentation
-                            </Label>
+                        <SettingsFieldRow
+                            id="show-bounding-boxes-for-segmentation"
+                            label="Show Bounding Boxes for Segmentation"
+                        >
                             <Switch
                                 id="show-bounding-boxes-for-segmentation"
                                 bind:checked={showBoundingBoxesForSegmentation}
                                 disabled={isSaving}
                             />
-                        </div>
-                        <div class="grid grid-cols-2 items-center gap-4">
-                            <Label
-                                for="show-annotation-text-labels"
-                                class="text-right text-foreground"
-                            >
-                                Show Annotation Text Labels
-                            </Label>
+                        </SettingsFieldRow>
+                        <SettingsFieldRow
+                            id="show-annotation-text-labels"
+                            label="Show Annotation Text Labels"
+                        >
                             <Switch
                                 id="show-annotation-text-labels"
                                 bind:checked={showAnnotationTextLabels}
                                 disabled={isSaving}
                             />
-                        </div>
+                        </SettingsFieldRow>
                     </div>
                 </div>
 

--- a/lightly_studio_view/src/lib/components/Settings/SettingsFieldRow/SettingsFieldRow.svelte
+++ b/lightly_studio_view/src/lib/components/Settings/SettingsFieldRow/SettingsFieldRow.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte';
+    import { Label } from '$lib/components/ui/label';
+
+    interface Props {
+        id: string;
+        label: string;
+        children: Snippet;
+    }
+
+    const { id, label, children }: Props = $props();
+</script>
+
+<div class="grid grid-cols-2 items-center gap-4">
+    <Label for={id} class="text-right text-foreground">
+        {label}
+    </Label>
+    {@render children()}
+</div>

--- a/lightly_studio_view/src/lib/components/Settings/SettingsFieldRow/index.ts
+++ b/lightly_studio_view/src/lib/components/Settings/SettingsFieldRow/index.ts
@@ -1,0 +1,1 @@
+export { default as SettingsFieldRow } from './SettingsFieldRow.svelte';

--- a/lightly_studio_view/src/lib/components/Settings/ShortcutSettingRow/ShortcutSettingRow.svelte
+++ b/lightly_studio_view/src/lib/components/Settings/ShortcutSettingRow/ShortcutSettingRow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Label } from '$lib/components/ui/label';
+    import { SettingsFieldRow } from '../SettingsFieldRow';
 
     interface Props {
         id: string;
@@ -13,10 +13,7 @@
     const { id, label, value, isRecording, disabled = false, onStartRecording }: Props = $props();
 </script>
 
-<div class="grid grid-cols-2 items-center gap-4">
-    <Label for={id} class="text-right text-foreground">
-        {label}
-    </Label>
+<SettingsFieldRow {id} {label}>
     <button
         {id}
         type="button"
@@ -30,4 +27,4 @@
             <span>{value}</span>
         {/if}
     </button>
-</div>
+</SettingsFieldRow>

--- a/lightly_studio_view/src/lib/components/Settings/ShortcutSettingRow/index.ts
+++ b/lightly_studio_view/src/lib/components/Settings/ShortcutSettingRow/index.ts
@@ -1,0 +1,1 @@
+export { default as ShortcutSettingRow } from './ShortcutSettingRow.svelte';


### PR DESCRIPTION
## What has changed and why?

Extracts the repeated two-column grid layout (Label + control) into a reusable `SettingsFieldRow` component. This is step 3 of the SettingsDialog refactor.

**Changes:**
- New `SettingsFieldRow/SettingsFieldRow.svelte` — pure layout component that renders a `Label` on the left and a `children` snippet on the right in a two-column grid.
- `SettingsDialog.svelte` — replaced 5 instances of the repeated `<div class="grid grid-cols-2 ..."><Label ...>` pattern with `<SettingsFieldRow>`. Removed direct `Label` import since it is now owned by `SettingsFieldRow`.

**Not changed:**
- No behavior changes — `Select`, `Switch`, and label-control association (`for`/`id`) are preserved.
- No new tests — `SettingsFieldRow` is a pure layout component with no behavior to test. All 13 existing dialog tests pass unchanged.

## How has it been tested?

- All 13 existing `SettingsDialog.test.ts` tests pass.
- `svelte-check` reports 0 errors and 0 warnings.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  - Settings interface components refactored to use a new unified layout wrapper for consistent two-column grid-based row rendering across settings dialog, grid view options, annotation settings, and shortcut configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1091)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->