### PR TITLE
Drop `video:` from auto completion

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/completionAdapter/completionAdapterBuildSchemaCompletions.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/completionAdapter/completionAdapterBuildSchemaCompletions.test.ts
@@ -8,7 +8,7 @@ vi.mock('monaco-editor', () => ({
 }));
 
 describe('buildSchemaCompletions', () => {
-    it('includes scope fields and top-level keywords in image scope', async () => {
+    it('includes scope fields and top-level keywords in image scope except `video:`', async () => {
         const { buildSchemaCompletions } = await import(
             './completionAdapterBuildSchemaCompletions'
         );
@@ -16,7 +16,7 @@ describe('buildSchemaCompletions', () => {
         const items = buildSchemaCompletions('image', range as never);
         const labels = items.map((i) => i.label);
         expect(labels).toContain('width');
-        expect(labels).toContain('video:');
+        expect(labels).not.toContain('video:');
         expect(labels).toContain('object_detection');
         expect(labels).toContain('segmentation_mask');
     });

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/completionAdapter/completionAdapterBuildSchemaCompletions.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/completionAdapter/completionAdapterBuildSchemaCompletions.ts
@@ -22,8 +22,7 @@ export function buildSchemaCompletions<Scope extends keyof typeof SCOPES>(
     }
 
     const keywords = TOP_LEVEL_KEYWORDS.filter((kw) => {
-        if (scope === 'image') return true;
-        if (scope === 'video') return kw.name !== 'video:';
+        if (scope === 'image' || scope === 'video') return kw.name !== 'video:';
         return ALLOWED_NESTED_KEYWORDS.has(kw.name);
     });
 

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/useSyntaxCompletion.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/useSyntaxCompletion.test.ts
@@ -418,6 +418,24 @@ describe('useSyntaxCompletion', () => {
         expect(labels).toContain('duration_s');
         expect(labels).toContain('file_name');
         expect(labels).not.toContain('created_at');
+        expect(labels).not.toContain('video:');
+    });
+
+    it('filters `video:` even when provided by the LSP completion source', async () => {
+        const { provideCompletionItems } = await loadAndAttach([
+            { label: 'video:', kind: LspCompletionItemKind.Keyword },
+            { label: 'AND', kind: LspCompletionItemKind.Keyword }
+        ]);
+        const result = await provideCompletionItems(
+            makeModel('') as never,
+            { lineNumber: 1, column: 1 } as never
+        );
+
+        const labels = result.suggestions.map((suggestion) =>
+            typeof suggestion.label === 'string' ? suggestion.label : suggestion.label.label
+        );
+        expect(labels).not.toContain('video:');
+        expect(labels).toContain('AND');
     });
 
     it('resolves field scope from cursor context (object_detection)', async () => {

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/useSyntaxCompletion.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/useSyntaxCompletion.ts
@@ -25,6 +25,13 @@ function completionLabel(item: monaco.languages.CompletionItem): string {
     return typeof item.label === 'string' ? item.label : item.label.label;
 }
 
+// Keep parsing support for leading `video:` queries, but do not advertise the
+// prefix in autocomplete for now. Filtering here ensures it is removed no
+// matter whether it comes from Langium's LSP completions or our schema fallback.
+function shouldShowSuggestion(item: monaco.languages.CompletionItem): boolean {
+    return completionLabel(item) !== 'video:';
+}
+
 async function getCompletions(
     model: monaco.editor.ITextModel,
     position: monaco.Position
@@ -56,9 +63,9 @@ async function getCompletions(
 
     const scope = detectScopeAt(model.getValue(), model.getOffsetAt(position));
 
-    const lspSuggestions = (result?.items ?? []).map((item) =>
-        lspToMonacoCompletion(item, fallbackRange, scope)
-    );
+    const lspSuggestions = (result?.items ?? [])
+        .map((item) => lspToMonacoCompletion(item, fallbackRange, scope))
+        .filter(shouldShowSuggestion);
 
     // Langium's default provider only emits literal-string keywords from the
     // grammar, so terminal-defined names (width, fps, object_detection, …)
@@ -69,7 +76,7 @@ async function getCompletions(
         (suggestion) => !seen.has(completionLabel(suggestion))
     );
 
-    return { suggestions: [...lspSuggestions, ...schemaSuggestions] };
+    return { suggestions: [...lspSuggestions, ...schemaSuggestions].filter(shouldShowSuggestion) };
 }
 
 /**


### PR DESCRIPTION
## What has changed and why?
The keyword is still parsed and you can use it in the query, but auto completion doesn't show it.

## How has it been tested?

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined query editor autocompletion to enforce proper scope-based keyword filtering. The `video:` keyword is now correctly excluded from suggestions when working in image scope. Filtering is consistently applied across all completion sources, ensuring more relevant and accurate suggestions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1092)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->