### PR TITLE
feat: pass collection_ids to request images

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/getAnnotationsFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/getAnnotationsFilter.test.ts
@@ -4,12 +4,12 @@ import { getAnnotationsFilter } from './getAnnotationsFilter';
 describe('getAnnotationsFilter', () => {
     it('returns annotation_label_ids when set', () => {
         const result = getAnnotationsFilter({ annotation_label_ids: ['a', 'b'] });
-        expect(result).toEqual({ annotation_label_ids: ['a', 'b'] });
+        expect(result).toEqual({ annotation_label_ids: ['a', 'b'], filter_type: 'annotations' });
     });
 
     it('returns collection_ids when set', () => {
         const result = getAnnotationsFilter({ collection_ids: ['c1', 'c2'] });
-        expect(result).toEqual({ collection_ids: ['c1', 'c2'] });
+        expect(result).toEqual({ collection_ids: ['c1', 'c2'], filter_type: 'annotations' });
     });
 
     it('returns both fields when both are set', () => {
@@ -17,7 +17,11 @@ describe('getAnnotationsFilter', () => {
             annotation_label_ids: ['a'],
             collection_ids: ['c1']
         });
-        expect(result).toEqual({ annotation_label_ids: ['a'], collection_ids: ['c1'] });
+        expect(result).toEqual({
+            annotation_label_ids: ['a'],
+            collection_ids: ['c1'],
+            filter_type: 'annotations'
+        });
     });
 
     it('returns undefined when both are empty arrays', () => {

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/getAnnotationsFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/getAnnotationsFilter.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getAnnotationsFilter } from './getAnnotationsFilter';
+
+describe('getAnnotationsFilter', () => {
+    it('returns annotation_label_ids when set', () => {
+        const result = getAnnotationsFilter({ annotation_label_ids: ['a', 'b'] });
+        expect(result).toEqual({ annotation_label_ids: ['a', 'b'] });
+    });
+
+    it('returns collection_ids when set', () => {
+        const result = getAnnotationsFilter({ collection_ids: ['c1', 'c2'] });
+        expect(result).toEqual({ collection_ids: ['c1', 'c2'] });
+    });
+
+    it('returns both fields when both are set', () => {
+        const result = getAnnotationsFilter({
+            annotation_label_ids: ['a'],
+            collection_ids: ['c1']
+        });
+        expect(result).toEqual({ annotation_label_ids: ['a'], collection_ids: ['c1'] });
+    });
+
+    it('returns undefined when both are empty arrays', () => {
+        const result = getAnnotationsFilter({ annotation_label_ids: [], collection_ids: [] });
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when both are absent', () => {
+        const result = getAnnotationsFilter({});
+        expect(result).toBeUndefined();
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/getAnnotationsFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/getAnnotationsFilter.ts
@@ -1,0 +1,23 @@
+type AnnotationsFilterInput = {
+    annotation_label_ids?: string[];
+    collection_ids?: string[];
+};
+
+type AnnotationsFilter = {
+    annotation_label_ids?: string[];
+    collection_ids?: string[];
+};
+
+export const getAnnotationsFilter = (
+    filters: AnnotationsFilterInput
+): AnnotationsFilter | undefined => {
+    const annotation_label_ids = filters.annotation_label_ids?.length
+        ? filters.annotation_label_ids
+        : undefined;
+    const collection_ids = filters.collection_ids?.length ? filters.collection_ids : undefined;
+    if (!annotation_label_ids && !collection_ids) return undefined;
+    return {
+        ...(annotation_label_ids && { annotation_label_ids }),
+        ...(collection_ids && { collection_ids })
+    };
+};

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/getAnnotationsFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/getAnnotationsFilter.ts
@@ -1,12 +1,6 @@
-type AnnotationsFilterInput = {
-    annotation_label_ids?: string[];
-    collection_ids?: string[];
-};
+import type { AnnotationsFilter } from '$lib/api/lightly_studio_local/types.gen';
 
-type AnnotationsFilter = {
-    annotation_label_ids?: string[];
-    collection_ids?: string[];
-};
+type AnnotationsFilterInput = Pick<AnnotationsFilter, 'annotation_label_ids' | 'collection_ids'>;
 
 export const getAnnotationsFilter = (
     filters: AnnotationsFilterInput
@@ -17,6 +11,7 @@ export const getAnnotationsFilter = (
     const collection_ids = filters.collection_ids?.length ? filters.collection_ids : undefined;
     if (!annotation_label_ids && !collection_ids) return undefined;
     return {
+        filter_type: 'annotations',
         ...(annotation_label_ids && { annotation_label_ids }),
         ...(collection_ids && { collection_ids })
     };

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
@@ -32,4 +32,23 @@ describe('buildRequestBody', () => {
 
         expect(result.filters?.sample_filter?.annotations_filter).toBeUndefined();
     });
+
+    it('propagates both annotation_label_ids and collection_ids', () => {
+        const params: ImagesInfiniteParams = {
+            collection_id: 'col-1',
+            mode: 'normal',
+            filters: {
+                annotation_label_ids: ['lbl-1'],
+                collection_ids: ['coll-1']
+            }
+        };
+
+        const result = buildRequestBody(params, 0);
+
+        expect(result.filters?.sample_filter?.annotations_filter).toEqual({
+            annotation_label_ids: ['lbl-1'],
+            collection_ids: ['coll-1'],
+            filter_type: 'annotations'
+        });
+    });
 });

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
@@ -16,7 +16,8 @@ describe('buildRequestBody', () => {
         const result = buildRequestBody(params, 0);
 
         expect(result.filters?.sample_filter?.annotations_filter).toEqual({
-            collection_ids: ['label-1', 'label-2']
+            collection_ids: ['label-1', 'label-2'],
+            filter_type: 'annotations'
         });
     });
 

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildRequestBody, type ImagesInfiniteParams } from './useImagesInfinite';
+
+vi.mock('$lib/hooks/useMetadataFilters/useMetadataFilters', () => ({
+    createMetadataFilters: vi.fn(() => [])
+}));
+
+describe('buildRequestBody', () => {
+    it('propagates collection_ids to annotations_filter', () => {
+        const params: ImagesInfiniteParams = {
+            collection_id: 'col-1',
+            mode: 'normal',
+            filters: { collection_ids: ['label-1', 'label-2'] }
+        };
+
+        const result = buildRequestBody(params, 0);
+
+        expect(result.filters?.sample_filter?.annotations_filter).toEqual({
+            collection_ids: ['label-1', 'label-2']
+        });
+    });
+
+    it('omits annotations_filter when collection_ids is empty', () => {
+        const params: ImagesInfiniteParams = {
+            collection_id: 'col-1',
+            mode: 'normal',
+            filters: { collection_ids: [] }
+        };
+
+        const result = buildRequestBody(params, 0);
+
+        expect(result.filters?.sample_filter?.annotations_filter).toBeUndefined();
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
@@ -10,13 +10,13 @@ describe('buildRequestBody', () => {
         const params: ImagesInfiniteParams = {
             collection_id: 'col-1',
             mode: 'normal',
-            filters: { collection_ids: ['label-1', 'label-2'] }
+            filters: { collection_ids: ['coll-1', 'coll-2'] }
         };
 
         const result = buildRequestBody(params, 0);
 
         expect(result.filters?.sample_filter?.annotations_filter).toEqual({
-            collection_ids: ['label-1', 'label-2'],
+            collection_ids: ['coll-1', 'coll-2'],
             filter_type: 'annotations'
         });
     });

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
@@ -100,7 +100,6 @@ const createImagesInfiniteOptions = (params: ImagesInfiniteParams) => {
     });
 };
 
-
 export const buildRequestBody = (
     params: ImagesInfiniteParams,
     pageParam: number

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
@@ -113,10 +113,6 @@ export const buildRequestBody = (
         filters: {
             sample_filter: {
                 query_expr: params.query_expr ?? undefined,
-                annotations_filter: isNormalModeParams(params)
-                    ? getAnnotationsFilter(params.filters ?? {})
-                    : undefined,
-
                 metadata_filters: params.metadata_values
                     ? createMetadataFilters(params.metadata_values)
                     : undefined

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
@@ -114,7 +114,7 @@ export const buildRequestBody = (
             sample_filter: {
                 query_expr: params.query_expr ?? undefined,
                 annotations_filter: isNormalModeParams(params)
-                    ? { collection_ids: params.filters?.collection_ids }
+                    ? getAnnotationsFilter(params.filters ?? {})
                     : undefined,
 
                 metadata_filters: params.metadata_values

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
@@ -6,6 +6,7 @@ import type { DimensionBounds } from '$lib/services/loadDimensionBounds';
 import { createMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import type { MetadataValues } from '$lib/services/types';
 import { GRID_PAGE_SIZE } from '$lib/constants';
+import { getAnnotationsFilter } from './getAnnotationsFilter';
 
 // Define mode-aware parameter types.
 interface ClassifierSamples {
@@ -15,6 +16,7 @@ interface ClassifierSamples {
 
 interface NormalModeFilters {
     annotation_label_ids?: string[];
+    collection_ids?: string[];
     tag_ids?: string[];
     dimensions?: DimensionBounds;
     query_expr?: QueryExpr;
@@ -98,7 +100,11 @@ const createImagesInfiniteOptions = (params: ImagesInfiniteParams) => {
     });
 };
 
-const buildRequestBody = (params: ImagesInfiniteParams, pageParam: number): ReadImagesRequest => {
+
+export const buildRequestBody = (
+    params: ImagesInfiniteParams,
+    pageParam: number
+): ReadImagesRequest => {
     const baseBody: ReadImagesRequest = {
         pagination: {
             offset: pageParam,
@@ -108,6 +114,10 @@ const buildRequestBody = (params: ImagesInfiniteParams, pageParam: number): Read
         filters: {
             sample_filter: {
                 query_expr: params.query_expr ?? undefined,
+                annotations_filter: isNormalModeParams(params)
+                    ? { collection_ids: params.filters?.collection_ids }
+                    : undefined,
+
                 metadata_filters: params.metadata_values
                     ? createMetadataFilters(params.metadata_values)
                     : undefined
@@ -132,11 +142,7 @@ const buildRequestBody = (params: ImagesInfiniteParams, pageParam: number): Read
                 ...baseBody.filters,
                 sample_filter: {
                     ...(baseBody.filters?.sample_filter ?? {}),
-                    annotations_filter: params.filters.annotation_label_ids?.length
-                        ? {
-                              annotation_label_ids: params.filters.annotation_label_ids
-                          }
-                        : undefined,
+                    annotations_filter: getAnnotationsFilter(params.filters),
                     tag_ids: params.filters.tag_ids?.length ? params.filters.tag_ids : undefined,
                     sample_ids: params.filters.sample_ids?.length
                         ? params.filters.sample_ids

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -633,6 +633,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/collections/{collection_id}/annotation_collections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read Annotation Collections
+         * @description List annotation collections under the given parent collection.
+         */
+        get: operations["read_annotation_collections"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/collections/{collection_id}/annotations/sample_ids": {
         parameters: {
             query?: never;
@@ -1963,6 +1983,19 @@ export interface components {
             parent_sample_id: string;
             /** Object Track Id */
             object_track_id?: string | null;
+        };
+        /**
+         * AnnotationCollectionView
+         * @description Slim collection view used for the annotation collections menu.
+         */
+        AnnotationCollectionView: {
+            /**
+             * Collection Id
+             * Format: uuid
+             */
+            collection_id: string;
+            /** Name */
+            name: string;
         };
         /**
          * AnnotationCreateInput
@@ -5256,6 +5289,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnnotationView"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_annotation_collections: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnnotationCollectionView"][];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## What has changed and why?

Pass collection_ids for images quesry

## How has it been tested?

Add a small test and create function to build annotations filter

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image filtering now supports collection-based filters in addition to annotation-label filters and applies them correctly depending on viewing mode.

* **Tests**
  * Added tests ensuring annotation and collection filters are included in requests when present and omitted when empty.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1094)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->