### PR TITLE
Remove minimap from query editor

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
@@ -63,7 +63,8 @@ export const useQueryEditor = () => {
             theme: LIGHTLY_QUERY_THEME_ID,
             automaticLayout: true,
             readOnly: options.readOnly ?? false,
-            minimap: { enabled: false }
+            minimap: { enabled: false },
+            wordWrap: "off"
         });
 
         const detachLanguage = language.attach(model);

--- a/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
@@ -62,7 +62,8 @@ export const useQueryEditor = () => {
             model,
             theme: LIGHTLY_QUERY_THEME_ID,
             automaticLayout: true,
-            readOnly: options.readOnly ?? false
+            readOnly: options.readOnly ?? false,
+            minimap: { enabled: false }
         });
 
         const detachLanguage = language.attach(model);

--- a/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
@@ -64,7 +64,7 @@ export const useQueryEditor = () => {
             automaticLayout: true,
             readOnly: options.readOnly ?? false,
             minimap: { enabled: false },
-            wordWrap: "off"
+            wordWrap: 'on'
         });
 
         const detachLanguage = language.attach(model);


### PR DESCRIPTION
## What has changed and why?

Remove minimap from query editor

## How has it been tested?

Tested manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Disabled the minimap in the query editor for a cleaner interface.

* **Chores**
  * Preserved existing read-only behavior and other editor options; no public API or hook signature changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1097)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->