### PR TITLE
Change `==` to `=` in the Langium grammar

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
@@ -6,8 +6,11 @@
     import { useQueryEditor } from './useQueryEditor';
     import type { QueryExprTranslationResult } from './language/query-expr-translation';
 
-    const LIGHTLY_QUERY_DEFAULT_VALUE = `width > 1920 AND ("reviewed" IN tags)
-AND object_detection(label = "car" and x > 10)`;
+    const LIGHTLY_QUERY_DEFAULT_VALUE = `# Example query
+width < 500
+AND "reviewed" IN tags
+AND object_detection(label = "person" AND x > 10)
+`;
 
     interface QueryEditorProps {
         value?: string;

--- a/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
@@ -7,7 +7,7 @@
     import type { QueryExprTranslationResult } from './language/query-expr-translation';
 
     const LIGHTLY_QUERY_DEFAULT_VALUE = `width > 1920 AND ("reviewed" IN tags)
-AND object_detection(label == "car" and x > 10)`;
+AND object_detection(label = "car" and x > 10)`;
 
     interface QueryEditorProps {
         value?: string;

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/detectScopeAt.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/detectScopeAt.test.ts
@@ -8,36 +8,36 @@ describe('detectScopeAt', () => {
     });
 
     it('returns video scope when query starts with video prefix', () => {
-        const text = 'video: fps == 30';
+        const text = 'video: fps = 30';
         expect(detectScopeAt(text, text.length)).toBe('video');
     });
 
     it('returns object_detection scope inside object_detection(...)', () => {
-        const text = 'object_detection(label == "cat" AND width > 10)';
+        const text = 'object_detection(label = "cat" AND width > 10)';
         const offset = text.indexOf('width') + 2;
         expect(detectScopeAt(text, offset)).toBe('object_detection');
     });
 
     it('returns classification scope inside classification(...)', () => {
-        const text = 'classification(label == "car")';
+        const text = 'classification(label = "car")';
         const offset = text.indexOf('label') + 2;
         expect(detectScopeAt(text, offset)).toBe('classification');
     });
 
     it('returns segmentation_mask scope inside segmentation_mask(...)', () => {
-        const text = 'segmentation_mask(label == "road" AND width > 10)';
+        const text = 'segmentation_mask(label = "road" AND width > 10)';
         const offset = text.indexOf('width') + 2;
         expect(detectScopeAt(text, offset)).toBe('segmentation_mask');
     });
 
     it('falls back to outer scope after nested expression closes', () => {
-        const text = 'object_detection(label == "cat") AND width > 10';
+        const text = 'object_detection(label = "cat") AND width > 10';
         const offset = text.lastIndexOf('width') + 2;
         expect(detectScopeAt(text, offset)).toBe('image');
     });
 
     it('ignores pseudo tokens inside string literals while parsing scope frames', () => {
-        const text = 'object_detection(label == "foo object_detection(bar)") AND width > 1';
+        const text = 'object_detection(label = "foo object_detection(bar)") AND width > 1';
         const offset = text.lastIndexOf('width') + 2;
         expect(detectScopeAt(text, offset)).toBe('image');
     });

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query-schema.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query-schema.ts
@@ -44,7 +44,7 @@ export const SCOPES: Record<Scope, ScopeDoc> = {
             {
                 name: 'fps',
                 type: 'float',
-                description: 'Frames per second. Equality only (`==`, `!=`).'
+                description: 'Frames per second. Equality only (`=`, `!=`).'
             },
             { name: 'duration_s', type: 'float', description: 'Duration in seconds.' },
             { name: 'file_name', type: 'string', description: 'Video file name.' },
@@ -113,12 +113,12 @@ export const TOP_LEVEL_KEYWORDS: KeywordDoc[] = [
     {
         name: 'classification',
         description: 'Filter on the image classification annotation.',
-        insertText: 'classification(${1:label == "..."})'
+        insertText: 'classification(${1:label = "..."})'
     },
     {
         name: 'segmentation_mask',
         description: 'Filter on segmentation mask annotations inside an image.',
-        insertText: 'segmentation_mask(${1:label == "..."})'
+        insertText: 'segmentation_mask(${1:label = "..."})'
     }
 ];
 

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
@@ -14,7 +14,7 @@ interface NotExpression extends Expression {
 
 interface ComparisonExpression extends Expression {
   left: Expression;
-  operator: '==' | '!=' | '<' | '>' | '<=' | '>=';
+  operator: '=' | '!=' | '<' | '>' | '<=' | '>=';
   right: Expression;
 }
 
@@ -60,11 +60,11 @@ SampleUnary<isImage> returns Expression:
     | AnnotationQuery;
 
 SampleComparison<isImage> returns ComparisonExpression:
-  SampleIntFieldReference<isImage> {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=IntLiteral
-   | SampleOrdinalFloatFieldReference<isImage> {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=NumericLiteral
-   | SampleEqualityFloatFieldReference<isImage> {ComparisonExpression.left=current} operator=('==' | '!=') right=NumericLiteral
-   | SampleStringFieldReference<isImage> {ComparisonExpression.left=current} operator=('==' | '!=') right=StringLiteral
-   | SampleDateTimeFieldReference<isImage> {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=StringLiteral;
+  SampleIntFieldReference<isImage> {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=IntLiteral
+   | SampleOrdinalFloatFieldReference<isImage> {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=NumericLiteral
+   | SampleEqualityFloatFieldReference<isImage> {ComparisonExpression.left=current} operator=('=' | '!=') right=NumericLiteral
+   | SampleStringFieldReference<isImage> {ComparisonExpression.left=current} operator=('=' | '!=') right=StringLiteral
+   | SampleDateTimeFieldReference<isImage> {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=StringLiteral;
 
 SampleIntFieldReference<isImage> returns FieldReference:
   (<isImage> {FieldReference} member=ImageIntFieldName)
@@ -98,8 +98,8 @@ ObjectDetectionUnary returns Expression:
     | ObjectDetectionComparison;
 
 ObjectDetectionComparison returns ComparisonExpression:
-  ObjectDetectionIntFieldReference {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=IntLiteral
-   | ObjectDetectionStringFieldReference {ComparisonExpression.left=current} operator=('==' | '!=') right=StringLiteral;
+  ObjectDetectionIntFieldReference {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=IntLiteral
+   | ObjectDetectionStringFieldReference {ComparisonExpression.left=current} operator=('=' | '!=') right=StringLiteral;
 
 ObjectDetectionIntFieldReference returns FieldReference:
   {FieldReference} member=ObjectDetectionIntFieldName;
@@ -122,7 +122,7 @@ ClassificationUnary returns Expression:
     | ClassificationComparison;
 
 ClassificationComparison returns ComparisonExpression:
-  ClassificationFieldReference {ComparisonExpression.left=current} operator=('==' | '!=') right=StringLiteral;
+  ClassificationFieldReference {ComparisonExpression.left=current} operator=('=' | '!=') right=StringLiteral;
 
 ClassificationFieldReference returns Expression:
   {FieldReference} member=LABEL;
@@ -142,8 +142,8 @@ SegmentationMaskUnary returns Expression:
     | SegmentationMaskComparison;
 
 SegmentationMaskComparison returns ComparisonExpression:
-  SegmentationMaskIntFieldReference {ComparisonExpression.left=current} operator=('==' | '!=' | '<' | '>' | '<=' | '>=') right=IntLiteral
-   | SegmentationMaskStringFieldReference {ComparisonExpression.left=current} operator=('==' | '!=') right=StringLiteral;
+  SegmentationMaskIntFieldReference {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=IntLiteral
+   | SegmentationMaskStringFieldReference {ComparisonExpression.left=current} operator=('=' | '!=') right=StringLiteral;
 
 SegmentationMaskIntFieldReference returns FieldReference:
   {FieldReference} member=SegmentationMaskIntFieldName;

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -52,22 +52,22 @@ describe('parseLightlyQuery error handling', () => {
 
     const PARSE_FAILURE_CASES: Array<{ name: string; source: string }> = [
         { name: 'empty input', source: '' },
-        { name: 'unknown field', source: 'x == 1' },
-        { name: 'single equals operator', source: 'height = 400' },
-        { name: 'unterminated string literal', source: 'file_name == "cat' },
+        { name: 'unknown field', source: 'x = 1' },
+        { name: 'double equals operator', source: 'height == 400' },
+        { name: 'unterminated string literal', source: 'file_name = "cat' },
         { name: 'unmatched opening paren', source: '(height > 400' },
         { name: 'unmatched closing paren', source: 'height > 400)' },
         { name: 'trailing boolean operator', source: 'height > 400 AND' },
         { name: 'missing right-hand side', source: 'height >' },
-        { name: 'string compared to int field', source: 'height == "tall"' },
+        { name: 'string compared to int field', source: 'height = "tall"' },
         { name: 'obj detection without arguments', source: 'object_detection()' },
-        { name: 'obj detection unknown field', source: 'object_detection(file_name == "a.jpg")' },
+        { name: 'obj detection unknown field', source: 'object_detection(file_name = "a.jpg")' },
         { name: 'segmentation without arguments', source: 'segmentation_mask()' },
         {
             name: 'segmentation unknown field',
-            source: 'segmentation_mask(file_name == "a.jpg")'
+            source: 'segmentation_mask(file_name = "a.jpg")'
         },
-        { name: 'classification unknown field', source: 'classification(x == 0)' },
+        { name: 'classification unknown field', source: 'classification(x = 0)' },
         { name: 'wrong in operator use', source: '"jpg" IN file_name' },
         { name: 'stray punctuation', source: '@@@' }
     ];
@@ -78,7 +78,7 @@ describe('parseLightlyQuery error handling', () => {
     });
 
     it('returns an error result for an invalid datetime literal', () => {
-        const result = parseLightlyQuery(parser, 'created_at == "not-a-date"');
+        const result = parseLightlyQuery(parser, 'created_at = "not-a-date"');
 
         expect(result).toEqual({
             status: 'error',
@@ -181,7 +181,7 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     },
     {
         name: 'image file name equality',
-        source: 'file_name == "cat.jpg"',
+        source: 'file_name = "cat.jpg"',
         expected: query(str('image', 'file_name', '==', 'cat.jpg'))
     },
     {
@@ -205,7 +205,7 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     /* Object detection expression */
     {
         name: 'object detection label',
-        source: 'object_detection(label == "cat")',
+        source: 'object_detection(label = "cat")',
         expected: query(objectDetection(str('object_detection', 'label', '==', 'cat')))
     },
     {
@@ -232,12 +232,12 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     /* Classification expression */
     {
         name: 'classification label',
-        source: 'classification(label == "cat")',
+        source: 'classification(label = "cat")',
         expected: query(classification(str('classification', 'label', '==', 'cat')))
     },
     {
         name: 'segmentation label',
-        source: 'segmentation_mask(label == "cat")',
+        source: 'segmentation_mask(label = "cat")',
         expected: query(segmentationMask(str('segmentation_mask', 'label', '==', 'cat')))
     },
     {
@@ -259,7 +259,7 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     },
     {
         name: 'boolean or',
-        source: 'file_name == "cat.jpg" OR file_name == "dog.jpg"',
+        source: 'file_name = "cat.jpg" OR file_name = "dog.jpg"',
         expected: query(
             or(
                 str('image', 'file_name', '==', 'cat.jpg'),
@@ -286,7 +286,7 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     /* Boolean operators in subexpressions */
     {
         name: 'object detection boolean expression',
-        source: 'object_detection(label == "cat" AND width >= 50 AND height >= 40)',
+        source: 'object_detection(label = "cat" AND width >= 50 AND height >= 40)',
         expected: query(
             objectDetection(
                 and(
@@ -299,7 +299,7 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     },
     {
         name: 'object detection alternatives',
-        source: 'object_detection(label == "cat" OR label == "dog")',
+        source: 'object_detection(label = "cat" OR label = "dog")',
         expected: query(
             objectDetection(
                 or(
@@ -311,12 +311,12 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     },
     {
         name: 'object detection negation',
-        source: 'object_detection(NOT label == "background")',
+        source: 'object_detection(NOT label = "background")',
         expected: query(objectDetection(not(str('object_detection', 'label', '==', 'background'))))
     },
     {
         name: 'segmentation boolean expression',
-        source: 'segmentation_mask(label == "cat" AND width >= 50 AND height >= 40)',
+        source: 'segmentation_mask(label = "cat" AND width >= 50 AND height >= 40)',
         expected: query(
             segmentationMask(
                 and(
@@ -331,7 +331,7 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     /* Additional syntax features */
     {
         name: 'single quoted string',
-        source: "file_name == 'frame-0001.jpg'",
+        source: "file_name = 'frame-0001.jpg'",
         expected: query(str('image', 'file_name', '==', 'frame-0001.jpg'))
     },
     {
@@ -341,7 +341,7 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     },
     {
         name: 'multiline whitespace',
-        source: 'height > 400\nAND "reviewed" IN tags\nAND object_detection(label == "cat")',
+        source: 'height > 400\nAND "reviewed" IN tags\nAND object_detection(label = "cat")',
         expected: query(
             and(
                 int('image', 'height', '>', 400),
@@ -361,7 +361,7 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     /* Complex queries */
     {
         name: 'complex reviewed large cat image',
-        source: 'height > 400 AND width >= 640 AND "reviewed" IN tags AND object_detection(label == "cat" AND width > 80 AND height > 80)',
+        source: 'height > 400 AND width >= 640 AND "reviewed" IN tags AND object_detection(label = "cat" AND width > 80 AND height > 80)',
         expected: query(
             and(
                 int('image', 'height', '>', 400),
@@ -379,7 +379,7 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
     },
     {
         name: 'complex dataset curation query',
-        source: '(file_path_abs != "/datasets/archive/bad.jpg" AND created_at >= "2025-01-01T00:00:00Z") AND ("training" IN tags OR "validation" IN tags) AND object_detection((label == "cat" OR label == "dog") AND NOT (x < 5 OR y < 5))',
+        source: '(file_path_abs != "/datasets/archive/bad.jpg" AND created_at >= "2025-01-01T00:00:00Z") AND ("training" IN tags OR "validation" IN tags) AND object_detection((label = "cat" OR label = "dog") AND NOT (x < 5 OR y < 5))',
         expected: query(
             and(
                 and(

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.ts
@@ -1,7 +1,11 @@
 // Shared contract for translating a parsed query into the backend QueryExpr.
 // Both sides import this module so the request method and result shape stay
 // in sync.
-import type { EqualityComparisonOperator, QueryExpr } from '$lib/api/lightly_studio_local';
+import type {
+    EqualityComparisonOperator,
+    OrdinalComparisonOperator,
+    QueryExpr
+} from '$lib/api/lightly_studio_local';
 import {
     isBooleanExpression,
     isComparisonExpression,
@@ -159,7 +163,7 @@ function visitComparisonExpression(
                     return {
                         type: 'datetime_expr',
                         field: { table, name: fieldName },
-                        operator: expr.operator,
+                        operator: toOrdinalComparisonOperator(expr.operator),
                         value: parseDatetimeLiteral(right.value)
                     };
                 }
@@ -211,7 +215,7 @@ function visitComparisonExpression(
                     return {
                         type: 'integer_expr',
                         field: { table, name: fieldName },
-                        operator: expr.operator,
+                        operator: toOrdinalComparisonOperator(expr.operator),
                         value: right.value
                     };
                 }
@@ -221,7 +225,7 @@ function visitComparisonExpression(
                     return {
                         type: 'ordinal_float_expr',
                         field: { table, name: fieldName },
-                        operator: expr.operator,
+                        operator: toOrdinalComparisonOperator(expr.operator),
                         value: right.value
                     };
                 }
@@ -238,7 +242,7 @@ function visitComparisonExpression(
                     return {
                         type: 'integer_expr',
                         field: { table, name: fieldName },
-                        operator: expr.operator,
+                        operator: toOrdinalComparisonOperator(expr.operator),
                         value: right.value
                     };
                 }
@@ -248,7 +252,7 @@ function visitComparisonExpression(
                     return {
                         type: 'integer_expr',
                         field: { table, name: fieldName },
-                        operator: expr.operator,
+                        operator: toOrdinalComparisonOperator(expr.operator),
                         value: right.value
                     };
                 }
@@ -258,7 +262,7 @@ function visitComparisonExpression(
                     return {
                         type: 'integer_expr',
                         field: { table, name: fieldName },
-                        operator: expr.operator,
+                        operator: toOrdinalComparisonOperator(expr.operator),
                         value: right.value
                     };
                 }
@@ -312,11 +316,34 @@ function toBooleanExprType(operator: string): 'and' | 'or' {
 }
 
 function toEqualityComparisonOperator(operator: string): EqualityComparisonOperator {
-    if (operator === '==' || operator === '!=') {
+    if (operator === '=') {
+        return '==';
+    }
+
+    if (operator === '!=') {
         return operator;
     }
 
     throw new Error(`Unsupported equality operator: ${operator}`);
+}
+
+function toOrdinalComparisonOperator(operator: string): OrdinalComparisonOperator {
+    if (operator === '=') {
+        return '==';
+    }
+
+    if (
+        operator === '==' ||
+        operator === '!=' ||
+        operator === '<' ||
+        operator === '>' ||
+        operator === '<=' ||
+        operator === '>='
+    ) {
+        return operator;
+    }
+
+    throw new Error(`Unsupported ordinal operator: ${operator}`);
 }
 
 function parseDatetimeLiteral(value: string): Date {

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/completionAdapter/completionAdapterEnrichWithSchemaDocs.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/completionAdapter/completionAdapterEnrichWithSchemaDocs.test.ts
@@ -19,7 +19,7 @@ describe('enrichWithSchemaDocs', () => {
         const result = enrichWithSchemaDocs({ label: 'fps' } as never, 'video');
         expect(result.detail).toBe('(field) Video.fps: float');
         expect(result.documentation).toEqual({
-            value: 'Frames per second. Equality only (`==`, `!=`).'
+            value: 'Frames per second. Equality only (`=`, `!=`).'
         });
     });
 

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/syntaxDocumentation/getFieldHover.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/syntaxDocumentation/getFieldHover.test.ts
@@ -40,7 +40,7 @@ describe('getFieldHover', () => {
     it('returns object-detection field hover inside object_detection(...)', async () => {
         const { getFieldHover } = await import('./getFieldHover');
         const model = makeSyntaxDocModel({
-            text: 'object_detection(label == "cat")',
+            text: 'object_detection(label = "cat")',
             wordAtPosition: { word: 'label', startColumn: 18, endColumn: 23 },
             includeGetValue: true,
             includeGetOffsetAt: true

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/syntaxDocumentation/getKeywordHover.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/syntaxDocumentation/getKeywordHover.test.ts
@@ -36,7 +36,7 @@ describe('getKeywordHover', () => {
     it('returns keyword hover for `video:` when Monaco strips trailing colon', async () => {
         const { getKeywordHover } = await import('./getKeywordHover');
         const model = makeSyntaxDocModel({
-            text: 'video: fps == 30',
+            text: 'video: fps = 30',
             wordAtPosition: { word: 'video', startColumn: 1, endColumn: 6 },
             includeGetValueInRange: true
         });

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/useSyntaxCompletion.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/useSyntaxCompletion.test.ts
@@ -399,7 +399,7 @@ describe('useSyntaxCompletion', () => {
 
         expect(result.suggestions[0].detail).toBe('(field) Video.fps: float');
         expect(result.suggestions[0].documentation).toEqual({
-            value: 'Frames per second. Equality only (`==`, `!=`).'
+            value: 'Frames per second. Equality only (`=`, `!=`).'
         });
     });
 
@@ -458,7 +458,7 @@ describe('useSyntaxCompletion', () => {
             { label: 'label', kind: LspCompletionItemKind.Field }
         ]);
         const result = await provideCompletionItems(
-            makeModel('segmentation_mask(label == "road" AND width > 10)') as never,
+            makeModel('segmentation_mask(label = "road" AND width > 10)') as never,
             { lineNumber: 1, column: 41 } as never
         );
 

--- a/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { ComponentProps } from 'svelte';
     import QueryEditor from '$lib/components/QueryEditor/QueryEditor.svelte';
+    import Typography from '$lib/components/Typography/Typography.svelte';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
 
     type OnSaveHandler = ComponentProps<typeof QueryEditor>['onSave'];
@@ -21,6 +22,30 @@
     };
 </script>
 
-<div class="flex h-full flex-1 flex-col rounded-[1vw] bg-card p-4">
+<div class="flex h-full min-w-0 flex-1 flex-col rounded-[1vw] bg-card p-4">
+    <div class="mb-3 min-w-0">
+        <Typography variant="h5" component="h2" className="text-foreground">Query Filter</Typography
+        >
+        <Typography
+            variant="body2"
+            component="div"
+            className="mt-1 min-w-0 break-words text-muted-foreground [&_code]:break-all"
+        >
+            <p>Write a query expression to filter your dataset. Available syntax:</p>
+            <ul class="my-1 ml-4 list-disc space-y-1">
+                <li>Logical operations: <code>AND</code>, <code>OR</code>, <code>NOT</code></li>
+                <li>
+                    Image fields: <code>file_name</code>, <code>file_path_abs</code>,
+                    <code>width</code>, <code>height</code>, <code>created_at</code>
+                </li>
+                <li>Tag membership: <code>"tag_name" IN tags</code></li>
+                <li>
+                    Annotation conditions: <code>segmentation_mask(…)</code>,
+                    <code>object_detection(…)</code>, <code>classification(…)</code>
+                </li>
+            </ul>
+            <p>Tip: Completion hints will show as you type a space or a left parenthesis.</p>
+        </Typography>
+    </div>
     <QueryEditor height="100%" onSave={handleQueryEditorValueChange} />
 </div>


### PR DESCRIPTION
## What has changed and why?
SQL has =, Python has ==, we want the grammar to be as close to SQL syntax as possible.

## How has it been tested?
Modified tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated query syntax to use single equals (`=`) instead of double equals (`==`) for equality comparisons in sample, object detection, classification, and segmentation mask queries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1098)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->