### PR TITLE
Add an explainer paragraph above the query editor

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
@@ -6,10 +6,10 @@
     import { useQueryEditor } from './useQueryEditor';
     import type { QueryExprTranslationResult } from './language/query-expr-translation';
 
-    const LIGHTLY_QUERY_DEFAULT_VALUE = `# Example query, change according to your needs
+    const LIGHTLY_QUERY_DEFAULT_VALUE = `# Example query
 width < 500
 AND "reviewed" IN tags
-AND object_detection(label == "person" AND x > 10
+AND object_detection(label == "person" AND x > 10)
 `;
 
     interface QueryEditorProps {

--- a/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
@@ -6,8 +6,11 @@
     import { useQueryEditor } from './useQueryEditor';
     import type { QueryExprTranslationResult } from './language/query-expr-translation';
 
-    const LIGHTLY_QUERY_DEFAULT_VALUE = `width > 1920 AND ("reviewed" IN tags)
-AND object_detection(label == "car" and x > 10)`;
+    const LIGHTLY_QUERY_DEFAULT_VALUE = `# Example query, change according to your needs
+width < 500
+AND "reviewed" IN tags
+AND object_detection(label == "person" AND x > 10
+`;
 
     interface QueryEditorProps {
         value?: string;

--- a/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { ComponentProps } from 'svelte';
     import QueryEditor from '$lib/components/QueryEditor/QueryEditor.svelte';
+    import Typography from '$lib/components/Typography/Typography.svelte';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
 
     type OnSaveHandler = ComponentProps<typeof QueryEditor>['onSave'];
@@ -21,12 +22,17 @@
     };
 </script>
 
-<div class="flex h-full flex-1 flex-col rounded-[1vw] bg-card p-4">
-    <div class="mb-3">
-        <h2 class="text-lg font-semibold text-foreground">Query Filter</h2>
-        <div class="mt-1 text-sm text-muted-foreground">
+<div class="flex h-full min-w-0 flex-1 flex-col rounded-[1vw] bg-card p-4">
+    <div class="mb-3 min-w-0">
+        <Typography variant="h5" component="h2" className="text-foreground">Query Filter</Typography
+        >
+        <Typography
+            variant="body2"
+            component="div"
+            className="mt-1 min-w-0 break-words text-muted-foreground [&_code]:break-all"
+        >
             <p>Write a query expression to filter your dataset. Available syntax:</p>
-            <ul class="my-1.5 ml-4 list-disc space-y-1.5">
+            <ul class="my-1 ml-4 list-disc space-y-1">
                 <li>Logical operations: <code>AND</code>, <code>OR</code>, <code>NOT</code></li>
                 <li>
                     Image fields: <code>file_name</code>, <code>file_name_abs</code>,
@@ -39,7 +45,7 @@
                 </li>
             </ul>
             <p>Tip: Completion hints will show as you type a space or a left parenthesis.</p>
-        </div>
+        </Typography>
     </div>
     <QueryEditor height="100%" onSave={handleQueryEditorValueChange} />
 </div>

--- a/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
@@ -35,7 +35,7 @@
             <ul class="my-1 ml-4 list-disc space-y-1">
                 <li>Logical operations: <code>AND</code>, <code>OR</code>, <code>NOT</code></li>
                 <li>
-                    Image fields: <code>file_name</code>, <code>file_name_abs</code>,
+                    Image fields: <code>file_name</code>, <code>file_path_abs</code>,
                     <code>width</code>, <code>height</code>, <code>created_at</code>
                 </li>
                 <li>Tag membership: <code>"tag_name" IN tags</code></li>

--- a/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
@@ -34,11 +34,11 @@
                 </li>
                 <li>Tag membership: <code>"tag_name" IN tags</code></li>
                 <li>
-                    Annotation conditions: <code>segmentation_mask(...)</code>,
-                    <code>object_detection(...)</code>, <code>classification(...)</code>
+                    Annotation conditions: <code>segmentation_mask(…)</code>,
+                    <code>object_detection(…)</code>, <code>classification(…)</code>
                 </li>
             </ul>
-            <p>Tip: Completion hints will show up as you type a space or a left parenthesis.</p>
+            <p>Tip: Completion hints will show as you type a space or a left parenthesis.</p>
         </div>
     </div>
     <QueryEditor height="100%" onSave={handleQueryEditorValueChange} />

--- a/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
@@ -22,5 +22,24 @@
 </script>
 
 <div class="flex h-full flex-1 flex-col rounded-[1vw] bg-card p-4">
+    <div class="mb-3">
+        <h2 class="text-lg font-semibold text-foreground">Query Filter</h2>
+        <div class="mt-1 text-sm text-muted-foreground">
+            <p>Write a query expression to filter your dataset. Available syntax:</p>
+            <ul class="my-1.5 ml-4 list-disc space-y-1.5">
+                <li>Logical operations: <code>AND</code>, <code>OR</code>, <code>NOT</code></li>
+                <li>
+                    Image fields: <code>file_name</code>, <code>file_name_abs</code>,
+                    <code>width</code>, <code>height</code>, <code>created_at</code>
+                </li>
+                <li>Tag membership: <code>"tag_name" IN tags</code></li>
+                <li>
+                    Annotation conditions: <code>segmentation_mask(...)</code>,
+                    <code>object_detection(...)</code>, <code>classification(...)</code>
+                </li>
+            </ul>
+            <p>Tip: Completion hints will show up as you type a space or a left parenthesis.</p>
+        </div>
+    </div>
     <QueryEditor height="100%" onSave={handleQueryEditorValueChange} />
 </div>


### PR DESCRIPTION
## What has changed and why?

Add an explainer paragraph above the query editor.

Also adjusted the default query.

## How has it been tested?

Manually:

<img width="496" height="517" alt="Screenshot 2026-05-12 at 11 44 43" src="https://github.com/user-attachments/assets/0b118300-59f5-4118-94e7-48e96b7128b5" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Query Filter" help section above the query editor with usage guidance, supported syntax examples, and a tip about completion hints.

* **Documentation**
  * Updated the default query example to a multi-line sample demonstrating tag filters and an object-detection condition for "person".

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1099)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->