### PR TITLE
Do not overflow docs tooltips

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.test.ts
@@ -129,6 +129,18 @@ describe('useQueryEditor', () => {
         );
     });
 
+    it('uses fixed overflow widgets so hover docs are not clipped at the top edge', () => {
+        const { mount } = useQueryEditor();
+        const el = document.createElement('div');
+
+        mount(el, { value: '' });
+
+        expect(mocks.editorCreate).toHaveBeenCalledWith(
+            el,
+            expect.objectContaining({ fixedOverflowWidgets: true })
+        );
+    });
+
     it('publishes model changes back through onChange', () => {
         const { mount } = useQueryEditor();
         const el = document.createElement('div');

--- a/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
@@ -64,7 +64,8 @@ export const useQueryEditor = () => {
             automaticLayout: true,
             readOnly: options.readOnly ?? false,
             minimap: { enabled: false },
-            wordWrap: 'on'
+            wordWrap: 'on',
+            fixedOverflowWidgets: true
         });
 
         const detachLanguage = language.attach(model);


### PR DESCRIPTION
## What has changed and why?
Especially for first line words, they appeared above the word and were thus hidden.

## How has it been tested?
Manually, also added a test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query editor hover documentation display by preventing clipping at the top edge of the viewport.

* **Tests**
  * Added a test verifying the query editor’s overflow widget behavior to ensure hover documentation displays correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1101)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1101)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->