### PR TITLE
Highlight string literals in query editor

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
@@ -10,6 +10,33 @@ import { useSyntaxDocumentation } from './useLightlyQueryLanguage/useSyntaxDocum
 const LIGHTLY_QUERY_LANGUAGE_ID = 'lightly-query';
 const LIGHTLY_QUERY_THEME_ID = 'lightly-query-theme';
 
+/** Regex source for the STRING terminal in the generated Monarch grammar. */
+const STRING_REGEX_SOURCE = `"([^"\\\\\\n\\r]|\\\\.)*"|'([^'\\\\\\n\\r]|\\\\.)*'`;
+
+/**
+ * Patch the generated Monarch config so that quoted strings use the
+ * `string.quoted` token instead of the generic `string` token.
+ * This lets us style them differently from field-name keywords.
+ */
+const patchStringToken = (
+    config: monaco.languages.IMonarchLanguage
+): monaco.languages.IMonarchLanguage => {
+    const patched = structuredClone(config);
+    const tokenizer = (patched as Record<string, unknown>).tokenizer as
+        | Record<string, Array<{ regex: RegExp; action: { token: string } }>>
+        | undefined;
+    const rules = tokenizer?.initial;
+    if (rules) {
+        for (const rule of rules) {
+            if (rule.regex?.source === STRING_REGEX_SOURCE) {
+                rule.action = { token: 'string.quoted' };
+                break;
+            }
+        }
+    }
+    return patched;
+};
+
 self.MonacoEnvironment = {
     getWorker() {
         return new editorWorker();
@@ -29,14 +56,17 @@ const setupMonaco = () => {
     monaco.languages.register({ id: LIGHTLY_QUERY_LANGUAGE_ID });
     monaco.languages.setMonarchTokensProvider(
         LIGHTLY_QUERY_LANGUAGE_ID,
-        lightlyQueryMonarch as monaco.languages.IMonarchLanguage
+        patchStringToken(lightlyQueryMonarch as monaco.languages.IMonarchLanguage)
     );
     useSyntaxDocumentation({ languageId: LIGHTLY_QUERY_LANGUAGE_ID });
     useSyntaxCompletion({ languageId: LIGHTLY_QUERY_LANGUAGE_ID });
     monaco.editor.defineTheme(LIGHTLY_QUERY_THEME_ID, {
         base: 'vs-dark',
         inherit: true,
-        rules: [],
+        rules: [
+            { token: 'string', foreground: '569cd6' },
+            { token: 'string.quoted', foreground: 'ce9178' }
+        ],
         colors: {}
     });
     monacoSetupDone = true;


### PR DESCRIPTION
## What has changed and why?

Highlight quoted string orange and regular keywords blue in the query editor.

The implementation is slightly custom (hacky), it is apparently not easy to emit a different token from Langium.

## How has it been tested?

- Manually

<img width="467" height="115" alt="Screenshot 2026-05-12 at 13 58 01" src="https://github.com/user-attachments/assets/3951c31d-f342-4706-99cf-51768363b9f5" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced syntax highlighting in the query editor with improved visual distinction for quoted strings and better tokenization accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1102)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->