### PR TITLE
Add ImageDatasetEvaluate.classification

### DIFF
--- a/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
+++ b/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
@@ -28,6 +28,13 @@ class ObjectDetectionEvaluationConfig(BaseModel):
     iou_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
 
 
+class ClassificationEvaluationConfig(BaseModel):
+    """Configuration for classification evaluation runs.
+
+    Currently has no fields. Placeholder for future task-specific options.
+    """
+
+
 class ImageDatasetEvaluate:
     """Task-specific evaluation entry points for image datasets.
 
@@ -92,6 +99,54 @@ class ImageDatasetEvaluate:
                 gt_annotation_collection_id=gt_collection_id,
                 pred_annotation_collection_id=pred_collection_id,
                 task_type=EvaluationTaskType.OBJECT_DETECTION,
+                config_json=config.model_dump(),
+            ),
+        )
+        return {}
+
+    def classification(
+        self,
+        name: str,
+        gt_collection_name: str,
+        pred_collection_name: str,
+        config: ClassificationEvaluationConfig | None = None,
+    ) -> Mapping[str, float]:
+        """Create a classification evaluation run.
+
+        For now, this method only persists an ``EvaluationRun`` entry.
+        Metric computation and metric persistence are intentionally deferred.
+
+        Args:
+            name: Display name of the evaluation run.
+            gt_collection_name: Name of the annotation collection containing ground truth labels.
+            pred_collection_name: Name of the annotation collection containing predictions.
+            config: Optional classification evaluation config. If omitted,
+                defaults are used.
+
+        Returns:
+            Empty mapping for now. Future implementations can return aggregate
+            metrics once metric computation is enabled.
+        """
+        config = config or ClassificationEvaluationConfig()
+        gt_collection_id = resolve_and_validate_collection(
+            session=self.session,
+            collection_id=self.collection_id,
+            collection_name=gt_collection_name,
+            task_type=EvaluationTaskType.CLASSIFICATION,
+        )
+        pred_collection_id = resolve_and_validate_collection(
+            session=self.session,
+            collection_id=self.collection_id,
+            collection_name=pred_collection_name,
+            task_type=EvaluationTaskType.CLASSIFICATION,
+        )
+        evaluation_run_resolver.create(
+            session=self.session,
+            evaluation_run_input=EvaluationRunCreate(
+                name=name,
+                gt_annotation_collection_id=gt_collection_id,
+                pred_annotation_collection_id=pred_collection_id,
+                task_type=EvaluationTaskType.CLASSIFICATION,
                 config_json=config.model_dump(),
             ),
         )

--- a/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
+++ b/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
@@ -169,7 +169,18 @@ class ImageDatasetEvaluate:
     ) -> tuple[UUID, UUID, EvaluationRunTable]:
         """Validate gt + pred collections and persist the evaluation run.
 
-        Returns the resolved gt collection id, pred collection id, and the created run.
+        Args:
+            name: Display name of the evaluation run.
+            gt_collection_name: Name of the annotation collection containing ground
+                truth labels.
+            pred_collection_name: Name of the annotation collection containing
+                predictions.
+            task_type: Evaluation task type; determines the expected annotation type
+                for both collections and is stored on the run.
+            config_json: Task-specific configuration to persist on the run.
+
+        Returns:
+            Tuple of (gt_collection_id, pred_collection_id, evaluation_run).
         """
         gt_collection_id = resolve_and_validate_collection(
             session=self.session,

--- a/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
+++ b/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -14,6 +15,7 @@ from lightly_studio.evaluation.validators import resolve_and_validate_collection
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.evaluation_run import (
     EvaluationRunCreate,
+    EvaluationRunTable,
     EvaluationTaskType,
 )
 from lightly_studio.resolvers import (
@@ -81,27 +83,12 @@ class ImageDatasetEvaluate:
                 defaults are used.
         """
         config = config or ObjectDetectionEvaluationConfig()
-        gt_collection_id = resolve_and_validate_collection(
-            session=self.session,
-            collection_id=self.collection_id,
-            collection_name=gt_collection_name,
+        gt_collection_id, pred_collection_id, evaluation_run = self._create_evaluation_run(
+            name=name,
+            gt_collection_name=gt_collection_name,
+            pred_collection_name=pred_collection_name,
             task_type=EvaluationTaskType.OBJECT_DETECTION,
-        )
-        pred_collection_id = resolve_and_validate_collection(
-            session=self.session,
-            collection_id=self.collection_id,
-            collection_name=pred_collection_name,
-            task_type=EvaluationTaskType.OBJECT_DETECTION,
-        )
-        evaluation_run = evaluation_run_resolver.create(
-            session=self.session,
-            evaluation_run_input=EvaluationRunCreate(
-                name=name,
-                gt_annotation_collection_id=gt_collection_id,
-                pred_annotation_collection_id=pred_collection_id,
-                task_type=EvaluationTaskType.OBJECT_DETECTION,
-                config_json=config.model_dump(),
-            ),
+            config_json=config.model_dump(),
         )
 
         selected_sample_ids = {sample.sample_id for sample in self.samples}
@@ -164,28 +151,49 @@ class ImageDatasetEvaluate:
                 defaults are used.
         """
         config = config or ClassificationEvaluationConfig()
+        self._create_evaluation_run(
+            name=name,
+            gt_collection_name=gt_collection_name,
+            pred_collection_name=pred_collection_name,
+            task_type=EvaluationTaskType.CLASSIFICATION,
+            config_json=config.model_dump(),
+        )
+
+    def _create_evaluation_run(
+        self,
+        name: str,
+        gt_collection_name: str,
+        pred_collection_name: str,
+        task_type: EvaluationTaskType,
+        config_json: dict[str, Any],
+    ) -> tuple[UUID, UUID, EvaluationRunTable]:
+        """Validate gt + pred collections and persist the evaluation run.
+
+        Returns the resolved gt collection id, pred collection id, and the created run.
+        """
         gt_collection_id = resolve_and_validate_collection(
             session=self.session,
             collection_id=self.collection_id,
             collection_name=gt_collection_name,
-            task_type=EvaluationTaskType.CLASSIFICATION,
+            task_type=task_type,
         )
         pred_collection_id = resolve_and_validate_collection(
             session=self.session,
             collection_id=self.collection_id,
             collection_name=pred_collection_name,
-            task_type=EvaluationTaskType.CLASSIFICATION,
+            task_type=task_type,
         )
-        evaluation_run_resolver.create(
+        evaluation_run = evaluation_run_resolver.create(
             session=self.session,
             evaluation_run_input=EvaluationRunCreate(
                 name=name,
                 gt_annotation_collection_id=gt_collection_id,
                 pred_annotation_collection_id=pred_collection_id,
-                task_type=EvaluationTaskType.CLASSIFICATION,
-                config_json=config.model_dump(),
+                task_type=task_type,
+                config_json=config_json,
             ),
         )
+        return gt_collection_id, pred_collection_id, evaluation_run
 
     @staticmethod
     def _group_by_parent_sample_id(

--- a/lightly_studio/src/lightly_studio/evaluation/validators.py
+++ b/lightly_studio/src/lightly_studio/evaluation/validators.py
@@ -15,6 +15,7 @@ from lightly_studio.resolvers import collection_resolver
 
 _TASK_TO_ANNOTATION_TYPE: dict[EvaluationTaskType, AnnotationType] = {
     EvaluationTaskType.OBJECT_DETECTION: AnnotationType.OBJECT_DETECTION,
+    EvaluationTaskType.CLASSIFICATION: AnnotationType.CLASSIFICATION,
 }
 
 

--- a/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
+++ b/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import pytest
 
 from lightly_studio.core.image.image_dataset import ImageDataset
-from lightly_studio.evaluation.image_dataset_evaluate import ObjectDetectionEvaluationConfig
+from lightly_studio.evaluation.image_dataset_evaluate import (
+    ClassificationEvaluationConfig,
+    ObjectDetectionEvaluationConfig,
+)
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.evaluation_run import EvaluationTaskType
@@ -90,6 +93,87 @@ def test_object_detection_evaluation__raises_on_wrong_annotation_type(
 
     with pytest.raises(ValueError, match="object_detection"):
         dataset.evaluate().object_detection(
+            name="run-1",
+            gt_collection_name="gt",
+            pred_collection_name="pred",
+        )
+
+
+def test_classification_evaluation(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Creates an evaluation run for classification and no sample metrics yet."""
+    dataset = ImageDataset.create(name="test_dataset")
+    collection_resolver.get_or_create_child_collection(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+        name="gt",
+    )
+    collection_resolver.get_or_create_child_collection(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+        name="pred",
+    )
+
+    metrics = dataset.evaluate().classification(
+        name="run-1",
+        gt_collection_name="gt",
+        pred_collection_name="pred",
+        config=ClassificationEvaluationConfig(),
+    )
+
+    assert metrics == {}
+
+    evaluation_runs = evaluation_run_resolver.get_all_by_dataset_id(
+        session=dataset.session,
+        dataset_id=dataset.dataset_id,
+    )
+    assert len(evaluation_runs) == 1
+    assert evaluation_runs[0].name == "run-1"
+    assert evaluation_runs[0].task_type == EvaluationTaskType.CLASSIFICATION
+    assert evaluation_runs[0].config_json == {}
+
+    sample_metrics = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(
+        session=dataset.session,
+        evaluation_run_id=evaluation_runs[0].id,
+    )
+    assert sample_metrics == []
+
+
+def test_classification_evaluation__raises_on_wrong_annotation_type(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Raises ValueError when a collection contains non-classification annotations."""
+    dataset = ImageDataset.create(name="test_dataset")
+    label = create_annotation_label(
+        session=dataset.session, root_collection_id=dataset.collection_id
+    )
+    image = create_image(session=dataset.session, collection_id=dataset.collection_id)
+    collection_resolver.get_or_create_child_collection(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+        name="gt",
+    )
+    collection_resolver.get_or_create_child_collection(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+        name="pred",
+    )
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_collection_name="gt",
+    )
+
+    with pytest.raises(ValueError, match="classification"):
+        dataset.evaluate().classification(
             name="run-1",
             gt_collection_name="gt",
             pred_collection_name="pred",

--- a/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
+++ b/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from uuid import UUID
+
 import pytest
+from sqlmodel import Session
 
 from lightly_studio.core.image.image_dataset import ImageDataset
 from lightly_studio.evaluation.image_dataset_evaluate import (
@@ -28,18 +31,7 @@ def test_object_detection_evaluation(
         root_collection_id=dataset.collection_id,
     )
     image = create_image(session=dataset.session, collection_id=dataset.collection_id)
-    collection_resolver.get_or_create_child_collection(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="gt",
-    )
-    collection_resolver.get_or_create_child_collection(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="pred",
-    )
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
     # This GT box overlaps the first prediction and should count as one TP.
     create_annotation(
         session=dataset.session,
@@ -111,18 +103,7 @@ def test_object_detection_evaluation__raises_on_wrong_annotation_type(
         session=dataset.session, root_collection_id=dataset.collection_id
     )
     image = create_image(session=dataset.session, collection_id=dataset.collection_id)
-    collection_resolver.get_or_create_child_collection(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="gt",
-    )
-    collection_resolver.get_or_create_child_collection(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="pred",
-    )
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
     create_annotation(
         session=dataset.session,
         collection_id=dataset.collection_id,
@@ -164,18 +145,7 @@ def test_object_detection_evaluation__filters_to_samples_covered_by_both_collect
         collection_id=dataset.collection_id,
         file_path_abs="/path/to/uncovered.png",
     )
-    collection_resolver.get_or_create_child_collection(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="gt",
-    )
-    collection_resolver.get_or_create_child_collection(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="pred",
-    )
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
     create_annotation(
         session=dataset.session,
         collection_id=dataset.collection_id,
@@ -215,18 +185,7 @@ def test_classification_evaluation(
 ) -> None:
     """Creates an evaluation run for classification and no sample metrics yet."""
     dataset = ImageDataset.create(name="test_dataset")
-    collection_resolver.get_or_create_child_collection(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="gt",
-    )
-    collection_resolver.get_or_create_child_collection(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="pred",
-    )
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
 
     dataset.evaluate().classification(
         name="run-1",
@@ -260,18 +219,7 @@ def test_classification_evaluation__raises_on_wrong_annotation_type(
         session=dataset.session, root_collection_id=dataset.collection_id
     )
     image = create_image(session=dataset.session, collection_id=dataset.collection_id)
-    collection_resolver.get_or_create_child_collection(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="gt",
-    )
-    collection_resolver.get_or_create_child_collection(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="pred",
-    )
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
     create_annotation(
         session=dataset.session,
         collection_id=dataset.collection_id,
@@ -286,4 +234,21 @@ def test_classification_evaluation__raises_on_wrong_annotation_type(
             name="run-1",
             gt_collection_name="gt",
             pred_collection_name="pred",
+        )
+
+
+def _create_gt_and_pred_collections(session: Session, collection_id: UUID) -> None:
+    """Create child 'gt' and 'pred' annotation collections under the parent collection.
+
+    Args:
+        session: Database session used by resolver calls.
+        collection_id: ID of the parent collection under which the child collections
+            are created.
+    """
+    for name in ("gt", "pred"):
+        collection_resolver.get_or_create_child_collection(
+            session=session,
+            collection_id=collection_id,
+            sample_type=SampleType.ANNOTATION,
+            name=name,
         )


### PR DESCRIPTION
## What has changed and why?

Adds the `ImageDatasetEvaluate.classification()` method. Atm, it only creates an EvaluationRunCreate. Will create the sample information in another issue. This is the classification equivalent of https://github.com/lightly-ai/lightly-studio/pull/1079/changes adding the same for object detection.

## How has it been tested?

New unittests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added classification evaluation for image datasets; evaluation runs for classification can be created and persisted (no per-sample metrics produced yet).
* **Refactor**
  * Centralized evaluation-run creation and collection resolution/validation across task types.
* **Tests**
  * Added tests for classification evaluation and for rejecting wrong annotation types during validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1105)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->