### PR TITLE
annotation_resolver.get_all_by_parent_sample_ids: add extra filters

### DIFF
--- a/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
+++ b/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import Any
 from uuid import UUID
 
@@ -12,7 +12,7 @@ from sqlmodel import Session
 from lightly_studio.core.image.image_sample import ImageSample
 from lightly_studio.evaluation import object_detection_metric
 from lightly_studio.evaluation.validators import resolve_and_validate_collection
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
 from lightly_studio.models.evaluation_run import (
     EvaluationRunCreate,
     EvaluationRunTable,
@@ -20,6 +20,7 @@ from lightly_studio.models.evaluation_run import (
 )
 from lightly_studio.resolvers import (
     annotation_collection_coverage_resolver,
+    annotation_resolver,
     evaluation_run_resolver,
 )
 
@@ -107,15 +108,17 @@ class ImageDatasetEvaluate:
         selected_sample_ids &= gt_covered_sample_ids & pred_covered_sample_ids
         # TODO(Horatiu, 05/2026): if the number of annotations per sample is large, we may want
         # to avoid loading them all into memory at once and instead stream them in batches.
-        gt_annotations = object_detection_metric.get_object_detection_annotations(
+        gt_annotations = annotation_resolver.get_all_by_parent_sample_ids(
             session=self.session,
-            collection_id=gt_collection_id,
-            sample_ids=selected_sample_ids,
+            parent_sample_ids=list(selected_sample_ids),
+            annotation_type=AnnotationType.OBJECT_DETECTION,
+            annotation_collection_id=gt_collection_id,
         )
-        pred_annotations = object_detection_metric.get_object_detection_annotations(
+        pred_annotations = annotation_resolver.get_all_by_parent_sample_ids(
             session=self.session,
-            collection_id=pred_collection_id,
-            sample_ids=selected_sample_ids,
+            parent_sample_ids=list(selected_sample_ids),
+            annotation_type=AnnotationType.OBJECT_DETECTION,
+            annotation_collection_id=pred_collection_id,
         )
 
         gt_per_sample = self._group_by_parent_sample_id(annotations=gt_annotations)
@@ -208,7 +211,7 @@ class ImageDatasetEvaluate:
 
     @staticmethod
     def _group_by_parent_sample_id(
-        annotations: list[AnnotationBaseTable],
+        annotations: Sequence[AnnotationBaseTable],
     ) -> dict[UUID, list[AnnotationBaseTable]]:
         """Group annotation rows by their parent image sample id."""
         grouped: dict[UUID, list[AnnotationBaseTable]] = {}

--- a/lightly_studio/src/lightly_studio/evaluation/object_detection_metric.py
+++ b/lightly_studio/src/lightly_studio/evaluation/object_detection_metric.py
@@ -10,9 +10,9 @@ import numpy as np
 from numpy.typing import NDArray
 from sqlmodel import Session
 
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
-from lightly_studio.resolvers import annotation_resolver, evaluation_sample_metric_resolver
+from lightly_studio.resolvers import evaluation_sample_metric_resolver
 
 SAMPLE_BATCH_SIZE = 32  # Number of samples to process in a single batch
 
@@ -140,26 +140,6 @@ def match_image(
         ),
         iou_threshold=iou_threshold,
     )
-
-
-def get_object_detection_annotations(
-    session: Session,
-    collection_id: UUID,
-    sample_ids: set[UUID],
-) -> list[AnnotationBaseTable]:
-    """Return object-detection annotations for selected parent samples."""
-    if not sample_ids:
-        return []
-    annotations = annotation_resolver.get_all_by_parent_sample_ids(
-        session=session,
-        parent_sample_ids=list(sample_ids),
-    )
-    return [
-        annotation
-        for annotation in annotations
-        if annotation.sample.collection_id == collection_id
-        and annotation.annotation_type == AnnotationType.OBJECT_DETECTION
-    ]
 
 
 def create_and_persist_object_detection_metrics_per_sample(  # noqa: PLR0913

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_by_parent_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_by_parent_sample_ids.py
@@ -7,16 +7,29 @@ from uuid import UUID
 
 from sqlmodel import Session, col, func, select
 
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
 from lightly_studio.models.image import ImageTable
+from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.video import VideoFrameTable, VideoTable
 
 
 def get_all_by_parent_sample_ids(
     session: Session,
     parent_sample_ids: Sequence[UUID],
+    annotation_type: AnnotationType | None = None,
+    annotation_collection_id: UUID | None = None,
 ) -> Sequence[AnnotationBaseTable]:
-    """Get all annotations belonging to the provided parent sample IDs."""
+    """Get all annotations belonging to the provided parent sample IDs.
+
+    Args:
+        session: SQLAlchemy session.
+        parent_sample_ids: Parent sample IDs to fetch annotations for.
+        annotation_type: If set, only annotations of this type are returned.
+        annotation_collection_id: If set, only annotations belonging to this
+            annotation collection are returned.
+    """
+    if not parent_sample_ids:
+        return []
     annotations_statement = (
         select(AnnotationBaseTable)
         .outerjoin(
@@ -35,4 +48,13 @@ def get_all_by_parent_sample_ids(
             col(AnnotationBaseTable.sample_id).asc(),
         )
     )
+    if annotation_type is not None:
+        annotations_statement = annotations_statement.where(
+            col(AnnotationBaseTable.annotation_type) == annotation_type
+        )
+    if annotation_collection_id is not None:
+        annotations_statement = annotations_statement.join(
+            SampleTable,
+            col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
+        ).where(col(SampleTable.collection_id) == annotation_collection_id)
     return session.exec(annotations_statement).all()

--- a/lightly_studio/tests/resolvers/annotations/test_get_all_by_parent_sample_ids.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_all_by_parent_sample_ids.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from sqlmodel import Session
 
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.resolvers import annotation_resolver
 from tests.helpers_resolvers import (
     AnnotationDetails,
+    create_annotation,
     create_annotation_label,
     create_annotations,
     create_collection,
@@ -75,3 +77,67 @@ def test_get_all_by_parent_sample_ids_with_no_parent_sample_ids_returns_empty_re
     )
 
     assert result == []
+
+
+def test_get_all_by_parent_sample_ids__filters_by_annotation_type(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    od_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+
+    result = annotation_resolver.get_all_by_parent_sample_ids(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+    assert [annotation.sample_id for annotation in result] == [od_annotation.sample_id]
+
+
+def test_get_all_by_parent_sample_ids__filters_by_annotation_collection_id(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    annotation_in_gt = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name="gt",
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name="pred",
+    )
+
+    result = annotation_resolver.get_all_by_parent_sample_ids(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_collection_id=annotation_in_gt.sample.collection_id,
+    )
+    assert [annotation.sample_id for annotation in result] == [annotation_in_gt.sample_id]


### PR DESCRIPTION
## What has changed and why?

`annotation_resolver.get_all_by_parent_sample_ids` now accepts optional `annotation_type` and `annotation_collection_id` filters, applied in SQL via a JOIN on `SampleTable`. This replaces the inefficient client-side filtering inside `evaluation/object_detection_metric.get_object_detection_annotations`.

`get_object_detection_annotations` is deleted; `image_dataset_evaluate.object_detection()` now calls the resolver directly with the new filters.

This also prepares upcoming classification per-sample metrics needing to fetch annotations scoped by both annotation type and annotation collection. It can reuse the updated resolver.

## How has it been tested?

Two new tests, one per filter. 

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved object-detection annotation retrieval with enhanced filtering capabilities by annotation type and collection, enabling more flexible data queries while maintaining existing functionality.

* **Tests**
  * Added comprehensive test coverage for annotation filtering by type and collection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1108)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->