### PR TITLE
Move get_object_detection_annotations query to a resolver function

### DIFF
--- a/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
+++ b/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import Any
 from uuid import UUID
 
@@ -12,7 +12,7 @@ from sqlmodel import Session
 from lightly_studio.core.image.image_sample import ImageSample
 from lightly_studio.evaluation import object_detection_metric
 from lightly_studio.evaluation.validators import resolve_and_validate_collection
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
 from lightly_studio.models.evaluation_run import (
     EvaluationRunCreate,
     EvaluationRunTable,
@@ -20,6 +20,7 @@ from lightly_studio.models.evaluation_run import (
 )
 from lightly_studio.resolvers import (
     annotation_collection_coverage_resolver,
+    annotation_resolver,
     evaluation_run_resolver,
 )
 
@@ -124,15 +125,17 @@ class ImageDatasetEvaluate:
         selected_sample_ids &= gt_covered_sample_ids & pred_covered_sample_ids
         # TODO(Horatiu, 05/2026): if the number of annotations per sample is large, we may want
         # to avoid loading them all into memory at once and instead stream them in batches.
-        gt_annotations = object_detection_metric.get_object_detection_annotations(
+        gt_annotations = annotation_resolver.get_all_by_collection_id_and_parent_sample_ids(
             session=self.session,
-            collection_id=gt_collection_id,
-            sample_ids=selected_sample_ids,
+            parent_sample_ids=list(selected_sample_ids),
+            annotation_collection_id=gt_collection_id,
+            annotation_type=AnnotationType.OBJECT_DETECTION,
         )
-        pred_annotations = object_detection_metric.get_object_detection_annotations(
+        pred_annotations = annotation_resolver.get_all_by_collection_id_and_parent_sample_ids(
             session=self.session,
-            collection_id=pred_collection_id,
-            sample_ids=selected_sample_ids,
+            parent_sample_ids=list(selected_sample_ids),
+            annotation_collection_id=pred_collection_id,
+            annotation_type=AnnotationType.OBJECT_DETECTION,
         )
 
         gt_per_sample = self._group_by_parent_sample_id(annotations=gt_annotations)
@@ -230,7 +233,7 @@ class ImageDatasetEvaluate:
 
     @staticmethod
     def _group_by_parent_sample_id(
-        annotations: list[AnnotationBaseTable],
+        annotations: Sequence[AnnotationBaseTable],
     ) -> dict[UUID, list[AnnotationBaseTable]]:
         """Group annotation rows by their parent image sample id."""
         grouped: dict[UUID, list[AnnotationBaseTable]] = {}

--- a/lightly_studio/src/lightly_studio/evaluation/object_detection_metric.py
+++ b/lightly_studio/src/lightly_studio/evaluation/object_detection_metric.py
@@ -8,12 +8,10 @@ from uuid import UUID
 
 import numpy as np
 from numpy.typing import NDArray
-from sqlalchemy.orm import joinedload
-from sqlmodel import Session, col, select
+from sqlmodel import Session
 
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
-from lightly_studio.models.sample import SampleTable
 from lightly_studio.resolvers import evaluation_sample_metric_resolver
 
 SAMPLE_BATCH_SIZE = 32  # Number of samples to process in a single batch
@@ -142,29 +140,6 @@ def match_image(
         ),
         iou_threshold=iou_threshold,
     )
-
-
-def get_object_detection_annotations(
-    session: Session,
-    collection_id: UUID,
-    sample_ids: set[UUID],
-) -> list[AnnotationBaseTable]:
-    """Return object-detection annotations for selected parent samples."""
-    if not sample_ids:
-        return []
-
-    stmt = (
-        select(AnnotationBaseTable)
-        .join(
-            SampleTable,
-            col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
-        )
-        .where(col(AnnotationBaseTable.parent_sample_id).in_(sample_ids))
-        .where(col(AnnotationBaseTable.annotation_type) == AnnotationType.OBJECT_DETECTION)
-        .where(col(SampleTable.collection_id) == collection_id)
-        .options(joinedload(AnnotationBaseTable.object_detection_details))
-    )
-    return list(session.exec(stmt).all())
 
 
 def create_and_persist_object_detection_metrics_per_sample(  # noqa: PLR0913

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
@@ -11,6 +11,9 @@ from lightly_studio.resolvers.annotation_resolver.get_adjacent_annotations impor
     get_adjacent_annotations,
 )
 from lightly_studio.resolvers.annotation_resolver.get_all import get_all
+from lightly_studio.resolvers.annotation_resolver.get_all_by_collection_id_and_parent_sample_ids import (  # noqa: E501
+    get_all_by_collection_id_and_parent_sample_ids,
+)
 from lightly_studio.resolvers.annotation_resolver.get_all_by_collection_name import (
     get_all_by_collection_name,
 )
@@ -46,6 +49,7 @@ __all__ = [
     "delete_annotations",
     "get_adjacent_annotations",
     "get_all",
+    "get_all_by_collection_id_and_parent_sample_ids",
     "get_all_by_collection_name",
     "get_all_by_object_track_id",
     "get_all_by_parent_sample_ids",

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_by_collection_id_and_parent_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_by_collection_id_and_parent_sample_ids.py
@@ -17,7 +17,7 @@ def get_all_by_collection_id_and_parent_sample_ids(
     parent_sample_ids: Sequence[UUID],
     annotation_collection_id: UUID,
     annotation_type: AnnotationType,
-) -> Sequence[AnnotationBaseTable]:
+) -> list[AnnotationBaseTable]:
     """Get annotations of a given type from an annotation collection for parent samples.
 
     Eagerly loads the type-specific details relationship so callers can iterate

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_by_collection_id_and_parent_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_by_collection_id_and_parent_sample_ids.py
@@ -1,0 +1,51 @@
+"""Get annotations of a given type from an annotation collection for parent samples."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy.orm import joinedload
+from sqlmodel import Session, col, select
+
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from lightly_studio.models.sample import SampleTable
+
+
+def get_all_by_collection_id_and_parent_sample_ids(
+    session: Session,
+    parent_sample_ids: Sequence[UUID],
+    annotation_collection_id: UUID,
+    annotation_type: AnnotationType,
+) -> Sequence[AnnotationBaseTable]:
+    """Get annotations of a given type from an annotation collection for parent samples.
+
+    Eagerly loads the type-specific details relationship so callers can iterate
+    without triggering N+1 queries:
+    - OBJECT_DETECTION: object_detection_details
+    - SEGMENTATION_MASK: segmentation_details
+    - CLASSIFICATION: no extra load (label_id is on AnnotationBaseTable itself)
+
+    Args:
+        session: Database session.
+        parent_sample_ids: Parent sample IDs to fetch annotations for.
+        annotation_collection_id: ID of the annotation collection the annotation
+            samples must belong to.
+        annotation_type: Annotation type to filter by.
+    """
+    statement = (
+        select(AnnotationBaseTable)
+        .join(
+            SampleTable,
+            col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
+        )
+        .where(col(AnnotationBaseTable.parent_sample_id).in_(parent_sample_ids))
+        .where(col(AnnotationBaseTable.annotation_type) == annotation_type)
+        .where(col(SampleTable.collection_id) == annotation_collection_id)
+    )
+    if annotation_type == AnnotationType.OBJECT_DETECTION:
+        statement = statement.options(joinedload(AnnotationBaseTable.object_detection_details))
+    elif annotation_type == AnnotationType.SEGMENTATION_MASK:
+        statement = statement.options(joinedload(AnnotationBaseTable.segmentation_details))
+
+    return list(session.exec(statement).all())

--- a/lightly_studio/tests/resolvers/annotations/test_get_all_by_collection_id_and_parent_sample_ids.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_all_by_collection_id_and_parent_sample_ids.py
@@ -1,0 +1,116 @@
+"""Tests for get_all_by_collection_id_and_parent_sample_ids resolver."""
+
+from __future__ import annotations
+
+from sqlalchemy import inspect
+from sqlmodel import Session
+
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.resolvers import annotation_resolver
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
+
+
+def test_get_all_by_collection_id_and_parent_sample_ids__filters_by_annotation_type(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    od_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+
+    result = annotation_resolver.get_all_by_collection_id_and_parent_sample_ids(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_collection_id=od_annotation.sample.collection_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+    assert [annotation.sample_id for annotation in result] == [od_annotation.sample_id]
+
+
+def test_get_all_by_collection_id_and_parent_sample_ids__filters_by_annotation_collection_id(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    annotation_in_gt = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name="gt",
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name="pred",
+    )
+
+    result = annotation_resolver.get_all_by_collection_id_and_parent_sample_ids(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_collection_id=annotation_in_gt.sample.collection_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+    assert [annotation.sample_id for annotation in result] == [annotation_in_gt.sample_id]
+
+
+def test_get_all_by_collection_id_and_parent_sample_ids__eager_loads_object_detection_details(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+    db_session.expire_all()
+
+    result = annotation_resolver.get_all_by_collection_id_and_parent_sample_ids(
+        session=db_session,
+        parent_sample_ids=[image.sample_id],
+        annotation_collection_id=annotation.sample.collection_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+
+    assert len(result) == 1
+    # Without joinedload, the relationship would be in `unloaded` until accessed.
+    state = inspect(result[0])
+    assert state is not None
+    assert "object_detection_details" not in state.unloaded


### PR DESCRIPTION
## What has changed and why?

New resolver `annotation_resolver.get_all_by_collection_id_and_parent_sample_ids` takes `annotation_type` and `annotation_collection_id` as parameters, with conditional `joinedload` for type-specific details. `image_dataset_evaluate.object_detection()` calls it directly; the inline query in `evaluation/object_detection_metric.get_object_detection_annotations` is removed.

Prepares upcoming classification per-sample metrics to reuse the same resolver.

Replaces #1108.

## How has it been tested?

Three new tests covering both filters and eager loading.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by consolidating object detection annotation loading logic into a shared resolver component, reducing code duplication across the evaluation system.

* **Tests**
  * Added comprehensive tests validating annotation filtering and data loading behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1113)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->