### PR TITLE
Disable query editor scrollbar

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.test.ts
@@ -141,6 +141,18 @@ describe('useQueryEditor', () => {
         );
     });
 
+    it('does not allow scrolling past the last line when content fits', () => {
+        const { mount } = useQueryEditor();
+        const el = document.createElement('div');
+
+        mount(el, { value: '' });
+
+        expect(mocks.editorCreate).toHaveBeenCalledWith(
+            el,
+            expect.objectContaining({ scrollBeyondLastLine: false })
+        );
+    });
+
     it('publishes model changes back through onChange', () => {
         const { mount } = useQueryEditor();
         const el = document.createElement('div');

--- a/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useQueryEditor.ts
@@ -95,7 +95,8 @@ export const useQueryEditor = () => {
             readOnly: options.readOnly ?? false,
             minimap: { enabled: false },
             wordWrap: 'on',
-            fixedOverflowWidgets: true
+            fixedOverflowWidgets: true,
+            scrollBeyondLastLine: false
         });
 
         const detachLanguage = language.attach(model);


### PR DESCRIPTION
## What has changed and why?
The scrollbar is almost never necessary

## How has it been tested?
Manually and with a unit test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query editor scrolling behavior to prevent scrolling beyond the last line of content, improving code visibility and editor usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1114)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->