### PR TITLE
Migrate useFeatureFlags and useMetadataFilters away from schema.d.ts

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useFeatureFlags/useFeatureFlag.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useFeatureFlags/useFeatureFlag.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 import { useFeatureFlags } from './useFeatureFlags';
-import collection from '$lib/services/collection';
+import * as sdkModule from '$lib/api/lightly_studio_local/sdk.gen';
 
 describe('useFeatureFlags', () => {
     beforeEach(() => {
@@ -15,7 +15,11 @@ describe('useFeatureFlags', () => {
 
     it('should update feature flags when API call succeeds', async () => {
         const mockFeatures = ['feature1', 'feature2'];
-        const mockedGet = vi.spyOn(collection, 'GET').mockResolvedValueOnce({ data: mockFeatures });
+        const spy = vi.spyOn(sdkModule, 'getFeatures').mockResolvedValueOnce({
+            data: mockFeatures,
+            request: new Request('http://localhost'),
+            response: new Response()
+        });
 
         const { featureFlags } = useFeatureFlags();
 
@@ -23,12 +27,12 @@ describe('useFeatureFlags', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(get(featureFlags)).toEqual(mockFeatures);
-        expect(mockedGet).toHaveBeenCalledWith('/api/features');
+        expect(spy).toHaveBeenCalled();
     });
 
     it('should handle API call failure gracefully', async () => {
         const _error: Error = new Error('API Error');
-        const mockedGet = vi.spyOn(collection, 'GET').mockRejectedValueOnce(_error);
+        const spy = vi.spyOn(sdkModule, 'getFeatures').mockRejectedValueOnce(_error);
 
         const { featureFlags, error } = useFeatureFlags();
 
@@ -37,6 +41,6 @@ describe('useFeatureFlags', () => {
 
         expect(get(featureFlags)).toEqual([]);
         expect(get(error)).toEqual(_error);
-        expect(mockedGet).toHaveBeenCalledWith('/api/features');
+        expect(spy).toHaveBeenCalled();
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useFeatureFlags/useFeatureFlags.ts
+++ b/lightly_studio_view/src/lib/hooks/useFeatureFlags/useFeatureFlags.ts
@@ -1,4 +1,4 @@
-import { getFeatures } from '$lib/api/lightly_studio_local';
+import { getFeatures } from '$lib/api/lightly_studio_local/sdk.gen';
 import { readonly, writable } from 'svelte/store';
 
 export const useFeatureFlags = () => {

--- a/lightly_studio_view/src/lib/hooks/useFeatureFlags/useFeatureFlags.ts
+++ b/lightly_studio_view/src/lib/hooks/useFeatureFlags/useFeatureFlags.ts
@@ -1,11 +1,10 @@
-import client from '$lib/services/collection';
+import { getFeatures } from '$lib/api/lightly_studio_local';
 import { readonly, writable } from 'svelte/store';
 
 export const useFeatureFlags = () => {
     const featureFlags = writable([] as string[]);
     const error = writable<Error | null>(null);
-    client
-        .GET('/api/features')
+    getFeatures()
         .then((response) => {
             if (response.data) {
                 featureFlags.set(response.data);

--- a/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.ts
@@ -1,10 +1,8 @@
 import { getMetadataInfo } from '$lib/api/lightly_studio_local';
+import type { MetadataInfoView, MetadataFilter } from '$lib/api/lightly_studio_local';
 import { get, writable } from 'svelte/store';
-import type { components } from '$lib/schema';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 import { validate as validateUUID } from 'uuid';
-
-type MetadataInfo = components['schemas']['MetadataInfoView'];
 type MetadataBounds = Record<string, { min: number; max: number }>;
 type MetadataValues = Record<string, { min: number; max: number }>;
 
@@ -34,7 +32,7 @@ const loadInitialMetadataInfo = async (collection_id: string) => {
     const bounds: MetadataBounds = {};
     const values: MetadataValues = {};
 
-    metadataInfoData.forEach((info: MetadataInfo) => {
+    metadataInfoData.forEach((info: MetadataInfoView) => {
         if (info.type === 'integer' || info.type === 'float') {
             if (info.min != null && info.max != null) {
                 bounds[info.name] = { min: info.min, max: info.max };
@@ -47,8 +45,6 @@ const loadInitialMetadataInfo = async (collection_id: string) => {
     updateMetadataValues(values);
     updateMetadataInfo(metadataInfoData);
 };
-
-type MetadataFilter = components['schemas']['MetadataFilter'];
 
 export const createMetadataFilters = (metadataValues: MetadataValues): MetadataFilter[] => {
     const filters: MetadataFilter[] = [];


### PR DESCRIPTION
## What has changed and why?

Migrates two frontend hooks away from the deprecated `schema.d.ts` / `openapi-fetch` client to the auto-generated SDK client (`lightly_studio_local`):

- **`useFeatureFlags`**: Replaced `client.GET('/api/features')` with `getFeatures()` from the SDK.
- **`useMetadataFilters`**: Replaced `components['schemas']['MetadataInfoView']` and `components['schemas']['MetadataFilter']` type imports with direct imports from the SDK module.
- **`useFeatureFlag.test.ts`**: Updated mocks to spy on the SDK module instead of the openapi-fetch client.

This is part of the effort to deprecate `schema.d.ts` (LIG-9569).

## How has it been tested?

- Updated unit tests pass
- Manual verification that feature flags and metadata filters load correctly

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved feature-flag retrieval to use centralized helpers for more consistent behavior.
  * Streamlined metadata filter type handling by relying on shared API types, reducing local complexity.
* **Tests**
  * Updated feature-flag tests with new mock patterns and stronger async/error assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1119)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->