### PR TITLE
Add per-sample classification metrics

### DIFF
--- a/lightly_studio/src/lightly_studio/evaluation/classification_metric.py
+++ b/lightly_studio/src/lightly_studio/evaluation/classification_metric.py
@@ -1,0 +1,106 @@
+"""Classification evaluation metric primitives."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.evaluation.evaluation_data import EvaluationData
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
+from lightly_studio.resolvers import evaluation_sample_metric_resolver
+
+METRIC_BATCH_SIZE = 32  # Buffer size for evaluation_sample_metric_resolver.create_many
+
+
+def create_and_persist_classification_metrics_per_sample(
+    session: Session,
+    data: EvaluationData,
+) -> None:
+    """Create and persist per-sample classification metrics.
+
+    For each selected sample, writes two metric rows: ``is_correct`` (1.0 if the
+    prediction's label matches the ground truth, 0.0 otherwise) and
+    ``confidence`` (the prediction's confidence).
+
+    Each selected sample must have exactly one ground-truth annotation and
+    exactly one prediction annotation in their respective annotation collections,
+    and the prediction must have a non-None confidence. Validation runs in a
+    first pass over all samples before any persistence, so nothing is written
+    on error.
+
+    Raises:
+        ValueError: If any selected sample has 0 or >1 GT/prediction annotations,
+            or if a prediction has a None confidence.
+    """
+    # Pass 1: validate all samples up front, before any persistence.
+    gt_by_sample: dict[UUID, AnnotationBaseTable] = {}
+    pred_by_sample: dict[UUID, AnnotationBaseTable] = {}
+    for sample_id in data.selected_sample_ids:
+        gt = _require_single(
+            annotations=data.gt_per_sample.get(sample_id, []),
+            sample_id=sample_id,
+            kind="ground truth",
+        )
+        pred = _require_single(
+            annotations=data.pred_per_sample.get(sample_id, []),
+            sample_id=sample_id,
+            kind="prediction",
+        )
+        if pred.confidence is None:
+            raise ValueError(
+                f"Classification evaluation expected a non-None prediction confidence "
+                f"for sample {sample_id}, got None."
+            )
+        gt_by_sample[sample_id] = gt
+        pred_by_sample[sample_id] = pred
+
+    # Pass 2: build and persist metrics in batches.
+    metrics_to_persist: list[EvaluationSampleMetricCreate] = []
+    for sample_id in data.selected_sample_ids:
+        gt = gt_by_sample[sample_id]
+        pred = pred_by_sample[sample_id]
+        # pred.confidence is guaranteed non-None by pass 1, but mypy can't see that.
+        assert pred.confidence is not None
+        is_correct = 1.0 if pred.annotation_label_id == gt.annotation_label_id else 0.0
+        metrics_to_persist.extend(
+            [
+                EvaluationSampleMetricCreate(
+                    evaluation_run_id=data.evaluation_run_id,
+                    sample_id=sample_id,
+                    metric_name="is_correct",
+                    value=is_correct,
+                ),
+                EvaluationSampleMetricCreate(
+                    evaluation_run_id=data.evaluation_run_id,
+                    sample_id=sample_id,
+                    metric_name="confidence",
+                    value=float(pred.confidence),
+                ),
+            ]
+        )
+
+        if len(metrics_to_persist) >= METRIC_BATCH_SIZE:
+            evaluation_sample_metric_resolver.create_many(
+                session=session,
+                records=metrics_to_persist,
+            )
+            metrics_to_persist.clear()
+    if metrics_to_persist:
+        evaluation_sample_metric_resolver.create_many(
+            session=session,
+            records=metrics_to_persist,
+        )
+
+
+def _require_single(
+    annotations: list[AnnotationBaseTable], *, sample_id: UUID, kind: str
+) -> AnnotationBaseTable:
+    """Return the lone annotation, or raise if there are 0 or >1."""
+    if len(annotations) != 1:
+        raise ValueError(
+            f"Classification evaluation expected exactly 1 {kind} annotation for "
+            f"sample {sample_id}, found {len(annotations)}."
+        )
+    return annotations[0]

--- a/lightly_studio/src/lightly_studio/evaluation/classification_metric.py
+++ b/lightly_studio/src/lightly_studio/evaluation/classification_metric.py
@@ -26,17 +26,18 @@ def create_and_persist_classification_metrics_per_sample(
 
     Each selected sample must have exactly one ground-truth annotation and
     exactly one prediction annotation in their respective annotation collections,
-    and the prediction must have a non-None confidence. Validation runs in a
-    first pass over all samples before any persistence, so nothing is written
-    on error.
+    and the prediction must have a non-None confidence. All validation runs and
+    metric rows are built before any persistence, so nothing is written on error.
 
     Raises:
         ValueError: If any selected sample has 0 or >1 GT/prediction annotations,
             or if a prediction has a None confidence.
     """
-    # Pass 1: validate all samples up front, before any persistence.
-    gt_by_sample: dict[UUID, AnnotationBaseTable] = {}
-    pred_by_sample: dict[UUID, AnnotationBaseTable] = {}
+    # Pass 1: validate every sample and build all metric rows up front, before
+    # any persistence. Reading ORM attributes here is safe because no commit has
+    # happened yet — pass 2's batch commits would otherwise expire the ORM rows
+    # (expire_on_commit=True) and force lazy reloads on later reads.
+    metrics_to_persist: list[EvaluationSampleMetricCreate] = []
     for sample_id in data.selected_sample_ids:
         gt = _require_single(
             annotations=data.gt_per_sample.get(sample_id, []),
@@ -53,16 +54,6 @@ def create_and_persist_classification_metrics_per_sample(
                 f"Classification evaluation expected a non-None prediction confidence "
                 f"for sample {sample_id}, got None."
             )
-        gt_by_sample[sample_id] = gt
-        pred_by_sample[sample_id] = pred
-
-    # Pass 2: build and persist metrics in batches.
-    metrics_to_persist: list[EvaluationSampleMetricCreate] = []
-    for sample_id in data.selected_sample_ids:
-        gt = gt_by_sample[sample_id]
-        pred = pred_by_sample[sample_id]
-        # pred.confidence is guaranteed non-None by pass 1, but mypy can't see that.
-        assert pred.confidence is not None
         is_correct = 1.0 if pred.annotation_label_id == gt.annotation_label_id else 0.0
         metrics_to_persist.extend(
             [
@@ -81,16 +72,11 @@ def create_and_persist_classification_metrics_per_sample(
             ]
         )
 
-        if len(metrics_to_persist) >= METRIC_BATCH_SIZE:
-            evaluation_sample_metric_resolver.create_many(
-                session=session,
-                records=metrics_to_persist,
-            )
-            metrics_to_persist.clear()
-    if metrics_to_persist:
+    # Pass 2: persist in batches. No ORM reads here, so commits are safe.
+    for batch_start in range(0, len(metrics_to_persist), METRIC_BATCH_SIZE):
         evaluation_sample_metric_resolver.create_many(
             session=session,
-            records=metrics_to_persist,
+            records=metrics_to_persist[batch_start : batch_start + METRIC_BATCH_SIZE],
         )
 
 

--- a/lightly_studio/src/lightly_studio/evaluation/classification_metric.py
+++ b/lightly_studio/src/lightly_studio/evaluation/classification_metric.py
@@ -20,18 +20,21 @@ def create_and_persist_classification_metrics_per_sample(
 ) -> None:
     """Create and persist per-sample classification metrics.
 
-    For each selected sample, writes two metric rows: ``is_correct`` (1.0 if the
-    prediction's label matches the ground truth, 0.0 otherwise) and
-    ``confidence`` (the prediction's confidence).
+    For each selected sample, writes a single ``disagreement`` metric row in
+    ``[0, 1]``. Higher values indicate stronger disagreement between the ground
+    truth and the prediction. The score is ``1 - c`` when labels match and
+    ``c`` when they differ, where ``c`` is the prediction's confidence. If the
+    prediction's confidence is ``None`` (e.g. annotator-vs-annotator
+    comparisons), ``c`` defaults to ``1.0``, which degrades the score to a
+    binary 0/1.
 
     Each selected sample must have exactly one ground-truth annotation and
-    exactly one prediction annotation in their respective annotation collections,
-    and the prediction must have a non-None confidence. All validation runs and
-    metric rows are built before any persistence, so nothing is written on error.
+    exactly one prediction annotation in their respective annotation collections.
+    All validation runs and metric rows are built before any persistence, so
+    nothing is written on error.
 
     Raises:
-        ValueError: If any selected sample has 0 or >1 GT/prediction annotations,
-            or if a prediction has a None confidence.
+        ValueError: If any selected sample has 0 or >1 GT/prediction annotations.
     """
     # Pass 1: validate every sample and build all metric rows up front, before
     # any persistence. Reading ORM attributes here is safe because no commit has
@@ -49,27 +52,16 @@ def create_and_persist_classification_metrics_per_sample(
             sample_id=sample_id,
             kind="prediction",
         )
-        if pred.confidence is None:
-            raise ValueError(
-                f"Classification evaluation expected a non-None prediction confidence "
-                f"for sample {sample_id}, got None."
+        confidence = 1.0 if pred.confidence is None else float(pred.confidence)
+        labels_agree = pred.annotation_label_id == gt.annotation_label_id
+        disagreement = (1.0 - confidence) if labels_agree else confidence
+        metrics_to_persist.append(
+            EvaluationSampleMetricCreate(
+                evaluation_run_id=data.evaluation_run_id,
+                sample_id=sample_id,
+                metric_name="disagreement",
+                value=disagreement,
             )
-        is_correct = 1.0 if pred.annotation_label_id == gt.annotation_label_id else 0.0
-        metrics_to_persist.extend(
-            [
-                EvaluationSampleMetricCreate(
-                    evaluation_run_id=data.evaluation_run_id,
-                    sample_id=sample_id,
-                    metric_name="is_correct",
-                    value=is_correct,
-                ),
-                EvaluationSampleMetricCreate(
-                    evaluation_run_id=data.evaluation_run_id,
-                    sample_id=sample_id,
-                    metric_name="confidence",
-                    value=float(pred.confidence),
-                ),
-            ]
         )
 
     # Pass 2: persist in batches. No ORM reads here, so commits are safe.

--- a/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
+++ b/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 from sqlmodel import Session
 
 from lightly_studio.core.image.image_sample import ImageSample
-from lightly_studio.evaluation import object_detection_metric, validators
+from lightly_studio.evaluation import classification_metric, object_detection_metric, validators
 from lightly_studio.evaluation.evaluation_data import EvaluationData
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.evaluation_run import (
@@ -134,11 +134,8 @@ class ImageDatasetEvaluate:
         gt_collection_name: str,
         pred_collection_name: str,
         config: ClassificationEvaluationConfig | None = None,
-    ) -> None:
-        """Create a classification evaluation run.
-
-        For now, this method only persists an ``EvaluationRun`` entry.
-        Metric computation and metric persistence are intentionally deferred.
+    ) -> EvaluationResult:
+        """Create a classification evaluation run and persist per-image metrics.
 
         Args:
             name: Display name of the evaluation run.
@@ -146,15 +143,23 @@ class ImageDatasetEvaluate:
             pred_collection_name: Name of the annotation collection containing predictions.
             config: Optional classification evaluation config. If omitted,
                 defaults are used.
+
+        Returns:
+            Summary of the samples and annotations used by the evaluation.
         """
         config = config or ClassificationEvaluationConfig()
-        self._create_evaluation_run(
+        data = self._prepare_evaluation_data(
             name=name,
             gt_collection_name=gt_collection_name,
             pred_collection_name=pred_collection_name,
             task_type=EvaluationTaskType.CLASSIFICATION,
             config_json=config.model_dump(),
         )
+        classification_metric.create_and_persist_classification_metrics_per_sample(
+            session=self.session,
+            data=data,
+        )
+        return EvaluationResult.from_evaluation_data(data)
 
     def _prepare_evaluation_data(
         self,

--- a/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
+++ b/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
@@ -341,7 +341,9 @@ def test_classification_evaluation__raises_on_none_prediction_confidence(
         annotation_collection_name="pred",
     )
 
-    with pytest.raises(ValueError, match="Classification evaluation expected a non-None prediction confidence "):
+    with pytest.raises(
+        ValueError, match="Classification evaluation expected a non-None prediction confidence "
+    ):
         dataset.evaluate().classification(
             name="run-1",
             gt_collection_name="gt",

--- a/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
+++ b/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
@@ -189,16 +189,41 @@ def test_object_detection_evaluation__filters_to_samples_covered_by_both_collect
 def test_classification_evaluation(
     patch_collection: None,  # noqa: ARG001
 ) -> None:
-    """Creates an evaluation run for classification and no sample metrics yet."""
+    """Creates an evaluation run for classification and persists sample metrics."""
     dataset = ImageDataset.create(name="test_dataset")
+    label = create_annotation_label(
+        session=dataset.session, root_collection_id=dataset.collection_id
+    )
+    image = create_image(session=dataset.session, collection_id=dataset.collection_id)
     _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_collection_name="gt",
+    )
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        # 0.5 is exactly representable in float32 (DB column is float32-precision).
+        annotation_data={"confidence": 0.5},
+        annotation_collection_name="pred",
+    )
 
-    dataset.evaluate().classification(
+    result = dataset.evaluate().classification(
         name="run-1",
         gt_collection_name="gt",
         pred_collection_name="pred",
         config=ClassificationEvaluationConfig(),
     )
+    assert result.sample_count == 1
+    assert result.gt_annotation_count == 1
+    assert result.pred_annotation_count == 1
 
     evaluation_runs = evaluation_run_resolver.get_all_by_dataset_id(
         session=dataset.session,
@@ -213,7 +238,210 @@ def test_classification_evaluation(
         session=dataset.session,
         evaluation_run_id=evaluation_runs[0].id,
     )
-    assert sample_metrics == []
+    assert {(metric.sample_id, metric.metric_name): metric.value for metric in sample_metrics} == {
+        (image.sample_id, "is_correct"): 1.0,
+        (image.sample_id, "confidence"): 0.5,
+    }
+
+
+def test_classification_evaluation__incorrect_prediction(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Persists is_correct=0.0 when the prediction label differs from the ground truth."""
+    dataset = ImageDataset.create(name="test_dataset")
+    gt_label = create_annotation_label(
+        session=dataset.session,
+        root_collection_id=dataset.collection_id,
+        label_name="A",
+    )
+    pred_label = create_annotation_label(
+        session=dataset.session,
+        root_collection_id=dataset.collection_id,
+        label_name="B",
+    )
+    image = create_image(session=dataset.session, collection_id=dataset.collection_id)
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=gt_label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_collection_name="gt",
+    )
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=pred_label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={"confidence": 0.25},
+        annotation_collection_name="pred",
+    )
+
+    dataset.evaluate().classification(
+        name="run-1",
+        gt_collection_name="gt",
+        pred_collection_name="pred",
+    )
+
+    evaluation_runs = evaluation_run_resolver.get_all_by_dataset_id(
+        session=dataset.session,
+        dataset_id=dataset.dataset_id,
+    )
+    sample_metrics = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(
+        session=dataset.session,
+        evaluation_run_id=evaluation_runs[0].id,
+    )
+    assert {(metric.sample_id, metric.metric_name): metric.value for metric in sample_metrics} == {
+        (image.sample_id, "is_correct"): 0.0,
+        (image.sample_id, "confidence"): 0.25,
+    }
+
+
+def test_classification_evaluation__filters_to_samples_covered_by_both_collections(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Creates metrics only for samples covered by both GT and prediction collections."""
+    dataset = ImageDataset.create(name="test_dataset")
+    label = create_annotation_label(
+        session=dataset.session, root_collection_id=dataset.collection_id
+    )
+    image_covered_by_both = create_image(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/covered_by_both.png",
+    )
+    create_image(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/covered_only_by_gt.png",
+    )
+    create_image(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/uncovered.png",
+    )
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image_covered_by_both.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_collection_name="gt",
+    )
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image_covered_by_both.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={"confidence": 0.9},
+        annotation_collection_name="pred",
+    )
+
+    result = dataset.evaluate().classification(
+        name="run-1",
+        gt_collection_name="gt",
+        pred_collection_name="pred",
+    )
+    assert result.sample_count == 1
+    assert result.gt_annotation_count == 1
+    assert result.pred_annotation_count == 1
+
+    evaluation_runs = evaluation_run_resolver.get_all_by_dataset_id(
+        session=dataset.session,
+        dataset_id=dataset.dataset_id,
+    )
+    sample_metrics = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(
+        session=dataset.session,
+        evaluation_run_id=evaluation_runs[0].id,
+    )
+    assert len(sample_metrics) == 2
+    assert {metric.sample_id for metric in sample_metrics} == {image_covered_by_both.sample_id}
+
+
+@pytest.mark.parametrize(
+    ("collection_name", "kind"),
+    [("gt", "ground truth"), ("pred", "prediction")],
+)
+def test_classification_evaluation__raises_on_multiple_annotations(
+    patch_collection: None,  # noqa: ARG001
+    collection_name: str,
+    kind: str,
+) -> None:
+    """Raises ValueError when a sample has more than one annotation in one collection."""
+    dataset = ImageDataset.create(name="test_dataset")
+    label = create_annotation_label(
+        session=dataset.session, root_collection_id=dataset.collection_id
+    )
+    image = create_image(session=dataset.session, collection_id=dataset.collection_id)
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
+    # The other collection has exactly one annotation.
+    other_collection_name = "pred" if collection_name == "gt" else "gt"
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={"confidence": 0.5},
+        annotation_collection_name=other_collection_name,
+    )
+    # The target collection has two annotations on the same sample.
+    for _ in range(2):
+        create_annotation(
+            session=dataset.session,
+            collection_id=dataset.collection_id,
+            sample_id=image.sample_id,
+            annotation_label_id=label.annotation_label_id,
+            annotation_type=AnnotationType.CLASSIFICATION,
+            annotation_data={"confidence": 0.5},
+            annotation_collection_name=collection_name,
+        )
+
+    with pytest.raises(ValueError, match=f"exactly 1 {kind} annotation"):
+        dataset.evaluate().classification(
+            name="run-1",
+            gt_collection_name="gt",
+            pred_collection_name="pred",
+        )
+
+
+def test_classification_evaluation__raises_on_none_prediction_confidence(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Raises ValueError when a prediction annotation has confidence=None."""
+    dataset = ImageDataset.create(name="test_dataset")
+    label = create_annotation_label(
+        session=dataset.session, root_collection_id=dataset.collection_id
+    )
+    image = create_image(session=dataset.session, collection_id=dataset.collection_id)
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_collection_name="gt",
+    )
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_collection_name="pred",
+    )
+
+    with pytest.raises(ValueError, match="non-None prediction confidence"):
+        dataset.evaluate().classification(
+            name="run-1",
+            gt_collection_name="gt",
+            pred_collection_name="pred",
+        )
 
 
 def test_classification_evaluation__raises_on_wrong_annotation_type(

--- a/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
+++ b/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
@@ -186,13 +186,37 @@ def test_object_detection_evaluation__filters_to_samples_covered_by_both_collect
     assert {metric.sample_id for metric in sample_metrics} == {image_covered_by_both.sample_id}
 
 
+@pytest.mark.parametrize(
+    ("gt_label_name", "pred_label_name", "pred_confidence", "expected_is_correct"),
+    [
+        # Confidence values must be exactly representable in float32
+        # (DB column is float32-precision).
+        ("A", "A", 0.5, 1.0),
+        ("A", "B", 0.25, 0.0),
+    ],
+)
 def test_classification_evaluation(
     patch_collection: None,  # noqa: ARG001
+    gt_label_name: str,
+    pred_label_name: str,
+    pred_confidence: float,
+    expected_is_correct: float,
 ) -> None:
-    """Creates an evaluation run for classification and persists sample metrics."""
+    """Persists per-sample classification metrics for matching and mismatching labels."""
     dataset = ImageDataset.create(name="test_dataset")
-    label = create_annotation_label(
-        session=dataset.session, root_collection_id=dataset.collection_id
+    gt_label = create_annotation_label(
+        session=dataset.session,
+        root_collection_id=dataset.collection_id,
+        label_name=gt_label_name,
+    )
+    pred_label = (
+        gt_label
+        if pred_label_name == gt_label_name
+        else create_annotation_label(
+            session=dataset.session,
+            root_collection_id=dataset.collection_id,
+            label_name=pred_label_name,
+        )
     )
     image = create_image(session=dataset.session, collection_id=dataset.collection_id)
     _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
@@ -200,7 +224,7 @@ def test_classification_evaluation(
         session=dataset.session,
         collection_id=dataset.collection_id,
         sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
+        annotation_label_id=gt_label.annotation_label_id,
         annotation_type=AnnotationType.CLASSIFICATION,
         annotation_collection_name="gt",
     )
@@ -208,10 +232,9 @@ def test_classification_evaluation(
         session=dataset.session,
         collection_id=dataset.collection_id,
         sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
+        annotation_label_id=pred_label.annotation_label_id,
         annotation_type=AnnotationType.CLASSIFICATION,
-        # 0.5 is exactly representable in float32 (DB column is float32-precision).
-        annotation_data={"confidence": 0.5},
+        annotation_data={"confidence": pred_confidence},
         annotation_collection_name="pred",
     )
 
@@ -239,127 +262,9 @@ def test_classification_evaluation(
         evaluation_run_id=evaluation_runs[0].id,
     )
     assert {(metric.sample_id, metric.metric_name): metric.value for metric in sample_metrics} == {
-        (image.sample_id, "is_correct"): 1.0,
-        (image.sample_id, "confidence"): 0.5,
+        (image.sample_id, "is_correct"): expected_is_correct,
+        (image.sample_id, "confidence"): pred_confidence,
     }
-
-
-def test_classification_evaluation__incorrect_prediction(
-    patch_collection: None,  # noqa: ARG001
-) -> None:
-    """Persists is_correct=0.0 when the prediction label differs from the ground truth."""
-    dataset = ImageDataset.create(name="test_dataset")
-    gt_label = create_annotation_label(
-        session=dataset.session,
-        root_collection_id=dataset.collection_id,
-        label_name="A",
-    )
-    pred_label = create_annotation_label(
-        session=dataset.session,
-        root_collection_id=dataset.collection_id,
-        label_name="B",
-    )
-    image = create_image(session=dataset.session, collection_id=dataset.collection_id)
-    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
-    create_annotation(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=gt_label.annotation_label_id,
-        annotation_type=AnnotationType.CLASSIFICATION,
-        annotation_collection_name="gt",
-    )
-    create_annotation(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=pred_label.annotation_label_id,
-        annotation_type=AnnotationType.CLASSIFICATION,
-        annotation_data={"confidence": 0.25},
-        annotation_collection_name="pred",
-    )
-
-    dataset.evaluate().classification(
-        name="run-1",
-        gt_collection_name="gt",
-        pred_collection_name="pred",
-    )
-
-    evaluation_runs = evaluation_run_resolver.get_all_by_dataset_id(
-        session=dataset.session,
-        dataset_id=dataset.dataset_id,
-    )
-    sample_metrics = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(
-        session=dataset.session,
-        evaluation_run_id=evaluation_runs[0].id,
-    )
-    assert {(metric.sample_id, metric.metric_name): metric.value for metric in sample_metrics} == {
-        (image.sample_id, "is_correct"): 0.0,
-        (image.sample_id, "confidence"): 0.25,
-    }
-
-
-def test_classification_evaluation__filters_to_samples_covered_by_both_collections(
-    patch_collection: None,  # noqa: ARG001
-) -> None:
-    """Creates metrics only for samples covered by both GT and prediction collections."""
-    dataset = ImageDataset.create(name="test_dataset")
-    label = create_annotation_label(
-        session=dataset.session, root_collection_id=dataset.collection_id
-    )
-    image_covered_by_both = create_image(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        file_path_abs="/path/to/covered_by_both.png",
-    )
-    create_image(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        file_path_abs="/path/to/covered_only_by_gt.png",
-    )
-    create_image(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        file_path_abs="/path/to/uncovered.png",
-    )
-    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
-    create_annotation(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_id=image_covered_by_both.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.CLASSIFICATION,
-        annotation_collection_name="gt",
-    )
-    create_annotation(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_id=image_covered_by_both.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.CLASSIFICATION,
-        annotation_data={"confidence": 0.9},
-        annotation_collection_name="pred",
-    )
-
-    result = dataset.evaluate().classification(
-        name="run-1",
-        gt_collection_name="gt",
-        pred_collection_name="pred",
-    )
-    assert result.sample_count == 1
-    assert result.gt_annotation_count == 1
-    assert result.pred_annotation_count == 1
-
-    evaluation_runs = evaluation_run_resolver.get_all_by_dataset_id(
-        session=dataset.session,
-        dataset_id=dataset.dataset_id,
-    )
-    sample_metrics = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(
-        session=dataset.session,
-        evaluation_run_id=evaluation_runs[0].id,
-    )
-    assert len(sample_metrics) == 2
-    assert {metric.sample_id for metric in sample_metrics} == {image_covered_by_both.sample_id}
 
 
 @pytest.mark.parametrize(
@@ -436,7 +341,7 @@ def test_classification_evaluation__raises_on_none_prediction_confidence(
         annotation_collection_name="pred",
     )
 
-    with pytest.raises(ValueError, match="non-None prediction confidence"):
+    with pytest.raises(ValueError, match="Classification evaluation expected a non-None prediction confidence "):
         dataset.evaluate().classification(
             name="run-1",
             gt_collection_name="gt",

--- a/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
+++ b/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
@@ -187,22 +187,28 @@ def test_object_detection_evaluation__filters_to_samples_covered_by_both_collect
 
 
 @pytest.mark.parametrize(
-    ("gt_label_name", "pred_label_name", "pred_confidence", "expected_is_correct"),
+    ("gt_label_name", "pred_label_name", "pred_confidence", "expected_disagreement"),
     [
         # Confidence values must be exactly representable in float32
         # (DB column is float32-precision).
-        ("A", "A", 0.5, 1.0),
-        ("A", "B", 0.25, 0.0),
+        # agree, c=0.5 -> 1 - c = 0.5
+        ("A", "A", 0.5, 0.5),
+        # disagree, c=0.25 -> c = 0.25
+        ("A", "B", 0.25, 0.25),
+        # agree, c defaults to 1.0 -> 1 - c = 0.0
+        ("A", "A", None, 0.0),
+        # disagree, c defaults to 1.0 -> c = 1.0
+        ("A", "B", None, 1.0),
     ],
 )
 def test_classification_evaluation(
     patch_collection: None,  # noqa: ARG001
     gt_label_name: str,
     pred_label_name: str,
-    pred_confidence: float,
-    expected_is_correct: float,
+    pred_confidence: float | None,
+    expected_disagreement: float,
 ) -> None:
-    """Persists per-sample classification metrics for matching and mismatching labels."""
+    """Persists per-sample disagreement metric for matching and mismatching labels."""
     dataset = ImageDataset.create(name="test_dataset")
     gt_label = create_annotation_label(
         session=dataset.session,
@@ -234,7 +240,9 @@ def test_classification_evaluation(
         sample_id=image.sample_id,
         annotation_label_id=pred_label.annotation_label_id,
         annotation_type=AnnotationType.CLASSIFICATION,
-        annotation_data={"confidence": pred_confidence},
+        annotation_data=(
+            {"confidence": pred_confidence} if pred_confidence is not None else None
+        ),
         annotation_collection_name="pred",
     )
 
@@ -262,8 +270,7 @@ def test_classification_evaluation(
         evaluation_run_id=evaluation_runs[0].id,
     )
     assert {(metric.sample_id, metric.metric_name): metric.value for metric in sample_metrics} == {
-        (image.sample_id, "is_correct"): expected_is_correct,
-        (image.sample_id, "confidence"): pred_confidence,
+        (image.sample_id, "disagreement"): expected_disagreement,
     }
 
 
@@ -308,43 +315,6 @@ def test_classification_evaluation__raises_on_multiple_annotations(
         )
 
     with pytest.raises(ValueError, match=f"exactly 1 {kind} annotation"):
-        dataset.evaluate().classification(
-            name="run-1",
-            gt_collection_name="gt",
-            pred_collection_name="pred",
-        )
-
-
-def test_classification_evaluation__raises_on_none_prediction_confidence(
-    patch_collection: None,  # noqa: ARG001
-) -> None:
-    """Raises ValueError when a prediction annotation has confidence=None."""
-    dataset = ImageDataset.create(name="test_dataset")
-    label = create_annotation_label(
-        session=dataset.session, root_collection_id=dataset.collection_id
-    )
-    image = create_image(session=dataset.session, collection_id=dataset.collection_id)
-    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
-    create_annotation(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.CLASSIFICATION,
-        annotation_collection_name="gt",
-    )
-    create_annotation(
-        session=dataset.session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.CLASSIFICATION,
-        annotation_collection_name="pred",
-    )
-
-    with pytest.raises(
-        ValueError, match="Classification evaluation expected a non-None prediction confidence "
-    ):
         dataset.evaluate().classification(
             name="run-1",
             gt_collection_name="gt",

--- a/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
+++ b/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
@@ -283,7 +283,8 @@ def test_classification_evaluation__raises_on_multiple_annotations(
     )
     image = create_image(session=dataset.session, collection_id=dataset.collection_id)
     _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
-    # The other collection has exactly one annotation.
+    # The other collection has exactly one annotation. Confidence only matters
+    # for predictions, so only set it on the pred side.
     other_collection_name = "pred" if collection_name == "gt" else "gt"
     create_annotation(
         session=dataset.session,
@@ -291,7 +292,7 @@ def test_classification_evaluation__raises_on_multiple_annotations(
         sample_id=image.sample_id,
         annotation_label_id=label.annotation_label_id,
         annotation_type=AnnotationType.CLASSIFICATION,
-        annotation_data={"confidence": 0.5},
+        annotation_data={"confidence": 0.5} if other_collection_name == "pred" else None,
         annotation_collection_name=other_collection_name,
     )
     # The target collection has two annotations on the same sample.
@@ -302,7 +303,7 @@ def test_classification_evaluation__raises_on_multiple_annotations(
             sample_id=image.sample_id,
             annotation_label_id=label.annotation_label_id,
             annotation_type=AnnotationType.CLASSIFICATION,
-            annotation_data={"confidence": 0.5},
+            annotation_data={"confidence": 0.5} if collection_name == "pred" else None,
             annotation_collection_name=collection_name,
         )
 

--- a/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
+++ b/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
@@ -240,9 +240,7 @@ def test_classification_evaluation(
         sample_id=image.sample_id,
         annotation_label_id=pred_label.annotation_label_id,
         annotation_type=AnnotationType.CLASSIFICATION,
-        annotation_data=(
-            {"confidence": pred_confidence} if pred_confidence is not None else None
-        ),
+        annotation_data=({"confidence": pred_confidence} if pred_confidence is not None else None),
         annotation_collection_name="pred",
     )
 


### PR DESCRIPTION
## What has changed and why?

Implements [LIG-9488](https://linear.app/lightly/issue/LIG-9488/classification-sample-metric-implementation). `ImageDatasetEvaluate.classification()` now computes and persists a single per-sample `disagreement` metric in `[0, 1]` so samples can be sorted/filtered by it in the GUI. The metric module is `evaluation/classification_metric.py` and uses the shared helper introduced in #1116.

The disagreement score is defined as `1 - c` when the prediction label matches the ground truth and `c` when it differs, where `c` is the prediction's confidence. If the prediction's confidence is `None` (e.g. annotator-vs-annotator comparisons), `c` defaults to `1.0`, which degrades the score to a clean binary 0/1.

Strict contract: each sample must have exactly one GT and one prediction annotation per collection — otherwise we raise. Validation runs in a first pass before any persistence, so a malformed sample never leaves partial metric rows behind.

## How has it been tested?

Updated `test_classification_evaluation` to assert the `disagreement` metric row across four cases (agree/disagree, with and without a confidence), plus existing tests for coverage filtering, multiple annotations (parametrized over gt/pred), and wrong annotation type.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Classification evaluation now computes and persists a per-sample `disagreement` metric in [0, 1] and returns an evaluation summary.

* **Bug Fixes**
  * Evaluation validates exactly one ground-truth and one prediction per sample; missing prediction confidence is treated as `1.0` rather than raising.

* **Tests**
  * Added tests verifying disagreement values for agreeing/disagreeing labels, with and without prediction confidence, and error cases for multiple annotations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1122)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
