### PR TITLE
Update Svelte version

### DIFF
--- a/lightly_studio_view/package-lock.json
+++ b/lightly_studio_view/package-lock.json
@@ -1799,6 +1799,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@storybook/addon-docs": {
       "version": "10.2.10",
       "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.2.10.tgz",
@@ -2055,22 +2062,23 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.19.0.tgz",
-      "integrity": "sha512-UTx28Ad4sYsLU//gqkEo5aFOPFBRT2uXCmXTsURqhurDCvzkVwXruJgBcHDaMiK6RKKpYRteDUaXYqZyGPgCXQ==",
+      "version": "2.59.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.59.1.tgz",
+      "integrity": "sha512-d8OON70AphLdDesuTIl//M2O6fRTIicX8aYv8vhCiYEhTTI2OboKqey0Hu1A4VFhqwgqtq0vKDmPFGkw8kKmgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
         "@types/cookie": "^0.6.0",
+        "acorn": "^8.14.1",
         "cookie": "^0.6.0",
-        "devalue": "^5.1.0",
+        "devalue": "^5.6.4",
         "esm-env": "^1.2.2",
-        "import-meta-resolve": "^4.1.0",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
         "mrmime": "^2.0.0",
-        "sade": "^1.8.1",
-        "set-cookie-parser": "^2.6.0",
+        "set-cookie-parser": "^3.0.0",
         "sirv": "^3.0.0"
       },
       "bin": {
@@ -2080,17 +2088,20 @@
         "node": ">=18.13"
       },
       "peerDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "vite": "^5.0.3 || ^6.0.0"
+        "typescript": "^5.3.3 || ^6.0.0",
+        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@sveltejs/kit/node_modules/devalue": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
-      "integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "4.0.4",
@@ -2548,8 +2559,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -2722,7 +2732,7 @@
       "version": "8.26.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.1.tgz",
       "integrity": "sha512-n4THUQW27VmQMx+3P+B0Yptl7ydfceUj4ON/AQILAASwgYdZ/2dhfymRMh5egRUrvK5lSmaOm77Ry+lmXPOgBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4512,6 +4522,12 @@
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/devalue": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
+      "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
       "license": "MIT"
     },
     "node_modules/didyoumean": {
@@ -8078,9 +8094,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8435,21 +8451,23 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.39.10",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.39.10.tgz",
-      "integrity": "sha512-Q3gqCGIgl4r0CR7OaWYjVo22nqFmLLSfn1MiWNFaITamvqhGBD3kyqk51EKuO4Nd1z8QliO5KIz7a2Ka9Rxilw==",
+      "version": "5.55.5",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
+      "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
         "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
-        "aria-query": "^5.3.1",
+        "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
+        "devalue": "^5.6.4",
         "esm-env": "^1.2.1",
-        "esrap": "^2.1.0",
+        "esrap": "^2.2.4",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -8681,21 +8699,29 @@
       }
     },
     "node_modules/svelte/node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/svelte/node_modules/esrap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.1.0.tgz",
-      "integrity": "sha512-yzmPNpl7TBbMRC5Lj2JlJZNPml0tzqoqP5B1JXycNUwtqma9AKCO0M2wHrdgsHcy1WRW7S9rJknAMtByg3usgA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.8.tgz",
+      "integrity": "sha512-MPweq2EvEGj8jwOI7Hgycw/QIHzqA1EbAM8lG7p+FBfZbZq/hQ6h3AMsqnu/djzisH1KVWNzbb7LSgIVtMlPSg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/svelte2tsx": {

--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
@@ -62,6 +62,7 @@
     let hasOffscreen = false;
     let resizeObserver: ResizeObserver | null = null;
     // Shared workers multiplex multiple canvases
+    // svelte-ignore state_referenced_locally
     const canvasId = `${sampleId}-${createCanvasInstanceSuffix()}`;
 
     type ColorParser = (color: string) => [number, number, number, number];

--- a/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
@@ -10,6 +10,7 @@
 
     let { collectionId }: Props = $props();
 
+    // svelte-ignore state_referenced_locally
     const annotationCollectionsQuery = useAnnotationCollections({ collectionId });
     const items = $derived(
         ($annotationCollectionsQuery.data ?? []).map((c) => ({ id: c.collection_id, name: c.name }))

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsBreadcrumb/AnnotationDetailsBreadcrumb.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsBreadcrumb/AnnotationDetailsBreadcrumb.svelte
@@ -26,7 +26,7 @@
 
     const { query: sampleAdjacentQuery } = $derived(
         useAdjacentAnnotations({
-            sampleId: page.params.annotationId,
+            sampleId: page.params.annotationId!,
             collectionId: collectionId
         })
     );

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsNavigation/AnnotationDetailsNavigation.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsNavigation/AnnotationDetailsNavigation.svelte
@@ -8,7 +8,7 @@
     const collectionId = $derived(page.params.collection_id!);
     const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type!);
-    const annotationId = $derived(page.params.annotationId);
+    const annotationId = $derived(page.params.annotationId!);
 
     const { query: sampleAdjacentQuery } = $derived(
         useAdjacentAnnotations({

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationDetailsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationDetailsPanel.svelte
@@ -26,6 +26,7 @@
 
     const { isEditingMode } = page.data.globalStorage;
 
+    // svelte-ignore state_referenced_locally
     const { deleteAnnotation } = useDeleteAnnotation({
         collectionId
     });

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationMetadata/AnnotationMetadataLabel/AnnotationMetadataLabel.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationMetadata/AnnotationMetadataLabel/AnnotationMetadataLabel.svelte
@@ -27,15 +27,18 @@
         trackId?: number | null;
     } = $props();
 
+    // svelte-ignore state_referenced_locally
     const result = useAnnotationLabels({ collectionId });
     const { addReversibleAction } = useGlobalStorage();
 
+    // svelte-ignore state_referenced_locally
     const { updateAnnotation, refetch } = useAnnotation({
         collectionId,
         annotationId,
         onUpdate
     });
 
+    // svelte-ignore state_referenced_locally
     const { updateAnnotations: updateAnnotationsRaw } = useUpdateAnnotationsMutation({
         collectionId
     });

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationImageGridItem/AnnotationImageGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationImageGridItem/AnnotationImageGridItem.svelte
@@ -29,7 +29,9 @@
     const { gridViewThumbnailQualityStore } = useSettings();
 
     // Store collection version for cache busting
+    // svelte-ignore state_referenced_locally
     let collectionVersion = $state(cachedCollectionVersion);
+    // svelte-ignore state_referenced_locally
     let collectionVersionLoaded = $state(!!cachedCollectionVersion);
 
     // Component is loaded when both collection version and image are loaded

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
@@ -33,12 +33,14 @@
     const { isHidden } = useHideAnnotations();
     const { customLabelColorsStore } = useCustomLabelColors();
 
+    // svelte-ignore state_referenced_locally
     if (!annotation.object_detection_details && !annotation.segmentation_details) {
         throw new Error(
             'Unsupported annotation: Only annotations with object_detection_details or segmentation_details are supported. Please check the annotation data.'
         );
     }
 
+    // svelte-ignore state_referenced_locally
     const {
         width: annotationWidth,
         height: annotationHeight,
@@ -46,7 +48,7 @@
         y: annotationY
     } = getBoundingBox(annotation);
 
-    const segmentationMask = annotation?.segmentation_details?.segmentation_mask;
+    const segmentationMask = $derived(annotation?.segmentation_details?.segmentation_mask);
     // Calculate values directly without using state
     const scale = $derived(
         Math.min(
@@ -69,7 +71,7 @@
         );
     }
 
-    let labelName = annotation.annotation_label.annotation_label_name;
+    const labelName = $derived(annotation.annotation_label.annotation_label_name);
 
     const colorStroke = $derived.by(
         () => $customLabelColorsStore[labelName]?.color ?? getColorByLabel(labelName, 1).color
@@ -81,7 +83,7 @@
     });
     const opacity = $derived($customLabelColorsStore[labelName]?.alpha ?? 0.4);
 
-    const isRLESegmentation = !!segmentationMask;
+    const isRLESegmentation = $derived(!!segmentationMask);
 
     // Calculate values for use in template
     const xOffset = $derived(getXOffset());
@@ -133,7 +135,7 @@
                     viewBox={`${annotationX} ${annotationY} ${annotationWidth} ${annotationHeight}`}
                 >
                     <SampleAnnotationSegmentationRLE
-                        segmentation={segmentationMask}
+                        segmentation={segmentationMask!}
                         width={sample.width}
                         {colorFill}
                         {opacity}

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -84,6 +84,7 @@
         isPending
     } = $derived(useAnnotationsInfinite(queryParams));
 
+    // svelte-ignore state_referenced_locally
     const { updateAnnotations: updateAnnotationsRaw } = useUpdateAnnotationsMutation({
         collectionId: collection_id
     });

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/SelectedAnnotations.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/SelectedAnnotations.svelte
@@ -17,6 +17,7 @@
 
     const { selectedAnnotations, onSelect, disabled, isLoading, collectionId }: Props = $props();
 
+    // svelte-ignore state_referenced_locally
     const result = useAnnotationLabels({ collectionId });
 
     const items = $derived(getSelectionItems($result.data || []));

--- a/lightly_studio_view/src/lib/components/Captions/Captions.svelte
+++ b/lightly_studio_view/src/lib/components/Captions/Captions.svelte
@@ -13,6 +13,7 @@
     } = $props();
 
     // Fetch collection details to get parent_collection_id
+    // svelte-ignore state_referenced_locally
     const collectionQuery = createQuery(
         readCollectionOptions({
             path: { collection_id: collectionId }

--- a/lightly_studio_view/src/lib/components/Captions/CaptionsItem/CaptionsItem.svelte
+++ b/lightly_studio_view/src/lib/components/Captions/CaptionsItem/CaptionsItem.svelte
@@ -47,6 +47,7 @@
     // For captions page, page.data.collection is the CAPTION collection (sample_type: CAPTION),
     // not the parent collection that contains the actual samples (IMAGE or VIDEO)
     // We need to fetch the collection for the sample's collection_id to get the correct sample type
+    // svelte-ignore state_referenced_locally
     const sampleCollectionQuery = createQuery({
         ...readCollectionOptions({
             path: { collection_id: item.collection_id || '' }
@@ -58,6 +59,7 @@
     const sampleType = $derived(sampleCollection?.sample_type);
 
     // Fetch video data if it's a video sample to get the first frame
+    // svelte-ignore state_referenced_locally
     const videoQuery = createQuery({
         ...getVideoByIdOptions({
             path: { sample_id: item.sample_id }

--- a/lightly_studio_view/src/lib/components/CollectionSearch/CollectionSearch.svelte
+++ b/lightly_studio_view/src/lib/components/CollectionSearch/CollectionSearch.svelte
@@ -33,10 +33,13 @@
         onError
     }: Props = $props();
 
+    // svelte-ignore state_referenced_locally
     let queryText = $state(initialQueryText);
+    // svelte-ignore state_referenced_locally
     let submittedQueryText = $state(initialQueryText);
     let fileInput = $state<HTMLInputElement | null>(null);
 
+    // svelte-ignore state_referenced_locally
     const { dragOver, handleDragOver, handleDragLeave, handleDrop, handlePaste, handleFileSelect } =
         useFileDrop({
             onFileAccepted: async (file) => {

--- a/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/CombinedMetadataDimensionsFilters.svelte
+++ b/lightly_studio_view/src/lib/components/CombinedMetadataDimensionsFilters/CombinedMetadataDimensionsFilters.svelte
@@ -10,7 +10,7 @@
     import VideoFrameBoundsFilter from '../VideoFrameBoundsFilter/VideoFrameBoundsFilter.svelte';
     import VideoFieldBoundsFilters from '../VideoFieldBoundsFilters/VideoFieldBoundsFilters.svelte';
 
-    const collectionId = page.params.collection_id;
+    const collectionId = page.params.collection_id!;
 
     const {
         isVideos = false,

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -16,6 +16,7 @@
 
     const { setRangeSelectionForCollection } = useGlobalStorage();
 
+    // svelte-ignore state_referenced_locally
     const embeddingFilter = isVideos
         ? useEmbeddingFilterForVideos(collectionIdStore, setRangeSelectionForCollection)
         : useEmbeddingFilterForImages(collectionIdStore, setRangeSelectionForCollection);

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -46,7 +46,7 @@
         youtube_vis_segmentation: 'YouTube-VIS Video Segmentation Masks'
     };
     const exportTypeTriggerContent = $derived(exportTypeLabels[exportType]);
-    let collectionId = page.params.collection_id;
+    let collectionId = page.params.collection_id!;
 
     //
     // Sample export

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
@@ -29,7 +29,7 @@
     const exportOptions: ClassifierExportType[] = ['sklearn', 'lightly'];
 
     // Subscribe to page params
-    const collectionId = page.params.collection_id;
+    const collectionId = page.params.collection_id!;
 
     const client = useQueryClient();
 

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/CreateClassifierDialog.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/CreateClassifierDialog.svelte
@@ -14,7 +14,7 @@
     const { createClassifier } = useClassifiers();
 
     let classifierName = $state('');
-    let collectionId = page.params.collection_id;
+    let collectionId = page.params.collection_id!;
     let isSubmitting = $state(false);
     let submitError = $state<string | null>(null);
 

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/RefineClassifierDialog.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/RefineClassifierDialog.svelte
@@ -29,7 +29,7 @@
     const { openClassifiersMenu, switchToManageTab, scrollToAndSelectClassifier } =
         useClassifiersMenu();
 
-    let collectionId = page.params.collection_id;
+    let collectionId = page.params.collection_id!;
     let isSubmitting = $state(false);
     let showInstructions = $state(false);
     let submitError = $state<string | null>(null);

--- a/lightly_studio_view/src/lib/components/FrameAnnotationsPanel/FrameAnnotationsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/FrameAnnotationsPanel/FrameAnnotationsPanel.svelte
@@ -37,6 +37,7 @@
     }: Props = $props();
 
     const { isEditingMode } = page.data.globalStorage;
+    // svelte-ignore state_referenced_locally
     const annotationLabels = useAnnotationLabels({ collectionId });
     const items = $derived(getSelectionItems($annotationLabels.data || []));
     const annotations = $derived(

--- a/lightly_studio_view/src/lib/components/FrameDetailsNavigation/FrameDetailsNavigation.svelte
+++ b/lightly_studio_view/src/lib/components/FrameDetailsNavigation/FrameDetailsNavigation.svelte
@@ -8,8 +8,8 @@
 
     const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type!);
-    const collectionId = $derived(page.params.collection_id);
-    const sampleId = $derived(page.params.sample_id);
+    const collectionId = $derived(page.params.collection_id!);
+    const sampleId = $derived(page.params.sample_id!);
     const isFromVideos = $derived(Boolean(page.url.searchParams.get('from_video')));
 
     const { query: sampleAdjacentQuery } = $derived(

--- a/lightly_studio_view/src/lib/components/Grid/Grid.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.svelte
@@ -48,6 +48,7 @@
         gridProps?: Partial<ComponentProps<typeof VirtualGrid>>;
     } = $props();
 
+    // svelte-ignore state_referenced_locally
     let previousScrollResetKey = scrollResetKey;
     let previousInitialScrollPosition = $state<number | undefined>(undefined);
     let pendingRestoreRaf: number | undefined;

--- a/lightly_studio_view/src/lib/components/GroupsComponentsMenu/GroupsComponentsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/GroupsComponentsMenu/GroupsComponentsMenu.svelte
@@ -19,8 +19,10 @@
         collectionId: string;
     } = $props();
 
+    // svelte-ignore state_referenced_locally
     const { groupComponents } = useGroupComponents({ groupId });
     const components = $derived<GroupComponentView[]>($groupComponents.data ?? []);
+    // svelte-ignore state_referenced_locally
     let selectedComponentId = $state(componentId);
     const selectedIndex = $derived(
         components.findIndex((c) => c.details?.sample_id === selectedComponentId)

--- a/lightly_studio_view/src/lib/components/Header/Header.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Header.svelte
@@ -22,6 +22,7 @@
     const isVideos = $derived(isVideosRoute(page.route.id));
     const { settingsStore } = useSettings();
 
+    // svelte-ignore state_referenced_locally
     const hasEmbeddingsQuery = useHasEmbeddings({ collectionId: collection.collection_id });
     const hasEmbeddings = $derived(!!$hasEmbeddingsQuery.data);
 

--- a/lightly_studio_view/src/lib/components/Images/Images.svelte
+++ b/lightly_studio_view/src/lib/components/Images/Images.svelte
@@ -41,12 +41,14 @@
         useSelectedAnnotationsFilter();
     const { selectedCollectionIds } = useAnnotationCollectionsFilter();
 
+    // svelte-ignore state_referenced_locally
     const { tagsSelected } = useTags({
         collection_id,
         kind: ['sample']
     });
 
     const { dimensionsValues: dimensions } = useDimensions();
+    // svelte-ignore state_referenced_locally
     const { metadataValues } = useMetadataFilters(collection_id);
 
     const {
@@ -133,6 +135,7 @@
             ? $infiniteSamples.data.pages.flatMap((page: { data?: ImageView[] }) => page.data ?? [])
             : []
     );
+    // svelte-ignore state_referenced_locally
     const selectedSampleIds = getSelectedSampleIds(collection_id);
     let selectionAnchorSampleId = $state<string | null>(null);
 

--- a/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
@@ -47,7 +47,7 @@
         ($p) =>
             ({
                 routeId: $p.route.id,
-                collectionId: $p.params.collection_id,
+                collectionId: $p.params.collection_id!,
                 sampleId: $p.params.sampleId || $p.params.sample_id || null,
                 annotationId: $p.params.annotationId || null,
                 sampleType: ($p.params.collection_type as SampleType) ?? null
@@ -56,7 +56,7 @@
 
     const queryClient = useQueryClient();
 
-    const collectionId = $page.params.collection_id;
+    const collectionId = $page.params.collection_id!;
 
     const { tagsSelected } = useTags({ collection_id: collectionId, kind: ['annotation'] });
 

--- a/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
@@ -104,6 +104,7 @@
         }
     });
 
+    // svelte-ignore state_referenced_locally
     let previousIsOpen = isOpen;
     $effect(() => {
         if (!isOpen && previousIsOpen) {

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -18,7 +18,7 @@
     import { page } from '$app/state';
     import { isVideosRoute } from '$lib/routes';
 
-    const collectionId = page.params.collection_id;
+    const collectionId = page.params.collection_id!;
     const { setShowPlot, getRangeSelection, setRangeSelectionForCollection } = useGlobalStorage();
     const rangeSelection = getRangeSelection(collectionId);
     const setRangeSelection = (selection: Point[] | null) => {

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.svelte
@@ -49,7 +49,7 @@
         return $collectionIdToName[annotation.annotation_collection_id] ?? label;
     });
 
-    const segmentationMask = annotation?.segmentation_details?.segmentation_mask;
+    const segmentationMask = $derived(annotation?.segmentation_details?.segmentation_mask);
 
     const annotationId = $derived(annotation.sample_id);
 
@@ -84,6 +84,7 @@
         segmentationMask ? 0 : ($customLabelColorsStore[colorLabel]?.alpha ?? 1.0) * 0.4
     );
 
+    // svelte-ignore state_referenced_locally
     let boundingBox = $state<BoundingBox>(getBoundingBox(annotation));
 
     const onResize = (newBbox: BoundingBox) => {

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationBox/SampleAnnotationBox.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationBox/SampleAnnotationBox.svelte
@@ -15,11 +15,12 @@
         annotationId: string;
         isPrediction?: boolean;
     } = $props();
+    // svelte-ignore state_referenced_locally
     const [x, y, width, height] = bbox;
 
     // Define different styles for predictions vs. ground truth
-    const strokeDashArray = isPrediction ? '5,5' : 'none';
-    const strokeOpacity = isPrediction ? 0.8 : 1;
+    const strokeDashArray = $derived(isPrediction ? '5,5' : 'none');
+    const strokeOpacity = $derived(isPrediction ? 0.8 : 1);
 </script>
 
 <rect

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationLabel/SampleAnnotationLabel.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationLabel/SampleAnnotationLabel.svelte
@@ -37,8 +37,8 @@
     const paddingX = 5;
 
     // Adjust styling for prediction labels
-    const labelOpacity = isPrediction ? 0.8 : 1;
-    const labelFontStyle = isPrediction ? 'italic' : 'normal';
+    const labelOpacity = $derived(isPrediction ? 0.8 : 1);
+    const labelFontStyle = $derived(isPrediction ? 'italic' : 'normal');
 </script>
 
 <!-- This is a tricky way to have 'unscaled components, in this case we need to have unscaled text -->

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationSegmentationRLE/SampleAnnotationSegmentationRLE.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationSegmentationRLE/SampleAnnotationSegmentationRLE.svelte
@@ -17,6 +17,7 @@
         prerenderedHeight?: number;
     } = $props();
 
+    // svelte-ignore state_referenced_locally
     if (!segmentation) {
         throw new Error('Segmentation data is required');
     }

--- a/lightly_studio_view/src/lib/components/SampleDetails/ImageDetails.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/ImageDetails.svelte
@@ -22,7 +22,7 @@
         children?: Snippet;
     } = $props();
 
-    const collectionId = collection.collection_id!;
+    const collectionId = $derived(collection.collection_id!);
 
     // Get route parameters from page
     const datasetId = $derived(page.params.dataset_id!);

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.svelte
@@ -37,10 +37,13 @@
         setLockedAnnotationIds
     } = useAnnotationLabelContext();
 
+    // svelte-ignore state_referenced_locally
     const annotationLabels = useAnnotationLabels({ collectionId });
+    // svelte-ignore state_referenced_locally
     const { createAnnotation } = useCreateAnnotation({
         collectionId
     });
+    // svelte-ignore state_referenced_locally
     const { deleteAnnotation } = useDeleteAnnotation({
         collectionId
     });

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsBreadcrumb/SampleDetailsBreadcrumb.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsBreadcrumb/SampleDetailsBreadcrumb.svelte
@@ -26,7 +26,7 @@
 
     const { query: sampleAdjacentQuery } = $derived(
         useAdjacentImages({
-            sampleId: page.params.sampleId,
+            sampleId: page.params.sampleId!,
             collectionId
         })
     );

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -30,10 +30,15 @@
 
     const { isEditingMode, addReversibleAction } = useGlobalStorage();
 
+    // svelte-ignore state_referenced_locally
     const annotationLabels = useAnnotationLabels({ collectionId });
+    // svelte-ignore state_referenced_locally
     const { createAnnotation } = useCreateAnnotation({ collectionId });
+    // svelte-ignore state_referenced_locally
     const { deleteAnnotation } = useDeleteAnnotation({ collectionId });
+    // svelte-ignore state_referenced_locally
     const { createLabel } = useCreateLabel({ collectionId });
+    // svelte-ignore state_referenced_locally
     const { updateAnnotations } = useUpdateAnnotationsMutation({ collectionId });
     const datasetId = $derived(page.params.dataset_id!);
     const { refetch: refetchRootCollection } = $derived.by(() =>

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsNavigation/SampleDetailsNavigation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsNavigation/SampleDetailsNavigation.svelte
@@ -8,11 +8,11 @@
 
     const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type!);
-    const collectionId = $derived(page.params.collection_id);
+    const collectionId = $derived(page.params.collection_id!);
 
     const { query: sampleAdjacentQuery } = $derived(
         useAdjacentImages({
-            sampleId: page.params.sampleId,
+            sampleId: page.params.sampleId!,
             collectionId
         })
     );

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsPanel.svelte
@@ -80,6 +80,7 @@
     const { isEditingMode, lastAnnotationLabel } = useGlobalStorage();
 
     // Annotation details must use the first annotation from sample.annotations
+    // svelte-ignore state_referenced_locally
     const annotationLabelContext = createAnnotationLabelContext({
         isOnAnnotationDetailsView: isOnAnnotationDetailsView,
         annotationId: isOnAnnotationDetailsView ? sample.annotations![0].sample_id : null

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSelectableBox/SampleDetailsSelectableBox.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSelectableBox/SampleDetailsSelectableBox.svelte
@@ -12,6 +12,7 @@
 
     const { getSelectedSampleIds, toggleSampleSelection } = useGlobalStorage();
 
+    // svelte-ignore state_referenced_locally
     const selectedSampleIds = getSelectedSampleIds(collectionId);
 </script>
 

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsToolbarTooltip/SampleDetailsToolbarTooltip.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsToolbarTooltip/SampleDetailsToolbarTooltip.svelte
@@ -17,6 +17,7 @@
     let visible = $state(false);
 </script>
 
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
     class="relative"
     onpointerenter={() => (visible = true)}

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleEraserRect/SampleEraserRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleEraserRect/SampleEraserRect.svelte
@@ -156,7 +156,7 @@
         refetch();
     };
 
-    const datasetId = $derived(page.params.dataset_id);
+    const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type ?? page.data.collectionType);
     const currentAnnotationId = $derived(
         annotationLabelContext.annotationId ?? sample.annotations[0]?.sample_id ?? ''

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleEraserRect/SampleEraserRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleEraserRect/SampleEraserRect.svelte
@@ -54,11 +54,14 @@
         setAnnotationId
     } = useAnnotationLabelContext();
 
+    // svelte-ignore state_referenced_locally
     const { deleteAnnotation } = useDeleteAnnotation({
         collectionId
     });
+    // svelte-ignore state_referenced_locally
     const annotationLabels = useAnnotationLabels({ collectionId });
     const { addReversibleAction } = useGlobalStorage();
+    // svelte-ignore state_referenced_locally
     const { createAnnotation } = useCreateAnnotation({
         collectionId
     });

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleObjectDetectionRect/SampleObjectDetectionRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleObjectDetectionRect/SampleObjectDetectionRect.svelte
@@ -50,11 +50,15 @@
 
     let temporaryBbox = $state<BoundingBox | null>(null);
     let shouldDisableInteraction = $state(false);
+    // svelte-ignore state_referenced_locally
     const labels = useAnnotationLabels({ collectionId });
+    // svelte-ignore state_referenced_locally
     const { createLabel } = useCreateLabel({ collectionId });
+    // svelte-ignore state_referenced_locally
     const { createAnnotation } = useCreateAnnotation({
         collectionId
     });
+    // svelte-ignore state_referenced_locally
     const { deleteAnnotation } = useDeleteAnnotation({
         collectionId
     });

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect/SampleSegmentationMaskRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect/SampleSegmentationMaskRect.svelte
@@ -48,6 +48,7 @@
         onFinishBrushPendingChange
     }: SampleSegmentationMaskRectProps = $props();
 
+    // svelte-ignore state_referenced_locally
     const labels = useAnnotationLabels({ collectionId });
     const activeAnnotationId = $derived.by(() => {
         if (annotationLabelContext.annotationId) return annotationLabelContext.annotationId;

--- a/lightly_studio_view/src/lib/components/SegmentTags/SegmentTags.svelte
+++ b/lightly_studio_view/src/lib/components/SegmentTags/SegmentTags.svelte
@@ -21,6 +21,7 @@
 
     let { tags, collectionId, sampleId, onRefetch = () => {} }: Props = $props();
 
+    // svelte-ignore state_referenced_locally
     const { removeTagFromSample } = useRemoveTagFromSample({ collectionId });
 
     async function handleRemoveTag(tagId: string) {
@@ -42,6 +43,7 @@
         useTags({ collection_id: collectionId, kind: [tagKind] })
     );
 
+    // svelte-ignore state_referenced_locally
     const {
         busy: addTagBusy,
         addExisting,

--- a/lightly_studio_view/src/lib/components/SelectableSvgGroup/SelectableSvgGroup.svelte
+++ b/lightly_studio_view/src/lib/components/SelectableSvgGroup/SelectableSvgGroup.svelte
@@ -16,6 +16,7 @@
         box: BoundingBox;
     } = $props();
 
+    // svelte-ignore state_referenced_locally
     const { x, y, width, height } = box;
     const handleSelect = () => {
         onSelect(groupId);

--- a/lightly_studio_view/src/lib/components/SideMenu/SideMenu/SideMenu.svelte
+++ b/lightly_studio_view/src/lib/components/SideMenu/SideMenu/SideMenu.svelte
@@ -19,6 +19,7 @@
         containerProps,
         showColorMarker
     }: SideMenuProps = $props();
+    // svelte-ignore state_referenced_locally
     let selectedItemsIds = $state(initialSelectedItemsIds ?? []);
 
     const handleCheckedChange = (id: string) => {

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagRenameInput.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagRenameInput.svelte
@@ -21,6 +21,7 @@
         onCancel: () => void;
     } = $props();
 
+    // svelte-ignore state_referenced_locally
     let renameValue = $state(tag.name);
     let renameInputRef = $state<HTMLInputElement | null>(null);
 

--- a/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
+++ b/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
@@ -31,6 +31,7 @@
     let videoEl: HTMLVideoElement | null = $state(null);
     let frameRequestId: number | null = $state(null);
 
+    // svelte-ignore state_referenced_locally
     const {
         currentFrame,
         frames: videoFrames,

--- a/lightly_studio_view/src/lib/components/VideoDetailsNavigation/VideoDetailsNavigation.svelte
+++ b/lightly_studio_view/src/lib/components/VideoDetailsNavigation/VideoDetailsNavigation.svelte
@@ -7,8 +7,8 @@
 
     const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type!);
-    const collectionId = $derived(page.params.collection_id);
-    const sampleId = $derived(page.params.sample_id);
+    const collectionId = $derived(page.params.collection_id!);
+    const sampleId = $derived(page.params.sample_id!);
 
     const { query: sampleAdjacentQuery } = $derived(
         useAdjacentVideos({

--- a/lightly_studio_view/src/lib/components/VideoFieldBoundsFilters/VideoFieldBoundsFilters.svelte
+++ b/lightly_studio_view/src/lib/components/VideoFieldBoundsFilters/VideoFieldBoundsFilters.svelte
@@ -4,7 +4,7 @@
     import { formatInteger } from '$lib/utils';
     import { Slider } from '$lib/components/ui/slider/index.js';
     const { videoBounds, videoBoundsValues, updateVideoBoundsValues } = useVideoBounds(
-        page.params.collection_id
+        page.params.collection_id!
     );
 
     const handleChangeWidth = (newValues: number[]) => {

--- a/lightly_studio_view/src/lib/components/VideoFrameBoundsFilter/VideoFrameBoundsFilter.svelte
+++ b/lightly_studio_view/src/lib/components/VideoFrameBoundsFilter/VideoFrameBoundsFilter.svelte
@@ -4,7 +4,7 @@
     import { Slider } from '$lib/components/ui/slider/index.js';
     import { useVideoFramesBounds } from '$lib/hooks/useVideoFramesBounds/useVideoFramesBounds';
     const { videoFramesBounds, videoFramesBoundsValues, updateVideoFramesBoundsValues } =
-        useVideoFramesBounds(page.params.collection_id);
+        useVideoFramesBounds(page.params.collection_id!);
 
     const handleChangeFrameNumber = (newValues: number[]) => {
         if (!$videoFramesBoundsValues) return;

--- a/lightly_studio_view/src/lib/components/VideoItem/VideoItem.svelte
+++ b/lightly_studio_view/src/lib/components/VideoItem/VideoItem.svelte
@@ -38,6 +38,7 @@
     const HOVER_DELAY = 200;
     let isHovering = false;
     // Start it with the initial frame
+    // svelte-ignore state_referenced_locally
     let frames = $state<FrameView[]>(video.frame == null ? [] : [video.frame]);
 
     async function handleMouseEnter() {

--- a/lightly_studio_view/src/lib/components/VideoPlayer/VideoPlayer.svelte
+++ b/lightly_studio_view/src/lib/components/VideoPlayer/VideoPlayer.svelte
@@ -60,6 +60,7 @@
         preload: 'metadata'
     };
 
+    // svelte-ignore state_referenced_locally
     const { class: videoClass, ...restVideoProps } = videoProps;
     const mergedVideoProps = { ...defaultVideoProps, ...restVideoProps };
 

--- a/lightly_studio_view/src/lib/components/ui/color-picker/color-picker.svelte
+++ b/lightly_studio_view/src/lib/components/ui/color-picker/color-picker.svelte
@@ -25,7 +25,9 @@
 
     let isOpen = $state(false);
     let triggerElement: HTMLElement;
+    // svelte-ignore state_referenced_locally
     let colorValue = $state(initialColor);
+    // svelte-ignore state_referenced_locally
     let alphaValue = $state(initialAlpha);
 
     // Predefined colors for quick selection

--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifierUtils.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifierUtils.ts
@@ -133,7 +133,7 @@ export function useClassifierUtils(): UseClassifierUtilsReturn {
     };
 
     async function prepareSamples(): Promise<PrepareSamplesResponse> {
-        const collectionId = page.params.collection_id;
+        const collectionId = page.params.collection_id!;
         const selectedSampleIds = getSelectedSampleIds(collectionId);
         const selectedIds = get(selectedSampleIds);
         const positives = Array.from(selectedIds);

--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.ts
@@ -98,7 +98,7 @@ export function useClassifiers(): UseClassifiersReturn {
         try {
             const response = await client.GET('/api/classifiers/get_all_classifiers', {
                 params: {
-                    query: { collection_id: page.params.collection_id }
+                    query: { collection_id: page.params.collection_id! }
                 }
             });
             if (response.data?.classifiers) {
@@ -234,7 +234,7 @@ export function useClassifiers(): UseClassifiersReturn {
                             params: {
                                 path: {
                                     classifier_id: classifier_id,
-                                    collection_id: page.params.collection_id
+                                    collection_id: page.params.collection_id!
                                 }
                             }
                         }

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/annotations/[annotationId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/annotations/[annotationId]/+page.svelte
@@ -12,7 +12,7 @@
 
     const collectionId = $derived(page.params.collection_id!);
 
-    const annotationId = $derived(page.params.annotationId);
+    const annotationId = $derived(page.params.annotationId!);
 
     const {
         annotation: annotationDetailsResponse,

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/captions/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/captions/+page.svelte
@@ -2,7 +2,7 @@
     import { page } from '$app/state';
     import Captions from '$lib/components/Captions/Captions.svelte';
 
-    const collectionId = $derived(page.params.collection_id);
+    const collectionId = $derived(page.params.collection_id!);
 </script>
 
 {#key collectionId}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
@@ -20,7 +20,7 @@
     import { useScrollRestoration } from '$lib/hooks/useScrollRestoration/useScrollRestoration';
     import { onMount } from 'svelte';
 
-    const collectionId = $derived(page.params.collection_id);
+    const collectionId = $derived(page.params.collection_id!);
 
     const { metadataValues } = $derived(useMetadataFilters(collectionId));
     const { videoFramesBoundsValues } = $derived(useVideoFramesBounds(collectionId));

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/+page.svelte
@@ -6,6 +6,7 @@
 
     const { data } = $props();
 
+    // svelte-ignore state_referenced_locally
     const {
         sampleSize,
         globalStorage: { textEmbedding }

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
@@ -9,9 +9,9 @@
 
     createSampleDetailsToolbarContext();
 
-    const sampleId = $derived(page.params.sampleId);
+    const sampleId = $derived(page.params.sampleId!);
     const datasetId = $derived(page.params.dataset_id!);
-    const collectionType = $derived(page.params.collection_type);
+    const collectionType = $derived(page.params.collection_type!);
     const collection = page.data.collection;
     const collectionId = $derived(page.params.collection_id!);
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
@@ -16,7 +16,9 @@
     $effect(() => {
         loadById(data.params.sample_id);
     });
+    // svelte-ignore state_referenced_locally
     const frameNumber = data.frameNumber ? parseInt(data.frameNumber) : undefined;
+    // svelte-ignore state_referenced_locally
     const { collection } = useCollectionWithChildren({
         collectionId: data.params.dataset_id
     });


### PR DESCRIPTION
## What has changed and why?

Update Svelte and SvelteKit version:
```
npm update @sveltejs/kit svelte
```

The new version types page params stricter, as `string | undefined`. The type errors are solved with the `!` operator.

Note that a more proper fix would be to use `!` only from `+page.svelte` files and pass only needed arguments to Svelte componets that currently directly read `page`. The refactor though is out of scope.

Follow-up: `npm run check` passes but prints warnings. To be addressed separately.

## How has it been tested?

Existing tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety for route parameter handling across the application to ensure parameters are properly validated and consistently treated as required values, improving stability and reliability.

* **Bug Fixes**
  * Fixed potential issues where route parameters could be improperly handled as undefined values in various components and features throughout the annotation and data exploration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->