### PR TITLE
Migrate export collection endpoints off legacy openapi-fetch client

### DIFF
--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportSamplesCount/useExportSamplesCount.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportSamplesCount/useExportSamplesCount.test.ts
@@ -1,7 +1,14 @@
-import { client } from '$lib/services/collection';
 import { get } from 'svelte/store';
 import { describe, expect, it, vi } from 'vitest';
 import { useExportSamplesCount } from './useExportSamplesCount';
+
+const mocks = vi.hoisted(() => ({
+    exportCollectionStats: vi.fn()
+}));
+
+vi.mock('$lib/api/lightly_studio_local', () => ({
+    exportCollectionStats: mocks.exportCollectionStats
+}));
 
 const defaultProps: Parameters<typeof useExportSamplesCount>[0] = {
     collection_id: 'test-collection',
@@ -13,25 +20,21 @@ const defaultProps: Parameters<typeof useExportSamplesCount>[0] = {
 describe('useExportStats', () => {
     beforeEach(vi.resetAllMocks);
 
-    it('should call samples_paths endpoint', () => {
-        const mockedSpy = vi.spyOn(client, 'POST').mockResolvedValueOnce({ data: 0 });
+    it('should call export stats endpoint', () => {
+        mocks.exportCollectionStats.mockResolvedValueOnce({ data: 0 });
         useExportSamplesCount(defaultProps);
-        expect(mockedSpy).toHaveBeenCalledWith('/api/collections/{collection_id}/export/stats', {
+        expect(mocks.exportCollectionStats).toHaveBeenCalledWith({
+            path: { collection_id: 'test-collection' },
             body: {
                 include: defaultProps.includeFilter,
                 exclude: undefined
-            },
-            params: {
-                path: {
-                    collection_id: 'test-collection'
-                }
             }
         });
     });
 
     it('should reflect loading state', async () => {
         const expectedCount = 42;
-        vi.spyOn(client, 'POST').mockResolvedValueOnce({ data: expectedCount });
+        mocks.exportCollectionStats.mockResolvedValueOnce({ data: expectedCount });
         const { isLoading, count, error } = useExportSamplesCount(defaultProps);
 
         // Initial state
@@ -48,11 +51,11 @@ describe('useExportStats', () => {
 
     it('should handle errors', async () => {
         const errorMessage = 'API Error';
-        vi.spyOn(client, 'POST').mockRejectedValueOnce(new Error(errorMessage));
+        mocks.exportCollectionStats.mockRejectedValueOnce(new Error(errorMessage));
 
         const { isLoading, count, error } = useExportSamplesCount(defaultProps);
 
-        // // Wait for error to be displayed
+        // Wait for error state
         await vi.waitFor(() => {
             expect(get(isLoading)).toBe(false);
             expect(get(count)).toBe(0);

--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportSamplesCount/useExportSamplesCount.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportSamplesCount/useExportSamplesCount.ts
@@ -1,4 +1,4 @@
-import { client } from '$lib/services/collection';
+import { exportCollectionStats } from '$lib/api/lightly_studio_local';
 import type { ExportFilter } from '$lib/services/types';
 import { writable, type Readable } from 'svelte/store';
 
@@ -33,18 +33,13 @@ export function useExportSamplesCount({
     if (hasIncludeFilter || hasExcludeFilter) {
         isLoading.set(true);
 
-        client
-            .POST('/api/collections/{collection_id}/export/stats', {
-                params: {
-                    path: {
-                        collection_id
-                    }
-                },
-                body: {
-                    include: includeFilter,
-                    exclude: excludeFilter
-                }
-            })
+        exportCollectionStats({
+            path: { collection_id },
+            body: {
+                include: includeFilter,
+                exclude: excludeFilter
+            }
+        })
             .then((response) => {
                 if (response?.data) {
                     count.set(response.data);

--- a/lightly_studio_view/src/lib/services/exportCollection.ts
+++ b/lightly_studio_view/src/lib/services/exportCollection.ts
@@ -1,6 +1,6 @@
+import { exportCollectionToAbsolutePaths } from '$lib/api/lightly_studio_local';
 import type { ExportFilter, LoadResult } from '$lib/services/types';
 import { triggerDownloadBlob } from '$lib/utils';
-import { client } from './collection';
 
 type ExportCollectionResult = LoadResult<Blob | undefined>;
 type ExportCollectionParams = {
@@ -10,7 +10,6 @@ type ExportCollectionParams = {
     excludeFilter?: ExportFilter;
 };
 
-// TODO: properly abstract each endpoint and use the types of client to make the request
 export const exportCollection = async ({
     collection_id,
     filename = '',
@@ -19,12 +18,8 @@ export const exportCollection = async ({
 }: ExportCollectionParams): Promise<ExportCollectionResult> => {
     const result: ExportCollectionResult = { data: undefined, error: undefined };
     try {
-        const response = await client.POST('/api/collections/{collection_id}/export', {
-            params: {
-                path: {
-                    collection_id: collection_id
-                }
-            },
+        const response = await exportCollectionToAbsolutePaths({
+            path: { collection_id },
             body: {
                 include: includeFilter,
                 exclude: excludeFilter
@@ -32,16 +27,16 @@ export const exportCollection = async ({
             headers: {
                 'Access-Control-Expose-Headers': 'Content-Disposition'
             },
-            parseAs: 'blob'
+            parseAs: 'text'
         });
         if (response.error) {
             throw new Error(JSON.stringify(response.error, null, 2));
         }
 
-        if (!response.data) {
+        if (!response.data || typeof response.data !== 'string') {
             throw new Error('No data');
         }
-        result.data = response.data;
+        result.data = new Blob([response.data], { type: 'text/plain' });
 
         // trigger download as a certain filename
         filename =


### PR DESCRIPTION
## What has changed and why?

Migrates the export collection endpoints (`/export` and `/export/stats`) off the legacy `openapi-fetch` client to use the generated API functions (`exportCollectionToAbsolutePaths`, `exportCollectionStats`).

This is part of the ongoing effort to deprecate the legacy `schema.d.ts`-based client in favor of the generated, type-safe API layer.

Changes:
- `exportCollection.ts`: Replace `client.POST` with `exportCollectionToAbsolutePaths`, parse response as text and wrap in a Blob
- `useExportSamplesCount.ts`: Replace `client.POST` with `exportCollectionStats`
- `useExportSamplesCount.test.ts`: Mock the new API function directly instead of spying on the legacy client

## How has it been tested?

- Updated unit tests pass
- Manual verification of export flow

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal API integration for sample export statistics and collection export operations to use improved service abstractions, strengthening code maintainability and consistency across all export workflows and features.
  * Updated comprehensive test coverage to thoroughly validate the refactored implementation and ensure proper handling of loading states, success cases, and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1130)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->