### PR TITLE
Fix sort priority when combining order_by with embedding similarity

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_adjacent_images.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_adjacent_images.py
@@ -87,7 +87,7 @@ def _base_query(
         tiebreaker = []
     if ordering_expression is not None:
         order_col = (
-            ordering_expression + [expr.to_column_element() for expr in order_by] + tiebreaker
+            [expr.to_column_element() for expr in order_by] + ordering_expression + tiebreaker
             if order_by
             else [*ordering_expression, *tiebreaker]
         )

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_all_by_collection_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_all_by_collection_id.py
@@ -165,7 +165,6 @@ def _get_all_with_similarity(  # noqa: PLR0913
         samples_query = samples_query.where(col(ImageTable.sample_id).in_(sample_ids))
         total_count_query = total_count_query.where(col(ImageTable.sample_id).in_(sample_ids))
 
-    samples_query = samples_query.order_by(distance_expr)
     if order_by:
         if any(
             isinstance(expr, OrderByMetadataField) for expr in order_by
@@ -179,6 +178,7 @@ def _get_all_with_similarity(  # noqa: PLR0913
                 samples_query = expr.apply_join(samples_query)  # type: ignore[arg-type,assignment]
         for expr in order_by:
             samples_query = samples_query.order_by(expr.to_column_element())
+    samples_query = samples_query.order_by(distance_expr)
     if not order_by or not _file_path_abs_in_order_by(order_by):
         file_path_col = col(ImageTable.file_path_abs)
         tiebreaker = (

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_adjacent_images.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_adjacent_images.py
@@ -353,6 +353,74 @@ def test_get_adjacent_images__with_similarity_and_order_by(db_session: Session) 
     assert result.next_sample_id == image_c.sample_id
 
 
+def test_get_adjacent_images__similarity_is_tiebreaker_when_order_by_values_equal(
+    db_session: Session,
+) -> None:
+    collection = helpers_resolvers.create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    embedding_model = helpers_resolvers.create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_name="embedding-tiebreaker",
+        embedding_dimension=2,
+    )
+
+    # image_a and image_b share the same width but differ in similarity to the query
+    image_a = helpers_resolvers.create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/images/a.png",
+        width=100,
+    )
+    image_b = helpers_resolvers.create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/images/b.png",
+        width=100,
+    )
+    image_c = helpers_resolvers.create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/images/c.png",
+        width=200,
+    )
+
+    helpers_resolvers.create_sample_embedding(
+        session=db_session,
+        sample_id=image_a.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[1.0, 0.0],
+    )
+    helpers_resolvers.create_sample_embedding(
+        session=db_session,
+        sample_id=image_b.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[-1.0, 0.0],
+    )
+    helpers_resolvers.create_sample_embedding(
+        session=db_session,
+        sample_id=image_c.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[0.0, 1.0],
+    )
+
+    # Sorted order: image_a (100, close), image_b (100, far), image_c (200)
+    # image_b's previous is image_a, next is image_c.
+    result = image_resolver.get_adjacent_images(
+        session=db_session,
+        sample_id=image_b.sample_id,
+        collection_id=collection_id,
+        text_embedding=[1.0, 0.0],
+        order_by=[OrderByField(ImageSampleField.width)],
+    )
+
+    assert result is not None
+    assert result.previous_sample_id == image_a.sample_id
+    assert result.sample_id == image_b.sample_id
+    assert result.next_sample_id == image_c.sample_id
+
+
 def test_get_adjacent_images__sort_by_width_desc_with_duplicate_values(db_session: Session) -> None:
     collection = helpers_resolvers.create_collection(session=db_session)
     collection_id = collection.collection_id

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
@@ -754,6 +754,73 @@ def test_get_all_by_collection_id__with_similarity_and_order_by(db_session: Sess
     assert result.samples[2].file_name == "c.png"
 
 
+def test_get_all_by_collection_id__similarity_is_tiebreaker_when_order_by_values_equal(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_name="example_embedding_model",
+        embedding_dimension=2,
+    )
+
+    # image_a and image_b share the same width but differ in similarity to the query
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/images/a.png",
+        width=100,
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/images/b.png",
+        width=100,
+    )
+    image_c = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/images/c.png",
+        width=200,
+    )
+
+    create_sample_embedding(
+        session=db_session,
+        sample_id=image_a.sample_id,
+        embedding=[1.0, 0.0],
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=image_b.sample_id,
+        embedding=[-1.0, 0.0],
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=image_c.sample_id,
+        embedding=[0.0, 1.0],
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+
+    result = image_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=collection_id,
+        text_embedding=[1.0, 0.0],
+        order_by=[OrderByField(ImageSampleField.width)],
+    )
+
+    assert len(result.samples) == 3
+    # width is the primary sort: image_a (100) and image_b (100) are tied, image_c (200) is last.
+    # similarity distance breaks the tie: image_a is closest → image_a before image_b.
+    assert result.samples[0].sample_id == image_a.sample_id
+    assert result.samples[1].sample_id == image_b.sample_id
+    assert result.samples[2].sample_id == image_c.sample_id
+
+
 def test_get_all_by_collection_id__sort_by_metadata_field_asc(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id


### PR DESCRIPTION
## What has changed and why?

When both `order_by` and `text_embedding` are provided, `order_by` is now the primary sort and similarity distance is the secondary tiebreaker

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted result ordering precedence in similarity-based search when custom sort fields contain equal values, ensuring similarity is properly used as a tiebreaker.

* **Tests**
  * Added tests validating ordering behavior in similarity-based queries with custom sort conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1132)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->