### PR TITLE
Add useSortFields hook combining image, metadata, and evaluation metric sort fields

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.test.ts
@@ -1,0 +1,140 @@
+import { get, writable } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MetadataInfoView } from '$lib/api/lightly_studio_local';
+import type { EvaluationRunMetricsInfoView } from '$lib/api/lightly_studio_local/types.gen';
+import { useSortFields } from './useSortFields';
+
+const metadataInfo = writable<MetadataInfoView[]>([]);
+const metricsInfo = writable<{ data: EvaluationRunMetricsInfoView[] | null }>({ data: null });
+
+vi.mock('$lib/hooks/useMetadataFilters/useMetadataFilters', () => ({
+    useMetadataFilters: () => ({ metadataInfo })
+}));
+
+vi.mock('$lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo', () => ({
+    useEvaluationSampleMetricsInfo: () => metricsInfo
+}));
+
+describe('useSortFields', () => {
+    beforeEach(() => {
+        metadataInfo.set([]);
+        metricsInfo.set({ data: null });
+    });
+
+    describe('allSortFields', () => {
+        it('contains the five base image sort fields', () => {
+            const { allSortFields } = useSortFields({ datasetId: 'ds1' });
+            const fields = get(allSortFields);
+
+            expect(fields).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ source: 'image', value: 'file_name' }),
+                    expect.objectContaining({ source: 'image', value: 'file_path_abs' }),
+                    expect.objectContaining({ source: 'image', value: 'created_at' }),
+                    expect.objectContaining({ source: 'image', value: 'width' }),
+                    expect.objectContaining({ source: 'image', value: 'height' })
+                ])
+            );
+        });
+
+        it('includes metadata fields of supported types with metadata. prefix label', () => {
+            metadataInfo.set([
+                { name: 'score', type: 'float' },
+                { name: 'count', type: 'integer' },
+                { name: 'label', type: 'string' },
+                { name: 'active', type: 'boolean' }
+            ]);
+            const { allSortFields } = useSortFields({ datasetId: 'ds1' });
+            const fields = get(allSortFields);
+
+            expect(fields).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        source: 'metadata',
+                        value: 'score',
+                        label: 'metadata.score',
+                        is_numeric: true
+                    }),
+                    expect.objectContaining({
+                        source: 'metadata',
+                        value: 'count',
+                        label: 'metadata.count',
+                        is_numeric: true
+                    }),
+                    expect.objectContaining({
+                        source: 'metadata',
+                        value: 'label',
+                        label: 'metadata.label',
+                        is_numeric: false
+                    }),
+                    expect.objectContaining({
+                        source: 'metadata',
+                        value: 'active',
+                        label: 'metadata.active',
+                        is_numeric: false
+                    })
+                ])
+            );
+        });
+
+        it('excludes list and dict metadata fields', () => {
+            metadataInfo.set([
+                { name: 'tags', type: 'list' },
+                { name: 'nested', type: 'dict' },
+                { name: 'score', type: 'float' }
+            ]);
+            const { allSortFields } = useSortFields({ datasetId: 'ds1' });
+            const fields = get(allSortFields);
+
+            expect(fields.map((f) => ('value' in f ? f.value : null))).not.toContain('tags');
+            expect(fields.map((f) => ('value' in f ? f.value : null))).not.toContain('nested');
+        });
+
+        it('includes evaluation metric fields with run_name_metric_name label', () => {
+            metricsInfo.set({
+                data: [
+                    {
+                        run_name: 'run1',
+                        metrics: [
+                            { metric_name: 'precision', min_value: 0, max_value: 1 },
+                            { metric_name: 'recall', min_value: 0, max_value: 1 }
+                        ]
+                    }
+                ]
+            });
+            const { allSortFields } = useSortFields({ datasetId: 'ds1' });
+            const fields = get(allSortFields);
+
+            expect(fields).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        source: 'evaluation_metric',
+                        evaluation_run_name: 'run1',
+                        metric_name: 'precision',
+                        label: 'run1_precision'
+                    }),
+                    expect.objectContaining({
+                        source: 'evaluation_metric',
+                        evaluation_run_name: 'run1',
+                        metric_name: 'recall',
+                        label: 'run1_recall'
+                    })
+                ])
+            );
+        });
+
+        it('updates reactively when metadataInfo changes', () => {
+            const { allSortFields } = useSortFields({ datasetId: 'ds1' });
+
+            expect(
+                get(allSortFields).find((f) => 'value' in f && f.value === 'brightness')
+            ).toBeUndefined();
+
+            metadataInfo.set([{ name: 'brightness', type: 'float' }]);
+
+            expect(
+                get(allSortFields).find((f) => 'value' in f && f.value === 'brightness')
+            ).toBeDefined();
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.ts
+++ b/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.ts
@@ -1,23 +1,33 @@
-import { derived } from 'svelte/store';
+import { derived, type Readable } from 'svelte/store';
 import type { SortFieldExpr } from '$lib/api/lightly_studio_local';
 import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import { useEvaluationSampleMetricsInfo } from '$lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo';
 
-export type ImageSortField = {
+export interface ImageSortField {
     source: SortFieldExpr['source'];
     value: string;
     label: string;
     is_numeric?: boolean;
-};
+}
 
-export type EvalSortField = {
+export interface EvalSortField {
     source: 'evaluation_metric';
     evaluation_run_name: string;
     metric_name: string;
     label: string;
-};
+}
 
 export type SortField = ImageSortField | EvalSortField;
+
+export interface UseSortFieldsParams {
+    datasetId: string;
+}
+
+export interface UseSortFieldsReturn {
+    metadataSortFields: Readable<ImageSortField[]>;
+    evalSortFields: Readable<EvalSortField[]>;
+    allSortFields: Readable<SortField[]>;
+}
 
 export const IMAGE_SORT_FIELDS: ImageSortField[] = [
     { source: 'image', value: 'file_name', label: 'file name' },
@@ -27,7 +37,7 @@ export const IMAGE_SORT_FIELDS: ImageSortField[] = [
     { source: 'image', value: 'height', label: 'height' }
 ];
 
-export function useSortFields({ datasetId }: { datasetId: string }) {
+export function useSortFields({ datasetId }: UseSortFieldsParams): UseSortFieldsReturn {
     const { metadataInfo } = useMetadataFilters();
     const metricsInfo = useEvaluationSampleMetricsInfo({ datasetId });
 

--- a/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.ts
+++ b/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.ts
@@ -19,11 +19,11 @@ export interface EvalSortField {
 
 export type SortField = ImageSortField | EvalSortField;
 
-export interface UseSortFieldsParams {
+interface UseSortFieldsParams {
     datasetId: string;
 }
 
-export interface UseSortFieldsReturn {
+interface UseSortFieldsReturn {
     metadataSortFields: Readable<ImageSortField[]>;
     evalSortFields: Readable<EvalSortField[]>;
     allSortFields: Readable<SortField[]>;

--- a/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.ts
+++ b/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.ts
@@ -24,8 +24,6 @@ interface UseSortFieldsParams {
 }
 
 interface UseSortFieldsReturn {
-    metadataSortFields: Readable<ImageSortField[]>;
-    evalSortFields: Readable<EvalSortField[]>;
     allSortFields: Readable<SortField[]>;
 }
 
@@ -76,5 +74,5 @@ export function useSortFields({ datasetId }: UseSortFieldsParams): UseSortFields
         ]
     );
 
-    return { metadataSortFields, evalSortFields, allSortFields };
+    return { allSortFields };
 }

--- a/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.ts
+++ b/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.ts
@@ -1,0 +1,70 @@
+import { derived } from 'svelte/store';
+import type { SortFieldExpr } from '$lib/api/lightly_studio_local';
+import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
+import { useEvaluationSampleMetricsInfo } from '$lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo';
+
+export type ImageSortField = {
+    source: SortFieldExpr['source'];
+    value: string;
+    label: string;
+    is_numeric?: boolean;
+};
+
+export type EvalSortField = {
+    source: 'evaluation_metric';
+    evaluation_run_name: string;
+    metric_name: string;
+    label: string;
+};
+
+export type SortField = ImageSortField | EvalSortField;
+
+export const IMAGE_SORT_FIELDS: ImageSortField[] = [
+    { source: 'image', value: 'file_name', label: 'file name' },
+    { source: 'image', value: 'file_path_abs', label: 'file path' },
+    { source: 'image', value: 'created_at', label: 'created at' },
+    { source: 'image', value: 'width', label: 'width' },
+    { source: 'image', value: 'height', label: 'height' }
+];
+
+export function useSortFields({ datasetId }: { datasetId: string }) {
+    const { metadataInfo } = useMetadataFilters();
+    const metricsInfo = useEvaluationSampleMetricsInfo({ datasetId });
+
+    const metadataSortFields = derived(metadataInfo, ($metadataInfo) =>
+        ($metadataInfo ?? [])
+            .filter((info) => ['integer', 'float', 'string', 'boolean'].includes(info.type))
+            .map(
+                (info): ImageSortField => ({
+                    source: 'metadata' as SortFieldExpr['source'],
+                    value: info.name,
+                    label: `metadata.${info.name}`,
+                    is_numeric: info.type === 'integer' || info.type === 'float'
+                })
+            )
+    );
+
+    const evalSortFields = derived(metricsInfo, ($metricsInfo) =>
+        ($metricsInfo.data ?? []).flatMap((run) =>
+            run.metrics.map(
+                (metric): EvalSortField => ({
+                    source: 'evaluation_metric',
+                    evaluation_run_name: run.run_name,
+                    metric_name: metric.metric_name,
+                    label: `${run.run_name}_${metric.metric_name}`
+                })
+            )
+        )
+    );
+
+    const allSortFields = derived(
+        [metadataSortFields, evalSortFields],
+        ([$metadataSortFields, $evalSortFields]) => [
+            ...IMAGE_SORT_FIELDS,
+            ...$metadataSortFields,
+            ...$evalSortFields
+        ]
+    );
+
+    return { metadataSortFields, evalSortFields, allSortFields };
+}


### PR DESCRIPTION
## What has changed and why?

Introduces a new `useSortFields` hook that aggregates all available sort fields into a single store.

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded sorting: includes base image attributes, supported primitive metadata (numeric flags shown), and evaluation-metric results with clear run_metric labels; sort options update reactively when metadata changes.

* **Tests**
  * Added unit tests validating image, metadata, and metric sort entries, exclusion of unsupported metadata types, and reactive updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1133)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->