### PR TITLE
feat: refactor useImagesInfinite

### DIFF
--- a/lightly_studio_view/src/lib/components/Images/Images.svelte
+++ b/lightly_studio_view/src/lib/components/Images/Images.svelte
@@ -8,10 +8,8 @@
     import { routeHelpers } from '$lib/routes';
     import { onMount } from 'svelte';
     import type { Readable } from 'svelte/store';
-    import {
-        useImagesInfinite,
-        type ImagesInfiniteParams
-    } from '$lib/hooks/useImagesInfinite/useImagesInfinite';
+    import { useImagesInfinite } from '$lib/hooks/useImagesInfinite/useImagesInfinite';
+    import type { ImagesInfiniteParams } from '$lib/hooks/useImagesInfinite/types';
     import { useScrollRestoration } from '$lib/hooks/useScrollRestoration/useScrollRestoration';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
     import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -1,6 +1,6 @@
 import { derived, get, writable } from 'svelte/store';
 import { createMetadataFilters } from '../useMetadataFilters/useMetadataFilters';
-import type { ImagesInfiniteParams } from '../useImagesInfinite/useImagesInfinite';
+import type { ImagesInfiniteParams } from '../useImagesInfinite/types';
 import type { DimensionBounds } from '$lib/services/loadDimensionBounds';
 import type {
     AnnotationsFilter,

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildRequestBody } from './buildRequestBody';
+import type { ImagesInfiniteParams } from './types';
+
+vi.mock('$lib/hooks/useMetadataFilters/useMetadataFilters', () => ({
+    createMetadataFilters: vi.fn(() => [{ mocked: true }])
+}));
+
+describe('buildRequestBody', () => {
+    describe('pagination', () => {
+        it('uses pageParam as offset', () => {
+            const result = buildRequestBody({ collection_id: 'col-1', mode: 'normal' }, 40);
+            expect(result.pagination?.offset).toBe(40);
+        });
+    });
+
+    describe('normal mode', () => {
+        it('returns base body when no filters provided', () => {
+            const result = buildRequestBody({ collection_id: 'col-1', mode: 'normal' }, 0);
+            expect(result.sample_ids).toBeUndefined();
+            expect(result.filters?.sample_filter?.annotations_filter).toBeUndefined();
+            expect(result.filters?.width).toBeUndefined();
+            expect(result.filters?.height).toBeUndefined();
+        });
+
+        it('propagates collection_ids to annotations_filter', () => {
+            const params: ImagesInfiniteParams = {
+                collection_id: 'col-1',
+                mode: 'normal',
+                filters: { collection_ids: ['coll-1', 'coll-2'] }
+            };
+
+            const result = buildRequestBody(params, 0);
+
+            expect(result.filters?.sample_filter?.annotations_filter).toEqual({
+                collection_ids: ['coll-1', 'coll-2'],
+                filter_type: 'annotations'
+            });
+        });
+
+        it('omits annotations_filter when collection_ids is empty', () => {
+            const params: ImagesInfiniteParams = {
+                collection_id: 'col-1',
+                mode: 'normal',
+                filters: { collection_ids: [] }
+            };
+
+            const result = buildRequestBody(params, 0);
+
+            expect(result.filters?.sample_filter?.annotations_filter).toBeUndefined();
+        });
+
+        it('propagates both annotation_label_ids and collection_ids', () => {
+            const params: ImagesInfiniteParams = {
+                collection_id: 'col-1',
+                mode: 'normal',
+                filters: { annotation_label_ids: ['lbl-1'], collection_ids: ['coll-1'] }
+            };
+
+            const result = buildRequestBody(params, 0);
+
+            expect(result.filters?.sample_filter?.annotations_filter).toEqual({
+                annotation_label_ids: ['lbl-1'],
+                collection_ids: ['coll-1'],
+                filter_type: 'annotations'
+            });
+        });
+
+        it('propagates tag_ids', () => {
+            const result = buildRequestBody(
+                { collection_id: 'col-1', mode: 'normal', filters: { tag_ids: ['t1', 't2'] } },
+                0
+            );
+            expect(result.filters?.sample_filter?.tag_ids).toEqual(['t1', 't2']);
+        });
+
+        it('omits tag_ids when empty', () => {
+            const result = buildRequestBody(
+                { collection_id: 'col-1', mode: 'normal', filters: { tag_ids: [] } },
+                0
+            );
+            expect(result.filters?.sample_filter?.tag_ids).toBeUndefined();
+        });
+
+        it('propagates sample_ids', () => {
+            const result = buildRequestBody(
+                { collection_id: 'col-1', mode: 'normal', filters: { sample_ids: ['s1'] } },
+                0
+            );
+            expect(result.filters?.sample_filter?.sample_ids).toEqual(['s1']);
+        });
+
+        it('omits sample_ids when empty', () => {
+            const result = buildRequestBody(
+                { collection_id: 'col-1', mode: 'normal', filters: { sample_ids: [] } },
+                0
+            );
+            expect(result.filters?.sample_filter?.sample_ids).toBeUndefined();
+        });
+
+        it('maps dimensions to width and height filters', () => {
+            const result = buildRequestBody(
+                {
+                    collection_id: 'col-1',
+                    mode: 'normal',
+                    filters: {
+                        dimensions: {
+                            min_width: 100,
+                            max_width: 800,
+                            min_height: 50,
+                            max_height: 600
+                        }
+                    }
+                },
+                0
+            );
+            expect(result.filters?.width).toEqual({ min: 100, max: 800 });
+            expect(result.filters?.height).toEqual({ min: 50, max: 600 });
+        });
+
+        it('omits width and height when dimensions not set', () => {
+            const result = buildRequestBody(
+                { collection_id: 'col-1', mode: 'normal', filters: {} },
+                0
+            );
+            expect(result.filters?.width).toBeUndefined();
+            expect(result.filters?.height).toBeUndefined();
+        });
+    });
+
+    describe('classifier mode', () => {
+        it('merges positive and negative sample ids into sample_ids', () => {
+            const result = buildRequestBody(
+                {
+                    collection_id: 'col-1',
+                    mode: 'classifier',
+                    classifierSamples: {
+                        positiveSampleIds: ['p1', 'p2'],
+                        negativeSampleIds: ['n1']
+                    }
+                },
+                0
+            );
+            expect(result.sample_ids).toEqual(['p1', 'p2', 'n1']);
+        });
+
+        it('returns base body when classifierSamples is undefined', () => {
+            const result = buildRequestBody({ collection_id: 'col-1', mode: 'classifier' }, 0);
+            expect(result.sample_ids).toBeUndefined();
+        });
+    });
+
+    describe('common fields', () => {
+        it('passes sort_by through', () => {
+            const sort = [
+                {
+                    source: 'image' as const,
+                    field_name: 'score',
+                    direction: 'desc' as const,
+                    is_numeric: false
+                }
+            ];
+            const result = buildRequestBody(
+                { collection_id: 'col-1', mode: 'normal', sort_by: sort },
+                0
+            );
+            expect(result.sort_by).toEqual(sort);
+        });
+
+        it('converts null sort_by to undefined', () => {
+            const result = buildRequestBody(
+                { collection_id: 'col-1', mode: 'normal', sort_by: null },
+                0
+            );
+            expect(result.sort_by).toBeUndefined();
+        });
+
+        it('passes text_embedding through', () => {
+            const result = buildRequestBody(
+                { collection_id: 'col-1', mode: 'normal', text_embedding: [0.1, 0.2] },
+                0
+            );
+            expect(result.text_embedding).toEqual([0.1, 0.2]);
+        });
+
+        it('applies metadata_values via createMetadataFilters', () => {
+            const result = buildRequestBody(
+                {
+                    collection_id: 'col-1',
+                    mode: 'normal',
+                    metadata_values: { key: { min: 0, max: 1 } }
+                },
+                0
+            );
+            expect(result.filters?.sample_filter?.metadata_filters).toEqual([{ mocked: true }]);
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
@@ -2,68 +2,69 @@ import type { ReadImagesRequest } from '$lib/api/lightly_studio_local';
 import { createMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import { GRID_PAGE_SIZE } from '$lib/constants';
 import { getAnnotationsFilter } from './getAnnotationsFilter';
-import type { ImagesInfiniteParams } from './types';
+import type { ClassifierSamples, ImagesInfiniteParams, NormalModeFilters } from './types';
+
+const buildBaseBody = (params: ImagesInfiniteParams, pageParam: number): ReadImagesRequest => ({
+    pagination: {
+        offset: pageParam,
+        limit: GRID_PAGE_SIZE
+    },
+    text_embedding: params.text_embedding,
+    sort_by: params.sort_by ?? undefined,
+    filters: {
+        sample_filter: {
+            query_expr: params.query_expr ?? undefined,
+            metadata_filters: params.metadata_values
+                ? createMetadataFilters(params.metadata_values)
+                : undefined
+        }
+    }
+});
+
+const withClassifierSamples = (
+    base: ReadImagesRequest,
+    samples: ClassifierSamples
+): ReadImagesRequest => ({
+    ...base,
+    sample_ids: [...samples.positiveSampleIds, ...samples.negativeSampleIds]
+});
+
+const withNormalFilters = (
+    base: ReadImagesRequest,
+    filters: NormalModeFilters
+): ReadImagesRequest => ({
+    ...base,
+    filters: {
+        ...base.filters,
+        sample_filter: {
+            ...(base.filters?.sample_filter ?? {}),
+            annotations_filter: getAnnotationsFilter(filters),
+            tag_ids: filters.tag_ids?.length ? filters.tag_ids : undefined,
+            sample_ids: filters.sample_ids?.length ? filters.sample_ids : undefined
+        },
+        // TODO(Malte, 10/2025): Share the width/height mapping with useImageFilters to avoid drift.
+        width: filters.dimensions
+            ? { min: filters.dimensions.min_width, max: filters.dimensions.max_width }
+            : undefined,
+        height: filters.dimensions
+            ? { min: filters.dimensions.min_height, max: filters.dimensions.max_height }
+            : undefined
+    }
+});
 
 export const buildRequestBody = (
     params: ImagesInfiniteParams,
     pageParam: number
 ): ReadImagesRequest => {
-    const baseBody: ReadImagesRequest = {
-        pagination: {
-            offset: pageParam,
-            limit: GRID_PAGE_SIZE
-        },
-        text_embedding: params.text_embedding,
-        sort_by: params.sort_by ?? undefined,
-        filters: {
-            sample_filter: {
-                query_expr: params.query_expr ?? undefined,
-                metadata_filters: params.metadata_values
-                    ? createMetadataFilters(params.metadata_values)
-                    : undefined
-            }
-        }
-    };
+    const base = buildBaseBody(params, pageParam);
 
     if (params.mode === 'classifier' && params.classifierSamples) {
-        const allSampleIds = [
-            ...params.classifierSamples.positiveSampleIds,
-            ...params.classifierSamples.negativeSampleIds
-        ];
-
-        return {
-            ...baseBody,
-            sample_ids: allSampleIds
-        };
-    } else if (params.mode === 'normal' && params.filters) {
-        return {
-            ...baseBody,
-            filters: {
-                ...baseBody.filters,
-                sample_filter: {
-                    ...(baseBody.filters?.sample_filter ?? {}),
-                    annotations_filter: getAnnotationsFilter(params.filters),
-                    tag_ids: params.filters.tag_ids?.length ? params.filters.tag_ids : undefined,
-                    sample_ids: params.filters.sample_ids?.length
-                        ? params.filters.sample_ids
-                        : undefined
-                },
-                // TODO(Malte, 10/2025): Share the width/height mapping with useImageFilters to avoid drift.
-                width: params.filters.dimensions
-                    ? {
-                          min: params.filters.dimensions.min_width,
-                          max: params.filters.dimensions.max_width
-                      }
-                    : undefined,
-                height: params.filters.dimensions
-                    ? {
-                          min: params.filters.dimensions.min_height,
-                          max: params.filters.dimensions.max_height
-                      }
-                    : undefined
-            }
-        };
+        return withClassifierSamples(base, params.classifierSamples);
     }
 
-    return baseBody;
+    if (params.mode === 'normal' && params.filters) {
+        return withNormalFilters(base, params.filters);
+    }
+
+    return base;
 };

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createImagesInfiniteOptions } from './createImagesInfiniteOptions';
+import type { SortFieldExpr } from '$lib/api/lightly_studio_local';
+
+type Options = ReturnType<typeof createImagesInfiniteOptions>;
+type QueryFnContext = { pageParam: number; signal: AbortSignal };
+
+const callQueryFn = (options: Options, ctx: QueryFnContext) => {
+    const fn = options.queryFn as (ctx: QueryFnContext) => Promise<unknown>;
+    return fn(ctx);
+};
+
+const readImagesMock = vi.fn();
+
+vi.mock('$lib/api/lightly_studio_local', () => ({
+    readImages: (...args: unknown[]) => readImagesMock(...args)
+}));
+
+vi.mock('$lib/hooks/useMetadataFilters/useMetadataFilters', () => ({
+    createMetadataFilters: vi.fn(() => [])
+}));
+
+describe('createImagesInfiniteOptions', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        readImagesMock.mockResolvedValue({ data: { data: [], total_count: 0, nextCursor: null } });
+    });
+
+    describe('query key', () => {
+        it('includes collection_id and mode', () => {
+            const options = createImagesInfiniteOptions({ collection_id: 'col-1', mode: 'normal' });
+            expect(options.queryKey[1]).toBe('col-1');
+            expect(options.queryKey[2]).toBe('normal');
+        });
+
+        it('puts filters in query key for normal mode', () => {
+            const filters = { tag_ids: ['t1'] };
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                filters
+            });
+            expect(options.queryKey[3]).toBe(filters);
+        });
+
+        it('puts classifierSamples in query key for classifier mode', () => {
+            const classifierSamples = { positiveSampleIds: ['s1'], negativeSampleIds: [] };
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'classifier',
+                classifierSamples
+            });
+            expect(options.queryKey[3]).toBe(classifierSamples);
+        });
+
+        it('includes sort_by in query key', () => {
+            const sort: SortFieldExpr[] = [
+                { source: 'image', field_name: 'score', direction: 'desc', is_numeric: false }
+            ];
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                sort_by: sort
+            });
+            expect(options.queryKey).toContain(sort);
+        });
+
+        it('includes null in query key when sort_by is null', () => {
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                sort_by: null
+            });
+            expect(options.queryKey).toContain(null);
+        });
+
+        it('produces different keys for different sort_by values', () => {
+            const sort1: SortFieldExpr[] = [
+                { source: 'image', field_name: 'score', direction: 'desc', is_numeric: false }
+            ];
+            const sort2: SortFieldExpr[] = [
+                { source: 'image', field_name: 'filename', direction: 'asc', is_numeric: false }
+            ];
+            const options1 = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                sort_by: sort1
+            });
+            const options2 = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                sort_by: sort2
+            });
+            expect(options1.queryKey).not.toEqual(options2.queryKey);
+        });
+    });
+
+    describe('enabled', () => {
+        it('is true for normal mode', () => {
+            const options = createImagesInfiniteOptions({ collection_id: 'col-1', mode: 'normal' });
+            expect(options.enabled).toBe(true);
+        });
+
+        it('is false for classifier mode without classifierSamples', () => {
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'classifier'
+            });
+            expect(options.enabled).toBe(false);
+        });
+
+        it('is true for classifier mode with classifierSamples defined', () => {
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'classifier',
+                classifierSamples: { positiveSampleIds: [], negativeSampleIds: [] }
+            });
+            expect(options.enabled).toBe(true);
+        });
+    });
+
+    describe('queryFn', () => {
+        it('passes sort_by to readImages', async () => {
+            const sort: SortFieldExpr[] = [
+                { source: 'image', field_name: 'score', direction: 'desc', is_numeric: false }
+            ];
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                sort_by: sort
+            });
+
+            await callQueryFn(options, { pageParam: 0, signal: new AbortController().signal });
+
+            expect(readImagesMock).toHaveBeenCalledWith(
+                expect.objectContaining({ body: expect.objectContaining({ sort_by: sort }) })
+            );
+        });
+
+        it('passes sort_by as undefined when sort_by is null', async () => {
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                sort_by: null
+            });
+
+            await callQueryFn(options, { pageParam: 0, signal: new AbortController().signal });
+
+            expect(readImagesMock).toHaveBeenCalledWith(
+                expect.objectContaining({ body: expect.objectContaining({ sort_by: undefined }) })
+            );
+        });
+
+        it('passes sort_by as undefined when sort_by is not provided', async () => {
+            const options = createImagesInfiniteOptions({ collection_id: 'col-1', mode: 'normal' });
+
+            await callQueryFn(options, { pageParam: 0, signal: new AbortController().signal });
+
+            expect(readImagesMock).toHaveBeenCalledWith(
+                expect.objectContaining({ body: expect.objectContaining({ sort_by: undefined }) })
+            );
+        });
+
+        it('passes collection_id to readImages path', async () => {
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-42',
+                mode: 'normal'
+            });
+
+            await callQueryFn(options, { pageParam: 0, signal: new AbortController().signal });
+
+            expect(readImagesMock).toHaveBeenCalledWith(
+                expect.objectContaining({ path: { collection_id: 'col-42' } })
+            );
+        });
+
+        it('returns data from readImages response', async () => {
+            const mockData = { data: [{ id: 'img-1' }], total_count: 1, nextCursor: null };
+            readImagesMock.mockResolvedValue({ data: mockData });
+            const options = createImagesInfiniteOptions({ collection_id: 'col-1', mode: 'normal' });
+
+            const result = await callQueryFn(options, {
+                pageParam: 0,
+                signal: new AbortController().signal
+            });
+
+            expect(result).toBe(mockData);
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.ts
@@ -2,12 +2,10 @@ import type { InfiniteData } from '@tanstack/svelte-query';
 import { infiniteQueryOptions } from '@tanstack/svelte-query';
 import type { ReadImagesError, ReadImagesResponse } from '$lib/api/lightly_studio_local';
 import { readImages } from '$lib/api/lightly_studio_local';
-import { buildRequestBody } from './buildRequestBody';
 import type { ImagesInfiniteParams, SamplesQueryKey } from './types';
+import { buildRequestBody } from './buildRequestBody';
 
-// Create infinite query options for samples with mode-aware logic.
 export const createImagesInfiniteOptions = (params: ImagesInfiniteParams) => {
-    // Build query key with intelligent structure to minimize refetches.
     const queryKey: SamplesQueryKey = [
         'readImagesInfinite',
         params.collection_id,

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -1,4 +1,9 @@
-import type { QueryExpr, SortFieldExpr } from '$lib/api/lightly_studio_local';
+import type {
+    AnnotationsFilter,
+    QueryExpr,
+    ReadImagesRequest,
+    SampleFilter
+} from '$lib/api/lightly_studio_local';
 import type { DimensionBounds } from '$lib/services/loadDimensionBounds';
 import type { MetadataValues } from '$lib/services/types';
 
@@ -7,45 +12,30 @@ export interface ClassifierSamples {
     negativeSampleIds: string[];
 }
 
-export interface NormalModeFilters {
-    annotation_label_ids?: string[];
-    collection_ids?: string[];
-    tag_ids?: string[];
-    dimensions?: DimensionBounds;
-    query_expr?: QueryExpr;
-    sample_ids?: string[];
-}
-
-export interface CommonFilters {
-    metadata_values?: MetadataValues;
-    text_embedding?: number[];
-}
-
-export interface NormalModeParams {
-    mode: 'normal';
-    filters?: NormalModeFilters;
-}
-
-interface ClassifierModeParams {
-    mode: 'classifier';
-    classifierSamples?: ClassifierSamples;
-}
+export type NormalModeFilters = Pick<AnnotationsFilter, 'annotation_label_ids' | 'collection_ids'> &
+    Pick<SampleFilter, 'tag_ids' | 'sample_ids'> & {
+        dimensions?: DimensionBounds;
+    };
 
 export type ImagesInfiniteParams = {
-    query_expr?: QueryExpr;
     collection_id: string;
-    sort_by?: SortFieldExpr[] | null;
-} & (NormalModeParams | ClassifierModeParams) &
-    CommonFilters;
+    query_expr?: QueryExpr;
+    sort_by?: ReadImagesRequest['sort_by'];
+    text_embedding?: ReadImagesRequest['text_embedding'];
+    metadata_values?: MetadataValues;
+} & (
+    | { mode: 'normal'; filters?: NormalModeFilters }
+    | { mode: 'classifier'; classifierSamples?: ClassifierSamples }
+);
 
 export type SamplesQueryKey = readonly [
+    'readImagesInfinite',
     string,
-    string,
-    'normal' | 'classifier',
+    ImagesInfiniteParams['mode'],
     NormalModeFilters | ClassifierSamples | undefined,
     {
         metadata_values?: MetadataValues;
-        text_embedding?: number[];
+        text_embedding?: ReadImagesRequest['text_embedding'];
     },
-    SortFieldExpr[] | null | undefined
+    ReadImagesRequest['sort_by']
 ];

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
@@ -1,14 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
-import { buildRequestBody, type ImagesInfiniteParams } from './useImagesInfinite';
-import type { SortFieldExpr } from '$lib/api/lightly_studio_local';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { QueryClient, CreateInfiniteQueryResult } from '@tanstack/svelte-query';
 import * as tanstackQuery from '@tanstack/svelte-query';
 import { useImagesInfinite } from './useImagesInfinite';
 
-const readImagesMock = vi.fn();
-
 vi.mock('$lib/api/lightly_studio_local', () => ({
-    readImages: (...args: unknown[]) => readImagesMock(...args)
+    readImages: vi.fn()
 }));
 
 vi.mock('$lib/hooks/useMetadataFilters/useMetadataFilters', () => ({
@@ -21,149 +17,26 @@ describe('useImagesInfinite', () => {
         invalidateQueries: mockInvalidateQueries
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let capturedOptions: any;
-
     beforeEach(() => {
         vi.resetAllMocks();
-        capturedOptions = undefined;
-
         vi.spyOn(tanstackQuery, 'useQueryClient').mockReturnValue(mockQueryClient as QueryClient);
-        vi.spyOn(tanstackQuery, 'createInfiniteQuery').mockImplementation((options) => {
-            capturedOptions = options;
-            return {
-                subscribe: (fn: (value: unknown) => void) => {
-                    fn({});
-                    return vi.fn();
-                }
-            } as CreateInfiniteQueryResult<unknown, Error>;
-        });
-
-        readImagesMock.mockResolvedValue({ data: { data: [], total_count: 0, nextCursor: null } });
-    });
-
-    describe('sort_by in query key', () => {
-        it('includes sort_by in the query key when provided', () => {
-            const sort: SortFieldExpr[] = [
-                { source: 'image', field_name: 'score', direction: 'desc', is_numeric: false }
-            ];
-
-            useImagesInfinite({ collection_id: 'coll-1', mode: 'normal', sort_by: sort });
-
-            expect(capturedOptions.queryKey).toContain(sort);
-        });
-
-        it('includes null in the query key when sort_by is null', () => {
-            useImagesInfinite({ collection_id: 'coll-1', mode: 'normal', sort_by: null });
-
-            expect(capturedOptions.queryKey).toContain(null);
-        });
-
-        it('produces different query keys for different sort_by values', () => {
-            const sort1: SortFieldExpr[] = [
-                { source: 'image', field_name: 'score', direction: 'desc', is_numeric: false }
-            ];
-            const sort2: SortFieldExpr[] = [
-                { source: 'image', field_name: 'filename', direction: 'asc', is_numeric: false }
-            ];
-
-            useImagesInfinite({ collection_id: 'coll-1', mode: 'normal', sort_by: sort1 });
-            const queryKey1 = capturedOptions.queryKey;
-
-            useImagesInfinite({ collection_id: 'coll-1', mode: 'normal', sort_by: sort2 });
-            const queryKey2 = capturedOptions.queryKey;
-
-            expect(queryKey1).not.toEqual(queryKey2);
-        });
-    });
-
-    describe('sort_by in request body', () => {
-        it('passes sort_by to readImages when provided', async () => {
-            const sort: SortFieldExpr[] = [
-                { source: 'image', field_name: 'score', direction: 'desc', is_numeric: false }
-            ];
-
-            useImagesInfinite({ collection_id: 'coll-1', mode: 'normal', sort_by: sort });
-
-            await capturedOptions.queryFn({ pageParam: 0, signal: new AbortController().signal });
-
-            expect(readImagesMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    body: expect.objectContaining({ sort_by: sort })
-                })
-            );
-        });
-
-        it('passes sort_by as undefined to readImages when sort_by is null', async () => {
-            useImagesInfinite({ collection_id: 'coll-1', mode: 'normal', sort_by: null });
-
-            await capturedOptions.queryFn({ pageParam: 0, signal: new AbortController().signal });
-
-            expect(readImagesMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    body: expect.objectContaining({ sort_by: undefined })
-                })
-            );
-        });
-
-        it('passes sort_by as undefined to readImages when sort_by is not provided', async () => {
-            useImagesInfinite({ collection_id: 'coll-1', mode: 'normal' });
-
-            await capturedOptions.queryFn({ pageParam: 0, signal: new AbortController().signal });
-
-            expect(readImagesMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    body: expect.objectContaining({ sort_by: undefined })
-                })
-            );
-        });
-    });
-});
-
-describe('buildRequestBody', () => {
-    it('propagates collection_ids to annotations_filter', () => {
-        const params: ImagesInfiniteParams = {
-            collection_id: 'col-1',
-            mode: 'normal',
-            filters: { collection_ids: ['coll-1', 'coll-2'] }
-        };
-
-        const result = buildRequestBody(params, 0);
-
-        expect(result.filters?.sample_filter?.annotations_filter).toEqual({
-            collection_ids: ['coll-1', 'coll-2'],
-            filter_type: 'annotations'
-        });
-    });
-
-    it('omits annotations_filter when collection_ids is empty', () => {
-        const params: ImagesInfiniteParams = {
-            collection_id: 'col-1',
-            mode: 'normal',
-            filters: { collection_ids: [] }
-        };
-
-        const result = buildRequestBody(params, 0);
-
-        expect(result.filters?.sample_filter?.annotations_filter).toBeUndefined();
-    });
-
-    it('propagates both annotation_label_ids and collection_ids', () => {
-        const params: ImagesInfiniteParams = {
-            collection_id: 'col-1',
-            mode: 'normal',
-            filters: {
-                annotation_label_ids: ['lbl-1'],
-                collection_ids: ['coll-1']
+        vi.spyOn(tanstackQuery, 'createInfiniteQuery').mockReturnValue({
+            subscribe: (fn: (value: unknown) => void) => {
+                fn({});
+                return vi.fn();
             }
-        };
+        } as CreateInfiniteQueryResult<unknown, Error>);
+    });
 
-        const result = buildRequestBody(params, 0);
+    it('calls invalidateQueries with the correct key on refresh', () => {
+        const { refresh } = useImagesInfinite({ collection_id: 'coll-1', mode: 'normal' });
 
-        expect(result.filters?.sample_filter?.annotations_filter).toEqual({
-            annotation_label_ids: ['lbl-1'],
-            collection_ids: ['coll-1'],
-            filter_type: 'annotations'
-        });
+        refresh();
+
+        expect(mockInvalidateQueries).toHaveBeenCalledWith(
+            expect.objectContaining({
+                queryKey: expect.arrayContaining(['readImagesInfinite', 'coll-1'])
+            })
+        );
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.ts
@@ -2,9 +2,6 @@ import { createInfiniteQuery, useQueryClient } from '@tanstack/svelte-query';
 import { createImagesInfiniteOptions } from './createImagesInfiniteOptions';
 import type { ImagesInfiniteParams } from './types';
 
-export type { ImagesInfiniteParams } from './types';
-export { buildRequestBody } from './buildRequestBody';
-
 export const useImagesInfinite = (params: ImagesInfiniteParams) => {
     const samplesOptions = createImagesInfiniteOptions(params);
     const samples = createInfiniteQuery(samplesOptions);


### PR DESCRIPTION
## Summary

Refactor `useImagesInfinite` into single-responsibility files and lean on auto-generated API types.

- **Split by responsibility:** `useImagesInfinite.ts` is now just the hook; extracted `createImagesInfiniteOptions.ts`, `buildRequestBody.ts`, and `types.ts`.
- **`buildRequestBody` refactor:** flat dispatch over three small helpers (`buildBaseBody`, `withClassifierSamples`, `withNormalFilters`) instead of one nested if/else cascade.
- **Lean types:** dropped indirection-only interfaces (`CommonFilters`, `NormalModeParams`, `ClassifierModeParams`) and derived field types via `Pick`/indexed access from generated `AnnotationsFilter`, `SampleFilter`, `ReadImagesRequest`. Removed dead `NormalModeFilters.query_expr` field.
- **Removed unused indirection:** inlined the trivial `isNormalModeParams` and `isQueryEnabled` helpers at their call sites.
- **Tests:** added focused test files per function (`buildRequestBody.test.ts`, `createImagesInfiniteOptions.test.ts`) — 37 tests covering pagination, normal/classifier modes, query key structure, `enabled` flag, and `queryFn` behavior.
- **Consumer updates:** `Images.svelte`, `useEmbeddingFilterForImages.ts`, and `useImageFilters.ts` import from the new file locations and use `mode === 'normal'` checks directly.
## How has it been tested?

By introduced test and checking manually images grid

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for image request handling and infinite query options.

* **Refactor**
  * Restructured internal image filtering and infinite scroll logic for improved code organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1137)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->