### PR TITLE
Refactor buildRequestBody into mode-specific helpers

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
@@ -2,68 +2,69 @@ import type { ReadImagesRequest } from '$lib/api/lightly_studio_local';
 import { createMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import { GRID_PAGE_SIZE } from '$lib/constants';
 import { getAnnotationsFilter } from './getAnnotationsFilter';
-import type { ImagesInfiniteParams } from './types';
+import type { ClassifierSamples, ImagesInfiniteParams, NormalModeFilters } from './types';
+
+const buildBaseBody = (params: ImagesInfiniteParams, pageParam: number): ReadImagesRequest => ({
+    pagination: {
+        offset: pageParam,
+        limit: GRID_PAGE_SIZE
+    },
+    text_embedding: params.text_embedding,
+    sort_by: params.sort_by ?? undefined,
+    filters: {
+        sample_filter: {
+            query_expr: params.query_expr ?? undefined,
+            metadata_filters: params.metadata_values
+                ? createMetadataFilters(params.metadata_values)
+                : undefined
+        }
+    }
+});
+
+const withClassifierSamples = (
+    base: ReadImagesRequest,
+    samples: ClassifierSamples
+): ReadImagesRequest => ({
+    ...base,
+    sample_ids: [...samples.positiveSampleIds, ...samples.negativeSampleIds]
+});
+
+const withNormalFilters = (
+    base: ReadImagesRequest,
+    filters: NormalModeFilters
+): ReadImagesRequest => ({
+    ...base,
+    filters: {
+        ...base.filters,
+        sample_filter: {
+            ...(base.filters?.sample_filter ?? {}),
+            annotations_filter: getAnnotationsFilter(filters),
+            tag_ids: filters.tag_ids?.length ? filters.tag_ids : undefined,
+            sample_ids: filters.sample_ids?.length ? filters.sample_ids : undefined
+        },
+        // TODO(Malte, 10/2025): Share the width/height mapping with useImageFilters to avoid drift.
+        width: filters.dimensions
+            ? { min: filters.dimensions.min_width, max: filters.dimensions.max_width }
+            : undefined,
+        height: filters.dimensions
+            ? { min: filters.dimensions.min_height, max: filters.dimensions.max_height }
+            : undefined
+    }
+});
 
 export const buildRequestBody = (
     params: ImagesInfiniteParams,
     pageParam: number
 ): ReadImagesRequest => {
-    const baseBody: ReadImagesRequest = {
-        pagination: {
-            offset: pageParam,
-            limit: GRID_PAGE_SIZE
-        },
-        text_embedding: params.text_embedding,
-        sort_by: params.sort_by ?? undefined,
-        filters: {
-            sample_filter: {
-                query_expr: params.query_expr ?? undefined,
-                metadata_filters: params.metadata_values
-                    ? createMetadataFilters(params.metadata_values)
-                    : undefined
-            }
-        }
-    };
+    const base = buildBaseBody(params, pageParam);
 
     if (params.mode === 'classifier' && params.classifierSamples) {
-        const allSampleIds = [
-            ...params.classifierSamples.positiveSampleIds,
-            ...params.classifierSamples.negativeSampleIds
-        ];
-
-        return {
-            ...baseBody,
-            sample_ids: allSampleIds
-        };
-    } else if (params.mode === 'normal' && params.filters) {
-        return {
-            ...baseBody,
-            filters: {
-                ...baseBody.filters,
-                sample_filter: {
-                    ...(baseBody.filters?.sample_filter ?? {}),
-                    annotations_filter: getAnnotationsFilter(params.filters),
-                    tag_ids: params.filters.tag_ids?.length ? params.filters.tag_ids : undefined,
-                    sample_ids: params.filters.sample_ids?.length
-                        ? params.filters.sample_ids
-                        : undefined
-                },
-                // TODO(Malte, 10/2025): Share the width/height mapping with useImageFilters to avoid drift.
-                width: params.filters.dimensions
-                    ? {
-                          min: params.filters.dimensions.min_width,
-                          max: params.filters.dimensions.max_width
-                      }
-                    : undefined,
-                height: params.filters.dimensions
-                    ? {
-                          min: params.filters.dimensions.min_height,
-                          max: params.filters.dimensions.max_height
-                      }
-                    : undefined
-            }
-        };
+        return withClassifierSamples(base, params.classifierSamples);
     }
 
-    return baseBody;
+    if (params.mode === 'normal' && params.filters) {
+        return withNormalFilters(base, params.filters);
+    }
+
+    return base;
 };

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -12,7 +12,6 @@ export interface NormalModeFilters {
     collection_ids?: string[];
     tag_ids?: string[];
     dimensions?: DimensionBounds;
-    query_expr?: QueryExpr;
     sample_ids?: string[];
 }
 


### PR DESCRIPTION


## What has changed and why?
Replace the nested if/else-if cascade with a flat dispatch over three small helpers:
- buildBaseBody (pagination, sort, embedding, metadata)
- withClassifierSamples (merges positive/negative sample ids)
- withNormalFilters (annotations, tags, sample ids, dimensions)

Also drop NormalModeFilters.query_expr — it was dead (never read; only the top-level params.query_expr is used).

## How has it been tested?

Let's limit testing by existing tests + static checks, the test will come as a separate PR

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code structure for image filtering and request handling to improve maintainability and consistency across different filtering modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1143)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->