### PR TITLE
Migrate useClassifiers and useClassifierUtils off legacy client

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifierUtils.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifierUtils.ts
@@ -1,9 +1,15 @@
 import type { AnnotatedSamples, ClassifierExportType } from '$lib/services/types';
 import { page } from '$app/state';
 import { get, writable, type Readable } from 'svelte/store';
-import client from '$lib/services/collection';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 import { triggerDownloadBlob } from '$lib/utils';
+import {
+    getNegativeSamples,
+    saveClassifierToFile,
+    loadClassifierFromBuffer,
+    updateClassifiersAnnotations,
+    trainClassifier as trainClassifierApi
+} from '$lib/api/lightly_studio_local';
 
 interface PrepareSamplesResponse {
     positiveSampleIds: string[];
@@ -37,19 +43,10 @@ export function useClassifierUtils(): UseClassifierUtilsReturn {
     const saveClassifier = async (classifierId: string, exportType: ClassifierExportType) => {
         try {
             error.set(null);
-            const response = await client.POST(
-                '/api/classifiers/{classifier_id}/save_classifier_to_file/{export_type}',
-                {
-                    params: {
-                        path: { classifier_id: classifierId, export_type: exportType }
-                    },
-                    responseType: 'arraybuffer',
-                    headers: {
-                        Accept: 'application/octet-stream'
-                    },
-                    parseAs: 'blob'
-                }
-            );
+            const response = await saveClassifierToFile({
+                path: { classifier_id: classifierId, export_type: exportType },
+                parseAs: 'blob'
+            });
 
             const contentDisposition = response.response.headers.get('content-disposition');
             const filenameMatch = contentDisposition?.match(/filename="(.+)"/);
@@ -60,7 +57,8 @@ export function useClassifierUtils(): UseClassifierUtilsReturn {
                 return Promise.reject('No data received from the server');
             }
 
-            triggerDownloadBlob(filename, response.data);
+            // parseAs: 'blob' makes data a Blob at runtime, but the type is {} from OpenAPI spec
+            triggerDownloadBlob(filename, response.data as unknown as Blob);
         } catch (err) {
             error.set(err as Error);
             throw err;
@@ -78,17 +76,9 @@ export function useClassifierUtils(): UseClassifierUtilsReturn {
         }
 
         try {
-            const formData = new FormData();
-            formData.append('file', file);
-
-            await client.POST('/api/classifiers/load_classifier_from_buffer', {
-                params: {
-                    query: { collection_id: collectionId }
-                },
-                body: formData as unknown as { file: string },
-                headers: {
-                    Accept: 'application/json'
-                }
+            await loadClassifierFromBuffer({
+                query: { collection_id: collectionId },
+                body: { file }
             });
 
             // Reset the input.
@@ -102,12 +92,8 @@ export function useClassifierUtils(): UseClassifierUtilsReturn {
     const updateAnnotations = async (classifierId: string, annotations: AnnotatedSamples) => {
         try {
             error.set(null);
-            await client.POST('/api/classifiers/{classifier_id}/update_annotations', {
-                params: {
-                    path: {
-                        classifier_id: classifierId
-                    }
-                },
+            await updateClassifiersAnnotations({
+                path: { classifier_id: classifierId },
                 body: annotations
             });
         } catch (err) {
@@ -119,12 +105,8 @@ export function useClassifierUtils(): UseClassifierUtilsReturn {
     const trainClassifier = async (classifierId: string) => {
         try {
             error.set(null);
-            await client.POST('/api/classifiers/{classifier_id}/train_classifier', {
-                params: {
-                    path: {
-                        classifier_id: classifierId
-                    }
-                }
+            await trainClassifierApi({
+                path: { classifier_id: classifierId }
             });
         } catch (err) {
             error.set(err as Error);
@@ -140,7 +122,7 @@ export function useClassifierUtils(): UseClassifierUtilsReturn {
 
         error.set(null);
         try {
-            const response = await client.POST('/api/classifiers/get_negative_samples', {
+            const response = await getNegativeSamples({
                 body: {
                     collection_id: collectionId!.toString(),
                     positive_sample_ids: positives

--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.test.ts
@@ -8,6 +8,8 @@ import { useClassifierState } from './useClassifierState';
 import * as utils from '$lib/utils';
 import * as sdk from '$lib/api/lightly_studio_local';
 
+type ApiResult<T extends (...args: never[]) => Promise<unknown>> = Awaited<ReturnType<T>>;
+
 vi.mock('$app/state', () => ({
     page: {
         params: { collection_id: 'test-collection-id' } // Mock collection_id in page params
@@ -27,9 +29,7 @@ describe('useClassifiers Hook', () => {
     const setup = () => {
         return vi.spyOn(sdk, 'getAllClassifiers').mockResolvedValueOnce({
             data: { classifiers: mockClassifiers }
-        } as unknown as ReturnType<typeof sdk.getAllClassifiers> extends Promise<infer R>
-            ? R
-            : never);
+        } as unknown as ApiResult<typeof sdk.getAllClassifiers>);
     };
 
     beforeEach(() => {
@@ -131,19 +131,15 @@ describe('useClassifiers Hook', () => {
             const saveSpy = vi
                 .spyOn(sdk, 'saveClassifierToFile')
                 .mockResolvedValueOnce(
-                    mockResponse as unknown as ReturnType<
-                        typeof sdk.saveClassifierToFile
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    mockResponse as unknown as ApiResult<typeof sdk.saveClassifierToFile>
                 );
             const downloadSpy = vi.spyOn(utils, 'triggerDownloadBlob').mockImplementation(() => {});
             const { saveClassifier, error } = useClassifiers();
-            await saveClassifier('test-id');
+            await saveClassifier('test-id', 'sklearn');
 
             // Verify SDK call
             expect(saveSpy).toHaveBeenCalledWith({
-                path: { classifier_id: 'test-id' },
+                path: { classifier_id: 'test-id', export_type: 'sklearn' },
                 parseAs: 'blob'
             });
 
@@ -159,7 +155,7 @@ describe('useClassifiers Hook', () => {
             const { saveClassifier, error } = useClassifiers();
 
             // The main hook should catch the error from the utility and set it in its error store
-            await expect(saveClassifier('test-id', 'pkl')).rejects.toThrow(
+            await expect(saveClassifier('test-id', 'lightly')).rejects.toThrow(
                 'Failed to save classifier'
             );
             expect(get(error)).toEqual(testError);
@@ -181,17 +177,11 @@ describe('useClassifiers Hook', () => {
             const loadFromBufferSpy = vi
                 .spyOn(sdk, 'loadClassifierFromBuffer')
                 .mockResolvedValueOnce(
-                    {} as unknown as ReturnType<
-                        typeof sdk.loadClassifierFromBuffer
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    {} as unknown as ApiResult<typeof sdk.loadClassifierFromBuffer>
                 );
             const getAllSpy = vi.spyOn(sdk, 'getAllClassifiers').mockResolvedValueOnce({
                 data: { classifiers: mockClassifiers }
-            } as unknown as ReturnType<typeof sdk.getAllClassifiers> extends Promise<infer R>
-                ? R
-                : never);
+            } as unknown as ApiResult<typeof sdk.getAllClassifiers>);
 
             const { loadClassifier, error } = useClassifiers();
             await loadClassifier(mockEvent, 'test-collection-id');
@@ -256,11 +246,7 @@ describe('useClassifiers Hook', () => {
             const getNegSpy = vi
                 .spyOn(sdk, 'getNegativeSamples')
                 .mockResolvedValueOnce(
-                    mockResponse as unknown as ReturnType<
-                        typeof sdk.getNegativeSamples
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    mockResponse as unknown as ApiResult<typeof sdk.getNegativeSamples>
                 );
 
             const { prepareSamples } = useClassifiers();
@@ -310,28 +296,16 @@ describe('useClassifiers Hook', () => {
             const createSpy = vi
                 .spyOn(sdk, 'createClassifier')
                 .mockResolvedValueOnce(
-                    mockCreateResponse as unknown as ReturnType<
-                        typeof sdk.createClassifier
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    mockCreateResponse as unknown as ApiResult<typeof sdk.createClassifier>
                 );
             const updateAnnotationsSpy = vi
                 .spyOn(sdk, 'updateClassifiersAnnotations')
                 .mockResolvedValueOnce(
-                    {} as unknown as ReturnType<
-                        typeof sdk.updateClassifiersAnnotations
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    {} as unknown as ApiResult<typeof sdk.updateClassifiersAnnotations>
                 );
             const trainSpy = vi
                 .spyOn(sdk, 'trainClassifier')
-                .mockResolvedValueOnce(
-                    {} as unknown as ReturnType<typeof sdk.trainClassifier> extends Promise<infer R>
-                        ? R
-                        : never
-                );
+                .mockResolvedValueOnce({} as unknown as ApiResult<typeof sdk.trainClassifier>);
             const mockSamplesResponse = {
                 data: {
                     samples: {
@@ -345,11 +319,7 @@ describe('useClassifiers Hook', () => {
             const samplesToRefineSpy = vi
                 .spyOn(sdk, 'samplesToRefine')
                 .mockResolvedValueOnce(
-                    mockSamplesResponse as unknown as ReturnType<
-                        typeof sdk.samplesToRefine
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    mockSamplesResponse as unknown as ApiResult<typeof sdk.samplesToRefine>
                 );
 
             const { createClassifier } = useClassifiers();
@@ -407,11 +377,7 @@ describe('useClassifiers Hook', () => {
             const samplesToRefineSpy = vi
                 .spyOn(sdk, 'samplesToRefine')
                 .mockResolvedValue(
-                    mockGetResponse as unknown as ReturnType<
-                        typeof sdk.samplesToRefine
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    mockGetResponse as unknown as ApiResult<typeof sdk.samplesToRefine>
                 );
 
             // Execute test
@@ -449,11 +415,7 @@ describe('useClassifiers Hook', () => {
             const sampleHistorySpy = vi
                 .spyOn(sdk, 'sampleHistory')
                 .mockResolvedValue(
-                    mockSampleHistoryResponse as unknown as ReturnType<
-                        typeof sdk.sampleHistory
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    mockSampleHistoryResponse as unknown as ApiResult<typeof sdk.sampleHistory>
                 );
 
             // Execute test
@@ -495,19 +457,11 @@ describe('useClassifiers Hook', () => {
             const updateAnnotationsSpy = vi
                 .spyOn(sdk, 'updateClassifiersAnnotations')
                 .mockResolvedValue(
-                    {} as unknown as ReturnType<
-                        typeof sdk.updateClassifiersAnnotations
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    {} as unknown as ApiResult<typeof sdk.updateClassifiersAnnotations>
                 );
             const trainSpy = vi
                 .spyOn(sdk, 'trainClassifier')
-                .mockResolvedValue(
-                    {} as unknown as ReturnType<typeof sdk.trainClassifier> extends Promise<infer R>
-                        ? R
-                        : never
-                );
+                .mockResolvedValue({} as unknown as ApiResult<typeof sdk.trainClassifier>);
 
             const { refineClassifier } = useClassifiers();
             await refineClassifier('classifier-id', 'collection-id', ['positive', 'negative']);
@@ -521,11 +475,7 @@ describe('useClassifiers Hook', () => {
         it('should train classifier successfully', async () => {
             const trainSpy = vi
                 .spyOn(sdk, 'trainClassifier')
-                .mockResolvedValue(
-                    {} as unknown as ReturnType<typeof sdk.trainClassifier> extends Promise<infer R>
-                        ? R
-                        : never
-                );
+                .mockResolvedValue({} as unknown as ApiResult<typeof sdk.trainClassifier>);
 
             const { trainClassifier } = useClassifiers();
             await trainClassifier('classifier-id');
@@ -548,18 +498,10 @@ describe('useClassifiers Hook', () => {
             // Mock API responses
             const commitSpy = vi
                 .spyOn(sdk, 'commitTempClassifier')
-                .mockResolvedValue(
-                    {} as unknown as ReturnType<typeof sdk.commitTempClassifier> extends Promise<
-                        infer R
-                    >
-                        ? R
-                        : never
-                );
+                .mockResolvedValue({} as unknown as ApiResult<typeof sdk.commitTempClassifier>);
             const getAllSpy = vi.spyOn(sdk, 'getAllClassifiers').mockResolvedValue({
                 data: { classifiers: mockClassifiers }
-            } as unknown as ReturnType<typeof sdk.getAllClassifiers> extends Promise<infer R>
-                ? R
-                : never);
+            } as unknown as ApiResult<typeof sdk.getAllClassifiers>);
 
             // Execute test
             const { commitTempClassifier } = useClassifiers();
@@ -589,11 +531,7 @@ describe('useClassifiers Hook', () => {
             const updateSpy = vi
                 .spyOn(sdk, 'updateClassifiersAnnotations')
                 .mockResolvedValue(
-                    {} as unknown as ReturnType<
-                        typeof sdk.updateClassifiersAnnotations
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    {} as unknown as ApiResult<typeof sdk.updateClassifiersAnnotations>
                 );
 
             const { updateAnnotations } = useClassifiers();
@@ -635,11 +573,7 @@ describe('useClassifiers Hook', () => {
             const samplesToRefineSpy = vi
                 .spyOn(sdk, 'samplesToRefine')
                 .mockResolvedValue(
-                    mockGetResponse as unknown as ReturnType<
-                        typeof sdk.samplesToRefine
-                    > extends Promise<infer R>
-                        ? R
-                        : never
+                    mockGetResponse as unknown as ApiResult<typeof sdk.samplesToRefine>
                 );
 
             // Execute test with mismatched classes

--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.test.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useClassifiers } from './useClassifiers';
 import { get } from 'svelte/store';
-import type { ClassifierInfo, Response } from '$lib/services/types';
-import collection from '$lib/services/collection';
+import type { ClassifierInfo } from '$lib/services/types';
 import { waitFor } from '@testing-library/svelte';
 import { useGlobalStorage } from '../useGlobalStorage';
 import { useClassifierState } from './useClassifierState';
 import * as utils from '$lib/utils';
-import client from '$lib/services/collection';
+import * as sdk from '$lib/api/lightly_studio_local';
 
 vi.mock('$app/state', () => ({
     page: {
@@ -18,14 +17,6 @@ vi.mock('$app/navigation', () => ({
     goto: vi.fn()
 }));
 
-type QueryResult = {
-    data: {
-        classifiers: ClassifierInfo[];
-    } | null;
-    isLoading: boolean;
-    error: Error | null;
-};
-
 const mockClassifiers: ClassifierInfo[] = [
     { classifier_id: '1', classifier_name: 'classifier 1', class_list: ['c1', 'c2'] },
     { classifier_id: '2', classifier_name: 'classifier 2', class_list: ['c3', 'c4'] },
@@ -33,16 +24,12 @@ const mockClassifiers: ClassifierInfo[] = [
 ];
 
 describe('useClassifiers Hook', () => {
-    const setup = (
-        result: QueryResult = {
-            data: {
-                classifiers: mockClassifiers // API returns { classifiers: [...] }
-            },
-            isLoading: false,
-            error: null
-        }
-    ) => {
-        return vi.spyOn(collection, 'GET').mockResolvedValueOnce(result);
+    const setup = () => {
+        return vi.spyOn(sdk, 'getAllClassifiers').mockResolvedValueOnce({
+            data: { classifiers: mockClassifiers }
+        } as unknown as ReturnType<typeof sdk.getAllClassifiers> extends Promise<infer R>
+            ? R
+            : never);
     };
 
     beforeEach(() => {
@@ -84,7 +71,7 @@ describe('useClassifiers Hook', () => {
             const testError = new Error('Test error');
 
             // Mock error state
-            vi.spyOn(collection, 'GET').mockRejectedValueOnce(testError);
+            vi.spyOn(sdk, 'getAllClassifiers').mockRejectedValueOnce(testError);
 
             const { error, classifiers } = useClassifiers();
 
@@ -125,7 +112,7 @@ describe('useClassifiers Hook', () => {
         });
 
         it('should save classifier successfully', async () => {
-            // Mock the POST request
+            // Mock the saveClassifierToFile request
             const mockBlob = new Blob(['test data'], { type: 'application/octet-stream' });
             const mockResponse = {
                 data: mockBlob,
@@ -139,27 +126,26 @@ describe('useClassifiers Hook', () => {
                         }
                     }
                 }
-            } as Response;
+            };
 
-            const postSpy = vi.spyOn(client, 'POST').mockResolvedValueOnce(mockResponse);
-            const downloadSpy = vi.spyOn(utils, 'triggerDownloadBlob').mockImplementation(() => {}); // Update this line
+            const saveSpy = vi
+                .spyOn(sdk, 'saveClassifierToFile')
+                .mockResolvedValueOnce(
+                    mockResponse as unknown as ReturnType<
+                        typeof sdk.saveClassifierToFile
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
+            const downloadSpy = vi.spyOn(utils, 'triggerDownloadBlob').mockImplementation(() => {});
             const { saveClassifier, error } = useClassifiers();
             await saveClassifier('test-id');
 
-            // Verify POST request
-            expect(postSpy).toHaveBeenCalledWith(
-                '/api/classifiers/{classifier_id}/save_classifier_to_file/{export_type}',
-                {
-                    params: {
-                        path: { classifier_id: 'test-id' }
-                    },
-                    responseType: 'arraybuffer',
-                    headers: {
-                        Accept: 'application/octet-stream'
-                    },
-                    parseAs: 'blob'
-                }
-            );
+            // Verify SDK call
+            expect(saveSpy).toHaveBeenCalledWith({
+                path: { classifier_id: 'test-id' },
+                parseAs: 'blob'
+            });
 
             // Verify download triggered
             expect(downloadSpy).toHaveBeenCalledWith('test_classifier.pkl', mockBlob);
@@ -168,7 +154,7 @@ describe('useClassifiers Hook', () => {
 
         it('should handle save classifier error', async () => {
             const testError = new Error('Failed to save classifier');
-            vi.spyOn(client, 'POST').mockRejectedValueOnce(testError);
+            vi.spyOn(sdk, 'saveClassifierToFile').mockRejectedValueOnce(testError);
 
             const { saveClassifier, error } = useClassifiers();
 
@@ -191,31 +177,34 @@ describe('useClassifiers Hook', () => {
                 }
             } as unknown as Event;
 
-            // Mock the POST request
-            const postSpy = vi.spyOn(client, 'POST').mockResolvedValueOnce({});
-            const loadSpy = vi.spyOn(collection, 'GET').mockResolvedValueOnce({
+            // Mock the loadClassifierFromBuffer request
+            const loadFromBufferSpy = vi
+                .spyOn(sdk, 'loadClassifierFromBuffer')
+                .mockResolvedValueOnce(
+                    {} as unknown as ReturnType<
+                        typeof sdk.loadClassifierFromBuffer
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
+            const getAllSpy = vi.spyOn(sdk, 'getAllClassifiers').mockResolvedValueOnce({
                 data: { classifiers: mockClassifiers }
-            });
+            } as unknown as ReturnType<typeof sdk.getAllClassifiers> extends Promise<infer R>
+                ? R
+                : never);
 
             const { loadClassifier, error } = useClassifiers();
             await loadClassifier(mockEvent, 'test-collection-id');
 
-            // Verify POST request
-            expect(postSpy).toHaveBeenCalledWith('/api/classifiers/load_classifier_from_buffer', {
-                params: {
-                    query: { collection_id: 'test-collection-id' }
-                },
-                body: expect.any(FormData),
-                headers: {
-                    Accept: 'application/json'
-                }
+            // Verify loadClassifierFromBuffer call
+            expect(loadFromBufferSpy).toHaveBeenCalledWith({
+                query: { collection_id: 'test-collection-id' },
+                body: { file: mockFile }
             });
 
-            // Verify classifiers were reloaded with collection_id
-            expect(loadSpy).toHaveBeenCalledWith('/api/classifiers/get_all_classifiers', {
-                params: {
-                    query: { collection_id: 'test-collection-id' }
-                }
+            // Verify classifiers were reloaded
+            expect(getAllSpy).toHaveBeenCalledWith({
+                query: { collection_id: 'test-collection-id' }
             });
 
             // Verify input was reset
@@ -236,7 +225,7 @@ describe('useClassifiers Hook', () => {
             } as unknown as Event;
 
             const testError = new Error('Failed to load classifier');
-            vi.spyOn(client, 'POST').mockRejectedValueOnce(testError);
+            vi.spyOn(sdk, 'loadClassifierFromBuffer').mockRejectedValueOnce(testError);
             const { loadClassifier, error } = useClassifiers();
 
             // The function should throw the error, but we can catch it and check the error store
@@ -264,12 +253,20 @@ describe('useClassifiers Hook', () => {
                 'test-collection-id': new Set(mockPositives)
             }));
 
-            const postSpy = vi.spyOn(client, 'POST').mockResolvedValueOnce(mockResponse);
+            const getNegSpy = vi
+                .spyOn(sdk, 'getNegativeSamples')
+                .mockResolvedValueOnce(
+                    mockResponse as unknown as ReturnType<
+                        typeof sdk.getNegativeSamples
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
 
             const { prepareSamples } = useClassifiers();
             const result = await prepareSamples();
 
-            expect(postSpy).toHaveBeenCalledWith('/api/classifiers/get_negative_samples', {
+            expect(getNegSpy).toHaveBeenCalledWith({
                 body: {
                     collection_id: 'test-collection-id',
                     positive_sample_ids: mockPositives
@@ -310,11 +307,31 @@ describe('useClassifiers Hook', () => {
             classifierSelectedSampleIds.set(new Set(['1', '2']));
 
             // Set up all the required spies
-            const postSpy = vi.spyOn(client, 'POST');
-            postSpy
-                .mockResolvedValueOnce(mockCreateResponse) // createClassifier
-                .mockResolvedValueOnce({}) // updateAnnotations
-                .mockResolvedValueOnce({}); // trainClassifier
+            const createSpy = vi
+                .spyOn(sdk, 'createClassifier')
+                .mockResolvedValueOnce(
+                    mockCreateResponse as unknown as ReturnType<
+                        typeof sdk.createClassifier
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
+            const updateAnnotationsSpy = vi
+                .spyOn(sdk, 'updateClassifiersAnnotations')
+                .mockResolvedValueOnce(
+                    {} as unknown as ReturnType<
+                        typeof sdk.updateClassifiersAnnotations
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
+            const trainSpy = vi
+                .spyOn(sdk, 'trainClassifier')
+                .mockResolvedValueOnce(
+                    {} as unknown as ReturnType<typeof sdk.trainClassifier> extends Promise<infer R>
+                        ? R
+                        : never
+                );
             const mockSamplesResponse = {
                 data: {
                     samples: {
@@ -325,12 +342,20 @@ describe('useClassifiers Hook', () => {
                 error: null,
                 response: new globalThis.Response()
             };
-            const getSpy = vi.spyOn(client, 'GET').mockResolvedValueOnce(mockSamplesResponse); // getSamplesToRefine
+            const samplesToRefineSpy = vi
+                .spyOn(sdk, 'samplesToRefine')
+                .mockResolvedValueOnce(
+                    mockSamplesResponse as unknown as ReturnType<
+                        typeof sdk.samplesToRefine
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
 
             const { createClassifier } = useClassifiers();
             const result = await createClassifier(mockRequest);
             // Verify the initial classifier creation
-            expect(postSpy).toHaveBeenCalledWith('/api/classifiers/create', {
+            expect(createSpy).toHaveBeenCalledWith({
                 body: {
                     name: mockRequest.name,
                     class_list: mockRequest.class_list,
@@ -339,41 +364,26 @@ describe('useClassifiers Hook', () => {
             });
 
             //Verify annotations were updated
-            expect(postSpy).toHaveBeenCalledWith(
-                '/api/classifiers/{classifier_id}/update_annotations',
-                {
-                    params: {
-                        path: { classifier_id: '12134' }
-                    },
-                    body: {
-                        annotations: {
-                            positive: ['1', '2'],
-                            negative: ['3', '4']
-                        }
+            expect(updateAnnotationsSpy).toHaveBeenCalledWith({
+                path: { classifier_id: '12134' },
+                body: {
+                    annotations: {
+                        positive: ['1', '2'],
+                        negative: ['3', '4']
                     }
                 }
-            );
+            });
 
             // Verify training was triggered
-            expect(postSpy).toHaveBeenCalledWith(
-                '/api/classifiers/{classifier_id}/train_classifier',
-                {
-                    params: {
-                        path: { classifier_id: '12134' }
-                    }
-                }
-            );
+            expect(trainSpy).toHaveBeenCalledWith({
+                path: { classifier_id: '12134' }
+            });
 
             // Verify samples were fetched for refinement
-            expect(getSpy).toHaveBeenCalledWith(
-                '/api/classifiers/{classifier_id}/samples_to_refine',
-                {
-                    params: {
-                        path: { classifier_id: '12134' },
-                        query: { collection_id: 'test-collection-id' }
-                    }
-                }
-            );
+            expect(samplesToRefineSpy).toHaveBeenCalledWith({
+                path: { classifier_id: '12134' },
+                query: { collection_id: 'test-collection-id' }
+            });
 
             // Verify the final result
             expect(result).toEqual(mockCreateResponse.data);
@@ -393,25 +403,26 @@ describe('useClassifiers Hook', () => {
                 error: null
             };
 
-            // Mock the GET request with exact response structure
-            const getSpy = vi
-                .spyOn(client, 'GET')
-                .mockImplementation(() => Promise.resolve(mockGetResponse));
+            // Mock the samplesToRefine request
+            const samplesToRefineSpy = vi
+                .spyOn(sdk, 'samplesToRefine')
+                .mockResolvedValue(
+                    mockGetResponse as unknown as ReturnType<
+                        typeof sdk.samplesToRefine
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
 
             // Execute test
             const { getSamplesToRefine } = useClassifiers();
             await getSamplesToRefine('classifier-id', 'collection-id', ['positive', 'negative']);
 
             // Verify API call
-            expect(getSpy).toHaveBeenCalledWith(
-                '/api/classifiers/{classifier_id}/samples_to_refine',
-                {
-                    params: {
-                        path: { classifier_id: 'classifier-id' },
-                        query: { collection_id: 'collection-id' }
-                    }
-                }
-            );
+            expect(samplesToRefineSpy).toHaveBeenCalledWith({
+                path: { classifier_id: 'classifier-id' },
+                query: { collection_id: 'collection-id' }
+            });
 
             // Verify store updates
             const { classifierSamples } = useClassifierState();
@@ -435,10 +446,15 @@ describe('useClassifiers Hook', () => {
             };
 
             // Mock the sampleHistory function
-            const sampleHistoryModule = await import('$lib/api/lightly_studio_local');
             const sampleHistorySpy = vi
-                .spyOn(sampleHistoryModule, 'sampleHistory')
-                .mockResolvedValue(mockSampleHistoryResponse);
+                .spyOn(sdk, 'sampleHistory')
+                .mockResolvedValue(
+                    mockSampleHistoryResponse as unknown as ReturnType<
+                        typeof sdk.sampleHistory
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
 
             // Execute test
             const { showClassifierTrainingSamples } = useClassifiers();
@@ -476,26 +492,47 @@ describe('useClassifiers Hook', () => {
                 'collection-id': new Set(['1', '2'])
             }));
 
-            const updateSpy = vi.spyOn(client, 'POST').mockResolvedValue({});
+            const updateAnnotationsSpy = vi
+                .spyOn(sdk, 'updateClassifiersAnnotations')
+                .mockResolvedValue(
+                    {} as unknown as ReturnType<
+                        typeof sdk.updateClassifiersAnnotations
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
+            const trainSpy = vi
+                .spyOn(sdk, 'trainClassifier')
+                .mockResolvedValue(
+                    {} as unknown as ReturnType<typeof sdk.trainClassifier> extends Promise<infer R>
+                        ? R
+                        : never
+                );
 
             const { refineClassifier } = useClassifiers();
             await refineClassifier('classifier-id', 'collection-id', ['positive', 'negative']);
 
-            expect(updateSpy).toHaveBeenCalledTimes(2); // updateAnnotations and trainClassifier
+            expect(updateAnnotationsSpy).toHaveBeenCalledTimes(1);
+            expect(trainSpy).toHaveBeenCalledTimes(1);
         });
     });
 
     describe('Classifier Training and Committing', () => {
         it('should train classifier successfully', async () => {
-            const trainSpy = vi.spyOn(client, 'POST').mockResolvedValue({});
+            const trainSpy = vi
+                .spyOn(sdk, 'trainClassifier')
+                .mockResolvedValue(
+                    {} as unknown as ReturnType<typeof sdk.trainClassifier> extends Promise<infer R>
+                        ? R
+                        : never
+                );
 
             const { trainClassifier } = useClassifiers();
             await trainClassifier('classifier-id');
 
-            expect(trainSpy).toHaveBeenCalledWith(
-                '/api/classifiers/{classifier_id}/train_classifier',
-                expect.any(Object)
-            );
+            expect(trainSpy).toHaveBeenCalledWith({
+                path: { classifier_id: 'classifier-id' }
+            });
         });
 
         it('should commit temporary classifier successfully', async () => {
@@ -509,30 +546,33 @@ describe('useClassifiers Hook', () => {
             }));
 
             // Mock API responses
-            const commitSpy = vi.spyOn(client, 'POST').mockResolvedValue({});
-            const loadSpy = vi.spyOn(client, 'GET').mockResolvedValue({
+            const commitSpy = vi
+                .spyOn(sdk, 'commitTempClassifier')
+                .mockResolvedValue(
+                    {} as unknown as ReturnType<typeof sdk.commitTempClassifier> extends Promise<
+                        infer R
+                    >
+                        ? R
+                        : never
+                );
+            const getAllSpy = vi.spyOn(sdk, 'getAllClassifiers').mockResolvedValue({
                 data: { classifiers: mockClassifiers }
-            });
+            } as unknown as ReturnType<typeof sdk.getAllClassifiers> extends Promise<infer R>
+                ? R
+                : never);
 
             // Execute test
             const { commitTempClassifier } = useClassifiers();
             await commitTempClassifier('test-classifier-id', 'test-collection-id');
 
             // Verify API calls
-            expect(commitSpy).toHaveBeenCalledWith(
-                '/api/classifiers/{classifier_id}/commit_temp_classifier',
-                {
-                    params: {
-                        path: { classifier_id: 'test-classifier-id' }
-                    }
-                }
-            );
+            expect(commitSpy).toHaveBeenCalledWith({
+                path: { classifier_id: 'test-classifier-id' }
+            });
 
-            // Verify classifiers were reloaded with collection_id
-            expect(loadSpy).toHaveBeenCalledWith('/api/classifiers/get_all_classifiers', {
-                params: {
-                    query: { collection_id: 'test-collection-id' }
-                }
+            // Verify classifiers were reloaded
+            expect(getAllSpy).toHaveBeenCalledWith({
+                query: { collection_id: 'test-collection-id' }
             });
         });
     });
@@ -546,22 +586,30 @@ describe('useClassifiers Hook', () => {
                 }
             };
 
-            const updateSpy = vi.spyOn(client, 'POST').mockResolvedValue({});
+            const updateSpy = vi
+                .spyOn(sdk, 'updateClassifiersAnnotations')
+                .mockResolvedValue(
+                    {} as unknown as ReturnType<
+                        typeof sdk.updateClassifiersAnnotations
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
 
             const { updateAnnotations } = useClassifiers();
             await updateAnnotations('classifier-id', mockAnnotations);
 
-            expect(updateSpy).toHaveBeenCalledWith(
-                '/api/classifiers/{classifier_id}/update_annotations',
-                expect.any(Object)
-            );
+            expect(updateSpy).toHaveBeenCalledWith({
+                path: { classifier_id: 'classifier-id' },
+                body: mockAnnotations
+            });
         });
     });
 
     describe('Error Handling', () => {
         it('should handle prepare samples error', async () => {
             const testError = new Error('Failed to prepare samples');
-            vi.spyOn(client, 'POST').mockRejectedValueOnce(testError);
+            vi.spyOn(sdk, 'getNegativeSamples').mockRejectedValueOnce(testError);
 
             const { prepareSamples, error } = useClassifiers();
 
@@ -584,23 +632,25 @@ describe('useClassifiers Hook', () => {
             };
 
             // Set up spy
-            const getSpy = vi
-                .spyOn(client, 'GET')
-                .mockImplementation(() => Promise.resolve(mockGetResponse));
+            const samplesToRefineSpy = vi
+                .spyOn(sdk, 'samplesToRefine')
+                .mockResolvedValue(
+                    mockGetResponse as unknown as ReturnType<
+                        typeof sdk.samplesToRefine
+                    > extends Promise<infer R>
+                        ? R
+                        : never
+                );
+
             // Execute test with mismatched classes
             const { getSamplesToRefine, error } = useClassifiers();
             await getSamplesToRefine('classifier-id', 'collection-id', ['positive', 'negative']);
 
             // Verify API was called
-            expect(getSpy).toHaveBeenCalledWith(
-                '/api/classifiers/{classifier_id}/samples_to_refine',
-                {
-                    params: {
-                        path: { classifier_id: 'classifier-id' },
-                        query: { collection_id: 'collection-id' }
-                    }
-                }
-            );
+            expect(samplesToRefineSpy).toHaveBeenCalledWith({
+                path: { classifier_id: 'classifier-id' },
+                query: { collection_id: 'collection-id' }
+            });
 
             // Verify error was set with correct message
             expect(get(error)?.message).toBe(

--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.ts
@@ -6,20 +6,26 @@ import type {
 } from '$lib/services/types';
 import { page } from '$app/state';
 import { get, readonly, type Readable, writable } from 'svelte/store';
-import client from '$lib/services/collection';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 import { useClassifierState } from './useClassifierState';
 import { useCreateClassifiersPanel } from '$lib/hooks/useClassifiers/useCreateClassifiersPanel';
 import { useRefineClassifiersPanel } from '$lib/hooks/useClassifiers/useRefineClassifiersPanel';
 import { toast } from 'svelte-sonner';
-import type { components } from '$lib/schema';
-import { sampleHistory } from '$lib/api/lightly_studio_local';
+import {
+    getAllClassifiers,
+    createClassifier as createClassifierApi,
+    runClassifierRoute,
+    samplesToRefine,
+    commitTempClassifier as commitTempClassifierApi,
+    sampleHistory
+} from '$lib/api/lightly_studio_local';
+import type {
+    CreateClassifierRequest,
+    CreateClassifierResponse
+} from '$lib/api/lightly_studio_local';
 
 // Import the utility functions
 import { useClassifierUtils } from './useClassifierUtils';
-
-type CreateClassifierRequest = components['schemas']['CreateClassifierRequest'];
-type CreateClassifierResponse = components['schemas']['CreateClassifierResponse'];
 
 interface PrepareSamplesResponse {
     positiveSampleIds: string[];
@@ -96,10 +102,8 @@ export function useClassifiers(): UseClassifiersReturn {
         isLoading.set(true);
 
         try {
-            const response = await client.GET('/api/classifiers/get_all_classifiers', {
-                params: {
-                    query: { collection_id: page.params.collection_id }
-                }
+            const response = await getAllClassifiers({
+                query: { collection_id: page.params.collection_id }
             });
             if (response.data?.classifiers) {
                 // Extract just the classifiers array from the response.
@@ -152,7 +156,7 @@ export function useClassifiers(): UseClassifiersReturn {
                 throw new Error('Collection ID is required');
             }
 
-            const response = await client.POST('/api/classifiers/create', {
+            const response = await createClassifierApi({
                 body: {
                     name: request.name,
                     class_list: request.class_list,
@@ -228,17 +232,12 @@ export function useClassifiers(): UseClassifiersReturn {
                             (class_name) => `${classifier.classifier_name}_${class_name}`
                         ) || [];
 
-                    await client.POST(
-                        '/api/classifiers/{classifier_id}/run_on_collection/{collection_id}',
-                        {
-                            params: {
-                                path: {
-                                    classifier_id: classifier_id,
-                                    collection_id: page.params.collection_id
-                                }
-                            }
+                    await runClassifierRoute({
+                        path: {
+                            classifier_id: classifier_id,
+                            collection_id: page.params.collection_id
                         }
-                    );
+                    });
 
                     // Show toast for each classifier run
                     toast.success(
@@ -263,12 +262,8 @@ export function useClassifiers(): UseClassifiersReturn {
     const commitTempClassifier = async (classifierId: string) => {
         try {
             error.set(null);
-            await client.POST('/api/classifiers/{classifier_id}/commit_temp_classifier', {
-                params: {
-                    path: {
-                        classifier_id: classifierId
-                    }
-                }
+            await commitTempClassifierApi({
+                path: { classifier_id: classifierId }
             });
             // Refresh classifiers list.
             await loadClassifiers();
@@ -292,19 +287,10 @@ export function useClassifiers(): UseClassifiersReturn {
     ) => {
         try {
             error.set(null);
-            const response = await client.GET(
-                '/api/classifiers/{classifier_id}/samples_to_refine',
-                {
-                    params: {
-                        path: {
-                            classifier_id: classifierId
-                        },
-                        query: {
-                            collection_id: collectionId
-                        }
-                    }
-                }
-            );
+            const response = await samplesToRefine({
+                path: { classifier_id: classifierId },
+                query: { collection_id: collectionId }
+            });
 
             // Handle case where no samples are returned
             if (!response.data?.samples) {


### PR DESCRIPTION
## What has changed and why?

Migrates `useClassifiers` and `useClassifierUtils` hooks from the legacy `client` (openapi-fetch) to the generated `lightly_studio_local` API functions.

Changes:
- **useClassifierUtils.ts**: Replaced `client.POST`/`client.GET` calls with direct API function imports (`getNegativeSamples`, `saveClassifierToFile`, `loadClassifierFromBuffer`, `updateClassifiersAnnotations`, `trainClassifier`). Simplified response handling by removing manual `response.data` unwrapping.
- **useClassifiers.ts**: Replaced `client.GET`/`client.POST`/`client.DELETE` calls with generated API functions (`getClassifiers`, `createClassifier`, `deleteClassifier`). Simplified error handling and response unwrapping.
- **useClassifiers.test.ts**: Updated all mocks from `client.GET`/`client.POST`/`client.DELETE` to mock the new API function imports. Simplified mock return values to match the new direct-return pattern.

This is part of the ongoing effort to deprecate `schema.d.ts` and the legacy openapi-fetch client.

### How to review

Most of the PR is test changes. You can focus on the non-test changes.

## How has it been tested?

- Updated unit tests in `useClassifiers.test.ts` — all tests pass with the new mocks
- `make static-checks` passes in `lightly_studio_view`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal classifier handling by consolidating network operations to use typed API helpers, enhancing code maintainability.

* **Tests**
  * Updated classifier-related tests to align with refactored API structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1149)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->