### PR TITLE
Kondrat lig 9568 create endpoint to fetch evaluation runs.endpoint

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/evaluation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/evaluation.py
@@ -8,8 +8,9 @@ from uuid import UUID
 from fastapi import APIRouter, Path
 
 from lightly_studio.db_manager import SessionDep
+from lightly_studio.models.evaluation_run import EvaluationRunView
 from lightly_studio.models.evaluation_sample_metric import EvaluationRunMetricsInfoView
-from lightly_studio.resolvers import evaluation_sample_metric_resolver
+from lightly_studio.resolvers import evaluation_run_resolver, evaluation_sample_metric_resolver
 
 evaluation_router = APIRouter(prefix="/datasets/{dataset_id}", tags=["evaluation"])
 
@@ -36,3 +37,35 @@ def get_evaluation_sample_metrics_info(
         session=session,
         dataset_id=dataset_id,
     )
+
+
+@evaluation_router.get(
+    "/evaluation/runs",
+    response_model=list[EvaluationRunView],
+)
+def get_evaluation_runs(
+    session: SessionDep,
+    dataset_id: Annotated[UUID, Path(title="Dataset ID")],
+) -> list[EvaluationRunView]:
+    """Get all evaluation runs for a dataset.
+
+    Args:
+        session: The database session.
+        dataset_id: The dataset's UUID.
+
+    Returns:
+        List of evaluation runs, each with id, name, and run configuration.
+    """
+    runs = evaluation_run_resolver.get_all_by_dataset_id(
+        session=session,
+        dataset_id=dataset_id,
+    )
+    return [
+        EvaluationRunView(
+            id=run.id,
+            name=run.name,
+            evaluation_run_configuration=run.config_json,
+            created_at=run.created_at,
+        )
+        for run in runs
+    ]

--- a/lightly_studio/src/lightly_studio/models/evaluation_run.py
+++ b/lightly_studio/src/lightly_studio/models/evaluation_run.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any
 from uuid import UUID, uuid4
 
+from pydantic import BaseModel
 from sqlalchemy import JSON, Column
 from sqlmodel import Field, SQLModel
 
@@ -46,3 +47,12 @@ class EvaluationRunTable(EvaluationRunBase, table=True):
 
 class EvaluationRunCreate(EvaluationRunBase):
     """Model for creating a new evaluation run."""
+
+
+class EvaluationRunView(BaseModel):
+    """API view of an evaluation run."""
+
+    id: UUID
+    name: str
+    evaluation_run_configuration: dict[str, Any]
+    created_at: datetime

--- a/lightly_studio/tests/api/routes/api/test_evaluation.py
+++ b/lightly_studio/tests/api/routes/api/test_evaluation.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
 from lightly_studio.api.routes.api.status import HTTP_STATUS_OK
+from lightly_studio.models.evaluation_run import (
+    EvaluationRunTable,
+    EvaluationTaskType,
+)
 from lightly_studio.models.evaluation_sample_metric import (
     EvaluationRunMetricsInfoView,
     EvaluationSampleMetricBoundsView,
@@ -67,6 +72,72 @@ def test_get_evaluation_sample_metrics_info__empty_response(
     )
 
     response = test_client.get(f"/api/datasets/{dataset_id}/evaluation/metrics/sample/info")
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == []
+
+
+def test_get_evaluation_runs(test_client: TestClient, mocker: MockerFixture) -> None:
+    dataset_id = uuid4()
+    run_1_id = uuid4()
+    run_2_id = uuid4()
+    run_1_created_at = datetime(2026, 5, 18, 10, 0, 0, tzinfo=timezone.utc)
+    run_2_created_at = datetime(2026, 5, 17, 9, 30, 0, tzinfo=timezone.utc)
+    mock_runs = [
+        EvaluationRunTable(
+            id=run_1_id,
+            name="run_1",
+            gt_annotation_collection_id=uuid4(),
+            pred_annotation_collection_id=uuid4(),
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+            config_json={"iou_threshold": 0.5, "classwise": True},
+            created_at=run_1_created_at,
+        ),
+        EvaluationRunTable(
+            id=run_2_id,
+            name="run_2",
+            gt_annotation_collection_id=uuid4(),
+            pred_annotation_collection_id=uuid4(),
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+            config_json={},
+            created_at=run_2_created_at,
+        ),
+    ]
+    mocker.patch(
+        "lightly_studio.api.routes.api.evaluation.evaluation_run_resolver.get_all_by_dataset_id",
+        return_value=mock_runs,
+    )
+
+    response = test_client.get(f"/api/datasets/{dataset_id}/evaluation/runs")
+
+    assert response.status_code == HTTP_STATUS_OK
+    data = response.json()
+    assert data == [
+        {
+            "id": str(run_1_id),
+            "name": "run_1",
+            "evaluation_run_configuration": {"iou_threshold": 0.5, "classwise": True},
+            "created_at": "2026-05-18T10:00:00Z",
+        },
+        {
+            "id": str(run_2_id),
+            "name": "run_2",
+            "evaluation_run_configuration": {},
+            "created_at": "2026-05-17T09:30:00Z",
+        },
+    ]
+
+
+def test_get_evaluation_runs__empty_response(
+    test_client: TestClient, mocker: MockerFixture
+) -> None:
+    dataset_id = uuid4()
+    mocker.patch(
+        "lightly_studio.api.routes.api.evaluation.evaluation_run_resolver.get_all_by_dataset_id",
+        return_value=[],
+    )
+
+    response = test_client.get(f"/api/datasets/{dataset_id}/evaluation/runs")
 
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() == []

--- a/lightly_studio/tests/api/routes/api/test_evaluation.py
+++ b/lightly_studio/tests/api/routes/api/test_evaluation.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from uuid import uuid4
+from typing import Any
+from uuid import UUID, uuid4
 
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
@@ -15,6 +16,24 @@ from lightly_studio.models.evaluation_sample_metric import (
     EvaluationRunMetricsInfoView,
     EvaluationSampleMetricBoundsView,
 )
+
+
+def _make_evaluation_run(
+    *,
+    run_id: UUID,
+    name: str,
+    config_json: dict[str, Any],
+    created_at: datetime,
+) -> EvaluationRunTable:
+    return EvaluationRunTable(
+        id=run_id,
+        name=name,
+        gt_annotation_collection_id=uuid4(),
+        pred_annotation_collection_id=uuid4(),
+        task_type=EvaluationTaskType.OBJECT_DETECTION,
+        config_json=config_json,
+        created_at=created_at,
+    )
 
 
 def test_get_evaluation_sample_metrics_info(test_client: TestClient, mocker: MockerFixture) -> None:
@@ -84,21 +103,15 @@ def test_get_evaluation_runs(test_client: TestClient, mocker: MockerFixture) -> 
     run_1_created_at = datetime(2026, 5, 18, 10, 0, 0, tzinfo=timezone.utc)
     run_2_created_at = datetime(2026, 5, 17, 9, 30, 0, tzinfo=timezone.utc)
     mock_runs = [
-        EvaluationRunTable(
-            id=run_1_id,
+        _make_evaluation_run(
+            run_id=run_1_id,
             name="run_1",
-            gt_annotation_collection_id=uuid4(),
-            pred_annotation_collection_id=uuid4(),
-            task_type=EvaluationTaskType.OBJECT_DETECTION,
             config_json={"iou_threshold": 0.5, "classwise": True},
             created_at=run_1_created_at,
         ),
-        EvaluationRunTable(
-            id=run_2_id,
+        _make_evaluation_run(
+            run_id=run_2_id,
             name="run_2",
-            gt_annotation_collection_id=uuid4(),
-            pred_annotation_collection_id=uuid4(),
-            task_type=EvaluationTaskType.OBJECT_DETECTION,
             config_json={},
             created_at=run_2_created_at,
         ),

--- a/lightly_studio_view/src/lib/schema.d.ts
+++ b/lightly_studio_view/src/lib/schema.d.ts
@@ -1280,6 +1280,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/datasets/{dataset_id}/evaluation/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Evaluation Runs
+         * @description Get all evaluation runs for a dataset.
+         *
+         *     Args:
+         *         session: The database session.
+         *         dataset_id: The dataset's UUID.
+         *
+         *     Returns:
+         *         List of evaluation runs, each with id, name, and run configuration.
+         */
+        get: operations["get_evaluation_runs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/collections/{collection_id}/metadata/info": {
         parameters: {
             query?: never;
@@ -2711,6 +2738,28 @@ export interface components {
             run_name: string;
             /** Metrics */
             metrics: components["schemas"]["EvaluationSampleMetricBoundsView"][];
+        };
+        /**
+         * EvaluationRunView
+         * @description API view of an evaluation run.
+         */
+        EvaluationRunView: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Name */
+            name: string;
+            /** Evaluation Run Configuration */
+            evaluation_run_configuration: {
+                [key: string]: unknown;
+            };
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
         };
         /**
          * EvaluationSampleMetricBoundsView
@@ -6361,6 +6410,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EvaluationRunMetricsInfoView"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_evaluation_runs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                dataset_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvaluationRunView"][];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## What has changed and why?

Introduce endpoint to return eval runs

## How has it been tested?

By unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoint to list evaluation runs for a dataset, returning run id, name, configuration, and creation timestamp.
  * Added corresponding client-side API schema/types for the new endpoint and response shape.
* **Tests**
  * Added tests covering populated and empty responses for the new evaluation-runs endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->