### PR TITLE
Fix windows path resolution

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/add_annotations.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_annotations.py
@@ -107,13 +107,20 @@ def add_annotations_from_labelformat(  # noqa: PLR0913
 
 
 def normalize_images_root(images_root: PathLike) -> str:
-    """Return absolute local roots and preserve remote roots."""
+    """Return absolute local roots and preserve remote roots.
+
+    Local paths are returned in posix form (forward slashes) so they can be
+    safely joined with `posixpath.join` and compared across platforms. On
+    Windows, `str(Path(...).absolute())` yields backslashes that, when joined
+    with posix-separated relative paths, produce mixed-separator strings that
+    fail to match what was stored at ingestion time.
+    """
     images_root_str = str(images_root)
     protocol, _ = fsspec.core.split_protocol(images_root_str)
     if protocol is None:
-        return str(Path(images_root_str).absolute())
+        return Path(images_root_str).absolute().as_posix()
     if protocol == "file":
-        return str(Path(fsspec.core.strip_protocol(images_root_str)).absolute())
+        return Path(fsspec.core.strip_protocol(images_root_str)).absolute().as_posix()
     return images_root_str
 
 

--- a/lightly_studio/tests/core/image/test_add_annotations.py
+++ b/lightly_studio/tests/core/image/test_add_annotations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import posixpath
 from pathlib import Path
 
 from labelformat.formats.labelformat import LabelformatObjectDetectionInput
@@ -24,7 +25,7 @@ def test_add_annotations_from_labelformat__resolved_path_and_collection_name(
         collection.collection_id,
         [
             ImageStub(
-                path=str(Path("images/image.jpg").absolute()),
+                path=Path("images/image.jpg").absolute().as_posix(),
                 width=100,
                 height=200,
             ),
@@ -65,8 +66,35 @@ def test_add_annotations_from_labelformat__missing_images(db_session: Session) -
     samples = image_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     ).samples
-    assert missing_paths == ["/images/nonexistent.jpg"]
+    images_root = Path("/images").absolute().as_posix()
+    assert missing_paths == [f"{images_root}/nonexistent.jpg"]
     assert len(samples) == 0
+
+
+def test_normalize_images_root__local_path_is_posix() -> None:
+    # On Windows, `str(Path(...).absolute())` returns backslashes which, when
+    # joined with posix-separated labelformat filenames via `posixpath.join`,
+    # produce mixed-separator strings that fail to match ingested paths.
+    # The normalized root must therefore be in posix form.
+    result = add_annotations.normalize_images_root(Path("some") / "images")
+
+    assert "\\" not in result
+    assert result.endswith("some/images")
+    assert Path(result).is_absolute()
+
+
+def test_normalize_images_root__joins_cleanly_with_posix_filename() -> None:
+    root = add_annotations.normalize_images_root(Path("data") / "coco")
+    joined = posixpath.join(root, "images/0001.jpg")
+
+    assert "\\" not in joined
+    assert joined.endswith("data/coco/images/0001.jpg")
+
+
+def test_normalize_images_root__preserves_remote_protocol() -> None:
+    result = add_annotations.normalize_images_root("s3://bucket/path")
+
+    assert result == "s3://bucket/path"
 
 
 def _get_labelformat_input_obj_det(filename: str) -> LabelformatObjectDetectionInput:


### PR DESCRIPTION
## What has changed and why?

Update to handle also windows paths

## How has it been tested?

new tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path normalization to ensure consistent handling across different operating systems when working with both local and remote image storage locations.
  * Enhanced path separator consistency to enable reliable path joining and comparison operations across Windows, Mac, and Linux systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->