### PR TITLE
Add useEvaluationRuns hook to fetch dataset evaluation runs

### DIFF
--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -23,3 +23,4 @@ export { useTextEmbedding } from '$lib/hooks/useTextEmbedding/useTextEmbedding';
 export { useSearchEmbedding } from '$lib/hooks/useSearchEmbedding/useSearchEmbedding';
 export { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
 export { useEvaluationSampleMetricsInfo } from '$lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo';
+export { useEvaluationRuns } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';

--- a/lightly_studio_view/src/lib/hooks/useEvaluationRuns/useEvaluationRuns.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEvaluationRuns/useEvaluationRuns.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useEvaluationRuns } from './useEvaluationRuns';
+import { getEvaluationRuns } from '$lib/api/lightly_studio_local/sdk.gen';
+import { getEvaluationRunsOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import type { CreateQueryOptions, CreateQueryResult } from '@tanstack/svelte-query';
+import type { EvaluationRunView } from '$lib/api/lightly_studio_local/types.gen';
+import * as tanstackQuery from '@tanstack/svelte-query';
+
+vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
+    getEvaluationRuns: vi.fn()
+}));
+
+describe('useEvaluationRuns', () => {
+    const mockQueryResult = {
+        data: [],
+        isSuccess: true,
+        subscribe: vi.fn()
+    } as unknown as CreateQueryResult<EvaluationRunView[], Error>;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.spyOn(tanstackQuery, 'createQuery').mockReturnValue(mockQueryResult);
+    });
+
+    it('creates the query with the correct query key for the given dataset id', () => {
+        const datasetId = 'dataset-1';
+        const createQuerySpy = vi.spyOn(tanstackQuery, 'createQuery');
+
+        useEvaluationRuns({ datasetId });
+
+        const optionsArg = createQuerySpy.mock.calls[0][0] as CreateQueryOptions;
+        const expectedOptions = getEvaluationRunsOptions({
+            path: { dataset_id: datasetId }
+        });
+
+        expect(optionsArg.queryKey).toEqual(expectedOptions.queryKey);
+    });
+
+    it('calls the SDK function with the correct dataset id', async () => {
+        const datasetId = 'dataset-2';
+        const createQuerySpy = vi.spyOn(tanstackQuery, 'createQuery');
+
+        vi.mocked(getEvaluationRuns).mockResolvedValue(
+            [] as unknown as Awaited<ReturnType<typeof getEvaluationRuns>>
+        );
+
+        useEvaluationRuns({ datasetId });
+
+        const optionsArg = createQuerySpy.mock.calls[0][0] as CreateQueryOptions;
+
+        await (
+            optionsArg.queryFn as (ctx: {
+                queryKey: unknown;
+                signal: AbortSignal;
+            }) => Promise<unknown>
+        )({
+            queryKey: optionsArg.queryKey,
+            signal: new AbortController().signal
+        });
+
+        expect(getEvaluationRuns).toHaveBeenCalledWith(
+            expect.objectContaining({
+                path: { dataset_id: datasetId },
+                throwOnError: true,
+                signal: expect.any(AbortSignal)
+            })
+        );
+    });
+
+    it('returns the result of createQuery', () => {
+        const result = useEvaluationRuns({ datasetId: 'dataset-3' });
+
+        expect(result).toMatchObject({ data: [], isSuccess: true });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useEvaluationRuns/useEvaluationRuns.ts
+++ b/lightly_studio_view/src/lib/hooks/useEvaluationRuns/useEvaluationRuns.ts
@@ -1,0 +1,17 @@
+import { getEvaluationRunsOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import type { EvaluationRunView } from '$lib/api/lightly_studio_local/types.gen';
+import { createQuery, type CreateQueryResult } from '@tanstack/svelte-query';
+
+interface UseEvaluationRunsParams {
+    datasetId: string;
+}
+
+export const useEvaluationRuns = ({
+    datasetId
+}: UseEvaluationRunsParams): CreateQueryResult<EvaluationRunView[], Error> => {
+    return createQuery(
+        getEvaluationRunsOptions({
+            path: { dataset_id: datasetId }
+        })
+    );
+};


### PR DESCRIPTION
## Summary
First PR of a 5-PR stack that adds an Evaluation Runs side-panel to the dataset view.

Data-layer only: introduces a `useEvaluationRuns` Svelte-query hook that wraps the existing `getEvaluationRuns` endpoint, plus the hook index export.

## Stack order
1. **[1/5] (this PR)** Add `useEvaluationRuns` hook
2. [2/5] Add `EvaluationRunItem` component
3. [3/5] Add `EvaluationRunsPanel` + `showEvaluationRuns` global toggle
4. [4/5] Extract `DatasetGridHeader` from the layout (pure refactor)
5. [5/5] Wire `EvaluationRunsPanel` into the dataset layout


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new evaluation-runs hook to the public API for managing evaluation runs data with integrated query behaviors.

* **Tests**
  * Added test coverage for the evaluation-runs hook, validating query construction, SDK interaction, and returned result handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->