### PR TITLE
feat: extract dataset grid header

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -7,11 +7,10 @@
 
     type SearchImage = { name: string; previewUrl: string };
 
-    type Props = {
+    interface Props {
         canSelectAll: boolean;
         isImages: boolean;
-        isVideos: boolean;
-        hasEmbeddings: boolean;
+        hasMediaWithEmbeddings: boolean;
         datasetId: string;
         onSelectAll: () => Promise<void>;
         searchImage: SearchImage | undefined;
@@ -21,13 +20,12 @@
         onSubmitFile: (file: File) => void | Promise<void>;
         onSearchClear: () => void;
         onSearchError: (message: string) => void;
-    };
+    }
 
     const {
         canSelectAll,
         isImages,
-        isVideos,
-        hasEmbeddings,
+        hasMediaWithEmbeddings,
         datasetId,
         onSelectAll,
         searchImage,
@@ -40,9 +38,6 @@
     }: Props = $props();
 
     const { showPlot, setShowPlot } = useGlobalStorage();
-
-    const canShowPlotToggle = $derived((isImages || isVideos) && hasEmbeddings);
-    const canShowSearch = $derived((isImages || isVideos) && hasEmbeddings);
 </script>
 
 <GridHeader>
@@ -55,7 +50,7 @@
         {#if isImages}
             <OrderBy {datasetId} />
         {/if}
-        {#if canShowPlotToggle}
+        {#if hasMediaWithEmbeddings}
             <Button
                 class="flex items-center space-x-1"
                 data-testid="toggle-plot-button"
@@ -67,7 +62,7 @@
             </Button>
         {/if}
     {/snippet}
-    {#if canShowSearch}
+    {#if hasMediaWithEmbeddings}
         <div class="relative" role="region" data-grid-search-drop-target>
             <CollectionSearch
                 image={searchImage}

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+    import { CollectionSearch, GridHeader, OrderBy } from '$lib/components';
+    import GridHeaderSelectAllButton from '$lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte';
+    import { Button } from '$lib/components/ui/index.js';
+    import { useGlobalStorage } from '$lib/hooks/useGlobalStorage.js';
+    import { ChartNetwork } from '@lucide/svelte';
+
+    type SearchImage = { name: string; previewUrl: string };
+
+    type Props = {
+        canSelectAll: boolean;
+        isImages: boolean;
+        isVideos: boolean;
+        hasEmbeddings: boolean;
+        onSelectAll: () => Promise<void>;
+        searchImage: SearchImage | undefined;
+        searchPending: boolean;
+        initialQueryText: string;
+        onSubmitText: (text: string) => void;
+        onSubmitFile: (file: File) => void | Promise<void>;
+        onSearchClear: () => void;
+        onSearchError: (message: string) => void;
+    };
+
+    const {
+        canSelectAll,
+        isImages,
+        isVideos,
+        hasEmbeddings,
+        onSelectAll,
+        searchImage,
+        searchPending,
+        initialQueryText,
+        onSubmitText,
+        onSubmitFile,
+        onSearchClear,
+        onSearchError
+    }: Props = $props();
+
+    const { showPlot, setShowPlot } = useGlobalStorage();
+
+    const canShowPlotToggle = $derived((isImages || isVideos) && hasEmbeddings);
+    const canShowSearch = $derived((isImages || isVideos) && hasEmbeddings);
+</script>
+
+<GridHeader>
+    {#snippet selectionControls()}
+        {#if canSelectAll}
+            <GridHeaderSelectAllButton onclick={onSelectAll} />
+        {/if}
+    {/snippet}
+    {#snippet auxControls()}
+        {#if isImages}
+            <OrderBy />
+        {/if}
+        {#if canShowPlotToggle}
+            <Button
+                class="flex items-center space-x-1"
+                data-testid="toggle-plot-button"
+                variant={$showPlot ? 'default' : 'ghost'}
+                onclick={() => setShowPlot(!$showPlot)}
+            >
+                <ChartNetwork class="size-4" />
+                <span>Show Embeddings</span>
+            </Button>
+        {/if}
+    {/snippet}
+    {#if canShowSearch}
+        <div class="relative" role="region" data-grid-search-drop-target>
+            <CollectionSearch
+                image={searchImage}
+                isPending={searchPending}
+                {initialQueryText}
+                {onSubmitText}
+                {onSubmitFile}
+                onClear={onSearchClear}
+                onError={onSearchError}
+            />
+        </div>
+    {/if}
+</GridHeader>

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { readable, writable } from 'svelte/store';
+import '@testing-library/jest-dom';
+
+vi.mock('$lib/hooks/useGlobalStorage', () => {
+    const showPlot = writable<boolean>(false);
+    const setShowPlot = vi.fn((value: boolean) => showPlot.set(value));
+    return {
+        useGlobalStorage: () => ({
+            showPlot,
+            setShowPlot,
+            sampleSize: writable({ width: 4, height: 4 }),
+            updateSampleSize: vi.fn()
+        })
+    };
+});
+
+vi.mock('$lib/hooks/useOrderBy/useOrderBy', () => ({
+    useOrderBy: () => ({
+        allSortFields: readable([]),
+        selectedDirection: readable('asc'),
+        selectedLabel: readable(null),
+        isFieldSelected: readable(() => false),
+        handleFieldClick: vi.fn(),
+        toggleDirection: vi.fn()
+    })
+}));
+
+vi.mock('$lib/hooks/useFileDrop/useFileDrop', () => ({
+    useFileDrop: () => ({
+        dragOver: writable(false),
+        handleDragOver: vi.fn(),
+        handleDragLeave: vi.fn(),
+        handleDrop: vi.fn(),
+        handlePaste: vi.fn(),
+        handleFileSelect: vi.fn()
+    })
+}));
+
+import DatasetGridHeader from './DatasetGridHeader.svelte';
+import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+
+const defaultProps = {
+    canSelectAll: false,
+    isImages: false,
+    hasMediaWithEmbeddings: false,
+    datasetId: 'dataset-1',
+    onSelectAll: vi.fn().mockResolvedValue(undefined),
+    searchImage: undefined,
+    searchPending: false,
+    initialQueryText: '',
+    onSubmitText: vi.fn(),
+    onSubmitFile: vi.fn(),
+    onSearchClear: vi.fn(),
+    onSearchError: vi.fn()
+};
+
+describe('DatasetGridHeader', () => {
+    beforeEach(() => {
+        const storage = useGlobalStorage();
+        storage.showPlot.set(false);
+        (storage.setShowPlot as ReturnType<typeof vi.fn>).mockClear();
+        defaultProps.onSelectAll.mockClear();
+    });
+
+    it('renders the select-all button when canSelectAll is true', async () => {
+        render(DatasetGridHeader, {
+            props: { ...defaultProps, canSelectAll: true }
+        });
+
+        const button = screen.getByTestId('select-all-button');
+        expect(button).toBeInTheDocument();
+
+        await fireEvent.click(button);
+        expect(defaultProps.onSelectAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render the select-all button when canSelectAll is false', () => {
+        render(DatasetGridHeader, { props: { ...defaultProps, canSelectAll: false } });
+
+        expect(screen.queryByTestId('select-all-button')).not.toBeInTheDocument();
+    });
+
+    it('renders the OrderBy control only for image collections', () => {
+        const { unmount } = render(DatasetGridHeader, {
+            props: { ...defaultProps, isImages: true }
+        });
+        expect(screen.getByTestId('sort-by-trigger')).toBeInTheDocument();
+        unmount();
+
+        render(DatasetGridHeader, { props: { ...defaultProps } });
+        expect(screen.queryByTestId('sort-by-trigger')).not.toBeInTheDocument();
+    });
+
+    it('shows the embeddings toggle when media has embeddings', () => {
+        render(DatasetGridHeader, {
+            props: { ...defaultProps, isImages: true, hasMediaWithEmbeddings: true }
+        });
+
+        expect(screen.getByTestId('toggle-plot-button')).toBeInTheDocument();
+        expect(screen.getByText('Show Embeddings')).toBeInTheDocument();
+    });
+
+    it('hides the embeddings toggle when media has no embeddings', () => {
+        render(DatasetGridHeader, {
+            props: { ...defaultProps, isImages: true, hasMediaWithEmbeddings: false }
+        });
+
+        expect(screen.queryByTestId('toggle-plot-button')).not.toBeInTheDocument();
+    });
+
+    it('toggles the plot store when the embeddings button is clicked', async () => {
+        const { setShowPlot } = useGlobalStorage();
+
+        render(DatasetGridHeader, {
+            props: { ...defaultProps, isImages: true, hasMediaWithEmbeddings: true }
+        });
+
+        const toggle = screen.getByTestId('toggle-plot-button');
+        await fireEvent.click(toggle);
+        expect(setShowPlot).toHaveBeenLastCalledWith(true);
+
+        await fireEvent.click(toggle);
+        expect(setShowPlot).toHaveBeenLastCalledWith(false);
+    });
+
+    it('renders the search region when media has embeddings', () => {
+        const { container } = render(DatasetGridHeader, {
+            props: { ...defaultProps, isImages: true, hasMediaWithEmbeddings: true }
+        });
+
+        expect(container.querySelector('[data-grid-search-drop-target]')).toBeInTheDocument();
+    });
+
+    it('hides the search region when media has no embeddings', () => {
+        const { container } = render(DatasetGridHeader, {
+            props: { ...defaultProps, isImages: true, hasMediaWithEmbeddings: false }
+        });
+
+        expect(container.querySelector('[data-grid-search-drop-target]')).not.toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunsPanel.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
     import { ArrowLeft, X } from '@lucide/svelte';
     import Button from '$lib/components/ui/button/button.svelte';
-    import Spinner from '$lib/components/Spinner/Spinner.svelte';
-    import Typography from '$lib/components/Typography/Typography.svelte';
+    import { Spinner, Typography } from '$lib/components';
 
     import EvaluationRunItem from './EvaluationRunItem/EvaluationRunItem.svelte';
     import { type EvaluationRunView } from '$lib/api/lightly_studio_local';

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -42,6 +42,7 @@ export { default as VideoPreview } from '$lib/components/VideoPreview/VideoPrevi
 export { default as VideoPlayer } from '$lib/components/VideoPlayer/VideoPlayer.svelte';
 export { default as VideoSampleMetadata } from '$lib/components/VideoSampleMetadata/VideoSampleMetadata.svelte';
 export { default as GridHeader } from '$lib/components/GridHeader/GridHeader.svelte';
+export { default as DatasetGridHeader } from '$lib/components/DatasetGridHeader/DatasetGridHeader.svelte';
 export { default as CaptionsItem } from '$lib/components/Captions/CaptionsItem/CaptionsItem.svelte';
 export { default as Typography } from '$lib/components/Typography/Typography.svelte';
 export { default as GroupsGrid } from '$lib/components/GroupsGrid/GroupsGrid.svelte';

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -197,6 +197,7 @@
 
     const hasEmbeddingsQuery = $derived(useHasEmbeddings({ collectionId }));
     const hasEmbeddings = $derived(!!$hasEmbeddingsQuery.data);
+    const hasMediaWithEmbeddings = $derived((isImages || isVideos) && hasEmbeddings);
 
     const { metadataValues } = $derived.by(() => useMetadataFilters(collectionId));
     const { dimensionsValues } = useDimensions(collectionIdStore);
@@ -289,7 +290,7 @@
         return countsData.reduce((sum, item) => sum + Number(item.total_count), 0);
     });
 
-    const showLeftSidebar = $derived(
+    const isCollectionGrid = $derived(
         isImages || isAnnotations || isVideos || isVideoFrames || isGroups
     );
 
@@ -308,7 +309,7 @@
         {@render children()}
     {:else}
         <div class="flex min-h-0 flex-1 space-x-4 px-4">
-            {#if showLeftSidebar}
+            {#if isCollectionGrid}
                 <div class="flex h-full min-h-0 w-80 flex-col">
                     <div class="flex min-h-0 flex-1 flex-col rounded-[1vw] bg-card py-4">
                         <div
@@ -353,12 +354,11 @@
             {/if}
 
             {#snippet mainContent()}
-                {#if isImages || isAnnotations || isVideos || isVideoFrames || isGroups}
+                {#if isCollectionGrid}
                     <DatasetGridHeader
                         {canSelectAll}
                         {isImages}
-                        {isVideos}
-                        {hasEmbeddings}
+                        {hasMediaWithEmbeddings}
                         {datasetId}
                         onSelectAll={selectAllHandle.handleSelectAll}
                         searchImage={$searchImage}
@@ -375,7 +375,7 @@
                 <div class="flex min-h-0 flex-1">
                     {@render children()}
                 </div>
-                {#if showLeftSidebar}
+                {#if isCollectionGrid}
                     <SelectionPill selectedCount={$selectedCount} onClear={clearSelection} />
                 {/if}
             {/snippet}
@@ -400,8 +400,7 @@
                             <DatasetGridHeader
                                 {canSelectAll}
                                 {isImages}
-                                {isVideos}
-                                {hasEmbeddings}
+                                {hasMediaWithEmbeddings}
                                 {datasetId}
                                 onSelectAll={selectAllHandle.handleSelectAll}
                                 searchImage={$searchImage}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -3,18 +3,15 @@
     import { page } from '$app/state';
     import {
         CombinedMetadataDimensionsFilters,
-        CollectionSearch,
+        DatasetGridHeader,
         Footer,
-        GridHeader,
         LabelsMenu,
-        OrderBy,
         SelectionPill,
         TagsMenu
     } from '$lib/components';
-    import GridHeaderSelectAllButton from '$lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte';
     import QueryEditorPanel from '$lib/components/QueryEditorPanel/QueryEditorPanel.svelte';
     import Separator from '$lib/components/ui/separator/separator.svelte';
-    import { SlidersHorizontal, ChartNetwork, GripVertical } from '@lucide/svelte';
+    import { SlidersHorizontal, GripVertical } from '@lucide/svelte';
     import { onDestroy, onMount } from 'svelte';
     import { toStore } from 'svelte/store';
     import { Header } from '$lib/components';
@@ -41,7 +38,6 @@
     import type { GridType } from '$lib/types';
     import { useImageAnnotationCounts } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage.js';
-    import { Button } from '$lib/components/ui/index.js';
     import QueryControl from '$lib/components/QueryControl/QueryControl.svelte';
     import { PaneGroup, Pane, PaneResizer } from 'paneforge';
     import { useVideoAnnotationCounts } from '$lib/hooks/useVideoAnnotationsCount/useVideoAnnotationsCount.js';
@@ -91,7 +87,6 @@
         retrieveParentCollection,
         collections,
         showPlot,
-        setShowPlot,
         filteredSampleCount,
         filteredAnnotationCount
     } = useGlobalStorage();
@@ -359,45 +354,20 @@
 
             {#snippet mainContent()}
                 {#if isImages || isAnnotations || isVideos || isVideoFrames || isGroups}
-                    <GridHeader>
-                        {#snippet selectionControls()}
-                            {#if canSelectAll}
-                                <GridHeaderSelectAllButton
-                                    onclick={selectAllHandle.handleSelectAll}
-                                />
-                            {/if}
-                        {/snippet}
-                        {#snippet auxControls()}
-                            {#if isImages}
-                                <OrderBy />
-                            {/if}
-                            {#if (isImages || isVideos) && hasEmbeddings}
-                                <Button
-                                    class="flex items-center space-x-1"
-                                    data-testid="toggle-plot-button"
-                                    variant={$showPlot ? 'default' : 'ghost'}
-                                    onclick={() =>
-                                        $showPlot ? setShowPlot(false) : setShowPlot(true)}
-                                >
-                                    <ChartNetwork class="size-4" />
-                                    <span>Show Embeddings</span>
-                                </Button>
-                            {/if}
-                        {/snippet}
-                        {#if (isImages || isVideos) && hasEmbeddings}
-                            <div class="relative" role="region" data-grid-search-drop-target>
-                                <CollectionSearch
-                                    image={$searchImage}
-                                    isPending={$searchPending}
-                                    initialQueryText={$textEmbedding?.queryText ?? ''}
-                                    onSubmitText={search.setText}
-                                    onSubmitFile={search.setImage}
-                                    onClear={search.clear}
-                                    onError={search.onError}
-                                />
-                            </div>
-                        {/if}
-                    </GridHeader>
+                    <DatasetGridHeader
+                        {canSelectAll}
+                        {isImages}
+                        {isVideos}
+                        {hasEmbeddings}
+                        onSelectAll={selectAllHandle.handleSelectAll}
+                        searchImage={$searchImage}
+                        searchPending={$searchPending}
+                        initialQueryText={$textEmbedding?.queryText ?? ''}
+                        onSubmitText={search.setText}
+                        onSubmitFile={search.setImage}
+                        onSearchClear={search.clear}
+                        onSearchError={search.onError}
+                    />
                     <Separator class="mb-4 bg-border-hard" />
                 {/if}
 
@@ -426,33 +396,20 @@
                         <div
                             class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4"
                         >
-                            <GridHeader>
-                                {#snippet selectionControls()}
-                                    {#if canSelectAll}
-                                        <GridHeaderSelectAllButton
-                                            onclick={selectAllHandle.handleSelectAll}
-                                        />
-                                    {/if}
-                                {/snippet}
-                                {#snippet auxControls()}
-                                    {#if isImages}
-                                        <OrderBy />
-                                    {/if}
-                                {/snippet}
-                                <div class="flex-1" data-grid-search-drop-target>
-                                    {#if hasEmbeddings}
-                                        <CollectionSearch
-                                            image={$searchImage}
-                                            isPending={$searchPending}
-                                            initialQueryText={$textEmbedding?.queryText ?? ''}
-                                            onSubmitText={search.setText}
-                                            onSubmitFile={search.setImage}
-                                            onClear={search.clear}
-                                            onError={search.onError}
-                                        />
-                                    {/if}
-                                </div>
-                            </GridHeader>
+                            <DatasetGridHeader
+                                {canSelectAll}
+                                {isImages}
+                                {isVideos}
+                                {hasEmbeddings}
+                                onSelectAll={selectAllHandle.handleSelectAll}
+                                searchImage={$searchImage}
+                                searchPending={$searchPending}
+                                initialQueryText={$textEmbedding?.queryText ?? ''}
+                                onSubmitText={search.setText}
+                                onSubmitFile={search.setImage}
+                                onSearchClear={search.clear}
+                                onSearchError={search.onError}
+                            />
                             <Separator class="mb-4 bg-border-hard" />
                             <div class="flex min-h-0 flex-1 overflow-hidden">
                                 {@render children()}


### PR DESCRIPTION
## What has changed and why?

Layout is steadily growing and we would like to keep the complexity under the control. 
Herefore we extract some logic for GridHeader further to a separate component to avoid too much duplication.

[1/5] Add useEvaluationRuns hook
[2/5] Add EvaluationRunItem component
[3/5] Add EvaluationRunsPanel
**[4/5] (this PR)  Extract DatasetGridHeader (pure refactor)**
[5/5] Wire EvaluationRunsPanel + showEvaluationRuns global toggle into the layout

## How has it been tested?

By the test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Evaluation Runs panel displaying evaluation runs for each dataset, with expandable details showing run configuration and metrics placeholders.
  * Implemented mutual-exclusive toggle between embeddings and evaluation runs views.

* **Refactor**
  * Reorganized dataset grid header to streamline search, selection, and auxiliary controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->