### PR TITLE
Add tag coloring helpers to tag_resolver

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from uuid import UUID
 
@@ -203,7 +204,7 @@ def remove_sample_ids_from_tag_id(
     return tag
 
 
-def get_names_by_ids(session: Session, tag_ids: list[UUID]) -> dict[UUID, str]:
+def get_names_by_ids(session: Session, tag_ids: Sequence[UUID]) -> dict[UUID, str]:
     """Return ``{tag_id: name}`` for the requested tags."""
     if not tag_ids:
         return {}
@@ -213,7 +214,7 @@ def get_names_by_ids(session: Session, tag_ids: list[UUID]) -> dict[UUID, str]:
 
 def get_tags_by_sample(
     session: Session,
-    tag_ids: list[UUID],
+    tag_ids: Sequence[UUID],
 ) -> dict[UUID, set[UUID]]:
     """Return ``{sample_id: {tag_id, ...}}`` for the requested tags."""
     if not tag_ids:
@@ -223,6 +224,8 @@ def get_tags_by_sample(
     )
     result: dict[UUID, set[UUID]] = {}
     for sample_id, tag_id in session.exec(stmt).all():
+        assert sample_id is not None
+        assert tag_id is not None
         result.setdefault(sample_id, set()).add(tag_id)
     return result
 

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -203,6 +203,30 @@ def remove_sample_ids_from_tag_id(
     return tag
 
 
+def get_names_by_ids(session: Session, tag_ids: list[UUID]) -> dict[UUID, str]:
+    """Return ``{tag_id: name}`` for the requested tags."""
+    if not tag_ids:
+        return {}
+    stmt = select(TagTable.tag_id, TagTable.name).where(col(TagTable.tag_id).in_(tag_ids))
+    return dict(session.exec(stmt).all())
+
+
+def get_tags_by_sample(
+    session: Session,
+    tag_ids: list[UUID],
+) -> dict[UUID, set[UUID]]:
+    """Return ``{sample_id: {tag_id, ...}}`` for the requested tags."""
+    if not tag_ids:
+        return {}
+    stmt = select(SampleTagLinkTable.sample_id, SampleTagLinkTable.tag_id).where(
+        col(SampleTagLinkTable.tag_id).in_(tag_ids)
+    )
+    result: dict[UUID, set[UUID]] = {}
+    for sample_id, tag_id in session.exec(stmt).all():
+        result.setdefault(sample_id, set()).add(tag_id)
+    return result
+
+
 def get_or_create_sample_tag_by_name(
     session: Session,
     collection_id: UUID,

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -263,32 +263,6 @@ def test_delete_tag__removes_sample_links(db_session: Session) -> None:
     assert image_2.sample.tags == []
 
 
-def test_get_or_create_sample_tag_by_name(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-
-    # Create an existing tag
-    existing_tag = create_tag(
-        session=db_session, collection_id=collection_id, tag_name="existing_tag"
-    )
-
-    # Case 1: Get existing tag
-    result_tag = tag_resolver.get_or_create_sample_tag_by_name(
-        session=db_session, collection_id=collection_id, tag_name="existing_tag"
-    )
-    assert result_tag.tag_id == existing_tag.tag_id
-    assert result_tag.name == "existing_tag"
-
-    # Case 2: Create new tag
-    new_tag = tag_resolver.get_or_create_sample_tag_by_name(
-        session=db_session, collection_id=collection_id, tag_name="new_tag"
-    )
-    assert new_tag.tag_id != existing_tag.tag_id
-    assert new_tag.name == "new_tag"
-    assert new_tag.collection_id == collection_id
-    assert new_tag.kind == "sample"
-
-
 def test_get_names_by_ids(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     cid = collection.collection_id
@@ -296,9 +270,7 @@ def test_get_names_by_ids(db_session: Session) -> None:
     tag_a = create_tag(session=db_session, collection_id=cid, tag_name="alpha")
     tag_b = create_tag(session=db_session, collection_id=cid, tag_name="beta")
 
-    result = tag_resolver.get_names_by_ids(
-        session=db_session, tag_ids=[tag_a.tag_id, tag_b.tag_id]
-    )
+    result = tag_resolver.get_names_by_ids(session=db_session, tag_ids=[tag_a.tag_id, tag_b.tag_id])
     assert result == {tag_a.tag_id: "alpha", tag_b.tag_id: "beta"}
 
 
@@ -346,6 +318,32 @@ def test_get_tags_by_sample__no_memberships(db_session: Session) -> None:
 
     result = tag_resolver.get_tags_by_sample(session=db_session, tag_ids=[tag.tag_id])
     assert result == {}
+
+
+def test_get_or_create_sample_tag_by_name(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    # Create an existing tag
+    existing_tag = create_tag(
+        session=db_session, collection_id=collection_id, tag_name="existing_tag"
+    )
+
+    # Case 1: Get existing tag
+    result_tag = tag_resolver.get_or_create_sample_tag_by_name(
+        session=db_session, collection_id=collection_id, tag_name="existing_tag"
+    )
+    assert result_tag.tag_id == existing_tag.tag_id
+    assert result_tag.name == "existing_tag"
+
+    # Case 2: Create new tag
+    new_tag = tag_resolver.get_or_create_sample_tag_by_name(
+        session=db_session, collection_id=collection_id, tag_name="new_tag"
+    )
+    assert new_tag.tag_id != existing_tag.tag_id
+    assert new_tag.name == "new_tag"
+    assert new_tag.collection_id == collection_id
+    assert new_tag.kind == "sample"
 
 
 def test_add_tag_to_sample(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -289,6 +289,65 @@ def test_get_or_create_sample_tag_by_name(db_session: Session) -> None:
     assert new_tag.kind == "sample"
 
 
+def test_get_names_by_ids(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    cid = collection.collection_id
+
+    tag_a = create_tag(session=db_session, collection_id=cid, tag_name="alpha")
+    tag_b = create_tag(session=db_session, collection_id=cid, tag_name="beta")
+
+    result = tag_resolver.get_names_by_ids(
+        session=db_session, tag_ids=[tag_a.tag_id, tag_b.tag_id]
+    )
+    assert result == {tag_a.tag_id: "alpha", tag_b.tag_id: "beta"}
+
+
+def test_get_names_by_ids__empty(db_session: Session) -> None:
+    result = tag_resolver.get_names_by_ids(session=db_session, tag_ids=[])
+    assert result == {}
+
+
+def test_get_names_by_ids__unknown_id(db_session: Session) -> None:
+    result = tag_resolver.get_names_by_ids(session=db_session, tag_ids=[uuid4()])
+    assert result == {}
+
+
+def test_get_tags_by_sample(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    cid = collection.collection_id
+
+    img_a = create_image(session=db_session, collection_id=cid, file_path_abs="a.png")
+    img_b = create_image(session=db_session, collection_id=cid, file_path_abs="b.png")
+
+    tag_1 = create_tag(session=db_session, collection_id=cid, tag_name="tag_1")
+    tag_2 = create_tag(session=db_session, collection_id=cid, tag_name="tag_2")
+
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag_1.tag_id, sample=img_a.sample)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag_2.tag_id, sample=img_a.sample)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag_1.tag_id, sample=img_b.sample)
+
+    result = tag_resolver.get_tags_by_sample(
+        session=db_session, tag_ids=[tag_1.tag_id, tag_2.tag_id]
+    )
+    assert result[img_a.sample_id] == {tag_1.tag_id, tag_2.tag_id}
+    assert result[img_b.sample_id] == {tag_1.tag_id}
+
+
+def test_get_tags_by_sample__empty(db_session: Session) -> None:
+    result = tag_resolver.get_tags_by_sample(session=db_session, tag_ids=[])
+    assert result == {}
+
+
+def test_get_tags_by_sample__no_memberships(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    cid = collection.collection_id
+
+    tag = create_tag(session=db_session, collection_id=cid, tag_name="lonely")
+
+    result = tag_resolver.get_tags_by_sample(session=db_session, tag_ids=[tag.tag_id])
+    assert result == {}
+
+
 def test_add_tag_to_sample(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id


### PR DESCRIPTION
## What has changed and why?

Create two bulk lookup helpers in `tag_resolver`. They will be used for embedding coloring:

- `get_names_by_ids(session, tag_ids)` — returns `{tag_id: name}` for a list of tag IDs.
- `get_tags_by_sample(session, tag_ids)` — returns `{sample_id: {tag_id, ...}}` for sample-tag membership lookups.


## How has it been tested?

New tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch query helpers to efficiently fetch tag names and to retrieve tag associations per sample, improving performance for tag-related lookups.

* **Tests**
  * Added comprehensive unit tests covering normal and edge cases for the new tag lookup behaviors (empty inputs, non-existent IDs, and membership mappings).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->