### PR TITLE
feat: wire evaluation runs panel

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -2,12 +2,14 @@
     import { CollectionSearch, GridHeader, OrderBy } from '$lib/components';
     import GridHeaderSelectAllButton from '$lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte';
     import { Button } from '$lib/components/ui/index.js';
-    import { useGlobalStorage } from '$lib/hooks/useGlobalStorage.js';
-    import { ChartNetwork } from '@lucide/svelte';
+    import { Tooltip } from '$lib/components/ui/tooltip';
+    import { useGlobalStorage } from '$lib/hooks';
+    import { ChartNetwork, Gauge } from '@lucide/svelte';
 
     type SearchImage = { name: string; previewUrl: string };
 
     interface Props {
+        compact?: boolean;
         canSelectAll: boolean;
         isImages: boolean;
         hasMediaWithEmbeddings: boolean;
@@ -23,6 +25,7 @@
     }
 
     const {
+        compact = false,
         canSelectAll,
         isImages,
         hasMediaWithEmbeddings,
@@ -37,7 +40,7 @@
         onSearchError
     }: Props = $props();
 
-    const { showPlot, setShowPlot } = useGlobalStorage();
+    const { showPlot, setShowPlot, showEvaluationRuns, setShowEvaluationRuns } = useGlobalStorage();
 </script>
 
 <GridHeader>
@@ -51,15 +54,40 @@
             <OrderBy {datasetId} />
         {/if}
         {#if hasMediaWithEmbeddings}
-            <Button
-                class="flex items-center space-x-1"
-                data-testid="toggle-plot-button"
-                variant={$showPlot ? 'default' : 'ghost'}
-                onclick={() => setShowPlot(!$showPlot)}
+            <Tooltip
+                content={$showPlot ? 'Hide Embeddings plot' : 'Show Embeddings plot'}
+                position="bottom"
             >
-                <ChartNetwork class="size-4" />
-                <span>Show Embeddings</span>
-            </Button>
+                <Button
+                    class="flex items-center space-x-1"
+                    data-testid="toggle-plot-button"
+                    variant={$showPlot ? 'default' : 'ghost'}
+                    onclick={() => setShowPlot(!$showPlot)}
+                >
+                    <ChartNetwork class="size-4" />
+                    {#if !compact}
+                        <span>Show Embeddings</span>
+                    {/if}
+                </Button>
+            </Tooltip>
+        {/if}
+        {#if isImages}
+            <Tooltip
+                content={$showEvaluationRuns ? 'Hide Evaluation Runs' : 'Show Evaluation Runs'}
+                position="bottom"
+            >
+                <Button
+                    class="flex items-center space-x-1"
+                    data-testid="toggle-evaluation-runs-button"
+                    variant={$showEvaluationRuns ? 'default' : 'ghost'}
+                    onclick={() => setShowEvaluationRuns(!$showEvaluationRuns)}
+                >
+                    <Gauge class="size-4" />
+                    {#if !compact}
+                        <span>Evaluation Runs</span>
+                    {/if}
+                </Button>
+            </Tooltip>
         {/if}
     {/snippet}
     {#if hasMediaWithEmbeddings}

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -6,10 +6,15 @@ import '@testing-library/jest-dom';
 vi.mock('$lib/hooks/useGlobalStorage', () => {
     const showPlot = writable<boolean>(false);
     const setShowPlot = vi.fn((value: boolean) => showPlot.set(value));
+
+    const showEvaluationRuns = writable<boolean>(false);
+    const setShowEvaluationRuns = vi.fn((value: boolean) => showEvaluationRuns.set(value));
     return {
         useGlobalStorage: () => ({
             showPlot,
             setShowPlot,
+            showEvaluationRuns,
+            setShowEvaluationRuns,
             sampleSize: writable({ width: 4, height: 4 }),
             updateSampleSize: vi.fn()
         })
@@ -43,6 +48,7 @@ import DatasetGridHeader from './DatasetGridHeader.svelte';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 
 const defaultProps = {
+    compact: false,
     canSelectAll: false,
     isImages: false,
     hasMediaWithEmbeddings: false,
@@ -62,6 +68,8 @@ describe('DatasetGridHeader', () => {
         const storage = useGlobalStorage();
         storage.showPlot.set(false);
         (storage.setShowPlot as ReturnType<typeof vi.fn>).mockClear();
+        storage.showEvaluationRuns.set(false);
+        (storage.setShowEvaluationRuns as ReturnType<typeof vi.fn>).mockClear();
         defaultProps.onSelectAll.mockClear();
     });
 
@@ -140,5 +148,51 @@ describe('DatasetGridHeader', () => {
         });
 
         expect(container.querySelector('[data-grid-search-drop-target]')).not.toBeInTheDocument();
+    });
+
+    it('shows the evaluation runs toggle for image collections', () => {
+        render(DatasetGridHeader, {
+            props: { ...defaultProps, isImages: true }
+        });
+
+        expect(screen.getByTestId('toggle-evaluation-runs-button')).toBeInTheDocument();
+        expect(screen.getByText('Evaluation Runs')).toBeInTheDocument();
+    });
+
+    it('hides the evaluation runs toggle for non-image collections', () => {
+        render(DatasetGridHeader, { props: { ...defaultProps, isImages: false } });
+
+        expect(screen.queryByTestId('toggle-evaluation-runs-button')).not.toBeInTheDocument();
+    });
+
+    it('toggles the evaluation runs store when the button is clicked', async () => {
+        const { setShowEvaluationRuns } = useGlobalStorage();
+
+        render(DatasetGridHeader, {
+            props: { ...defaultProps, isImages: true }
+        });
+
+        const toggle = screen.getByTestId('toggle-evaluation-runs-button');
+        await fireEvent.click(toggle);
+        expect(setShowEvaluationRuns).toHaveBeenLastCalledWith(true);
+
+        await fireEvent.click(toggle);
+        expect(setShowEvaluationRuns).toHaveBeenLastCalledWith(false);
+    });
+
+    it('hides the embeddings and evaluation runs labels in compact mode', () => {
+        render(DatasetGridHeader, {
+            props: {
+                ...defaultProps,
+                compact: true,
+                isImages: true,
+                hasMediaWithEmbeddings: true
+            }
+        });
+
+        expect(screen.getByTestId('toggle-plot-button')).toBeInTheDocument();
+        expect(screen.queryByText('Show Embeddings')).not.toBeInTheDocument();
+        expect(screen.getByTestId('toggle-evaluation-runs-button')).toBeInTheDocument();
+        expect(screen.queryByText('Evaluation Runs')).not.toBeInTheDocument();
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useEvaluationRuns/useEvaluationRuns.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEvaluationRuns/useEvaluationRuns.test.ts
@@ -26,7 +26,7 @@ describe('useEvaluationRuns', () => {
         const datasetId = 'dataset-1';
         const createQuerySpy = vi.spyOn(tanstackQuery, 'createQuery');
 
-        useEvaluationRuns({ datasetId });
+        useEvaluationRuns(() => ({ datasetId }));
 
         const optionsArg = createQuerySpy.mock.calls[0][0]() as CreateQueryOptions;
         const expectedOptions = getEvaluationRunsOptions({
@@ -44,7 +44,7 @@ describe('useEvaluationRuns', () => {
             [] as unknown as Awaited<ReturnType<typeof getEvaluationRuns>>
         );
 
-        useEvaluationRuns({ datasetId });
+        useEvaluationRuns(() => ({ datasetId }));
 
         const optionsArg = createQuerySpy.mock.calls[0][0]() as CreateQueryOptions;
 
@@ -68,7 +68,7 @@ describe('useEvaluationRuns', () => {
     });
 
     it('returns the result of createQuery', () => {
-        const result = useEvaluationRuns({ datasetId: 'dataset-3' });
+        const result = useEvaluationRuns(() => ({ datasetId: 'dataset-3' }));
 
         expect(result).toMatchObject({ data: [], isSuccess: true });
     });

--- a/lightly_studio_view/src/lib/hooks/useEvaluationRuns/useEvaluationRuns.ts
+++ b/lightly_studio_view/src/lib/hooks/useEvaluationRuns/useEvaluationRuns.ts
@@ -1,17 +1,10 @@
 import { getEvaluationRunsOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
-import type { EvaluationRunView } from '$lib/api/lightly_studio_local/types.gen';
-import { createQuery, type CreateQueryResult } from '@tanstack/svelte-query';
+import { createQuery } from '@tanstack/svelte-query';
 
-interface UseEvaluationRunsParams {
-    datasetId: string;
-}
-
-export const useEvaluationRuns = ({
-    datasetId
-}: UseEvaluationRunsParams): CreateQueryResult<EvaluationRunView[], Error> => {
+export const useEvaluationRuns = (getParams: () => { datasetId: string }) => {
     return createQuery(() =>
         getEvaluationRunsOptions({
-            path: { dataset_id: datasetId }
+            path: { dataset_id: getParams().datasetId }
         })
     );
 };

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
@@ -77,6 +77,7 @@ export type TextEmbedding = {
 };
 
 const showPlot = writable<boolean>(false);
+const showEvaluationRuns = writable<boolean>(false);
 const rangeSelectionBycollection = writable<Record<string, Point[] | null>>({});
 
 // Rewrite the hook to return values and methods
@@ -305,6 +306,16 @@ export const useGlobalStorage = () => {
         showPlot,
         setShowPlot: (show: boolean) => {
             showPlot.set(show);
+            if (show) {
+                showEvaluationRuns.set(false);
+            }
+        },
+        showEvaluationRuns,
+        setShowEvaluationRuns: (show: boolean) => {
+            showEvaluationRuns.set(show);
+            if (show) {
+                showPlot.set(false);
+            }
         },
         getRangeSelection,
         setRangeSelectionForCollection: (collectionId: string, selection: Point[] | null) => {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -63,6 +63,7 @@
     import { shutdownMaskRendererPool } from '$lib/workers/maskRendererPool';
     import { GRID_IMAGE_SEARCH_DROP_EVENT, type GridItemDragData } from '$lib/components/GridItem';
     import { useSearchEmbedding } from '$lib/hooks/useSearchEmbedding/useSearchEmbedding';
+    import { useEvaluationRuns } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
     const { data, children } = $props();
     const {
         collection,
@@ -87,9 +88,14 @@
         retrieveParentCollection,
         collections,
         showPlot,
+        showEvaluationRuns,
+        setShowEvaluationRuns,
         filteredSampleCount,
         filteredAnnotationCount
     } = useGlobalStorage();
+
+    const evaluationRunsQuery = useEvaluationRuns(() => ({ datasetId: collection.dataset_id }));
+    const evaluationRuns = $derived(evaluationRunsQuery.data ?? []);
 
     const parentCollection = $derived.by(() =>
         retrieveParentCollection($collections, collectionId)
@@ -301,6 +307,8 @@
     const { featureFlags } = useFeatureFlags();
     const isQueryFilterEnabled = $derived($featureFlags.includes('query_filter'));
     let isQueryFilterEditing = $state(false);
+
+    const isSidePanelOpen = $derived($showPlot || $showEvaluationRuns);
 </script>
 
 <div class="flex-none">
@@ -364,6 +372,7 @@
                         {isImages}
                         {hasMediaWithEmbeddings}
                         {datasetId}
+                        compact={isSidePanelOpen}
                         onSelectAll={selectAllHandle.handleSelectAll}
                         searchImage={$searchImage}
                         searchPending={$searchPending}
@@ -394,7 +403,30 @@
                 </PaneResizer>
             {/snippet}
 
-            {#if (isImages || isVideos) && $showPlot}
+            {#if $showEvaluationRuns}
+                <PaneGroup direction="horizontal" class="flex-1">
+                    <Pane defaultSize={65} minSize={35} class="flex">
+                        <div
+                            class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
+                        >
+                            {@render mainContent()}
+                        </div>
+                    </Pane>
+
+                    {@render paneResizer()}
+
+                    <Pane defaultSize={35} minSize={25} class="flex min-h-0 flex-col">
+                        {#await import('$lib/components/EvaluationRunsPanel/EvaluationRunsPanel.svelte') then { default: EvaluationRunsPanel }}
+                            <EvaluationRunsPanel
+                                onClose={() => setShowEvaluationRuns(false)}
+                                {evaluationRuns}
+                                isLoading={evaluationRunsQuery.isLoading}
+                                error={evaluationRunsQuery.error?.message}
+                            />
+                        {/await}
+                    </Pane>
+                </PaneGroup>
+            {:else if (isImages || isVideos) && $showPlot}
                 <!-- When plot is shown, use PaneGroup for the main content + plot -->
                 <PaneGroup direction="horizontal" class="flex-1">
                     <Pane defaultSize={50} minSize={30} class="flex">
@@ -406,6 +438,7 @@
                                 {isImages}
                                 {hasMediaWithEmbeddings}
                                 {datasetId}
+                                compact={isSidePanelOpen}
                                 onSelectAll={selectAllHandle.handleSelectAll}
                                 searchImage={$searchImage}
                                 searchPending={$searchPending}


### PR DESCRIPTION
## What has changed and why?

This PR wires evaluation panel to layout.
- added flag to show evaluation panel to [useGlobalStorage.ts‎](https://github.com/lightly-ai/lightly-studio/pull/1173/changes#diff-34a3245833a416865ecb98af8e680f4ac6f96a14cebe49c1c19b6072a7b99cdd)
- introduced toggle button [to show evaluation panel](https://github.com/lightly-ai/lightly-studio/pull/1173/changes#diff-8eefba6f053ee476de8ad7e37652748ebe63cc285563ef77fe7a2a92cc2a58c6)
- add tests for introduced logic in DatasetGridheader
- introduce "compact" mode for the header to reduce size of the header when we have side panel opened

## How has it been tested?

1. Start `make start-e2e-evaluations` to be able to have evaluation runs
2. Click "show evaluation run" icon
3. See evaluation runs

https://github.com/user-attachments/assets/0a8161ac-d73d-46a2-a97e-f75662791194





## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Evaluation Runs" toggle to display evaluation results in a dedicated side panel for image collections
  * Plot and Evaluation Runs are mutually exclusive visualization modes—enabling one automatically disables the other
  * Toggle buttons now include descriptive tooltips for better usability
  * Dataset grid headers automatically adopt a compact layout when side panels are open, optimizing screen space

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->