### PR TITLE
Embedding coloring factor out common logic

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring.py
@@ -10,6 +10,7 @@ from sqlmodel import Session
 
 from lightly_studio.api.routes.api.embedding_coloring import metadata
 
+
 class TagColorBy(BaseModel):
     """Color samples by tag membership."""
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring.py
@@ -10,11 +10,6 @@ from sqlmodel import Session
 
 from lightly_studio.api.routes.api.embedding_coloring import metadata
 
-# Categories 0 and 1 are reserved (0 = excluded by filter, 1 = unassigned),
-# so real color categories start at 2.
-_COLOR_OFFSET = 2
-
-
 class TagColorBy(BaseModel):
     """Color samples by tag membership."""
 
@@ -66,13 +61,10 @@ def build_color_data(
     if not isinstance(color_by, MetadataFieldColorBy):
         return list(fulfils_filter), {}
 
-    color_categories, legend = metadata.build_metadata_color_maps(
+    return metadata.build_metadata_color_maps(
         session=session,
         collection_id=collection_id,
         key=color_by.key,
         sample_ids=sample_ids,
         fulfils_filter=fulfils_filter,
-        start_cat=_COLOR_OFFSET,
     )
-    legend[1] = "Unassigned"
-    return color_categories, legend

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -18,7 +18,8 @@ class ColorScale(Protocol[T_contra]):
         legend: Mapping from color category integer to a human-readable label.
     """
 
-    legend: dict[int, str]
+    @property
+    def legend(self) -> dict[int, str]: ...
 
     def value_to_category(self, value: T_contra) -> int | None:
         """Return the color category for a value, or None if unmapped."""
@@ -63,7 +64,7 @@ class DiscreteColorScale(Generic[T]):
         """
         lookup: dict[T, int] = {}
         legend: dict[int, str] = {}
-        for i, value in enumerate(sorted(values)):
+        for i, value in enumerate(sorted(values, key=format_fn)):
             cat = start_cat + i
             lookup[value] = cat
             legend[cat] = format_fn(value)
@@ -93,9 +94,8 @@ def assign_color_categories(
         if fulfils_filter[i] == 0:
             cat = 0
         elif sid in sample_to_value:
-            cat = scale.value_to_category(sample_to_value[sid])
-            if cat is None:
-                cat = 1
+            mapped = scale.value_to_category(sample_to_value[sid])
+            cat = mapped if mapped is not None else 1
         else:
             cat = 1
         color_categories.append(cat)

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -19,7 +19,9 @@ class ColorScale(Protocol[T_contra]):
     """
 
     @property
-    def legend(self) -> dict[int, str]: ...
+    def legend(self) -> dict[int, str]:
+        """Mapping from color category integer to a human-readable label."""
+        ...
 
     def value_to_category(self, value: T_contra) -> int | None:
         """Return the color category for a value, or None if unmapped."""

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -1,0 +1,104 @@
+"""Generic helpers for assigning per-sample color categories."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Generic, Protocol, TypeVar
+from uuid import UUID
+
+T = TypeVar("T")
+T_contra = TypeVar("T_contra", contravariant=True)
+
+
+class ColorScale(Protocol[T_contra]):
+    """Protocol for mapping values to color categories.
+
+    Attributes:
+        legend: Mapping from color category integer to a human-readable label.
+    """
+
+    legend: dict[int, str]
+
+    def value_to_category(self, value: T_contra) -> int | None:
+        """Return the color category for a value, or None if unmapped."""
+        ...
+
+
+@dataclass(frozen=True)
+class DiscreteColorScale(Generic[T]):
+    """ColorScale implementation for a finite set of discrete values.
+
+    Attributes:
+        legend: Mapping from color category integer to a human-readable label.
+    """
+
+    _lookup: dict[T, int]
+    legend: dict[int, str]
+
+    def value_to_category(self, value: T) -> int | None:
+        """Return the color category for a value, or None if unmapped."""
+        return self._lookup.get(value)
+
+    @classmethod
+    def from_values(
+        cls,
+        values: set[T],
+        start_cat: int = 2,
+        format_fn: Callable[[T], str] = str,
+    ) -> DiscreteColorScale[T]:
+        """Build a DiscreteColorScale by assigning a category to each unique value.
+
+        Values are sorted before assignment to ensure deterministic ordering.
+
+        Args:
+            values: Unique values to assign color categories to.
+            start_cat: First category ID to assign. Defaults to 2, reserving
+                0 for filtered-out samples and 1 for unassigned samples.
+            format_fn: Function to produce a legend label from a value.
+                Defaults to ``str``.
+
+        Returns:
+            A DiscreteColorScale with one category per value.
+        """
+        lookup: dict[T, int] = {}
+        legend: dict[int, str] = {}
+        for i, value in enumerate(sorted(values)):
+            cat = start_cat + i
+            lookup[value] = cat
+            legend[cat] = format_fn(value)
+        return cls(_lookup=lookup, legend=legend)
+
+
+def assign_color_categories(
+    sample_ids: Sequence[UUID],
+    fulfils_filter: Sequence[int],
+    sample_to_value: Mapping[UUID, T],
+    scale: ColorScale[T],
+) -> tuple[list[int], dict[int, str]]:
+    """Return color categories and a legend for the given samples.
+
+    Args:
+        sample_ids: Sample IDs.
+        fulfils_filter: Binary indicator per sample. 0 means filtered out.
+        sample_to_value: Mapping from sample ID to a value.
+        scale: Color scale used to map values to categories.
+
+    Returns:
+        A tuple of `(color_categories, legend)`. Category 0 means filtered
+        out and 1 means unassigned (missing or unmapped value).
+    """
+    color_categories: list[int] = []
+    for i, sid in enumerate(sample_ids):
+        if fulfils_filter[i] == 0:
+            cat = 0
+        elif sid in sample_to_value:
+            cat = scale.value_to_category(sample_to_value[sid])
+            if cat is None:
+                cat = 1
+        else:
+            cat = 1
+        color_categories.append(cat)
+
+    legend = {0: "Filtered out", 1: "Unassigned", **scale.legend}
+    return color_categories, legend

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
@@ -56,7 +56,7 @@ def _build_metadata_color_scale(
     key: str,
     sample_to_value: dict[UUID, Any],
     metadata_type: str | None,
-) -> DiscreteColorScale:
+) -> DiscreteColorScale[Any]:
     """Build a DiscreteColorScale for one metadata key across all collection samples."""
     if metadata_type == "string":
         str_values: set[str] = set(sample_to_value.values())

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
@@ -2,30 +2,22 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
 from sqlmodel import Session
 
+from lightly_studio.api.routes.api.embedding_coloring import coloring_helpers
+from lightly_studio.api.routes.api.embedding_coloring.coloring_helpers import DiscreteColorScale
 from lightly_studio.resolvers.metadata_resolver import sample as sample_metadata_resolver
 
 
-@dataclass(frozen=True)
-class MetadataColorScale:
-    """Lookup maps built from metadata fields for per-sample color assignment."""
-
-    value_to_category: dict[bool, int] | dict[str, int]
-    legend: dict[int, str]
-
-
-def build_metadata_color_maps(  # noqa: PLR0913
+def build_metadata_color_maps(
     session: Session,
     collection_id: UUID,
     key: str,
     sample_ids: list[UUID],
     fulfils_filter: list[int],
-    start_cat: int,
 ) -> tuple[list[int], dict[int, str]]:
     """Build color categories and a legend for metadata-based sample coloring.
 
@@ -36,8 +28,6 @@ def build_metadata_color_maps(  # noqa: PLR0913
         sample_ids: Sample IDs in the order for which to build color categories.
         fulfils_filter: Per-sample filter flags where 0 means filtered out and 1
             means the sample fulfils the filter.
-        start_cat: First category ID available for metadata values, usually 2 to
-            reserve, 0 for filtered-out samples and 1 for unassigned samples.
 
     Returns:
         A tuple of `(color_categories, color_legend)` for the provided samples. The
@@ -53,93 +43,33 @@ def build_metadata_color_maps(  # noqa: PLR0913
         key=key,
         sample_to_value=sample_to_value,
         metadata_type=metadata_type,
-        start_cat=start_cat,
     )
-    color_categories = _assign_sample_categories(
+    return coloring_helpers.assign_color_categories(
         sample_ids=sample_ids,
         fulfils_filter=fulfils_filter,
         sample_to_value=sample_to_value,
         scale=scale,
     )
-    return color_categories, scale.legend
 
 
 def _build_metadata_color_scale(
     key: str,
     sample_to_value: dict[UUID, Any],
     metadata_type: str | None,
-    start_cat: int,
-) -> MetadataColorScale:
-    """Build a MetadataColorScale for one metadata key across all collection samples."""
+) -> DiscreteColorScale:
+    """Build a DiscreteColorScale for one metadata key across all collection samples."""
     if metadata_type == "string":
         str_values: set[str] = set(sample_to_value.values())
-        return _build_color_scale_str(values=str_values, start_cat=start_cat)
+        return DiscreteColorScale.from_values(values=str_values)
     if metadata_type == "boolean":
         bool_values: set[bool] = set(sample_to_value.values())
-        return _build_color_scale_bool(values=bool_values, start_cat=start_cat)
+        return DiscreteColorScale.from_values(
+            values=bool_values,
+            format_fn=lambda v: str(v).lower(),
+        )
 
     raise ValueError(
         f"Metadata field '{key}' has unsupported type {metadata_type!r}. "
         "Only 'string' and 'boolean' fields can be used for coloring."
     )
 
-
-def _assign_sample_categories(
-    sample_ids: list[UUID],
-    fulfils_filter: list[int],
-    sample_to_value: dict[UUID, Any],
-    scale: MetadataColorScale,
-) -> list[int]:
-    """Return a color category per sample (0 = filtered out, 1 = unassigned)."""
-    color_categories: list[int] = []
-    for i, sample_id in enumerate(sample_ids):
-        if fulfils_filter[i] == 0:
-            color_categories.append(0)
-            continue
-        cat = _find_metadata_category(
-            sample_id=sample_id,
-            sample_to_value=sample_to_value,
-            scale=scale,
-        )
-        color_categories.append(cat if cat is not None else 1)
-    return color_categories
-
-
-def _build_color_scale_str(
-    values: set[str],
-    start_cat: int,
-) -> MetadataColorScale:
-    """Build a MetadataColorScale for string metadata values."""
-    value_to_category: dict[str, int] = {}
-    legend: dict[int, str] = {}
-    for i, value in enumerate(sorted(values)):
-        value_to_category[value] = start_cat + i
-        legend[start_cat + i] = value
-    return MetadataColorScale(value_to_category=value_to_category, legend=legend)
-
-
-def _build_color_scale_bool(
-    values: set[bool],
-    start_cat: int,
-) -> MetadataColorScale:
-    """Build a MetadataColorScale for boolean metadata values."""
-    value_to_category: dict[bool, int] = {}
-    legend: dict[int, str] = {}
-    for i, value in enumerate(sorted(values)):
-        label = str(value).lower()
-
-        value_to_category[value] = start_cat + i
-        legend[start_cat + i] = label
-    return MetadataColorScale(value_to_category=value_to_category, legend=legend)
-
-
-def _find_metadata_category(
-    sample_id: UUID,
-    sample_to_value: dict[UUID, Any],
-    scale: MetadataColorScale,
-) -> int | None:
-    """Return the color category for the metadata field, or None."""
-    value = sample_to_value.get(sample_id)
-    if value is None:
-        return None
-    return scale.value_to_category.get(value)

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
@@ -72,4 +72,3 @@ def _build_metadata_color_scale(
         f"Metadata field '{key}' has unsupported type {metadata_type!r}. "
         "Only 'string' and 'boolean' fields can be used for coloring."
     )
-

--- a/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
+++ b/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
@@ -1,0 +1,167 @@
+"""Unit tests for the coloring_helpers module."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from lightly_studio.api.routes.api.embedding_coloring.coloring_helpers import (
+    DiscreteColorScale,
+    assign_color_categories,
+)
+
+
+class TestDiscreteColorScale:
+    """Tests for DiscreteColorScale."""
+
+    def test_value_to_category__known_value(self) -> None:
+        scale = DiscreteColorScale(_lookup={"a": 2, "b": 3}, legend={2: "a", 3: "b"})
+        assert scale.value_to_category("a") == 2
+        assert scale.value_to_category("b") == 3
+
+    def test_value_to_category__unknown_value(self) -> None:
+        scale = DiscreteColorScale(_lookup={"a": 2}, legend={2: "a"})
+        assert scale.value_to_category("z") is None
+
+    def test_from_values__strings(self) -> None:
+        scale = DiscreteColorScale.from_values(values={"Paris", "London", "Berlin"})
+        assert scale.value_to_category("Berlin") == 2
+        assert scale.value_to_category("London") == 3
+        assert scale.value_to_category("Paris") == 4
+        assert scale.legend == {2: "Berlin", 3: "London", 4: "Paris"}
+
+    def test_from_values__booleans(self) -> None:
+        scale = DiscreteColorScale.from_values(
+            values={True, False},
+            format_fn=lambda v: str(v).lower(),
+        )
+        # Sorted by format_fn: "false" < "true"
+        assert scale.value_to_category(False) == 2
+        assert scale.value_to_category(True) == 3
+        assert scale.legend == {2: "false", 3: "true"}
+
+    def test_from_values__custom_start_cat(self) -> None:
+        scale = DiscreteColorScale.from_values(values={"x", "y"}, start_cat=10)
+        assert scale.value_to_category("x") == 10
+        assert scale.value_to_category("y") == 11
+        assert scale.legend == {10: "x", 11: "y"}
+
+    def test_from_values__empty(self) -> None:
+        scale = DiscreteColorScale.from_values(values=set())
+        assert scale.legend == {}
+        assert scale.value_to_category("anything") is None
+
+    def test_from_values__single_value(self) -> None:
+        scale = DiscreteColorScale.from_values(values={"only"})
+        assert scale.value_to_category("only") == 2
+        assert scale.legend == {2: "only"}
+
+    def test_from_values__deterministic_ordering(self) -> None:
+        """Repeated calls with the same values produce the same assignment."""
+        for _ in range(5):
+            scale = DiscreteColorScale.from_values(values={"c", "a", "b"})
+            assert scale.legend == {2: "a", 3: "b", 4: "c"}
+
+
+class TestAssignColorCategories:
+    """Tests for assign_color_categories."""
+
+    def test_all_samples_have_values(self) -> None:
+        ids = [uuid4(), uuid4()]
+        scale = DiscreteColorScale.from_values(values={"cat", "dog"})
+        sample_to_value = {ids[0]: "cat", ids[1]: "dog"}
+
+        categories, legend = assign_color_categories(
+            sample_ids=ids,
+            fulfils_filter=[1, 1],
+            sample_to_value=sample_to_value,
+            scale=scale,
+        )
+
+        assert categories[0] == scale.value_to_category("cat")
+        assert categories[1] == scale.value_to_category("dog")
+        assert legend[0] == "Filtered out"
+        assert legend[1] == "Unassigned"
+
+    def test_filtered_out_sample_gets_category_zero(self) -> None:
+        sid = uuid4()
+        scale = DiscreteColorScale.from_values(values={"val"})
+
+        categories, _ = assign_color_categories(
+            sample_ids=[sid],
+            fulfils_filter=[0],
+            sample_to_value={sid: "val"},
+            scale=scale,
+        )
+
+        assert categories == [0]
+
+    def test_missing_value_gets_unassigned(self) -> None:
+        sid = uuid4()
+        scale = DiscreteColorScale.from_values(values={"val"})
+
+        categories, legend = assign_color_categories(
+            sample_ids=[sid],
+            fulfils_filter=[1],
+            sample_to_value={},
+            scale=scale,
+        )
+
+        assert categories == [1]
+        assert legend[1] == "Unassigned"
+
+    def test_mixed_scenario(self) -> None:
+        """Filtered-out, valued, and missing samples in one call."""
+        ids = [uuid4(), uuid4(), uuid4(), uuid4()]
+        scale = DiscreteColorScale.from_values(values={"Paris", "London"})
+        sample_to_value: dict[UUID, str] = {
+            ids[0]: "Paris",
+            ids[1]: "London",
+            # ids[2] has no value
+            ids[3]: "Paris",
+        }
+
+        categories, legend = assign_color_categories(
+            sample_ids=ids,
+            fulfils_filter=[1, 0, 1, 1],
+            sample_to_value=sample_to_value,
+            scale=scale,
+        )
+
+        assert categories[0] == scale.value_to_category("Paris")  # valued
+        assert categories[1] == 0  # filtered out
+        assert categories[2] == 1  # unassigned (missing)
+        assert categories[3] == scale.value_to_category("Paris")  # valued
+
+        # Legend includes reserved entries + scale entries
+        assert legend[0] == "Filtered out"
+        assert legend[1] == "Unassigned"
+        assert "London" in legend.values()
+        assert "Paris" in legend.values()
+
+    def test_empty_samples(self) -> None:
+        scale = DiscreteColorScale.from_values(values={"x"})
+
+        categories, legend = assign_color_categories(
+            sample_ids=[],
+            fulfils_filter=[],
+            sample_to_value={},
+            scale=scale,
+        )
+
+        assert categories == []
+        assert legend[0] == "Filtered out"
+        assert legend[1] == "Unassigned"
+
+    def test_unmapped_value_in_scale_gets_unassigned(self) -> None:
+        """A sample whose value exists but isn't in the scale gets category 1."""
+        sid = uuid4()
+        scale = DiscreteColorScale.from_values(values={"known"})
+
+        categories, _ = assign_color_categories(
+            sample_ids=[sid],
+            fulfils_filter=[1],
+            sample_to_value={sid: "unknown"},
+            scale=scale,
+        )
+
+        assert categories == [1]

--- a/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
+++ b/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 from uuid import UUID, uuid4
 
-from lightly_studio.api.routes.api.embedding_coloring.coloring_helpers import (
-    DiscreteColorScale,
-    assign_color_categories,
-)
+from lightly_studio.api.routes.api.embedding_coloring import coloring_helpers
+from lightly_studio.api.routes.api.embedding_coloring.coloring_helpers import DiscreteColorScale
 
 
 class TestDiscreteColorScale:
@@ -17,9 +15,6 @@ class TestDiscreteColorScale:
         scale = DiscreteColorScale(_lookup={"a": 2, "b": 3}, legend={2: "a", 3: "b"})
         assert scale.value_to_category("a") == 2
         assert scale.value_to_category("b") == 3
-
-    def test_value_to_category__unknown_value(self) -> None:
-        scale = DiscreteColorScale(_lookup={"a": 2}, legend={2: "a"})
         assert scale.value_to_category("z") is None
 
     def test_from_values__strings(self) -> None:
@@ -55,113 +50,87 @@ class TestDiscreteColorScale:
         assert scale.value_to_category("only") == 2
         assert scale.legend == {2: "only"}
 
-    def test_from_values__deterministic_ordering(self) -> None:
-        """Repeated calls with the same values produce the same assignment."""
-        for _ in range(5):
-            scale = DiscreteColorScale.from_values(values={"c", "a", "b"})
-            assert scale.legend == {2: "a", 3: "b", 4: "c"}
+
+def test_assign_color_categories() -> None:
+    ids = [uuid4(), uuid4()]
+    scale = DiscreteColorScale.from_values(values={"cat", "dog"})
+    sample_to_value = {ids[0]: "cat", ids[1]: "dog"}
+
+    categories, legend = coloring_helpers.assign_color_categories(
+        sample_ids=ids,
+        fulfils_filter=[1, 1],
+        sample_to_value=sample_to_value,
+        scale=scale,
+    )
+
+    assert legend == ["Filtered out", "Unassigned", "cat", "dog"]
+    assert categories == [2, 3]
 
 
-class TestAssignColorCategories:
-    """Tests for assign_color_categories."""
+def test_assign_color_categories__missing_and_filtered_out() -> None:
+    ids = [uuid4(), uuid4()]
+    scale = DiscreteColorScale.from_values(values={"cat"})
+    sample_to_value = {ids[0]: "cat"}  # ids[1] is missing
 
-    def test_all_samples_have_values(self) -> None:
-        ids = [uuid4(), uuid4()]
-        scale = DiscreteColorScale.from_values(values={"cat", "dog"})
-        sample_to_value = {ids[0]: "cat", ids[1]: "dog"}
+    categories, legend = coloring_helpers.assign_color_categories(
+        sample_ids=ids,
+        fulfils_filter=[0, 1],
+        sample_to_value=sample_to_value,
+        scale=scale,
+    )
 
-        categories, legend = assign_color_categories(
-            sample_ids=ids,
-            fulfils_filter=[1, 1],
-            sample_to_value=sample_to_value,
-            scale=scale,
-        )
+    assert legend == ["Filtered out", "Unassigned", "cat"]
+    assert categories == [0, 1]
 
-        assert categories[0] == scale.value_to_category("cat")
-        assert categories[1] == scale.value_to_category("dog")
-        assert legend[0] == "Filtered out"
-        assert legend[1] == "Unassigned"
 
-    def test_filtered_out_sample_gets_category_zero(self) -> None:
-        sid = uuid4()
-        scale = DiscreteColorScale.from_values(values={"val"})
+def test_assign_color_categories__mixed() -> None:
+    """Filtered-out, valued, and missing samples in one call."""
+    ids = [uuid4(), uuid4(), uuid4(), uuid4()]
+    scale = DiscreteColorScale.from_values(values={"Paris", "London"})
+    sample_to_value: dict[UUID, str] = {
+        ids[0]: "Paris",
+        ids[1]: "London",
+        # ids[2] has no value
+        ids[3]: "Paris",
+    }
 
-        categories, _ = assign_color_categories(
-            sample_ids=[sid],
-            fulfils_filter=[0],
-            sample_to_value={sid: "val"},
-            scale=scale,
-        )
+    categories, legend = coloring_helpers.assign_color_categories(
+        sample_ids=ids,
+        fulfils_filter=[1, 0, 1, 1],
+        sample_to_value=sample_to_value,
+        scale=scale,
+    )
 
-        assert categories == [0]
+    # Legend includes reserved entries + scale entries
+    assert legend == ["Filtered out", "Unassigned", "London", "Paris"]
+    assert categories == [3, 0, 1, 3]
 
-    def test_missing_value_gets_unassigned(self) -> None:
-        sid = uuid4()
-        scale = DiscreteColorScale.from_values(values={"val"})
 
-        categories, legend = assign_color_categories(
-            sample_ids=[sid],
-            fulfils_filter=[1],
-            sample_to_value={},
-            scale=scale,
-        )
+def test_assign_color_categories__empty() -> None:
+    scale = DiscreteColorScale.from_values(values={"x"})
 
-        assert categories == [1]
-        assert legend[1] == "Unassigned"
+    categories, legend = coloring_helpers.assign_color_categories(
+        sample_ids=[],
+        fulfils_filter=[],
+        sample_to_value={},
+        scale=scale,
+    )
 
-    def test_mixed_scenario(self) -> None:
-        """Filtered-out, valued, and missing samples in one call."""
-        ids = [uuid4(), uuid4(), uuid4(), uuid4()]
-        scale = DiscreteColorScale.from_values(values={"Paris", "London"})
-        sample_to_value: dict[UUID, str] = {
-            ids[0]: "Paris",
-            ids[1]: "London",
-            # ids[2] has no value
-            ids[3]: "Paris",
-        }
+    assert legend == ["Filtered out", "Unassigned"]
+    assert categories == []
 
-        categories, legend = assign_color_categories(
-            sample_ids=ids,
-            fulfils_filter=[1, 0, 1, 1],
-            sample_to_value=sample_to_value,
-            scale=scale,
-        )
 
-        assert categories[0] == scale.value_to_category("Paris")  # valued
-        assert categories[1] == 0  # filtered out
-        assert categories[2] == 1  # unassigned (missing)
-        assert categories[3] == scale.value_to_category("Paris")  # valued
+def test_assign_color_categories__unmapped_value() -> None:
+    """A sample whose value exists but isn't in the scale gets category 1."""
+    sid = uuid4()
+    scale = DiscreteColorScale.from_values(values={"known"})
 
-        # Legend includes reserved entries + scale entries
-        assert legend[0] == "Filtered out"
-        assert legend[1] == "Unassigned"
-        assert "London" in legend.values()
-        assert "Paris" in legend.values()
+    categories, _ = coloring_helpers.assign_color_categories(
+        sample_ids=[sid],
+        fulfils_filter=[1],
+        sample_to_value={sid: "unknown"},
+        scale=scale,
+    )
 
-    def test_empty_samples(self) -> None:
-        scale = DiscreteColorScale.from_values(values={"x"})
-
-        categories, legend = assign_color_categories(
-            sample_ids=[],
-            fulfils_filter=[],
-            sample_to_value={},
-            scale=scale,
-        )
-
-        assert categories == []
-        assert legend[0] == "Filtered out"
-        assert legend[1] == "Unassigned"
-
-    def test_unmapped_value_in_scale_gets_unassigned(self) -> None:
-        """A sample whose value exists but isn't in the scale gets category 1."""
-        sid = uuid4()
-        scale = DiscreteColorScale.from_values(values={"known"})
-
-        categories, _ = assign_color_categories(
-            sample_ids=[sid],
-            fulfils_filter=[1],
-            sample_to_value={sid: "unknown"},
-            scale=scale,
-        )
-
-        assert categories == [1]
+    assert legend == ["Filtered out", "Unassigned", "known"]
+    assert categories == [1]

--- a/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
+++ b/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
@@ -41,7 +41,7 @@ class TestDiscreteColorScale:
         assert scale.legend == {10: "x", 11: "y"}
 
     def test_from_values__empty(self) -> None:
-        scale = DiscreteColorScale.from_values(values=set())
+        scale = DiscreteColorScale.from_values(values=set[str]())
         assert scale.legend == {}
         assert scale.value_to_category("anything") is None
 
@@ -63,7 +63,7 @@ def test_assign_color_categories() -> None:
         scale=scale,
     )
 
-    assert legend == ["Filtered out", "Unassigned", "cat", "dog"]
+    assert legend == {0: "Filtered out", 1: "Unassigned", 2: "cat", 3: "dog"}
     assert categories == [2, 3]
 
 
@@ -79,7 +79,7 @@ def test_assign_color_categories__missing_and_filtered_out() -> None:
         scale=scale,
     )
 
-    assert legend == ["Filtered out", "Unassigned", "cat"]
+    assert legend == {0: "Filtered out", 1: "Unassigned", 2: "cat"}
     assert categories == [0, 1]
 
 
@@ -102,7 +102,7 @@ def test_assign_color_categories__mixed() -> None:
     )
 
     # Legend includes reserved entries + scale entries
-    assert legend == ["Filtered out", "Unassigned", "London", "Paris"]
+    assert legend == {0: "Filtered out", 1: "Unassigned", 2: "London", 3: "Paris"}
     assert categories == [3, 0, 1, 3]
 
 
@@ -116,7 +116,7 @@ def test_assign_color_categories__empty() -> None:
         scale=scale,
     )
 
-    assert legend == ["Filtered out", "Unassigned"]
+    assert legend == {0: "Filtered out", 1: "Unassigned", 2: "x"}
     assert categories == []
 
 
@@ -125,12 +125,12 @@ def test_assign_color_categories__unmapped_value() -> None:
     sid = uuid4()
     scale = DiscreteColorScale.from_values(values={"known"})
 
-    categories, _ = coloring_helpers.assign_color_categories(
+    categories, legend = coloring_helpers.assign_color_categories(
         sample_ids=[sid],
         fulfils_filter=[1],
         sample_to_value={sid: "unknown"},
         scale=scale,
     )
 
-    assert legend == ["Filtered out", "Unassigned", "known"]
+    assert legend == {0: "Filtered out", 1: "Unassigned", 2: "known"}
     assert categories == [1]

--- a/lightly_studio/tests/api/routes/api/test_embeddings2d.py
+++ b/lightly_studio/tests/api/routes/api/test_embeddings2d.py
@@ -286,6 +286,7 @@ def test_get_embeddings2d__with_metadata_field_color_by(
     assert sample_id_to_color[str(samples[3].sample_id)] == 1  # Unassigned
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
+    assert legend["0"] == "Filtered out"
     assert legend["1"] == "Unassigned"
     assert legend["2"] == "London"
     assert legend["3"] == "Paris"
@@ -371,6 +372,7 @@ def test_get_embeddings2d__with_boolean_metadata_color_by(
     assert sample_id_to_color[str(samples[2].sample_id)] == 2  # False -> cat 2
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
+    assert legend["0"] == "Filtered out"
     assert legend["1"] == "Unassigned"
     assert legend["2"] == "false"
     assert legend["3"] == "true"
@@ -438,6 +440,7 @@ def test_get_embeddings2d__with_metadata_field_color_by_and_sample_ids_filter(
     assert sample_id_to_color[str(samples[3].sample_id)] == 0  # Berlin, filtered
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
+    assert legend["0"] == "Filtered out"
     assert legend["1"] == "Unassigned"
     assert legend["2"] == "Berlin"
     assert legend["3"] == "London"


### PR DESCRIPTION
## What has changed and why?

Factor out common logic in preparation for adding ColorByTag. The new structure should also support extension to integer ranges.

Changes:
* Moved functionality to `coloring_helper.py`
* Made the functions generic for type safety
* Introduced `ColorScale` protocol. The legend stays a dict, but the value mapping is a function - it will support ranges later on.
* The whole 0-filtered, 1-unassigned logic moved to `coloring_helper.py`

## How has it been tested?

New tests.

I have kept the existing integration tests for `embeddings_2d.py`, even though there is some overlap with the new tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized color category assignment logic for improved code maintainability and clarity in the embedding coloring system.
  * Enhanced color legend to explicitly distinguish between "Filtered out" and "Unassigned" sample categories in the visualization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->