### PR TITLE
Implement AnnotationColorBy for embedding plot coloring

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/annotations.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/annotations.py
@@ -51,18 +51,14 @@ def build_annotation_color_maps(
         if ann.annotation_label_id in requested:
             sample_to_labels[ann.parent_sample_id].add(ann.annotation_label_id)
 
+    sample_to_value = coloring_helpers.first_match_per_sample(
+        sample_to_candidates=sample_to_labels, priority_order=annotation_label_ids
+    )
+
     scale = DiscreteColorScale.from_values(
         values=annotation_label_ids,
         format_fn=lambda lid: names.get(str(lid), str(lid)),
     )
-
-    # First-match-wins: map each sample to its earliest matching label.
-    sample_to_value: dict[UUID, UUID] = {}
-    for sid, labels in sample_to_labels.items():
-        for lid in annotation_label_ids:
-            if lid in labels:
-                sample_to_value[sid] = lid
-                break
 
     return coloring_helpers.assign_color_categories(
         sample_ids=sample_ids,

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/annotations.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/annotations.py
@@ -1,0 +1,72 @@
+"""Annotation-based coloring helpers for 2D embedding plots."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.api.routes.api.embedding_coloring import coloring_helpers
+from lightly_studio.api.routes.api.embedding_coloring.coloring_helpers import DiscreteColorScale
+from lightly_studio.resolvers import annotation_label_resolver, annotation_resolver
+
+
+def build_annotation_color_maps(
+    session: Session,
+    annotation_label_ids: list[UUID],
+    sample_ids: list[UUID],
+    fulfils_filter: list[int],
+) -> tuple[list[int], dict[int, str]]:
+    """Build color categories and a legend for annotation-based sample coloring.
+
+    Each selected annotation label gets a consecutive color category (starting
+    at 2) in the order given by *annotation_label_ids*.  When a sample carries
+    multiple selected labels the **first match wins** — it receives the category
+    of the label with the lowest index in *annotation_label_ids*.
+
+    All requested label categories appear in the legend even if no samples
+    match.
+
+    Args:
+        session: Database session.
+        annotation_label_ids: Ordered label IDs that define coloring priority.
+        sample_ids: Sample IDs in the order for which to build color categories.
+        fulfils_filter: Per-sample filter flags where 0 means filtered out.
+
+    Returns:
+        A tuple of `(color_categories, color_legend)` for the provided samples.
+        The length of `color_categories` is the number of samples. The
+        `color_legend` is a mapping from color ID to a human-readable string.
+    """
+    names = annotation_label_resolver.names_by_ids(session=session, ids=annotation_label_ids)
+    annotations = annotation_resolver.get_all_by_parent_sample_ids(
+        session=session, parent_sample_ids=sample_ids
+    )
+
+    # Build a lookup: parent_sample_id → set of annotation_label_ids.
+    sample_to_labels: dict[UUID, set[UUID]] = defaultdict(set)
+    requested = set(annotation_label_ids)
+    for ann in annotations:
+        if ann.annotation_label_id in requested:
+            sample_to_labels[ann.parent_sample_id].add(ann.annotation_label_id)
+
+    scale = DiscreteColorScale.from_values(
+        values=annotation_label_ids,
+        format_fn=lambda lid: names.get(str(lid), str(lid)),
+    )
+
+    # First-match-wins: map each sample to its earliest matching label.
+    sample_to_value: dict[UUID, UUID] = {}
+    for sid, labels in sample_to_labels.items():
+        for lid in annotation_label_ids:
+            if lid in labels:
+                sample_to_value[sid] = lid
+                break
+
+    return coloring_helpers.assign_color_categories(
+        sample_ids=sample_ids,
+        fulfils_filter=fulfils_filter,
+        sample_to_value=sample_to_value,
+        scale=scale,
+    )

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 from sqlmodel import Session
+from typing_extensions import assert_never
 
 from lightly_studio.api.routes.api.embedding_coloring import (
     annotations as annotation_coloring,
@@ -90,4 +91,8 @@ def build_color_data(
             fulfils_filter=fulfils_filter,
         )
 
-    return list(fulfils_filter), {}
+    # Static check that all ColorBy variants are handled above.
+    if color_by is not None:
+        assert_never(color_by)
+
+    return list(fulfils_filter), {0: "Not filtered", 1: "Filtered"}

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring.py
@@ -8,7 +8,13 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 from sqlmodel import Session
 
-from lightly_studio.api.routes.api.embedding_coloring import metadata, tags
+from lightly_studio.api.routes.api.embedding_coloring import (
+    annotations as annotation_coloring,
+)
+from lightly_studio.api.routes.api.embedding_coloring import (
+    metadata,
+    tags,
+)
 
 
 class TagColorBy(BaseModel):
@@ -72,6 +78,14 @@ def build_color_data(
             session=session,
             collection_id=collection_id,
             key=color_by.key,
+            sample_ids=sample_ids,
+            fulfils_filter=fulfils_filter,
+        )
+
+    if isinstance(color_by, AnnotationColorBy):
+        return annotation_coloring.build_annotation_color_maps(
+            session=session,
+            annotation_label_ids=color_by.annotation_label_ids,
             sample_ids=sample_ids,
             fulfils_filter=fulfils_filter,
         )

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring.py
@@ -95,4 +95,4 @@ def build_color_data(
     if color_by is not None:
         assert_never(color_by)
 
-    return list(fulfils_filter), {0: "Not filtered", 1: "Filtered"}
+    return list(fulfils_filter), {}

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -110,3 +110,29 @@ def assign_color_categories(
 
     legend = {0: "Filtered out", 1: "Unassigned", **scale.legend}
     return color_categories, legend
+
+
+def first_match_per_sample(
+    sample_to_candidates: Mapping[UUID, Iterable[T]],
+    priority_order: Sequence[T],
+) -> dict[UUID, T]:
+    """Map each sample to the first matching value from a priority-ordered list.
+
+    Samples with no match are omitted from the result.
+
+    Args:
+        sample_to_candidates: Mapping from sample ID to the set (or any
+            iterable) of candidate values the sample carries.
+        priority_order: Values in priority order — the first match wins.
+
+    Returns:
+        A mapping from sample ID to the winning value.
+    """
+    result: dict[UUID, T] = {}
+    for sid, candidates in sample_to_candidates.items():
+        candidate_set = candidates if isinstance(candidates, set) else set(candidates)
+        for value in priority_order:
+            if value in candidate_set:
+                result[sid] = value
+                break
+    return result

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/tags.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/tags.py
@@ -37,19 +37,14 @@ def build_tag_color_maps(
     """
     names = tag_resolver.get_names_by_ids(session=session, tag_ids=tag_ids)
     sample_to_tags = tag_resolver.get_tags_by_sample(session=session, tag_ids=tag_ids)
+    sample_to_value = coloring_helpers.first_match_per_sample(
+        sample_to_candidates=sample_to_tags, priority_order=tag_ids
+    )
 
     scale = DiscreteColorScale.from_values(
         values=tag_ids,
         format_fn=lambda tid: names.get(tid, str(tid)),
     )
-
-    # First-match-wins: map each sample to its earliest matching tag.
-    sample_to_value: dict[UUID, UUID] = {}
-    for sid, sample_tags in sample_to_tags.items():
-        for tid in tag_ids:
-            if tid in sample_tags:
-                sample_to_value[sid] = tid
-                break
 
     return coloring_helpers.assign_color_categories(
         sample_ids=sample_ids,

--- a/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
+++ b/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
@@ -134,3 +134,22 @@ def test_assign_color_categories__unmapped_value() -> None:
 
     assert legend == {0: "Filtered out", 1: "Unassigned", 2: "known"}
     assert categories == [1]
+
+
+def test_first_match_per_sample() -> None:
+    """First match wins per priority order; unmatched samples are omitted."""
+    a, b, c = uuid4(), uuid4(), uuid4()
+    label_x, label_y, label_z = uuid4(), uuid4(), uuid4()
+
+    sample_to_candidates: dict[UUID, set[UUID]] = {
+        a: {label_y, label_x},  # Has both; label_x is first in priority
+        b: {label_z},  # label_z is not in priority list
+        c: {label_y},  # Matches label_y
+    }
+    priority_order = [label_x, label_y]
+
+    result = coloring_helpers.first_match_per_sample(
+        sample_to_candidates=sample_to_candidates, priority_order=priority_order
+    )
+
+    assert result == {a: label_x, c: label_y}

--- a/lightly_studio/tests/api/routes/api/test_embeddings2d.py
+++ b/lightly_studio/tests/api/routes/api/test_embeddings2d.py
@@ -26,6 +26,8 @@ from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
 from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
     create_collection,
     create_embedding_model,
     create_sample_embedding,
@@ -635,6 +637,160 @@ def test_get_embeddings2d__with_tag_color_by_and_filter(
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
     assert legend["2"] == "color_tag"
+
+
+def test_get_embeddings2d__with_annotation_color_by(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    n_samples = 5
+
+    collection_id = fill_db_with_samples_and_embeddings(
+        session=db_session,
+        n_samples=n_samples,
+        embedding_model_names=["model_a"],
+        embedding_dimension=EMBEDDING_DIMENSION,
+    )
+
+    samples = image_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=collection_id,
+    ).samples
+    assert len(samples) == n_samples
+
+    label_cat = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="cat"
+    )
+    label_dog = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="dog"
+    )
+
+    # samples[0] has "cat", samples[1] has "dog",
+    # samples[2] has both (first-match-wins → cat), samples[3,4] unannotated.
+    create_annotation(
+        session=db_session,
+        collection_id=collection_id,
+        sample_id=samples[0].sample_id,
+        annotation_label_id=label_cat.annotation_label_id,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection_id,
+        sample_id=samples[1].sample_id,
+        annotation_label_id=label_dog.annotation_label_id,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection_id,
+        sample_id=samples[2].sample_id,
+        annotation_label_id=label_cat.annotation_label_id,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection_id,
+        sample_id=samples[2].sample_id,
+        annotation_label_id=label_dog.annotation_label_id,
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/embeddings2d/default",
+        json={
+            "filters": {},
+            "color_by": {
+                "type": "annotation",
+                "annotation_label_ids": [
+                    str(label_cat.annotation_label_id),
+                    str(label_dog.annotation_label_id),
+                ],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+
+    table = ipc.open_stream(pa.BufferReader(response.content)).read_all()
+    sample_ids_payload = table.column("sample_id").to_pylist()
+    color_category = table.column("color_category").to_numpy(zero_copy_only=False)
+
+    sample_id_to_color = dict(zip(sample_ids_payload, color_category))
+    assert sample_id_to_color[str(samples[0].sample_id)] == 2  # cat
+    assert sample_id_to_color[str(samples[1].sample_id)] == 3  # dog
+    assert sample_id_to_color[str(samples[2].sample_id)] == 2  # both → cat (first match)
+    assert sample_id_to_color[str(samples[3].sample_id)] == 1  # Unassigned
+    assert sample_id_to_color[str(samples[4].sample_id)] == 1  # Unassigned
+
+    legend = json.loads(table.schema.metadata[b"color_legend"])
+    assert legend["0"] == "Filtered out"
+    assert legend["1"] == "Unassigned"
+    assert legend["2"] == "cat"
+    assert legend["3"] == "dog"
+
+
+def test_get_embeddings2d__with_annotation_color_by_and_filter(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    n_samples = 4
+
+    collection_id = fill_db_with_samples_and_embeddings(
+        session=db_session,
+        n_samples=n_samples,
+        embedding_model_names=["model_a"],
+        embedding_dimension=EMBEDDING_DIMENSION,
+    )
+
+    samples = image_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=collection_id,
+    ).samples
+    assert len(samples) == n_samples
+
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="cat"
+    )
+
+    # All samples get annotated.
+    for sample in samples:
+        create_annotation(
+            session=db_session,
+            collection_id=collection_id,
+            sample_id=sample.sample_id,
+            annotation_label_id=label.annotation_label_id,
+        )
+
+    # Only first two pass the filter.
+    selected_sample_ids = [samples[0].sample_id, samples[1].sample_id]
+    image_filter = ImageFilter(
+        sample_filter=SampleFilter(sample_ids=selected_sample_ids),
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/embeddings2d/default",
+        json={
+            "filters": image_filter.model_dump(mode="json"),
+            "color_by": {
+                "type": "annotation",
+                "annotation_label_ids": [str(label.annotation_label_id)],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+
+    table = ipc.open_stream(pa.BufferReader(response.content)).read_all()
+    sample_ids_payload = table.column("sample_id").to_pylist()
+    color_category = table.column("color_category").to_numpy(zero_copy_only=False)
+
+    sample_id_to_color = dict(zip(sample_ids_payload, color_category))
+    # First two pass filter and have the label → category 2.
+    assert sample_id_to_color[str(samples[0].sample_id)] == 2
+    assert sample_id_to_color[str(samples[1].sample_id)] == 2
+    # Last two are filtered out → category 0.
+    assert sample_id_to_color[str(samples[2].sample_id)] == 0
+    assert sample_id_to_color[str(samples[3].sample_id)] == 0
+
+    legend = json.loads(table.schema.metadata[b"color_legend"])
+    assert legend["2"] == "cat"
 
 
 """Benchmark for the /embeddings2d/default endpoint.

--- a/lightly_studio/tests/api/routes/api/test_embeddings2d.py
+++ b/lightly_studio/tests/api/routes/api/test_embeddings2d.py
@@ -559,10 +559,12 @@ def test_get_embeddings2d__with_tag_color_by(
     assert sample_id_to_color[str(samples[4].sample_id)] == 1  # Unassigned
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend["0"] == "Filtered out"
-    assert legend["1"] == "Unassigned"
-    assert legend["2"] == "alpha"
-    assert legend["3"] == "beta"
+    assert legend == {
+        "0": "Filtered out",
+        "1": "Unassigned",
+        "2": "alpha",
+        "3": "beta",
+    }
 
 
 def test_get_embeddings2d__with_tag_color_by_and_filter(
@@ -636,7 +638,11 @@ def test_get_embeddings2d__with_tag_color_by_and_filter(
     assert sample_id_to_color[str(samples[3].sample_id)] == 0
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend["2"] == "color_tag"
+    assert legend == {
+        "0": "Filtered out",
+        "1": "Unassigned",
+        "2": "color_tag",
+    }
 
 
 def test_get_embeddings2d__with_annotation_color_by(
@@ -720,10 +726,12 @@ def test_get_embeddings2d__with_annotation_color_by(
     assert sample_id_to_color[str(samples[4].sample_id)] == 1  # Unassigned
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend["0"] == "Filtered out"
-    assert legend["1"] == "Unassigned"
-    assert legend["2"] == "cat"
-    assert legend["3"] == "dog"
+    assert legend == {
+        "0": "Filtered out",
+        "1": "Unassigned",
+        "2": "cat",
+        "3": "dog",
+    }
 
 
 def test_get_embeddings2d__with_annotation_color_by_and_filter(
@@ -790,7 +798,7 @@ def test_get_embeddings2d__with_annotation_color_by_and_filter(
     assert sample_id_to_color[str(samples[3].sample_id)] == 0
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend["2"] == "cat"
+    assert legend == {"0": "Filtered out", "1": "Unassigned", "2": "cat"}
 
 
 """Benchmark for the /embeddings2d/default endpoint.


### PR DESCRIPTION
## What has changed and why?

Implement `AnnotationColorBy` in `build_color_data()`, completing the embedding plot coloring support for annotation labels.

If a sample is assigned multiple labels the first one in the list wins.

## How has it been tested?

Two integration tests in `test_embeddings2d.py`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added annotation-based coloring for 2D embedding plots — color points by selected annotation labels, with a "first-match-wins" priority when multiple labels apply, and honoring sample filters.
* **Refactor**
  * Shared priority logic applied to tag-based coloring to ensure consistent first-match behavior.
* **Tests**
  * Added tests covering annotation-based coloring, multi-label priority, and filter interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->