### PR TITLE
Add frontend similarity sampling UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sample selection respects the current image or video filters.
 - Added sort-by support via GUI.
+- Added similarity selection option.
 
 ### Changed
 

--- a/lightly_studio_view/e2e/general/samples-grid.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/samples-grid.e2e-test.ts
@@ -239,14 +239,16 @@ test('Similarity search computes metadata and sorts images by similarity', async
     const similarityPromise = page.waitForResponse(
         (response) =>
             response.url().includes(`/metadata/similarity/${queryTagId}`) &&
-            response.status() === 204
+            response.status() === 200
     );
 
     await samplesPage.createSimilaritySelection(queryTagId!);
 
-    await similarityPromise;
+    const similarityResponse = await similarityPromise;
+    const similarityMetadataName = await similarityResponse.json();
+    expect(typeof similarityMetadataName).toBe('string');
+    expect(similarityMetadataName).toContain('similarity');
     await expect(page.getByText('Similarity sort applied')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByTestId('sort-by-trigger')).toHaveText('Similarity');
 });
 
 test('Selection shows error toast when tag already exists', async ({ page, samplesPage }) => {

--- a/lightly_studio_view/e2e/general/samples-grid.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/samples-grid.e2e-test.ts
@@ -223,6 +223,32 @@ test('Typicality selection creates tag with correct number of samples', async ({
     expect(sampleCount).toBe(nSamples);
 });
 
+test('Similarity search computes metadata and sorts images by similarity', async ({
+    page,
+    samplesPage
+}) => {
+    const timestamp = Date.now();
+    const queryTagName = `similarity_query_${timestamp}`;
+
+    await samplesPage.createDiversitySelection(5, queryTagName);
+    await expect(page.getByText('Selection created successfully')).toBeVisible({ timeout: 10000 });
+
+    const queryTagId = await samplesPage.getTagIdByName(queryTagName);
+    expect(queryTagId).toBeTruthy();
+
+    const similarityPromise = page.waitForResponse(
+        (response) =>
+            response.url().includes(`/metadata/similarity/${queryTagId}`) &&
+            response.status() === 204
+    );
+
+    await samplesPage.createSimilaritySelection(queryTagId!);
+
+    await similarityPromise;
+    await expect(page.getByText('Similarity sort applied')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('sort-by-trigger')).toHaveText('Similarity');
+});
+
 test('Selection shows error toast when tag already exists', async ({ page, samplesPage }) => {
     // samplesPage fixture automatically navigates and loads samples
 

--- a/lightly_studio_view/e2e/pages/samples-page.ts
+++ b/lightly_studio_view/e2e/pages/samples-page.ts
@@ -133,9 +133,10 @@ export class SamplesPage {
     }
 
     async createSelection(
-        strategy: 'diversity' | 'typicality',
+        strategy: 'diversity' | 'typicality' | 'similarity',
         nSamples: number,
-        tagName: string
+        tagName: string,
+        queryTagId?: string
     ): Promise<void> {
         await this.page.getByTestId('menu-trigger').click();
         await this.page.getByTestId('menu-selection').click();
@@ -143,12 +144,17 @@ export class SamplesPage {
         await this.page.getByTestId('selection-dialog-strategy-select').click();
         await this.page.getByTestId(`selection-strategy-${strategy}`).click();
 
-        const nSamplesInput = this.page.getByTestId('selection-dialog-n-samples-input');
-        await nSamplesInput.clear();
-        await nSamplesInput.fill(nSamples.toString());
+        if (strategy === 'similarity' && queryTagId) {
+            await this.page.getByTestId('selection-dialog-query-tag-select').click();
+            await this.page.getByTestId(`selection-query-tag-${queryTagId}`).click();
+        } else {
+            const nSamplesInput = this.page.getByTestId('selection-dialog-n-samples-input');
+            await nSamplesInput.clear();
+            await nSamplesInput.fill(nSamples.toString());
 
-        const tagNameInput = this.page.getByTestId('selection-dialog-tag-name-input');
-        await tagNameInput.fill(tagName);
+            const tagNameInput = this.page.getByTestId('selection-dialog-tag-name-input');
+            await tagNameInput.fill(tagName);
+        }
 
         await pressButton(this.page, 'selection-dialog-submit');
     }
@@ -159,6 +165,10 @@ export class SamplesPage {
 
     async createTypicalitySelection(nSamples: number, tagName: string): Promise<void> {
         return this.createSelection('typicality', nSamples, tagName);
+    }
+
+    async createSimilaritySelection(queryTagId: string): Promise<void> {
+        return this.createSelection('similarity', 0, '', queryTagId);
     }
 
     async pressTag(tagName: string): Promise<void> {
@@ -215,6 +225,15 @@ export class SamplesPage {
             if (labelText) tagLabelsText.push(labelText);
         }
         return tagLabelsText;
+    }
+
+    async getTagIdByName(tagName: string): Promise<string | null> {
+        const tagLabel = this.page
+            .getByTestId('tags-menu-label')
+            .filter({ hasText: tagName })
+            .first();
+        const input = tagLabel.locator('xpath=ancestor::label[1]//input').first();
+        return input.getAttribute('name');
     }
 
     async getNumSelectedSamples(): Promise<number> {

--- a/lightly_studio_view/e2e/pages/samples-page.ts
+++ b/lightly_studio_view/e2e/pages/samples-page.ts
@@ -243,10 +243,9 @@ export class SamplesPage {
     }
 
     async getTagIdByName(tagName: string): Promise<string | null> {
-        const tagLabel = this.page
-            .getByTestId('tags-menu-label')
-            .filter({ hasText: tagName })
-            .first();
+        const tagLabel = this.page.getByTestId('tags-menu-label').getByText(tagName, {
+            exact: true
+        });
         const input = tagLabel.locator('xpath=ancestor::label[1]//input').first();
         return input.getAttribute('name');
     }

--- a/lightly_studio_view/e2e/pages/samples-page.ts
+++ b/lightly_studio_view/e2e/pages/samples-page.ts
@@ -133,18 +133,33 @@ export class SamplesPage {
     }
 
     async createSelection(
+        strategy: 'diversity' | 'typicality',
+        nSamples: number,
+        tagName: string
+    ): Promise<void>;
+    async createSelection(
+        strategy: 'similarity',
+        nSamples: number,
+        tagName: string,
+        queryTagId: string
+    ): Promise<void>;
+    async createSelection(
         strategy: 'diversity' | 'typicality' | 'similarity',
         nSamples: number,
         tagName: string,
         queryTagId?: string
     ): Promise<void> {
+        if (strategy === 'similarity' && !queryTagId) {
+            throw new Error('queryTagId required for similarity strategy');
+        }
+
         await this.page.getByTestId('menu-trigger').click();
         await this.page.getByTestId('menu-selection').click();
 
         await this.page.getByTestId('selection-dialog-strategy-select').click();
         await this.page.getByTestId(`selection-strategy-${strategy}`).click();
 
-        if (strategy === 'similarity' && queryTagId) {
+        if (strategy === 'similarity') {
             await this.page.getByTestId('selection-dialog-query-tag-select').click();
             await this.page.getByTestId(`selection-query-tag-${queryTagId}`).click();
         } else {

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
@@ -1,5 +1,6 @@
 import {
     createCombinationSelection,
+    computeSimilarityMetadata,
     computeTypicalityMetadata
 } from '$lib/api/lightly_studio_local/sdk.gen';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
@@ -21,6 +22,7 @@ vi.mock('$lib/api/lightly_studio_local/sdk.gen', async () => {
     return {
         ...actual,
         createCombinationSelection: vi.fn(),
+        computeSimilarityMetadata: vi.fn(),
         computeTypicalityMetadata: vi.fn()
     };
 });
@@ -88,6 +90,12 @@ describe('CreateSelectionDialog', () => {
         });
         vi.mocked(computeTypicalityMetadata).mockResolvedValue({
             data: undefined,
+            error: undefined,
+            request: mockRequest,
+            response: mockResponse
+        });
+        vi.mocked(computeSimilarityMetadata).mockResolvedValue({
+            data: 'similarity',
             error: undefined,
             request: mockRequest,
             response: mockResponse
@@ -209,5 +217,19 @@ describe('CreateSelectionDialog', () => {
                 })
             );
         });
+    });
+
+    it('disables similarity search for video collections', async () => {
+        pageMock.data.collection.sample_type = 'video';
+
+        render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+
+        expect(await screen.findByTestId('selection-strategy-similarity')).toHaveAttribute(
+            'data-disabled'
+        );
     });
 });

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
@@ -6,6 +6,7 @@ import {
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { readable, writable, type Writable } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SortDirection } from '$lib/api/lightly_studio_local';
 import CreateSelectionDialog from './CreateSelectionDialog.svelte';
 
 const pageMock = vi.hoisted(() => ({
@@ -29,6 +30,9 @@ vi.mock('$lib/api/lightly_studio_local/sdk.gen', async () => {
 
 vi.mock('$lib/hooks/useTags/useTags', () => ({
     useTags: () => ({
+        tags: readable([
+            { tag_id: 'tag-1', name: 'Query Tag', kind: 'sample' as const, description: null }
+        ]),
         loadTags: vi.fn()
     })
 }));
@@ -51,10 +55,12 @@ vi.mock('svelte-sonner', () => ({
 let imageFilterStore: Writable<Record<string, unknown> | null>;
 let videoFilterStore: Writable<Record<string, unknown> | null>;
 let filteredSampleCountStore: Writable<number>;
+const updateSortByMock = vi.fn();
 
 vi.mock('$lib/hooks/useImageFilters/useImageFilters', () => ({
     useImageFilters: () => ({
-        imageFilter: imageFilterStore
+        imageFilter: imageFilterStore,
+        updateSortBy: updateSortByMock
     })
 }));
 
@@ -81,6 +87,7 @@ describe('CreateSelectionDialog', () => {
         imageFilterStore = writable(null);
         videoFilterStore = writable(null);
         filteredSampleCountStore = writable(0);
+        updateSortByMock.mockReset();
 
         vi.mocked(createCombinationSelection).mockResolvedValue({
             data: undefined,
@@ -217,6 +224,42 @@ describe('CreateSelectionDialog', () => {
                 })
             );
         });
+    });
+
+    it('computes similarity metadata and applies similarity sorting', async () => {
+        filteredSampleCountStore.set(100);
+
+        render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-similarity'));
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-query-tag-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-query-tag-tag-1'));
+        await fireEvent.click(screen.getByTestId('selection-dialog-submit'));
+
+        await waitFor(() => {
+            expect(computeSimilarityMetadata).toHaveBeenCalledWith({
+                path: { collection_id: 'test-collection-id', query_tag_id: 'tag-1' },
+                body: {
+                    embedding_model_name: null,
+                    metadata_name: 'similarity'
+                }
+            });
+        });
+
+        expect(updateSortByMock).toHaveBeenCalledWith([
+            {
+                source: 'metadata',
+                field_name: 'similarity',
+                direction: SortDirection.DESC,
+                is_numeric: true
+            }
+        ]);
     });
 
     it('disables similarity search for video collections', async () => {

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
@@ -31,6 +31,7 @@
         page.data.collection?.sample_type === 'video' ||
             page.data.collection?.sample_type === 'video_frame'
     );
+    const isSimilaritySupported = $derived(!isVideoCollection);
 
     const { imageFilter } = useImageFilters();
     const { videoFilter } = useVideoFilters();
@@ -184,6 +185,11 @@
 
                 handleSelectionSuccess();
             } else if (selectionStrategy === 'similarity') {
+                if (!isSimilaritySupported) {
+                    toast.error('Similarity search is only available for image collections.');
+                    return;
+                }
+
                 loadingMessage = 'Computing similarity metadata...';
                 const similarityResponse = await computeSimilarityMetadata({
                     path: { collection_id: collectionId, query_tag_id: queryTagId },
@@ -276,6 +282,7 @@
                                         value="similarity"
                                         label="Similarity Search"
                                         data-testid="selection-strategy-similarity"
+                                        disabled={!isSimilaritySupported}
                                         >Similarity Search</Select.Item
                                     >
                                 </Select.Group>

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
     import { page } from '$app/state';
+    import { SortDirection } from '$lib/api/lightly_studio_local';
     import {
         createCombinationSelection,
+        computeSimilarityMetadata,
         computeTypicalityMetadata
     } from '$lib/api/lightly_studio_local/sdk.gen';
     import { Button } from '$lib/components/ui/button';
@@ -10,17 +12,17 @@
     import { Label } from '$lib/components/ui/label';
     import * as Select from '$lib/components/ui/select';
     import { toast } from 'svelte-sonner';
+    import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
     import { useTags } from '$lib/hooks/useTags/useTags';
     import { useSelectionDialog } from '$lib/hooks/useSelectionDialog/useSelectionDialog';
-    import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
     import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
     import type { SelectionRequest } from '$lib/api/lightly_studio_local/types.gen';
 
     // Get collection ID from URL params
     const collectionId = $derived(page.params.collection_id!);
-
-    const { loadTags } = $derived(useTags({ collection_id: collectionId, kind: ['sample'] }));
+    const { loadTags, tags } = $derived(useTags({ collection_id: collectionId, kind: ['sample'] }));
+    const { updateSortBy } = useImageFilters();
 
     const { isSelectionDialogOpen, openSelectionDialog, closeSelectionDialog } =
         useSelectionDialog();
@@ -52,21 +54,31 @@
     );
 
     // Form state
-    let selectionStrategy = $state<'diversity' | 'typicality' | ''>('');
+    let selectionStrategy = $state<'diversity' | 'typicality' | 'similarity' | ''>('');
     let nSamplesToSelect = $state<number>(10);
+    let queryTagId = $state<string>('');
     let selectionResultTagName = $state<string>('');
     let isSubmitting = $state(false);
     let loadingMessage = $state<string>('');
 
     // Form validation
     const isFormValid = $derived(
-        selectionStrategy !== '' && nSamplesToSelect > 0 && selectionResultTagName.trim().length > 0
+        selectionStrategy !== '' &&
+            (selectionStrategy === 'similarity'
+                ? queryTagId !== ''
+                : nSamplesToSelect > 0 && selectionResultTagName.trim().length > 0)
+    );
+
+    const selectedQueryTagName = $derived(
+        $tags.find((tag) => tag.tag_id === queryTagId)?.name ?? 'Select tag'
     );
 
     const noSamples = $derived($filteredSampleCount === 0);
 
     const notEnoughSamples = $derived(
-        $filteredSampleCount > 0 && nSamplesToSelect > $filteredSampleCount
+        selectionStrategy !== 'similarity' &&
+            $filteredSampleCount > 0 &&
+            nSamplesToSelect > $filteredSampleCount
     );
 
     const selectionDescription = $derived(
@@ -90,6 +102,7 @@
 
         selectionStrategy = '';
         nSamplesToSelect = 10;
+        queryTagId = '';
         selectionResultTagName = '';
     }
 
@@ -170,6 +183,39 @@
                 }
 
                 handleSelectionSuccess();
+            } else if (selectionStrategy === 'similarity') {
+                loadingMessage = 'Computing similarity metadata...';
+                const similarityResponse = await computeSimilarityMetadata({
+                    path: { collection_id: collectionId, query_tag_id: queryTagId },
+                    body: {
+                        embedding_model_name: null,
+                        metadata_name: 'similarity'
+                    }
+                });
+
+                responseError = similarityResponse.error as SelectionError;
+                if (similarityResponse.error) {
+                    toast.error(
+                        'Failed to compute similarity metadata: ' +
+                            (responseError.error || 'Unknown error')
+                    );
+                    return;
+                }
+
+                updateSortBy([
+                    {
+                        source: 'metadata',
+                        field_name: 'similarity',
+                        direction: SortDirection.DESC,
+                        is_numeric: true
+                    }
+                ]);
+                toast.success('Similarity sort applied');
+                closeSelectionDialog();
+                selectionStrategy = '';
+                nSamplesToSelect = 10;
+                queryTagId = '';
+                selectionResultTagName = '';
             }
         } catch (error) {
             toast.error('Failed to create selection: ' + (error as Error).message);
@@ -189,7 +235,7 @@
         <Dialog.Content class="border-border bg-background sm:max-w-[425px]">
             <form onsubmit={handleFormSubmit}>
                 <Dialog.Header>
-                    <Dialog.Title class="text-foreground">Create Selection</Dialog.Title>
+                    <Dialog.Title class="text-foreground">Create Sampling</Dialog.Title>
                     <Dialog.Description class="text-foreground">
                         {selectionDescription}
                     </Dialog.Description>
@@ -208,7 +254,9 @@
                                     ? 'Diversity'
                                     : selectionStrategy === 'typicality'
                                       ? 'Typicality'
-                                      : 'Select strategy'}
+                                      : selectionStrategy === 'similarity'
+                                        ? 'Similarity Search'
+                                        : 'Select strategy'}
                             </Select.Trigger>
                             <Select.Content>
                                 <Select.Group>
@@ -224,41 +272,78 @@
                                         data-testid="selection-strategy-typicality"
                                         >Typicality</Select.Item
                                     >
+                                    <Select.Item
+                                        value="similarity"
+                                        label="Similarity Search"
+                                        data-testid="selection-strategy-similarity"
+                                        >Similarity Search</Select.Item
+                                    >
                                 </Select.Group>
                             </Select.Content>
                         </Select.Root>
                     </div>
 
-                    <!-- Number of Samples Input -->
-                    <div class="grid grid-cols-4 items-center gap-4">
-                        <Label for="n-samples" class="text-right text-foreground">
-                            Number of Samples
-                        </Label>
-                        <Input
-                            id="n-samples"
-                            type="number"
-                            bind:value={nSamplesToSelect}
-                            min="1"
-                            class="col-span-3"
-                            placeholder="Enter number of samples"
-                            required
-                            data-testid="selection-dialog-n-samples-input"
-                        />
-                    </div>
+                    {#if selectionStrategy === 'similarity'}
+                        <div class="grid grid-cols-4 items-center gap-4">
+                            <Label for="query-tag" class="text-right text-foreground">
+                                Query Tag
+                            </Label>
+                            <Select.Root type="single" name="query-tag" bind:value={queryTagId}>
+                                <Select.Trigger
+                                    class="col-span-3"
+                                    data-testid="selection-dialog-query-tag-select"
+                                >
+                                    {selectedQueryTagName}
+                                </Select.Trigger>
+                                <Select.Content>
+                                    <Select.Group>
+                                        {#each $tags as tag (tag.tag_id)}
+                                            <Select.Item
+                                                value={tag.tag_id}
+                                                label={tag.name}
+                                                data-testid={`selection-query-tag-${tag.tag_id}`}
+                                            >
+                                                {tag.name}
+                                            </Select.Item>
+                                        {/each}
+                                    </Select.Group>
+                                </Select.Content>
+                            </Select.Root>
+                        </div>
+                    {:else}
+                        <!-- Number of Samples Input -->
+                        <div class="grid grid-cols-4 items-center gap-4">
+                            <Label for="n-samples" class="text-right text-foreground">
+                                Number of Samples
+                            </Label>
+                            <Input
+                                id="n-samples"
+                                type="number"
+                                bind:value={nSamplesToSelect}
+                                min="1"
+                                class="col-span-3"
+                                placeholder="Enter number of samples"
+                                required
+                                data-testid="selection-dialog-n-samples-input"
+                            />
+                        </div>
 
-                    <!-- Tag Name Input -->
-                    <div class="grid grid-cols-4 items-center gap-4">
-                        <Label for="tag-name" class="text-right text-foreground">Tag Name</Label>
-                        <Input
-                            id="tag-name"
-                            type="text"
-                            bind:value={selectionResultTagName}
-                            class="col-span-3"
-                            placeholder="Enter a tag for the sampled subset"
-                            required
-                            data-testid="selection-dialog-tag-name-input"
-                        />
-                    </div>
+                        <!-- Tag Name Input -->
+                        <div class="grid grid-cols-4 items-center gap-4">
+                            <Label for="tag-name" class="text-right text-foreground">
+                                Tag Name
+                            </Label>
+                            <Input
+                                id="tag-name"
+                                type="text"
+                                bind:value={selectionResultTagName}
+                                class="col-span-3"
+                                placeholder="Enter a tag for the sampled subset"
+                                required
+                                data-testid="selection-dialog-tag-name-input"
+                            />
+                        </div>
+                    {/if}
 
                     <!-- Warning when no samples match the current filters -->
                     {#if noSamples}
@@ -297,7 +382,13 @@
                         disabled={!isFormValid || isSubmitting || notEnoughSamples || noSamples}
                         data-testid="selection-dialog-submit"
                     >
-                        {isSubmitting ? loadingMessage || 'Creating...' : 'Create Selection'}
+                        {#if isSubmitting}
+                            {loadingMessage || 'Creating...'}
+                        {:else if selectionStrategy === 'similarity'}
+                            Apply Similarity Search
+                        {:else}
+                            Create Selection
+                        {/if}
                     </Button>
                 </Dialog.Footer>
             </form>

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
@@ -95,9 +95,9 @@
         submitSelection();
     }
 
-    function handleSelectionSuccess() {
+    async function handleSelectionSuccess() {
         toast.success('Selection created successfully');
-        loadTags();
+        await loadTags();
 
         closeSelectionDialog();
 
@@ -139,7 +139,7 @@
                     return;
                 }
 
-                handleSelectionSuccess();
+                await handleSelectionSuccess();
             } else if (selectionStrategy === 'typicality') {
                 // First, compute typicality metadata.
                 loadingMessage = 'Computing typicality metadata...';
@@ -183,7 +183,7 @@
                     return;
                 }
 
-                handleSelectionSuccess();
+                await handleSelectionSuccess();
             } else if (selectionStrategy === 'similarity') {
                 if (!isSimilaritySupported) {
                     toast.error('Similarity search is only available for image collections.');

--- a/lightly_studio_view/src/lib/hooks/useTags/useTags.ts
+++ b/lightly_studio_view/src/lib/hooks/useTags/useTags.ts
@@ -13,7 +13,7 @@ interface UseTagsReturn {
     tagsSelected: Readable<Set<string>>;
     clearTagsSelected: () => void;
     clearTagSelected: (tagId: string) => void;
-    loadTags: () => void;
+    loadTags: () => Promise<void>;
     tagSelectionToggle: (tagId: string) => void;
     isLoading: Readable<boolean>;
     error: Readable<Error | null>;
@@ -28,12 +28,12 @@ export function useTags(options: UseTagsOptions): UseTagsReturn {
     const error = writable<Error | null>(null);
     const isLoading = writable(false);
 
-    const loadTags = () => {
+    const loadTags = async () => {
         if (get(isLoading)) return;
         if (!collection_id) return;
 
         isLoading.set(true);
-        readTags({
+        await readTags({
             path: {
                 collection_id
             }
@@ -74,7 +74,7 @@ export function useTags(options: UseTagsOptions): UseTagsReturn {
 
     // Auto-load tags when hook is initialized
     if (!get(isLoaded) && collection_id) {
-        loadTags();
+        void loadTags();
         isLoaded.set(true);
     }
 


### PR DESCRIPTION
## What has changed and why?
After typicality and diversity, we want to add similarity to the list.

## How has it been tested?
Added tests, also tested manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Similarity Search" sampling strategy: select a query tag/image to apply similarity-based sorting; dialog title now "Create Sampling", includes a Query Tag dropdown and "Apply Similarity Search" action (disabled for unsupported collections like video).

* **Tests**
  * Added unit and end-to-end tests for similarity metadata computation and similarity-based sorting and behavior.

* **Documentation**
  * Changelog updated with "Added similarity selection option."

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->