### PR TITLE
Add interactive plot legend category visibility

### DIFF
--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -108,8 +108,13 @@
         })
     );
     const categoryCount = $derived.by(() => getCategoryCount($colorLegend));
-    const categoryColors = $derived.by(() => getCategoryColors($colorLegend, $hiddenCategories));
-    const legendEntries = $derived.by(() => getLegendEntries($colorLegend, $hiddenCategories));
+    const useLabelColors = $derived($selectedColorByType !== 'metadata');
+    const categoryColors = $derived.by(() =>
+        getCategoryColors($colorLegend, $hiddenCategories, useLabelColors)
+    );
+    const legendEntries = $derived.by(() =>
+        getLegendEntries($colorLegend, $hiddenCategories, useLabelColors)
+    );
     const handleMouseUp = () => {
         const hadRangeSelection = $rangeSelection !== null;
         if (!hadRangeSelection) {

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -17,11 +17,7 @@
     import { useCategoryVisibility } from './useCategoryVisibility/useCategoryVisibility';
     import { isEqual } from 'lodash-es';
     import { NOT_FILTERED_CATEGORY } from './plotCategories';
-    import {
-        getCategoryColors,
-        getCategoryCount,
-        getLegendEntries
-    } from './plotColorUtils';
+    import { getCategoryColors, getCategoryCount, getLegendEntries } from './plotColorUtils';
     import { page } from '$app/state';
     import { isVideosRoute } from '$lib/routes';
     import { usePlotColorByType } from './PlotColorByPopover/usePlotColorByType/usePlotColorByType';

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -14,13 +14,13 @@
     import { usePlotData } from './usePlotData/usePlotData';
     import PlotPanelLegend from './PlotPanelLegend.svelte';
     import PlotColorByPopover from './PlotColorByPopover/PlotColorByPopover.svelte';
+    import { useCategoryVisibility } from './useCategoryVisibility/useCategoryVisibility';
     import { isEqual } from 'lodash-es';
     import { NOT_FILTERED_CATEGORY } from './plotCategories';
     import {
-        FILTERED_COLOR,
         getCategoryColors,
         getCategoryCount,
-        NOT_FILTERED_COLOR
+        getLegendEntries
     } from './plotColorUtils';
     import { page } from '$app/state';
     import { isVideosRoute } from '$lib/routes';
@@ -94,6 +94,12 @@
         })
     );
     const filteredLabel = $derived($colorLegend.get(1) ?? 'Filtered');
+    const {
+        hiddenCategories,
+        toggleCategoryVisibility,
+        focusCategoryVisibility,
+        resetCategoryVisibility
+    } = useCategoryVisibility();
 
     const hasActiveFilter = $derived(filter !== null || activeSampleIds.length > 0);
 
@@ -106,7 +112,8 @@
         })
     );
     const categoryCount = $derived.by(() => getCategoryCount($colorLegend));
-    const categoryColors = $derived.by(() => getCategoryColors($colorLegend));
+    const categoryColors = $derived.by(() => getCategoryColors($colorLegend, $hiddenCategories));
+    const legendEntries = $derived.by(() => getLegendEntries($colorLegend, $hiddenCategories));
     const handleMouseUp = () => {
         const hadRangeSelection = $rangeSelection !== null;
         if (!hadRangeSelection) {
@@ -295,8 +302,16 @@
                         rangeSelection={$rangeSelection}
                     />
                     <PlotPanelLegend
-                        categoryColors={[NOT_FILTERED_COLOR, FILTERED_COLOR]}
+                        {categoryColors}
                         {filteredLabel}
+                        {legendEntries}
+                        onToggleCategory={toggleCategoryVisibility}
+                        onDoubleClickCategory={(category) => {
+                            focusCategoryVisibility(
+                                legendEntries.map((entry) => entry.cat),
+                                category
+                            );
+                        }}
                     />
                 {/if}
             </div>
@@ -316,6 +331,7 @@
                 selectedKey={selectedColorByKey}
                 onSelectedKeyChange={(key) => {
                     selectedColorByKey = key;
+                    resetCategoryVisibility();
                 }}
             />
             <Button

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
@@ -49,10 +49,7 @@
                 onclick={() => onToggleCategory?.(entry.cat)}
                 ondblclick={() => onDoubleClickCategory?.(entry.cat)}
             >
-                <span
-                    class="legend-dot shrink-0"
-                    style={`background-color: ${entry.color}`}
-                ></span>
+                <span class="legend-dot shrink-0" style={`background-color: ${entry.color}`}></span>
                 <span class="truncate">{entry.label}</span>
             </button>
         {/each}

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
@@ -1,26 +1,62 @@
 <script lang="ts">
+    interface LegendEntry {
+        cat: number;
+        label: string;
+        color: string;
+        hidden: boolean;
+    }
+
     interface Props {
         categoryColors: string[];
         filteredLabel?: string;
+        legendEntries?: LegendEntry[];
+        onToggleCategory?: (cat: number) => void;
+        onDoubleClickCategory?: (cat: number) => void;
     }
 
-    let { categoryColors, filteredLabel = 'Filtered' }: Props = $props();
+    let {
+        categoryColors,
+        filteredLabel = 'Filtered',
+        legendEntries = [],
+        onToggleCategory,
+        onDoubleClickCategory
+    }: Props = $props();
 </script>
 
 <div
-    class="absolute bottom-1 left-3 flex items-start gap-1.5 rounded-md border border-white/10 bg-black/60 px-2 py-1 text-xs text-muted-foreground backdrop-blur-sm"
+    class="absolute bottom-1 left-3 flex max-h-[calc(100%-0.5rem)] flex-col items-start gap-1 overflow-y-auto rounded-md border border-white/10 bg-black/60 px-2 py-1 text-xs text-muted-foreground backdrop-blur-sm"
     data-testid="plot-legend"
 >
-    <div class="flex flex-col items-start gap-1">
-        <span class="flex items-center gap-1.5">
-            <span class="legend-dot" style={`background-color: ${categoryColors[0]}`}></span>
-            Not Filtered
-        </span>
-        <span class="flex items-center gap-1.5">
-            <span class="legend-dot" style={`background-color: ${categoryColors[1]}`}></span>
-            {filteredLabel}
-        </span>
-    </div>
+    <span class="flex items-center gap-1.5">
+        <span class="legend-dot" style={`background-color: ${categoryColors[0]}`}></span>
+        Not Filtered
+    </span>
+    <span class="flex items-center gap-1.5">
+        <span class="legend-dot" style={`background-color: ${categoryColors[1]}`}></span>
+        {filteredLabel}
+    </span>
+    {#if legendEntries.length > 0}
+        <span class="my-0.5 w-full border-t border-white/10"></span>
+        {#each legendEntries as entry (entry.cat)}
+            <button
+                type="button"
+                class="flex w-full cursor-pointer items-center gap-1.5 rounded text-left transition-opacity hover:opacity-80 {entry.hidden
+                    ? 'opacity-40'
+                    : ''}"
+                data-testid={`plot-legend-entry-${entry.cat}`}
+                aria-pressed={entry.hidden}
+                title={entry.hidden ? 'Show category' : 'Hide category'}
+                onclick={() => onToggleCategory?.(entry.cat)}
+                ondblclick={() => onDoubleClickCategory?.(entry.cat)}
+            >
+                <span
+                    class="legend-dot shrink-0"
+                    style={`background-color: ${entry.color}`}
+                ></span>
+                <span class="truncate">{entry.label}</span>
+            </button>
+        {/each}
+    {/if}
 </div>
 
 <style>

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+    import { cn } from '$lib/utils';
+
     interface LegendEntry {
         cat: number;
         label: string;
@@ -40,9 +42,10 @@
         {#each legendEntries as entry (entry.cat)}
             <button
                 type="button"
-                class="flex w-full cursor-pointer items-center gap-1.5 rounded text-left transition-opacity hover:opacity-80 {entry.hidden
-                    ? 'opacity-40'
-                    : ''}"
+                class={cn(
+                    'flex w-full cursor-pointer items-center gap-1.5 rounded text-left transition-opacity hover:opacity-80',
+                    entry.hidden && 'opacity-40'
+                )}
                 data-testid={`plot-legend-entry-${entry.cat}`}
                 aria-pressed={entry.hidden}
                 title={entry.hidden ? 'Show category' : 'Hide category'}

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.test.ts
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import PlotPanelLegend from './PlotPanelLegend.svelte';
+import { FILTERED_COLOR, NOT_FILTERED_COLOR } from './plotColorUtils';
+
+describe('PlotPanelLegend', () => {
+    it('renders the fixed entries and the custom legend list', () => {
+        render(PlotPanelLegend, {
+            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'hsl(0, 70%, 55%)'],
+            filteredLabel: 'Unassigned',
+            legendEntries: [
+                { cat: 2, label: 'metadata.split: train', color: 'hsl(0, 70%, 55%)', hidden: false }
+            ]
+        });
+
+        expect(screen.getByTestId('plot-legend')).toHaveTextContent('Not Filtered');
+        expect(screen.getByTestId('plot-legend')).toHaveTextContent('Unassigned');
+        expect(screen.getByRole('button', { name: 'metadata.split: train' })).toBeInTheDocument();
+    });
+
+    it('calls the single-click handler for custom legend entries', async () => {
+        const onToggleCategory = vi.fn();
+
+        render(PlotPanelLegend, {
+            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'hsl(0, 70%, 55%)'],
+            legendEntries: [{ cat: 2, label: 'Train', color: 'hsl(0, 70%, 55%)', hidden: false }],
+            onToggleCategory
+        });
+
+        await fireEvent.click(screen.getByTestId('plot-legend-entry-2'));
+
+        expect(onToggleCategory).toHaveBeenCalledWith(2);
+    });
+
+    it('calls the double-click handler for custom legend entries', async () => {
+        const onDoubleClickCategory = vi.fn();
+
+        render(PlotPanelLegend, {
+            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'hsl(0, 70%, 55%)'],
+            legendEntries: [{ cat: 2, label: 'Train', color: 'hsl(0, 70%, 55%)', hidden: false }],
+            onDoubleClickCategory
+        });
+
+        await fireEvent.dblClick(screen.getByTestId('plot-legend-entry-2'));
+
+        expect(onDoubleClickCategory).toHaveBeenCalledWith(2);
+    });
+});

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
@@ -76,6 +76,22 @@ describe('plotColorUtils', () => {
         ]);
     });
 
+    it('uses discrete legend colors when label colors are disabled', () => {
+        expect(
+            getLegendEntries(
+                new Map([
+                    [2, 'Train'],
+                    [3, 'Validation']
+                ]),
+                new Set(),
+                false
+            )
+        ).toEqual([
+            { cat: 2, label: 'Train', color: 'hsl(0, 70%, 55%)', hidden: false },
+            { cat: 3, label: 'Validation', color: 'hsl(180, 70%, 55%)', hidden: false }
+        ]);
+    });
+
     it('returns filtered color for hidden categories', () => {
         const legend = new Map([
             [0, ''],

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
@@ -7,7 +7,6 @@ import {
     getLegendEntries,
     NOT_FILTERED_COLOR
 } from './plotColorUtils';
-import { getColorByLabel } from '$lib/utils/getColorByLabel';
 
 describe('plotColorUtils', () => {
     it('returns the reserved count when the legend is empty', () => {
@@ -34,7 +33,7 @@ describe('plotColorUtils', () => {
             [3, 'Validation']
         ]);
 
-        expect(getCategoryColors(colorLegend)).toEqual([
+        expect(getCategoryColors(colorLegend, new Set(), true)).toEqual([
             NOT_FILTERED_COLOR,
             FILTERED_COLOR,
             getColorByLabel('Train').color,
@@ -48,7 +47,7 @@ describe('plotColorUtils', () => {
             [3, 'Validation']
         ]);
 
-        expect(getCategoryColors(colorLegend, new Set([3]))).toEqual([
+        expect(getCategoryColors(colorLegend, new Set([3]), true)).toEqual([
             NOT_FILTERED_COLOR,
             FILTERED_COLOR,
             getColorByLabel('Train').color,
@@ -68,7 +67,12 @@ describe('plotColorUtils', () => {
             )
         ).toEqual([
             { cat: 2, label: 'Train', color: getColorByLabel('Train').color, hidden: false },
-            { cat: 3, label: 'Validation', color: getColorByLabel('Validation').color, hidden: true }
+            {
+                cat: 3,
+                label: 'Validation',
+                color: getColorByLabel('Validation').color,
+                hidden: true
+            }
         ]);
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
@@ -4,57 +4,71 @@ import {
     FILTERED_COLOR,
     getCategoryColors,
     getCategoryCount,
+    getLegendEntries,
     NOT_FILTERED_COLOR
 } from './plotColorUtils';
+import { getColorByLabel } from '$lib/utils/getColorByLabel';
 
 describe('plotColorUtils', () => {
-    it('returns the reserved count when category data is empty', () => {
+    it('returns the reserved count when the legend is empty', () => {
         expect(getCategoryCount(undefined)).toBe(2);
-        expect(getCategoryCount(null)).toBe(2);
-        expect(getCategoryCount(new Map())).toBe(2);
     });
 
-    it('returns max category plus one', () => {
-        expect(
-            getCategoryCount(
-                new Map([
-                    [0, 'a'],
-                    [1, 'b'],
-                    [2, 'c'],
-                    [3, 'd']
-                ])
-            )
-        ).toBe(4);
-        expect(
-            getCategoryCount(
-                new Map([
-                    [0, 'a'],
-                    [1, 'b']
-                ])
-            )
-        ).toBe(2);
+    it('returns the highest legend category plus one', () => {
+        const colorLegend = new Map([
+            [1, 'Filtered'],
+            [2, 'Train'],
+            [4, 'Validation']
+        ]);
+
+        expect(getCategoryCount(colorLegend)).toBe(5);
     });
 
     it('keeps the reserved categories fixed', () => {
-        const legend = new Map([
-            [0, 'none'],
-            [1, 'filtered']
-        ]);
-        expect(getCategoryColors(legend)).toEqual([NOT_FILTERED_COLOR, FILTERED_COLOR]);
+        expect(getCategoryColors(undefined)).toEqual([NOT_FILTERED_COLOR, FILTERED_COLOR]);
     });
 
-    it('uses hsl colors for categories above the reserved slots', () => {
-        const legend = new Map([
-            [0, ''],
-            [1, ''],
-            [2, ''],
-            [3, '']
+    it('uses label-based colors for categories above the reserved slots', () => {
+        const colorLegend = new Map([
+            [2, 'Train'],
+            [3, 'Validation']
         ]);
-        expect(getCategoryColors(legend)).toEqual([
+
+        expect(getCategoryColors(colorLegend)).toEqual([
             NOT_FILTERED_COLOR,
             FILTERED_COLOR,
-            'hsl(0, 70%, 55%)',
-            'hsl(180, 70%, 55%)'
+            getColorByLabel('Train').color,
+            getColorByLabel('Validation').color
+        ]);
+    });
+
+    it('renders hidden categories with the filtered color', () => {
+        const colorLegend = new Map([
+            [2, 'Train'],
+            [3, 'Validation']
+        ]);
+
+        expect(getCategoryColors(colorLegend, new Set([3]))).toEqual([
+            NOT_FILTERED_COLOR,
+            FILTERED_COLOR,
+            getColorByLabel('Train').color,
+            FILTERED_COLOR
+        ]);
+    });
+
+    it('builds legend entries from categories above the reserved slots', () => {
+        expect(
+            getLegendEntries(
+                new Map([
+                    [1, 'Filtered'],
+                    [3, 'Validation'],
+                    [2, 'Train']
+                ]),
+                new Set([3])
+            )
+        ).toEqual([
+            { cat: 2, label: 'Train', color: getColorByLabel('Train').color, hidden: false },
+            { cat: 3, label: 'Validation', color: getColorByLabel('Validation').color, hidden: true }
         ]);
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -74,7 +74,8 @@ export function getCategoryColors(
 
 export function getLegendEntries(
     colorLegend?: ReadonlyMap<number, string> | null,
-    hiddenCategories: ReadonlySet<number> = new Set()
+    hiddenCategories: ReadonlySet<number> = new Set(),
+    useLabelColors: boolean = true
 ): LegendEntry[] {
     if (!colorLegend || colorLegend.size === 0) {
         return [];
@@ -88,7 +89,7 @@ export function getLegendEntries(
         .map(([category, label]) => ({
             cat: category,
             label,
-            color: getBaseCategoryColor(category, categoryCount, label),
+            color: getBaseCategoryColor(category, categoryCount, useLabelColors ? label : ''),
             hidden: hiddenCategories.has(category)
         }));
 }

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -7,6 +7,13 @@ const RESERVED_CATEGORY_COUNT = 2;
 export const NOT_FILTERED_COLOR = '#9CA3AF';
 export const FILTERED_COLOR = '#F59E0B';
 
+interface LegendEntry {
+    cat: number;
+    label: string;
+    color: string;
+    hidden: boolean;
+}
+
 function getMaxCategoryFromLegend(colorLegend?: ReadonlyMap<number, string> | null): number {
     if (!colorLegend || colorLegend.size === 0) {
         return RESERVED_CATEGORY_COUNT - 1;
@@ -68,7 +75,7 @@ export function getCategoryColors(
 export function getLegendEntries(
     colorLegend?: ReadonlyMap<number, string> | null,
     hiddenCategories: ReadonlySet<number> = new Set()
-) {
+): LegendEntry[] {
     if (!colorLegend || colorLegend.size === 0) {
         return [];
     }

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -64,3 +64,24 @@ export function getCategoryColors(
         return getBaseCategoryColor(category, categoryCount, label);
     });
 }
+
+export function getLegendEntries(
+    colorLegend?: ReadonlyMap<number, string> | null,
+    hiddenCategories: ReadonlySet<number> = new Set()
+) {
+    if (!colorLegend || colorLegend.size === 0) {
+        return [];
+    }
+
+    const categoryCount = getCategoryCount(colorLegend);
+
+    return [...colorLegend.entries()]
+        .filter(([category]) => category >= RESERVED_CATEGORY_COUNT)
+        .sort(([leftCategory], [rightCategory]) => leftCategory - rightCategory)
+        .map(([category, label]) => ({
+            cat: category,
+            label,
+            color: getBaseCategoryColor(category, categoryCount, label),
+            hidden: hiddenCategories.has(category)
+        }));
+}

--- a/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.test.ts
@@ -1,0 +1,36 @@
+import { get } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+import { useCategoryVisibility } from './useCategoryVisibility';
+
+describe('useCategoryVisibility', () => {
+    it('toggles hidden categories', () => {
+        const { hiddenCategories, toggleCategoryVisibility } = useCategoryVisibility();
+
+        toggleCategoryVisibility(2);
+        expect(get(hiddenCategories)).toEqual(new Set([2]));
+
+        toggleCategoryVisibility(2);
+        expect(get(hiddenCategories)).toEqual(new Set());
+    });
+
+    it('focuses one category and restores all categories on a second focus', () => {
+        const { hiddenCategories, focusCategoryVisibility } = useCategoryVisibility();
+        const categories = [2, 3, 4];
+
+        focusCategoryVisibility(categories, 3);
+        expect(get(hiddenCategories)).toEqual(new Set([2, 4]));
+
+        focusCategoryVisibility(categories, 3);
+        expect(get(hiddenCategories)).toEqual(new Set());
+    });
+
+    it('resets hidden categories', () => {
+        const { hiddenCategories, resetCategoryVisibility, toggleCategoryVisibility } =
+            useCategoryVisibility();
+
+        toggleCategoryVisibility(4);
+        resetCategoryVisibility();
+
+        expect(get(hiddenCategories)).toEqual(new Set());
+    });
+});

--- a/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.ts
@@ -1,0 +1,69 @@
+import { writable, type Readable } from 'svelte/store';
+
+interface UseCategoryVisibilityReturn {
+    hiddenCategories: Readable<Set<number>>;
+    toggleCategoryVisibility: (category: number) => void;
+    focusCategoryVisibility: (categories: number[], category: number) => void;
+    resetCategoryVisibility: () => void;
+}
+
+/**
+ * Tracks hidden plot categories and exposes focused visibility helpers for the PlotPanel.
+ */
+export const useCategoryVisibility = (): UseCategoryVisibilityReturn => {
+    const hiddenCategories = writable(new Set<number>());
+
+    const getToggledHiddenCategories = (
+        currentHiddenCategories: ReadonlySet<number>,
+        category: number
+    ) => {
+        const nextHiddenCategories = new Set(currentHiddenCategories);
+
+        if (nextHiddenCategories.has(category)) {
+            nextHiddenCategories.delete(category);
+        } else {
+            nextHiddenCategories.add(category);
+        }
+
+        return nextHiddenCategories;
+    };
+
+    const getFocusedHiddenCategories = (
+        currentHiddenCategories: ReadonlySet<number>,
+        categories: number[],
+        category: number
+    ) => {
+        const visibleCategories = categories.filter(
+            (visibleCategory) => !currentHiddenCategories.has(visibleCategory)
+        );
+
+        if (visibleCategories.length === 1 && visibleCategories[0] === category) {
+            return new Set<number>();
+        }
+
+        return new Set(categories.filter((visibleCategory) => visibleCategory !== category));
+    };
+
+    const toggleCategoryVisibility = (category: number) => {
+        hiddenCategories.update((currentHiddenCategories) =>
+            getToggledHiddenCategories(currentHiddenCategories, category)
+        );
+    };
+
+    const focusCategoryVisibility = (categories: number[], category: number) => {
+        hiddenCategories.update((currentHiddenCategories) =>
+            getFocusedHiddenCategories(currentHiddenCategories, categories, category)
+        );
+    };
+
+    const resetCategoryVisibility = () => {
+        hiddenCategories.set(new Set<number>());
+    };
+
+    return {
+        hiddenCategories,
+        toggleCategoryVisibility,
+        focusCategoryVisibility,
+        resetCategoryVisibility
+    };
+};

--- a/lightly_studio_view/src/lib/utils/getColorByLabel.test.ts
+++ b/lightly_studio_view/src/lib/utils/getColorByLabel.test.ts
@@ -14,22 +14,4 @@ describe('getColorByLabel', () => {
         const result2 = getColorByLabel('test2');
         expect(result1).not.toEqual(result2);
     });
-
-    test('returns different colors for different strings 1', () => {
-        const result1 = getColorByLabel('afternoon');
-        const result2 = getColorByLabel('night');
-        expect(result1).not.toEqual(result2);
-    });
-
-    test('returns different colors for different strings 2', () => {
-        const result1 = getColorByLabel('1');
-        const result2 = getColorByLabel('1');
-        expect(result1).toEqual(result2);
-    });
-
-    test('returns different colors for different strings 3', () => {
-        const result1 = getColorByLabel('1-2');
-        const result2 = getColorByLabel('1-2');
-        expect(result1).toEqual(result2);
-    });
 });

--- a/lightly_studio_view/src/lib/utils/getColorByLabel.test.ts
+++ b/lightly_studio_view/src/lib/utils/getColorByLabel.test.ts
@@ -14,4 +14,22 @@ describe('getColorByLabel', () => {
         const result2 = getColorByLabel('test2');
         expect(result1).not.toEqual(result2);
     });
+
+    test('returns different colors for different strings 1', () => {
+        const result1 = getColorByLabel('afternoon');
+        const result2 = getColorByLabel('night');
+        expect(result1).not.toEqual(result2);
+    });
+
+    test('returns different colors for different strings 2', () => {
+        const result1 = getColorByLabel('1');
+        const result2 = getColorByLabel('1');
+        expect(result1).toEqual(result2);
+    });
+
+    test('returns different colors for different strings 3', () => {
+        const result1 = getColorByLabel('1-2');
+        const result2 = getColorByLabel('1-2');
+        expect(result1).toEqual(result2);
+    });
 });


### PR DESCRIPTION
## What has changed and why?

Added category visibility controls to the plot legend in the embedding plot.

Key changes:

- Add a `useCategoryVisibility` store to track hidden categories and support toggle, focus, and reset behavior
- Update `PlotPanelLegend` to render dynamic category entries that can be clicked to hide/show categories

## How has it been tested?

Unit tests + manual testing.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legend supports toggling per-category visibility (single-click) and focusing a category (double-click)
  * Visibility resets when the active "color by" selection changes
  * Legend area is scrollable and always shows a "Not Filtered" label plus filtered label

* **Tests**
  * Added tests covering legend rendering, single-/double-click interactions, and category visibility store behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->