### PR TITLE
Add frontend similarity selection UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sample selection respects the current image or video filters.
 - Added sort-by support via GUI.
+- Added similarity selection option.
 
 ### Changed
 

--- a/lightly_studio_view/e2e/general/samples-grid.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/samples-grid.e2e-test.ts
@@ -180,8 +180,7 @@ test('Diversity selection creates tag with correct number of samples', async ({
 
     // Filter by the new tag and verify the correct number of samples.
     await samplesPage.pressTag(selectionTagName);
-    const sampleCount = await samplesPage.getSamples().count();
-    expect(sampleCount).toBe(nSamples);
+    await expect(samplesPage.getSamples()).toHaveCount(nSamples);
 });
 
 test('Typicality selection creates tag with correct number of samples', async ({
@@ -219,8 +218,7 @@ test('Typicality selection creates tag with correct number of samples', async ({
 
     // Filter by the new tag and verify the correct number of samples.
     await samplesPage.pressTag(selectionTagName);
-    const sampleCount = await samplesPage.getSamples().count();
-    expect(sampleCount).toBe(nSamples);
+    await expect(samplesPage.getSamples()).toHaveCount(nSamples);
 });
 
 test('Selection shows error toast when tag already exists', async ({ page, samplesPage }) => {

--- a/lightly_studio_view/e2e/general/samples-grid.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/samples-grid.e2e-test.ts
@@ -178,9 +178,8 @@ test('Diversity selection creates tag with correct number of samples', async ({
     const tagNames = await samplesPage.getTagNames();
     expect(tagNames).toContain(selectionTagName);
 
-    // Filter by the new tag and verify the correct number of samples.
-    await samplesPage.pressTag(selectionTagName);
-    await expect(samplesPage.getSamples()).toHaveCount(nSamples);
+    // The newly created selection tag is already applied, so the grid should show the subset.
+    await expect(samplesPage.getSamples()).toHaveCount(nSamples, { timeout: 10000 });
 });
 
 test('Typicality selection creates tag with correct number of samples', async ({
@@ -216,9 +215,8 @@ test('Typicality selection creates tag with correct number of samples', async ({
     const tagNames = await samplesPage.getTagNames();
     expect(tagNames).toContain(selectionTagName);
 
-    // Filter by the new tag and verify the correct number of samples.
-    await samplesPage.pressTag(selectionTagName);
-    await expect(samplesPage.getSamples()).toHaveCount(nSamples);
+    // The newly created selection tag is already applied, so the grid should show the subset.
+    await expect(samplesPage.getSamples()).toHaveCount(nSamples, { timeout: 10000 });
 });
 
 test('Selection shows error toast when tag already exists', async ({ page, samplesPage }) => {

--- a/lightly_studio_view/e2e/pages/samples-page.ts
+++ b/lightly_studio_view/e2e/pages/samples-page.ts
@@ -1,6 +1,8 @@
 import { expect, type Page } from '@playwright/test';
 import { pressButton, waitForRequestsToSettle } from '../utils';
 
+type SelectionStrategy = 'diversity' | 'typicality' | 'similarity';
+
 export class SamplesPage {
     constructor(public readonly page: Page) {
         this.page = page;
@@ -133,18 +135,7 @@ export class SamplesPage {
     }
 
     async createSelection(
-        strategy: 'diversity' | 'typicality',
-        nSamples: number,
-        tagName: string
-    ): Promise<void>;
-    async createSelection(
-        strategy: 'similarity',
-        nSamples: number,
-        tagName: string,
-        queryTagId: string
-    ): Promise<void>;
-    async createSelection(
-        strategy: 'diversity' | 'typicality' | 'similarity',
+        strategy: SelectionStrategy,
         nSamples: number,
         tagName: string,
         queryTagId?: string

--- a/lightly_studio_view/e2e/pages/samples-page.ts
+++ b/lightly_studio_view/e2e/pages/samples-page.ts
@@ -136,19 +136,40 @@ export class SamplesPage {
         strategy: 'diversity' | 'typicality',
         nSamples: number,
         tagName: string
+    ): Promise<void>;
+    async createSelection(
+        strategy: 'similarity',
+        nSamples: number,
+        tagName: string,
+        queryTagId: string
+    ): Promise<void>;
+    async createSelection(
+        strategy: 'diversity' | 'typicality' | 'similarity',
+        nSamples: number,
+        tagName: string,
+        queryTagId?: string
     ): Promise<void> {
+        if (strategy === 'similarity' && !queryTagId) {
+            throw new Error('queryTagId required for similarity strategy');
+        }
+
         await this.page.getByTestId('menu-trigger').click();
         await this.page.getByTestId('menu-selection').click();
 
         await this.page.getByTestId('selection-dialog-strategy-select').click();
         await this.page.getByTestId(`selection-strategy-${strategy}`).click();
 
-        const nSamplesInput = this.page.getByTestId('selection-dialog-n-samples-input');
-        await nSamplesInput.clear();
-        await nSamplesInput.fill(nSamples.toString());
+        if (strategy === 'similarity') {
+            await this.page.getByTestId('selection-dialog-query-tag-select').click();
+            await this.page.getByTestId(`selection-query-tag-${queryTagId}`).click();
+        } else {
+            const nSamplesInput = this.page.getByTestId('selection-dialog-n-samples-input');
+            await nSamplesInput.clear();
+            await nSamplesInput.fill(nSamples.toString());
 
-        const tagNameInput = this.page.getByTestId('selection-dialog-tag-name-input');
-        await tagNameInput.fill(tagName);
+            const tagNameInput = this.page.getByTestId('selection-dialog-tag-name-input');
+            await tagNameInput.fill(tagName);
+        }
 
         await pressButton(this.page, 'selection-dialog-submit');
     }
@@ -164,15 +185,19 @@ export class SamplesPage {
     async pressTag(tagName: string): Promise<void> {
         await expect(this.page.getByTestId('sample-grid-item').first()).toBeVisible();
 
-        const tagLabels = this.page.getByTestId('tags-menu-label');
-        const labelCount = await tagLabels.count();
-        for (let i = 0; i < labelCount; i++) {
-            const labelText = await tagLabels.nth(i).textContent();
-            if (labelText === tagName) {
-                await tagLabels.nth(i).click();
-                break;
-            }
-        }
+        const tagLabel = this.page.getByTestId('tags-menu-label').getByText(tagName, {
+            exact: true
+        });
+        await expect(tagLabel).toBeVisible();
+
+        const listResponsePromise = this.page.waitForResponse(
+            (response) => response.url().includes('/images/list') && response.status() === 200,
+            { timeout: 15000 }
+        );
+
+        await tagLabel.click();
+        await listResponsePromise;
+        await waitForRequestsToSettle(this.page, '/images/list');
 
         await this.getSamples().first().waitFor({
             state: 'attached',
@@ -215,6 +240,13 @@ export class SamplesPage {
             if (labelText) tagLabelsText.push(labelText);
         }
         return tagLabelsText;
+    }
+
+    async getTagIdByName(tagName: string): Promise<string | null> {
+        const tagLabel = this.page.getByTestId('tags-menu-label').getByText(tagName, {
+            exact: true
+        });
+        return tagLabel.getAttribute('for');
     }
 
     async getNumSelectedSamples(): Promise<number> {

--- a/lightly_studio_view/src/lib/components/SegmentTags/SegmentTags.test.ts
+++ b/lightly_studio_view/src/lib/components/SegmentTags/SegmentTags.test.ts
@@ -52,6 +52,7 @@ vi.spyOn(hooks, 'useTags').mockImplementation(() => ({
     tagsSelected: writable(new Set<string>()),
     clearTagsSelected: vi.fn(),
     clearTagSelected: vi.fn(),
+    setTagSelected: vi.fn(),
     tagSelectionToggle: vi.fn(),
     isLoading: writable(false),
     error: writable(null)

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
@@ -1,5 +1,6 @@
 import {
     createCombinationSelection,
+    computeSimilarityMetadata,
     computeTypicalityMetadata
 } from '$lib/api/lightly_studio_local/sdk.gen';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
@@ -21,13 +22,20 @@ vi.mock('$lib/api/lightly_studio_local/sdk.gen', async () => {
     return {
         ...actual,
         createCombinationSelection: vi.fn(),
+        computeSimilarityMetadata: vi.fn(),
         computeTypicalityMetadata: vi.fn()
     };
 });
 
+let tagsStore: Writable<unknown[]>;
+const loadTagsMock = vi.fn();
+const setTagSelectedMock = vi.fn();
+
 vi.mock('$lib/hooks/useTags/useTags', () => ({
     useTags: () => ({
-        loadTags: vi.fn()
+        tags: tagsStore,
+        loadTags: loadTagsMock,
+        setTagSelected: setTagSelectedMock
     })
 }));
 
@@ -49,10 +57,12 @@ vi.mock('svelte-sonner', () => ({
 let imageFilterStore: Writable<Record<string, unknown> | null>;
 let videoFilterStore: Writable<Record<string, unknown> | null>;
 let filteredSampleCountStore: Writable<number>;
+const updateSortByMock = vi.fn();
 
 vi.mock('$lib/hooks/useImageFilters/useImageFilters', () => ({
     useImageFilters: () => ({
-        imageFilter: imageFilterStore
+        imageFilter: imageFilterStore,
+        updateSortBy: updateSortByMock
     })
 }));
 
@@ -79,6 +89,25 @@ describe('CreateSelectionDialog', () => {
         imageFilterStore = writable(null);
         videoFilterStore = writable(null);
         filteredSampleCountStore = writable(0);
+        tagsStore = writable([
+            { tag_id: 'tag-1', name: 'Query Tag', description: null, kind: 'sample' as const }
+        ]);
+        updateSortByMock.mockReset();
+        loadTagsMock.mockReset();
+        setTagSelectedMock.mockReset();
+
+        loadTagsMock.mockImplementation(async () => {
+            tagsStore.set([
+                { tag_id: 'tag-1', name: 'Query Tag', description: null, kind: 'sample' },
+                { tag_id: 'new-tag-id', name: 'my-tag', description: null, kind: 'sample' },
+                {
+                    tag_id: 'similarity-tag-id',
+                    name: 'similarity-tag',
+                    description: null,
+                    kind: 'sample'
+                }
+            ]);
+        });
 
         vi.mocked(createCombinationSelection).mockResolvedValue({
             data: undefined,
@@ -88,6 +117,12 @@ describe('CreateSelectionDialog', () => {
         });
         vi.mocked(computeTypicalityMetadata).mockResolvedValue({
             data: undefined,
+            error: undefined,
+            request: mockRequest,
+            response: mockResponse
+        });
+        vi.mocked(computeSimilarityMetadata).mockResolvedValue({
+            data: 'similarity',
             error: undefined,
             request: mockRequest,
             response: mockResponse
@@ -117,6 +152,11 @@ describe('CreateSelectionDialog', () => {
 
         render(CreateSelectionDialog);
 
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-diversity'));
+
         const input = screen.getByTestId('selection-dialog-n-samples-input');
         await fireEvent.input(input, { target: { value: '10' } });
 
@@ -125,22 +165,37 @@ describe('CreateSelectionDialog', () => {
         ).toBeInTheDocument();
     });
 
-    it('does not show the not enough samples warning when filteredSampleCount is 0', () => {
+    it('does not show the not enough samples warning when filteredSampleCount is 0', async () => {
         render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-diversity'));
 
         expect(
             screen.queryByTestId('selection-dialog-not-enough-samples-warning')
         ).not.toBeInTheDocument();
     });
 
-    it('shows the no samples warning when filteredSampleCount is 0', () => {
+    it('shows the no samples warning when filteredSampleCount is 0', async () => {
         render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-diversity'));
 
         expect(screen.getByTestId('selection-dialog-no-samples-warning')).toBeInTheDocument();
     });
 
-    it('disables the submit button when filteredSampleCount is 0', () => {
+    it('disables the submit button when filteredSampleCount is 0', async () => {
         render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-diversity'));
 
         expect(screen.getByTestId('selection-dialog-submit')).toBeDisabled();
     });
@@ -149,6 +204,11 @@ describe('CreateSelectionDialog', () => {
         filteredSampleCountStore.set(5);
 
         render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-diversity'));
 
         const input = screen.getByTestId('selection-dialog-n-samples-input');
         await fireEvent.input(input, { target: { value: '10' } });
@@ -181,6 +241,10 @@ describe('CreateSelectionDialog', () => {
                 })
             );
         });
+
+        await waitFor(() => {
+            expect(setTagSelectedMock).toHaveBeenCalledWith('new-tag-id', true);
+        });
     });
 
     it('passes the video filter to the diversity selection API call for video collections', async () => {
@@ -209,5 +273,73 @@ describe('CreateSelectionDialog', () => {
                 })
             );
         });
+    });
+
+    it('computes similarity metadata, applies similarity sorting, and creates selection', async () => {
+        filteredSampleCountStore.set(100);
+
+        render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-similarity'));
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-query-tag-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-query-tag-tag-1'));
+
+        await fireEvent.input(screen.getByTestId('selection-dialog-tag-name-input'), {
+            target: { value: 'similarity-tag' }
+        });
+        await fireEvent.input(screen.getByTestId('selection-dialog-n-samples-input'), {
+            target: { value: '20' }
+        });
+
+        await fireEvent.click(screen.getByTestId('selection-dialog-submit'));
+
+        await waitFor(() => {
+            expect(computeSimilarityMetadata).toHaveBeenCalledWith({
+                path: { collection_id: 'test-collection-id', query_tag_id: 'tag-1' },
+                body: {
+                    embedding_model_name: null,
+                    metadata_name: 'similarity'
+                }
+            });
+        });
+
+        await waitFor(() => {
+            expect(createCombinationSelection).toHaveBeenCalledWith({
+                path: { collection_id: 'test-collection-id' },
+                body: expect.objectContaining({
+                    n_samples_to_select: 20,
+                    selection_result_tag_name: 'similarity-tag',
+                    strategies: [
+                        {
+                            strategy_name: 'weights',
+                            metadata_key: 'similarity'
+                        }
+                    ]
+                })
+            });
+        });
+
+        await waitFor(() => {
+            expect(setTagSelectedMock).toHaveBeenCalledWith('similarity-tag-id', true);
+        });
+    });
+
+    it('disables similarity for video collections', async () => {
+        pageMock.data.collection.sample_type = 'video';
+
+        render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+
+        expect(await screen.findByTestId('selection-strategy-similarity')).toHaveAttribute(
+            'data-disabled'
+        );
     });
 });

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
@@ -8,6 +8,13 @@ import { readable, writable, type Writable } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import CreateSelectionDialog from './CreateSelectionDialog.svelte';
 
+type MockTag = {
+    tag_id: string;
+    name: string;
+    description: string | null;
+    kind: 'sample';
+};
+
 const pageMock = vi.hoisted(() => ({
     params: { collection_id: 'test-collection-id' },
     data: { collection: { sample_type: 'image' as string } }
@@ -27,7 +34,7 @@ vi.mock('$lib/api/lightly_studio_local/sdk.gen', async () => {
     };
 });
 
-let tagsStore: Writable<unknown[]>;
+let tagsStore: Writable<MockTag[]>;
 const loadTagsMock = vi.fn();
 const setTagSelectedMock = vi.fn();
 
@@ -340,6 +347,25 @@ describe('CreateSelectionDialog', () => {
 
         expect(await screen.findByTestId('selection-strategy-similarity')).toHaveAttribute(
             'data-disabled'
+        );
+    });
+
+    it('shows an empty state when no sample tags are available for similarity', async () => {
+        tagsStore = writable([]);
+        filteredSampleCountStore.set(100);
+
+        render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-similarity'));
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-query-tag-select'), {
+            key: 'Enter'
+        });
+
+        expect(await screen.findByTestId('selection-dialog-no-query-tags')).toHaveTextContent(
+            'No sample tags available.'
         );
     });
 });

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
@@ -288,15 +288,24 @@
                                 </Select.Trigger>
                                 <Select.Content>
                                     <Select.Group>
-                                        {#each $tags as tag (tag.tag_id)}
-                                            <Select.Item
-                                                value={tag.tag_id}
-                                                label={tag.name}
-                                                data-testid={`selection-query-tag-${tag.tag_id}`}
+                                        {#if $tags.length === 0}
+                                            <div
+                                                class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
+                                                data-testid="selection-dialog-no-query-tags"
                                             >
-                                                {tag.name}
-                                            </Select.Item>
-                                        {/each}
+                                                No sample tags available.
+                                            </div>
+                                        {:else}
+                                            {#each $tags as tag (tag.tag_id)}
+                                                <Select.Item
+                                                    value={tag.tag_id}
+                                                    label={tag.name}
+                                                    data-testid={`selection-query-tag-${tag.tag_id}`}
+                                                >
+                                                    {tag.name}
+                                                </Select.Item>
+                                            {/each}
+                                        {/if}
                                     </Select.Group>
                                 </Select.Content>
                             </Select.Root>

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
@@ -2,6 +2,7 @@
     import { page } from '$app/state';
     import {
         createCombinationSelection,
+        computeSimilarityMetadata,
         computeTypicalityMetadata
     } from '$lib/api/lightly_studio_local/sdk.gen';
     import { Button } from '$lib/components/ui/button';
@@ -20,7 +21,9 @@
     // Get collection ID from URL params
     const collectionId = $derived(page.params.collection_id!);
 
-    const { loadTags } = $derived(useTags({ collection_id: collectionId, kind: ['sample'] }));
+    const { loadTags, tags, setTagSelected } = $derived(
+        useTags({ collection_id: collectionId, kind: ['sample'] })
+    );
 
     const { isSelectionDialogOpen, openSelectionDialog, closeSelectionDialog } =
         useSelectionDialog();
@@ -52,15 +55,30 @@
     );
 
     // Form state
-    let selectionStrategy = $state<'diversity' | 'typicality' | ''>('');
+    let selectionStrategy = $state<'diversity' | 'typicality' | 'similarity' | ''>('');
     let nSamplesToSelect = $state<number>(10);
+    let queryTagId = $state('');
     let selectionResultTagName = $state<string>('');
     let isSubmitting = $state(false);
     let loadingMessage = $state<string>('');
 
+    const STRATEGY_LABELS: Record<string, string> = {
+        diversity: 'Diversity',
+        typicality: 'Typicality',
+        similarity: 'Similarity'
+    };
+
     // Form validation
     const isFormValid = $derived(
-        selectionStrategy !== '' && nSamplesToSelect > 0 && selectionResultTagName.trim().length > 0
+        selectionStrategy !== '' &&
+            (selectionStrategy === 'similarity' ? queryTagId !== '' : true) &&
+            nSamplesToSelect > 0 &&
+            selectionResultTagName.trim().length > 0
+    );
+
+    const isSimilaritySupported = $derived(!isVideoCollection);
+    const selectedQueryTagName = $derived(
+        $tags.find((tag) => tag.tag_id === queryTagId)?.name ?? 'Select tag'
     );
 
     const noSamples = $derived($filteredSampleCount === 0);
@@ -82,15 +100,49 @@
         submitSelection();
     }
 
-    function handleSelectionSuccess() {
-        toast.success('Selection created successfully');
-        loadTags();
-
-        closeSelectionDialog();
-
+    function resetForm() {
         selectionStrategy = '';
         nSamplesToSelect = 10;
+        queryTagId = '';
         selectionResultTagName = '';
+    }
+
+    async function handleSelectionSuccess() {
+        const createdTagName = selectionResultTagName;
+        toast.success('Selection created successfully');
+        await loadTags();
+
+        // Select the newly created tag
+        const newTag = $tags.find((tag) => tag.name === createdTagName);
+        if (newTag) {
+            setTagSelected(newTag.tag_id, true);
+        }
+
+        closeSelectionDialog();
+        resetForm();
+    }
+
+    async function performSelection(strategies: SelectionRequest['strategies']) {
+        loadingMessage = 'Creating selection...';
+        const response = await createCombinationSelection({
+            path: { collection_id: collectionId },
+            body: {
+                n_samples_to_select: nSamplesToSelect,
+                selection_result_tag_name: selectionResultTagName,
+                strategies,
+                filter: selectionFilter ?? undefined
+            }
+        });
+
+        if (response.error) {
+            toast.error(
+                (response.error as { error?: string }).error || 'Failed to create selection'
+            );
+            return false;
+        }
+
+        await handleSelectionSuccess();
+        return true;
     }
 
     async function submitSelection() {
@@ -100,34 +152,15 @@
             error: string;
         };
 
-        let responseError: SelectionError | null = null;
-
         try {
             if (selectionStrategy === 'diversity') {
-                const response = await createCombinationSelection({
-                    path: { collection_id: collectionId },
-                    body: {
-                        n_samples_to_select: nSamplesToSelect,
-                        selection_result_tag_name: selectionResultTagName,
-                        strategies: [
-                            {
-                                strategy_name: 'diversity',
-                                embedding_model_name: null
-                            }
-                        ],
-                        filter: selectionFilter ?? undefined
+                await performSelection([
+                    {
+                        strategy_name: 'diversity',
+                        embedding_model_name: null
                     }
-                });
-
-                responseError = response.error as SelectionError;
-                if (responseError) {
-                    toast.error(String(responseError.error) || 'Failed to create selection');
-                    return;
-                }
-
-                handleSelectionSuccess();
+                ]);
             } else if (selectionStrategy === 'typicality') {
-                // First, compute typicality metadata.
                 loadingMessage = 'Computing typicality metadata...';
                 const typicalityResponse = await computeTypicalityMetadata({
                     path: { collection_id: collectionId },
@@ -137,39 +170,49 @@
                     }
                 });
 
-                responseError = typicalityResponse.error as SelectionError;
                 if (typicalityResponse.error) {
                     toast.error(
                         'Failed to compute typicality metadata: ' +
-                            (responseError.error || 'Unknown error')
+                            ((typicalityResponse.error as SelectionError).error || 'Unknown error')
                     );
                     return;
                 }
 
-                // Then create selection with weighting strategy.
-                loadingMessage = 'Creating selection...';
-                const selectionResponse = await createCombinationSelection({
-                    path: { collection_id: collectionId },
-                    body: {
-                        n_samples_to_select: nSamplesToSelect,
-                        selection_result_tag_name: selectionResultTagName,
-                        strategies: [
-                            {
-                                strategy_name: 'weights',
-                                metadata_key: 'typicality'
-                            }
-                        ],
-                        filter: selectionFilter ?? undefined
+                await performSelection([
+                    {
+                        strategy_name: 'weights',
+                        metadata_key: 'typicality'
                     }
-                });
-
-                responseError = selectionResponse.error as SelectionError;
-                if (responseError) {
-                    toast.error(responseError.error || 'Failed to create selection');
+                ]);
+            } else if (selectionStrategy === 'similarity') {
+                if (!isSimilaritySupported) {
+                    toast.error('Similarity is only available for image collections.');
                     return;
                 }
 
-                handleSelectionSuccess();
+                loadingMessage = 'Computing similarity metadata...';
+                const response = await computeSimilarityMetadata({
+                    path: { collection_id: collectionId, query_tag_id: queryTagId },
+                    body: {
+                        embedding_model_name: null,
+                        metadata_name: 'similarity'
+                    }
+                });
+
+                if (response.error) {
+                    toast.error(
+                        'Failed to compute similarity metadata: ' +
+                            ((response.error as SelectionError).error || 'Unknown error')
+                    );
+                    return;
+                }
+
+                await performSelection([
+                    {
+                        strategy_name: 'weights',
+                        metadata_key: 'similarity'
+                    }
+                ]);
             }
         } catch (error) {
             toast.error('Failed to create selection: ' + (error as Error).message);
@@ -204,11 +247,7 @@
                                 class="col-span-3"
                                 data-testid="selection-dialog-strategy-select"
                             >
-                                {selectionStrategy === 'diversity'
-                                    ? 'Diversity'
-                                    : selectionStrategy === 'typicality'
-                                      ? 'Typicality'
-                                      : 'Select strategy'}
+                                {STRATEGY_LABELS[selectionStrategy] ?? 'Select strategy'}
                             </Select.Trigger>
                             <Select.Content>
                                 <Select.Group>
@@ -224,10 +263,45 @@
                                         data-testid="selection-strategy-typicality"
                                         >Typicality</Select.Item
                                     >
+                                    <Select.Item
+                                        value="similarity"
+                                        label="Similarity"
+                                        data-testid="selection-strategy-similarity"
+                                        disabled={!isSimilaritySupported}>Similarity</Select.Item
+                                    >
                                 </Select.Group>
                             </Select.Content>
                         </Select.Root>
                     </div>
+
+                    {#if selectionStrategy === 'similarity'}
+                        <div class="grid grid-cols-4 items-center gap-4">
+                            <Label for="query-tag" class="text-right text-foreground">
+                                Query Tag
+                            </Label>
+                            <Select.Root type="single" name="query-tag" bind:value={queryTagId}>
+                                <Select.Trigger
+                                    class="col-span-3"
+                                    data-testid="selection-dialog-query-tag-select"
+                                >
+                                    {selectedQueryTagName}
+                                </Select.Trigger>
+                                <Select.Content>
+                                    <Select.Group>
+                                        {#each $tags as tag (tag.tag_id)}
+                                            <Select.Item
+                                                value={tag.tag_id}
+                                                label={tag.name}
+                                                data-testid={`selection-query-tag-${tag.tag_id}`}
+                                            >
+                                                {tag.name}
+                                            </Select.Item>
+                                        {/each}
+                                    </Select.Group>
+                                </Select.Content>
+                            </Select.Root>
+                        </div>
+                    {/if}
 
                     <!-- Number of Samples Input -->
                     <div class="grid grid-cols-4 items-center gap-4">

--- a/lightly_studio_view/src/lib/hooks/useTags/useTags.ts
+++ b/lightly_studio_view/src/lib/hooks/useTags/useTags.ts
@@ -13,7 +13,8 @@ interface UseTagsReturn {
     tagsSelected: Readable<Set<string>>;
     clearTagsSelected: () => void;
     clearTagSelected: (tagId: string) => void;
-    loadTags: () => void;
+    setTagSelected: (tagId: string, isSelected: boolean) => void;
+    loadTags: () => Promise<void>;
     tagSelectionToggle: (tagId: string) => void;
     isLoading: Readable<boolean>;
     error: Readable<Error | null>;
@@ -27,13 +28,14 @@ export function useTags(options: UseTagsOptions): UseTagsReturn {
     const isLoaded = writable(false);
     const error = writable<Error | null>(null);
     const isLoading = writable(false);
+    let currentLoadPromise: Promise<void> | null = null;
 
-    const loadTags = () => {
-        if (get(isLoading)) return;
+    const loadTags = async () => {
+        if (get(isLoading)) return currentLoadPromise ?? Promise.resolve();
         if (!collection_id) return;
 
         isLoading.set(true);
-        readTags({
+        currentLoadPromise = readTags({
             path: {
                 collection_id
             }
@@ -69,12 +71,15 @@ export function useTags(options: UseTagsOptions): UseTagsReturn {
             })
             .finally(() => {
                 isLoading.set(false);
+                currentLoadPromise = null;
             });
+
+        return currentLoadPromise;
     };
 
     // Auto-load tags when hook is initialized
     if (!get(isLoaded) && collection_id) {
-        loadTags();
+        void loadTags();
         isLoaded.set(true);
     }
 
@@ -130,11 +135,27 @@ export function useTags(options: UseTagsOptions): UseTagsReturn {
         });
     };
 
+    const setTagSelected = (tagId: string, isSelected: boolean) => {
+        tagsSelectedByCollection.update((selectedByCollection) => {
+            const selected = new Set(selectedByCollection[collection_id] ?? []);
+            if (isSelected) {
+                selected.add(tagId);
+            } else {
+                selected.delete(tagId);
+            }
+            return {
+                ...selectedByCollection,
+                [collection_id]: selected
+            };
+        });
+    };
+
     return {
         tags: readonly(tags),
         loadTags,
         tagsSelected: readonly(tagsSelectedForCollection),
         tagSelectionToggle,
+        setTagSelected,
         clearTagsSelected,
         clearTagSelected,
         isLoading: readonly(isLoading),


### PR DESCRIPTION
## What has changed and why?
After typicality and diversity, we want to add similarity to the list.

It now automatically selects the tag that was created by a selection (also typicality/diversity)

## How has it been tested?
Added a test and manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Similarity Search option in the selection dialog: a Query Tag picker, similarity computation, and automatic numeric-descending sort by similarity (disabled for video collections); updated labels/messages for the similarity flow.

* **Tests**
  * Added and updated E2E and unit tests covering similarity metadata, selection flow, sorting, and video-collection disabling.

* **Documentation**
  * CHANGELOG updated to mention the similarity selection option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->