### PR TITLE
Support integer metadata fields for embedding plot colouring

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Generic, Protocol, TypeVar
@@ -97,6 +98,59 @@ class DiscreteColorScale(Generic[T]):
             A DiscreteColorScale backed by the provided lookup and legend.
         """
         return cls(_lookup=lookup, legend=legend)
+
+    @classmethod
+    def from_integers(
+        cls,
+        values: Iterable[int],
+        start_cat: int = 2,
+        max_categories: int = 50,
+    ) -> DiscreteColorScale[int]:
+        """Build a color scale for integer values.
+
+        When the number of unique values is at most ``max_categories``, each
+        unique value gets its own category. Otherwise the range [min, max] is
+        split into at most ``max_categories`` equal-width buckets and each value
+        is mapped to the bucket that contains it.
+
+        In both cases categories are ordered numerically (smallest value first).
+
+        Args:
+            values: Integer values to build the scale from. Need not be unique.
+            start_cat: First category ID to assign. Defaults to 2, reserving
+                0 for filtered-out samples and 1 for unassigned samples.
+            max_categories: Maximum number of distinct color categories before
+                bucketing is applied. Defaults to 50.
+
+        Returns:
+            A DiscreteColorScale mapping each integer to a color category.
+        """
+        unique_values = sorted(set(values))
+
+        if len(unique_values) <= max_categories:
+            return DiscreteColorScale.from_values(values=unique_values, start_cat=start_cat)
+
+        min_val = unique_values[0]
+        max_val = unique_values[-1]
+        value_range = max_val - min_val
+        raw_width = value_range / max_categories
+        magnitude = 10 ** math.floor(math.log10(raw_width)) if raw_width >= 1 else 1
+        bucket_width = math.ceil(raw_width / magnitude) * magnitude
+
+        num_buckets = math.ceil((value_range + 1) / bucket_width)
+
+        def _bucket_idx(value: int) -> int:
+            return min((value - min_val) // bucket_width, num_buckets - 1)
+
+        def _label(bucket_start: int) -> str:
+            return f"{bucket_start}-{bucket_start + bucket_width - 1}"
+
+        legend: dict[int, str] = {
+            start_cat + i: _label(min_val + i * bucket_width) for i in range(num_buckets)
+        }
+        lookup: dict[int, int] = {v: start_cat + _bucket_idx(v) for v in unique_values}
+
+        return DiscreteColorScale.from_lookup(lookup=lookup, legend=legend)
 
 
 def assign_color_categories(

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -150,7 +150,7 @@ class DiscreteColorScale(Generic[T]):
         }
         lookup: dict[int, int] = {v: start_cat + _bucket_idx(v) for v in unique_values}
 
-        return cls.from_lookup(lookup=lookup, legend=legend)
+        return DiscreteColorScale.from_lookup(lookup=lookup, legend=legend)
 
 
 def assign_color_categories(

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -143,6 +143,8 @@ class DiscreteColorScale(Generic[T]):
             return min((value - min_val) // bucket_width, num_buckets - 1)
 
         def _label(bucket_start: int) -> str:
+            if bucket_width == 1:
+                return str(bucket_start)
             return f"{bucket_start}-{bucket_start + bucket_width - 1}"
 
         legend: dict[int, str] = {

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -80,26 +80,6 @@ class DiscreteColorScale(Generic[T]):
         return cls(_lookup=lookup, legend=legend)
 
     @classmethod
-    def from_lookup(
-        cls,
-        lookup: dict[T, int],
-        legend: dict[int, str],
-    ) -> DiscreteColorScale[T]:
-        """Build a DiscreteColorScale from a pre-computed lookup and legend.
-
-        Use this when multiple values map to the same category (e.g. buckets),
-        which ``from_values`` cannot express.
-
-        Args:
-            lookup: Mapping from value to color category integer.
-            legend: Mapping from color category integer to a human-readable label.
-
-        Returns:
-            A DiscreteColorScale backed by the provided lookup and legend.
-        """
-        return cls(_lookup=lookup, legend=legend)
-
-    @classmethod
     def from_integers(
         cls,
         values: Iterable[int],
@@ -152,7 +132,7 @@ class DiscreteColorScale(Generic[T]):
         }
         lookup: dict[int, int] = {v: start_cat + _bucket_idx(v) for v in unique_values}
 
-        return DiscreteColorScale.from_lookup(lookup=lookup, legend=legend)
+        return DiscreteColorScale[int](_lookup=lookup, legend=legend)
 
 
 def assign_color_categories(

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -80,6 +80,26 @@ class DiscreteColorScale(Generic[T]):
         return cls(_lookup=lookup, legend=legend)
 
     @classmethod
+    def from_lookup(
+        cls,
+        lookup: dict[T, int],
+        legend: dict[int, str],
+    ) -> DiscreteColorScale[T]:
+        """Build a DiscreteColorScale from a pre-computed lookup and legend.
+
+        Use this when multiple values map to the same category (e.g. buckets),
+        which ``from_values`` cannot express.
+
+        Args:
+            lookup: Mapping from value to color category integer.
+            legend: Mapping from color category integer to a human-readable label.
+
+        Returns:
+            A DiscreteColorScale backed by the provided lookup and legend.
+        """
+        return cls(_lookup=lookup, legend=legend)
+
+    @classmethod
     def from_integers(
         cls,
         values: Iterable[int],
@@ -130,7 +150,7 @@ class DiscreteColorScale(Generic[T]):
         }
         lookup: dict[int, int] = {v: start_cat + _bucket_idx(v) for v in unique_values}
 
-        return cls(_lookup=lookup, legend=legend)
+        return cls.from_lookup(lookup=lookup, legend=legend)
 
 
 def assign_color_categories(

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -80,26 +80,6 @@ class DiscreteColorScale(Generic[T]):
         return cls(_lookup=lookup, legend=legend)
 
     @classmethod
-    def from_lookup(
-        cls,
-        lookup: dict[T, int],
-        legend: dict[int, str],
-    ) -> DiscreteColorScale[T]:
-        """Build a DiscreteColorScale from a pre-computed lookup and legend.
-
-        Use this when multiple values map to the same category (e.g. buckets),
-        which ``from_values`` cannot express.
-
-        Args:
-            lookup: Mapping from value to color category integer.
-            legend: Mapping from color category integer to a human-readable label.
-
-        Returns:
-            A DiscreteColorScale backed by the provided lookup and legend.
-        """
-        return cls(_lookup=lookup, legend=legend)
-
-    @classmethod
     def from_integers(
         cls,
         values: Iterable[int],

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -78,6 +78,26 @@ class DiscreteColorScale(Generic[T]):
             legend[cat] = format_fn(value)
         return cls(_lookup=lookup, legend=legend)
 
+    @classmethod
+    def from_lookup(
+        cls,
+        lookup: dict[T, int],
+        legend: dict[int, str],
+    ) -> DiscreteColorScale[T]:
+        """Build a DiscreteColorScale from a pre-computed lookup and legend.
+
+        Use this when multiple values map to the same category (e.g. buckets),
+        which ``from_values`` cannot express.
+
+        Args:
+            lookup: Mapping from value to color category integer.
+            legend: Mapping from color category integer to a human-readable label.
+
+        Returns:
+            A DiscreteColorScale backed by the provided lookup and legend.
+        """
+        return cls(_lookup=lookup, legend=legend)
+
 
 def assign_color_categories(
     sample_ids: Sequence[UUID],

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -130,7 +130,7 @@ class DiscreteColorScale(Generic[T]):
         }
         lookup: dict[int, int] = {v: start_cat + _bucket_idx(v) for v in unique_values}
 
-        return DiscreteColorScale.from_lookup(lookup=lookup, legend=legend)
+        return cls(_lookup=lookup, legend=legend)
 
 
 def assign_color_categories(

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from typing import Any
 from uuid import UUID
 
@@ -11,8 +10,6 @@ from sqlmodel import Session
 from lightly_studio.api.routes.api.embedding_coloring import coloring_helpers
 from lightly_studio.api.routes.api.embedding_coloring.coloring_helpers import DiscreteColorScale
 from lightly_studio.resolvers.metadata_resolver import sample as sample_metadata_resolver
-
-_MAX_INTEGER_CATEGORIES = 50
 
 
 def build_metadata_color_maps(
@@ -70,49 +67,9 @@ def _build_metadata_color_scale(
             format_fn=lambda v: "true" if v else "false",
         )
     if metadata_type == "integer":
-        return _build_integer_color_scale(sample_to_value)
+        return DiscreteColorScale.from_integers(values=(int(v) for v in sample_to_value.values()))
 
     raise ValueError(
         f"Metadata field '{key}' has unsupported type {metadata_type!r}. "
         "Only 'string', 'boolean', and 'integer' fields can be used for coloring."
     )
-
-
-def _build_integer_color_scale(
-    sample_to_value: dict[UUID, Any],
-) -> DiscreteColorScale[int]:
-    """Build a color scale for an integer metadata field.
-
-    When the number of unique values is at most ``_MAX_INTEGER_CATEGORIES``, each
-    unique value gets its own category.  Otherwise the range [min, max] is split
-    into at most ``_MAX_INTEGER_CATEGORIES`` equal-width buckets and each sample is
-    mapped to the bucket that contains its value.
-
-    In both cases categories are ordered numerically (smallest value first).
-    """
-    unique_values = sorted({int(v) for v in sample_to_value.values()})
-
-    if len(unique_values) <= _MAX_INTEGER_CATEGORIES:
-        return DiscreteColorScale.from_values(values=unique_values)
-
-    # Bucket into at most _MAX_INTEGER_CATEGORIES ranges.
-    min_val = unique_values[0]
-    max_val = unique_values[-1]
-    value_range = max_val - min_val
-    # Round bucket width up to a "nice" power-of-ten multiple so labels are readable.
-    raw_width = value_range / _MAX_INTEGER_CATEGORIES
-    magnitude = 10 ** math.floor(math.log10(raw_width)) if raw_width >= 1 else 1
-    bucket_width = math.ceil(raw_width / magnitude) * magnitude
-
-    num_buckets = math.ceil((value_range + 1) / bucket_width)
-
-    def _bucket_idx(value: int) -> int:
-        return min((value - min_val) // bucket_width, num_buckets - 1)
-
-    def _label(bucket_start: int) -> str:
-        return f"{bucket_start}-{bucket_start + bucket_width - 1}"
-
-    legend: dict[int, str] = {2 + i: _label(min_val + i * bucket_width) for i in range(num_buckets)}
-    lookup: dict[int, int] = {v: 2 + _bucket_idx(v) for v in unique_values}
-
-    return DiscreteColorScale.from_lookup(lookup=lookup, legend=legend)

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
@@ -112,9 +112,7 @@ def _build_integer_color_scale(
     def _label(bucket_start: int) -> str:
         return f"{bucket_start}-{bucket_start + bucket_width - 1}"
 
-    legend: dict[int, str] = {
-        2 + i: _label(min_val + i * bucket_width) for i in range(num_buckets)
-    }
+    legend: dict[int, str] = {2 + i: _label(min_val + i * bucket_width) for i in range(num_buckets)}
     lookup: dict[int, int] = {v: 2 + _bucket_idx(v) for v in unique_values}
 
     return DiscreteColorScale(_lookup=lookup, legend=legend)

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
@@ -115,4 +115,4 @@ def _build_integer_color_scale(
     legend: dict[int, str] = {2 + i: _label(min_val + i * bucket_width) for i in range(num_buckets)}
     lookup: dict[int, int] = {v: 2 + _bucket_idx(v) for v in unique_values}
 
-    return DiscreteColorScale(_lookup=lookup, legend=legend)
+    return DiscreteColorScale.from_lookup(lookup=lookup, legend=legend)

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
@@ -104,7 +104,7 @@ def _build_integer_color_scale(
     magnitude = 10 ** math.floor(math.log10(raw_width)) if raw_width >= 1 else 1
     bucket_width = math.ceil(raw_width / magnitude) * magnitude
 
-    num_buckets = math.ceil(value_range / bucket_width)
+    num_buckets = math.ceil((value_range + 1) / bucket_width)
 
     def _bucket_idx(value: int) -> int:
         return min((value - min_val) // bucket_width, num_buckets - 1)

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 from uuid import UUID
 
@@ -10,6 +11,8 @@ from sqlmodel import Session
 from lightly_studio.api.routes.api.embedding_coloring import coloring_helpers
 from lightly_studio.api.routes.api.embedding_coloring.coloring_helpers import DiscreteColorScale
 from lightly_studio.resolvers.metadata_resolver import sample as sample_metadata_resolver
+
+_MAX_INTEGER_CATEGORIES = 50
 
 
 def build_metadata_color_maps(
@@ -66,8 +69,52 @@ def _build_metadata_color_scale(
             values=[False, True],
             format_fn=lambda v: "true" if v else "false",
         )
+    if metadata_type == "integer":
+        return _build_integer_color_scale(sample_to_value)
 
     raise ValueError(
         f"Metadata field '{key}' has unsupported type {metadata_type!r}. "
-        "Only 'string' and 'boolean' fields can be used for coloring."
+        "Only 'string', 'boolean', and 'integer' fields can be used for coloring."
     )
+
+
+def _build_integer_color_scale(
+    sample_to_value: dict[UUID, Any],
+) -> DiscreteColorScale[int]:
+    """Build a color scale for an integer metadata field.
+
+    When the number of unique values is at most ``_MAX_INTEGER_CATEGORIES``, each
+    unique value gets its own category.  Otherwise the range [min, max] is split
+    into at most ``_MAX_INTEGER_CATEGORIES`` equal-width buckets and each sample is
+    mapped to the bucket that contains its value.
+
+    In both cases categories are ordered numerically (smallest value first).
+    """
+    unique_values = sorted({int(v) for v in sample_to_value.values()})
+
+    if len(unique_values) <= _MAX_INTEGER_CATEGORIES:
+        return DiscreteColorScale.from_values(values=unique_values)
+
+    # Bucket into at most _MAX_INTEGER_CATEGORIES ranges.
+    min_val = unique_values[0]
+    max_val = unique_values[-1]
+    value_range = max_val - min_val
+    # Round bucket width up to a "nice" power-of-ten multiple so labels are readable.
+    raw_width = value_range / _MAX_INTEGER_CATEGORIES
+    magnitude = 10 ** math.floor(math.log10(raw_width)) if raw_width >= 1 else 1
+    bucket_width = math.ceil(raw_width / magnitude) * magnitude
+
+    num_buckets = math.ceil(value_range / bucket_width)
+
+    def _bucket_idx(value: int) -> int:
+        return min((value - min_val) // bucket_width, num_buckets - 1)
+
+    def _label(bucket_start: int) -> str:
+        return f"{bucket_start}-{bucket_start + bucket_width - 1}"
+
+    legend: dict[int, str] = {
+        2 + i: _label(min_val + i * bucket_width) for i in range(num_buckets)
+    }
+    lookup: dict[int, int] = {v: 2 + _bucket_idx(v) for v in unique_values}
+
+    return DiscreteColorScale(_lookup=lookup, legend=legend)

--- a/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
+++ b/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
@@ -92,6 +92,13 @@ class TestDiscreteColorScale:
         assert scale.value_to_category(300) == 3
         assert scale.legend == {2: "0-199", 3: "200-399"}
 
+    def test_from_integers__bucketing_width_one(self) -> None:
+        scale = DiscreteColorScale.from_integers(values=[0, 1, 2], max_categories=2)
+        assert scale.value_to_category(0) == 2
+        assert scale.value_to_category(1) == 3
+        assert scale.value_to_category(2) == 4
+        assert scale.legend == {2: "0", 3: "1", 4: "2"}
+
 
 def test_assign_color_categories() -> None:
     ids = [uuid4(), uuid4()]

--- a/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
+++ b/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
@@ -50,6 +50,48 @@ class TestDiscreteColorScale:
         assert scale.value_to_category("only") == 2
         assert scale.legend == {2: "only"}
 
+    def test_from_integers__few_values(self) -> None:
+        scale = DiscreteColorScale.from_integers(values=[3, 1, 2])
+        assert scale.value_to_category(1) == 2
+        assert scale.value_to_category(2) == 3
+        assert scale.value_to_category(3) == 4
+        assert scale.legend == {2: "1", 3: "2", 4: "3"}
+
+    def test_from_integers__empty(self) -> None:
+        scale = DiscreteColorScale.from_integers(values=[])
+        assert scale.legend == {}
+        assert scale.value_to_category(0) is None
+
+    def test_from_integers__duplicates_deduplicated(self) -> None:
+        scale = DiscreteColorScale.from_integers(values=[5, 5, 3, 3, 1])
+        assert scale.value_to_category(1) == 2
+        assert scale.value_to_category(3) == 3
+        assert scale.value_to_category(5) == 4
+        assert scale.legend == {2: "1", 3: "3", 4: "5"}
+
+    def test_from_integers__custom_start_cat(self) -> None:
+        scale = DiscreteColorScale.from_integers(values=[10, 20], start_cat=5)
+        assert scale.value_to_category(10) == 5
+        assert scale.value_to_category(20) == 6
+        assert scale.legend == {5: "10", 6: "20"}
+
+    def test_from_integers__exactly_max_categories_no_bucketing(self) -> None:
+        scale = DiscreteColorScale.from_integers(values=[1, 2, 3], max_categories=3)
+        assert scale.value_to_category(1) == 2
+        assert scale.value_to_category(2) == 3
+        assert scale.value_to_category(3) == 4
+        assert scale.legend == {2: "1", 3: "2", 4: "3"}
+
+    def test_from_integers__bucketing(self) -> None:
+        # value_range=300, raw_width=150, magnitude=100, bucket_width=200
+        # -> 2 buckets: [0, 199] and [200, 399]
+        scale = DiscreteColorScale.from_integers(values=[0, 100, 200, 300], max_categories=2)
+        assert scale.value_to_category(0) == 2
+        assert scale.value_to_category(100) == 2
+        assert scale.value_to_category(200) == 3
+        assert scale.value_to_category(300) == 3
+        assert scale.legend == {2: "0-199", 3: "200-399"}
+
 
 def test_assign_color_categories() -> None:
     ids = [uuid4(), uuid4()]

--- a/lightly_studio/tests/api/routes/api/test_embeddings2d.py
+++ b/lightly_studio/tests/api/routes/api/test_embeddings2d.py
@@ -431,7 +431,6 @@ def test_get_embeddings2d__with_integer_metadata_color_by(
     assert legend["4"] == "30"
 
 
-
 def test_get_embeddings2d__with_integer_metadata_color_by__buckets_when_more_than_50_unique_values(
     test_client: TestClient,
     db_session: Session,
@@ -478,9 +477,9 @@ def test_get_embeddings2d__with_integer_metadata_color_by__buckets_when_more_tha
 
     # score=0 and score=1 share bucket "0-1" -> same category.
     sample_id_to_color = dict(zip(sample_ids_payload, color_category))
-    assert sample_id_to_color[str(samples[0].sample_id)] == 2   # score=0 -> bucket "0-1"
-    assert sample_id_to_color[str(samples[1].sample_id)] == 2   # score=1 -> bucket "0-1"
-    assert sample_id_to_color[str(samples[2].sample_id)] == 3   # score=2 -> bucket "2-3"
+    assert sample_id_to_color[str(samples[0].sample_id)] == 2  # score=0 -> bucket "0-1"
+    assert sample_id_to_color[str(samples[1].sample_id)] == 2  # score=1 -> bucket "0-1"
+    assert sample_id_to_color[str(samples[2].sample_id)] == 3  # score=2 -> bucket "2-3"
     assert sample_id_to_color[str(samples[99].sample_id)] == 51  # score=99 -> bucket "98-99"
 
 

--- a/lightly_studio/tests/api/routes/api/test_embeddings2d.py
+++ b/lightly_studio/tests/api/routes/api/test_embeddings2d.py
@@ -380,6 +380,110 @@ def test_get_embeddings2d__with_boolean_metadata_color_by(
     assert legend["3"] == "true"
 
 
+def test_get_embeddings2d__with_integer_metadata_color_by(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    n_samples = 3
+
+    collection_id = fill_db_with_samples_and_embeddings(
+        session=db_session,
+        n_samples=n_samples,
+        embedding_model_names=["model_a"],
+        embedding_dimension=EMBEDDING_DIMENSION,
+    )
+
+    samples = image_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=collection_id,
+    ).samples
+    assert len(samples) == n_samples
+
+    scores = [10, 30, 20]
+    for sample, score in zip(samples, scores):
+        sample.sample["score"] = score
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/embeddings2d/default",
+        json={
+            "filters": {},
+            "color_by": {"type": "metadata_field", "key": "score"},
+        },
+    )
+
+    assert response.status_code == 200
+
+    table = ipc.open_stream(pa.BufferReader(response.content)).read_all()
+    sample_ids_payload = table.column("sample_id").to_pylist()
+    color_category = table.column("color_category").to_numpy(zero_copy_only=False)
+
+    # Values are sorted numerically: 10 -> cat 2, 20 -> cat 3, 30 -> cat 4.
+    sample_id_to_color = dict(zip(sample_ids_payload, color_category))
+    assert sample_id_to_color[str(samples[0].sample_id)] == 2  # score=10
+    assert sample_id_to_color[str(samples[1].sample_id)] == 4  # score=30
+    assert sample_id_to_color[str(samples[2].sample_id)] == 3  # score=20
+
+    legend = json.loads(table.schema.metadata[b"color_legend"])
+    assert legend["0"] == "Filtered out"
+    assert legend["1"] == "Unassigned"
+    assert legend["2"] == "10"
+    assert legend["3"] == "20"
+    assert legend["4"] == "30"
+
+
+
+def test_get_embeddings2d__with_integer_metadata_color_by__buckets_when_more_than_50_unique_values(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    """When there are more than 50 unique integer values, values are grouped into buckets."""
+    n_samples = 100
+
+    collection_id = fill_db_with_samples_and_embeddings(
+        session=db_session,
+        n_samples=n_samples,
+        embedding_model_names=["model_a"],
+        embedding_dimension=EMBEDDING_DIMENSION,
+    )
+
+    samples = image_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=collection_id,
+    ).samples
+    assert len(samples) == n_samples
+
+    for i, sample in enumerate(samples):
+        sample.sample["score"] = i  # scores 0..99
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/embeddings2d/default",
+        json={
+            "filters": {},
+            "color_by": {"type": "metadata_field", "key": "score"},
+        },
+    )
+
+    assert response.status_code == 200
+
+    table = ipc.open_stream(pa.BufferReader(response.content)).read_all()
+    sample_ids_payload = table.column("sample_id").to_pylist()
+    color_category = table.column("color_category").to_numpy(zero_copy_only=False)
+
+    legend = json.loads(table.schema.metadata[b"color_legend"])
+    assert legend["0"] == "Filtered out"
+    assert legend["1"] == "Unassigned"
+    assert legend["2"] == "0-1"
+    assert legend["51"] == "98-99"
+    assert len(legend) == 52  # 2 reserved + 50 buckets
+
+    # score=0 and score=1 share bucket "0-1" -> same category.
+    sample_id_to_color = dict(zip(sample_ids_payload, color_category))
+    assert sample_id_to_color[str(samples[0].sample_id)] == 2   # score=0 -> bucket "0-1"
+    assert sample_id_to_color[str(samples[1].sample_id)] == 2   # score=1 -> bucket "0-1"
+    assert sample_id_to_color[str(samples[2].sample_id)] == 3   # score=2 -> bucket "2-3"
+    assert sample_id_to_color[str(samples[99].sample_id)] == 51  # score=99 -> bucket "98-99"
+
+
 def test_get_embeddings2d__with_metadata_field_color_by_and_sample_ids_filter(
     test_client: TestClient,
     db_session: Session,
@@ -456,7 +560,6 @@ def test_get_embeddings2d__with_metadata_field_color_by_and_sample_ids_filter(
         {"a": 1},
         [1, 2, 3],
         1.5,
-        2,
     ],
 )
 def test_get_embeddings2d__with_unsupported_metadata_color_by(


### PR DESCRIPTION
## What has changed and why?

Adds support for integer metadata fields in the embedding plot color-by feature. When there are more than 50 unique values, the range is split into up to 50 equal-width buckets (e.g., "0-1", "2-3").

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 2D embedding visualizations now support integer metadata coloring: integers map to discrete categories or are bucketed into readable numeric ranges (up to 50 categories) with clear legend labels.

* **Bug Fixes**
  * Validation message for metadata coloring clarified to explicitly allow string, boolean, and integer types.

* **Tests**
  * Added tests for integer coloring, bucketing behavior, deduplication, empty inputs, custom start categories, and exact-category cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->