### PR TITLE
Add annotations color-by option to embedding plot 

### DIFF
--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
@@ -9,11 +9,13 @@
         selectedKey: string | null;
         onSelectedKeyChange: (key: string | null) => void;
         withTags: boolean;
+        withAnnotationLabels: boolean;
     }
 
     const supportedTypes = new Set(['string', 'boolean']);
 
-    let { collectionId, selectedKey, onSelectedKeyChange, withTags }: Props = $props();
+    let { collectionId, selectedKey, onSelectedKeyChange, withTags, withAnnotationLabels }: Props =
+        $props();
 
     const { metadataInfo } = useMetadataFilters(collectionId);
     const { selectedColorByType, setSelectedColorByType, clearSelectedColorByType } =
@@ -25,12 +27,15 @@
 
     const colorByOptions = $derived.by(() => {
         const tagsOption = withTags ? [{ value: 'tags', label: 'tags' }] : [];
+        const annotationLabelsOption = withAnnotationLabels
+            ? [{ value: 'annotation_label', label: 'annotations' }]
+            : [];
         const metadataOptions = colorableFields.map((field) => ({
             value: field.name,
             label: `metadata.${field.name}`
         }));
 
-        return [...tagsOption, ...metadataOptions];
+        return [...tagsOption, ...annotationLabelsOption, ...metadataOptions];
     });
 
     const isSelectDisabled = $derived(colorByOptions.length === 0 && !selectedKey);
@@ -64,6 +69,12 @@
         }
 
         if (value === 'tags') {
+            setSelectedColorByType(value);
+            onSelectedKeyChange(null);
+            return;
+        }
+
+        if (value === 'annotation_label') {
             setSelectedColorByType(value);
             onSelectedKeyChange(null);
             return;

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
@@ -25,14 +25,20 @@
         ($metadataInfo ?? []).filter((field) => supportedTypes.has(field.type))
     );
 
-    const colorByOptions = $derived.by(() => {
-        const tagsOption = withTags ? [{ value: 'tags', label: 'tags' }] : [];
-        const annotationLabelsOption = withAnnotationLabels
-            ? [{ value: 'annotation_label', label: 'annotations' }]
+    type ColorByOption =
+        | { type: 'tags'; label: string }
+        | { type: 'annotation_label'; label: string }
+        | { type: 'metadata'; label: string; fieldName: string };
+
+    const colorByOptions = $derived.by((): ColorByOption[] => {
+        const tagsOption: ColorByOption[] = withTags ? [{ type: 'tags', label: 'tags' }] : [];
+        const annotationLabelsOption: ColorByOption[] = withAnnotationLabels
+            ? [{ type: 'annotation_label', label: 'annotations' }]
             : [];
-        const metadataOptions = colorableFields.map((field) => ({
-            value: field.name,
-            label: `metadata.${field.name}`
+        const metadataOptions: ColorByOption[] = colorableFields.map((field) => ({
+            type: 'metadata',
+            label: `metadata.${field.name}`,
+            fieldName: field.name
         }));
 
         return [...tagsOption, ...annotationLabelsOption, ...metadataOptions];
@@ -40,10 +46,13 @@
 
     const isSelectDisabled = $derived(colorByOptions.length === 0 && !selectedKey);
     const selectValue = $derived.by(() => {
-        if (selectedKey) {
-            return selectedKey;
-        }
-        return $selectedColorByType ?? '';
+        const idx = colorByOptions.findIndex((opt) => {
+            if (opt.type === 'metadata') {
+                return opt.fieldName === selectedKey;
+            }
+            return !selectedKey && opt.type === $selectedColorByType;
+        });
+        return idx >= 0 ? String(idx) : '';
     });
     const triggerLabel = $derived.by(() => {
         if (isSelectDisabled) {
@@ -68,20 +77,19 @@
             return;
         }
 
-        if (value === 'tags') {
-            setSelectedColorByType(value);
-            onSelectedKeyChange(null);
-            return;
-        }
+        const option = colorByOptions[Number(value)];
+        if (!option) return;
 
-        if (value === 'annotation_label') {
-            setSelectedColorByType(value);
+        if (option.type === 'tags') {
+            setSelectedColorByType('tags');
             onSelectedKeyChange(null);
-            return;
+        } else if (option.type === 'annotation_label') {
+            setSelectedColorByType('annotation_label');
+            onSelectedKeyChange(null);
+        } else {
+            setSelectedColorByType('metadata');
+            onSelectedKeyChange(option.fieldName);
         }
-
-        setSelectedColorByType('metadata');
-        onSelectedKeyChange(value);
     };
 </script>
 
@@ -97,8 +105,8 @@
         </div>
     </Select.Trigger>
     <Select.Content class="max-h-64" data-testid="plot-color-by-options">
-        {#each colorByOptions as option (option.value)}
-            <Select.Item value={option.value} label={option.label}>
+        {#each colorByOptions as option, i (option.type === 'metadata' ? `metadata:${option.fieldName}` : `type:${option.type}`)}
+            <Select.Item value={String(i)} label={option.label}>
                 {option.label}
             </Select.Item>
         {/each}

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.test.ts
@@ -45,7 +45,8 @@ describe('PlotColorByPopover', () => {
             collectionId: 'test-collection-id',
             selectedKey: null,
             onSelectedKeyChange: vi.fn(),
-            withTags: false
+            withTags: false,
+            withAnnotationLabels: false
         });
 
         await user.click(screen.getByTestId('plot-color-by-button'));
@@ -65,7 +66,8 @@ describe('PlotColorByPopover', () => {
             collectionId: 'test-collection-id',
             selectedKey: null,
             onSelectedKeyChange,
-            withTags: false
+            withTags: false,
+            withAnnotationLabels: false
         });
 
         await user.click(screen.getByTestId('plot-color-by-button'));
@@ -82,7 +84,8 @@ describe('PlotColorByPopover', () => {
             collectionId: 'test-collection-id',
             selectedKey: null,
             onSelectedKeyChange: vi.fn(),
-            withTags: true
+            withTags: true,
+            withAnnotationLabels: false
         });
 
         await user.click(screen.getByTestId('plot-color-by-button'));
@@ -97,7 +100,8 @@ describe('PlotColorByPopover', () => {
             collectionId: 'test-collection-id',
             selectedKey: null,
             onSelectedKeyChange: vi.fn(),
-            withTags: false
+            withTags: false,
+            withAnnotationLabels: false
         });
 
         await user.click(screen.getByTestId('plot-color-by-button'));
@@ -114,7 +118,8 @@ describe('PlotColorByPopover', () => {
             collectionId: 'test-collection-id',
             selectedKey: null,
             onSelectedKeyChange,
-            withTags: true
+            withTags: true,
+            withAnnotationLabels: false
         });
 
         await user.click(screen.getByTestId('plot-color-by-button'));
@@ -122,6 +127,58 @@ describe('PlotColorByPopover', () => {
 
         expect(onSelectedKeyChange).toHaveBeenCalledWith(null);
         expect(get(colorByType.selectedColorByType)).toBe('tags');
+    });
+
+    it('renders an annotations option when withAnnotationLabels is true', async () => {
+        const user = userEvent.setup();
+
+        render(PlotColorByPopover, {
+            collectionId: 'test-collection-id',
+            selectedKey: null,
+            onSelectedKeyChange: vi.fn(),
+            withTags: false,
+            withAnnotationLabels: true
+        });
+
+        await user.click(screen.getByTestId('plot-color-by-button'));
+
+        expect(screen.getByRole('option', { name: 'annotations' })).toBeInTheDocument();
+    });
+
+    it('does not render an annotations option when withAnnotationLabels is false', async () => {
+        const user = userEvent.setup();
+
+        render(PlotColorByPopover, {
+            collectionId: 'test-collection-id',
+            selectedKey: null,
+            onSelectedKeyChange: vi.fn(),
+            withTags: false,
+            withAnnotationLabels: false
+        });
+
+        await user.click(screen.getByTestId('plot-color-by-button'));
+
+        expect(screen.queryByRole('option', { name: 'annotations' })).not.toBeInTheDocument();
+    });
+
+    it('selecting annotations stores annotation_label as the selected type', async () => {
+        const user = userEvent.setup();
+        const onSelectedKeyChange = vi.fn();
+        const colorByType = usePlotColorByType('test-collection-id');
+
+        render(PlotColorByPopover, {
+            collectionId: 'test-collection-id',
+            selectedKey: null,
+            onSelectedKeyChange,
+            withTags: false,
+            withAnnotationLabels: true
+        });
+
+        await user.click(screen.getByTestId('plot-color-by-button'));
+        await user.click(screen.getByRole('option', { name: 'annotations' }));
+
+        expect(onSelectedKeyChange).toHaveBeenCalledWith(null);
+        expect(get(colorByType.selectedColorByType)).toBe('annotation_label');
     });
 
     it('clicking the selected metadata field clears the selected type', async () => {
@@ -135,7 +192,8 @@ describe('PlotColorByPopover', () => {
             collectionId: 'test-collection-id',
             selectedKey: 'split',
             onSelectedKeyChange,
-            withTags: false
+            withTags: false,
+            withAnnotationLabels: false
         });
 
         await user.click(screen.getByTestId('plot-color-by-button'));
@@ -150,7 +208,8 @@ describe('PlotColorByPopover', () => {
             collectionId: 'test-collection-id',
             selectedKey: 'split',
             onSelectedKeyChange: vi.fn(),
-            withTags: false
+            withTags: false,
+            withAnnotationLabels: false
         });
 
         expect(screen.getByTestId('plot-color-by-button')).toHaveTextContent('metadata.split');
@@ -163,10 +222,25 @@ describe('PlotColorByPopover', () => {
             collectionId: 'test-collection-id',
             selectedKey: null,
             onSelectedKeyChange: vi.fn(),
-            withTags: true
+            withTags: true,
+            withAnnotationLabels: false
         });
 
         expect(screen.getByTestId('plot-color-by-button')).toHaveTextContent('tags');
+    });
+
+    it('button shows annotations when annotation_label is selected', () => {
+        usePlotColorByType('test-collection-id').setSelectedColorByType('annotation_label');
+
+        render(PlotColorByPopover, {
+            collectionId: 'test-collection-id',
+            selectedKey: null,
+            onSelectedKeyChange: vi.fn(),
+            withTags: false,
+            withAnnotationLabels: true
+        });
+
+        expect(screen.getByTestId('plot-color-by-button')).toHaveTextContent('annotations');
     });
 
     it('shows the empty state when no supported metadata fields exist and withTags is false', async () => {
@@ -176,7 +250,8 @@ describe('PlotColorByPopover', () => {
             collectionId: 'test-collection-id',
             selectedKey: null,
             onSelectedKeyChange: vi.fn(),
-            withTags: false
+            withTags: false,
+            withAnnotationLabels: false
         });
 
         expect(screen.getByTestId('plot-color-by-button')).toBeDisabled();

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.test.ts
@@ -181,6 +181,50 @@ describe('PlotColorByPopover', () => {
         expect(get(colorByType.selectedColorByType)).toBe('annotation_label');
     });
 
+    it('selecting a metadata field named annotation_label routes to metadata when annotation labels are also available', async () => {
+        metadataInfoStore.set([{ name: 'annotation_label', type: 'string' }]);
+
+        const user = userEvent.setup();
+        const onSelectedKeyChange = vi.fn();
+        const colorByType = usePlotColorByType('test-collection-id');
+
+        render(PlotColorByPopover, {
+            collectionId: 'test-collection-id',
+            selectedKey: null,
+            onSelectedKeyChange,
+            withTags: false,
+            withAnnotationLabels: true
+        });
+
+        await user.click(screen.getByTestId('plot-color-by-button'));
+        await user.click(screen.getByRole('option', { name: 'metadata.annotation_label' }));
+
+        expect(onSelectedKeyChange).toHaveBeenCalledWith('annotation_label');
+        expect(get(colorByType.selectedColorByType)).toBe('metadata');
+    });
+
+    it('selecting a metadata field named tags routes to metadata when tags are also available', async () => {
+        metadataInfoStore.set([{ name: 'tags', type: 'string' }]);
+
+        const user = userEvent.setup();
+        const onSelectedKeyChange = vi.fn();
+        const colorByType = usePlotColorByType('test-collection-id');
+
+        render(PlotColorByPopover, {
+            collectionId: 'test-collection-id',
+            selectedKey: null,
+            onSelectedKeyChange,
+            withTags: true,
+            withAnnotationLabels: false
+        });
+
+        await user.click(screen.getByTestId('plot-color-by-button'));
+        await user.click(screen.getByRole('option', { name: 'metadata.tags' }));
+
+        expect(onSelectedKeyChange).toHaveBeenCalledWith('tags');
+        expect(get(colorByType.selectedColorByType)).toBe('metadata');
+    });
+
     it('clicking the selected metadata field clears the selected type', async () => {
         const user = userEvent.setup();
         const onSelectedKeyChange = vi.fn();

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -23,6 +23,8 @@
     import { usePlotColorByType } from './PlotColorByPopover/usePlotColorByType/usePlotColorByType';
     import { useTags } from '$lib/hooks/useTags/useTags';
     import { usePlotColorBy } from './usePlotColorBy/usePlotColorBy';
+    import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
+    import { writable } from 'svelte/store';
 
     const collectionId = page.params.collection_id;
     const { setShowPlot, getRangeSelection, setRangeSelectionForCollection } = useGlobalStorage();
@@ -71,9 +73,15 @@
 
     const { selectedColorByType } = usePlotColorByType(collectionId);
     const { tags } = useTags({ collection_id: collectionId, kind: ['sample'] });
+    const annotationLabelsQuery = useAnnotationLabels(() => ({ collectionId }));
+    const annotationLabels = writable<{ annotation_label_id: string }[]>([]);
+    $effect(() => {
+        annotationLabels.set(annotationLabelsQuery.data ?? []);
+    });
     const { colorBy, selectedColorByKey, setSelectedColorByKey } = usePlotColorBy({
         selectedColorByType,
-        tags
+        tags,
+        annotationLabels
     });
 
     const embeddingsData = $derived(useEmbeddings(collectionId, filter, $colorBy));
@@ -328,6 +336,7 @@
             <PlotColorByPopover
                 {collectionId}
                 withTags={$tags.length > 0}
+                withAnnotationLabels={$annotationLabels.length > 0}
                 selectedKey={$selectedColorByKey}
                 onSelectedKeyChange={(key) => {
                     setSelectedColorByKey(key);

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -76,7 +76,12 @@
     const annotationLabelsQuery = useAnnotationLabels(() => ({ collectionId }));
     const annotationLabels = writable<{ annotation_label_id: string }[]>([]);
     $effect(() => {
-        annotationLabels.set(annotationLabelsQuery.data ?? []);
+        annotationLabels.set(
+            (annotationLabelsQuery.data ?? []).filter(
+                (l): l is { annotation_label_id: string } & typeof l =>
+                    l.annotation_label_id !== undefined
+            )
+        );
     });
     const { colorBy, selectedColorByKey, setSelectedColorByKey } = usePlotColorBy({
         selectedColorByType,

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
@@ -87,6 +87,9 @@ vi.mock('$lib/hooks/useTags/useTags', () => ({
         tags: tagsStore
     })
 }));
+vi.mock('$lib/hooks/useAnnotationLabels/useAnnotationLabels', () => ({
+    useAnnotationLabels: () => ({ data: [] })
+}));
 
 vi.mock('$lib/hooks/useGlobalStorage', () => {
     return {

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
@@ -40,7 +40,7 @@
     {#if legendEntries.length > 0}
         <span class="my-0.5 w-full shrink-0 border-t border-white/10"></span>
         <div class="flex w-full flex-col gap-1 overflow-y-auto dark:[color-scheme:dark]">
-            {#each legendEntries as entry (entry.cat)}
+            {#each legendEntries.toSorted( (a, b) => a.label.localeCompare(b.label) ) as entry (entry.cat)}
                 <button
                     type="button"
                     class={cn(

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
@@ -26,36 +26,39 @@
 </script>
 
 <div
-    class="absolute bottom-1 left-3 flex max-h-[calc(100%-0.5rem)] flex-col items-start gap-1 overflow-y-auto rounded-md border border-white/10 bg-black/60 px-2 py-1 text-xs text-muted-foreground backdrop-blur-sm"
+    class="absolute bottom-1 left-3 flex max-h-[calc(100%-0.5rem)] flex-col items-start gap-1 overflow-hidden rounded-md border border-white/10 bg-black/60 px-2 py-1 text-xs text-muted-foreground backdrop-blur-sm"
     data-testid="plot-legend"
 >
-    <span class="flex items-center gap-1.5">
+    <span class="flex shrink-0 items-center gap-1.5">
         <span class="legend-dot" style={`background-color: ${categoryColors[0]}`}></span>
         Not Filtered
     </span>
-    <span class="flex items-center gap-1.5">
+    <span class="flex shrink-0 items-center gap-1.5">
         <span class="legend-dot" style={`background-color: ${categoryColors[1]}`}></span>
         {filteredLabel}
     </span>
     {#if legendEntries.length > 0}
-        <span class="my-0.5 w-full border-t border-white/10"></span>
-        {#each legendEntries as entry (entry.cat)}
-            <button
-                type="button"
-                class={cn(
-                    'flex w-full cursor-pointer items-center gap-1.5 rounded text-left transition-opacity hover:opacity-80',
-                    entry.hidden && 'opacity-40'
-                )}
-                data-testid={`plot-legend-entry-${entry.cat}`}
-                aria-pressed={entry.hidden}
-                title={entry.hidden ? 'Show category' : 'Hide category'}
-                onclick={() => onToggleCategory?.(entry.cat)}
-                ondblclick={() => onDoubleClickCategory?.(entry.cat)}
-            >
-                <span class="legend-dot shrink-0" style={`background-color: ${entry.color}`}></span>
-                <span class="truncate">{entry.label}</span>
-            </button>
-        {/each}
+        <span class="my-0.5 w-full shrink-0 border-t border-white/10"></span>
+        <div class="flex w-full flex-col gap-1 overflow-y-auto dark:[color-scheme:dark]">
+            {#each legendEntries as entry (entry.cat)}
+                <button
+                    type="button"
+                    class={cn(
+                        'flex w-full cursor-pointer items-center gap-1.5 rounded text-left transition-opacity hover:opacity-80',
+                        entry.hidden && 'opacity-40'
+                    )}
+                    data-testid={`plot-legend-entry-${entry.cat}`}
+                    aria-pressed={entry.hidden}
+                    title={entry.hidden ? 'Show category' : 'Hide category'}
+                    onclick={() => onToggleCategory?.(entry.cat)}
+                    ondblclick={() => onDoubleClickCategory?.(entry.cat)}
+                >
+                    <span class="legend-dot shrink-0" style={`background-color: ${entry.color}`}
+                    ></span>
+                    <span class="truncate">{entry.label}</span>
+                </button>
+            {/each}
+        </div>
     {/if}
 </div>
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotColorBy/usePlotColorBy.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotColorBy/usePlotColorBy.test.ts
@@ -6,7 +6,8 @@ describe('usePlotColorBy', () => {
     it('returns null when no type is selected', () => {
         const { colorBy } = usePlotColorBy({
             selectedColorByType: writable(null),
-            tags: writable([])
+            tags: writable([]),
+            annotationLabels: writable([])
         });
 
         expect(get(colorBy)).toBeNull();
@@ -15,7 +16,8 @@ describe('usePlotColorBy', () => {
     it('returns metadata_field colorBy when metadata type is selected with a key', () => {
         const { colorBy, setSelectedColorByKey } = usePlotColorBy({
             selectedColorByType: writable('metadata'),
-            tags: writable([])
+            tags: writable([]),
+            annotationLabels: writable([])
         });
 
         setSelectedColorByKey('split');
@@ -26,7 +28,8 @@ describe('usePlotColorBy', () => {
     it('returns null when metadata type is selected but key is null', () => {
         const { colorBy } = usePlotColorBy({
             selectedColorByType: writable('metadata'),
-            tags: writable([])
+            tags: writable([]),
+            annotationLabels: writable([])
         });
 
         expect(get(colorBy)).toBeNull();
@@ -35,7 +38,8 @@ describe('usePlotColorBy', () => {
     it('returns tag colorBy with all tag IDs when tags type is selected', () => {
         const { colorBy } = usePlotColorBy({
             selectedColorByType: writable('tags'),
-            tags: writable([{ tag_id: 'tag-a' }, { tag_id: 'tag-b' }])
+            tags: writable([{ tag_id: 'tag-a' }, { tag_id: 'tag-b' }]),
+            annotationLabels: writable([])
         });
 
         expect(get(colorBy)).toEqual({ type: 'tag', tag_ids: ['tag-a', 'tag-b'] });
@@ -44,17 +48,45 @@ describe('usePlotColorBy', () => {
     it('returns tag colorBy with empty tag_ids when no tags exist', () => {
         const { colorBy } = usePlotColorBy({
             selectedColorByType: writable('tags'),
-            tags: writable([])
+            tags: writable([]),
+            annotationLabels: writable([])
         });
 
         expect(get(colorBy)).toEqual({ type: 'tag', tag_ids: [] });
+    });
+
+    it('returns annotation colorBy with all annotation label IDs when annotation_label type is selected', () => {
+        const { colorBy } = usePlotColorBy({
+            selectedColorByType: writable('annotation_label'),
+            tags: writable([]),
+            annotationLabels: writable([
+                { annotation_label_id: 'label-a' },
+                { annotation_label_id: 'label-b' }
+            ])
+        });
+
+        expect(get(colorBy)).toEqual({
+            type: 'annotation',
+            annotation_label_ids: ['label-a', 'label-b']
+        });
+    });
+
+    it('returns annotation colorBy with empty annotation_label_ids when no annotation labels exist', () => {
+        const { colorBy } = usePlotColorBy({
+            selectedColorByType: writable('annotation_label'),
+            tags: writable([]),
+            annotationLabels: writable([])
+        });
+
+        expect(get(colorBy)).toEqual({ type: 'annotation', annotation_label_ids: [] });
     });
 
     it('reacts to selectedColorByType changes', () => {
         const selectedColorByType = writable<'metadata' | 'tags' | 'annotation_label' | null>(null);
         const { colorBy, setSelectedColorByKey } = usePlotColorBy({
             selectedColorByType,
-            tags: writable([{ tag_id: 'tag-a' }])
+            tags: writable([{ tag_id: 'tag-a' }]),
+            annotationLabels: writable([{ annotation_label_id: 'label-a' }])
         });
 
         setSelectedColorByKey('split');
@@ -66,6 +98,12 @@ describe('usePlotColorBy', () => {
         selectedColorByType.set('tags');
         expect(get(colorBy)).toEqual({ type: 'tag', tag_ids: ['tag-a'] });
 
+        selectedColorByType.set('annotation_label');
+        expect(get(colorBy)).toEqual({
+            type: 'annotation',
+            annotation_label_ids: ['label-a']
+        });
+
         selectedColorByType.set(null);
         expect(get(colorBy)).toBeNull();
     });
@@ -73,7 +111,8 @@ describe('usePlotColorBy', () => {
     it('reacts to selectedColorByKey changes', () => {
         const { colorBy, setSelectedColorByKey } = usePlotColorBy({
             selectedColorByType: writable('metadata'),
-            tags: writable([])
+            tags: writable([]),
+            annotationLabels: writable([])
         });
 
         expect(get(colorBy)).toBeNull();
@@ -88,7 +127,8 @@ describe('usePlotColorBy', () => {
     it('exposes selectedColorByKey as a readable', () => {
         const { selectedColorByKey, setSelectedColorByKey } = usePlotColorBy({
             selectedColorByType: writable(null),
-            tags: writable([])
+            tags: writable([]),
+            annotationLabels: writable([])
         });
 
         expect(get(selectedColorByKey)).toBeNull();
@@ -101,12 +141,33 @@ describe('usePlotColorBy', () => {
         const tags = writable<{ tag_id: string }[]>([]);
         const { colorBy } = usePlotColorBy({
             selectedColorByType: writable('tags'),
-            tags
+            tags,
+            annotationLabels: writable([])
         });
 
         expect(get(colorBy)).toEqual({ type: 'tag', tag_ids: [] });
 
         tags.set([{ tag_id: 'tag-a' }, { tag_id: 'tag-b' }]);
         expect(get(colorBy)).toEqual({ type: 'tag', tag_ids: ['tag-a', 'tag-b'] });
+    });
+
+    it('reacts to annotationLabels changes', () => {
+        const annotationLabels = writable<{ annotation_label_id: string }[]>([]);
+        const { colorBy } = usePlotColorBy({
+            selectedColorByType: writable('annotation_label'),
+            tags: writable([]),
+            annotationLabels
+        });
+
+        expect(get(colorBy)).toEqual({ type: 'annotation', annotation_label_ids: [] });
+
+        annotationLabels.set([
+            { annotation_label_id: 'label-a' },
+            { annotation_label_id: 'label-b' }
+        ]);
+        expect(get(colorBy)).toEqual({
+            type: 'annotation',
+            annotation_label_ids: ['label-a', 'label-b']
+        });
     });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotColorBy/usePlotColorBy.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotColorBy/usePlotColorBy.ts
@@ -7,6 +7,7 @@ type ColorBy = GetEmbeddings2dRequest['color_by'];
 interface UsePlotColorByParams {
     selectedColorByType: Readable<PlotColorByType | null>;
     tags: Readable<{ tag_id: string }[]>;
+    annotationLabels: Readable<{ annotation_label_id: string }[]>;
 }
 
 interface UsePlotColorByReturn {
@@ -17,19 +18,29 @@ interface UsePlotColorByReturn {
 
 export function usePlotColorBy({
     selectedColorByType,
-    tags
+    tags,
+    annotationLabels
 }: UsePlotColorByParams): UsePlotColorByReturn {
     const selectedColorByKey = writable<string | null>(null);
 
     const colorBy = derived(
-        [selectedColorByType, selectedColorByKey, tags],
-        ([$selectedColorByType, $selectedColorByKey, $tags]): ColorBy => {
+        [selectedColorByType, selectedColorByKey, tags, annotationLabels],
+        ([$selectedColorByType, $selectedColorByKey, $tags, $annotationLabels]): ColorBy => {
             if ($selectedColorByType === 'metadata' && $selectedColorByKey) {
                 return { type: 'metadata_field', key: $selectedColorByKey };
             }
 
             if ($selectedColorByType === 'tags') {
                 return { type: 'tag', tag_ids: $tags.map((tag) => tag.tag_id) };
+            }
+
+            if ($selectedColorByType === 'annotation_label') {
+                return {
+                    type: 'annotation',
+                    annotation_label_ids: $annotationLabels.map(
+                        (label) => label.annotation_label_id
+                    )
+                };
             }
 
             return null;


### PR DESCRIPTION
## What has changed and why?

Adds an  "annotations" option to the embedding plot color-by popover when the collection has annotation labels and lists them in the legend.

## How has it been tested?

Unit tests.

- Add annotations.
- Open the embedding plot and select Annotations from the Color by menu.
- The embedding plot should be colorized based on annotation labels.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plot panels can be colored by annotation labels when available; an "annotations" option appears in the color-by menu and button when enabled.
  * Color-by logic now supports annotation-label selections alongside tags and metadata.

* **Bug Fixes**
  * Metadata selection correctly wins when field names collide with special options (e.g., "annotation_label" or "tags").
  * Empty-state ("Nothing to color by") behavior preserved.

* **UI Improvements**
  * Legend gains a scrollable entry area and renders entries in deterministic alphabetical order.

* **Tests**
  * Coverage expanded to validate annotation-label behavior, selection routing, and reactive updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->