### PR TITLE
Fix DatasetGridHeader to use collection dataset ID

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -13,7 +13,7 @@
         canSelectAll: boolean;
         isImages: boolean;
         hasMediaWithEmbeddings: boolean;
-        datasetId: string;
+        collectionDatasetId: string;
         onSelectAll: () => Promise<void>;
         searchImage: SearchImage | undefined;
         searchPending: boolean;
@@ -29,7 +29,6 @@
         canSelectAll,
         isImages,
         hasMediaWithEmbeddings,
-        datasetId,
         onSelectAll,
         searchImage,
         searchPending,
@@ -37,7 +36,8 @@
         onSubmitText,
         onSubmitFile,
         onSearchClear,
-        onSearchError
+        onSearchError,
+        collectionDatasetId
     }: Props = $props();
 
     const { showPlot, setShowPlot, showEvaluationRuns, setShowEvaluationRuns } = useGlobalStorage();
@@ -51,7 +51,7 @@
     {/snippet}
     {#snippet auxControls()}
         {#if isImages}
-            <OrderBy {datasetId} />
+            <OrderBy datasetId={collectionDatasetId} />
         {/if}
         {#if hasMediaWithEmbeddings}
             <Tooltip

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -52,7 +52,7 @@ const defaultProps = {
     canSelectAll: false,
     isImages: false,
     hasMediaWithEmbeddings: false,
-    datasetId: 'dataset-1',
+    collectionDatasetId: 'dataset-1',
     onSelectAll: vi.fn().mockResolvedValue(undefined),
     searchImage: undefined,
     searchPending: false,

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -375,7 +375,7 @@
                         {canSelectAll}
                         {isImages}
                         {hasMediaWithEmbeddings}
-                        {datasetId}
+                        collectionDatasetId={collection?.dataset_id}
                         compact={isSidePanelOpen}
                         onSelectAll={selectAllHandle.handleSelectAll}
                         searchImage={$searchImage}
@@ -441,7 +441,7 @@
                                 {canSelectAll}
                                 {isImages}
                                 {hasMediaWithEmbeddings}
-                                {datasetId}
+                                collectionDatasetId={collection?.dataset_id}
                                 compact={isSidePanelOpen}
                                 onSelectAll={selectAllHandle.handleSelectAll}
                                 searchImage={$searchImage}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -375,7 +375,7 @@
                         {canSelectAll}
                         {isImages}
                         {hasMediaWithEmbeddings}
-                        collectionDatasetId={collection?.dataset_id}
+                        collectionDatasetId={collection.dataset_id}
                         compact={isSidePanelOpen}
                         onSelectAll={selectAllHandle.handleSelectAll}
                         searchImage={$searchImage}
@@ -441,7 +441,7 @@
                                 {canSelectAll}
                                 {isImages}
                                 {hasMediaWithEmbeddings}
-                                collectionDatasetId={collection?.dataset_id}
+                                collectionDatasetId={collection.dataset_id}
                                 compact={isSidePanelOpen}
                                 onSelectAll={selectAllHandle.handleSelectAll}
                                 searchImage={$searchImage}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -76,6 +76,7 @@
         }
     } = $derived(data);
 
+    // The dataset ID actually contains the collection ID.
     const datasetId = $derived(page.params.dataset_id!);
     const collectionId = $derived(page.params.collection_id!);
     const collectionIdStore = toStore(() => collectionId);


### PR DESCRIPTION
## What has changed and why?

Renames the DatasetGridHeader prop from datasetId to collectionDatasetId. This ensures the OrderBy component receives the correct dataset ID scoped to the collection rather than the one from the URL.

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the dataset identification prop used by the grid header to a collection-specific name for consistent behavior across collection views.
* **Tests**
  * Updated component tests and fixtures to use the new prop name.
* **Other**
  * Updated layout usages to pass the renamed prop where the grid header is rendered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->