### PR TITLE
Add get_most_used_by_collection_id to tag resolver

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import sqlmodel
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import Session, col, select
+from sqlmodel import Session, col, func, select
 
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
 from lightly_studio.models.tag import TagCreate, TagTable
@@ -251,3 +251,41 @@ def get_or_create_sample_tag_by_name(
 
     new_tag = TagCreate(name=tag_name, collection_id=collection_id, kind="sample")
     return create(session=session, tag=new_tag)
+
+
+def get_most_used_by_collection_id(
+    session: Session,
+    collection_id: UUID,
+    limit: int = 30,
+) -> dict[UUID, str]:
+    """Return the most used tags in a collection.
+
+    Tags are ordered by descending number of sample assignments. Ties are
+    resolved deterministically by creation time and tag ID.
+
+    Args:
+        session: Database session for executing queries.
+        collection_id: The collection whose tags should be returned.
+        limit: Maximum number of tags to return.
+
+    Returns:
+        A mapping of tag ID to tag name for the most used tags in the collection.
+    """
+    usage_count = func.count(col(SampleTagLinkTable.sample_id))
+    query = (
+        select(TagTable.tag_id, TagTable.name, usage_count)
+        .where(TagTable.collection_id == collection_id)
+        .outerjoin(SampleTagLinkTable, col(SampleTagLinkTable.tag_id) == col(TagTable.tag_id))
+        .group_by(
+            col(TagTable.tag_id),
+            col(TagTable.name),
+            col(TagTable.created_at),
+        )
+        .order_by(
+            usage_count.desc(),
+            col(TagTable.created_at).asc(),
+            col(TagTable.tag_id).asc(),
+        )
+        .limit(limit)
+    )
+    return {tag_id: tag_name for tag_id, tag_name, _ in session.exec(query).all()}

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -498,3 +498,70 @@ def test_add_and_remove_sample_ids_to_tag_id__twice_same_sample_ids(
 
     # ensure all samples were removed again
     assert len(tag_1.samples) == 0
+
+
+def test_get_most_used_by_collection_id__orders_by_usage(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    most_used_tag = create_tag(session=db_session, collection_id=collection_id, tag_name="tag_1")
+    middle_used_tag = create_tag(session=db_session, collection_id=collection_id, tag_name="tag_2")
+    least_used_tag = create_tag(session=db_session, collection_id=collection_id, tag_name="tag_3")
+
+    images = [
+        create_image(
+            session=db_session, collection_id=collection_id, file_path_abs=f"sample{i}.png"
+        )
+        for i in range(4)
+    ]
+
+    tag_resolver.add_tag_to_sample(
+        session=db_session, tag_id=most_used_tag.tag_id, sample=images[0].sample
+    )
+    tag_resolver.add_tag_to_sample(
+        session=db_session, tag_id=most_used_tag.tag_id, sample=images[1].sample
+    )
+    tag_resolver.add_tag_to_sample(
+        session=db_session, tag_id=most_used_tag.tag_id, sample=images[2].sample
+    )
+    tag_resolver.add_tag_to_sample(
+        session=db_session, tag_id=middle_used_tag.tag_id, sample=images[0].sample
+    )
+    tag_resolver.add_tag_to_sample(
+        session=db_session, tag_id=middle_used_tag.tag_id, sample=images[1].sample
+    )
+    tag_resolver.add_tag_to_sample(
+        session=db_session, tag_id=least_used_tag.tag_id, sample=images[0].sample
+    )
+
+    tags = tag_resolver.get_most_used_by_collection_id(
+        session=db_session, collection_id=collection_id
+    )
+
+    assert list(tags.keys()) == [
+        most_used_tag.tag_id,
+        middle_used_tag.tag_id,
+        least_used_tag.tag_id,
+    ]
+    assert tags == {
+        most_used_tag.tag_id: most_used_tag.name,
+        middle_used_tag.tag_id: middle_used_tag.name,
+        least_used_tag.tag_id: least_used_tag.name,
+    }
+
+
+def test_get_most_used_by_collection_id__limits_to_30_tags(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    created_tags = [
+        create_tag(session=db_session, collection_id=collection_id, tag_name=f"tag_{i}")
+        for i in range(31)
+    ]
+
+    tags = tag_resolver.get_most_used_by_collection_id(
+        session=db_session, collection_id=collection_id
+    )
+
+    assert len(tags) == 30
+    assert list(tags.keys()) == [tag.tag_id for tag in created_tags[:30]]


### PR DESCRIPTION
## What has changed and why?

Adds `get_most_used_by_collection_id` to `tag_resolver`, returning up to 30 tags for a collection ordered by descending sample usage.

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to retrieve and display the most frequently used tags within a collection, ranked by usage count with consistent tie-breaking for reproducibility.

* **Tests**
  * Added test coverage for the new tag retrieval functionality, validating sort order accuracy and result limiting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->