### PR TITLE
Mute Unassigned category color in embedding plot

### DIFF
--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -17,7 +17,12 @@
     import { useCategoryVisibility } from './useCategoryVisibility/useCategoryVisibility';
     import { isEqual } from 'lodash-es';
     import { NOT_FILTERED_CATEGORY } from './plotCategories';
-    import { getCategoryColors, getCategoryCount, getLegendEntries } from './plotColorUtils';
+    import {
+        getCategoryColors,
+        getCategoryCount,
+        getLegendEntries,
+        hasColorByCategories
+    } from './plotColorUtils';
     import { page } from '$app/state';
     import { isVideosRoute } from '$lib/routes';
     import { usePlotColorByType } from './PlotColorByPopover/usePlotColorByType/usePlotColorByType';
@@ -120,8 +125,14 @@
     );
     const categoryCount = $derived.by(() => getCategoryCount($colorLegend));
     const useLabelColors = $derived($selectedColorByType !== 'metadata');
+    const colorLegendHasColorByCategories = $derived.by(() => hasColorByCategories($colorLegend));
     const categoryColors = $derived.by(() =>
-        getCategoryColors($colorLegend, $hiddenCategories, useLabelColors)
+        getCategoryColors(
+            $colorLegend,
+            $hiddenCategories,
+            useLabelColors,
+            colorLegendHasColorByCategories
+        )
     );
     const legendEntries = $derived.by(() =>
         getLegendEntries($colorLegend, $hiddenCategories, useLabelColors)

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -17,12 +17,7 @@
     import { useCategoryVisibility } from './useCategoryVisibility/useCategoryVisibility';
     import { isEqual } from 'lodash-es';
     import { NOT_FILTERED_CATEGORY } from './plotCategories';
-    import {
-        getCategoryColors,
-        getCategoryCount,
-        getLegendEntries,
-        hasColorByCategories
-    } from './plotColorUtils';
+    import { getCategoryColors, getCategoryCount, getLegendEntries } from './plotColorUtils';
     import { page } from '$app/state';
     import { isVideosRoute } from '$lib/routes';
     import { usePlotColorByType } from './PlotColorByPopover/usePlotColorByType/usePlotColorByType';
@@ -125,14 +120,8 @@
     );
     const categoryCount = $derived.by(() => getCategoryCount($colorLegend));
     const useLabelColors = $derived($selectedColorByType !== 'metadata');
-    const colorLegendHasColorByCategories = $derived.by(() => hasColorByCategories($colorLegend));
     const categoryColors = $derived.by(() =>
-        getCategoryColors(
-            $colorLegend,
-            $hiddenCategories,
-            useLabelColors,
-            colorLegendHasColorByCategories
-        )
+        getCategoryColors($colorLegend, $hiddenCategories, useLabelColors, $colorBy !== null)
     );
     const legendEntries = $derived.by(() =>
         getLegendEntries($colorLegend, $hiddenCategories, useLabelColors)

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
@@ -5,7 +5,6 @@ import {
     getCategoryColors,
     getCategoryCount,
     getLegendEntries,
-    hasColorByCategories,
     NOT_FILTERED_COLOR,
     UNASSIGNED_COLOR
 } from './plotColorUtils';
@@ -43,7 +42,7 @@ describe('plotColorUtils', () => {
         ]);
     });
 
-    it('renders hidden categories with the unassigned color when colorBy categories exist', () => {
+    it('renders hidden categories with the unassigned color when colorBy is active', () => {
         const colorLegend = new Map([
             [2, 'Train'],
             [3, 'Validation']
@@ -94,7 +93,7 @@ describe('plotColorUtils', () => {
         ]);
     });
 
-    it('returns unassigned color for hidden categories when colorBy categories exist', () => {
+    it('returns unassigned color for hidden categories when colorBy is active', () => {
         const legend = new Map([
             [0, ''],
             [1, ''],
@@ -108,23 +107,7 @@ describe('plotColorUtils', () => {
         ]);
     });
 
-    it('detects colorBy categories from the legend', () => {
-        const withColorBy = new Map([
-            [2, 'Train'],
-            [3, 'Validation']
-        ]);
-        expect(hasColorByCategories(withColorBy)).toBe(true);
-
-        const withoutColorBy = new Map([
-            [0, ''],
-            [1, '']
-        ]);
-        expect(hasColorByCategories(withoutColorBy)).toBe(false);
-
-        expect(hasColorByCategories(undefined)).toBe(false);
-    });
-
-    it('uses unassigned color for category 1 when colorBy categories exist', () => {
+    it('uses unassigned color for category 1 when colorBy is active', () => {
         const colorLegend = new Map([
             [2, 'Train'],
             [3, 'Validation']

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { getColorByLabel } from '$lib/utils';
 import {
     FILTERED_COLOR,
-    FILTERED_COLOR_MUTED,
     getCategoryColors,
     getCategoryCount,
     getLegendEntries,
-    NOT_FILTERED_COLOR
+    hasColorByCategories,
+    NOT_FILTERED_COLOR,
+    UNASSIGNED_COLOR
 } from './plotColorUtils';
 
 describe('plotColorUtils', () => {
@@ -34,25 +35,25 @@ describe('plotColorUtils', () => {
             [3, 'Validation']
         ]);
 
-        expect(getCategoryColors(colorLegend, new Set(), true)).toEqual([
+        expect(getCategoryColors(colorLegend, new Set(), true, true)).toEqual([
             NOT_FILTERED_COLOR,
-            FILTERED_COLOR_MUTED,
+            UNASSIGNED_COLOR,
             getColorByLabel('Train').color,
             getColorByLabel('Validation').color
         ]);
     });
 
-    it('renders hidden categories with the filtered color', () => {
+    it('renders hidden categories with the unassigned color when colorBy categories exist', () => {
         const colorLegend = new Map([
             [2, 'Train'],
             [3, 'Validation']
         ]);
 
-        expect(getCategoryColors(colorLegend, new Set([3]), true)).toEqual([
+        expect(getCategoryColors(colorLegend, new Set([3]), true, true)).toEqual([
             NOT_FILTERED_COLOR,
-            FILTERED_COLOR_MUTED,
+            UNASSIGNED_COLOR,
             getColorByLabel('Train').color,
-            FILTERED_COLOR_MUTED
+            UNASSIGNED_COLOR
         ]);
     });
 
@@ -93,34 +94,44 @@ describe('plotColorUtils', () => {
         ]);
     });
 
-    it('returns filtered color for hidden categories', () => {
+    it('returns unassigned color for hidden categories when colorBy categories exist', () => {
         const legend = new Map([
             [0, ''],
             [1, ''],
             [2, '']
         ]);
         const hiddenCategories = new Set([0, 2]);
-        expect(getCategoryColors(legend, hiddenCategories)).toEqual([
-            FILTERED_COLOR_MUTED,
-            FILTERED_COLOR_MUTED,
-            FILTERED_COLOR_MUTED
+        expect(getCategoryColors(legend, hiddenCategories, false, true)).toEqual([
+            UNASSIGNED_COLOR,
+            UNASSIGNED_COLOR,
+            UNASSIGNED_COLOR
         ]);
     });
 
-    it('uses muted filtered color for category 1 when colorBy is active', () => {
+    it('detects colorBy categories from the legend', () => {
         const withColorBy = new Map([
             [2, 'Train'],
             [3, 'Validation']
         ]);
-        expect(getCategoryColors(withColorBy)[1]).toBe(FILTERED_COLOR_MUTED);
+        expect(hasColorByCategories(withColorBy)).toBe(true);
 
         const withoutColorBy = new Map([
             [0, ''],
             [1, '']
         ]);
-        expect(getCategoryColors(withoutColorBy)[1]).toBe(FILTERED_COLOR);
+        expect(hasColorByCategories(withoutColorBy)).toBe(false);
 
-        expect(getCategoryColors(undefined)[1]).toBe(FILTERED_COLOR);
+        expect(hasColorByCategories(undefined)).toBe(false);
+    });
+
+    it('uses unassigned color for category 1 when colorBy categories exist', () => {
+        const colorLegend = new Map([
+            [2, 'Train'],
+            [3, 'Validation']
+        ]);
+
+        expect(getCategoryColors(colorLegend, new Set(), false, true)[1]).toBe(UNASSIGNED_COLOR);
+        expect(getCategoryColors(colorLegend)[1]).toBe(FILTERED_COLOR);
     });
 
     it('uses label colors for labeled categories when requested', () => {
@@ -132,9 +143,9 @@ describe('plotColorUtils', () => {
 
         const labelColor = getColorByLabel('labelName').color;
         const defaultColors = getCategoryColors(legend, new Set(), false);
-        const labelColors = getCategoryColors(legend, new Set(), true);
+        const labelColors = getCategoryColors(legend, new Set(), true, true);
 
-        expect(labelColors).toEqual([NOT_FILTERED_COLOR, FILTERED_COLOR_MUTED, labelColor]);
+        expect(labelColors).toEqual([NOT_FILTERED_COLOR, UNASSIGNED_COLOR, labelColor]);
         expect(defaultColors[2]).not.toBe(labelColor);
     });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { getColorByLabel } from '$lib/utils';
 import {
     FILTERED_COLOR,
+    FILTERED_COLOR_MUTED,
     getCategoryColors,
     getCategoryCount,
     getLegendEntries,
@@ -35,7 +36,7 @@ describe('plotColorUtils', () => {
 
         expect(getCategoryColors(colorLegend, new Set(), true)).toEqual([
             NOT_FILTERED_COLOR,
-            FILTERED_COLOR,
+            FILTERED_COLOR_MUTED,
             getColorByLabel('Train').color,
             getColorByLabel('Validation').color
         ]);
@@ -49,9 +50,9 @@ describe('plotColorUtils', () => {
 
         expect(getCategoryColors(colorLegend, new Set([3]), true)).toEqual([
             NOT_FILTERED_COLOR,
-            FILTERED_COLOR,
+            FILTERED_COLOR_MUTED,
             getColorByLabel('Train').color,
-            FILTERED_COLOR
+            FILTERED_COLOR_MUTED
         ]);
     });
 
@@ -100,10 +101,26 @@ describe('plotColorUtils', () => {
         ]);
         const hiddenCategories = new Set([0, 2]);
         expect(getCategoryColors(legend, hiddenCategories)).toEqual([
-            FILTERED_COLOR,
-            FILTERED_COLOR,
-            FILTERED_COLOR
+            FILTERED_COLOR_MUTED,
+            FILTERED_COLOR_MUTED,
+            FILTERED_COLOR_MUTED
         ]);
+    });
+
+    it('uses muted filtered color for category 1 when colorBy is active', () => {
+        const withColorBy = new Map([
+            [2, 'Train'],
+            [3, 'Validation']
+        ]);
+        expect(getCategoryColors(withColorBy)[1]).toBe(FILTERED_COLOR_MUTED);
+
+        const withoutColorBy = new Map([
+            [0, ''],
+            [1, '']
+        ]);
+        expect(getCategoryColors(withoutColorBy)[1]).toBe(FILTERED_COLOR);
+
+        expect(getCategoryColors(undefined)[1]).toBe(FILTERED_COLOR);
     });
 
     it('uses label colors for labeled categories when requested', () => {
@@ -117,7 +134,7 @@ describe('plotColorUtils', () => {
         const defaultColors = getCategoryColors(legend, new Set(), false);
         const labelColors = getCategoryColors(legend, new Set(), true);
 
-        expect(labelColors).toEqual([NOT_FILTERED_COLOR, FILTERED_COLOR, labelColor]);
+        expect(labelColors).toEqual([NOT_FILTERED_COLOR, FILTERED_COLOR_MUTED, labelColor]);
         expect(defaultColors[2]).not.toBe(labelColor);
     });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -6,6 +6,7 @@ const RESERVED_CATEGORY_COUNT = 2;
 
 export const NOT_FILTERED_COLOR = '#9CA3AF';
 export const FILTERED_COLOR = '#F59E0B';
+export const FILTERED_COLOR_MUTED = '#caac78';
 
 interface LegendEntry {
     cat: number;
@@ -36,13 +37,26 @@ function getDiscreteCategoryColor(category: number, categoryCount: number): stri
     return getDiscreteHslColor(category - RESERVED_CATEGORY_COUNT, totalColoredCategories);
 }
 
-function getBaseCategoryColor(category: number, categoryCount: number, label: string): string {
+function isColorByActive(colorLegend?: ReadonlyMap<number, string> | null): boolean {
+    if (!colorLegend) return false;
+    for (const key of colorLegend.keys()) {
+        if (key >= RESERVED_CATEGORY_COUNT) return true;
+    }
+    return false;
+}
+
+function getBaseCategoryColor(
+    category: number,
+    categoryCount: number,
+    label: string,
+    colorByActive: boolean = false
+): string {
     if (category === 0) {
         return NOT_FILTERED_COLOR;
     }
 
     if (category === 1) {
-        return FILTERED_COLOR;
+        return colorByActive ? FILTERED_COLOR_MUTED : FILTERED_COLOR;
     }
 
     if (label) {
@@ -62,13 +76,14 @@ export function getCategoryColors(
     useLabelColors: boolean = false
 ): string[] {
     const categoryCount = getCategoryCount(colorLegend);
+    const colorByActive = isColorByActive(colorLegend);
     return Array.from({ length: categoryCount }, (_, category) => {
         if (hiddenCategories.has(category)) {
-            return FILTERED_COLOR;
+            return colorByActive ? FILTERED_COLOR_MUTED : FILTERED_COLOR;
         }
 
         const label = useLabelColors ? (colorLegend?.get(category) ?? '') : '';
-        return getBaseCategoryColor(category, categoryCount, label);
+        return getBaseCategoryColor(category, categoryCount, label, colorByActive);
     });
 }
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -37,26 +37,18 @@ function getDiscreteCategoryColor(category: number, categoryCount: number): stri
     return getDiscreteHslColor(category - RESERVED_CATEGORY_COUNT, totalColoredCategories);
 }
 
-export function hasColorByCategories(colorLegend?: ReadonlyMap<number, string> | null): boolean {
-    if (!colorLegend) return false;
-    for (const key of colorLegend.keys()) {
-        if (key >= RESERVED_CATEGORY_COUNT) return true;
-    }
-    return false;
-}
-
 function getBaseCategoryColor(
     category: number,
     categoryCount: number,
     label: string,
-    hasColorByCategories: boolean = false
+    isColorByActive: boolean = false
 ): string {
     if (category === 0) {
         return NOT_FILTERED_COLOR;
     }
 
     if (category === 1) {
-        return hasColorByCategories ? UNASSIGNED_COLOR : FILTERED_COLOR;
+        return isColorByActive ? UNASSIGNED_COLOR : FILTERED_COLOR;
     }
 
     if (label) {
@@ -74,16 +66,16 @@ export function getCategoryColors(
     colorLegend?: ReadonlyMap<number, string> | null,
     hiddenCategories: ReadonlySet<number> = new Set(),
     useLabelColors: boolean = false,
-    hasColorByCategories: boolean = false
+    isColorByActive: boolean = false
 ): string[] {
     const categoryCount = getCategoryCount(colorLegend);
     return Array.from({ length: categoryCount }, (_, category) => {
         if (hiddenCategories.has(category)) {
-            return hasColorByCategories ? UNASSIGNED_COLOR : FILTERED_COLOR;
+            return isColorByActive ? UNASSIGNED_COLOR : FILTERED_COLOR;
         }
 
         const label = useLabelColors ? (colorLegend?.get(category) ?? '') : '';
-        return getBaseCategoryColor(category, categoryCount, label, hasColorByCategories);
+        return getBaseCategoryColor(category, categoryCount, label, isColorByActive);
     });
 }
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -6,7 +6,7 @@ const RESERVED_CATEGORY_COUNT = 2;
 
 export const NOT_FILTERED_COLOR = '#9CA3AF';
 export const FILTERED_COLOR = '#F59E0B';
-export const FILTERED_COLOR_MUTED = '#caac78';
+export const UNASSIGNED_COLOR = '#CAAC78';
 
 interface LegendEntry {
     cat: number;
@@ -37,7 +37,7 @@ function getDiscreteCategoryColor(category: number, categoryCount: number): stri
     return getDiscreteHslColor(category - RESERVED_CATEGORY_COUNT, totalColoredCategories);
 }
 
-function isColorByActive(colorLegend?: ReadonlyMap<number, string> | null): boolean {
+export function hasColorByCategories(colorLegend?: ReadonlyMap<number, string> | null): boolean {
     if (!colorLegend) return false;
     for (const key of colorLegend.keys()) {
         if (key >= RESERVED_CATEGORY_COUNT) return true;
@@ -49,14 +49,14 @@ function getBaseCategoryColor(
     category: number,
     categoryCount: number,
     label: string,
-    colorByActive: boolean = false
+    hasColorByCategories: boolean = false
 ): string {
     if (category === 0) {
         return NOT_FILTERED_COLOR;
     }
 
     if (category === 1) {
-        return colorByActive ? FILTERED_COLOR_MUTED : FILTERED_COLOR;
+        return hasColorByCategories ? UNASSIGNED_COLOR : FILTERED_COLOR;
     }
 
     if (label) {
@@ -73,17 +73,17 @@ export function getCategoryCount(colorLegend?: ReadonlyMap<number, string> | nul
 export function getCategoryColors(
     colorLegend?: ReadonlyMap<number, string> | null,
     hiddenCategories: ReadonlySet<number> = new Set(),
-    useLabelColors: boolean = false
+    useLabelColors: boolean = false,
+    hasColorByCategories: boolean = false
 ): string[] {
     const categoryCount = getCategoryCount(colorLegend);
-    const colorByActive = isColorByActive(colorLegend);
     return Array.from({ length: categoryCount }, (_, category) => {
         if (hiddenCategories.has(category)) {
-            return colorByActive ? FILTERED_COLOR_MUTED : FILTERED_COLOR;
+            return hasColorByCategories ? UNASSIGNED_COLOR : FILTERED_COLOR;
         }
 
         const label = useLabelColors ? (colorLegend?.get(category) ?? '') : '';
-        return getBaseCategoryColor(category, categoryCount, label, colorByActive);
+        return getBaseCategoryColor(category, categoryCount, label, hasColorByCategories);
     });
 }
 


### PR DESCRIPTION
## What has changed and why?

Mute `Unassigned` category color in embedding plot.

## How has it been tested?

- Manually
- Unit tests

<img width="1029" height="647" alt="Screenshot 2026-05-25 at 15 56 35" src="https://github.com/user-attachments/assets/fb3b27bb-0c12-4b87-8889-b8a98a604633" />
<img width="1029" height="647" alt="Screenshot 2026-05-25 at 15 56 42" src="https://github.com/user-attachments/assets/89e2452c-cbd3-4195-a44c-c0ebe93db313" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved color handling for hidden categories when using the "color by" feature; unassigned categories now display with a distinct visual indicator instead of blending with filtered items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->