### PR TITLE
[Do not merge] Dataset split plugin prototype

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/operator.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/operator.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
-from typing import Any
+from datetime import datetime
+from typing import Any, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND
+from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_CONFLICT,
+    HTTP_STATUS_NOT_FOUND,
+)
 from lightly_studio.db_manager import SessionDep
 from lightly_studio.plugins import operator_context
 from lightly_studio.plugins.base_operator import OperatorResult, OperatorStatus
+from lightly_studio.plugins.execution_registry import (
+    ExecutionRecord,
+    execution_registry,
+    worker_session,
+)
 from lightly_studio.plugins.operator_context import AnyFilter, ExecutionContext
 from lightly_studio.plugins.operator_registry import RegisteredOperatorMetadata, operator_registry
 from lightly_studio.plugins.parameter import BaseParameter
@@ -37,6 +46,32 @@ class ExecuteOperatorRequest(BaseModel):
     context: OperatorContextRequest
 
 
+class OperatorExecutionResponse(BaseModel):
+    """Per-execution state surfaced to the GUI."""
+
+    execution_id: UUID
+    operator_id: str
+    operator_name: str
+    status: OperatorStatus
+    started_at: datetime
+    finished_at: Optional[datetime] = None
+    result: Optional[OperatorResult] = None
+    error_message: Optional[str] = None
+
+    @classmethod
+    def from_record(cls, record: ExecutionRecord) -> "OperatorExecutionResponse":
+        return cls(
+            execution_id=record.execution_id,
+            operator_id=record.operator_id,
+            operator_name=record.operator_name,
+            status=record.status,
+            started_at=record.started_at,
+            finished_at=record.finished_at,
+            result=record.result,
+            error_message=record.error_message,
+        )
+
+
 @operator_router.get("")
 def get_operators() -> list[RegisteredOperatorMetadata]:
     """Get all registered operators (id, name)."""
@@ -55,23 +90,18 @@ def get_operator_parameters(operator_id: str) -> list[BaseParameter]:
     return operator.parameters
 
 
-@operator_router.post("/{operator_id}/execute", response_model=OperatorResult)
+@operator_router.post("/{operator_id}/execute", response_model=OperatorExecutionResponse)
 def execute_operator(
     operator_id: str,
     request: ExecuteOperatorRequest,
     session: SessionDep,
-) -> OperatorResult:
-    """Execute an operator with the provided parameters.
+) -> OperatorExecutionResponse:
+    """Dispatch an operator to the background worker pool.
 
-    Args:
-        operator_id: The ID of the operator to execute.
-        request: The execution request containing parameters and context.
-        session: Database session.
-
-    Returns:
-        The execution result.
+    Returns immediately with an ``OperatorExecutionResponse`` whose status is
+    ``RUNNING``. Poll ``GET /operators/executions/{execution_id}`` (or list all
+    via ``GET /operators/executions``) to follow progress.
     """
-    # Get the operator
     operator = operator_registry.get_by_id(operator_id=operator_id)
     if operator is None:
         raise HTTPException(
@@ -86,11 +116,10 @@ def execute_operator(
             message = f"Operator '{operator_id}' has been stopped and cannot be executed."
         else:
             message = f"Operator '{operator_id}' is in an error state and cannot be executed."
-        return OperatorResult(success=False, message=message)
+        raise HTTPException(status_code=HTTP_STATUS_CONFLICT, detail=message)
 
     context = request.context
 
-    # The context may specify a focused sub-collection; fall back to the route collection.
     collection = collection_resolver.get_by_id(session=session, collection_id=context.collection_id)
     if collection is None:
         raise HTTPException(
@@ -98,26 +127,64 @@ def execute_operator(
             detail=f"Collection '{context.collection_id}' not found",
         )
 
-    # Get the scopes for the collection and validate against the scopes supported by the operator.
     collection_scopes = operator_context.get_allowed_scopes_for_collection(
         sample_type=collection.sample_type,
         is_root_collection=collection.parent_collection_id is None,
     )
     if not any(scope in operator.supported_scopes for scope in collection_scopes):
         supported = ", ".join(s.value for s in operator.supported_scopes)
-        return OperatorResult(
-            success=False,
-            message=(
+        raise HTTPException(
+            status_code=HTTP_STATUS_CONFLICT,
+            detail=(
                 f"Operator '{operator.name}' cannot be executed in this context. "
                 f"Supported scopes: {supported}."
             ),
         )
 
-    # Execute the operator
-    return operator.execute(
-        session=session,
+    record = execution_registry.submit(
+        operator=operator,
+        operator_id=operator_id,
+        session_factory=worker_session,
         context=ExecutionContext(
             collection_id=context.collection_id, context_filter=context.context_filter
         ),
         parameters=request.parameters,
     )
+    return OperatorExecutionResponse.from_record(record)
+
+
+@operator_router.get("/executions", response_model=list[OperatorExecutionResponse])
+def list_executions() -> list[OperatorExecutionResponse]:
+    """List all known executions (running, succeeded, failed)."""
+    return [OperatorExecutionResponse.from_record(r) for r in execution_registry.list_all()]
+
+
+@operator_router.get(
+    "/executions/{execution_id}", response_model=OperatorExecutionResponse
+)
+def get_execution(execution_id: UUID) -> OperatorExecutionResponse:
+    """Get the current state of a single execution."""
+    record = execution_registry.get(execution_id)
+    if record is None:
+        raise HTTPException(
+            status_code=HTTP_STATUS_NOT_FOUND,
+            detail=f"Execution '{execution_id}' not found",
+        )
+    return OperatorExecutionResponse.from_record(record)
+
+
+@operator_router.delete("/executions/{execution_id}", status_code=204)
+def dismiss_execution(execution_id: UUID) -> None:
+    """Remove a finished execution from the registry. Refuses if still running."""
+    record = execution_registry.get(execution_id)
+    if record is None:
+        raise HTTPException(
+            status_code=HTTP_STATUS_NOT_FOUND,
+            detail=f"Execution '{execution_id}' not found",
+        )
+    if record.status == OperatorStatus.RUNNING:
+        raise HTTPException(
+            status_code=HTTP_STATUS_CONFLICT,
+            detail="Execution is still running and cannot be dismissed.",
+        )
+    execution_registry.remove(execution_id)

--- a/lightly_studio/src/lightly_studio/examples/example_split_by_tag.py
+++ b/lightly_studio/src/lightly_studio/examples/example_split_by_tag.py
@@ -1,0 +1,31 @@
+"""Demo: split a dataset into a new one from a tag via a GUI-triggered plugin.
+
+How to use:
+    1. Run this script.
+    2. In the GUI, tag a few samples (e.g. with a tag named "keep").
+    3. Open the operators menu and run "Split dataset by tag" with
+       tag="keep" and new_dataset_name="my_subset".
+    4. The sidebar will list a new dataset containing only the tagged samples.
+"""
+
+from __future__ import annotations
+
+from environs import Env
+
+import lightly_studio as ls
+from lightly_studio import db_manager
+from lightly_studio.examples.split_by_tag_operator import SplitByTagOperator
+from lightly_studio.plugins.operator_registry import operator_registry
+
+env = Env()
+env.read_env()
+
+db_manager.connect(cleanup_existing=True)
+
+dataset_path = env.path("EXAMPLES_DATASET_PATH", "/path/to/your/dataset")
+dataset = ls.ImageDataset.create()
+dataset.add_images_from_path(path=dataset_path)
+
+operator_registry.register(operator=SplitByTagOperator())
+
+ls.start_gui()

--- a/lightly_studio/src/lightly_studio/examples/split_by_tag_operator.py
+++ b/lightly_studio/src/lightly_studio/examples/split_by_tag_operator.py
@@ -7,6 +7,11 @@ Triggered from the GUI on an existing dataset, this operator can:
 
 If ``tag`` is empty, a fresh empty dataset is created and only the ``samples_path``
 images are loaded into it.
+
+All DB work uses only the session passed into ``execute()`` so the operator is safe
+to run from a background worker thread. The high-level ``lightly_studio`` API
+(``ImageDataset.create`` / ``add_images_from_path``) is avoided because it touches
+the process-global persistent session, which is not thread-safe.
 """
 
 from __future__ import annotations
@@ -14,9 +19,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from lightly_studio.core.image.image_dataset import _generate_embeddings_image
 from sqlmodel import Session
 
-import lightly_studio as ls
+from lightly_studio.core.image import add_images
+from lightly_studio.dataset import fsspec_lister
+from lightly_studio.models.collection import CollectionCreate, CollectionTable, SampleType
 from lightly_studio.plugins.base_operator import BaseOperator, OperatorResult
 from lightly_studio.plugins.operator_context import ExecutionContext, OperatorScope
 from lightly_studio.plugins.parameter import BaseParameter, BoolParameter, StringParameter
@@ -102,6 +110,7 @@ class SplitByTagOperator(BaseOperator):
             )
 
         copied_count = 0
+        new_root: CollectionTable
         if tag_name:
             result = self._copy_tagged_subset(
                 session=session,
@@ -112,17 +121,26 @@ class SplitByTagOperator(BaseOperator):
             )
             if isinstance(result, OperatorResult):
                 return result
-            copied_count = result
+            new_root, copied_count = result
         else:
-            # No tag: create a fresh empty dataset to be filled from the folder.
-            ls.ImageDataset.create(name=new_name)
+            new_root = collection_resolver.create(
+                session=session,
+                collection=CollectionCreate(name=new_name, sample_type=SampleType.IMAGE),
+            )
 
         added_count = 0
         if samples_path:
-            new_dataset = ls.ImageDataset.load(name=new_name)
-            samples_before = len(list(new_dataset))
-            new_dataset.add_images_from_path(path=samples_path)
-            added_count = len(list(new_dataset)) - samples_before
+            image_paths = list(fsspec_lister.iter_files_from_path(path=samples_path))
+            created_sample_ids = add_images.load_into_dataset_from_paths(
+                session=session,
+                root_collection_id=new_root.collection_id,
+                image_paths=image_paths,
+            )
+            _generate_embeddings_image(
+                session=session,
+                sample_ids=created_sample_ids,
+                collection_id=new_root.collection_id,)
+            added_count = len(created_sample_ids)
 
         mode_suffix = " (samples-only)" if tag_name and samples_only else ""
         path_suffix = f", added {added_count} from '{samples_path}'" if samples_path else ""
@@ -142,8 +160,7 @@ class SplitByTagOperator(BaseOperator):
         new_name: str,
         tag_name: str,
         samples_only: bool,
-    ) -> OperatorResult | int:
-        """Run the tag-driven copy. Returns the number of copied samples or an error."""
+    ) -> OperatorResult | tuple[CollectionTable, int]:
         source_collection = collection_resolver.get_by_id(
             session=session, collection_id=context.collection_id
         )
@@ -170,17 +187,17 @@ class SplitByTagOperator(BaseOperator):
 
         sample_ids = [s.sample_id for s in tagged.samples]
         if samples_only:
-            dataset_resolver.copy_images_subset(
+            new_root = dataset_resolver.copy_images_subset(
                 session=session,
                 dataset_id=source_collection.dataset_id,
                 copy_name=new_name,
                 sample_ids=sample_ids,
             )
         else:
-            dataset_resolver.deep_copy_subset(
+            new_root = dataset_resolver.deep_copy_subset(
                 session=session,
                 dataset_id=source_collection.dataset_id,
                 copy_name=new_name,
                 sample_ids=sample_ids,
             )
-        return len(sample_ids)
+        return new_root, len(sample_ids)

--- a/lightly_studio/src/lightly_studio/examples/split_by_tag_operator.py
+++ b/lightly_studio/src/lightly_studio/examples/split_by_tag_operator.py
@@ -1,0 +1,186 @@
+"""Operator plugin that creates a new dataset from a tag and/or a samples folder.
+
+Triggered from the GUI on an existing dataset, this operator can:
+- Copy the samples carrying a given tag into a new dataset (deep or samples-only).
+- Load images from a filesystem path into the new dataset.
+- Do both: split by tag, then top up the new dataset with images from disk.
+
+If ``tag`` is empty, a fresh empty dataset is created and only the ``samples_path``
+images are loaded into it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlmodel import Session
+
+import lightly_studio as ls
+from lightly_studio.plugins.base_operator import BaseOperator, OperatorResult
+from lightly_studio.plugins.operator_context import ExecutionContext, OperatorScope
+from lightly_studio.plugins.parameter import BaseParameter, BoolParameter, StringParameter
+from lightly_studio.resolvers import (
+    collection_resolver,
+    dataset_resolver,
+    sample_resolver,
+    tag_resolver,
+)
+from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
+
+
+@dataclass
+class SplitByTagOperator(BaseOperator):
+    """Create a new dataset from a tag selection and/or a folder of images."""
+
+    name: str = "Split dataset by tag"
+    description: str = (
+        "Create a new dataset from the current one. Optionally restrict to samples "
+        "carrying a tag, and optionally add images from a folder."
+    )
+
+    @property
+    def parameters(self) -> list[BaseParameter]:
+        return [
+            StringParameter(
+                name="new_dataset_name",
+                required=True,
+                description="Name of the new dataset to create.",
+            ),
+            StringParameter(
+                name="tag",
+                required=False,
+                default="",
+                description=(
+                    "Optional. Name of the tag to filter samples by. Leave empty to "
+                    "skip copying and only load images from 'samples_path'."
+                ),
+            ),
+            StringParameter(
+                name="samples_path",
+                required=False,
+                default="",
+                description=(
+                    "Optional. Filesystem path to a folder of images to add to the "
+                    "new dataset."
+                ),
+            ),
+            BoolParameter(
+                name="samples_only",
+                required=False,
+                default=False,
+                description=(
+                    "If true, copy only the image samples (no annotations, tags, "
+                    "embeddings, metadata, captions, or evaluation runs). Only "
+                    "applies when 'tag' is provided."
+                ),
+            ),
+        ]
+
+    @property
+    def supported_scopes(self) -> list[OperatorScope]:
+        return [OperatorScope.ROOT, OperatorScope.IMAGE]
+
+    def execute(
+        self,
+        *,
+        session: Session,
+        context: ExecutionContext,
+        parameters: dict[str, Any],
+    ) -> OperatorResult:
+        new_name = str(parameters["new_dataset_name"]).strip()
+        tag_name = str(parameters.get("tag") or "").strip()
+        samples_path = str(parameters.get("samples_path") or "").strip()
+        samples_only = bool(parameters.get("samples_only", False))
+
+        if not new_name:
+            return OperatorResult(success=False, message="'new_dataset_name' is required.")
+        if not tag_name and not samples_path:
+            return OperatorResult(
+                success=False,
+                message="Provide a 'tag', a 'samples_path', or both.",
+            )
+
+        copied_count = 0
+        if tag_name:
+            result = self._copy_tagged_subset(
+                session=session,
+                context=context,
+                new_name=new_name,
+                tag_name=tag_name,
+                samples_only=samples_only,
+            )
+            if isinstance(result, OperatorResult):
+                return result
+            copied_count = result
+        else:
+            # No tag: create a fresh empty dataset to be filled from the folder.
+            ls.ImageDataset.create(name=new_name)
+
+        added_count = 0
+        if samples_path:
+            new_dataset = ls.ImageDataset.load(name=new_name)
+            samples_before = len(list(new_dataset))
+            new_dataset.add_images_from_path(path=samples_path)
+            added_count = len(list(new_dataset)) - samples_before
+
+        mode_suffix = " (samples-only)" if tag_name and samples_only else ""
+        path_suffix = f", added {added_count} from '{samples_path}'" if samples_path else ""
+        return OperatorResult(
+            success=True,
+            message=(
+                f"Created dataset '{new_name}': copied {copied_count} samples"
+                f"{mode_suffix}{path_suffix}."
+            ),
+        )
+
+    def _copy_tagged_subset(
+        self,
+        *,
+        session: Session,
+        context: ExecutionContext,
+        new_name: str,
+        tag_name: str,
+        samples_only: bool,
+    ) -> OperatorResult | int:
+        """Run the tag-driven copy. Returns the number of copied samples or an error."""
+        source_collection = collection_resolver.get_by_id(
+            session=session, collection_id=context.collection_id
+        )
+        if source_collection is None:
+            return OperatorResult(
+                success=False, message=f"Collection {context.collection_id} not found."
+            )
+
+        tag = tag_resolver.get_by_name(
+            session=session, tag_name=tag_name, collection_id=context.collection_id
+        )
+        if tag is None:
+            return OperatorResult(
+                success=False, message=f"Tag '{tag_name}' not found in this dataset."
+            )
+
+        tagged = sample_resolver.get_filtered_samples(
+            session=session,
+            collection_id=context.collection_id,
+            filters=SampleFilter(tag_ids=[tag.tag_id]),
+        )
+        if tagged.total_count == 0:
+            return OperatorResult(success=False, message=f"No samples carry tag '{tag_name}'.")
+
+        sample_ids = [s.sample_id for s in tagged.samples]
+        if samples_only:
+            dataset_resolver.copy_images_subset(
+                session=session,
+                dataset_id=source_collection.dataset_id,
+                copy_name=new_name,
+                sample_ids=sample_ids,
+            )
+        else:
+            dataset_resolver.deep_copy_subset(
+                session=session,
+                dataset_id=source_collection.dataset_id,
+                copy_name=new_name,
+                sample_ids=sample_ids,
+            )
+        return len(sample_ids)

--- a/lightly_studio/src/lightly_studio/plugins/base_operator.py
+++ b/lightly_studio/src/lightly_studio/plugins/base_operator.py
@@ -14,11 +14,12 @@ from lightly_studio.plugins.parameter import BaseParameter
 
 
 class OperatorStatus(str, Enum):
-    """Lifecycle status of an operator."""
+    """Lifecycle status of an operator (or, per-execution, the run state)."""
 
     PENDING = "pending"
     STARTING = "starting"
     READY = "ready"
+    RUNNING = "running"
     STOPPING = "stopping"
     STOPPED = "stopped"
     ERROR = "error"

--- a/lightly_studio/src/lightly_studio/plugins/execution_registry.py
+++ b/lightly_studio/src/lightly_studio/plugins/execution_registry.py
@@ -1,0 +1,167 @@
+"""In-memory registry of operator executions.
+
+Operator executions are dispatched to a background thread pool. Each submission
+returns immediately with an ``ExecutionRecord``; the GUI polls the registry to
+follow progress.
+
+State is kept in-process only and is lost on server restart.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Generator
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio import db_manager
+from lightly_studio.plugins.base_operator import BaseOperator, OperatorResult, OperatorStatus
+from lightly_studio.plugins.operator_context import ExecutionContext
+
+logger = logging.getLogger(__name__)
+
+# Factory that yields a short-lived DB session for the worker thread.
+SessionFactory = Callable[[], AbstractContextManager[Session]]
+
+
+@contextmanager
+def worker_session() -> Generator[Session, None, None]:
+    """Open a fresh DB session for a background worker.
+
+    Bypasses ``db_manager.session()`` on purpose: that context manager commits the
+    *global* persistent session on enter/exit, which races with the request thread
+    when two threads touch it simultaneously. The worker owns its own session and
+    leaves the persistent session alone.
+    """
+    engine = db_manager.get_engine()._engine  # noqa: SLF001 — see module docstring
+    session = Session(engine, close_resets_only=False)
+    try:
+        yield session
+        if session.in_transaction():
+            session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+@dataclass
+class ExecutionRecord:
+    """Per-execution state surfaced to the GUI."""
+
+    execution_id: UUID
+    operator_id: str
+    operator_name: str
+    status: OperatorStatus
+    started_at: datetime
+    finished_at: Optional[datetime] = None
+    result: Optional[OperatorResult] = None
+    error_message: Optional[str] = None
+
+
+@dataclass
+class _RegistryState:
+    records: dict[UUID, ExecutionRecord] = field(default_factory=dict)
+
+
+class ExecutionRegistry:
+    """Tracks the lifecycle of operator executions across background threads."""
+
+    def __init__(self, max_workers: int = 4) -> None:
+        self._executor = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="op-exec"
+        )
+        self._state = _RegistryState()
+        self._lock = threading.Lock()
+
+    def submit(
+        self,
+        *,
+        operator: BaseOperator,
+        operator_id: str,
+        session_factory: SessionFactory,
+        context: ExecutionContext,
+        parameters: dict[str, Any],
+    ) -> ExecutionRecord:
+        """Submit an execution; returns the freshly-created RUNNING record."""
+        record = ExecutionRecord(
+            execution_id=uuid.uuid4(),
+            operator_id=operator_id,
+            operator_name=operator.name,
+            status=OperatorStatus.RUNNING,
+            started_at=datetime.now(timezone.utc),
+        )
+        with self._lock:
+            self._state.records[record.execution_id] = record
+        self._executor.submit(
+            self._run, record.execution_id, operator, session_factory, context, parameters
+        )
+        return record
+
+    def _run(
+        self,
+        execution_id: UUID,
+        operator: BaseOperator,
+        session_factory: SessionFactory,
+        context: ExecutionContext,
+        parameters: dict[str, Any],
+    ) -> None:
+        try:
+            with session_factory() as session:
+                result = operator.execute(
+                    session=session, context=context, parameters=parameters
+                )
+            # Use ERROR for soft failures (success=False) so the GUI can color them red.
+            status = OperatorStatus.READY if result.success else OperatorStatus.ERROR
+            self._mark_done(execution_id, status=status, result=result)
+        except Exception as exc:  # noqa: BLE001 — top-level worker, log and surface
+            logger.exception("Operator execution %s failed", execution_id)
+            self._mark_done(
+                execution_id,
+                status=OperatorStatus.ERROR,
+                error_message=str(exc) or exc.__class__.__name__,
+            )
+
+    def _mark_done(
+        self,
+        execution_id: UUID,
+        *,
+        status: OperatorStatus,
+        result: Optional[OperatorResult] = None,
+        error_message: Optional[str] = None,
+    ) -> None:
+        with self._lock:
+            record = self._state.records.get(execution_id)
+            if record is None:
+                return
+            record.status = status
+            record.finished_at = datetime.now(timezone.utc)
+            record.result = result
+            record.error_message = error_message
+
+    def get(self, execution_id: UUID) -> Optional[ExecutionRecord]:
+        with self._lock:
+            return self._state.records.get(execution_id)
+
+    def list_all(self) -> list[ExecutionRecord]:
+        with self._lock:
+            return list(self._state.records.values())
+
+    def remove(self, execution_id: UUID) -> Optional[ExecutionRecord]:
+        with self._lock:
+            return self._state.records.pop(execution_id, None)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=False)
+
+
+execution_registry = ExecutionRegistry()

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/__init__.py
@@ -1,8 +1,16 @@
 """Resolvers for dataset operations."""
 
-from lightly_studio.resolvers.dataset_resolver.deep_copy import deep_copy
+from lightly_studio.resolvers.dataset_resolver.copy_images_subset import copy_images_subset
+from lightly_studio.resolvers.dataset_resolver.deep_copy import deep_copy, deep_copy_subset
 from lightly_studio.resolvers.dataset_resolver.delete_dataset import delete_dataset
 from lightly_studio.resolvers.dataset_resolver.get_hierarchy import get_hierarchy
 from lightly_studio.resolvers.dataset_resolver.get_root_collection import get_root_collection
 
-__all__ = ["deep_copy", "delete_dataset", "get_hierarchy", "get_root_collection"]
+__all__ = [
+    "copy_images_subset",
+    "deep_copy",
+    "deep_copy_subset",
+    "delete_dataset",
+    "get_hierarchy",
+    "get_root_collection",
+]

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/copy_images_subset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/copy_images_subset.py
@@ -1,0 +1,95 @@
+"""Shallow image-only subset copy.
+
+Creates a new dataset that contains only the selected image samples (``SampleTable``
+plus their ``ImageTable`` rows). Unlike :func:`deep_copy_subset`, nothing else is
+copied — no annotations, captions, tags, labels, embeddings, metadata, evaluation
+runs, or object tracks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from uuid import UUID, uuid4
+
+from sqlmodel import Session, col, select
+
+from lightly_studio.models.collection import (
+    CollectionCreate,
+    CollectionTable,
+    SampleType,
+)
+from lightly_studio.models.image import ImageTable
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers import collection_resolver, dataset_resolver
+
+
+def copy_images_subset(
+    session: Session,
+    dataset_id: UUID,
+    copy_name: str,
+    sample_ids: Iterable[UUID],
+) -> CollectionTable:
+    """Create a new image dataset containing only the given image samples.
+
+    Args:
+        session: Database session.
+        dataset_id: Source dataset ID.
+        copy_name: Name for the new dataset's root collection.
+        sample_ids: Image sample IDs to copy. Non-image samples and IDs that do not
+            belong to the source dataset are silently ignored.
+
+    Returns:
+        The new root collection.
+
+    Raises:
+        ValueError: If the source dataset does not exist or its root collection is
+            not of sample type ``IMAGE``.
+    """
+    source_root = dataset_resolver.get_root_collection(session=session, dataset_id=dataset_id)
+    if source_root.sample_type != SampleType.IMAGE:
+        raise ValueError(
+            f"copy_images_subset only supports IMAGE datasets, got "
+            f"{source_root.sample_type.value}."
+        )
+
+    sample_id_set = set(sample_ids)
+
+    # Resolve which of the provided IDs correspond to image samples in this dataset.
+    if sample_id_set:
+        valid_ids = list(
+            session.exec(
+                select(ImageTable.sample_id)
+                .join(SampleTable, col(SampleTable.sample_id) == col(ImageTable.sample_id))
+                .where(
+                    col(SampleTable.collection_id) == source_root.collection_id,
+                    col(ImageTable.sample_id).in_(sample_id_set),
+                )
+            ).all()
+        )
+    else:
+        valid_ids = []
+
+    # Create the new dataset (collection_resolver.create handles dataset creation
+    # for root collections automatically).
+    new_root = collection_resolver.create(
+        session=session,
+        collection=CollectionCreate(name=copy_name, sample_type=SampleType.IMAGE),
+    )
+
+    # Copy SampleTable + ImageTable rows. Nothing else.
+    if valid_ids:
+        old_images = session.exec(
+            select(ImageTable).where(col(ImageTable.sample_id).in_(valid_ids))
+        ).all()
+        for old_image in old_images:
+            new_sample_id = uuid4()
+            session.add(
+                SampleTable(sample_id=new_sample_id, collection_id=new_root.collection_id)
+            )
+            new_image_data = old_image.model_dump(exclude={"created_at", "updated_at"})
+            new_image_data["sample_id"] = new_sample_id
+            session.add(ImageTable(**new_image_data))
+
+    session.commit()
+    session.refresh(new_root)
+    return new_root

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, TypeVar
 from uuid import UUID, uuid4
@@ -59,6 +60,9 @@ class DeepCopyContext:
     embedding_model_map: dict[UUID, UUID] = field(default_factory=dict)
     evaluation_run_map: dict[UUID, UUID] = field(default_factory=dict)
     new_dataset_id: UUID | None = None
+    # If set, restricts which samples (and their dependents) are copied.
+    # Sample-level entities that reference a sample outside this set are skipped.
+    sample_id_filter: set[UUID] | None = None
 
 
 def deep_copy(
@@ -79,9 +83,93 @@ def deep_copy(
     Returns:
         The newly created root collection.
     """
+    return _deep_copy_impl(
+        session=session,
+        dataset_id=dataset_id,
+        copy_name=copy_name,
+        sample_id_filter=None,
+    )
+
+
+def deep_copy_subset(
+    session: Session,
+    dataset_id: UUID,
+    copy_name: str,
+    sample_ids: Iterable[UUID],
+) -> CollectionTable:
+    """Deep copy a dataset, restricted to the given samples.
+
+    The full collection hierarchy and dataset-level entities (tags, labels, embedding
+    models, object tracks, evaluation runs) are always copied.
+
+    Sample-level rows are copied only for samples in ``sample_ids`` and for their
+    dependents (annotations, video frames, and captions whose ``parent_sample_id`` is
+    in the set). Pass parent samples (images / videos / frames) and their
+    annotations/captions/frames are pulled in automatically.
+
+    Sample IDs that do not exist in the dataset are ignored.
+
+    Args:
+        session: Database session.
+        dataset_id: Dataset ID to copy from.
+        copy_name: Name for the new dataset.
+        sample_ids: Sample IDs from the original dataset to include in the copy.
+
+    Returns:
+        The newly created root collection.
+    """
+    initial = set(sample_ids)
+    expanded = _expand_sample_id_filter(session=session, sample_ids=initial)
+    return _deep_copy_impl(
+        session=session,
+        dataset_id=dataset_id,
+        copy_name=copy_name,
+        sample_id_filter=expanded,
+    )
+
+
+def _expand_sample_id_filter(session: Session, sample_ids: set[UUID]) -> set[UUID]:
+    """Expand a sample-id set to include dependents that are themselves samples.
+
+    Annotations, video frames, and captions each have their own ``SampleTable`` row
+    that references a parent sample via ``parent_sample_id``. When the caller asks
+    for parent samples, we transitively pull in those child sample rows so that the
+    sample-level filter passes them through to the copy.
+    """
+    if not sample_ids:
+        return sample_ids
+    expanded: set[UUID] = set(sample_ids)
+    ann_ids = session.exec(
+        select(AnnotationBaseTable.sample_id).where(
+            col(AnnotationBaseTable.parent_sample_id).in_(sample_ids)
+        )
+    ).all()
+    expanded.update(ann_ids)
+    frame_ids = session.exec(
+        select(VideoFrameTable.sample_id).where(
+            col(VideoFrameTable.parent_sample_id).in_(sample_ids)
+        )
+    ).all()
+    expanded.update(frame_ids)
+    # Captions added in case a frame parent was just added above.
+    caption_ids = session.exec(
+        select(CaptionTable.sample_id).where(
+            col(CaptionTable.parent_sample_id).in_(expanded)
+        )
+    ).all()
+    expanded.update(caption_ids)
+    return expanded
+
+
+def _deep_copy_impl(
+    session: Session,
+    dataset_id: UUID,
+    copy_name: str,
+    sample_id_filter: set[UUID] | None,
+) -> CollectionTable:
     # If this fails, a new table was added. Update deep_copy to handle it, then update this count.
     table_coverage_utils.verify_table_coverage()
-    ctx = DeepCopyContext()
+    ctx = DeepCopyContext(sample_id_filter=sample_id_filter)
 
     # 1. Create new dataset entry.
     new_dataset_id = uuid4()
@@ -205,9 +293,10 @@ def _copy_samples(
 ) -> None:
     """Copy all samples, remapping collection_id to new collections."""
     # TODO (Mihnea, 01/2026): Handle large collections with batching if needed.
-    samples = session.exec(
-        select(SampleTable).where(col(SampleTable.collection_id).in_(old_collection_ids))
-    ).all()
+    stmt = select(SampleTable).where(col(SampleTable.collection_id).in_(old_collection_ids))
+    if ctx.sample_id_filter is not None:
+        stmt = stmt.where(col(SampleTable.sample_id).in_(ctx.sample_id_filter))
+    samples = session.exec(stmt).all()
 
     for old_sample in samples:
         new_id = uuid4()
@@ -323,6 +412,9 @@ def _copy_video_frames(
     ).all()
 
     for old_frame in frames:
+        # Skip frames whose parent video is not in the copied subset.
+        if old_frame.parent_sample_id not in ctx.sample_map:
+            continue
         new_frame = _copy_with_updates(
             old_frame,
             {
@@ -380,6 +472,9 @@ def _copy_captions(
     ).all()
 
     for old_caption in captions:
+        # Skip captions whose parent sample is not in the copied subset.
+        if old_caption.parent_sample_id not in ctx.sample_map:
+            continue
         new_caption = _copy_with_updates(
             old_caption,
             {
@@ -425,6 +520,9 @@ def _copy_annotations(
     ).all()
 
     for old_ann in annotations:
+        # Skip annotations whose parent sample is not in the copied subset.
+        if old_ann.parent_sample_id not in ctx.sample_map:
+            continue
         new_sample_id = ctx.sample_map[old_ann.sample_id]
         new_object_track_id = (
             ctx.object_track_map[old_ann.object_track_id]
@@ -612,6 +710,9 @@ def _copy_evaluation_sample_metrics(
     ).all()
 
     for old_metric in metrics:
+        # Skip metrics for samples that were filtered out of the subset copy.
+        if old_metric.sample_id not in ctx.sample_map:
+            continue
         new_metric = _copy_with_updates(
             old_metric,
             {
@@ -637,22 +738,29 @@ def _copy_evaluation_annotation_metrics(
     ).all()
 
     for old_metric in metrics:
+        # Skip metrics for samples that were filtered out of the subset copy.
+        if old_metric.sample_id not in ctx.sample_map:
+            continue
+        # If either annotation reference points to an excluded sample, null it
+        # rather than dropping the whole metric.
+        new_pred_id = (
+            ctx.sample_map.get(old_metric.pred_annotation_id)
+            if old_metric.pred_annotation_id is not None
+            else None
+        )
+        new_gt_id = (
+            ctx.sample_map.get(old_metric.gt_annotation_id)
+            if old_metric.gt_annotation_id is not None
+            else None
+        )
         new_metric = _copy_with_updates(
             old_metric,
             {
                 "id": uuid4(),
                 "evaluation_run_id": ctx.evaluation_run_map[old_metric.evaluation_run_id],
                 "sample_id": ctx.sample_map[old_metric.sample_id],
-                "pred_annotation_id": (
-                    ctx.sample_map[old_metric.pred_annotation_id]
-                    if old_metric.pred_annotation_id is not None
-                    else None
-                ),
-                "gt_annotation_id": (
-                    ctx.sample_map[old_metric.gt_annotation_id]
-                    if old_metric.gt_annotation_id is not None
-                    else None
-                ),
+                "pred_annotation_id": new_pred_id,
+                "gt_annotation_id": new_gt_id,
             },
         )
         session.add(new_metric)
@@ -673,6 +781,9 @@ def _copy_annotation_collection_coverage(
     ).all()
 
     for old_row in rows:
+        # Skip coverage rows whose parent sample is not in the copied subset.
+        if old_row.parent_sample_id not in ctx.sample_map:
+            continue
         new_row = AnnotationCollectionCoverageTable(
             annotation_collection_id=ctx.collection_map[old_row.annotation_collection_id],
             parent_sample_id=ctx.sample_map[old_row.parent_sample_id],

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_copy_images_subset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_copy_images_subset.py
@@ -1,0 +1,265 @@
+"""Tests for copy_images_subset resolver."""
+
+import uuid
+
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.models.collection import SampleType
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    dataset_resolver,
+    embedding_model_resolver,
+    image_resolver,
+    sample_embedding_resolver,
+    sample_resolver,
+    tag_resolver,
+)
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_embedding_model,
+    create_image,
+    create_sample_embedding,
+    create_tag,
+)
+
+
+def test_copy_images_subset__copies_only_selected_image_samples(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    img1 = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/a.png"
+    )
+    create_image(session=db_session, collection_id=original.collection_id, file_path_abs="/b.png")
+
+    # Act
+    copied = dataset_resolver.copy_images_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[img1.sample_id],
+    )
+
+    # Assert - only the selected image exists in the new dataset.
+    copied_images = image_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=copied.collection_id,
+    )
+    paths = [s.file_path_abs for s in copied_images.samples]
+    assert paths == ["/a.png"]
+
+
+def test_copy_images_subset__new_dataset_is_separate(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    img = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/a.png"
+    )
+
+    # Act
+    copied = dataset_resolver.copy_images_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[img.sample_id],
+    )
+
+    # Assert - new dataset has a different ID and is a root collection.
+    assert copied.dataset_id != original.dataset_id
+    assert copied.collection_id != original.collection_id
+    assert copied.parent_collection_id is None
+
+
+def test_copy_images_subset__does_not_copy_annotations(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    img = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/a.png"
+    )
+    label = create_annotation_label(
+        session=db_session, root_collection_id=original.collection_id, label_name="cat"
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=original.collection_id,
+        sample_id=img.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+
+    # Act
+    copied = dataset_resolver.copy_images_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[img.sample_id],
+    )
+
+    # Assert - no annotations in the new dataset.
+    copied_child_collection_ids = [c.collection_id for c in copied.children]
+    result = annotation_resolver.get_all(
+        session=db_session,
+        filters=AnnotationsFilter(
+            collection_ids=copied_child_collection_ids + [copied.collection_id],
+        ),
+    )
+    assert result.total_count == 0
+
+
+def test_copy_images_subset__does_not_copy_tags(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    img = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/a.png"
+    )
+    create_tag(session=db_session, collection_id=original.collection_id, tag_name="keep")
+
+    # Act
+    copied = dataset_resolver.copy_images_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[img.sample_id],
+    )
+
+    # Assert - no tags in the new dataset.
+    copied_tags = tag_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=copied.collection_id
+    )
+    assert copied_tags == []
+
+
+def test_copy_images_subset__does_not_copy_embeddings(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    img = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/a.png"
+    )
+    model = create_embedding_model(
+        session=db_session,
+        collection_id=original.collection_id,
+        embedding_model_name="m",
+        embedding_dimension=3,
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=img.sample_id,
+        embedding_model_id=model.embedding_model_id,
+        embedding=[1.0, 2.0, 3.0],
+    )
+
+    # Act
+    copied = dataset_resolver.copy_images_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[img.sample_id],
+    )
+
+    # Assert - no embedding models in the new dataset (and therefore no embeddings).
+    copied_models = embedding_model_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=copied.collection_id
+    )
+    assert copied_models == []
+    # Sanity check: the original embedding still exists.
+    original_embeddings = sample_embedding_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=original.collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
+    assert len(original_embeddings) == 1
+
+
+def test_copy_images_subset__original_unchanged(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    img1 = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/a.png"
+    )
+    create_image(session=db_session, collection_id=original.collection_id, file_path_abs="/b.png")
+
+    # Act
+    dataset_resolver.copy_images_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[img1.sample_id],
+    )
+
+    # Assert - original dataset still has both images.
+    original_samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=original.collection_id
+    )
+    assert original_samples.total_count == 2
+
+
+def test_copy_images_subset__empty_sample_ids_yields_empty_dataset(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    create_image(session=db_session, collection_id=original.collection_id, file_path_abs="/a.png")
+
+    # Act
+    copied = dataset_resolver.copy_images_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[],
+    )
+
+    # Assert - new dataset exists but is empty.
+    copied_samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=copied.collection_id
+    )
+    assert copied_samples.total_count == 0
+
+
+def test_copy_images_subset__unknown_sample_ids_ignored(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    img = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/a.png"
+    )
+
+    # Act
+    copied = dataset_resolver.copy_images_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[img.sample_id, uuid.uuid4()],
+    )
+
+    # Assert - only the valid image was copied.
+    copied_images = image_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=copied.collection_id
+    )
+    assert len(copied_images.samples) == 1
+
+
+def test_copy_images_subset__rejects_non_image_datasets(db_session: Session) -> None:
+    # Arrange - a VIDEO root collection.
+    video_root = create_collection(
+        session=db_session, collection_name="video_dataset", sample_type=SampleType.VIDEO
+    )
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="IMAGE"):
+        dataset_resolver.copy_images_subset(
+            session=db_session,
+            dataset_id=video_root.dataset_id,
+            copy_name="copied",
+            sample_ids=[],
+        )
+
+
+def test_copy_images_subset__raises_for_nonexistent_dataset(db_session: Session) -> None:
+    with pytest.raises(ValueError, match="not found"):
+        dataset_resolver.copy_images_subset(
+            session=db_session,
+            dataset_id=uuid.uuid4(),
+            copy_name="copied",
+            sample_ids=[],
+        )

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_subset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_subset.py
@@ -1,0 +1,225 @@
+"""Tests for deep_copy_subset resolver."""
+
+import uuid
+
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    dataset_resolver,
+    embedding_model_resolver,
+    image_resolver,
+    sample_embedding_resolver,
+    sample_resolver,
+)
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_embedding_model,
+    create_image,
+    create_sample_embedding,
+)
+
+
+def test_deep_copy_subset__keeps_only_selected_images(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    img1 = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/a.png"
+    )
+    img2 = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/b.png"
+    )
+    create_image(session=db_session, collection_id=original.collection_id, file_path_abs="/c.png")
+
+    # Act
+    copied = dataset_resolver.deep_copy_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[img1.sample_id, img2.sample_id],
+    )
+
+    # Assert - only the selected images are in the copy.
+    copied_images = image_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=copied.collection_id,
+    )
+    copied_paths = {s.file_path_abs for s in copied_images.samples}
+    assert copied_paths == {"/a.png", "/b.png"}
+
+
+def test_deep_copy_subset__empty_selection_copies_no_samples(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    create_image(session=db_session, collection_id=original.collection_id, file_path_abs="/a.png")
+
+    # Act
+    copied = dataset_resolver.deep_copy_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[],
+    )
+
+    # Assert - the new dataset exists but has no samples.
+    copied_samples = sample_resolver.get_filtered_samples(
+        session=db_session,
+        collection_id=copied.collection_id,
+    )
+    assert copied_samples.total_count == 0
+
+
+def test_deep_copy_subset__unknown_sample_ids_ignored(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    img = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/a.png"
+    )
+
+    # Act - mix of valid and unknown IDs.
+    copied = dataset_resolver.deep_copy_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[img.sample_id, uuid.uuid4(), uuid.uuid4()],
+    )
+
+    # Assert - only the valid image was copied.
+    copied_images = image_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=copied.collection_id,
+    )
+    assert len(copied_images.samples) == 1
+
+
+def test_deep_copy_subset__includes_annotations_of_kept_samples(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    kept = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/kept.png"
+    )
+    dropped = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/dropped.png"
+    )
+    label = create_annotation_label(
+        session=db_session, root_collection_id=original.collection_id, label_name="cat"
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=original.collection_id,
+        sample_id=kept.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=original.collection_id,
+        sample_id=dropped.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+
+    # Act - subset includes only the parent image; the annotation must follow.
+    copied = dataset_resolver.deep_copy_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[kept.sample_id],
+    )
+
+    # Assert - only the kept image's annotation made it into the copy.
+    result = annotation_resolver.get_all(
+        session=db_session,
+        filters=AnnotationsFilter(collection_ids=[copied.children[0].collection_id]),
+    )
+    assert result.total_count == 1
+
+
+def test_deep_copy_subset__copies_embeddings_for_kept_samples(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    kept = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/kept.png"
+    )
+    dropped = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/dropped.png"
+    )
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=original.collection_id,
+        embedding_model_name="model",
+        embedding_dimension=3,
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=kept.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[1.0, 2.0, 3.0],
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=dropped.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[4.0, 5.0, 6.0],
+    )
+
+    # Act
+    copied = dataset_resolver.deep_copy_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[kept.sample_id],
+    )
+
+    # Assert - the embedding model is copied; only the kept embedding follows.
+    copied_model_rows = embedding_model_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=copied.collection_id,
+    )
+    assert len(copied_model_rows) == 1
+    copied_embeddings = sample_embedding_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=copied.collection_id,
+        embedding_model_id=copied_model_rows[0].embedding_model_id,
+    )
+    assert len(copied_embeddings) == 1
+    assert tuple(copied_embeddings[0].embedding) == (1.0, 2.0, 3.0)
+
+
+def test_deep_copy_subset__original_dataset_unchanged(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    img1 = create_image(
+        session=db_session, collection_id=original.collection_id, file_path_abs="/a.png"
+    )
+    create_image(session=db_session, collection_id=original.collection_id, file_path_abs="/b.png")
+
+    # Act
+    dataset_resolver.deep_copy_subset(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+        sample_ids=[img1.sample_id],
+    )
+
+    # Assert - the source dataset is unchanged.
+    original_samples = sample_resolver.get_filtered_samples(
+        session=db_session,
+        collection_id=original.collection_id,
+    )
+    assert original_samples.total_count == 2
+
+
+def test_deep_copy_subset__raises_for_nonexistent_dataset(db_session: Session) -> None:
+    with pytest.raises(ValueError, match="not found"):
+        dataset_resolver.deep_copy_subset(
+            session=db_session,
+            dataset_id=uuid.uuid4(),
+            copy_name="copied",
+            sample_ids=[uuid.uuid4()],
+        )

--- a/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
@@ -9,6 +9,7 @@
         getOperatorParameters,
         type RegisteredOperatorMetadata
     } from '$lib/api/lightly_studio_local';
+    import { listExecutionsQueryKey } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
     import { toast } from 'svelte-sonner';
     import type { Operator } from '$lib/hooks/useOperators/useOperators';
     import { createOperatorFromMetadata } from '$lib/hooks/useOperators/useOperators';
@@ -40,7 +41,6 @@
     let parameters = $state<ParameterValues>({});
     let isExecuting = $state(false);
     let executionError = $state<string | undefined>(undefined);
-    let executionSuccess = $state<string | undefined>(undefined);
 
     const pageContext = storeDerived(
         page,
@@ -67,7 +67,6 @@
 
     function resetExecutionState() {
         executionError = undefined;
-        executionSuccess = undefined;
         isExecuting = false;
     }
 
@@ -124,7 +123,6 @@
 
         isExecuting = true;
         executionError = undefined;
-        executionSuccess = undefined;
 
         try {
             const response = await executeOperator({
@@ -143,18 +141,17 @@
             }
             if (!response.data) throw new Error('Operator execution returned no result.');
 
-            if (response.data.success) {
-                executionSuccess = response.data.message || 'Execution succeeded.';
-                toast.success('Operator executed', { description: executionSuccess });
-                queryClient.invalidateQueries();
-            } else {
-                executionError = response.data.message || 'Execution failed.';
-                toast.error('Operator execution failed', { description: executionError });
-            }
+            // Dispatch is async: the run continues in the background and is tracked
+            // by the running-executions panel. Close the dialog immediately.
+            toast.info('Operator started', {
+                description: `${response.data.operator_name} is running in the background.`
+            });
+            queryClient.invalidateQueries({ queryKey: listExecutionsQueryKey() });
+            onOpenChange(false);
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             executionError = message;
-            toast.error('Operator execution failed', { description: message });
+            toast.error('Failed to start operator', { description: message });
         } finally {
             isExecuting = false;
         }
@@ -237,20 +234,13 @@
                 {#if executionError}
                     <div class="text-sm text-destructive">Error: {executionError}</div>
                 {/if}
-                {#if executionSuccess}
-                    <div class="text-sm text-emerald-600">{executionSuccess}</div>
-                {/if}
             </div>
 
             <Dialog.Footer class="flex justify-end space-x-2">
-                <Button variant="outline" onclick={() => onOpenChange(false)}>
-                    {executionSuccess ? 'Close' : 'Cancel'}
+                <Button variant="outline" onclick={() => onOpenChange(false)}>Cancel</Button>
+                <Button onclick={handleExecute} disabled={!isFormValid || isExecuting}>
+                    {isExecuting ? 'Starting…' : 'Execute'}
                 </Button>
-                {#if !executionSuccess}
-                    <Button onclick={handleExecute} disabled={!isFormValid || isExecuting}>
-                        {isExecuting ? 'Executing...' : 'Execute'}
-                    </Button>
-                {/if}
             </Dialog.Footer>
         {:else}
             <div class="p-4">

--- a/lightly_studio_view/src/lib/components/Operator/RunningExecutionsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/RunningExecutionsPanel.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+    import { createQuery, useQueryClient } from '@tanstack/svelte-query';
+    import { Button } from '$lib/components/ui/button';
+    import { ChevronDown, ChevronUp, LoaderCircle, X } from '@lucide/svelte';
+    import { toast } from 'svelte-sonner';
+    import { dismissExecution } from '$lib/api/lightly_studio_local';
+    import {
+        listExecutionsOptions,
+        listExecutionsQueryKey
+    } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+    import {
+        OperatorStatus,
+        type OperatorExecutionResponse
+    } from '$lib/api/lightly_studio_local';
+
+    const POLL_INTERVAL_MS = 1000;
+    const queryClient = useQueryClient();
+
+    const executionsQuery = createQuery(() => ({
+        ...listExecutionsOptions(),
+        refetchInterval: (q: { state: { data?: OperatorExecutionResponse[] } }) => {
+            const data = q.state.data ?? [];
+            const hasRunning = data.some((r) => r.status === OperatorStatus.RUNNING);
+            // Only poll while at least one execution is running, otherwise idle.
+            return hasRunning ? POLL_INTERVAL_MS : false;
+        }
+    }));
+
+    // Notify on transitions RUNNING -> done.
+    const previousStatusById = new Map<string, OperatorStatus>();
+    $effect(() => {
+        const list = (executionsQuery.data ?? []) as OperatorExecutionResponse[];
+        for (const rec of list) {
+            const prev = previousStatusById.get(rec.execution_id);
+            if (prev === OperatorStatus.RUNNING && rec.status !== OperatorStatus.RUNNING) {
+                if (rec.status === OperatorStatus.ERROR) {
+                    toast.error(`${rec.operator_name} failed`, {
+                        description: rec.error_message || rec.result?.message || undefined
+                    });
+                } else {
+                    toast.success(`${rec.operator_name} finished`, {
+                        description: rec.result?.message || undefined
+                    });
+                }
+                // Other queries may depend on the side-effects of the operator.
+                queryClient.invalidateQueries();
+            }
+            previousStatusById.set(rec.execution_id, rec.status);
+        }
+    });
+
+    const executions = $derived((executionsQuery.data ?? []) as OperatorExecutionResponse[]);
+    const runningCount = $derived(
+        executions.filter((r) => r.status === OperatorStatus.RUNNING).length
+    );
+    const hasAny = $derived(executions.length > 0);
+
+    let minimized = $state(false);
+
+    async function handleDismiss(id: string) {
+        const response = await dismissExecution({ path: { execution_id: id } });
+        if (response.error) {
+            toast.error('Could not dismiss execution', {
+                description: String(response.error)
+            });
+            return;
+        }
+        queryClient.invalidateQueries({ queryKey: listExecutionsQueryKey() });
+    }
+
+    function statusLabel(status: OperatorStatus): string {
+        if (status === OperatorStatus.RUNNING) return 'Running';
+        if (status === OperatorStatus.ERROR) return 'Failed';
+        if (status === OperatorStatus.READY) return 'Succeeded';
+        return status;
+    }
+
+    function statusClass(status: OperatorStatus): string {
+        if (status === OperatorStatus.RUNNING)
+            return 'bg-blue-500/15 text-blue-700 dark:text-blue-300';
+        if (status === OperatorStatus.ERROR)
+            return 'bg-destructive/15 text-destructive';
+        return 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300';
+    }
+</script>
+
+{#if hasAny}
+    <div
+        class="fixed bottom-4 right-4 z-50 w-80 overflow-hidden rounded-lg border border-border bg-background shadow-xl"
+    >
+        <button
+            type="button"
+            class="flex w-full items-center justify-between gap-2 border-b border-border bg-muted px-3 py-2 text-left text-sm font-medium"
+            onclick={() => (minimized = !minimized)}
+        >
+            <span class="flex items-center gap-2">
+                {#if runningCount > 0}
+                    <LoaderCircle class="size-4 animate-spin text-blue-600" />
+                {/if}
+                <span>
+                    Operators
+                    {#if runningCount > 0}
+                        ({runningCount} running)
+                    {:else}
+                        ({executions.length} finished)
+                    {/if}
+                </span>
+            </span>
+            {#if minimized}
+                <ChevronUp class="size-4" />
+            {:else}
+                <ChevronDown class="size-4" />
+            {/if}
+        </button>
+
+        {#if !minimized}
+            <ul class="max-h-64 divide-y divide-border overflow-y-auto">
+                {#each executions as rec (rec.execution_id)}
+                    <li class="flex items-start gap-2 px-3 py-2 text-sm">
+                        <div class="min-w-0 flex-1">
+                            <div class="truncate font-medium" title={rec.operator_name}>
+                                {rec.operator_name}
+                            </div>
+                            <div class="mt-1 flex items-center gap-2">
+                                <span
+                                    class="inline-flex items-center rounded-full px-2 py-0.5 text-xs {statusClass(
+                                        rec.status
+                                    )}"
+                                >
+                                    {statusLabel(rec.status)}
+                                </span>
+                            </div>
+                            {#if rec.status !== OperatorStatus.RUNNING && (rec.result?.message || rec.error_message)}
+                                <div
+                                    class="mt-1 line-clamp-2 text-xs text-muted-foreground"
+                                    title={rec.error_message || rec.result?.message || ''}
+                                >
+                                    {rec.error_message || rec.result?.message}
+                                </div>
+                            {/if}
+                        </div>
+                        {#if rec.status !== OperatorStatus.RUNNING}
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                class="size-6 shrink-0"
+                                onclick={() => handleDismiss(rec.execution_id)}
+                                aria-label="Dismiss"
+                            >
+                                <X class="size-3.5" />
+                            </Button>
+                        {/if}
+                    </li>
+                {/each}
+            </ul>
+        {/if}
+    </div>
+{/if}

--- a/lightly_studio_view/src/routes/+layout.svelte
+++ b/lightly_studio_view/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
     import '../app.css';
     import { Toaster } from 'svelte-sonner';
     import { client } from '$lib/api/lightly_studio_local/client.gen';
+    import RunningExecutionsPanel from '$lib/components/Operator/RunningExecutionsPanel.svelte';
 
     interface ApiErrorWithStatus {
         error?: string;
@@ -53,5 +54,6 @@
     <div class="flex h-full w-full flex-col">
         {@render children()}
         <Toaster richColors />
+        <RunningExecutionsPanel />
     </div>
 </QueryClientProvider>


### PR DESCRIPTION
## What has changed and why?

New plugin to demonstrate dataset splitting

Test by running:
`uv run .\src\lightly_studio\examples\example_split_by_tag.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Operator execution is now asynchronous, running in the background rather than blocking.
  * New API endpoints to manage and view operator execution history and status.
  * Added "Split dataset by tag" operator to filter and copy datasets by specific tags.
  * New execution monitoring panel shows running operators with real-time status updates and completion notifications.

* **Tests**
  * Added comprehensive test coverage for dataset subset copying operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->