### PR TITLE
Rename to "Label Sources" and "Label Classes"

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
@@ -32,7 +32,7 @@
 </script>
 
 {#if items.length > 0}
-    <Segment title="Collections">
+    <Segment title="Label Sources">
         <SideMenu
             showColorMarker={$selectedCollectionIds.length > 1}
             {items}

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
@@ -19,7 +19,7 @@
     } = $props();
 </script>
 
-<Segment title="Labels">
+<Segment title="Label Classes">
     <div class="width-full space-y-2 overflow-hidden">
         {#each $annotationFilterRows as { label_name, current_count, total_count, selected } (label_name)}
             <div class="width-full flex items-center space-x-2" title={label_name}>


### PR DESCRIPTION
## What has changed and why?

<img width="695" height="317" alt="image" src="https://github.com/user-attachments/assets/fbc38802-56c0-475b-a5dd-a5522cdf5ca7" />

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated menu labels for improved clarity: "Collections" is now labeled as "Label Sources" and "Labels" is now labeled as "Label Classes".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->