### PR TITLE
Add uniform class balancing selection

### DIFF
--- a/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
@@ -354,7 +354,7 @@ describe('CreateSelectionDialog', () => {
         await fireEvent.pointerUp(await screen.findByTestId('selection-balancing-mode-uniform'));
 
         await fireEvent.input(screen.getByTestId('selection-dialog-tag-name-input'), {
-            target: { value: 'class-dist-tag' }
+            target: { value: 'my-tag' }
         });
         await fireEvent.click(screen.getByTestId('selection-dialog-submit'));
 
@@ -371,6 +371,10 @@ describe('CreateSelectionDialog', () => {
                     })
                 })
             );
+        });
+
+        await waitFor(() => {
+            expect(setTagSelectedMock).toHaveBeenCalledWith('new-tag-id', true);
         });
     });
 

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
@@ -336,7 +336,7 @@ describe('CreateSelectionDialog', () => {
         });
     });
 
-    it('submits class distribution selections with uniform target distribution', async () => {
+    it('submits class balancing selections with uniform target distribution', async () => {
         filteredSampleCountStore.set(100);
 
         render(CreateSelectionDialog);

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
@@ -344,9 +344,7 @@ describe('CreateSelectionDialog', () => {
         await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
             key: 'Enter'
         });
-        await fireEvent.pointerUp(
-            await screen.findByTestId('selection-strategy-class-distribution')
-        );
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-class-balancing'));
 
         await fireEvent.keyDown(screen.getByTestId('selection-dialog-balancing-mode-select'), {
             key: 'Enter'
@@ -386,9 +384,7 @@ describe('CreateSelectionDialog', () => {
         await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
             key: 'Enter'
         });
-        await fireEvent.pointerUp(
-            await screen.findByTestId('selection-strategy-class-distribution')
-        );
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-class-balancing'));
 
         await fireEvent.keyDown(screen.getByTestId('selection-dialog-balancing-mode-select'), {
             key: 'Enter'

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelection.test.ts
@@ -336,6 +336,64 @@ describe('CreateSelectionDialog', () => {
         });
     });
 
+    it('submits class distribution selections with uniform target distribution', async () => {
+        filteredSampleCountStore.set(100);
+
+        render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(
+            await screen.findByTestId('selection-strategy-class-distribution')
+        );
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-balancing-mode-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-balancing-mode-uniform'));
+
+        await fireEvent.input(screen.getByTestId('selection-dialog-tag-name-input'), {
+            target: { value: 'class-dist-tag' }
+        });
+        await fireEvent.click(screen.getByTestId('selection-dialog-submit'));
+
+        await waitFor(() => {
+            expect(createCombinationSelection).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.objectContaining({
+                        strategies: [
+                            {
+                                strategy_name: 'balance',
+                                target_distribution: 'uniform'
+                            }
+                        ]
+                    })
+                })
+            );
+        });
+    });
+
+    it('shows input balancing mode as disabled and coming soon', async () => {
+        filteredSampleCountStore.set(100);
+
+        render(CreateSelectionDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(
+            await screen.findByTestId('selection-strategy-class-distribution')
+        );
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-balancing-mode-select'), {
+            key: 'Enter'
+        });
+        const inputMode = await screen.findByTestId('selection-balancing-mode-input');
+        expect(inputMode).toHaveAttribute('data-disabled');
+        expect(inputMode).toHaveTextContent('Input (Coming soon)');
+    });
+
     it('disables similarity for video collections', async () => {
         pageMock.data.collection.sample_type = 'video';
 

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
@@ -57,7 +57,7 @@
 
     // Form state
     let selectionStrategy = $state<
-        'diversity' | 'typicality' | 'similarity' | 'class_distribution' | ''
+        'diversity' | 'typicality' | 'similarity' | 'class_balancing' | ''
     >('');
     let balancingMode = $state<BalancingMode>('uniform');
     let nSamplesToSelect = $state<number>(10);
@@ -70,7 +70,7 @@
         diversity: 'Diversity',
         typicality: 'Typicality',
         similarity: 'Similarity',
-        class_distribution: 'Class Balancing'
+        class_balancing: 'Class Balancing'
     };
 
     // Form validation
@@ -165,7 +165,7 @@
                         embedding_model_name: null
                     }
                 ]);
-            } else if (selectionStrategy === 'class_distribution') {
+            } else if (selectionStrategy === 'class_balancing') {
                 await performSelection([
                     {
                         strategy_name: 'balance',
@@ -276,9 +276,9 @@
                                         >Typicality</Select.Item
                                     >
                                     <Select.Item
-                                        value="class_distribution"
+                                        value="class_balancing"
                                         label="Class Balancing"
-                                        data-testid="selection-strategy-class-distribution"
+                                        data-testid="selection-strategy-class-balancing"
                                         >Class Balancing</Select.Item
                                     >
                                     <Select.Item
@@ -292,7 +292,7 @@
                         </Select.Root>
                     </div>
 
-                    {#if selectionStrategy === 'class_distribution'}
+                    {#if selectionStrategy === 'class_balancing'}
                         <div class="grid grid-cols-4 items-center gap-4">
                             <Label for="balancing-mode" class="text-right text-foreground">
                                 Balancing Mode

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
@@ -70,7 +70,7 @@
         diversity: 'Diversity',
         typicality: 'Typicality',
         similarity: 'Similarity',
-        class_distribution: 'Class Distribution'
+        class_distribution: 'Class Balancing'
     };
 
     // Form validation
@@ -277,9 +277,9 @@
                                     >
                                     <Select.Item
                                         value="class_distribution"
-                                        label="Class Distribution"
+                                        label="Class Balancing"
                                         data-testid="selection-strategy-class-distribution"
-                                        >Class Distribution</Select.Item
+                                        >Class Balancing</Select.Item
                                     >
                                     <Select.Item
                                         value="similarity"

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
@@ -17,6 +17,7 @@
     import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
     import type { SelectionRequest } from '$lib/api/lightly_studio_local/types.gen';
+    import { BALANCING_MODE_LABELS, type BalancingMode } from './balancingMode';
 
     // Get collection ID from URL params
     const collectionId = $derived(page.params.collection_id!);
@@ -58,7 +59,7 @@
     let selectionStrategy = $state<
         'diversity' | 'typicality' | 'similarity' | 'class_distribution' | ''
     >('');
-    let balancingMode = $state<'uniform' | 'dictionary'>('uniform');
+    let balancingMode = $state<BalancingMode>('uniform');
     let nSamplesToSelect = $state<number>(10);
     let queryTagId = $state('');
     let selectionResultTagName = $state<string>('');
@@ -168,7 +169,7 @@
                 await performSelection([
                     {
                         strategy_name: 'balance',
-                        target_distribution: balancingMode === 'uniform' ? 'uniform' : 'input'
+                        target_distribution: balancingMode
                     }
                 ]);
             } else if (selectionStrategy === 'typicality') {
@@ -305,18 +306,24 @@
                                     class="col-span-3"
                                     data-testid="selection-dialog-balancing-mode-select"
                                 >
-                                    {balancingMode === 'uniform' ? 'Uniform' : 'Dictionary'}
+                                    {BALANCING_MODE_LABELS[balancingMode]}
                                 </Select.Trigger>
                                 <Select.Content>
                                     <Select.Group>
-                                        <Select.Item value="uniform" label="Uniform"
+                                        <Select.Item
+                                            value="uniform"
+                                            label="Uniform"
+                                            data-testid="selection-balancing-mode-uniform"
                                             >Uniform</Select.Item
                                         >
                                         <Select.Item value="dictionary" label="Dictionary" disabled
                                             >Dictionary (Coming soon)</Select.Item
                                         >
-                                        <Select.Item value="input" label="Input" disabled
-                                            >Input (Coming soon)</Select.Item
+                                        <Select.Item
+                                            value="input"
+                                            label="Input"
+                                            data-testid="selection-balancing-mode-input"
+                                            disabled>Input (Coming soon)</Select.Item
                                         >
                                     </Select.Group>
                                 </Select.Content>

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
@@ -55,7 +55,10 @@
     );
 
     // Form state
-    let selectionStrategy = $state<'diversity' | 'typicality' | 'similarity' | ''>('');
+    let selectionStrategy = $state<
+        'diversity' | 'typicality' | 'similarity' | 'class_distribution' | ''
+    >('');
+    let balancingMode = $state<'uniform' | 'dictionary'>('uniform');
     let nSamplesToSelect = $state<number>(10);
     let queryTagId = $state('');
     let selectionResultTagName = $state<string>('');
@@ -65,7 +68,8 @@
     const STRATEGY_LABELS: Record<string, string> = {
         diversity: 'Diversity',
         typicality: 'Typicality',
-        similarity: 'Similarity'
+        similarity: 'Similarity',
+        class_distribution: 'Class Distribution'
     };
 
     // Form validation
@@ -158,6 +162,13 @@
                     {
                         strategy_name: 'diversity',
                         embedding_model_name: null
+                    }
+                ]);
+            } else if (selectionStrategy === 'class_distribution') {
+                await performSelection([
+                    {
+                        strategy_name: 'balance',
+                        target_distribution: balancingMode === 'uniform' ? 'uniform' : 'input'
                     }
                 ]);
             } else if (selectionStrategy === 'typicality') {
@@ -264,6 +275,12 @@
                                         >Typicality</Select.Item
                                     >
                                     <Select.Item
+                                        value="class_distribution"
+                                        label="Class Distribution"
+                                        data-testid="selection-strategy-class-distribution"
+                                        >Class Distribution</Select.Item
+                                    >
+                                    <Select.Item
                                         value="similarity"
                                         label="Similarity"
                                         data-testid="selection-strategy-similarity"
@@ -273,6 +290,39 @@
                             </Select.Content>
                         </Select.Root>
                     </div>
+
+                    {#if selectionStrategy === 'class_distribution'}
+                        <div class="grid grid-cols-4 items-center gap-4">
+                            <Label for="balancing-mode" class="text-right text-foreground">
+                                Balancing Mode
+                            </Label>
+                            <Select.Root
+                                type="single"
+                                name="balancing-mode"
+                                bind:value={balancingMode}
+                            >
+                                <Select.Trigger
+                                    class="col-span-3"
+                                    data-testid="selection-dialog-balancing-mode-select"
+                                >
+                                    {balancingMode === 'uniform' ? 'Uniform' : 'Dictionary'}
+                                </Select.Trigger>
+                                <Select.Content>
+                                    <Select.Group>
+                                        <Select.Item value="uniform" label="Uniform"
+                                            >Uniform</Select.Item
+                                        >
+                                        <Select.Item value="dictionary" label="Dictionary" disabled
+                                            >Dictionary (Coming soon)</Select.Item
+                                        >
+                                        <Select.Item value="input" label="Input" disabled
+                                            >Input (Coming soon)</Select.Item
+                                        >
+                                    </Select.Group>
+                                </Select.Content>
+                            </Select.Root>
+                        </div>
+                    {/if}
 
                     {#if selectionStrategy === 'similarity'}
                         <div class="grid grid-cols-4 items-center gap-4">

--- a/lightly_studio_view/src/lib/components/Selection/balancingMode.ts
+++ b/lightly_studio_view/src/lib/components/Selection/balancingMode.ts
@@ -1,0 +1,6 @@
+export type BalancingMode = 'uniform' | 'input';
+
+export const BALANCING_MODE_LABELS: Record<BalancingMode, string> = {
+    uniform: 'Uniform',
+    input: 'Input'
+} as const;

--- a/lightly_studio_view/src/lib/components/Selection/balancingMode.ts
+++ b/lightly_studio_view/src/lib/components/Selection/balancingMode.ts
@@ -3,4 +3,4 @@ export type BalancingMode = 'uniform' | 'input';
 export const BALANCING_MODE_LABELS: Record<BalancingMode, string> = {
     uniform: 'Uniform',
     input: 'Input'
-} as const;
+};


### PR DESCRIPTION
## What has changed and why?
There's a dropdown showing Input and Dictionary options, but they can't be used right now.

## How has it been tested?
Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

I will update the changelog once the feature is complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Class Distribution" selection strategy with a "Balancing Mode" control. "Uniform" is available; "Input" is shown as "Coming soon" and disabled.
  * Submitting Class Distribution applies a balanced selection using the chosen balancing mode and triggers the selection flow.

* **Tests**
  * Added UI tests covering the class distribution flow, confirming the balanced submission and the disabled "Input" mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->