### PR TITLE
Factor out filter chip, use it for query filter

### DIFF
--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+    import FilterChip from '$lib/components/FilterChip/FilterChip.svelte';
     import Segment from '$lib/components/Segment/Segment.svelte';
-    import { Checkbox } from '$lib/components/ui/checkbox';
-    import { X } from '@lucide/svelte';
     import { useEmbeddingFilterForImages } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForImages';
     import { useEmbeddingFilterForVideos } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForVideos';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
@@ -40,33 +39,20 @@
 
 {#if hasPlotFilterContext}
     <Segment title="Embeddings">
-        <div
-            class="rounded-md border border-amber-500/35 bg-amber-500/10 px-2 py-1.5"
-            data-testid="embedding-selection-filter-chip"
+        <FilterChip
+            checked={isPlotFilterApplied}
+            title="Embedding Plot Filter"
+            checkboxLabel="Embedding plot filter"
+            testId="embedding-selection-filter-chip"
+            onCheckedChange={(nextChecked) => setEmbeddingFilterVisibility(nextChecked === true)}
+            onClear={clearFilter}
         >
-            <div class="flex items-center gap-2">
-                <Checkbox
-                    checked={isPlotFilterApplied}
-                    aria-label="Embedding plot filter"
-                    onCheckedChange={(nextChecked) =>
-                        setEmbeddingFilterVisibility(nextChecked === true)}
-                />
-                <div class="min-w-0 flex-1">
-                    <div class="truncate text-sm font-medium">Embedding Plot Filter</div>
-                    <div class="text-xs text-muted-foreground">
-                        {plotFilterCount}
-                        {plotFilterCount === 1 ? plotFilterItemLabel : `${plotFilterItemLabel}s`}
-                    </div>
+            {#snippet subtitle()}
+                <div class="text-xs text-muted-foreground">
+                    {plotFilterCount}
+                    {plotFilterCount === 1 ? plotFilterItemLabel : `${plotFilterItemLabel}s`}
                 </div>
-                <button
-                    class="text-muted-foreground hover:text-foreground"
-                    onclick={clearFilter}
-                    title="Clear embedding plot filter"
-                    aria-label="Clear embedding plot filter"
-                >
-                    <X class="size-4" />
-                </button>
-            </div>
-        </div>
+            {/snippet}
+        </FilterChip>
     </Segment>
 {/if}

--- a/lightly_studio_view/src/lib/components/FilterChip/FilterChip.stories.svelte
+++ b/lightly_studio_view/src/lib/components/FilterChip/FilterChip.stories.svelte
@@ -1,0 +1,47 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import { fn } from 'storybook/test';
+    import FilterChip from './FilterChip.svelte';
+
+    const { Story } = defineMeta({
+        title: 'Components/FilterChip',
+        component: FilterChip,
+        tags: ['autodocs'],
+        argTypes: {
+            checked: { control: 'boolean' },
+            title: { control: 'text' },
+            checkboxLabel: { control: 'text' }
+        }
+    });
+</script>
+
+<Story
+    name="Default"
+    args={{
+        checked: true,
+        title: 'Has prediction',
+        checkboxLabel: 'Toggle has prediction filter',
+        onCheckedChange: fn(),
+        onClear: fn()
+    }}
+/>
+
+<Story
+    name="WithSubtitle"
+    args={{
+        checked: true,
+        title: 'Category Filter',
+        checkboxLabel: 'Toggle category filter',
+        onCheckedChange: fn(),
+        onClear: fn(),
+        onclick: fn()
+    }}
+>
+    {#snippet template(args)}
+        <FilterChip {...args}>
+            {#snippet subtitle()}
+                <div class="text-xs text-muted-foreground">Selected 14 categories</div>
+            {/snippet}
+        </FilterChip>
+    {/snippet}
+</Story>

--- a/lightly_studio_view/src/lib/components/FilterChip/FilterChip.svelte
+++ b/lightly_studio_view/src/lib/components/FilterChip/FilterChip.svelte
@@ -26,7 +26,7 @@
     }: Props = $props();
 </script>
 
-<div class="rounded-md border border-amber-500/35 bg-amber-500/10 px-2 py-1.5" data-testid={testId}>
+<div class="rounded-md border border-[#3c3c3c] bg-muted px-2 py-1.5" data-testid={testId}>
     <div class="flex items-center gap-2">
         <Checkbox {checked} aria-label={checkboxLabel} {onCheckedChange} />
         {#if onclick}

--- a/lightly_studio_view/src/lib/components/FilterChip/FilterChip.svelte
+++ b/lightly_studio_view/src/lib/components/FilterChip/FilterChip.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+    import { Checkbox } from '$lib/components/ui/checkbox';
+    import { X } from '@lucide/svelte';
+    import type { Snippet } from 'svelte';
+
+    interface Props {
+        checked: boolean;
+        title: string;
+        checkboxLabel: string;
+        onCheckedChange: (checked: boolean | 'indeterminate') => void;
+        onClear: () => void;
+        onclick?: () => void;
+        subtitle?: Snippet;
+        testId?: string;
+    }
+
+    let {
+        checked,
+        title,
+        checkboxLabel,
+        onCheckedChange,
+        onClear,
+        onclick,
+        subtitle,
+        testId
+    }: Props = $props();
+</script>
+
+<div class="rounded-md border border-amber-500/35 bg-amber-500/10 px-2 py-1.5" data-testid={testId}>
+    <div class="flex items-center gap-2">
+        <Checkbox {checked} aria-label={checkboxLabel} {onCheckedChange} />
+        {#if onclick}
+            <button type="button" class="min-w-0 flex-1 cursor-pointer text-left" {onclick}>
+                <div class="truncate text-sm font-medium">{title}</div>
+                {#if subtitle}{@render subtitle()}{/if}
+            </button>
+        {:else}
+            <div class="min-w-0 flex-1">
+                <div class="truncate text-sm font-medium">{title}</div>
+                {#if subtitle}{@render subtitle()}{/if}
+            </div>
+        {/if}
+        <button
+            class="text-muted-foreground hover:text-foreground"
+            onclick={onClear}
+            title="Clear {title.toLowerCase()}"
+            aria-label="Clear {title.toLowerCase()}"
+        >
+            <X class="size-4" />
+        </button>
+    </div>
+</div>

--- a/lightly_studio_view/src/lib/components/FilterChip/FilterChip.svelte
+++ b/lightly_studio_view/src/lib/components/FilterChip/FilterChip.svelte
@@ -41,6 +41,7 @@
             </div>
         {/if}
         <button
+            type="button"
             class="text-muted-foreground hover:text-foreground"
             onclick={onClear}
             title="Clear {title.toLowerCase()}"

--- a/lightly_studio_view/src/lib/components/QueryControl/QueryControl.svelte
+++ b/lightly_studio_view/src/lib/components/QueryControl/QueryControl.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+    import FilterChip from '$lib/components/FilterChip/FilterChip.svelte';
     import Segment from '$lib/components/Segment/Segment.svelte';
     import { Button } from '$lib/components/ui/index.js';
-    import { Checkbox } from '$lib/components/ui/checkbox/index.js';
     import { useFeatureFlags } from '$lib/hooks';
     import {
         useImageFilters,
@@ -10,9 +10,9 @@
     import { Pencil } from '@lucide/svelte';
 
     interface Props {
-        onToggle: () => void;
+        onOpen: () => void;
     }
-    let { onToggle }: Props = $props();
+    let { onOpen }: Props = $props();
 
     const { featureFlags } = useFeatureFlags();
     const isEnabled = $derived($featureFlags.includes('query_filter'));
@@ -30,43 +30,40 @@
 {#if isEnabled}
     <Segment title="Query">
         {#if lastQueryExpression}
-            <div
-                class="group flex items-center gap-2 rounded-md border border-border/60 bg-muted/30 p-2 transition-colors hover:bg-muted/50"
+            <FilterChip
+                checked={!!$imageQueryExpression?.query_expr_str}
+                title="Query Filter"
+                checkboxLabel={$imageQueryExpression?.query_expr_str
+                    ? 'Disable query filter'
+                    : 'Enable query filter'}
+                onCheckedChange={(v) => {
+                    if (v) {
+                        updateQueryExpr(lastQueryExpression!);
+                    } else {
+                        updateQueryExpr(undefined);
+                    }
+                }}
+                onClear={() => {
+                    updateQueryExpr(undefined);
+                    lastQueryExpression = null;
+                }}
+                onclick={onOpen}
             >
-                <Checkbox
-                    checked={!!$imageQueryExpression?.query_expr_str}
-                    onCheckedChange={(v: boolean | 'indeterminate') => {
-                        if (v) {
-                            updateQueryExpr(lastQueryExpression!);
-                        } else {
-                            updateQueryExpr(undefined);
-                        }
-                    }}
-                    aria-label={$imageQueryExpression?.query_expr_str
-                        ? 'Disable query filter'
-                        : 'Enable query filter'}
-                />
-                <button
-                    type="button"
-                    class="min-w-0 flex-1 cursor-pointer truncate text-left font-mono text-xs transition-colors {$imageQueryExpression?.query_expr_str
-                        ? 'text-foreground'
-                        : 'text-muted-foreground'}"
-                    onclick={onToggle}
-                    title={lastQueryExpression.query_expr_str}
-                >
-                    {lastQueryExpression.query_expr_str}
-                </button>
-                <Pencil
-                    class="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
-                    onclick={onToggle}
-                />
-            </div>
+                {#snippet subtitle()}
+                    <div
+                        class="truncate font-mono text-xs text-muted-foreground"
+                        title={lastQueryExpression?.query_expr_str}
+                    >
+                        {lastQueryExpression?.query_expr_str}
+                    </div>
+                {/snippet}
+            </FilterChip>
         {:else}
             <Button
                 variant="outline"
                 size="sm"
                 class="w-full justify-start gap-2 text-muted-foreground"
-                onclick={onToggle}
+                onclick={onOpen}
             >
                 <Pencil class="h-3.5 w-3.5" />
                 <span>Add query filter</span>

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -335,8 +335,8 @@
 
                             {#if isQueryFilterEnabled}
                                 <QueryControl
-                                    onToggle={() => {
-                                        isQueryFilterEditing = !isQueryFilterEditing;
+                                    onOpen={() => {
+                                        isQueryFilterEditing = true;
                                     }}
                                 />
                             {/if}


### PR DESCRIPTION
## What has changed and why?

Use the same UI element - dubbed `Filter Chip` - for query and embedding plot filter.

* Factored out the embedding plot design to a custom element
* Applied it to query filter
* Changed the color - no longer orange
* The query chip no longer closes the panel - for that we have the X button

## How has it been tested?

Manually.

<img width="334" height="715" alt="Screenshot 2026-05-26 at 22 25 53" src="https://github.com/user-attachments/assets/08598f9f-4b9c-4e93-88aa-2169e5dfac45" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable "Filter Chip" UI for filters: checkbox, title, optional subtitle, and clear action.
  * Storybook examples demonstrating the chip (default and with subtitle).

* **Refactor**
  * Replaced previous embedding and query filter UIs with the unified Filter Chip for consistent behavior and appearance.
  * Query filter now opens the editor via the chip and shows a truncated subtitle for query text or item counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->