### PR TITLE
Add class balancing form for sample selection dialog

### DIFF
--- a/lightly_studio_view/src/lib/components/Selection/ClassBalancingForm/ClassBalancingForm.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/ClassBalancingForm/ClassBalancingForm.stories.svelte
@@ -1,0 +1,25 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import { fn } from 'storybook/test';
+    import ClassBalancingForm from './ClassBalancingForm.svelte';
+
+    const { Story } = defineMeta({
+        title: 'Components/Selection/ClassBalancingForm',
+        component: ClassBalancingForm,
+        tags: ['autodocs'],
+        argTypes: {
+            balancingMode: {
+                control: 'select',
+                options: ['uniform', 'input']
+            }
+        }
+    });
+</script>
+
+<Story
+    name="Default"
+    args={{
+        balancingMode: 'uniform',
+        onBalancingModeChange: fn()
+    }}
+/>

--- a/lightly_studio_view/src/lib/components/Selection/ClassBalancingForm/ClassBalancingForm.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/ClassBalancingForm/ClassBalancingForm.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+    import { Label } from '$lib/components/ui/label';
+    import * as Select from '$lib/components/ui/select';
+    import { BALANCING_MODE_LABELS, type BalancingMode } from '../balancingMode';
+
+    interface Props {
+        balancingMode: BalancingMode;
+        onBalancingModeChange: (mode: BalancingMode) => void;
+    }
+
+    let { balancingMode, onBalancingModeChange }: Props = $props();
+</script>
+
+<div class="grid grid-cols-4 items-center gap-4">
+    <Label for="balancing-mode" class="text-right text-foreground">Balancing Mode</Label>
+    <Select.Root
+        type="single"
+        name="balancing-mode"
+        value={balancingMode}
+        onValueChange={(v) => onBalancingModeChange(v as BalancingMode)}
+    >
+        <Select.Trigger class="col-span-3" data-testid="selection-dialog-balancing-mode-select">
+            {BALANCING_MODE_LABELS[balancingMode]}
+        </Select.Trigger>
+        <Select.Content>
+            <Select.Group>
+                <Select.Item
+                    value="uniform"
+                    label="Uniform"
+                    data-testid="selection-balancing-mode-uniform">Uniform</Select.Item
+                >
+                <Select.Item value="dictionary" label="Dictionary" disabled
+                    >Dictionary (Coming soon)</Select.Item
+                >
+                <Select.Item
+                    value="input"
+                    label="Input"
+                    data-testid="selection-balancing-mode-input"
+                    disabled>Input (Coming soon)</Select.Item
+                >
+            </Select.Group>
+        </Select.Content>
+    </Select.Root>
+</div>

--- a/lightly_studio_view/src/lib/components/Selection/ClassBalancingForm/ClassBalancingForm.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/ClassBalancingForm/ClassBalancingForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { Label } from '$lib/components/ui/label';
     import * as Select from '$lib/components/ui/select';
-    import { BALANCING_MODE_LABELS, type BalancingMode } from '../balancingMode';
+    import { BALANCING_MODE_LABELS, type BalancingMode } from '$lib/components/Selection/balancingMode';
 
     interface Props {
         balancingMode: BalancingMode;

--- a/lightly_studio_view/src/lib/components/Selection/ClassBalancingForm/ClassBalancingForm.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/ClassBalancingForm/ClassBalancingForm.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
     import { Label } from '$lib/components/ui/label';
     import * as Select from '$lib/components/ui/select';
-    import { BALANCING_MODE_LABELS, type BalancingMode } from '$lib/components/Selection/balancingMode';
+    import {
+        BALANCING_MODE_LABELS,
+        type BalancingMode
+    } from '$lib/components/Selection/balancingMode';
 
     interface Props {
         balancingMode: BalancingMode;
@@ -19,7 +22,11 @@
         value={balancingMode}
         onValueChange={(v) => onBalancingModeChange(v as BalancingMode)}
     >
-        <Select.Trigger class="col-span-3" data-testid="selection-dialog-balancing-mode-select">
+        <Select.Trigger
+            id="balancing-mode"
+            class="col-span-3"
+            data-testid="selection-dialog-balancing-mode-select"
+        >
             {BALANCING_MODE_LABELS[balancingMode]}
         </Select.Trigger>
         <Select.Content>

--- a/lightly_studio_view/src/lib/components/Selection/ClassBalancingForm/ClassBalancingForm.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/ClassBalancingForm/ClassBalancingForm.test.ts
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ClassBalancingForm from './ClassBalancingForm.svelte';
+
+describe('ClassBalancingForm', () => {
+    beforeEach(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it('shows the current balancing mode label', () => {
+        render(ClassBalancingForm, {
+            props: { balancingMode: 'uniform', onBalancingModeChange: vi.fn() }
+        });
+
+        expect(screen.getByTestId('selection-dialog-balancing-mode-select')).toHaveTextContent(
+            'Uniform'
+        );
+    });
+
+    it('shows the uniform option in the dropdown', async () => {
+        render(ClassBalancingForm, {
+            props: { balancingMode: 'uniform', onBalancingModeChange: vi.fn() }
+        });
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-balancing-mode-select'), {
+            key: 'Enter'
+        });
+
+        expect(await screen.findByTestId('selection-balancing-mode-uniform')).toBeInTheDocument();
+    });
+
+    it('shows input balancing mode as disabled and coming soon', async () => {
+        render(ClassBalancingForm, {
+            props: { balancingMode: 'uniform', onBalancingModeChange: vi.fn() }
+        });
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-balancing-mode-select'), {
+            key: 'Enter'
+        });
+
+        const inputOption = await screen.findByTestId('selection-balancing-mode-input');
+        expect(inputOption).toHaveAttribute('data-disabled');
+        expect(inputOption).toHaveTextContent('Input (Coming soon)');
+    });
+});


### PR DESCRIPTION
## What has changed and why?

Adds `ClassBalancingForm` component that renders a balancing mode select dropdown.

## How has it been tested?

Unit tests + Storybook.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Class Balancing Mode selector with “Uniform” available; “Dictionary” and “Input” shown as coming soon (disabled).

* **Documentation**
  * Storybook entry added to preview and document the Class Balancing Form component.

* **Tests**
  * Test coverage added to verify UI behavior and disabled coming-soon options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->