### PR TITLE
Add similarity form for sample selection dialog

### DIFF
--- a/lightly_studio_view/src/lib/components/Selection/SimilarityForm/SimilarityForm.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/SimilarityForm/SimilarityForm.stories.svelte
@@ -1,0 +1,44 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import { fn } from 'storybook/test';
+    import SimilarityForm from './SimilarityForm.svelte';
+
+    const { Story } = defineMeta({
+        title: 'Components/Selection/SimilarityForm',
+        component: SimilarityForm,
+        tags: ['autodocs']
+    });
+</script>
+
+<Story
+    name="Default"
+    args={{
+        queryTagId: '',
+        tags: [
+            { tag_id: 'tag-1', name: 'Validation Set' },
+            { tag_id: 'tag-2', name: 'Reference Samples' }
+        ],
+        onQueryTagChange: fn()
+    }}
+/>
+
+<Story
+    name="WithSelectedTag"
+    args={{
+        queryTagId: 'tag-1',
+        tags: [
+            { tag_id: 'tag-1', name: 'Validation Set' },
+            { tag_id: 'tag-2', name: 'Reference Samples' }
+        ],
+        onQueryTagChange: fn()
+    }}
+/>
+
+<Story
+    name="NoTags"
+    args={{
+        queryTagId: '',
+        tags: [],
+        onQueryTagChange: fn()
+    }}
+/>

--- a/lightly_studio_view/src/lib/components/Selection/SimilarityForm/SimilarityForm.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/SimilarityForm/SimilarityForm.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+    import { Label } from '$lib/components/ui/label';
+    import * as Select from '$lib/components/ui/select';
+
+    interface Tag {
+        tag_id: string;
+        name: string;
+    }
+
+    interface Props {
+        queryTagId: string;
+        tags: Tag[];
+        onQueryTagChange: (tagId: string) => void;
+    }
+
+    let { queryTagId, tags, onQueryTagChange }: Props = $props();
+
+    const selectedQueryTagName = $derived(
+        tags.find((tag) => tag.tag_id === queryTagId)?.name ?? 'Select tag'
+    );
+</script>
+
+<div class="grid grid-cols-4 items-center gap-4">
+    <Label for="query-tag" class="text-right text-foreground">Query Tag</Label>
+    <Select.Root type="single" name="query-tag" value={queryTagId} onValueChange={onQueryTagChange}>
+        <Select.Trigger class="col-span-3" data-testid="selection-dialog-query-tag-select">
+            {selectedQueryTagName}
+        </Select.Trigger>
+        <Select.Content>
+            <Select.Group>
+                {#if tags.length === 0}
+                    <div
+                        class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
+                        data-testid="selection-dialog-no-query-tags"
+                    >
+                        No sample tags available.
+                    </div>
+                {:else}
+                    {#each tags as tag (tag.tag_id)}
+                        <Select.Item
+                            value={tag.tag_id}
+                            label={tag.name}
+                            data-testid={`selection-query-tag-${tag.tag_id}`}
+                        >
+                            {tag.name}
+                        </Select.Item>
+                    {/each}
+                {/if}
+            </Select.Group>
+        </Select.Content>
+    </Select.Root>
+</div>

--- a/lightly_studio_view/src/lib/components/Selection/SimilarityForm/SimilarityForm.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/SimilarityForm/SimilarityForm.test.ts
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SimilarityForm from './SimilarityForm.svelte';
+
+describe('SimilarityForm', () => {
+    beforeEach(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it('shows "Select tag" when no queryTagId is set', () => {
+        render(SimilarityForm, {
+            props: {
+                queryTagId: '',
+                tags: [{ tag_id: 'tag-1', name: 'My Tag' }],
+                onQueryTagChange: vi.fn()
+            }
+        });
+
+        expect(screen.getByTestId('selection-dialog-query-tag-select')).toHaveTextContent(
+            'Select tag'
+        );
+    });
+
+    it('shows the name of the selected tag', () => {
+        render(SimilarityForm, {
+            props: {
+                queryTagId: 'tag-1',
+                tags: [{ tag_id: 'tag-1', name: 'My Tag' }],
+                onQueryTagChange: vi.fn()
+            }
+        });
+
+        expect(screen.getByTestId('selection-dialog-query-tag-select')).toHaveTextContent('My Tag');
+    });
+
+    it('shows an empty state when no tags are provided', async () => {
+        render(SimilarityForm, {
+            props: { queryTagId: '', tags: [], onQueryTagChange: vi.fn() }
+        });
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-query-tag-select'), {
+            key: 'Enter'
+        });
+
+        expect(await screen.findByTestId('selection-dialog-no-query-tags')).toHaveTextContent(
+            'No sample tags available.'
+        );
+    });
+
+    it('calls onQueryTagChange with the selected tag id', async () => {
+        const onQueryTagChange = vi.fn();
+        render(SimilarityForm, {
+            props: {
+                queryTagId: '',
+                tags: [
+                    { tag_id: 'tag-1', name: 'First Tag' },
+                    { tag_id: 'tag-2', name: 'Second Tag' }
+                ],
+                onQueryTagChange
+            }
+        });
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-query-tag-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-query-tag-tag-2'));
+
+        expect(onQueryTagChange).toHaveBeenCalledWith('tag-2');
+    });
+
+    it('renders all provided tags in the dropdown', async () => {
+        render(SimilarityForm, {
+            props: {
+                queryTagId: '',
+                tags: [
+                    { tag_id: 'tag-1', name: 'First Tag' },
+                    { tag_id: 'tag-2', name: 'Second Tag' }
+                ],
+                onQueryTagChange: vi.fn()
+            }
+        });
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-query-tag-select'), {
+            key: 'Enter'
+        });
+
+        expect(await screen.findByTestId('selection-query-tag-tag-1')).toBeInTheDocument();
+        expect(screen.getByTestId('selection-query-tag-tag-2')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## What has changed and why?

Add `SimilarityForm` component that renders a query tag selector for the similarity-based sample selection. 

## How has it been tested?

Unit tests + Storybook

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Query Tag selector component allowing users to select tags from a dropdown list. Displays a placeholder when no tag is selected and an empty state message when no tags are available.

* **Documentation**
  * Added interactive component stories demonstrating the Query Tag selector with various states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->