### PR TITLE
Add strategy select component for sample selection dialog

### DIFF
--- a/lightly_studio_view/src/lib/components/Selection/StrategySelect/StrategySelect.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/StrategySelect/StrategySelect.stories.svelte
@@ -1,0 +1,45 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import { fn } from 'storybook/test';
+    import StrategySelect from './StrategySelect.svelte';
+
+    const { Story } = defineMeta({
+        title: 'Components/Selection/StrategySelect',
+        component: StrategySelect,
+        tags: ['autodocs'],
+        argTypes: {
+            value: {
+                control: 'select',
+                options: ['', 'diversity', 'typicality', 'similarity', 'class_balancing']
+            },
+            isSimilaritySupported: { control: 'boolean' }
+        }
+    });
+</script>
+
+<Story
+    name="Default"
+    args={{
+        value: '',
+        isSimilaritySupported: true,
+        onValueChange: fn()
+    }}
+/>
+
+<Story
+    name="Selected"
+    args={{
+        value: 'diversity',
+        isSimilaritySupported: true,
+        onValueChange: fn()
+    }}
+/>
+
+<Story
+    name="SimilarityDisabled"
+    args={{
+        value: '',
+        isSimilaritySupported: false,
+        onValueChange: fn()
+    }}
+/>

--- a/lightly_studio_view/src/lib/components/Selection/StrategySelect/StrategySelect.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/StrategySelect/StrategySelect.svelte
@@ -34,7 +34,11 @@
         {value}
         onValueChange={(v) => onValueChange(v as Strategy)}
     >
-        <Select.Trigger class="col-span-3" data-testid="selection-dialog-strategy-select">
+        <Select.Trigger
+            id="strategy"
+            class="col-span-3"
+            data-testid="selection-dialog-strategy-select"
+        >
             {STRATEGY_LABELS[value] ?? 'Select strategy'}
         </Select.Trigger>
         <Select.Content>

--- a/lightly_studio_view/src/lib/components/Selection/StrategySelect/StrategySelect.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/StrategySelect/StrategySelect.svelte
@@ -10,12 +10,18 @@
         onValueChange: (value: Strategy) => void;
     }
 
-    const STRATEGY_LABELS: Record<string, string> = {
-        diversity: 'Diversity',
-        typicality: 'Typicality',
-        similarity: 'Similarity',
-        class_balancing: 'Class Balancing'
-    };
+    const STRATEGIES: { value: Strategy; label: string; testId: string }[] = [
+        { value: 'diversity', label: 'Diversity', testId: 'selection-strategy-diversity' },
+        { value: 'typicality', label: 'Typicality', testId: 'selection-strategy-typicality' },
+        {
+            value: 'class_balancing',
+            label: 'Class Balancing',
+            testId: 'selection-strategy-class-balancing'
+        },
+        { value: 'similarity', label: 'Similarity', testId: 'selection-strategy-similarity' }
+    ];
+
+    const STRATEGY_LABELS = Object.fromEntries(STRATEGIES.map((s) => [s.value, s.label]));
 
     let { value, isSimilaritySupported, onValueChange }: Props = $props();
 </script>
@@ -33,27 +39,15 @@
         </Select.Trigger>
         <Select.Content>
             <Select.Group>
-                <Select.Item
-                    value="diversity"
-                    label="Diversity"
-                    data-testid="selection-strategy-diversity">Diversity</Select.Item
-                >
-                <Select.Item
-                    value="typicality"
-                    label="Typicality"
-                    data-testid="selection-strategy-typicality">Typicality</Select.Item
-                >
-                <Select.Item
-                    value="class_balancing"
-                    label="Class Balancing"
-                    data-testid="selection-strategy-class-balancing">Class Balancing</Select.Item
-                >
-                <Select.Item
-                    value="similarity"
-                    label="Similarity"
-                    data-testid="selection-strategy-similarity"
-                    disabled={!isSimilaritySupported}>Similarity</Select.Item
-                >
+                {#each STRATEGIES as strategy}
+                    <Select.Item
+                        value={strategy.value}
+                        label={strategy.label}
+                        data-testid={strategy.testId}
+                        disabled={strategy.value === 'similarity' && !isSimilaritySupported}
+                        >{strategy.label}</Select.Item
+                    >
+                {/each}
             </Select.Group>
         </Select.Content>
     </Select.Root>

--- a/lightly_studio_view/src/lib/components/Selection/StrategySelect/StrategySelect.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/StrategySelect/StrategySelect.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+    import { Label } from '$lib/components/ui/label';
+    import * as Select from '$lib/components/ui/select';
+
+    type Strategy = 'diversity' | 'typicality' | 'similarity' | 'class_balancing' | '';
+
+    interface Props {
+        value: Strategy;
+        isSimilaritySupported: boolean;
+        onValueChange: (value: Strategy) => void;
+    }
+
+    const STRATEGY_LABELS: Record<string, string> = {
+        diversity: 'Diversity',
+        typicality: 'Typicality',
+        similarity: 'Similarity',
+        class_balancing: 'Class Balancing'
+    };
+
+    let { value, isSimilaritySupported, onValueChange }: Props = $props();
+</script>
+
+<div class="grid grid-cols-4 items-center gap-4">
+    <Label for="strategy" class="text-right text-foreground">Strategy</Label>
+    <Select.Root
+        type="single"
+        name="strategy"
+        {value}
+        onValueChange={(v) => onValueChange(v as Strategy)}
+    >
+        <Select.Trigger class="col-span-3" data-testid="selection-dialog-strategy-select">
+            {STRATEGY_LABELS[value] ?? 'Select strategy'}
+        </Select.Trigger>
+        <Select.Content>
+            <Select.Group>
+                <Select.Item
+                    value="diversity"
+                    label="Diversity"
+                    data-testid="selection-strategy-diversity">Diversity</Select.Item
+                >
+                <Select.Item
+                    value="typicality"
+                    label="Typicality"
+                    data-testid="selection-strategy-typicality">Typicality</Select.Item
+                >
+                <Select.Item
+                    value="class_balancing"
+                    label="Class Balancing"
+                    data-testid="selection-strategy-class-balancing">Class Balancing</Select.Item
+                >
+                <Select.Item
+                    value="similarity"
+                    label="Similarity"
+                    data-testid="selection-strategy-similarity"
+                    disabled={!isSimilaritySupported}>Similarity</Select.Item
+                >
+            </Select.Group>
+        </Select.Content>
+    </Select.Root>
+</div>

--- a/lightly_studio_view/src/lib/components/Selection/StrategySelect/StrategySelect.test.ts
+++ b/lightly_studio_view/src/lib/components/Selection/StrategySelect/StrategySelect.test.ts
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import StrategySelect from './StrategySelect.svelte';
+
+describe('StrategySelect', () => {
+    beforeEach(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it('shows "Select strategy" when no strategy is selected', () => {
+        render(StrategySelect, {
+            props: { value: '', isSimilaritySupported: true, onValueChange: vi.fn() }
+        });
+
+        expect(screen.getByTestId('selection-dialog-strategy-select')).toHaveTextContent(
+            'Select strategy'
+        );
+    });
+
+    it('shows the label of the currently selected strategy', () => {
+        render(StrategySelect, {
+            props: { value: 'diversity', isSimilaritySupported: true, onValueChange: vi.fn() }
+        });
+
+        expect(screen.getByTestId('selection-dialog-strategy-select')).toHaveTextContent(
+            'Diversity'
+        );
+    });
+
+    it('calls onValueChange with the selected strategy value', async () => {
+        const onValueChange = vi.fn();
+        render(StrategySelect, {
+            props: { value: '', isSimilaritySupported: true, onValueChange }
+        });
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('selection-strategy-typicality'));
+
+        expect(onValueChange).toHaveBeenCalledWith('typicality');
+    });
+
+    it('disables the similarity option when isSimilaritySupported is false', async () => {
+        render(StrategySelect, {
+            props: { value: '', isSimilaritySupported: false, onValueChange: vi.fn() }
+        });
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+
+        expect(await screen.findByTestId('selection-strategy-similarity')).toHaveAttribute(
+            'data-disabled'
+        );
+    });
+
+    it('enables the similarity option when isSimilaritySupported is true', async () => {
+        render(StrategySelect, {
+            props: { value: '', isSimilaritySupported: true, onValueChange: vi.fn() }
+        });
+
+        await fireEvent.keyDown(screen.getByTestId('selection-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+
+        expect(await screen.findByTestId('selection-strategy-similarity')).not.toHaveAttribute(
+            'data-disabled'
+        );
+    });
+});


### PR DESCRIPTION
## What has changed and why?

Extracts the strategy selection dropdown into a `StrategySelect` component.

## How has it been tested?

Unit tests + storybook

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a strategy selection dropdown for choosing strategies (diversity, typicality, similarity, class balancing); similarity can be conditionally disabled.

* **Tests**
  * Added tests verifying default display, selection behavior, change events, and similarity-option disabling.

* **Documentation**
  * Added Storybook stories (Default, Selected, SimilarityDisabled) with interactive controls and examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->