### PR TITLE
Add annotation collection support to class balancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sample selection respects the current image or video filters.
 - Added sort-by support via GUI.
 - Added similarity selection option.
+- Added option to select annotation collection for class balancing.
 
 ### Changed
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -1,4 +1,4 @@
-"""API routes for exporting collection annotation tasks."""
+"""API routes for exporting collection annotations."""
 
 from __future__ import annotations
 

--- a/lightly_studio/src/lightly_studio/export/image_dataset_export.py
+++ b/lightly_studio/src/lightly_studio/export/image_dataset_export.py
@@ -53,7 +53,7 @@ class ImageDatasetExport:
                 defaults to "coco_export.json" in the current working directory.
 
         Raises:
-            ValueError: If the annotation task with the given name does not exist.
+            ValueError: If the annotation collection with the given name does not exist.
         """
         if output_json is None:
             output_json = DEFAULT_EXPORT_FILENAME

--- a/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
+++ b/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
@@ -37,7 +37,7 @@ class LightlyStudioInputBase:
 
         Args:
             session: The SQLModel session to use for database access. Used only in the
-                constructor to fetch the labels for the given annotation task.
+                constructor to fetch the labels for the given annotation collection.
             dataset_id: The dataset ID for label retrieval.
             samples: Dataset samples.
         """

--- a/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
+++ b/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
@@ -38,7 +38,7 @@ else:
 
 
 class AnnotationType(str, Enum):
-    """The type of annotation task."""
+    """The type of annotations."""
 
     CLASSIFICATION = "classification"
     SEGMENTATION_MASK = "segmentation_mask"

--- a/lightly_studio/src/lightly_studio/selection/select_via_db.py
+++ b/lightly_studio/src/lightly_studio/selection/select_via_db.py
@@ -11,8 +11,10 @@ from uuid import UUID, uuid4
 import numpy as np
 import sqlalchemy
 from numpy.typing import NDArray
-from sqlmodel import Session
+from sqlmodel import Session, col, select
 
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.tag import TagCreate
 from lightly_studio.resolvers import (
     annotation_label_resolver,
@@ -275,6 +277,68 @@ def _get_embeddings_by_sample_ids(
     return [embedding.embedding for embedding in embedding_tables]
 
 
+def _get_annotations_for_class_balancing(
+    session: Session,
+    parent_sample_ids: Sequence[UUID],
+    annotation_collection_id: UUID | None,
+) -> list[AnnotationBaseTable]:
+    """Resolve annotations that should contribute to class balancing."""
+    if annotation_collection_id is None:
+        return list(
+            annotation_resolver.get_all_by_parent_sample_ids(
+                session=session,
+                parent_sample_ids=parent_sample_ids,
+            )
+        )
+
+    annotations_statement = (
+        select(AnnotationBaseTable)
+        .join(SampleTable, col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id))
+        .where(col(AnnotationBaseTable.parent_sample_id).in_(parent_sample_ids))
+        .where(col(SampleTable.collection_id) == annotation_collection_id)
+    )
+    return list(session.exec(annotations_statement).all())
+
+
+def _add_annotation_class_balancing_to_mundig(
+    session: Session,
+    context: _SelectionContext,
+    strat: AnnotationClassBalancingStrategy,
+    mundig: Mundig,
+) -> None:
+    """Resolve annotation class balancing and add it to Mundig."""
+    annotations = _get_annotations_for_class_balancing(
+        session=session,
+        parent_sample_ids=context.input_sample_ids,
+        annotation_collection_id=strat.annotation_collection_id,
+    )
+    if strat.annotation_collection_id is not None and not annotations:
+        raise ValueError(
+            "Annotation collection with the given ID does not contain annotations "
+            "for the selected samples."
+        )
+    annotation_label_ids = [annotation.annotation_label_id for annotation in annotations]
+    sample_id_to_annotation_label_ids = defaultdict(list)
+    for annotation in annotations:
+        sample_id_to_annotation_label_ids[annotation.parent_sample_id].append(
+            annotation.annotation_label_id
+        )
+
+    class_distributions, target_values = _get_class_balancing_data(
+        session=session,
+        strat=strat,
+        dataset_id=context.dataset_id,
+        annotation_label_ids=annotation_label_ids,
+        input_sample_ids=context.input_sample_ids,
+        sample_id_to_annotation_label_ids=sample_id_to_annotation_label_ids,
+    )
+    mundig.add_class_balancing(
+        class_distributions=class_distributions,
+        target=target_values,
+        strength=strat.strength,
+    )
+
+
 def _add_strategy_to_mundig(
     session: Session,
     context: _SelectionContext,
@@ -342,29 +406,11 @@ def _add_strategy_to_mundig(
             strength=strat.strength,
         )
     elif isinstance(strat, AnnotationClassBalancingStrategy):
-        annotations = annotation_resolver.get_all_by_parent_sample_ids(
+        _add_annotation_class_balancing_to_mundig(
             session=session,
-            parent_sample_ids=context.input_sample_ids,
-        )
-        annotation_label_ids = [annotation.annotation_label_id for annotation in annotations]
-        sample_id_to_annotation_label_ids = defaultdict(list)
-        for annotation in annotations:
-            sample_id_to_annotation_label_ids[annotation.parent_sample_id].append(
-                annotation.annotation_label_id
-            )
-
-        class_distributions, target_values = _get_class_balancing_data(
-            session=session,
+            context=context,
             strat=strat,
-            dataset_id=context.dataset_id,
-            annotation_label_ids=annotation_label_ids,
-            input_sample_ids=context.input_sample_ids,
-            sample_id_to_annotation_label_ids=sample_id_to_annotation_label_ids,
-        )
-        mundig.add_class_balancing(
-            class_distributions=class_distributions,
-            target=target_values,
-            strength=strat.strength,
+            mundig=mundig,
         )
     else:
         raise ValueError(f"Selection strategy of type {type(strat)} is unknown.")

--- a/lightly_studio/src/lightly_studio/selection/selection_config.py
+++ b/lightly_studio/src/lightly_studio/selection/selection_config.py
@@ -54,5 +54,4 @@ class AnnotationClassBalancingStrategy(SelectionStrategy):
 
     strategy_name: Literal["balance"] = "balance"
     target_distribution: AnnotationClassToTarget | Literal["uniform"] | Literal["input"]
-    # TODO(Lukas 11/2025): Allow specifying the annotation task instead of merging annotations from
-    # all tasks.
+    annotation_collection_id: UUID | None = None

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -250,7 +250,10 @@ class AnnotationDetails:
 
 
 def create_annotations(
-    session: Session, collection_id: UUID, annotations: list[AnnotationDetails]
+    session: Session,
+    collection_id: UUID,
+    annotations: list[AnnotationDetails],
+    collection_name: str | None = None,
 ) -> list[AnnotationBaseTable]:
     """Create annotations.
 
@@ -258,6 +261,7 @@ def create_annotations(
         session: Database session.
         collection_id: ID of the collection.
         annotations: List of AnnotationDetails objects to create.
+        collection_name: Optional name of the annotation collection to create.
 
     Returns:
         List of AnnotationBaseTable objects.
@@ -281,6 +285,7 @@ def create_annotations(
         session=session,
         parent_collection_id=collection_id,
         annotations=annotations_to_create,
+        collection_name=collection_name,
     )
     return list(annotation_resolver.get_by_ids(session=session, annotation_ids=annotation_ids))
 

--- a/lightly_studio/tests/selection/test_select_via_db.py
+++ b/lightly_studio/tests/selection/test_select_via_db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from uuid import UUID, uuid4
 
 import numpy as np
@@ -697,7 +698,6 @@ def test_select_via_database_with_annotation_class_balancing_target_over_1(
 def test_select_via_database_with_annotation_class_balancing_uniform(
     db_session: Session,
 ) -> None:
-    """Runs selection with a simple annotation class balancing strategy."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=3, embedding_model_names=[]
     )
@@ -769,6 +769,146 @@ def test_select_via_database_with_annotation_class_balancing_uniform(
     selected_sample_ids = [sample.sample_id for sample in samples_in_tag]
     # Pick the first and last samples, because they resemble the uniform distribution the best.
     assert selected_sample_ids == [sample_ids[0], sample_ids[2]]
+
+
+def test_select_via_database__annotation_class_balancing__annotation_collection(
+    db_session: Session,
+) -> None:
+    collection_id = fill_db_with_samples_and_embeddings(
+        db_session, n_samples=3, embedding_model_names=[]
+    )
+    sample_ids = _all_sample_ids(db_session, collection_id)
+
+    label_cat = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="cat"
+    )
+    label_dog = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="dog"
+    )
+    label_bird = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="bird"
+    )
+
+    task_a_annotations = create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        collection_name="task-a",
+        annotations=[
+            AnnotationDetails(
+                sample_id=sample_ids[0],
+                annotation_label_id=label_cat.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=sample_ids[1],
+                annotation_label_id=label_dog.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=sample_ids[2],
+                annotation_label_id=label_cat.annotation_label_id,
+            ),
+        ],
+    )
+    # Task B annotations
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        collection_name="task-b",
+        annotations=[
+            AnnotationDetails(
+                sample_id=sample_ids[2],
+                annotation_label_id=label_bird.annotation_label_id,
+            ),
+        ],
+    )
+
+    task_a_collection_id = task_a_annotations[0].sample.collection_id
+    config = SelectionConfig(
+        n_samples_to_select=2,
+        collection_id=collection_id,
+        selection_result_tag_name="selection-tag",
+        strategies=[
+            AnnotationClassBalancingStrategy(
+                target_distribution="uniform",
+                annotation_collection_id=task_a_collection_id,
+            )
+        ],
+    )
+
+    select_via_database(
+        session=db_session,
+        config=config,
+        input_sample_ids=sample_ids,
+    )
+
+    tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
+    assert len(tags) == 1
+
+    selection_tag = tags[0]
+    samples_in_tag = image_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=collection_id,
+        filters=ImageFilter(sample_filter=SampleFilter(tag_ids=[selection_tag.tag_id])),
+    ).samples
+
+    expected_sample_paths = {"sample_0.jpg", "sample_1.jpg"}
+    actual_sample_paths = {sample.file_path_abs for sample in samples_in_tag}
+    assert actual_sample_paths == expected_sample_paths
+
+
+def test_select_via_database__annotation_class_balancing__annotation_collection_without_labels(
+    db_session: Session,
+) -> None:
+    """Raises a controlled error when the annotation collection has no labels for the inputs."""
+    collection_id = fill_db_with_samples_and_embeddings(
+        db_session, n_samples=3, embedding_model_names=[]
+    )
+    sample_ids = _all_sample_ids(db_session, collection_id)
+
+    label_cat = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="cat"
+    )
+
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        collection_name="task-a",
+        annotations=[
+            AnnotationDetails(
+                sample_id=sample_ids[0],
+                annotation_label_id=label_cat.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=sample_ids[1],
+                annotation_label_id=label_cat.annotation_label_id,
+            ),
+        ],
+    )
+    task_a_collection_id = annotations[0].sample.collection_id
+
+    config = SelectionConfig(
+        n_samples_to_select=1,
+        collection_id=collection_id,
+        selection_result_tag_name="selection-tag",
+        strategies=[
+            AnnotationClassBalancingStrategy(
+                target_distribution="uniform",
+                annotation_collection_id=task_a_collection_id,
+            )
+        ],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Annotation collection with the given ID does not contain annotations "
+            "for the selected samples."
+        ),
+    ):
+        select_via_database(
+            session=db_session,
+            config=config,
+            input_sample_ids=[sample_ids[2]],
+        )
 
 
 def test_select_via_database_with_annotation_class_balancing_input(


### PR DESCRIPTION
## What has changed and why?
Class balancing needs to know which annotation task is being used.

I've also removed the annotation task term where appropriate.

## How has it been tested?
Added a test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to select a specific annotation collection for class balancing.

* **Tests**
  * Added/extended database selection tests covering class balancing constrained by an annotation collection and the no-labels error case.

* **Documentation**
  * Updated changelog and docstrings to use annotation-collection terminology and document the new selection capability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->