### PR TITLE
Add annotation source support to class balancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added sort-by support via GUI.
 - Added similarity selection option.
 - Show confusion matrix in evaluation results for object detection.
+- Added option to select annotation source for class balancing.
 
 ### Changed
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -1,4 +1,4 @@
-"""API routes for exporting collection annotation tasks."""
+"""API routes for exporting collection annotations."""
 
 from __future__ import annotations
 

--- a/lightly_studio/src/lightly_studio/export/image_dataset_export.py
+++ b/lightly_studio/src/lightly_studio/export/image_dataset_export.py
@@ -53,7 +53,7 @@ class ImageDatasetExport:
                 defaults to "coco_export.json" in the current working directory.
 
         Raises:
-            ValueError: If the annotation task with the given name does not exist.
+            ValueError: If the annotation source with the given name does not exist.
         """
         if output_json is None:
             output_json = DEFAULT_EXPORT_FILENAME

--- a/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
+++ b/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
@@ -37,7 +37,7 @@ class LightlyStudioInputBase:
 
         Args:
             session: The SQLModel session to use for database access. Used only in the
-                constructor to fetch the labels for the given annotation task.
+                constructor to fetch the labels for the given annotation source.
             dataset_id: The dataset ID for label retrieval.
             samples: Dataset samples.
         """

--- a/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
+++ b/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
@@ -38,7 +38,7 @@ else:
 
 
 class AnnotationType(str, Enum):
-    """The type of annotation task."""
+    """The type of annotations."""
 
     CLASSIFICATION = "classification"
     SEGMENTATION_MASK = "segmentation_mask"

--- a/lightly_studio/src/lightly_studio/selection/select_via_db.py
+++ b/lightly_studio/src/lightly_studio/selection/select_via_db.py
@@ -10,9 +10,11 @@ from uuid import UUID, uuid4
 
 import numpy as np
 import sqlalchemy
+import sqlmodel
 from numpy.typing import NDArray
-from sqlmodel import Session
 
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.tag import TagCreate
 from lightly_studio.resolvers import (
     annotation_label_resolver,
@@ -86,7 +88,7 @@ def _aggregate_class_distributions(
 
 
 def _process_explicit_target_distribution(
-    session: Session,
+    session: sqlmodel.Session,
     dataset_id: UUID,
     target_distribution: dict[str, float],
     annotation_label_ids: Sequence[UUID],
@@ -139,7 +141,7 @@ def _process_explicit_target_distribution(
 
 
 def _get_class_balancing_data(  # noqa: PLR0913
-    session: Session,
+    session: sqlmodel.Session,
     strat: AnnotationClassBalancingStrategy,
     dataset_id: UUID,
     annotation_label_ids: Sequence[UUID],
@@ -194,7 +196,7 @@ def _get_class_balancing_data(  # noqa: PLR0913
 
 
 def select_via_database(
-    session: Session, config: SelectionConfig, input_sample_ids: list[UUID]
+    session: sqlmodel.Session, config: SelectionConfig, input_sample_ids: list[UUID]
 ) -> None:
     """Run selection using the provided candidate sample ids.
 
@@ -257,7 +259,7 @@ def select_via_database(
 
 
 def _get_embeddings_by_sample_ids(
-    session: Session,
+    session: sqlmodel.Session,
     context: _SelectionContext,
     embedding_model_name: str | None,
 ) -> list[list[float]]:
@@ -275,8 +277,73 @@ def _get_embeddings_by_sample_ids(
     return [embedding.embedding for embedding in embedding_tables]
 
 
+def _get_annotations_for_class_balancing(
+    session: sqlmodel.Session,
+    parent_sample_ids: Sequence[UUID],
+    annotation_source_id: UUID | None,
+) -> list[AnnotationBaseTable]:
+    """Resolve annotations that should contribute to class balancing."""
+    if annotation_source_id is None:
+        return list(
+            annotation_resolver.get_all_by_parent_sample_ids(
+                session=session,
+                parent_sample_ids=parent_sample_ids,
+            )
+        )
+
+    annotations_statement = (
+        sqlmodel.select(AnnotationBaseTable)
+        .join(
+            SampleTable,
+            sqlmodel.col(SampleTable.sample_id) == sqlmodel.col(AnnotationBaseTable.sample_id),
+        )
+        .where(sqlmodel.col(AnnotationBaseTable.parent_sample_id).in_(parent_sample_ids))
+        .where(sqlmodel.col(SampleTable.collection_id) == annotation_source_id)
+    )
+    return list(session.exec(annotations_statement).all())
+
+
+def _add_annotation_class_balancing_to_mundig(
+    session: sqlmodel.Session,
+    context: _SelectionContext,
+    strat: AnnotationClassBalancingStrategy,
+    mundig: Mundig,
+) -> None:
+    """Resolve annotation class balancing and add it to Mundig."""
+    annotations = _get_annotations_for_class_balancing(
+        session=session,
+        parent_sample_ids=context.input_sample_ids,
+        annotation_source_id=strat.annotation_source_id,
+    )
+    if strat.annotation_source_id is not None and not annotations:
+        raise ValueError(
+            "Annotation source with the given ID does not contain annotations "
+            "for the selected samples."
+        )
+    annotation_label_ids = [annotation.annotation_label_id for annotation in annotations]
+    sample_id_to_annotation_label_ids = defaultdict(list)
+    for annotation in annotations:
+        sample_id_to_annotation_label_ids[annotation.parent_sample_id].append(
+            annotation.annotation_label_id
+        )
+
+    class_distributions, target_values = _get_class_balancing_data(
+        session=session,
+        strat=strat,
+        dataset_id=context.dataset_id,
+        annotation_label_ids=annotation_label_ids,
+        input_sample_ids=context.input_sample_ids,
+        sample_id_to_annotation_label_ids=sample_id_to_annotation_label_ids,
+    )
+    mundig.add_class_balancing(
+        class_distributions=class_distributions,
+        target=target_values,
+        strength=strat.strength,
+    )
+
+
 def _add_strategy_to_mundig(
-    session: Session,
+    session: sqlmodel.Session,
     context: _SelectionContext,
     strat: object,
     mundig: Mundig,
@@ -342,29 +409,11 @@ def _add_strategy_to_mundig(
             strength=strat.strength,
         )
     elif isinstance(strat, AnnotationClassBalancingStrategy):
-        annotations = annotation_resolver.get_all_by_parent_sample_ids(
+        _add_annotation_class_balancing_to_mundig(
             session=session,
-            parent_sample_ids=context.input_sample_ids,
-        )
-        annotation_label_ids = [annotation.annotation_label_id for annotation in annotations]
-        sample_id_to_annotation_label_ids = defaultdict(list)
-        for annotation in annotations:
-            sample_id_to_annotation_label_ids[annotation.parent_sample_id].append(
-                annotation.annotation_label_id
-            )
-
-        class_distributions, target_values = _get_class_balancing_data(
-            session=session,
+            context=context,
             strat=strat,
-            dataset_id=context.dataset_id,
-            annotation_label_ids=annotation_label_ids,
-            input_sample_ids=context.input_sample_ids,
-            sample_id_to_annotation_label_ids=sample_id_to_annotation_label_ids,
-        )
-        mundig.add_class_balancing(
-            class_distributions=class_distributions,
-            target=target_values,
-            strength=strat.strength,
+            mundig=mundig,
         )
     else:
         raise ValueError(f"Selection strategy of type {type(strat)} is unknown.")

--- a/lightly_studio/src/lightly_studio/selection/select_via_db.py
+++ b/lightly_studio/src/lightly_studio/selection/select_via_db.py
@@ -159,16 +159,26 @@ def _get_class_balancing_data(  # noqa: PLR0913
             "Annotation source with the given ID does not contain annotations "
             "for the selected samples."
         )
-    annotation_label_ids = [annotation.annotation_label_id for annotation in annotations]
-    sample_id_to_annotation_label_ids = defaultdict(list)
-    for annotation in annotations:
-        sample_id_to_annotation_label_ids[annotation.parent_sample_id].append(
-            annotation.annotation_label_id
-        )
+
+    if annotation_label_ids is None:
+        annotation_label_ids = [annotation.annotation_label_id for annotation in annotations]
+    if sample_id_to_annotation_label_ids is None:
+        sample_id_to_annotation_label_ids = defaultdict(list)
+        for annotation in annotations:
+            sample_id_to_annotation_label_ids[annotation.parent_sample_id].append(
+                annotation.annotation_label_id
+            )
+    else:
+        sample_id_to_annotation_label_ids = {
+            sample_id: list(label_ids)
+            for sample_id, label_ids in sample_id_to_annotation_label_ids.items()
+        }
 
     if strat.target_distribution == "uniform":
-        target_keys_set = set(annotation_label_ids)
-        target_keys = list(target_keys_set)
+        # Keep first-seen order so the distribution columns stay stable and line up with values.
+        target_keys = list(dict.fromkeys(annotation_label_ids))
+        if not target_keys:
+            return np.zeros((len(input_sample_ids), 0), dtype=np.float32), []
         target_values = [1.0 / len(target_keys)] * len(target_keys)
     elif strat.target_distribution == "input":
         # Count the number of times each label appears in the input

--- a/lightly_studio/src/lightly_studio/selection/select_via_db.py
+++ b/lightly_studio/src/lightly_studio/selection/select_via_db.py
@@ -10,8 +10,8 @@ from uuid import UUID, uuid4
 
 import numpy as np
 import sqlalchemy
-import sqlmodel
 from numpy.typing import NDArray
+from sqlmodel import Session, col, select
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.sample import SampleTable
@@ -88,7 +88,7 @@ def _aggregate_class_distributions(
 
 
 def _process_explicit_target_distribution(
-    session: sqlmodel.Session,
+    session: Session,
     dataset_id: UUID,
     target_distribution: dict[str, float],
     annotation_label_ids: Sequence[UUID],
@@ -141,14 +141,31 @@ def _process_explicit_target_distribution(
 
 
 def _get_class_balancing_data(  # noqa: PLR0913
-    session: sqlmodel.Session,
+    session: Session,
     strat: AnnotationClassBalancingStrategy,
     dataset_id: UUID,
-    annotation_label_ids: Sequence[UUID],
     input_sample_ids: Sequence[UUID],
-    sample_id_to_annotation_label_ids: Mapping[UUID, list[UUID]],
+    annotation_label_ids: Sequence[UUID] | None = None,
+    sample_id_to_annotation_label_ids: Mapping[UUID, list[UUID]] | None = None,
 ) -> tuple[NDArray[np.float32], list[float]]:
     """Helper function to get class balancing data."""
+    annotations = _get_annotations_for_class_balancing(
+        session=session,
+        parent_sample_ids=input_sample_ids,
+        annotation_source_id=strat.annotation_source_id,
+    )
+    if strat.annotation_source_id is not None and not annotations:
+        raise ValueError(
+            "Annotation source with the given ID does not contain annotations "
+            "for the selected samples."
+        )
+    annotation_label_ids = [annotation.annotation_label_id for annotation in annotations]
+    sample_id_to_annotation_label_ids = defaultdict(list)
+    for annotation in annotations:
+        sample_id_to_annotation_label_ids[annotation.parent_sample_id].append(
+            annotation.annotation_label_id
+        )
+
     if strat.target_distribution == "uniform":
         target_keys_set = set(annotation_label_ids)
         target_keys = list(target_keys_set)
@@ -196,7 +213,7 @@ def _get_class_balancing_data(  # noqa: PLR0913
 
 
 def select_via_database(
-    session: sqlmodel.Session, config: SelectionConfig, input_sample_ids: list[UUID]
+    session: Session, config: SelectionConfig, input_sample_ids: list[UUID]
 ) -> None:
     """Run selection using the provided candidate sample ids.
 
@@ -259,7 +276,7 @@ def select_via_database(
 
 
 def _get_embeddings_by_sample_ids(
-    session: sqlmodel.Session,
+    session: Session,
     context: _SelectionContext,
     embedding_model_name: str | None,
 ) -> list[list[float]]:
@@ -278,7 +295,7 @@ def _get_embeddings_by_sample_ids(
 
 
 def _get_annotations_for_class_balancing(
-    session: sqlmodel.Session,
+    session: Session,
     parent_sample_ids: Sequence[UUID],
     annotation_source_id: UUID | None,
 ) -> list[AnnotationBaseTable]:
@@ -292,58 +309,19 @@ def _get_annotations_for_class_balancing(
         )
 
     annotations_statement = (
-        sqlmodel.select(AnnotationBaseTable)
+        select(AnnotationBaseTable)
         .join(
             SampleTable,
-            sqlmodel.col(SampleTable.sample_id) == sqlmodel.col(AnnotationBaseTable.sample_id),
+            col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
         )
-        .where(sqlmodel.col(AnnotationBaseTable.parent_sample_id).in_(parent_sample_ids))
-        .where(sqlmodel.col(SampleTable.collection_id) == annotation_source_id)
+        .where(col(AnnotationBaseTable.parent_sample_id).in_(parent_sample_ids))
+        .where(col(SampleTable.collection_id) == annotation_source_id)
     )
     return list(session.exec(annotations_statement).all())
 
 
-def _add_annotation_class_balancing_to_mundig(
-    session: sqlmodel.Session,
-    context: _SelectionContext,
-    strat: AnnotationClassBalancingStrategy,
-    mundig: Mundig,
-) -> None:
-    """Resolve annotation class balancing and add it to Mundig."""
-    annotations = _get_annotations_for_class_balancing(
-        session=session,
-        parent_sample_ids=context.input_sample_ids,
-        annotation_source_id=strat.annotation_source_id,
-    )
-    if strat.annotation_source_id is not None and not annotations:
-        raise ValueError(
-            "Annotation source with the given ID does not contain annotations "
-            "for the selected samples."
-        )
-    annotation_label_ids = [annotation.annotation_label_id for annotation in annotations]
-    sample_id_to_annotation_label_ids = defaultdict(list)
-    for annotation in annotations:
-        sample_id_to_annotation_label_ids[annotation.parent_sample_id].append(
-            annotation.annotation_label_id
-        )
-
-    class_distributions, target_values = _get_class_balancing_data(
-        session=session,
-        strat=strat,
-        dataset_id=context.dataset_id,
-        annotation_label_ids=annotation_label_ids,
-        input_sample_ids=context.input_sample_ids,
-        sample_id_to_annotation_label_ids=sample_id_to_annotation_label_ids,
-    )
-    mundig.add_class_balancing(
-        class_distributions=class_distributions,
-        target=target_values,
-        strength=strat.strength,
-    )
-
-
 def _add_strategy_to_mundig(
-    session: sqlmodel.Session,
+    session: Session,
     context: _SelectionContext,
     strat: object,
     mundig: Mundig,
@@ -409,11 +387,16 @@ def _add_strategy_to_mundig(
             strength=strat.strength,
         )
     elif isinstance(strat, AnnotationClassBalancingStrategy):
-        _add_annotation_class_balancing_to_mundig(
+        class_distributions, target_values = _get_class_balancing_data(
             session=session,
-            context=context,
             strat=strat,
-            mundig=mundig,
+            dataset_id=context.dataset_id,
+            input_sample_ids=context.input_sample_ids,
+        )
+        mundig.add_class_balancing(
+            class_distributions=class_distributions,
+            target=target_values,
+            strength=strat.strength,
         )
     else:
         raise ValueError(f"Selection strategy of type {type(strat)} is unknown.")

--- a/lightly_studio/src/lightly_studio/selection/select_via_db.py
+++ b/lightly_studio/src/lightly_studio/selection/select_via_db.py
@@ -140,13 +140,12 @@ def _process_explicit_target_distribution(
     return label_id_to_target, unused_label_ids, remaining_ratio
 
 
-def _get_class_balancing_data(  # noqa: PLR0913
+def _get_class_balancing_data(  # noqa: C901
     session: Session,
     strat: AnnotationClassBalancingStrategy,
     dataset_id: UUID,
     input_sample_ids: Sequence[UUID],
     annotation_label_ids: Sequence[UUID] | None = None,
-    sample_id_to_annotation_label_ids: Mapping[UUID, list[UUID]] | None = None,
 ) -> tuple[NDArray[np.float32], list[float]]:
     """Helper function to get class balancing data."""
     annotations = _get_annotations_for_class_balancing(
@@ -162,17 +161,11 @@ def _get_class_balancing_data(  # noqa: PLR0913
 
     if annotation_label_ids is None:
         annotation_label_ids = [annotation.annotation_label_id for annotation in annotations]
-    if sample_id_to_annotation_label_ids is None:
-        sample_id_to_annotation_label_ids = defaultdict(list)
-        for annotation in annotations:
-            sample_id_to_annotation_label_ids[annotation.parent_sample_id].append(
-                annotation.annotation_label_id
-            )
-    else:
-        sample_id_to_annotation_label_ids = {
-            sample_id: list(label_ids)
-            for sample_id, label_ids in sample_id_to_annotation_label_ids.items()
-        }
+    sample_id_to_annotation_label_ids = defaultdict(list)
+    for annotation in annotations:
+        sample_id_to_annotation_label_ids[annotation.parent_sample_id].append(
+            annotation.annotation_label_id
+        )
 
     if strat.target_distribution == "uniform":
         # Keep first-seen order so the distribution columns stay stable and line up with values.

--- a/lightly_studio/src/lightly_studio/selection/selection_config.py
+++ b/lightly_studio/src/lightly_studio/selection/selection_config.py
@@ -54,5 +54,4 @@ class AnnotationClassBalancingStrategy(SelectionStrategy):
 
     strategy_name: Literal["balance"] = "balance"
     target_distribution: AnnotationClassToTarget | Literal["uniform"] | Literal["input"]
-    # TODO(Lukas 11/2025): Allow specifying the annotation task instead of merging annotations from
-    # all tasks.
+    annotation_source_id: UUID | None = None

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -250,7 +250,10 @@ class AnnotationDetails:
 
 
 def create_annotations(
-    session: Session, collection_id: UUID, annotations: list[AnnotationDetails]
+    session: Session,
+    collection_id: UUID,
+    annotations: list[AnnotationDetails],
+    collection_name: str | None = None,
 ) -> list[AnnotationBaseTable]:
     """Create annotations.
 
@@ -258,6 +261,7 @@ def create_annotations(
         session: Database session.
         collection_id: ID of the collection.
         annotations: List of AnnotationDetails objects to create.
+        collection_name: Optional name of the annotation collection to create.
 
     Returns:
         List of AnnotationBaseTable objects.
@@ -281,6 +285,7 @@ def create_annotations(
         session=session,
         parent_collection_id=collection_id,
         annotations=annotations_to_create,
+        collection_name=collection_name,
     )
     return list(annotation_resolver.get_by_ids(session=session, annotation_ids=annotation_ids))
 

--- a/lightly_studio/tests/selection/test_select_via_db.py
+++ b/lightly_studio/tests/selection/test_select_via_db.py
@@ -20,7 +20,6 @@ from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from lightly_studio.selection.mundig import Mundig
 from lightly_studio.selection.select_via_db import (
     _aggregate_class_distributions,
-    _get_class_balancing_data,
     select_via_database,
 )
 from lightly_studio.selection.selection_config import (
@@ -34,7 +33,6 @@ from tests.helpers_resolvers import (
     AnnotationDetails,
     create_annotation_label,
     create_annotations,
-    create_collection,
     create_tag,
     fill_db_with_samples_and_embeddings,
 )
@@ -1022,131 +1020,6 @@ def test_aggregate_class_distributions() -> None:
         dtype=np.float32,
     )
     np.testing.assert_array_equal(class_distributions, expected_distributions)
-
-
-def test_get_class_balancing_data_input(db_session: Session) -> None:
-    """Test the 'input' distribution logic."""
-    dataset_id = UUID("00000000-0000-0000-0000-000000000000")
-    label_id_cat = UUID("00000000-0000-0000-0000-000000000001")
-    label_id_dog = UUID("00000000-0000-0000-0000-000000000002")
-    sample_id_1 = UUID("11111111-1111-1111-1111-111111111111")
-    sample_id_2 = UUID("22222222-2222-2222-2222-222222222222")
-
-    # The order of target keys depends on the insertion order in this list.
-    # 'cat' appears first, 'dog' appears second.
-    # Target Keys: [cat, dog]
-    all_annotation_labels = [label_id_cat, label_id_cat, label_id_dog]
-    input_sample_ids = [sample_id_1, sample_id_2]
-
-    sample_id_to_annotation_label_ids = {
-        sample_id_1: [label_id_cat],
-        sample_id_2: [label_id_cat, label_id_dog],
-    }
-
-    strat = AnnotationClassBalancingStrategy(target_distribution="input")
-
-    class_dist, target_vals = _get_class_balancing_data(
-        session=db_session,
-        strat=strat,
-        dataset_id=dataset_id,
-        annotation_label_ids=all_annotation_labels,
-        input_sample_ids=input_sample_ids,
-        sample_id_to_annotation_label_ids=sample_id_to_annotation_label_ids,
-    )
-
-    expected_vals = [2, 1]
-    assert target_vals == expected_vals
-
-    # Columns: [Cat, Dog]
-    # Row 0 (Sample 1): 1 Cat, 0 Dog
-    # Row 1 (Sample 2): 1 Cat, 1 Dog
-    expected_dist = np.array([[1.0, 0.0], [1.0, 1.0]])
-    np.testing.assert_array_equal(class_dist, expected_dist)
-
-
-def test_get_class_balancing_data_uniform(db_session: Session) -> None:
-    """Test the 'uniform' distribution logic."""
-    dataset_id = UUID("00000000-0000-0000-0000-000000000000")
-    label_id_cat = UUID("00000000-0000-0000-0000-000000000001")
-    label_id_dog = UUID("00000000-0000-0000-0000-000000000002")
-    sample_id_1 = UUID("11111111-1111-1111-1111-111111111111")
-    sample_id_2 = UUID("22222222-2222-2222-2222-222222222222")
-
-    all_annotation_labels = [label_id_cat, label_id_cat, label_id_dog]
-    input_sample_ids = [sample_id_1, sample_id_2]
-
-    sample_id_to_annotation_label_ids = {
-        sample_id_1: [label_id_cat],
-        sample_id_2: [label_id_cat, label_id_dog],
-    }
-
-    strat = AnnotationClassBalancingStrategy(target_distribution="uniform")
-
-    class_dist, target_vals = _get_class_balancing_data(
-        session=db_session,
-        strat=strat,
-        dataset_id=dataset_id,
-        annotation_label_ids=all_annotation_labels,
-        input_sample_ids=input_sample_ids,
-        sample_id_to_annotation_label_ids=sample_id_to_annotation_label_ids,
-    )
-
-    assert len(target_vals) == 2
-    assert target_vals == pytest.approx([0.5, 0.5], abs=1e-9)
-
-    expected_col_cat = np.array([1.0, 1.0], dtype=np.float32)
-    expected_col_dog = np.array([0.0, 1.0], dtype=np.float32)
-
-    np.testing.assert_array_equal(class_dist[:, 0], expected_col_cat)
-    np.testing.assert_array_equal(class_dist[:, 1], expected_col_dog)
-
-
-def test_get_class_balancing_data_target(db_session: Session) -> None:
-    """Test the 'target' (dict) distribution logic."""
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-    label_cat_obj = create_annotation_label(
-        session=db_session, root_collection_id=collection_id, label_name="cat"
-    )
-    label_dog_obj = create_annotation_label(
-        session=db_session, root_collection_id=collection_id, label_name="dog"
-    )
-
-    label_id_cat = label_cat_obj.annotation_label_id
-    label_id_dog = label_dog_obj.annotation_label_id
-
-    sample_id_1 = UUID("11111111-1111-1111-1111-111111111111")
-    sample_id_2 = UUID("22222222-2222-2222-2222-222222222222")
-
-    all_annotation_labels = [label_id_cat, label_id_cat, label_id_dog]
-    input_sample_ids = [sample_id_1, sample_id_2]
-
-    sample_id_to_annotation_label_ids = {
-        sample_id_1: [label_id_cat],
-        sample_id_2: [label_id_cat, label_id_dog],
-    }
-
-    distribution_dict = {
-        "dog": 0.7,
-        "cat": 0.3,
-    }
-
-    strat = AnnotationClassBalancingStrategy(target_distribution=distribution_dict)
-
-    class_dist, target_vals = _get_class_balancing_data(
-        session=db_session,
-        strat=strat,
-        dataset_id=collection.dataset_id,
-        annotation_label_ids=all_annotation_labels,
-        input_sample_ids=input_sample_ids,
-        sample_id_to_annotation_label_ids=sample_id_to_annotation_label_ids,
-    )
-
-    expected_vals = [0.7, 0.3]
-    assert target_vals == pytest.approx(expected_vals, abs=1e-9)
-
-    expected_dist = np.array([[0.0, 1.0], [1.0, 1.0]])
-    np.testing.assert_array_equal(class_dist, expected_dist)
 
 
 def _all_sample_ids(session: Session, collection_id: UUID) -> list[UUID]:

--- a/lightly_studio/tests/selection/test_select_via_db.py
+++ b/lightly_studio/tests/selection/test_select_via_db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from uuid import UUID, uuid4
 
 import numpy as np
@@ -697,7 +698,6 @@ def test_select_via_database_with_annotation_class_balancing_target_over_1(
 def test_select_via_database_with_annotation_class_balancing_uniform(
     db_session: Session,
 ) -> None:
-    """Runs selection with a simple annotation class balancing strategy."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=3, embedding_model_names=[]
     )
@@ -769,6 +769,146 @@ def test_select_via_database_with_annotation_class_balancing_uniform(
     selected_sample_ids = [sample.sample_id for sample in samples_in_tag]
     # Pick the first and last samples, because they resemble the uniform distribution the best.
     assert selected_sample_ids == [sample_ids[0], sample_ids[2]]
+
+
+def test_select_via_database__annotation_class_balancing__annotation_source(
+    db_session: Session,
+) -> None:
+    collection_id = fill_db_with_samples_and_embeddings(
+        db_session, n_samples=3, embedding_model_names=[]
+    )
+    sample_ids = _all_sample_ids(db_session, collection_id)
+
+    label_cat = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="cat"
+    )
+    label_dog = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="dog"
+    )
+    label_bird = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="bird"
+    )
+
+    annotation_source_a_annotations = create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        collection_name="source-a",
+        annotations=[
+            AnnotationDetails(
+                sample_id=sample_ids[0],
+                annotation_label_id=label_cat.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=sample_ids[1],
+                annotation_label_id=label_dog.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=sample_ids[2],
+                annotation_label_id=label_cat.annotation_label_id,
+            ),
+        ],
+    )
+    # Source B
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        collection_name="source-b",
+        annotations=[
+            AnnotationDetails(
+                sample_id=sample_ids[2],
+                annotation_label_id=label_bird.annotation_label_id,
+            ),
+        ],
+    )
+
+    annotation_source_id = annotation_source_a_annotations[0].sample.collection_id
+    config = SelectionConfig(
+        n_samples_to_select=2,
+        collection_id=collection_id,
+        selection_result_tag_name="selection-tag",
+        strategies=[
+            AnnotationClassBalancingStrategy(
+                target_distribution="uniform",
+                annotation_source_id=annotation_source_id,
+            )
+        ],
+    )
+
+    select_via_database(
+        session=db_session,
+        config=config,
+        input_sample_ids=sample_ids,
+    )
+
+    tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
+    assert len(tags) == 1
+
+    selection_tag = tags[0]
+    samples_in_tag = image_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=collection_id,
+        filters=ImageFilter(sample_filter=SampleFilter(tag_ids=[selection_tag.tag_id])),
+    ).samples
+
+    expected_sample_paths = {"sample_0.jpg", "sample_1.jpg"}
+    actual_sample_paths = {sample.file_path_abs for sample in samples_in_tag}
+    assert actual_sample_paths == expected_sample_paths
+
+
+def test_select_via_database__annotation_class_balancing__annotation_source_without_labels(
+    db_session: Session,
+) -> None:
+    """Raises a controlled error when the annotation source has no labels for the inputs."""
+    collection_id = fill_db_with_samples_and_embeddings(
+        db_session, n_samples=3, embedding_model_names=[]
+    )
+    sample_ids = _all_sample_ids(db_session, collection_id)
+
+    label_cat = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="cat"
+    )
+
+    annotations = create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        collection_name="source-a",
+        annotations=[
+            AnnotationDetails(
+                sample_id=sample_ids[0],
+                annotation_label_id=label_cat.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=sample_ids[1],
+                annotation_label_id=label_cat.annotation_label_id,
+            ),
+        ],
+    )
+    annotation_source_id = annotations[0].sample.collection_id
+
+    config = SelectionConfig(
+        n_samples_to_select=1,
+        collection_id=collection_id,
+        selection_result_tag_name="selection-tag",
+        strategies=[
+            AnnotationClassBalancingStrategy(
+                target_distribution="uniform",
+                annotation_source_id=annotation_source_id,
+            )
+        ],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Annotation source with the given ID does not contain annotations "
+            "for the selected samples."
+        ),
+    ):
+        select_via_database(
+            session=db_session,
+            config=config,
+            input_sample_ids=[sample_ids[2]],
+        )
 
 
 def test_select_via_database_with_annotation_class_balancing_input(

--- a/lightly_studio/tests/selection/test_select_via_db.py
+++ b/lightly_studio/tests/selection/test_select_via_db.py
@@ -773,6 +773,7 @@ def test_select_via_database_with_annotation_class_balancing_uniform(
 
 def test_select_via_database__annotation_class_balancing__annotation_source(
     db_session: Session,
+    mocker: MockerFixture,
 ) -> None:
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=3, embedding_model_names=[]
@@ -822,6 +823,7 @@ def test_select_via_database__annotation_class_balancing__annotation_source(
     )
 
     annotation_source_id = annotation_source_a_annotations[0].sample.collection_id
+    add_class_balancing_spy = mocker.spy(Mundig, "add_class_balancing")
     config = SelectionConfig(
         n_samples_to_select=2,
         collection_id=collection_id,
@@ -840,19 +842,17 @@ def test_select_via_database__annotation_class_balancing__annotation_source(
         input_sample_ids=sample_ids,
     )
 
-    tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
-    assert len(tags) == 1
+    add_class_balancing_spy.assert_called_once()
+    class_distributions = add_class_balancing_spy.call_args.kwargs["class_distributions"]
+    target = add_class_balancing_spy.call_args.kwargs["target"]
 
-    selection_tag = tags[0]
-    samples_in_tag = image_resolver.get_all_by_collection_id(
-        session=db_session,
-        collection_id=collection_id,
-        filters=ImageFilter(sample_filter=SampleFilter(tag_ids=[selection_tag.tag_id])),
-    ).samples
-
-    expected_sample_paths = {"sample_0.jpg", "sample_1.jpg"}
-    actual_sample_paths = {sample.file_path_abs for sample in samples_in_tag}
-    assert actual_sample_paths == expected_sample_paths
+    # Columns are the source-A labels [cat, dog], and source B's bird label is excluded.
+    assert class_distributions.shape == (3, 2)
+    assert {tuple(class_distributions[:, idx]) for idx in range(class_distributions.shape[1])} == {
+        (1.0, 0.0, 1.0),
+        (0.0, 1.0, 0.0),
+    }
+    assert target == pytest.approx([0.5, 0.5], abs=1e-9)
 
 
 def test_select_via_database__annotation_class_balancing__annotation_source_without_labels(


### PR DESCRIPTION
## What has changed and why?
Class balancing needs to know which annotation source is being used.

I've also removed the annotation task term where appropriate.

## How has it been tested?
Added tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to select a specific annotation source when configuring class balancing for dataset selection.

* **Documentation**
  * Updated wording to use "annotation source" instead of "annotation task" in user-facing docs and messages.

* **Bug Fixes / Behavior**
  * Class-balancing selection now respects a specified annotation source and raises a clear error when no labels are found for the chosen samples.

* **Tests**
  * Added tests covering annotation-source-scoped class balancing and the no-labels error case.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->