### PR TITLE
Load applied query when reopening query editor

### DIFF
--- a/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
@@ -14,7 +14,7 @@
     type OnSaveHandler = ComponentProps<typeof QueryEditor>['onSave'];
 
     const { onClose }: Props = $props();
-    const { updateQueryExpr } = useImageFilters();
+    const { imageQueryExpression, updateQueryExpr } = useImageFilters();
 
     const handleQueryEditorValueChange: OnSaveHandler = (value, parsed) => {
         if (!parsed) {
@@ -68,5 +68,9 @@
             <p>Tip: Completion hints will show as you type a space or a left parenthesis.</p>
         </Typography>
     </div>
-    <QueryEditor height="100%" onSave={handleQueryEditorValueChange} />
+    <QueryEditor
+        height="100%"
+        value={$imageQueryExpression?.query_expr_str}
+        onSave={handleQueryEditorValueChange}
+    />
 </div>


### PR DESCRIPTION
## What has changed and why?

Load a previously applied query when reopening query editor.

## How has it been tested?

- Manually

An end-to-end test is planned.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Query Editor component with configurable display height and improved save functionality for better user control and interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->