### PR TITLE
ci: update github actions to versions compatible with node 24

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -27,13 +27,13 @@ jobs:
       file-hash: ${{ steps.file-hash.outputs.hash }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       # Authenticate to download dev versions of lightly-mundig.
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           project_id: boris-250909
           credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Cache build
         id: cache-build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           lookup-only: true
           path: &cache-build-path |
@@ -65,7 +65,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: cache-playwright-browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: &cache-playwright-browsers-path ~/.cache/ms-playwright
           key: &cache-playwright-browsers-key >-
@@ -76,7 +76,7 @@ jobs:
 
       - name: Cache example dataset
         id: cache-example-dataset
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # No need to download a cached version in cache preparation step
           lookup-only: true
@@ -88,19 +88,19 @@ jobs:
       ### Setup steps for the workflow ###
       - name: Set Up Python
         if: steps.cache-build.outputs.cache-hit != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 
       - name: Set Up Uv
         if: steps.cache-build.outputs.cache-hit != 'true'
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.8.17"
           enable-cache: true
 
       - name: Set Up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'lightly_studio_view/.nvmrc'
           cache: 'npm'
@@ -211,20 +211,20 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       # Authenticate to download dev versions of lightly-mundig.
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           project_id: boris-250909
           credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
 
       - name: Check e2e success cache
         id: cache-success
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           lookup-only: true
           path: ${{ matrix.success_marker }}
@@ -235,7 +235,7 @@ jobs:
       - name: Cache build
         if: steps.cache-success.outputs.cache-hit != 'true'
         id: cache-build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           fail-on-cache-miss: true
           path: *cache-build-path
@@ -244,7 +244,7 @@ jobs:
       - name: Cache Playwright browsers
         if: steps.cache-success.outputs.cache-hit != 'true'
         id: cache-playwright-browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           fail-on-cache-miss: true
           path: *cache-playwright-browsers-path
@@ -253,7 +253,7 @@ jobs:
       - name: Cache example dataset
         if: steps.cache-success.outputs.cache-hit != 'true'
         id: cache-example-dataset
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           fail-on-cache-miss: true
           path: *cache-example-dataset-path
@@ -263,20 +263,20 @@ jobs:
 
       - name: Set Up Python
         if: steps.cache-success.outputs.cache-hit != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 
       - name: Set Up Uv
         if: steps.cache-success.outputs.cache-hit != 'true'
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.8.17"
           enable-cache: true
 
       - name: Set Up Node.js
         if: steps.cache-success.outputs.cache-hit != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'lightly_studio_view/.nvmrc'
           cache: 'npm'
@@ -376,7 +376,7 @@ jobs:
 
       - name: Upload performance metrics
         if: steps.cache-success.outputs.cache-hit != 'true' && (matrix.playwright_project == 'general' || matrix.playwright_project == 'videos')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: performance-metrics-${{ matrix.name }}
           path: lightly_studio_view/performance-metrics.json
@@ -388,7 +388,7 @@ jobs:
 
       - name: Save e2e success marker
         if: steps.cache-success.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ matrix.success_marker }}
           key: ${{ matrix.success_key }}-${{ needs.prepare-caches.outputs.file-hash }}
@@ -415,7 +415,7 @@ jobs:
           fi
 
       - name: Upload backend server log after failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure() && steps.cache-success.outputs.cache-hit != 'true'
         with:
           name: Backend Server Log (${{ matrix.name }})
@@ -424,7 +424,7 @@ jobs:
           retention-days: 5
 
       - name: Upload Playwright report after failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure() && steps.cache-success.outputs.cache-hit != 'true'
         with:
           name: ${{ matrix.artifact_name }}

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -20,25 +20,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       # Authenticate to download dev versions of lightly-mundig.
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           project_id: boris-250909
           credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
 
       - name: Set Up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.8.17"
           enable-cache: true
 
       - name: Set Up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 
@@ -55,23 +55,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           project_id: boris-250909
           credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
 
       - name: Set Up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 
       - name: Set Up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.8.17"
           python-version: "3.9"
@@ -125,25 +125,25 @@ jobs:
             run_view_tests: false
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       # Authenticate to download dev versions of lightly-mundig.
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           project_id: boris-250909
           credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
 
       - name: Set Up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.8.17"
           enable-cache: true
 
       - name: Set Up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 


### PR DESCRIPTION
This PR updates GitHub Actions to versions compatible with Node 24 to avoid deprecation warnings and future failures.

Summary of changes:
- actions/checkout@v4 -> actions/checkout@v6
- actions/setup-python@v5 -> actions/setup-python@v6
- astral-sh/setup-uv@v6 -> astral-sh/setup-uv@v8.1.0
- google-github-actions/auth@v2 -> google-github-actions/auth@v3
- actions/cache@v4 -> actions/cache@v5
- actions/setup-node@v4 -> actions/setup-node@v6
- actions/upload-artifact@v4 -> actions/upload-artifact@v7

These updates are recommended before the June 2nd, 2026 deadline when GitHub Actions runners switch to Node 24 by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependencies across CI/CD workflows to latest versions for improved reliability and security. Upgraded actions include checkout, authentication, Python environment setup, cache management, and artifact uploads. Changes apply to both end-to-end testing and unit test workflows in the continuous integration pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->