### PR TITLE
Allow 16 samples a row in the grid

### DIFF
--- a/lightly_studio_view/src/lib/components/ImageSizeControl/ImageSizeControl.svelte
+++ b/lightly_studio_view/src/lib/components/ImageSizeControl/ImageSizeControl.svelte
@@ -3,7 +3,7 @@
     import { throttle } from 'lodash-es';
     import { ZoomIn, ZoomOut } from '@lucide/svelte';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
-    const { min = 1, max = 12 } = $props();
+    const { min = 1, max = 16 } = $props();
 
     const { updateSampleSize, sampleSize } = useGlobalStorage();
 

--- a/lightly_studio_view/src/lib/components/ImageSizeControl/ImageSizeControl.test.ts
+++ b/lightly_studio_view/src/lib/components/ImageSizeControl/ImageSizeControl.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import '@testing-library/jest-dom';
+import ImageSizeControl from './ImageSizeControl.svelte';
+
+const sampleSize = writable({ width: 4, height: 4 });
+const updateSampleSize = vi.fn();
+
+vi.mock('$lib/hooks/useGlobalStorage', () => ({
+    useGlobalStorage: () => ({
+        updateSampleSize,
+        sampleSize
+    })
+}));
+
+describe('ImageSizeControl', () => {
+    beforeEach(() => {
+        sampleSize.set({ width: 4, height: 4 });
+        updateSampleSize.mockClear();
+    });
+
+    it('disables zoom out at the default max width (16)', () => {
+        sampleSize.set({ width: 16, height: 16 });
+        render(ImageSizeControl);
+
+        expect(screen.getByLabelText('Zoom out')).toBeDisabled();
+    });
+
+    it('disables zoom in at the minimum width (1)', () => {
+        sampleSize.set({ width: 1, height: 1 });
+        render(ImageSizeControl);
+
+        expect(screen.getByLabelText('Zoom in')).toBeDisabled();
+    });
+
+    it('increases width by one when clicking zoom out', async () => {
+        sampleSize.set({ width: 10, height: 10 });
+        render(ImageSizeControl);
+
+        await fireEvent.click(screen.getByLabelText('Zoom out'));
+
+        expect(updateSampleSize).toHaveBeenCalledWith(11);
+    });
+
+    it('respects a custom max prop', async () => {
+        sampleSize.set({ width: 16, height: 16 });
+        render(ImageSizeControl, { max: 20 });
+
+        const zoomOut = screen.getByLabelText('Zoom out');
+        expect(zoomOut).not.toBeDisabled();
+
+        await fireEvent.click(zoomOut);
+        expect(updateSampleSize).toHaveBeenCalledWith(17);
+    });
+});


### PR DESCRIPTION
## What has changed and why?

Update to allow max 16 items in a row in the grid instead of 12.

## How has it been tested?

Manually + new tests
<img width="3429" height="1304" alt="image" src="https://github.com/user-attachments/assets/04905f89-e283-465b-a962-dde384d0a37d" />

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased default maximum image sample size from 12 to 16, expanding the available range for image zoom and scaling operations.

* **Tests**
  * Comprehensive test suite added for image size controls, validating zoom button states and sample size update functionality across different configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->