### PR TITLE
Shorten top bar button text

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -66,7 +66,7 @@
                 >
                     <ChartNetwork class="size-4" />
                     {#if !compact}
-                        <span>Show Embeddings</span>
+                        <span>Embeddings</span>
                     {/if}
                 </Button>
             </Tooltip>
@@ -84,7 +84,7 @@
                 >
                     <Gauge class="size-4" />
                     {#if !compact}
-                        <span>Evaluation Runs</span>
+                        <span>Evaluation</span>
                     {/if}
                 </Button>
             </Tooltip>

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -108,7 +108,7 @@ describe('DatasetGridHeader', () => {
         });
 
         expect(screen.getByTestId('toggle-plot-button')).toBeInTheDocument();
-        expect(screen.getByText('Show Embeddings')).toBeInTheDocument();
+        expect(screen.getByText('Embeddings')).toBeInTheDocument();
     });
 
     it('hides the embeddings toggle when media has no embeddings', () => {
@@ -156,7 +156,7 @@ describe('DatasetGridHeader', () => {
         });
 
         expect(screen.getByTestId('toggle-evaluation-runs-button')).toBeInTheDocument();
-        expect(screen.getByText('Evaluation Runs')).toBeInTheDocument();
+        expect(screen.getByText('Evaluation')).toBeInTheDocument();
     });
 
     it('hides the evaluation runs toggle for non-image collections', () => {
@@ -191,8 +191,8 @@ describe('DatasetGridHeader', () => {
         });
 
         expect(screen.getByTestId('toggle-plot-button')).toBeInTheDocument();
-        expect(screen.queryByText('Show Embeddings')).not.toBeInTheDocument();
+        expect(screen.queryByText('Embeddings')).not.toBeInTheDocument();
         expect(screen.getByTestId('toggle-evaluation-runs-button')).toBeInTheDocument();
-        expect(screen.queryByText('Evaluation Runs')).not.toBeInTheDocument();
+        expect(screen.queryByText('Evaluation')).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## What has changed and why?

Renamed:
* "Show Embeddings" --> "Embeddings"
* "Evaluation Runs" --> "Evaluation"

## How has it been tested?

Manually

<img width="1249" height="286" alt="Screenshot 2026-05-27 at 15 02 59" src="https://github.com/user-attachments/assets/647a19d8-f134-4e44-9c1c-ccd63608020b" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dataset grid header toggle button labels for improved clarity and consistency across the interface.
  * The embeddings toggle now displays as 'Embeddings' instead of 'Show Embeddings'.
  * The evaluation runs toggle now displays as 'Evaluation' instead of 'Evaluation Runs'.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->