### PR TITLE
Rename selection to sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Our tool uses the fsspec library, which also supports other file systems. If you
 ### Dataset
 
 The dataset is the main entity of the python interface. It is used to setup the dataset,
-start the GUI, run queries and perform selections. It holds the connection to the
+start the GUI, run queries and perform sampling. It holds the connection to the
 database file.
 
 ```py
@@ -378,13 +378,13 @@ query.export().to_coco_object_detections()
 
 ```
 
-### Selection
-LightlyStudio offers a premium feature to perform automated data selection. [Contact us](https://www.lightly.ai/contact) to get access to premium features. Selecting the right subset of your data can save labeling cost and training time while improving model quality. Selection in LightlyStudio automatically picks the most useful samples -  those that are both representative (typical) and diverse (novel).
+### Sampling
+LightlyStudio offers a premium feature for automated data sampling. [Contact us](https://www.lightly.ai/contact) to get access to premium features. Sampling the right subset of your data can save labeling cost and training time while improving model quality. Sampling in LightlyStudio automatically picks the most useful samples - those that are both representative (typical) and diverse (novel).
 
 You can mix and match these strategies to fit your goal: stable core data, edge cases, or fixing class imbalances.
 
 ```py
-from lightly_studio.selection.selection_config import (
+from lightly_studio.sampling.sampling_config import (
     MetadataWeightingStrategy,
     EmbeddingDiversityStrategy,
     AnnotationClassBalancingStrategy,
@@ -396,10 +396,10 @@ from lightly_studio.selection.selection_config import (
 dataset.compute_typicality_metadata(metadata_name="typicality")
 
 # Select 10 samples by combining typicality, diversity, and class balancing.
-dataset.query().selection().multi_strategies(
+dataset.query().sampling().multi_strategies(
     n_samples_to_select=10,
-    selection_result_tag_name="multi_strategy_selection",
-    selection_strategies=[
+    sampling_result_tag_name="multi_strategy_sampling",
+    sampling_strategies=[
         MetadataWeightingStrategy(metadata_key="typicality", strength=1.0),
         EmbeddingDiversityStrategy(embedding_model_name="my_model_name", strength=2.0),
         AnnotationClassBalancingStrategy(target_distribution="uniform", strength=1.0),

--- a/lightly_studio/docs/docs/about-us.md
+++ b/lightly_studio/docs/docs/about-us.md
@@ -8,7 +8,7 @@ At Lightly, we aim to simplify the complexities of active learning and data mana
 
 ## What We Offer
 
-- **Active Learning Pipelines:** Intelligent data selection to enhance model performance with minimal data.
+- **Active Learning Pipelines:** Intelligent data sampling to enhance model performance with minimal data.
 - **Efficient Data Management:** Tools and services that optimize data workflows for scalability and efficiency.
 - **Expert Support:** Dedicated support to help you integrate our solutions seamlessly into your projects.
 

--- a/lightly_studio/docs/docs/api/index.md
+++ b/lightly_studio/docs/docs/api/index.md
@@ -12,7 +12,7 @@ LightlyStudio has a powerful Python interface. You can not only index datasets b
 - **Sampling** — [Sampling](../concepts_and_tools/sampling.md) covers diverse, metadata-weighted, similarity, class-balancing, and combined sampling strategies.
 
 The full API reference for each module is available in the navigation sidebar:
-[Dataset](dataset.md), [Sample](sample.md), [DatasetQuery](dataset_query.md), [Selection](selection.md), [Plugin](plugin.md), [Annotation](annotation.md).
+[Dataset](dataset.md), [Sample](sample.md), [DatasetQuery](dataset_query.md), [Sampling](sampling.md), [Plugin](plugin.md), [Annotation](annotation.md).
 
 ## API Reference
 

--- a/lightly_studio/docs/docs/api/sampling.md
+++ b/lightly_studio/docs/docs/api/sampling.md
@@ -1,0 +1,6 @@
+# Sampling
+
+Sampling operates on a `DatasetQuery`. For filtering, sorting, and slicing examples
+that define the input set for sampling, see [Search and Filter](../concepts_and_tools/search_and_filter.md#query-in-python).
+
+::: lightly_studio.sampling.sampling

--- a/lightly_studio/docs/docs/api/sampling.md
+++ b/lightly_studio/docs/docs/api/sampling.md
@@ -3,4 +3,4 @@
 Sampling operates on a `DatasetQuery`. For filtering, sorting, and slicing examples
 that define the input set for sampling, see [Search and Filter](../concepts_and_tools/search_and_filter.md#query-in-python).
 
-::: lightly_studio.sampling.sampling
+::: lightly_studio.sampling.sample

--- a/lightly_studio/docs/docs/api/selection.md
+++ b/lightly_studio/docs/docs/api/selection.md
@@ -1,6 +1,0 @@
-# Selection
-
-Selection operates on a `DatasetQuery`. For filtering, sorting, and slicing examples
-that define the input set for selection, see [Search and Filter](../concepts_and_tools/search_and_filter.md#query-in-python).
-
-::: lightly_studio.selection.select

--- a/lightly_studio/docs/docs/concepts_and_tools/sampling.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/sampling.md
@@ -4,7 +4,7 @@ Sampling helps you select representative subsets from your dataset. LightlyStudi
 
 ## Sampling in GUI
 
-Open the dialog from the `Menu` button in the top-right corner and select `Selection`. The dialog shows a dropdown with available sampling strategies. Specify the number of samples and the tag name that should be used. [Sampling in Python](#sampling-in-python) supports more sampling strategies than available in the GUI and also lets you learn more about how they work.
+Open the dialog from the `Menu` button in the top-right corner and select `Sampling`. The dialog shows a dropdown with available sampling strategies. Specify the number of samples and the tag name that should be used. [Sampling in Python](#sampling-in-python) supports more sampling strategies than available in the GUI and also lets you learn more about how they work.
 
 <video autoplay loop muted playsinline controls style="width: 100%;">
   <source src="https://storage.googleapis.com/lightly-public/studio/sampling_workflow.mp4" type="video/mp4">
@@ -12,11 +12,11 @@ Open the dialog from the `Menu` button in the top-right corner and select `Selec
 
 ## Sampling in Python
 
-Each strategy is configured directly from a [`DatasetQuery`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery) via [`selection()`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery.selection). The sampled items are stored under the tag passed as `selection_result_tag_name`, so you can filter or export them later. `selection_result_tag_name` must be a tag name that does not yet exist in the dataset.
+Each strategy is configured directly from a [`DatasetQuery`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery) via [`sampling()`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery.sampling). The sampled items are stored under the tag passed as `sampling_result_tag_name`, so you can filter or export them later. `sampling_result_tag_name` must be a tag name that does not yet exist in the dataset.
 
 ### Filtering before sampling
 
-By default, sampling considers all samples in the dataset. You can narrow the candidate set first with `match()`, and the selection will only consider the matching samples:
+By default, sampling considers all samples in the dataset. You can narrow the candidate set first with `match()`, and the sampling will only consider the matching samples:
 
 ```py
 import lightly_studio as ls
@@ -25,9 +25,9 @@ from lightly_studio.core.dataset_query import ImageSampleField
 dataset = ls.ImageDataset.load_or_create()
 
 # Sample 10 diverse items from images with width >= 1920 only.
-dataset.match(ImageSampleField.width >= 1920).selection().diverse(
+dataset.match(ImageSampleField.width >= 1920).sampling().diverse(
     n_samples_to_select=10,
-    selection_result_tag_name="diverse_hd",
+    sampling_result_tag_name="diverse_hd",
 )
 ```
 
@@ -47,13 +47,13 @@ dataset = ls.ImageDataset.load_or_create()
 dataset.add_images_from_path(path="/path/to/image_dataset")
 
 # Sample a diverse subset of 10 samples.
-dataset.query().selection().diverse(
+dataset.query().sampling().diverse(
     n_samples_to_select=10,
-    selection_result_tag_name="diverse_selection",
+    sampling_result_tag_name="diverse_sampling",
 )
 ```
 
-If your dataset has multiple embedding models, pass `embedding_model_name` to specify which one to use. See [`Selection.diverse`](../api/selection.md#lightly_studio.selection.select.Selection.diverse) for the full API reference.
+If your dataset has multiple embedding models, pass `embedding_model_name` to specify which one to use. See [`Sampling.diverse`](../api/sampling.md#lightly_studio.sampling.sampling.Sampling.diverse) for the full API reference.
 
 #### Metadata Weighting
 
@@ -65,22 +65,22 @@ import lightly_studio as ls
 dataset = ls.ImageDataset.load_or_create()
 
 # Sample the 5 items with the highest value of a custom "sharpness" metadata field.
-dataset.query().selection().metadata_weighting(
+dataset.query().sampling().metadata_weighting(
     n_samples_to_select=5,
-    selection_result_tag_name="sharpest_samples",
+    sampling_result_tag_name="sharpest_samples",
     metadata_key="sharpness",
 )
 
 # Sample the 5 items with the lowest value of a custom "sharpness" metadata field.
-dataset.query().selection().metadata_weighting(
+dataset.query().sampling().metadata_weighting(
     n_samples_to_select=5,
-    selection_result_tag_name="blurriest_samples",
+    sampling_result_tag_name="blurriest_samples",
     metadata_key="sharpness",
     strength=-1
 )
 ```
 
-See [`Selection.metadata_weighting`](../api/selection.md#lightly_studio.selection.select.Selection.metadata_weighting) for the full API reference.
+See [`Sampling.metadata_weighting`](../api/sampling.md#lightly_studio.sampling.sampling.Sampling.metadata_weighting) for the full API reference.
 
 #### Typicality Sampling and Outlier Sampling
 
@@ -97,16 +97,16 @@ dataset.add_images_from_path(path="/path/to/image_dataset")
 dataset.compute_typicality_metadata(metadata_name="typicality")
 
 # Sample the 5 most typical items.
-dataset.query().selection().metadata_weighting(
+dataset.query().sampling().metadata_weighting(
     n_samples_to_select=5,
-    selection_result_tag_name="typical_selection",
+    sampling_result_tag_name="typical_sampling",
     metadata_key="typicality",
 )
 
 # Sample 5 outliers.
-dataset.query().selection().metadata_weighting(
+dataset.query().sampling().metadata_weighting(
     n_samples_to_select=5,
-    selection_result_tag_name="outlier_selection",
+    sampling_result_tag_name="outlier_sampling",
     metadata_key="typicality",
     strength=-1
 )
@@ -136,9 +136,9 @@ metadata_name = dataset.compute_similarity_metadata(
 )
 
 # Sample the 10 items most similar to the query set.
-dataset.query().selection().metadata_weighting(
+dataset.query().sampling().metadata_weighting(
     n_samples_to_select=10,
-    selection_result_tag_name="similar_to_query_selection",
+    sampling_result_tag_name="similar_to_query_sampling",
     metadata_key=metadata_name,
 )
 ```
@@ -159,23 +159,23 @@ import lightly_studio as ls
 dataset = ls.ImageDataset.load_or_create()
 
 # Option 1: Balance classes uniformly (e.g. equal number of cats and dogs)
-dataset.query().selection().annotation_balancing(
+dataset.query().sampling().annotation_balancing(
     n_samples_to_select=50,
-    selection_result_tag_name="balanced_uniform",
+    sampling_result_tag_name="balanced_uniform",
     target_distribution="uniform",
 )
 
 # Option 2: Mirror the class distribution of the input set
-dataset.query().selection().annotation_balancing(
+dataset.query().sampling().annotation_balancing(
     n_samples_to_select=50,
-    selection_result_tag_name="balanced_input",
+    sampling_result_tag_name="balanced_input",
     target_distribution="input",
 )
 
 # Option 3: Define a specific target distribution (e.g. 20% cat, 80% dog)
-dataset.query().selection().annotation_balancing(
+dataset.query().sampling().annotation_balancing(
     n_samples_to_select=50,
-    selection_result_tag_name="balanced_custom",
+    sampling_result_tag_name="balanced_custom",
     target_distribution={"cat": 0.2, "dog": 0.8},
 )
 ```
@@ -194,7 +194,7 @@ You can combine several strategies into a single sampling run. All configured st
 
 ```py
 import lightly_studio as ls
-from lightly_studio.selection.selection_config import (
+from lightly_studio.sampling.sampling_config import (
     MetadataWeightingStrategy,
     EmbeddingDiversityStrategy,
 )
@@ -208,10 +208,10 @@ dataset.compute_typicality_metadata(metadata_name="typicality")
 
 # Sample 10 items by combining typicality and diversity,
 # with diversity weighted twice as strongly.
-dataset.query().selection().multi_strategies(
+dataset.query().sampling().multi_strategies(
     n_samples_to_select=10,
-    selection_result_tag_name="multi_strategy_selection",
-    selection_strategies=[
+    sampling_result_tag_name="multi_strategy_sampling",
+    sampling_strategies=[
         MetadataWeightingStrategy(metadata_key="typicality", strength=1.0),
         EmbeddingDiversityStrategy(embedding_model_name="my_model_name", strength=2.0),
     ],
@@ -220,7 +220,7 @@ dataset.query().selection().multi_strategies(
 
 ### Exporting Sampled Items
 
-Every sampling run writes its result to the tag passed as `selection_result_tag_name`. You can export those samples from the GUI, or query them in Python by matching on the tag.
+Every sampling run writes its result to the tag passed as `sampling_result_tag_name`. You can export those samples from the GUI, or query them in Python by matching on the tag.
 
 ```py
 import lightly_studio as ls
@@ -229,7 +229,7 @@ from lightly_studio.core.dataset_query import ImageSampleField
 dataset = ls.ImageDataset.load("my-dataset")
 
 sampled_items = (
-    dataset.match(ImageSampleField.tags.contains("diverse_selection")).to_list()
+    dataset.match(ImageSampleField.tags.contains("diverse_sampling")).to_list()
 )
 
 with open("export.txt", "w") as f:

--- a/lightly_studio/docs/docs/concepts_and_tools/sampling.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/sampling.md
@@ -53,7 +53,7 @@ dataset.query().sampling().diverse(
 )
 ```
 
-If your dataset has multiple embedding models, pass `embedding_model_name` to specify which one to use. See [`Sampling.diverse`](../api/sampling.md#lightly_studio.sampling.sampling.Sampling.diverse) for the full API reference.
+If your dataset has multiple embedding models, pass `embedding_model_name` to specify which one to use. See [`Sampling.diverse`](../api/sampling.md#lightly_studio.sampling.sample.Sampling.diverse) for the full API reference.
 
 #### Metadata Weighting
 
@@ -80,7 +80,7 @@ dataset.query().sampling().metadata_weighting(
 )
 ```
 
-See [`Sampling.metadata_weighting`](../api/sampling.md#lightly_studio.sampling.sampling.Sampling.metadata_weighting) for the full API reference.
+See [`Sampling.metadata_weighting`](../api/sampling.md#lightly_studio.sampling.sample.Sampling.metadata_weighting) for the full API reference.
 
 #### Typicality Sampling and Outlier Sampling
 

--- a/lightly_studio/docs/docs/dataset_setup/image_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/image_dataset.md
@@ -492,4 +492,4 @@ on dedicated pages.
 
 ### Querying the Dataset
 
-Use [Dataset Query in Python](../concepts_and_tools/search_and_filter.md#query-in-python) when you need reusable subsets in code for filtering, sorting, slicing, export, or selection. Image query expressions use `ImageSampleField`.
+Use [Dataset Query in Python](../concepts_and_tools/search_and_filter.md#query-in-python) when you need reusable subsets in code for filtering, sorting, slicing, export, or sampling. Image query expressions use `ImageSampleField`.

--- a/lightly_studio/docs/docs/dataset_setup/video_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/video_dataset.md
@@ -261,4 +261,4 @@ on dedicated pages.
 
 ### Querying the Dataset
 
-Use [Dataset Query in Python](../concepts_and_tools/search_and_filter.md#query-in-python) when you need reusable subsets in code for filtering, sorting, slicing, export, or selection. Video query expressions use `VideoSampleField`.
+Use [Dataset Query in Python](../concepts_and_tools/search_and_filter.md#query-in-python) when you need reusable subsets in code for filtering, sorting, slicing, export, or sampling. Video query expressions use `VideoSampleField`.

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -40,7 +40,7 @@ nav:
     - Dataset: api/dataset.md
     - Sample: api/sample.md
     - DatasetQuery: api/dataset_query.md
-    - Selection: api/selection.md
+    - Sampling: api/sampling.md
     - Plugin: api/plugin.md
     - Annotation: api/annotation.md
   - Concepts & Tools:

--- a/lightly_studio/src/lightly_studio/api/app.py
+++ b/lightly_studio/src/lightly_studio/api/app.py
@@ -40,7 +40,7 @@ from lightly_studio.api.routes.api import (
     metadata,
     operator,
     sample,
-    selection,
+    sampling,
     settings,
     text_embedding,
     version,
@@ -151,7 +151,7 @@ api_router.include_router(embeddings2d.embeddings2d_router)
 api_router.include_router(features.features_router)
 api_router.include_router(evaluation.evaluation_router)
 api_router.include_router(metadata.metadata_router)
-api_router.include_router(selection.selection_router)
+api_router.include_router(sampling.sampling_router)
 api_router.include_router(operator.operator_router)
 api_router.include_router(frame.frame_router)
 api_router.include_router(video.video_router)

--- a/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
@@ -1,4 +1,4 @@
-"""This module contains the API routes for managing selections."""
+"""This module contains the API routes for sampling."""
 
 from __future__ import annotations
 
@@ -13,16 +13,16 @@ from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.resolvers import image_resolver, video_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
-from lightly_studio.selection.select_via_db import select_via_database
-from lightly_studio.selection.selection_config import (
+from lightly_studio.sampling.sampling_config import (
     AnnotationClassBalancingStrategy,
     EmbeddingDiversityStrategy,
     EmbeddingSimilarityStrategy,
     MetadataWeightingStrategy,
-    SelectionConfig,
+    SamplingConfig,
 )
+from lightly_studio.sampling.sampling_via_db import sampling_via_database
 
-selection_router = APIRouter()
+sampling_router = APIRouter()
 
 Strategy = Annotated[
     Union[
@@ -40,16 +40,17 @@ CollectionFilter = Annotated[
 ]
 
 
-class SelectionRequest(BaseModel):
-    """Request model for selection."""
+class SamplingRequest(BaseModel):
+    """Request model for sampling."""
 
     n_samples_to_select: int = Field(gt=0, description="Number of samples to select")
-    selection_result_tag_name: str = Field(min_length=1, description="Name for the result tag")
+    sampling_result_tag_name: str = Field(min_length=1, description="Name for the result tag")
     strategies: list[Strategy]
     filter: CollectionFilter | None = None
 
 
-@selection_router.post(
+# TODO(lukas 5/2026): rename to /sampling
+@sampling_router.post(
     "/collections/{collection_id}/selection",
     status_code=204,
     response_model=None,
@@ -60,30 +61,30 @@ def create_combination_selection(
         CollectionTable,
         Depends(get_and_validate_collection_id),
     ],
-    request: SelectionRequest,
+    request: SamplingRequest,
 ) -> None:
-    """Create a combination selection on the collection.
+    """Create a combination sampling on the collection.
 
-    This endpoint performs combination selection using embeddings and metadata.
+    This endpoint performs combination sampling using embeddings and metadata.
     The selected samples are tagged with the specified tag name.
 
     Args:
         session: Database session dependency.
-        collection: collection to perform selection on.
-        request: Selection parameters including sample count and tag name.
+        collection: collection to perform sampling on.
+        request: Sampling parameters including sample count and tag name.
 
     Returns:
         None (204 No Content on success).
 
     Raises:
-        HTTPException: 400 if selection fails due to invalid parameters or other errors.
+        HTTPException: 400 if sampling fails due to invalid parameters or other errors.
     """
     if collection.sample_type not in (SampleType.IMAGE, SampleType.VIDEO):
         raise HTTPException(
             status_code=400,
-            detail="Selection is only supported for image and video collections.",
+            detail="Sampling is only supported for image and video collections.",
         )
-    # Get all samples in collection as input for selection.
+    # Get all samples in collection as input for sampling.
     if collection.sample_type == SampleType.IMAGE:
         if request.filter is None:
             image_filter = None
@@ -122,12 +123,12 @@ def create_combination_selection(
             detail=f"collection has only {len(input_sample_ids)} samples, "
             f"cannot select {request.n_samples_to_select}",
         )
-    # Create SelectionConfig with diversity strategy.
-    config = SelectionConfig(
+    # Create SamplingConfig with diversity strategy.
+    config = SamplingConfig(
         collection_id=collection.collection_id,
         n_samples_to_select=request.n_samples_to_select,
-        selection_result_tag_name=request.selection_result_tag_name,
+        sampling_result_tag_name=request.sampling_result_tag_name,
         strategies=request.strategies,
     )
-    # Perform selection via database.
-    select_via_database(session=session, config=config, input_sample_ids=input_sample_ids)
+    # Perform sampling via database.
+    sampling_via_database(session=session, config=config, input_sample_ids=input_sample_ids)

--- a/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
@@ -49,13 +49,12 @@ class SamplingRequest(BaseModel):
     filter: CollectionFilter | None = None
 
 
-# TODO(lukas 5/2026): rename to /sampling
 @sampling_router.post(
-    "/collections/{collection_id}/selection",
+    "/collections/{collection_id}/sampling",
     status_code=204,
     response_model=None,
 )
-def create_combination_selection(
+def create_sampling(
     session: SessionDep,
     collection: Annotated[
         CollectionTable,

--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -20,7 +20,7 @@ from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.video import VideoTable
 from lightly_studio.resolvers import tag_resolver
-from lightly_studio.selection.select import Selection
+from lightly_studio.sampling.sample import Sampling
 
 _SliceType = slice  # to avoid shadowing built-in slice in type annotations
 
@@ -108,16 +108,16 @@ class DatasetQuery(Generic[T]):
     query.add_tag('my_tag')
     ```
 
-    ## Selecting a subset of samples using smart selection
-    A Selection interface can be created from the current query results. It will only
-    select the samples matching the current query at the time of calling selection().
+    ## Selecting a subset of samples using sampling
+    A Sampling interface can be created from the current query results. It will only
+    select the samples matching the current query at the time of calling sampling().
     ```python
     # Choosing 100 diverse samples from the 'cat' tag.
     # Save them under the tag name "diverse_cats".
-    selection = dataset.query().match(
+    sampling = dataset.query().match(
         ImageSampleField.tags.contains('cat')
-    ).selection()
-    selection.diverse(100, "diverse_cats")
+    ).sampling()
+    sampling.diverse(100, "diverse_cats")
     ```
 
     ## Exporting the query results
@@ -344,18 +344,18 @@ class DatasetQuery(Generic[T]):
             session=self.session, tag_id=tag.tag_id, sample_ids=sample_ids
         )
 
-    def selection(self) -> Selection:
-        """Selection interface for this query.
+    def sampling(self) -> Sampling:
+        """Sampling interface for this query.
 
-        The returned Selection snapshots the current query results immediately.
+        The returned Sampling snapshots the current query results immediately.
         Mutating the query after calling this method will therefore not affect
-        the samples used by that Selection instance.
+        the samples used by that Sampling instance.
 
         Returns:
-            Selection interface operating on the current query result snapshot.
+            Sampling interface operating on the current query result snapshot.
         """
         input_sample_ids = (sample.sample_id for sample in self)
-        return Selection(
+        return Sampling(
             dataset_id=self.dataset.collection_id,
             session=self.session,
             input_sample_ids=input_sample_ids,

--- a/lightly_studio/src/lightly_studio/examples/example_sampling.py
+++ b/lightly_studio/src/lightly_studio/examples/example_sampling.py
@@ -1,4 +1,4 @@
-"""Example of how to run selection class."""
+"""Example of how to run sampling class."""
 
 from environs import Env
 
@@ -19,10 +19,10 @@ dataset_path = env.path("EXAMPLES_DATASET_PATH", "/path/to/your/dataset")
 dataset = ls.ImageDataset.create()
 dataset.add_images_from_path(path=str(dataset_path))
 
-# Run selection via the dataset query
-dataset.query().selection().diverse(
+# Run sampling via the dataset query
+dataset.query().sampling().diverse(
     n_samples_to_select=10,
-    selection_result_tag_name="diverse_selection",
+    sampling_result_tag_name="diverse_sampling",
 )
 
 ls.start_gui()

--- a/lightly_studio/src/lightly_studio/sampling/__init__.py
+++ b/lightly_studio/src/lightly_studio/sampling/__init__.py
@@ -1,0 +1,1 @@
+"""Sampling package."""

--- a/lightly_studio/src/lightly_studio/sampling/mundig.py
+++ b/lightly_studio/src/lightly_studio/sampling/mundig.py
@@ -1,4 +1,4 @@
-"""Python interface to the Mundig selection algorithm."""
+"""Python interface to the Mundig sampling algorithm."""
 
 from __future__ import annotations
 
@@ -13,21 +13,24 @@ import numpy as np
 
 
 class Mundig:
-    """Python interface for the Mundig selection algorithm.
+    """Python interface for the Mundig sampling algorithm.
 
     This class provides a Python interface to the lightly_mundig Rust library
-    for sample selection. It allows combining different selection strategies
+    for data sampling. It allows combining different sampling strategies
     such as diversity and weighting.
     """
 
     def __init__(self) -> None:
-        """Initialize the Mundig selection interface."""
+        """Initialize the Mundig sampling interface."""
+        # TODO(Lukas, 05/2026): Rename `self.mundig` and its call sites to
+        # match the upstream `Selection` naming once the broader sampling API is
+        # cleaned up across repositories.
         self.mundig = lightly_mundig.Selection()
 
         self.n_input_samples: int | None = None
 
     def run(self, n_samples: int) -> list[int]:
-        """Run the selection algorithm and return selected sample indices.
+        """Run the sampling algorithm and return selected sample indices.
 
         Args:
             n_samples: The number of samples to select.
@@ -41,7 +44,7 @@ class Mundig:
         return selected
 
     def add_diversity(self, embeddings: Iterable[Iterable[float]], strength: float = 1.0) -> None:
-        """Add diversity-based selection using sample embeddings.
+        """Add diversity-based sampling using sample embeddings.
 
         Args:
             embeddings:
@@ -80,7 +83,7 @@ class Mundig:
         query_embeddings: Iterable[Iterable[float]],
         strength: float = 1.0,
     ) -> None:
-        """Add a similarity-based selection strategy.
+        """Add a similarity-based sampling strategy.
 
         Args:
             embeddings:

--- a/lightly_studio/src/lightly_studio/sampling/sample.py
+++ b/lightly_studio/src/lightly_studio/sampling/sample.py
@@ -1,4 +1,4 @@
-"""Provides the user python interface to selection bound to sample ids."""
+"""Provides the user python interface to sampling bound to sample ids."""
 
 from __future__ import annotations
 
@@ -8,29 +8,29 @@ from uuid import UUID
 
 from sqlmodel import Session
 
-from lightly_studio.selection.select_via_db import select_via_database
-from lightly_studio.selection.selection_config import (
+from lightly_studio.sampling.sampling_config import (
     AnnotationClassBalancingStrategy,
     AnnotationClassToTarget,
     EmbeddingDiversityStrategy,
     MetadataWeightingStrategy,
-    SelectionConfig,
-    SelectionStrategy,
+    SamplingConfig,
+    SamplingStrategy,
 )
+from lightly_studio.sampling.sampling_via_db import sampling_via_database
 
 
-class Selection:
-    """Smart selection interface.
+class Sampling:
+    """Smart sampling interface.
 
-    The `Selection` class allows to select a subset of samples from a given set of input
+    The `Sampling` class allows to select a subset of samples from a given set of input
     samples. There are many different strategies to select samples, e.g. diversity based
     on embeddings or weighting based on numeric metadata. Multiple strategies can be
-    combined to form more complex selection strategies.
+    combined to form more complex sampling strategies.
 
-    The result of a selection is stored as a tag on the selected samples in the database.
-    The `selection_result_tag_name` must be a unique tag name that is not used yet.
+    The result of a sampling is stored as a tag on the selected samples in the database.
+    The `sampling_result_tag_name` must be a unique tag name that is not used yet.
 
-    # Creation of a Selection instance.
+    # Creation of a Sampling instance.
 
     Creation of an instance of this is easiest via the `DatasetQuery` class. By using
     a `match()` first, the samples to select from can be filtered down.
@@ -38,58 +38,58 @@ class Selection:
     from lightly_studio.core.dataset_query import ImageSampleField
 
     # Select from all samples in the dataset.
-    selection = dataset.query().selection()
+    sampling = dataset.query().sampling()
 
     # Select only from samples with width < 256.
     query_narrow_images = dataset.query().match(ImageSampleField.width < 256)
-    selection_among_narrow_images = query_narrow_images.selection()
+    sampling_among_narrow_images = query_narrow_images.sampling()
     ```
     See the `DatasetQuery.match()` documentation for more information on filtering.
-    By creating the `Selection` instance, the query is executed. Further changes to the
-    query do not affect the selection instance.
+    By creating the `Sampling` instance, the query is executed. Further changes to the
+    query do not affect the sampling instance.
 
-    # Performing single-strategy selections.
+    # Performing single-strategy samplings.
 
-    Once a `Selection` instance is created, different selection strategies can be
-    applied to select samples. Single-strategy selections are performed by calling
-    the respective method on the `Selection` instance. All methods take the number of
-    samples to select and a tag name for the selection result as mandatory arguments.
+    Once a `Sampling` instance is created, different sampling strategies can be
+    applied to select samples. Single-strategy samplings are performed by calling
+    the respective method on the `Sampling` instance. All methods take the number of
+    samples to select and a tag name for the sampling result as mandatory arguments.
     ```python
     # Select 100 diverse samples based on embeddings
-    selection.diverse(
+    sampling.diverse(
         n_samples_to_select=100,
-        selection_result_tag_name="diverse selection",
+        sampling_result_tag_name="diverse sampling",
     )
     # Select 50 samples weighted by numeric metadata "difficulty"
-    selection.metadata_weighting(
+    sampling.metadata_weighting(
         n_samples_to_select=50,
-        selection_result_tag_name="weighted selection",
+        sampling_result_tag_name="weighted sampling",
         metadata_key="difficulty",
     )
     # Select 100 samples with balanced annotation classes (e.g. uniform distribution)
-    selection.annotation_balancing(
+    sampling.annotation_balancing(
         n_samples_to_select=100,
-        selection_result_tag_name="balanced selection",
+        sampling_result_tag_name="balanced sampling",
         target_distribution="uniform",
     )
     ```
 
-    # Performing multi-strategy selections.
+    # Performing multi-strategy samplings.
 
-    More complex selection strategies can be formed by combining multiple selection
+    More complex sampling strategies can be formed by combining multiple sampling
     strategies. This is done via the `multi_strategies()` method, which takes a
-    list of selection strategies as an argument.
+    list of sampling strategies as an argument.
     ```python
-    from lightly_studio.selection.selection_config import (
+    from lightly_studio.sampling.sampling_config import (
         EmbeddingDiversityStrategy,
         MetadataWeightingStrategy
     )
 
     # Select 75 samples that are diverse and weighted by "difficulty"
-    selection.multi_strategies(
+    sampling.multi_strategies(
         n_samples_to_select=75,
-        selection_result_tag_name="diverse and weighted selection",
-        selection_strategies=[
+        sampling_result_tag_name="diverse and weighted sampling",
+        sampling_strategies=[
             EmbeddingDiversityStrategy(),
             MetadataWeightingStrategy(metadata_key="difficulty"),
         ],
@@ -103,12 +103,12 @@ class Selection:
         session: Session,
         input_sample_ids: Iterable[UUID],
     ) -> None:
-        """Create the selection interface.
+        """Create the sampling interface.
 
         Args:
-            dataset_id: Dataset in which the selection is performed.
-            session: Database session to resolve selection dependencies.
-            input_sample_ids: Candidate sample ids considered for selection.
+            dataset_id: Dataset in which the sampling is performed.
+            session: Database session to resolve sampling dependencies.
+            input_sample_ids: Candidate sample ids considered for sampling.
                 The iterable is consumed immediately to capture a stable snapshot.
         """
         self._dataset_id: Final[UUID] = dataset_id
@@ -118,85 +118,85 @@ class Selection:
     def metadata_weighting(
         self,
         n_samples_to_select: int,
-        selection_result_tag_name: str,
+        sampling_result_tag_name: str,
         metadata_key: str,
     ) -> None:
         """Select a subset based on numeric metadata weights.
 
         Args:
             n_samples_to_select: Number of samples to select.
-            selection_result_tag_name: Tag name for the selection result.
+            sampling_result_tag_name: Tag name for the sampling result.
             metadata_key: Metadata key used as weights (float or int values).
         """
         strategy = MetadataWeightingStrategy(metadata_key=metadata_key)
         self.multi_strategies(
             n_samples_to_select=n_samples_to_select,
-            selection_result_tag_name=selection_result_tag_name,
-            selection_strategies=[strategy],
+            sampling_result_tag_name=sampling_result_tag_name,
+            sampling_strategies=[strategy],
         )
 
     def diverse(
         self,
         n_samples_to_select: int,
-        selection_result_tag_name: str,
+        sampling_result_tag_name: str,
         embedding_model_name: str | None = None,
     ) -> None:
         """Select a diverse subset using embeddings.
 
         Args:
             n_samples_to_select: Number of samples to select.
-            selection_result_tag_name: Tag name for the selection result.
+            sampling_result_tag_name: Tag name for the sampling result.
             embedding_model_name: Optional embedding model name. If None, uses the only
                 available model or raises if multiple exist.
         """
         strategy = EmbeddingDiversityStrategy(embedding_model_name=embedding_model_name)
         self.multi_strategies(
             n_samples_to_select=n_samples_to_select,
-            selection_result_tag_name=selection_result_tag_name,
-            selection_strategies=[strategy],
+            sampling_result_tag_name=sampling_result_tag_name,
+            sampling_strategies=[strategy],
         )
 
     def annotation_balancing(
         self,
         n_samples_to_select: int,
-        selection_result_tag_name: str,
+        sampling_result_tag_name: str,
         target_distribution: AnnotationClassToTarget | Literal["uniform"] | Literal["input"],
     ) -> None:
         """Select a subset using annotation class balancing.
 
         Args:
             n_samples_to_select: Number of samples to select.
-            selection_result_tag_name: Tag name for the selection result.
+            sampling_result_tag_name: Tag name for the sampling result.
             target_distribution: Can be 'uniform', 'input',
                 or a dictionary mapping class names to target ratios.
         """
         strategy = AnnotationClassBalancingStrategy(target_distribution=target_distribution)
         self.multi_strategies(
             n_samples_to_select=n_samples_to_select,
-            selection_result_tag_name=selection_result_tag_name,
-            selection_strategies=[strategy],
+            sampling_result_tag_name=sampling_result_tag_name,
+            sampling_strategies=[strategy],
         )
 
     def multi_strategies(
         self,
         n_samples_to_select: int,
-        selection_result_tag_name: str,
-        selection_strategies: list[SelectionStrategy],
+        sampling_result_tag_name: str,
+        sampling_strategies: list[SamplingStrategy],
     ) -> None:
         """Select a subset based on multiple strategies.
 
         Args:
             n_samples_to_select: Number of samples to select.
-            selection_result_tag_name: Tag name for the selection result.
-            selection_strategies: Strategies to compose for selection.
+            sampling_result_tag_name: Tag name for the sampling result.
+            sampling_strategies: Strategies to compose for sampling.
         """
-        config = SelectionConfig(
+        config = SamplingConfig(
             collection_id=self._dataset_id,
             n_samples_to_select=n_samples_to_select,
-            selection_result_tag_name=selection_result_tag_name,
-            strategies=selection_strategies,
+            sampling_result_tag_name=sampling_result_tag_name,
+            strategies=sampling_strategies,
         )
-        select_via_database(
+        sampling_via_database(
             session=self._session,
             config=config,
             input_sample_ids=self._input_sample_ids,

--- a/lightly_studio/src/lightly_studio/sampling/sampling_config.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_config.py
@@ -1,4 +1,4 @@
-"""Pydantic models for the Selection configuration."""
+"""Pydantic models for the Sampling configuration."""
 
 from __future__ import annotations
 
@@ -12,45 +12,45 @@ AnnotationsClassName = str
 AnnotationClassToTarget = dict[AnnotationsClassName, float]
 
 
-class SelectionConfig(BaseModel):
-    """Configuration for the selection process."""
+class SamplingConfig(BaseModel):
+    """Configuration for the sampling process."""
 
     collection_id: UUID
     n_samples_to_select: int
-    selection_result_tag_name: str
-    strategies: Sequence[SelectionStrategy]
+    sampling_result_tag_name: str
+    strategies: Sequence[SamplingStrategy]
 
 
-class SelectionStrategy(BaseModel):
-    """Base class for selection strategies."""
+class SamplingStrategy(BaseModel):
+    """Base class for sampling strategies."""
 
     strength: float = 1.0
 
 
-class EmbeddingDiversityStrategy(SelectionStrategy):
-    """Selection strategy based on embedding diversity."""
+class EmbeddingDiversityStrategy(SamplingStrategy):
+    """Sampling strategy based on embedding diversity."""
 
     strategy_name: Literal["diversity"] = "diversity"
     embedding_model_name: str | None = None
 
 
-class EmbeddingSimilarityStrategy(SelectionStrategy):
-    """Selection strategy based on embedding similarity to a tagged query set."""
+class EmbeddingSimilarityStrategy(SamplingStrategy):
+    """Sampling strategy based on embedding similarity to a tagged query set."""
 
     strategy_name: Literal["similarity"] = "similarity"
     query_tag_name: str
     embedding_model_name: str | None = None
 
 
-class MetadataWeightingStrategy(SelectionStrategy):
-    """Selection strategy based on metadata weighting."""
+class MetadataWeightingStrategy(SamplingStrategy):
+    """Sampling strategy based on metadata weighting."""
 
     strategy_name: Literal["weights"] = "weights"
     metadata_key: str
 
 
-class AnnotationClassBalancingStrategy(SelectionStrategy):
-    """Selection strategy based on class balancing."""
+class AnnotationClassBalancingStrategy(SamplingStrategy):
+    """Sampling strategy based on class balancing."""
 
     strategy_name: Literal["balance"] = "balance"
     target_distribution: AnnotationClassToTarget | Literal["uniform"] | Literal["input"]

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -1,4 +1,4 @@
-"""Database selection functions for the selection process."""
+"""Database sampling functions for the sampling process."""
 
 from __future__ import annotations
 
@@ -26,13 +26,13 @@ from lightly_studio.resolvers import (
     tag_resolver,
 )
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
-from lightly_studio.selection.mundig import Mundig
-from lightly_studio.selection.selection_config import (
+from lightly_studio.sampling.mundig import Mundig
+from lightly_studio.sampling.sampling_config import (
     AnnotationClassBalancingStrategy,
     EmbeddingDiversityStrategy,
     EmbeddingSimilarityStrategy,
     MetadataWeightingStrategy,
-    SelectionConfig,
+    SamplingConfig,
 )
 
 EPSILON = 1e-6
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class _SelectionContext:
-    """Shared inputs used while resolving selection strategies."""
+class _SamplingContext:
+    """Shared inputs used while resolving sampling strategies."""
 
     collection_id: UUID
     dataset_id: UUID
@@ -134,7 +134,7 @@ def _process_explicit_target_distribution(
 
     all_label_ids = set(annotation_label_ids)
     unused_label_ids = all_label_ids - set(label_id_to_target.keys())
-    # `total_targets` can be more or less than 1.0. Both can be ignored, selection will still
+    # `total_targets` can be more or less than 1.0. Both can be ignored, sampling will still
     # try correctly to reach the target.
     remaining_ratio = max(1.0 - total_targets, 0.0)
     return label_id_to_target, unused_label_ids, remaining_ratio
@@ -156,7 +156,7 @@ def _get_class_balancing_data(  # noqa: C901
     if strat.annotation_source_id is not None and not annotations:
         raise ValueError(
             "Annotation source with the given ID does not contain annotations "
-            "for the selected samples."
+            "for the sampled samples."
         )
 
     if annotation_label_ids is None:
@@ -215,31 +215,31 @@ def _get_class_balancing_data(  # noqa: C901
     return class_distributions, target_values
 
 
-def select_via_database(
-    session: Session, config: SelectionConfig, input_sample_ids: list[UUID]
+def sampling_via_database(
+    session: Session, config: SamplingConfig, input_sample_ids: list[UUID]
 ) -> None:
-    """Run selection using the provided candidate sample ids.
+    """Run sampling using the provided candidate sample ids.
 
-    First resolves the selection config to concrete database values.
-    Then calls Mundig to run the selection with pure values.
+    First resolves the sampling config to concrete database values.
+    Then calls Mundig to run the sampling with pure values.
     Finally creates a tag for the selected set.
     """
     # Check if the tag name is already used
     existing_tag = tag_resolver.get_by_name(
         session=session,
-        tag_name=config.selection_result_tag_name,
+        tag_name=config.sampling_result_tag_name,
         collection_id=config.collection_id,
     )
     if existing_tag:
         msg = (
-            f"Tag with name {config.selection_result_tag_name} already exists in the "
+            f"Tag with name {config.sampling_result_tag_name} already exists in the "
             f"collection {config.collection_id}. Please use a different tag name."
         )
         raise ValueError(msg)
 
     n_samples_to_select = min(config.n_samples_to_select, len(input_sample_ids))
     if n_samples_to_select == 0:
-        logger.warning("No samples available for selection.")
+        logger.warning("No samples available for sampling.")
         return
 
     # Get root dataset id for balancing strategies
@@ -247,7 +247,7 @@ def select_via_database(
         session=session, collection_id=config.collection_id
     )
     dataset_id = root_collection.dataset_id
-    context = _SelectionContext(
+    context = _SamplingContext(
         collection_id=config.collection_id,
         dataset_id=dataset_id,
         input_sample_ids=input_sample_ids,
@@ -269,7 +269,7 @@ def select_via_database(
         session=session,
         tag=TagCreate(
             collection_id=config.collection_id,
-            name=config.selection_result_tag_name,
+            name=config.sampling_result_tag_name,
             kind="sample",
         ),
     )
@@ -280,7 +280,7 @@ def select_via_database(
 
 def _get_embeddings_by_sample_ids(
     session: Session,
-    context: _SelectionContext,
+    context: _SamplingContext,
     embedding_model_name: str | None,
 ) -> list[list[float]]:
     """Resolve sample embeddings for the given model and sample ids."""
@@ -325,11 +325,11 @@ def _get_annotations_for_class_balancing(
 
 def _add_strategy_to_mundig(
     session: Session,
-    context: _SelectionContext,
+    context: _SamplingContext,
     strat: object,
     mundig: Mundig,
 ) -> None:
-    """Resolve one selection strategy and add it to Mundig."""
+    """Resolve one sampling strategy and add it to Mundig."""
     if isinstance(strat, EmbeddingDiversityStrategy):
         mundig.add_diversity(
             embeddings=_get_embeddings_by_sample_ids(
@@ -402,4 +402,4 @@ def _add_strategy_to_mundig(
             strength=strat.strength,
         )
     else:
-        raise ValueError(f"Selection strategy of type {type(strat)} is unknown.")
+        raise ValueError(f"Sampling strategy of type {type(strat)} is unknown.")

--- a/lightly_studio/src/lightly_studio/selection/__init__.py
+++ b/lightly_studio/src/lightly_studio/selection/__init__.py
@@ -1,1 +1,0 @@
-"""Selection package."""

--- a/lightly_studio/tests/api/routes/api/test_sampling.py
+++ b/lightly_studio/tests/api/routes/api/test_sampling.py
@@ -1,4 +1,4 @@
-"""Test selection API endpoints."""
+"""Test sampling API endpoints."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 from sqlmodel import Session
 
+from lightly_studio.api.routes.api import sampling as sampling_api
 from lightly_studio.metadata import compute_typicality
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import (
@@ -20,22 +21,23 @@ from lightly_studio.resolvers import (
 from lightly_studio.resolvers.image_filter import FilterDimensions, ImageFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
+from lightly_studio.sampling.sampling_config import EmbeddingDiversityStrategy
 from tests import helpers_resolvers
 from tests.helpers_resolvers import ImageStub
 from tests.resolvers.video import helpers as video_helpers
 
 
-def test_create_combination_selection__diversity_success(
+def test_create_combination_sampling__diversity_success(
     test_client: TestClient, db_session: Session
 ) -> None:
-    """Test successful diversity selection."""
+    """Test successful diversity sampling."""
     collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
         session=db_session, n_samples=10, embedding_model_names=["test_embedding_model"]
     )
 
     request_data = {
         "n_samples_to_select": 3,
-        "selection_result_tag_name": "test_combination_selection",
+        "sampling_result_tag_name": "test_combination_sampling",
         "strategies": [
             {
                 "strategy_name": "diversity",
@@ -52,7 +54,7 @@ def test_create_combination_selection__diversity_success(
 
     # Verify tag was created with correct samples
     created_tag = tag_resolver.get_by_name(
-        session=db_session, tag_name="test_combination_selection", collection_id=collection_id
+        session=db_session, tag_name="test_combination_sampling", collection_id=collection_id
     )
     assert created_tag is not None
 
@@ -64,17 +66,47 @@ def test_create_combination_selection__diversity_success(
     assert len(result.samples) == 3
 
 
-def test_create_combination_selection__diversity_success_videos(
+def test_create_combination_selection__passes_request_to_sampling(
+    db_session: Session, mocker: MockerFixture
+) -> None:
+    """Test selection endpoint passes the request payload to sampling."""
+    collection = helpers_resolvers.create_collection(
+        session=db_session,
+        collection_name="legacy-selection-test",
+    )
+    spy = mocker.patch.object(sampling_api, "sampling_via_database")
+    mocker.patch.object(image_resolver, "get_sample_ids", return_value=["a", "b", "c"])
+
+    sampling_api.create_combination_selection(
+        session=db_session,
+        collection=collection,
+        request=sampling_api.SamplingRequest(
+            n_samples_to_select=3,
+            sampling_result_tag_name="selection_tag",
+            strategies=[
+                EmbeddingDiversityStrategy(
+                    strategy_name="diversity",
+                    embedding_model_name="test_embedding_model",
+                )
+            ],
+        ),
+    )
+
+    config = spy.call_args.kwargs["config"]
+    assert config.sampling_result_tag_name == "selection_tag"
+
+
+def test_create_combination_sampling__diversity_success_videos(
     test_client: TestClient, db_session: Session
 ) -> None:
-    """Test successful diversity selection on a video collection."""
+    """Test successful diversity sampling on a video collection."""
     collection_id = helpers_resolvers.fill_db_with_video_samples_and_embeddings(
         session=db_session, n_samples=10, embedding_model_names=["test_embedding_model"]
     )
 
     request_data = {
         "n_samples_to_select": 3,
-        "selection_result_tag_name": "test_combination_selection",
+        "sampling_result_tag_name": "test_combination_sampling",
         "strategies": [
             {
                 "strategy_name": "diversity",
@@ -89,7 +121,7 @@ def test_create_combination_selection__diversity_success_videos(
     assert response.text == ""
 
     created_tag = tag_resolver.get_by_name(
-        session=db_session, tag_name="test_combination_selection", collection_id=collection_id
+        session=db_session, tag_name="test_combination_sampling", collection_id=collection_id
     )
     assert created_tag is not None
 
@@ -100,17 +132,17 @@ def test_create_combination_selection__diversity_success_videos(
     assert len(result.samples) == 3
 
 
-def test_create_combination_selection__insufficient_samples(
+def test_create_combination_sampling__insufficient_samples(
     test_client: TestClient, db_session: Session
 ) -> None:
-    """Test diversity selection when requesting more samples than available."""
+    """Test diversity sampling when requesting more samples than available."""
     collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
         session=db_session, n_samples=2, embedding_model_names=["test_embedding_model"]
     )
 
     request_data = {
         "n_samples_to_select": 5,
-        "selection_result_tag_name": "test_selection",
+        "sampling_result_tag_name": "test_sampling",
         "strategies": [
             {
                 "strategy_name": "diversity",
@@ -126,17 +158,17 @@ def test_create_combination_selection__insufficient_samples(
     assert "has only 2 samples" in response.json()["detail"]
 
 
-def test_create_combination_selection__duplicate_tag_name(
+def test_create_combination_sampling__duplicate_tag_name(
     test_client: TestClient, db_session: Session
 ) -> None:
-    """Test diversity selection when tag name already exists."""
+    """Test diversity sampling when tag name already exists."""
     collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
         session=db_session, n_samples=5, embedding_model_names=["test_embedding_model"]
     )
 
     request_data = {
         "n_samples_to_select": 3,
-        "selection_result_tag_name": "duplicate_tag",
+        "sampling_result_tag_name": "duplicate_tag",
         "strategies": [
             {
                 "strategy_name": "diversity",
@@ -155,10 +187,10 @@ def test_create_combination_selection__duplicate_tag_name(
     assert "already exists" in response.json()["error"]
 
 
-def test_create_combination_selection__metadata_weighting_success(
+def test_create_combination_sampling__metadata_weighting_success(
     test_client: TestClient, db_session: Session
 ) -> None:
-    """Test successful diversity selection."""
+    """Test successful diversity sampling."""
     collection = helpers_resolvers.create_collection(
         session=db_session, collection_name="test_collection"
     )
@@ -189,7 +221,7 @@ def test_create_combination_selection__metadata_weighting_success(
 
     request_data = {
         "n_samples_to_select": 2,
-        "selection_result_tag_name": "test_combination_selection",
+        "sampling_result_tag_name": "test_combination_sampling",
         "strategies": [
             {"strategy_name": "weights", "metadata_key": "typicality"},
             {
@@ -208,7 +240,7 @@ def test_create_combination_selection__metadata_weighting_success(
 
     # Verify tag was created with correct samples
     created_tag = tag_resolver.get_by_name(
-        session=db_session, tag_name="test_combination_selection", collection_id=collection_id
+        session=db_session, tag_name="test_combination_sampling", collection_id=collection_id
     )
     assert created_tag is not None
 
@@ -224,10 +256,10 @@ def test_create_combination_selection__metadata_weighting_success(
     assert result.samples[1].file_name == "image3.jpg"
 
 
-def test_create_combination_selection__metadata_weighting_success_videos(
+def test_create_combination_sampling__metadata_weighting_success_videos(
     test_client: TestClient, db_session: Session
 ) -> None:
-    """Test successful metadata weighting + diversity selection on a video collection."""
+    """Test successful metadata weighting + diversity sampling on a video collection."""
     collection = helpers_resolvers.create_collection(
         session=db_session,
         collection_name="test_video_collection",
@@ -266,7 +298,7 @@ def test_create_combination_selection__metadata_weighting_success_videos(
 
     request_data = {
         "n_samples_to_select": 2,
-        "selection_result_tag_name": "test_combination_selection",
+        "sampling_result_tag_name": "test_combination_sampling",
         "strategies": [
             {"strategy_name": "weights", "metadata_key": "typicality"},
             {
@@ -283,7 +315,7 @@ def test_create_combination_selection__metadata_weighting_success_videos(
     assert response.text == ""
 
     created_tag = tag_resolver.get_by_name(
-        session=db_session, tag_name="test_combination_selection", collection_id=collection_id
+        session=db_session, tag_name="test_combination_sampling", collection_id=collection_id
     )
     assert created_tag is not None
 
@@ -297,10 +329,10 @@ def test_create_combination_selection__metadata_weighting_success_videos(
     assert result.samples[1].file_name == "video3.mp4"
 
 
-def test_create_combination_selection__embedding_similarity_success(
+def test_create_combination_sampling__embedding_similarity_success(
     test_client: TestClient, db_session: Session
 ) -> None:
-    """Similarity selection creates a tag with the most similar samples."""
+    """Similarity sampling creates a tag with the most similar samples."""
     collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
         session=db_session, n_samples=5, embedding_model_names=["embedding_model_1"]
     )
@@ -320,7 +352,7 @@ def test_create_combination_selection__embedding_similarity_success(
         f"/api/collections/{collection_id}/selection",
         json={
             "n_samples_to_select": 2,
-            "selection_result_tag_name": "similarity_selection",
+            "sampling_result_tag_name": "similarity_sampling",
             "strategies": [
                 {
                     "strategy_name": "similarity",
@@ -336,7 +368,7 @@ def test_create_combination_selection__embedding_similarity_success(
 
     created_tag = tag_resolver.get_by_name(
         session=db_session,
-        tag_name="similarity_selection",
+        tag_name="similarity_sampling",
         collection_id=collection_id,
     )
     assert created_tag is not None
@@ -349,10 +381,10 @@ def test_create_combination_selection__embedding_similarity_success(
     assert actual_sample_paths == {"sample_0.jpg", "sample_1.jpg"}
 
 
-def test_create_combination_selection__embedding_similarity_missing_query_tag(
+def test_create_combination_sampling__embedding_similarity_missing_query_tag(
     test_client: TestClient, db_session: Session
 ) -> None:
-    """Similarity selection fails if the query tag does not exist."""
+    """Similarity sampling fails if the query tag does not exist."""
     collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
         session=db_session, n_samples=5, embedding_model_names=["embedding_model_1"]
     )
@@ -361,7 +393,7 @@ def test_create_combination_selection__embedding_similarity_missing_query_tag(
         f"/api/collections/{collection_id}/selection",
         json={
             "n_samples_to_select": 2,
-            "selection_result_tag_name": "similarity_selection",
+            "sampling_result_tag_name": "similarity_sampling",
             "strategies": [
                 {
                     "strategy_name": "similarity",
@@ -376,10 +408,10 @@ def test_create_combination_selection__embedding_similarity_missing_query_tag(
     assert response.json()["error"] == "Query tag with name missing_query_tag not found."
 
 
-def test_create_combination_selection__embedding_similarity_query_tag_without_embeddings(
+def test_create_combination_sampling__embedding_similarity_query_tag_without_embeddings(
     test_client: TestClient, db_session: Session
 ) -> None:
-    """Similarity selection fails if the query tag has no embeddings."""
+    """Similarity sampling fails if the query tag has no embeddings."""
     collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
         session=db_session, n_samples=5, embedding_model_names=["embedding_model_1"]
     )
@@ -391,7 +423,7 @@ def test_create_combination_selection__embedding_similarity_query_tag_without_em
         f"/api/collections/{collection_id}/selection",
         json={
             "n_samples_to_select": 2,
-            "selection_result_tag_name": "similarity_selection",
+            "sampling_result_tag_name": "similarity_sampling",
             "strategies": [
                 {
                     "strategy_name": "similarity",
@@ -408,10 +440,10 @@ def test_create_combination_selection__embedding_similarity_query_tag_without_em
     )
 
 
-def test_create_combination_selection__annotation_class_balancing_success(
+def test_create_combination_sampling__annotation_class_balancing_success(
     test_client: TestClient, db_session: Session
 ) -> None:
-    """Class balancing selection returns an even class distribution."""
+    """Class balancing sampling returns an even class distribution."""
     collection = helpers_resolvers.create_collection(
         session=db_session, collection_name="annotation_balancing_collection"
     )
@@ -462,7 +494,7 @@ def test_create_combination_selection__annotation_class_balancing_success(
         f"/api/collections/{collection.collection_id}/selection",
         json={
             "n_samples_to_select": 2,
-            "selection_result_tag_name": "balanced_selection",
+            "sampling_result_tag_name": "balanced_sampling",
             "strategies": [
                 {
                     "strategy_name": "balance",
@@ -477,7 +509,7 @@ def test_create_combination_selection__annotation_class_balancing_success(
 
     created_tag = tag_resolver.get_by_name(
         session=db_session,
-        tag_name="balanced_selection",
+        tag_name="balanced_sampling",
         collection_id=collection.collection_id,
     )
     assert created_tag is not None
@@ -502,12 +534,12 @@ def test_create_combination_selection__annotation_class_balancing_success(
     assert selected_class_frequencies == {"class_a": 1, "class_b": 1}
 
 
-def test_create_combination_selection__image_filter_success(
+def test_create_combination_sampling__image_filter_success(
     test_client: TestClient,
     db_session: Session,
     mocker: MockerFixture,
 ) -> None:
-    """Selection succeeds when request fits within the ImageFilter pool."""
+    """Sampling succeeds when request fits within the ImageFilter pool."""
     collection = helpers_resolvers.create_collection(
         session=db_session, collection_name="test_collection"
     )
@@ -533,7 +565,7 @@ def test_create_combination_selection__image_filter_success(
         f"/api/collections/{collection_id}/selection",
         json={
             "n_samples_to_select": 2,
-            "selection_result_tag_name": "tag1",
+            "sampling_result_tag_name": "tag1",
             "strategies": [
                 {"strategy_name": "diversity", "embedding_model_name": "test_embedding_model"}
             ],
@@ -551,12 +583,12 @@ def test_create_combination_selection__image_filter_success(
     )
 
 
-def test_create_combination_selection__video_filter_success(
+def test_create_combination_sampling__video_filter_success(
     test_client: TestClient,
     db_session: Session,
     mocker: MockerFixture,
 ) -> None:
-    """Selection succeeds when request fits within the VideoFilter pool."""
+    """Sampling succeeds when request fits within the VideoFilter pool."""
     collection = helpers_resolvers.create_collection(
         session=db_session,
         collection_name="test_video_collection",
@@ -607,7 +639,7 @@ def test_create_combination_selection__video_filter_success(
         f"/api/collections/{collection_id}/selection",
         json={
             "n_samples_to_select": 2,
-            "selection_result_tag_name": "tag1",
+            "sampling_result_tag_name": "tag1",
             "strategies": [
                 {"strategy_name": "diversity", "embedding_model_name": "test_embedding_model"}
             ],
@@ -625,7 +657,7 @@ def test_create_combination_selection__video_filter_success(
     )
 
 
-def test_create_combination_selection__image_collection_rejects_video_filter(
+def test_create_combination_sampling__image_collection_rejects_video_filter(
     test_client: TestClient, db_session: Session
 ) -> None:
     """Image collections reject video filters."""
@@ -637,7 +669,7 @@ def test_create_combination_selection__image_collection_rejects_video_filter(
         f"/api/collections/{collection.collection_id}/selection",
         json={
             "n_samples_to_select": 1,
-            "selection_result_tag_name": "tag1",
+            "sampling_result_tag_name": "tag1",
             "strategies": [
                 {"strategy_name": "diversity", "embedding_model_name": "test_embedding_model"}
             ],
@@ -649,7 +681,7 @@ def test_create_combination_selection__image_collection_rejects_video_filter(
     assert response.json()["detail"] == "Invalid filter type for image collection."
 
 
-def test_create_combination_selection__video_collection_rejects_image_filter(
+def test_create_combination_sampling__video_collection_rejects_image_filter(
     test_client: TestClient, db_session: Session
 ) -> None:
     """Video collections reject image filters."""
@@ -663,7 +695,7 @@ def test_create_combination_selection__video_collection_rejects_image_filter(
         f"/api/collections/{collection.collection_id}/selection",
         json={
             "n_samples_to_select": 1,
-            "selection_result_tag_name": "tag1",
+            "sampling_result_tag_name": "tag1",
             "strategies": [
                 {"strategy_name": "diversity", "embedding_model_name": "test_embedding_model"}
             ],

--- a/lightly_studio/tests/api/routes/api/test_sampling.py
+++ b/lightly_studio/tests/api/routes/api/test_sampling.py
@@ -46,7 +46,7 @@ def test_create_combination_sampling__diversity_success(
         ],
     }
 
-    response = test_client.post(f"/api/collections/{collection_id}/selection", json=request_data)
+    response = test_client.post(f"/api/collections/{collection_id}/sampling", json=request_data)
 
     # Assert 204 No Content response
     assert response.status_code == 204
@@ -66,7 +66,7 @@ def test_create_combination_sampling__diversity_success(
     assert len(result.samples) == 3
 
 
-def test_create_combination_selection__passes_request_to_sampling(
+def test_create_sampling__passes_request_to_sampling(
     db_session: Session, mocker: MockerFixture
 ) -> None:
     """Test selection endpoint passes the request payload to sampling."""
@@ -77,7 +77,7 @@ def test_create_combination_selection__passes_request_to_sampling(
     spy = mocker.patch.object(sampling_api, "sampling_via_database")
     mocker.patch.object(image_resolver, "get_sample_ids", return_value=["a", "b", "c"])
 
-    sampling_api.create_combination_selection(
+    sampling_api.create_sampling(
         session=db_session,
         collection=collection,
         request=sampling_api.SamplingRequest(
@@ -115,7 +115,7 @@ def test_create_combination_sampling__diversity_success_videos(
         ],
     }
 
-    response = test_client.post(f"/api/collections/{collection_id}/selection", json=request_data)
+    response = test_client.post(f"/api/collections/{collection_id}/sampling", json=request_data)
 
     assert response.status_code == 204
     assert response.text == ""
@@ -151,7 +151,7 @@ def test_create_combination_sampling__insufficient_samples(
         ],
     }
 
-    response = test_client.post(f"/api/collections/{collection_id}/selection", json=request_data)
+    response = test_client.post(f"/api/collections/{collection_id}/sampling", json=request_data)
 
     assert response.status_code == 400
     assert "cannot select 5" in response.json()["detail"]
@@ -178,11 +178,11 @@ def test_create_combination_sampling__duplicate_tag_name(
     }
 
     # First request should succeed
-    response = test_client.post(f"/api/collections/{collection_id}/selection", json=request_data)
+    response = test_client.post(f"/api/collections/{collection_id}/sampling", json=request_data)
     assert response.status_code == 204
 
     # Second request with same tag name should fail
-    response = test_client.post(f"/api/collections/{collection_id}/selection", json=request_data)
+    response = test_client.post(f"/api/collections/{collection_id}/sampling", json=request_data)
     assert response.status_code == 400
     assert "already exists" in response.json()["error"]
 
@@ -232,7 +232,7 @@ def test_create_combination_sampling__metadata_weighting_success(
         ],
     }
 
-    response = test_client.post(f"/api/collections/{collection_id}/selection", json=request_data)
+    response = test_client.post(f"/api/collections/{collection_id}/sampling", json=request_data)
 
     # Assert 204 No Content response
     assert response.status_code == 204
@@ -309,7 +309,7 @@ def test_create_combination_sampling__metadata_weighting_success_videos(
         ],
     }
 
-    response = test_client.post(f"/api/collections/{collection_id}/selection", json=request_data)
+    response = test_client.post(f"/api/collections/{collection_id}/sampling", json=request_data)
 
     assert response.status_code == 204
     assert response.text == ""
@@ -349,7 +349,7 @@ def test_create_combination_sampling__embedding_similarity_success(
     )
 
     response = test_client.post(
-        f"/api/collections/{collection_id}/selection",
+        f"/api/collections/{collection_id}/sampling",
         json={
             "n_samples_to_select": 2,
             "sampling_result_tag_name": "similarity_sampling",
@@ -390,7 +390,7 @@ def test_create_combination_sampling__embedding_similarity_missing_query_tag(
     )
 
     response = test_client.post(
-        f"/api/collections/{collection_id}/selection",
+        f"/api/collections/{collection_id}/sampling",
         json={
             "n_samples_to_select": 2,
             "sampling_result_tag_name": "similarity_sampling",
@@ -420,7 +420,7 @@ def test_create_combination_sampling__embedding_similarity_query_tag_without_emb
     )
 
     response = test_client.post(
-        f"/api/collections/{collection_id}/selection",
+        f"/api/collections/{collection_id}/sampling",
         json={
             "n_samples_to_select": 2,
             "sampling_result_tag_name": "similarity_sampling",
@@ -491,7 +491,7 @@ def test_create_combination_sampling__annotation_class_balancing_success(
     )
 
     response = test_client.post(
-        f"/api/collections/{collection.collection_id}/selection",
+        f"/api/collections/{collection.collection_id}/sampling",
         json={
             "n_samples_to_select": 2,
             "sampling_result_tag_name": "balanced_sampling",
@@ -562,7 +562,7 @@ def test_create_combination_sampling__image_filter_success(
     spy_sample_resolver = mocker.spy(image_resolver, "get_sample_ids")
 
     response = test_client.post(
-        f"/api/collections/{collection_id}/selection",
+        f"/api/collections/{collection_id}/sampling",
         json={
             "n_samples_to_select": 2,
             "sampling_result_tag_name": "tag1",
@@ -636,7 +636,7 @@ def test_create_combination_sampling__video_filter_success(
     spy_video_resolver = mocker.spy(video_resolver, "get_sample_ids")
 
     response = test_client.post(
-        f"/api/collections/{collection_id}/selection",
+        f"/api/collections/{collection_id}/sampling",
         json={
             "n_samples_to_select": 2,
             "sampling_result_tag_name": "tag1",
@@ -666,7 +666,7 @@ def test_create_combination_sampling__image_collection_rejects_video_filter(
     )
 
     response = test_client.post(
-        f"/api/collections/{collection.collection_id}/selection",
+        f"/api/collections/{collection.collection_id}/sampling",
         json={
             "n_samples_to_select": 1,
             "sampling_result_tag_name": "tag1",
@@ -692,7 +692,7 @@ def test_create_combination_sampling__video_collection_rejects_image_filter(
     )
 
     response = test_client.post(
-        f"/api/collections/{collection.collection_id}/selection",
+        f"/api/collections/{collection.collection_id}/sampling",
         json={
             "n_samples_to_select": 1,
             "sampling_result_tag_name": "tag1",

--- a/lightly_studio/tests/core/dataset_query/test_dataset_query__select.py
+++ b/lightly_studio/tests/core/dataset_query/test_dataset_query__select.py
@@ -22,9 +22,9 @@ class TestDatasetQuerySelect:
         assert dataset_table is not None
         query = DatasetQuery(dataset=dataset_table, session=db_session)
 
-        query.selection().diverse(
+        query.sampling().diverse(
             n_samples_to_select=2,
-            selection_result_tag_name="selection_tag",
+            sampling_result_tag_name="selection_tag",
         )
 
         tag = tag_resolver.get_by_name(

--- a/lightly_studio/tests/sampling/helpers_sampling.py
+++ b/lightly_studio/tests/sampling/helpers_sampling.py
@@ -1,4 +1,4 @@
-"""Helpers for setting up the selection tests."""
+"""Helpers for setting up the sampling tests."""
 
 from __future__ import annotations
 

--- a/lightly_studio/tests/sampling/test_mundig.py
+++ b/lightly_studio/tests/sampling/test_mundig.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pytest_mock import MockerFixture
 
-from lightly_studio.selection.mundig import Mundig
+from lightly_studio.sampling.mundig import Mundig
 
 
 class TestMundig:
@@ -18,15 +18,15 @@ class TestMundig:
         """Test the diversity strategy."""
         mundig = Mundig()
         mundig.add_diversity([[1], [3], [5]])
-        selected = mundig.run(n_samples=2)
-        assert selected == [0, 2]
+        sampled = mundig.run(n_samples=2)
+        assert sampled == [0, 2]
 
     def test_diversity__pass_ndarray(self) -> None:
         """Test the diversity strategy with ndarray float64 input."""
         mundig = Mundig()
         mundig.add_diversity(np.array([[1], [3], [5]], dtype=np.float64))
-        selected = mundig.run(n_samples=2)
-        assert selected == [0, 2]
+        sampled = mundig.run(n_samples=2)
+        assert sampled == [0, 2]
 
     def test_diversity__pass_ndarray_zero_copy(self, mocker: MockerFixture) -> None:
         """Test that there is no ndarray copy if it already is np.float32.
@@ -56,27 +56,27 @@ class TestMundig:
         """Test the weighting strategy."""
         mundig = Mundig()
         mundig.add_weighting([1, 2, 3])
-        selected = mundig.run(n_samples=2)
-        assert selected == [2, 1]
+        sampled = mundig.run(n_samples=2)
+        assert sampled == [2, 1]
 
     def test_weighting__multiple(self) -> None:
         """Test the weighting strategy with multiple calls."""
         mundig = Mundig()
         mundig.add_weighting([1, 2, 3])
         mundig.add_weighting([6, 5, 3])
-        selected = mundig.run(n_samples=2)
-        assert selected == [1, 2]
+        sampled = mundig.run(n_samples=2)
+        assert sampled == [1, 2]
 
-    def test_similarity__selects_most_similar_samples(self) -> None:
-        """Test that similarity selects the samples closest to the query."""
+    def test_similarity__samples_most_similar_samples(self) -> None:
+        """Test that similarity samples the samples closest to the query."""
         mundig = Mundig()
         mundig.add_similarity(
             embeddings=[[1.0, 0.0], [0.0, 1.0], [0.9, 0.0]],
             query_embeddings=[[1.0, 0.0]],
         )
 
-        selected = mundig.run(n_samples=2)
-        assert selected == [0, 2]
+        sampled = mundig.run(n_samples=2)
+        assert sampled == [0, 2]
 
     def test_multiple__wrong_n_input_samples(self) -> None:
         """Check error is raised if input sample sizes differ."""
@@ -94,11 +94,11 @@ class TestMundig:
         # 5 samples, 2 classes
         class_distributions = [[1.0, 0.0], [0.3, 0.7], [0.0, 1.0], [0.0, 1.0], [1.0, 1.0]]
         mundig.add_class_balancing(class_distributions=class_distributions, target=[0.5, 0.5])
-        selected = mundig.run(n_samples=2)
+        sampled = mundig.run(n_samples=2)
 
         # Sample at index 4 with distribution [1.0, 1.0] is perfectly in balance with the target of
         # 50:50. Then sample at index 1 with distribution [0.3, 0.7] is the closest to 50:50.
-        assert selected == [4, 1]
+        assert sampled == [4, 1]
 
     def test_class_balancing_wrong_dimensions(self) -> None:
         """Test class balancing with wrong dimensions."""

--- a/lightly_studio/tests/sampling/test_sampling.py
+++ b/lightly_studio/tests/sampling/test_sampling.py
@@ -1,4 +1,4 @@
-"""Test user selection functions."""
+"""Test user sampling functions."""
 
 from __future__ import annotations
 
@@ -10,20 +10,20 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationType,
 )
 from lightly_studio.resolvers import collection_resolver, image_resolver
-from lightly_studio.selection import select as select_file
-from lightly_studio.selection.mundig import Mundig
-from lightly_studio.selection.selection_config import (
+from lightly_studio.sampling import sample as sampling_file
+from lightly_studio.sampling.mundig import Mundig
+from lightly_studio.sampling.sampling_config import (
     AnnotationClassBalancingStrategy,
     EmbeddingDiversityStrategy,
     MetadataWeightingStrategy,
-    SelectionConfig,
+    SamplingConfig,
 )
 from tests import helpers_resolvers
 from tests.helpers_resolvers import AnnotationDetails
-from tests.selection import helpers_selection
+from tests.sampling import helpers_sampling
 
 
-class TestSelect:
+class TestSampling:
     def test_diverse__embedding_model_name_unspecified(
         self, db_session: Session, mocker: MockerFixture
     ) -> None:
@@ -33,21 +33,19 @@ class TestSelect:
         collection_table = collection_resolver.get_by_id(db_session, collection_id)
         assert collection_table is not None
         query = DatasetQuery(collection_table, db_session)
-        spy_select_via_db = mocker.spy(select_file, "select_via_database")
+        spy_sampling_via_db = mocker.spy(sampling_file, "sampling_via_database")
 
-        query.selection().diverse(
-            n_samples_to_select=3, selection_result_tag_name="diverse_selection"
-        )
+        query.sampling().diverse(n_samples_to_select=3, sampling_result_tag_name="diverse_sampling")
 
         expected_sample_ids = [
             sample.sample_id for sample in DatasetQuery(collection_table, db_session)
         ]
-        spy_select_via_db.assert_called_once_with(
+        spy_sampling_via_db.assert_called_once_with(
             session=db_session,
-            config=SelectionConfig(
+            config=SamplingConfig(
                 collection_id=collection_id,
                 n_samples_to_select=3,
-                selection_result_tag_name="diverse_selection",
+                sampling_result_tag_name="diverse_sampling",
                 strategies=[EmbeddingDiversityStrategy(embedding_model_name=None)],
             ),
             input_sample_ids=expected_sample_ids,
@@ -62,23 +60,23 @@ class TestSelect:
         collection_table = collection_resolver.get_by_id(db_session, collection_id)
         assert collection_table is not None
         query = DatasetQuery(collection_table, db_session)
-        spy_select_via_db = mocker.spy(select_file, "select_via_database")
+        spy_sampling_via_db = mocker.spy(sampling_file, "sampling_via_database")
 
-        query.selection().diverse(
+        query.sampling().diverse(
             n_samples_to_select=3,
-            selection_result_tag_name="diverse_selection",
+            sampling_result_tag_name="diverse_sampling",
             embedding_model_name="embedding_model_1",
         )
 
         expected_sample_ids = [
             sample.sample_id for sample in DatasetQuery(collection_table, db_session)
         ]
-        spy_select_via_db.assert_called_once_with(
+        spy_sampling_via_db.assert_called_once_with(
             session=db_session,
-            config=SelectionConfig(
+            config=SamplingConfig(
                 collection_id=collection_id,
                 n_samples_to_select=3,
-                selection_result_tag_name="diverse_selection",
+                sampling_result_tag_name="diverse_sampling",
                 strategies=[EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1")],
             ),
             input_sample_ids=expected_sample_ids,
@@ -115,52 +113,52 @@ class TestSelect:
             ],
         )
 
-        spy_select_via_db = mocker.spy(select_file, "select_via_database")
+        spy_sampling_via_db = mocker.spy(sampling_file, "sampling_via_database")
 
-        query.selection().annotation_balancing(
+        query.sampling().annotation_balancing(
             n_samples_to_select=5,
-            selection_result_tag_name="balancing_selection",
+            sampling_result_tag_name="balancing_sampling",
             target_distribution="uniform",
         )
 
         expected_sample_ids = [sample.sample_id for sample in all_samples]
 
-        spy_select_via_db.assert_called_once_with(
+        spy_sampling_via_db.assert_called_once_with(
             session=db_session,
-            config=SelectionConfig(
+            config=SamplingConfig(
                 collection_id=collection_id,
                 n_samples_to_select=5,
-                selection_result_tag_name="balancing_selection",
+                sampling_result_tag_name="balancing_sampling",
                 strategies=[AnnotationClassBalancingStrategy(target_distribution="uniform")],
             ),
             input_sample_ids=expected_sample_ids,
         )
 
     def test_metadata_weighting(self, db_session: Session, mocker: MockerFixture) -> None:
-        collection_id = helpers_selection.fill_db_with_samples_and_metadata(
+        collection_id = helpers_sampling.fill_db_with_samples_and_metadata(
             session=db_session, metadata=[16.0, 50.0, 35.0], metadata_key="speed"
         )
         collection_table = collection_resolver.get_by_id(db_session, collection_id)
         assert collection_table is not None
         query = DatasetQuery(collection_table, db_session)
-        spy_select_via_db = mocker.spy(select_file, "select_via_database")
+        spy_sampling_via_db = mocker.spy(sampling_file, "sampling_via_database")
         spy_mundig_add_weighting = mocker.spy(Mundig, "add_weighting")
 
-        query.selection().metadata_weighting(
+        query.sampling().metadata_weighting(
             n_samples_to_select=2,
             metadata_key="speed",
-            selection_result_tag_name="weight_selection",
+            sampling_result_tag_name="weight_sampling",
         )
 
         expected_sample_ids = [
             sample.sample_id for sample in DatasetQuery(collection_table, db_session)
         ]
-        spy_select_via_db.assert_called_once_with(
+        spy_sampling_via_db.assert_called_once_with(
             session=db_session,
-            config=SelectionConfig(
+            config=SamplingConfig(
                 collection_id=collection_id,
                 n_samples_to_select=2,
-                selection_result_tag_name="weight_selection",
+                sampling_result_tag_name="weight_sampling",
                 strategies=[MetadataWeightingStrategy(metadata_key="speed")],
             ),
             input_sample_ids=expected_sample_ids,
@@ -173,7 +171,7 @@ class TestSelect:
         collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
             session=db_session, n_samples=5, embedding_model_names=["model_1", "model_2"]
         )
-        helpers_selection.fill_db_metadata(
+        helpers_sampling.fill_db_metadata(
             session=db_session,
             collection_id=collection_id,
             metadata=[15.0, 47.0, 35.0, 18.0, 29.5],
@@ -182,12 +180,12 @@ class TestSelect:
         collection_table = collection_resolver.get_by_id(db_session, collection_id)
         assert collection_table is not None
         query = DatasetQuery(collection_table, db_session)
-        spy_select_via_db = mocker.spy(select_file, "select_via_database")
+        spy_sampling_via_db = mocker.spy(sampling_file, "sampling_via_database")
 
-        query.selection().multi_strategies(
+        query.sampling().multi_strategies(
             n_samples_to_select=3,
-            selection_result_tag_name="multi_strategies_selection",
-            selection_strategies=[
+            sampling_result_tag_name="multi_strategies_sampling",
+            sampling_strategies=[
                 EmbeddingDiversityStrategy(embedding_model_name="model_1"),
                 EmbeddingDiversityStrategy(embedding_model_name="model_2"),
                 MetadataWeightingStrategy(metadata_key="speed"),
@@ -197,12 +195,12 @@ class TestSelect:
         expected_sample_ids = [
             sample.sample_id for sample in DatasetQuery(collection_table, db_session)
         ]
-        spy_select_via_db.assert_called_once_with(
+        spy_sampling_via_db.assert_called_once_with(
             session=db_session,
-            config=SelectionConfig(
+            config=SamplingConfig(
                 collection_id=collection_id,
                 n_samples_to_select=3,
-                selection_result_tag_name="multi_strategies_selection",
+                sampling_result_tag_name="multi_strategies_sampling",
                 strategies=[
                     EmbeddingDiversityStrategy(embedding_model_name="model_1"),
                     EmbeddingDiversityStrategy(embedding_model_name="model_2"),

--- a/lightly_studio/tests/sampling/test_sampling_via_db.py
+++ b/lightly_studio/tests/sampling/test_sampling_via_db.py
@@ -1,4 +1,4 @@
-"""Test database selection functions."""
+"""Test database sampling functions."""
 
 from __future__ import annotations
 
@@ -17,17 +17,17 @@ from lightly_studio.resolvers import (
 )
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
-from lightly_studio.selection.mundig import Mundig
-from lightly_studio.selection.select_via_db import (
-    _aggregate_class_distributions,
-    select_via_database,
-)
-from lightly_studio.selection.selection_config import (
+from lightly_studio.sampling.mundig import Mundig
+from lightly_studio.sampling.sampling_config import (
     AnnotationClassBalancingStrategy,
     EmbeddingDiversityStrategy,
     EmbeddingSimilarityStrategy,
-    SelectionConfig,
-    SelectionStrategy,
+    SamplingConfig,
+    SamplingStrategy,
+)
+from lightly_studio.sampling.sampling_via_db import (
+    _aggregate_class_distributions,
+    sampling_via_database,
 )
 from tests.helpers_resolvers import (
     AnnotationDetails,
@@ -38,29 +38,29 @@ from tests.helpers_resolvers import (
 )
 
 
-def test_select_via_database__embedding_diversity(
+def test_sampling_via_database__embedding_diversity(
     db_session: Session,
 ) -> None:
-    """Runs selection with a simple embedding diversity strategy."""
+    """Runs sampling with a simple embedding diversity strategy."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=20, embedding_model_names=["embedding_model_1"]
     )
 
-    selection_config = SelectionConfig(
+    sampling_config = SamplingConfig(
         collection_id=collection_id,
         n_samples_to_select=2,
-        selection_result_tag_name="selection_1",
+        sampling_result_tag_name="sampling_1",
         strategies=[EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1")],
     )
 
-    select_via_database(
-        db_session, selection_config, input_sample_ids=_all_sample_ids(db_session, collection_id)
+    sampling_via_database(
+        db_session, sampling_config, input_sample_ids=_all_sample_ids(db_session, collection_id)
     )
 
-    # Assert that the tag for the selected set was created with 2 samples
+    # Assert that the tag for the sampled set was created with 2 samples
     tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
     assert len(tags) == 1
-    assert tags[0].name == "selection_1"
+    assert tags[0].name == "sampling_1"
     samples_in_tag = image_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=collection_id,
@@ -69,39 +69,39 @@ def test_select_via_database__embedding_diversity(
     assert len(samples_in_tag) == 2
 
     # Assert that the samples in the tag are the expected ones:
-    # The first sample and most distant one should be selected.
+    # The first sample and most distant one should be sampled.
     expected_sample_paths = {"sample_0.jpg", "sample_19.jpg"}
     actual_sample_paths = {sample.file_path_abs for sample in samples_in_tag}
     assert actual_sample_paths == expected_sample_paths
 
 
-def test_select_via_database__multi_embedding_diversity(
+def test_sampling_via_database__multi_embedding_diversity(
     db_session: Session,
 ) -> None:
-    """Runs selection with multiple embedding diversity strategies."""
+    """Runs sampling with multiple embedding diversity strategies."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session,
         n_samples=20,
         embedding_model_names=["embedding_model_1", "embedding_model_2"],
     )
 
-    selection_config = SelectionConfig(
+    sampling_config = SamplingConfig(
         collection_id=collection_id,
         n_samples_to_select=2,
-        selection_result_tag_name="selection_1",
+        sampling_result_tag_name="sampling_1",
         strategies=[
             EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1"),
             EmbeddingDiversityStrategy(embedding_model_name="embedding_model_2"),
         ],
     )
-    select_via_database(
-        db_session, selection_config, input_sample_ids=_all_sample_ids(db_session, collection_id)
+    sampling_via_database(
+        db_session, sampling_config, input_sample_ids=_all_sample_ids(db_session, collection_id)
     )
 
-    # Assert that the tag for the selected set was created with 2 samples
+    # Assert that the tag for the sampled set was created with 2 samples
     tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
     assert len(tags) == 1
-    assert tags[0].name == "selection_1"
+    assert tags[0].name == "sampling_1"
     samples_in_tag = image_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=collection_id,
@@ -109,16 +109,16 @@ def test_select_via_database__multi_embedding_diversity(
     ).samples
 
     # Assert that the samples in the tag are the expected ones:
-    # The first sample and most distant one should be selected.
+    # The first sample and most distant one should be sampled.
     expected_sample_paths = {"sample_0.jpg", "sample_19.jpg"}
     actual_sample_paths = {sample.file_path_abs for sample in samples_in_tag}
     assert actual_sample_paths == expected_sample_paths
 
 
-def test_select_via_database__embedding_diversity__sample_filter_tags(
+def test_sampling_via_database__embedding_diversity__sample_filter_tags(
     db_session: Session,
 ) -> None:
-    """Runs selection with a filter for the input tag."""
+    """Runs sampling with a filter for the input tag."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=101, embedding_model_names=["embedding_model_1"]
     )
@@ -144,43 +144,43 @@ def test_select_via_database__embedding_diversity__sample_filter_tags(
         sample_ids=[s.sample_id for s in samples_5_through_14],
     )
 
-    # Run diversity selection with the tag as input
-    selection_config = SelectionConfig(
+    # Run diversity sampling with the tag as input
+    sampling_config = SamplingConfig(
         collection_id=collection_id,
         n_samples_to_select=2,
-        selection_result_tag_name="selection_1",
+        sampling_result_tag_name="sampling_1",
         strategies=[EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1")],
     )
-    select_via_database(
+    sampling_via_database(
         db_session,
-        selection_config,
+        sampling_config,
         input_sample_ids=[s.sample_id for s in samples_5_through_14],
     )
 
-    # Assert that the tag for the selected set was created with 2 samples
+    # Assert that the tag for the sampled set was created with 2 samples
     tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
     assert len(tags) == 2
-    tag_selected = next(
-        t for t in tags if t.name == "selection_1"
-    )  # Get the tag created by the selection
+    tag_sampled = next(
+        t for t in tags if t.name == "sampling_1"
+    )  # Get the tag created by the sampling
     samples_in_tag = image_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=collection_id,
-        filters=ImageFilter(sample_filter=SampleFilter(tag_ids=[tag_selected.tag_id])),
+        filters=ImageFilter(sample_filter=SampleFilter(tag_ids=[tag_sampled.tag_id])),
     ).samples
     assert len(samples_in_tag) == 2
 
     # Assert that the samples in the tag are the expected ones:
-    # The first sample and most distant one should be selected.
+    # The first sample and most distant one should be sampled.
     expected_sample_paths = {"sample_5.jpg", "sample_14.jpg"}
     actual_sample_paths = {sample.file_path_abs for sample in samples_in_tag}
     assert actual_sample_paths == expected_sample_paths
 
 
-def test_select_via_database__embedding_similarity(
+def test_sampling_via_database__embedding_similarity(
     db_session: Session,
 ) -> None:
-    """Runs selection with an embedding similarity strategy."""
+    """Runs sampling with an embedding similarity strategy."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=5, embedding_model_names=["embedding_model_1"]
     )
@@ -194,10 +194,10 @@ def test_select_via_database__embedding_similarity(
         sample_ids=[all_samples[0].sample_id, all_samples[1].sample_id],
     )
 
-    selection_config = SelectionConfig(
+    sampling_config = SamplingConfig(
         collection_id=collection_id,
         n_samples_to_select=2,
-        selection_result_tag_name="selection_1",
+        sampling_result_tag_name="sampling_1",
         strategies=[
             EmbeddingSimilarityStrategy(
                 query_tag_name="query_tag",
@@ -206,18 +206,18 @@ def test_select_via_database__embedding_similarity(
         ],
     )
 
-    select_via_database(
-        db_session, selection_config, input_sample_ids=_all_sample_ids(db_session, collection_id)
+    sampling_via_database(
+        db_session, sampling_config, input_sample_ids=_all_sample_ids(db_session, collection_id)
     )
 
     tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
     assert len(tags) == 2
 
-    selection_tag = next(tag for tag in tags if tag.name == "selection_1")
+    sampling_tag = next(tag for tag in tags if tag.name == "sampling_1")
     samples_in_tag = image_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=collection_id,
-        filters=ImageFilter(sample_filter=SampleFilter(tag_ids=[selection_tag.tag_id])),
+        filters=ImageFilter(sample_filter=SampleFilter(tag_ids=[sampling_tag.tag_id])),
     ).samples
 
     # Similarity returns the 2 samples that we compared against. Those are the most similar samples
@@ -227,10 +227,10 @@ def test_select_via_database__embedding_similarity(
     assert actual_sample_paths == expected_sample_paths
 
 
-def test_select_via_database__unknown_strategy(
+def test_sampling_via_database__unknown_strategy(
     db_session: Session,
 ) -> None:
-    """Runs selection with a non-existing strategy.
+    """Runs sampling with a non-existing strategy.
 
     Check for the correct error message.
     """
@@ -238,38 +238,38 @@ def test_select_via_database__unknown_strategy(
         db_session, n_samples=20, embedding_model_names=["embedding_model_1"]
     )
 
-    selection_config = SelectionConfig(
+    sampling_config = SamplingConfig(
         collection_id=collection_id,
         n_samples_to_select=2,
-        selection_result_tag_name="selection_1",
-        strategies=[SelectionStrategy()],
+        sampling_result_tag_name="sampling_1",
+        strategies=[SamplingStrategy()],
     )
 
-    expected_error = "Selection strategy of type <class "
-    "'lightly_studio.selection.selection_config.SelectionStrategy'> is unknown."
+    expected_error = "Sampling strategy of type <class "
+    "'lightly_studio.sampling.sampling_config.SamplingStrategy'> is unknown."
     with pytest.raises(
         ValueError,
         match=expected_error,
     ):
-        select_via_database(
+        sampling_via_database(
             db_session,
-            selection_config,
+            sampling_config,
             input_sample_ids=_all_sample_ids(db_session, collection_id),
         )
 
 
-def test_select_via_database__embedding_similarity__missing_query_tag(
+def test_sampling_via_database__embedding_similarity__missing_query_tag(
     db_session: Session,
 ) -> None:
-    """Runs selection with a missing similarity query tag."""
+    """Runs sampling with a missing similarity query tag."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=5, embedding_model_names=["embedding_model_1"]
     )
 
-    selection_config = SelectionConfig(
+    sampling_config = SamplingConfig(
         collection_id=collection_id,
         n_samples_to_select=2,
-        selection_result_tag_name="selection_1",
+        sampling_result_tag_name="sampling_1",
         strategies=[
             EmbeddingSimilarityStrategy(
                 query_tag_name="missing_query_tag",
@@ -282,26 +282,26 @@ def test_select_via_database__embedding_similarity__missing_query_tag(
         ValueError,
         match=r"Query tag with name missing_query_tag not found\.",
     ):
-        select_via_database(
+        sampling_via_database(
             db_session,
-            selection_config,
+            sampling_config,
             input_sample_ids=_all_sample_ids(db_session, collection_id),
         )
 
 
-def test_select_via_database__embedding_similarity__query_tag_without_embeddings(
+def test_sampling_via_database__embedding_similarity__query_tag_without_embeddings(
     db_session: Session,
 ) -> None:
-    """Runs selection with a query tag that has no embeddings."""
+    """Runs sampling with a query tag that has no embeddings."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=5, embedding_model_names=["embedding_model_1"]
     )
     create_tag(session=db_session, collection_id=collection_id, tag_name="empty_query_tag")
 
-    selection_config = SelectionConfig(
+    sampling_config = SamplingConfig(
         collection_id=collection_id,
         n_samples_to_select=2,
-        selection_result_tag_name="selection_1",
+        sampling_result_tag_name="sampling_1",
         strategies=[
             EmbeddingSimilarityStrategy(
                 query_tag_name="empty_query_tag",
@@ -317,35 +317,35 @@ def test_select_via_database__embedding_similarity__query_tag_without_embeddings
             r"embedding_model_1\."
         ),
     ):
-        select_via_database(
+        sampling_via_database(
             db_session,
-            selection_config,
+            sampling_config,
             input_sample_ids=_all_sample_ids(db_session, collection_id),
         )
 
 
-def test_select_via_database__more_samples_to_select_than_available(
+def test_sampling_via_database__more_samples_to_sampling_than_available(
     db_session: Session,
     mocker: MockerFixture,
 ) -> None:
-    """Runs selection when requesting more samples than available."""
+    """Runs sampling when requesting more samples than available."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=5, embedding_model_names=["embedding_model_1"]
     )
 
-    selection_config = SelectionConfig(
+    sampling_config = SamplingConfig(
         collection_id=collection_id,
         n_samples_to_select=10,  # Request more samples than available
-        selection_result_tag_name="selection_1",
+        sampling_result_tag_name="sampling_1",
         strategies=[EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1")],
     )
 
     # Spy on the mundig.run method to verify it's called with the correct parameters
     spy_mundig_run = mocker.spy(Mundig, "run")
 
-    select_via_database(
+    sampling_via_database(
         db_session,
-        selection_config,
+        sampling_config,
         input_sample_ids=_all_sample_ids(db_session, collection_id),
     )
 
@@ -353,10 +353,10 @@ def test_select_via_database__more_samples_to_select_than_available(
     spy_mundig_run.assert_called_once_with(self=mocker.ANY, n_samples=5)
 
 
-def test_select_via_database__zero_input_samples_available(
+def test_sampling_via_database__zero_input_samples_available(
     db_session: Session,
 ) -> None:
-    """Runs selection when no input samples are available."""
+    """Runs sampling when no input samples are available."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=20, embedding_model_names=["embedding_model_1"]
     )
@@ -372,61 +372,61 @@ def test_select_via_database__zero_input_samples_available(
         ),
     )
 
-    selection_config = SelectionConfig(
+    sampling_config = SamplingConfig(
         collection_id=collection_id,
         n_samples_to_select=5,
-        selection_result_tag_name="selection_1",
+        sampling_result_tag_name="sampling_1",
         strategies=[EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1")],
     )
 
-    select_via_database(db_session, selection_config, input_sample_ids=[])
+    sampling_via_database(db_session, sampling_config, input_sample_ids=[])
 
-    # Assert that no selection tag was created since there were no samples to select
+    # Assert that no sampling tag was created since there were no samples to sampling
     tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
     tag_names = [tag.name for tag in tags]
-    assert "selection_1" not in tag_names  # Selection tag should not be created
+    assert "sampling_1" not in tag_names  # Sampling tag should not be created
     assert "empty_tag" in tag_names  # Only the empty tag should exist
 
 
-def test_select_via_database__tag_name_already_exists(
+def test_sampling_via_database__tag_name_already_exists(
     db_session: Session,
 ) -> None:
-    """Runs selection when the selection result tag name already exists."""
+    """Runs sampling when the sampling result tag name already exists."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=20, embedding_model_names=["embedding_model_1"]
     )
 
-    selection_config = SelectionConfig(
+    sampling_config = SamplingConfig(
         collection_id=collection_id,
         n_samples_to_select=5,
-        selection_result_tag_name="selection_1",  # Same name as existing tag
+        sampling_result_tag_name="sampling_1",  # Same name as existing tag
         strategies=[EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1")],
     )
 
     candidate_sample_ids = _all_sample_ids(db_session, collection_id)
 
     # First creation of tag
-    select_via_database(db_session, selection_config, input_sample_ids=candidate_sample_ids)
+    sampling_via_database(db_session, sampling_config, input_sample_ids=candidate_sample_ids)
 
     expected_error = (
-        f"Tag with name {selection_config.selection_result_tag_name} already exists in the "
+        f"Tag with name {sampling_config.sampling_result_tag_name} already exists in the "
         f"collection {collection_id}. Please use a different tag name."
     )
     with pytest.raises(
         ValueError,
         match=expected_error,
     ):
-        select_via_database(
+        sampling_via_database(
             db_session,
-            selection_config,
+            sampling_config,
             input_sample_ids=candidate_sample_ids,
         )
 
 
-def test_select_via_database_with_annotation_class_balancing_target(
+def test_sampling_via_database_with_annotation_class_balancing_target(
     db_session: Session,
 ) -> None:
-    """Runs selection with a simple annotation class balancing strategy."""
+    """Runs sampling with a simple annotation class balancing strategy."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=3, embedding_model_names=[]
     )
@@ -473,10 +473,10 @@ def test_select_via_database_with_annotation_class_balancing_target(
         ],
     )
 
-    config = SelectionConfig(
+    config = SamplingConfig(
         n_samples_to_select=2,
         collection_id=collection_id,
-        selection_result_tag_name="selection-tag",
+        sampling_result_tag_name="sampling-tag",
         strategies=[
             AnnotationClassBalancingStrategy(
                 target_distribution={
@@ -488,7 +488,7 @@ def test_select_via_database_with_annotation_class_balancing_target(
         ],
     )
 
-    select_via_database(
+    sampling_via_database(
         session=db_session,
         config=config,
         input_sample_ids=sample_ids,
@@ -496,31 +496,31 @@ def test_select_via_database_with_annotation_class_balancing_target(
 
     tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
     assert len(tags) == 1
-    assert tags[0].name == "selection-tag"
+    assert tags[0].name == "sampling-tag"
     samples_in_tag = image_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=collection_id,
         filters=ImageFilter(sample_filter=SampleFilter(tag_ids=[tags[0].tag_id])),
     ).samples
 
-    selected_sample_ids = [sample.sample_id for sample in samples_in_tag]
+    sampled_sample_ids = [sample.sample_id for sample in samples_in_tag]
     # Pick the first two samples, because they resemble the [1, 1, 0] label distribution the best.
-    assert selected_sample_ids == [sample_ids[0], sample_ids[1]]
+    assert sampled_sample_ids == [sample_ids[0], sample_ids[1]]
 
 
-def test_select_via_database_with_annotation_class_balancing_missing_class(
+def test_sampling_via_database_with_annotation_class_balancing_missing_class(
     db_session: Session,
 ) -> None:
-    """Runs selection with a simple annotation class balancing strategy."""
+    """Runs sampling with a simple annotation class balancing strategy."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=1, embedding_model_names=[]
     )
     sample_ids = _all_sample_ids(db_session, collection_id)
 
-    config = SelectionConfig(
+    config = SamplingConfig(
         n_samples_to_select=2,
         collection_id=collection_id,
-        selection_result_tag_name="selection-tag",
+        sampling_result_tag_name="sampling-tag",
         strategies=[
             AnnotationClassBalancingStrategy(
                 target_distribution={"cat": 1},  # There is no cat label
@@ -529,17 +529,17 @@ def test_select_via_database_with_annotation_class_balancing_missing_class(
     )
 
     with pytest.raises(ValueError, match="Annotation label with this name does not exist: cat"):
-        select_via_database(
+        sampling_via_database(
             session=db_session,
             config=config,
             input_sample_ids=sample_ids,
         )
 
 
-def test_select_via_database_with_annotation_class_balancing_target_incomplete(
+def test_sampling_via_database_with_annotation_class_balancing_target_incomplete(
     db_session: Session, mocker: MockerFixture
 ) -> None:
-    """Runs selection with a simple annotation class balancing strategy."""
+    """Runs sampling with a simple annotation class balancing strategy."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=3, embedding_model_names=[]
     )
@@ -589,10 +589,10 @@ def test_select_via_database_with_annotation_class_balancing_target_incomplete(
         ],
     )
 
-    config = SelectionConfig(
+    config = SamplingConfig(
         n_samples_to_select=2,
         collection_id=collection_id,
-        selection_result_tag_name="selection-tag",
+        sampling_result_tag_name="sampling-tag",
         strategies=[
             AnnotationClassBalancingStrategy(
                 # This distribution gets translated to `cat: 0.5, dog+bird: 0.5`
@@ -604,14 +604,14 @@ def test_select_via_database_with_annotation_class_balancing_target_incomplete(
     )
 
     spy_mundig_run = mocker.spy(Mundig, "add_class_balancing")
-    select_via_database(
+    sampling_via_database(
         session=db_session,
         config=config,
         input_sample_ids=sample_ids,
     )
     tags = tag_resolver.get_all_by_collection_id(session=db_session, collection_id=collection_id)
     assert len(tags) == 1
-    assert tags[0].name == "selection-tag"
+    assert tags[0].name == "sampling-tag"
     samples_in_tag = image_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=collection_id,
@@ -632,10 +632,10 @@ def test_select_via_database_with_annotation_class_balancing_target_incomplete(
     assert call_args.kwargs["target"] == [0.5, 0.5]
 
 
-def test_select_via_database_with_annotation_class_balancing_target_over_1(
+def test_sampling_via_database_with_annotation_class_balancing_target_over_1(
     db_session: Session, mocker: MockerFixture
 ) -> None:
-    """Runs selection with a simple annotation class balancing strategy."""
+    """Runs sampling with a simple annotation class balancing strategy."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=3, embedding_model_names=[]
     )
@@ -665,10 +665,10 @@ def test_select_via_database_with_annotation_class_balancing_target_over_1(
         ],
     )
 
-    config = SelectionConfig(
+    config = SamplingConfig(
         n_samples_to_select=1,
         collection_id=collection_id,
-        selection_result_tag_name="selection-tag",
+        sampling_result_tag_name="sampling-tag",
         strategies=[
             AnnotationClassBalancingStrategy(
                 # This distribution gets translated to `cat: 1.5, other: 0.0`.
@@ -680,7 +680,7 @@ def test_select_via_database_with_annotation_class_balancing_target_over_1(
     )
 
     spy_mundig_run = mocker.spy(Mundig, "add_class_balancing")
-    select_via_database(
+    sampling_via_database(
         session=db_session,
         config=config,
         input_sample_ids=sample_ids,
@@ -693,7 +693,7 @@ def test_select_via_database_with_annotation_class_balancing_target_over_1(
     )
 
 
-def test_select_via_database_with_annotation_class_balancing_uniform(
+def test_sampling_via_database_with_annotation_class_balancing_uniform(
     db_session: Session,
 ) -> None:
     collection_id = fill_db_with_samples_and_embeddings(
@@ -742,14 +742,14 @@ def test_select_via_database_with_annotation_class_balancing_uniform(
         ],
     )
 
-    config = SelectionConfig(
+    config = SamplingConfig(
         n_samples_to_select=2,
         collection_id=collection_id,
-        selection_result_tag_name="selection-tag",
+        sampling_result_tag_name="sampling-tag",
         strategies=[AnnotationClassBalancingStrategy(target_distribution="uniform")],
     )
 
-    select_via_database(
+    sampling_via_database(
         session=db_session,
         config=config,
         input_sample_ids=sample_ids,
@@ -757,19 +757,19 @@ def test_select_via_database_with_annotation_class_balancing_uniform(
 
     tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
     assert len(tags) == 1
-    assert tags[0].name == "selection-tag"
+    assert tags[0].name == "sampling-tag"
     samples_in_tag = image_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=collection_id,
         filters=ImageFilter(sample_filter=SampleFilter(tag_ids=[tags[0].tag_id])),
     ).samples
 
-    selected_sample_ids = [sample.sample_id for sample in samples_in_tag]
+    sampled_sample_ids = [sample.sample_id for sample in samples_in_tag]
     # Pick the first and last samples, because they resemble the uniform distribution the best.
-    assert selected_sample_ids == [sample_ids[0], sample_ids[2]]
+    assert sampled_sample_ids == [sample_ids[0], sample_ids[2]]
 
 
-def test_select_via_database__annotation_class_balancing__annotation_source(
+def test_sampling_via_database__annotation_class_balancing__annotation_source(
     db_session: Session,
     mocker: MockerFixture,
 ) -> None:
@@ -822,10 +822,10 @@ def test_select_via_database__annotation_class_balancing__annotation_source(
 
     annotation_source_id = annotation_source_a_annotations[0].sample.collection_id
     add_class_balancing_spy = mocker.spy(Mundig, "add_class_balancing")
-    config = SelectionConfig(
+    config = SamplingConfig(
         n_samples_to_select=2,
         collection_id=collection_id,
-        selection_result_tag_name="selection-tag",
+        sampling_result_tag_name="sampling-tag",
         strategies=[
             AnnotationClassBalancingStrategy(
                 target_distribution="uniform",
@@ -834,7 +834,7 @@ def test_select_via_database__annotation_class_balancing__annotation_source(
         ],
     )
 
-    select_via_database(
+    sampling_via_database(
         session=db_session,
         config=config,
         input_sample_ids=sample_ids,
@@ -853,7 +853,7 @@ def test_select_via_database__annotation_class_balancing__annotation_source(
     assert target == pytest.approx([0.5, 0.5], abs=1e-9)
 
 
-def test_select_via_database__annotation_class_balancing__annotation_source_without_labels(
+def test_sampling_via_database__annotation_class_balancing__annotation_source_without_labels(
     db_session: Session,
 ) -> None:
     """Raises a controlled error when the annotation source has no labels for the inputs."""
@@ -883,10 +883,10 @@ def test_select_via_database__annotation_class_balancing__annotation_source_with
     )
     annotation_source_id = annotations[0].sample.collection_id
 
-    config = SelectionConfig(
+    config = SamplingConfig(
         n_samples_to_select=1,
         collection_id=collection_id,
-        selection_result_tag_name="selection-tag",
+        sampling_result_tag_name="sampling-tag",
         strategies=[
             AnnotationClassBalancingStrategy(
                 target_distribution="uniform",
@@ -899,20 +899,20 @@ def test_select_via_database__annotation_class_balancing__annotation_source_with
         ValueError,
         match=re.escape(
             "Annotation source with the given ID does not contain annotations "
-            "for the selected samples."
+            "for the sampled samples."
         ),
     ):
-        select_via_database(
+        sampling_via_database(
             session=db_session,
             config=config,
             input_sample_ids=[sample_ids[2]],
         )
 
 
-def test_select_via_database_with_annotation_class_balancing_input(
+def test_sampling_via_database_with_annotation_class_balancing_input(
     db_session: Session,
 ) -> None:
-    """Runs selection with a simple annotation class balancing strategy."""
+    """Runs sampling with a simple annotation class balancing strategy."""
     collection_id = fill_db_with_samples_and_embeddings(
         db_session, n_samples=3, embedding_model_names=[]
     )
@@ -955,14 +955,14 @@ def test_select_via_database_with_annotation_class_balancing_input(
         ],
     )
 
-    config = SelectionConfig(
+    config = SamplingConfig(
         n_samples_to_select=1,
         collection_id=collection_id,
-        selection_result_tag_name="selection-tag",
+        sampling_result_tag_name="sampling-tag",
         strategies=[AnnotationClassBalancingStrategy(target_distribution="input")],
     )
 
-    select_via_database(
+    sampling_via_database(
         session=db_session,
         config=config,
         input_sample_ids=sample_ids,
@@ -970,7 +970,7 @@ def test_select_via_database_with_annotation_class_balancing_input(
 
     tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
     assert len(tags) == 1
-    assert tags[0].name == "selection-tag"
+    assert tags[0].name == "sampling-tag"
     samples_in_tag = image_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=collection_id,

--- a/lightly_studio_view/e2e/general/samples-grid.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/samples-grid.e2e-test.ts
@@ -198,7 +198,7 @@ test('Typicality selection creates tag with correct number of samples', async ({
         (response) => response.url().includes('/metadata/typicality') && response.status() === 204
     );
     const selectionPromise = page.waitForResponse(
-        (response) => response.url().includes('/selection') && response.status() === 204
+        (response) => response.url().includes('/sampling') && response.status() === 204
     );
 
     // Create typicality selection.

--- a/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Selection/CreateSelectionDialog.svelte
@@ -10,7 +10,7 @@
     import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
     import { useCreateSelection } from '$lib/hooks/useCreateSelection';
-    import type { SelectionRequest } from '$lib/api/lightly_studio_local/types.gen';
+    import type { SamplingRequest } from '$lib/api/lightly_studio_local/types.gen';
     import { type BalancingMode } from '$lib/components/Selection/balancingMode';
     import StrategySelect from '$lib/components/Selection/StrategySelect/StrategySelect.svelte';
     import ClassBalancingForm from '$lib/components/Selection/ClassBalancingForm/ClassBalancingForm.svelte';
@@ -36,7 +36,7 @@
     const { filteredSampleCount } = useGlobalStorage();
 
     const currentFilter = $derived(isVideoCollection ? $videoFilter : $imageFilter);
-    const selectionFilter = $derived<SelectionRequest['filter']>(
+    const selectionFilter = $derived<SamplingRequest['filter']>(
         isVideoCollection
             ? currentFilter
                 ? {

--- a/lightly_studio_view/src/lib/hooks/useCreateSelection/useCreateSelection.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSelection/useCreateSelection.test.ts
@@ -64,7 +64,7 @@ describe('useCreateSelection', () => {
             path: { collection_id: 'col-1' },
             body: {
                 n_samples_to_select: 5,
-                selection_result_tag_name: 'my-tag',
+                sampling_result_tag_name: 'my-tag',
                 strategies: [{ strategy_name: 'diversity', embedding_model_name: null }],
                 filter: undefined
             }
@@ -108,7 +108,7 @@ describe('useCreateSelection', () => {
             path: { collection_id: 'col-1' },
             body: {
                 n_samples_to_select: 10,
-                selection_result_tag_name: 'result-tag',
+                sampling_result_tag_name: 'result-tag',
                 strategies: [{ strategy_name: 'weights', metadata_key: 'typicality' }],
                 filter: undefined
             }
@@ -149,7 +149,7 @@ describe('useCreateSelection', () => {
             path: { collection_id: 'col-1' },
             body: {
                 n_samples_to_select: 8,
-                selection_result_tag_name: 'sim-tag',
+                sampling_result_tag_name: 'sim-tag',
                 strategies: [{ strategy_name: 'weights', metadata_key: 'similarity' }],
                 filter: undefined
             }
@@ -391,7 +391,7 @@ describe('useCreateSelection', () => {
             path: { collection_id: 'col-1' },
             body: {
                 n_samples_to_select: 20,
-                selection_result_tag_name: 'balanced-tag',
+                sampling_result_tag_name: 'balanced-tag',
                 strategies: [{ strategy_name: 'balance', target_distribution: 'uniform' }],
                 filter: undefined
             }
@@ -429,7 +429,7 @@ describe('useCreateSelection', () => {
             path: { collection_id: 'col-1' },
             body: {
                 n_samples_to_select: 15,
-                selection_result_tag_name: 'balanced-tag',
+                sampling_result_tag_name: 'balanced-tag',
                 strategies: [{ strategy_name: 'balance', target_distribution: 'input' }],
                 filter: undefined
             }

--- a/lightly_studio_view/src/lib/hooks/useCreateSelection/useCreateSelection.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSelection/useCreateSelection.test.ts
@@ -1,5 +1,5 @@
 import {
-    createCombinationSelection,
+    createSampling,
     computeSimilarityMetadata,
     computeTypicalityMetadata
 } from '$lib/api/lightly_studio_local/sdk.gen';
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCreateSelection } from './useCreateSelection';
 
 vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
-    createCombinationSelection: vi.fn(),
+    createSampling: vi.fn(),
     computeSimilarityMetadata: vi.fn(),
     computeTypicalityMetadata: vi.fn()
 }));
@@ -27,8 +27,8 @@ describe('useCreateSelection', () => {
         vi.clearAllMocks();
     });
 
-    it('submit with diversity calls createCombinationSelection with correct args and resolves success', async () => {
-        vi.mocked(createCombinationSelection).mockResolvedValue({ data: {}, error: null } as never);
+    it('submit with diversity calls createSampling with correct args and resolves success', async () => {
+        vi.mocked(createSampling).mockResolvedValue({ data: {}, error: null } as never);
         const loadTags = vi.fn().mockResolvedValue(undefined);
         const setTagSelected = vi.fn();
         const closeSelectionDialog = vi.fn();
@@ -60,7 +60,7 @@ describe('useCreateSelection', () => {
         });
 
         expect(result).toBe(true);
-        expect(createCombinationSelection).toHaveBeenCalledWith({
+        expect(createSampling).toHaveBeenCalledWith({
             path: { collection_id: 'col-1' },
             body: {
                 n_samples_to_select: 5,
@@ -74,9 +74,9 @@ describe('useCreateSelection', () => {
         expect(closeSelectionDialog).toHaveBeenCalled();
     });
 
-    it('submit with typicality calls computeTypicalityMetadata first, then createCombinationSelection', async () => {
+    it('submit with typicality calls computeTypicalityMetadata first, then createSampling', async () => {
         vi.mocked(computeTypicalityMetadata).mockResolvedValue({ data: {}, error: null } as never);
-        vi.mocked(createCombinationSelection).mockResolvedValue({ data: {}, error: null } as never);
+        vi.mocked(createSampling).mockResolvedValue({ data: {}, error: null } as never);
         const loadTags = vi.fn().mockResolvedValue(undefined);
         const setTagSelected = vi.fn();
         const closeSelectionDialog = vi.fn();
@@ -104,7 +104,7 @@ describe('useCreateSelection', () => {
             path: { collection_id: 'col-1' },
             body: { embedding_model_name: null, metadata_name: 'typicality' }
         });
-        expect(createCombinationSelection).toHaveBeenCalledWith({
+        expect(createSampling).toHaveBeenCalledWith({
             path: { collection_id: 'col-1' },
             body: {
                 n_samples_to_select: 10,
@@ -115,9 +115,9 @@ describe('useCreateSelection', () => {
         });
     });
 
-    it('submit with similarity calls computeSimilarityMetadata first, then createCombinationSelection', async () => {
+    it('submit with similarity calls computeSimilarityMetadata first, then createSampling', async () => {
         vi.mocked(computeSimilarityMetadata).mockResolvedValue({ data: {}, error: null } as never);
-        vi.mocked(createCombinationSelection).mockResolvedValue({ data: {}, error: null } as never);
+        vi.mocked(createSampling).mockResolvedValue({ data: {}, error: null } as never);
         const loadTags = vi.fn().mockResolvedValue(undefined);
         const setTagSelected = vi.fn();
         const closeSelectionDialog = vi.fn();
@@ -145,7 +145,7 @@ describe('useCreateSelection', () => {
             path: { collection_id: 'col-1', query_tag_id: 'query-tag-id' },
             body: { embedding_model_name: null, metadata_name: 'similarity' }
         });
-        expect(createCombinationSelection).toHaveBeenCalledWith({
+        expect(createSampling).toHaveBeenCalledWith({
             path: { collection_id: 'col-1' },
             body: {
                 n_samples_to_select: 8,
@@ -184,7 +184,7 @@ describe('useCreateSelection', () => {
             'Similarity is only available for image collections.'
         );
         expect(computeSimilarityMetadata).not.toHaveBeenCalled();
-        expect(createCombinationSelection).not.toHaveBeenCalled();
+        expect(createSampling).not.toHaveBeenCalled();
     });
 
     it('API error in computeTypicalityMetadata toasts error and returns false without calling selection', async () => {
@@ -218,7 +218,7 @@ describe('useCreateSelection', () => {
         expect(toast.error).toHaveBeenCalledWith(
             'Failed to compute typicality metadata: typicality failed'
         );
-        expect(createCombinationSelection).not.toHaveBeenCalled();
+        expect(createSampling).not.toHaveBeenCalled();
     });
 
     it('API error in computeSimilarityMetadata toasts error and returns false without calling selection', async () => {
@@ -252,11 +252,11 @@ describe('useCreateSelection', () => {
         expect(toast.error).toHaveBeenCalledWith(
             'Failed to compute similarity metadata: similarity failed'
         );
-        expect(createCombinationSelection).not.toHaveBeenCalled();
+        expect(createSampling).not.toHaveBeenCalled();
     });
 
-    it('API error in createCombinationSelection toasts error and returns false', async () => {
-        vi.mocked(createCombinationSelection).mockResolvedValue({
+    it('API error in createSampling toasts error and returns false', async () => {
+        vi.mocked(createSampling).mockResolvedValue({
             data: null,
             error: { error: 'selection failed' }
         } as never);
@@ -301,7 +301,7 @@ describe('useCreateSelection', () => {
         });
 
         let submittingDuringCall = false;
-        vi.mocked(createCombinationSelection).mockImplementation(async () => {
+        vi.mocked(createSampling).mockImplementation(async () => {
             submittingDuringCall = get(hook.isSubmitting);
             return { data: {}, error: null } as never;
         });
@@ -341,7 +341,7 @@ describe('useCreateSelection', () => {
             messages.push(get(hook.loadingMessage));
             return { data: {}, error: null } as never;
         });
-        vi.mocked(createCombinationSelection).mockImplementation(async () => {
+        vi.mocked(createSampling).mockImplementation(async () => {
             messages.push(get(hook.loadingMessage));
             return { data: {}, error: null } as never;
         });
@@ -362,8 +362,8 @@ describe('useCreateSelection', () => {
         expect(get(hook.loadingMessage)).toBe('');
     });
 
-    it('submit with class_balancing and uniform mode calls createCombinationSelection with balance strategy', async () => {
-        vi.mocked(createCombinationSelection).mockResolvedValue({ data: {}, error: null } as never);
+    it('submit with class_balancing and uniform mode calls createSampling with balance strategy', async () => {
+        vi.mocked(createSampling).mockResolvedValue({ data: {}, error: null } as never);
         const loadTags = vi.fn().mockResolvedValue(undefined);
         const setTagSelected = vi.fn();
         const closeSelectionDialog = vi.fn();
@@ -387,7 +387,7 @@ describe('useCreateSelection', () => {
         });
 
         expect(result).toBe(true);
-        expect(createCombinationSelection).toHaveBeenCalledWith({
+        expect(createSampling).toHaveBeenCalledWith({
             path: { collection_id: 'col-1' },
             body: {
                 n_samples_to_select: 20,
@@ -401,7 +401,7 @@ describe('useCreateSelection', () => {
     });
 
     it('submit with class_balancing and input mode passes input as target_distribution', async () => {
-        vi.mocked(createCombinationSelection).mockResolvedValue({ data: {}, error: null } as never);
+        vi.mocked(createSampling).mockResolvedValue({ data: {}, error: null } as never);
         const loadTags = vi.fn().mockResolvedValue(undefined);
         const setTagSelected = vi.fn();
         const closeSelectionDialog = vi.fn();
@@ -425,7 +425,7 @@ describe('useCreateSelection', () => {
         });
 
         expect(result).toBe(true);
-        expect(createCombinationSelection).toHaveBeenCalledWith({
+        expect(createSampling).toHaveBeenCalledWith({
             path: { collection_id: 'col-1' },
             body: {
                 n_samples_to_select: 15,
@@ -436,8 +436,8 @@ describe('useCreateSelection', () => {
         });
     });
 
-    it('API error in createCombinationSelection for class_balancing toasts error and returns false', async () => {
-        vi.mocked(createCombinationSelection).mockResolvedValue({
+    it('API error in createSampling for class_balancing toasts error and returns false', async () => {
+        vi.mocked(createSampling).mockResolvedValue({
             data: null,
             error: { error: 'balance failed' }
         } as never);

--- a/lightly_studio_view/src/lib/hooks/useCreateSelection/useCreateSelection.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSelection/useCreateSelection.ts
@@ -6,7 +6,7 @@ import {
 import { get, readonly, writable, type Readable } from 'svelte/store';
 import { toast } from 'svelte-sonner';
 import type { TagView } from '$lib/services/types';
-import type { SelectionRequest } from '$lib/api/lightly_studio_local/types.gen';
+import type { SamplingRequest } from '$lib/api/lightly_studio_local/types.gen';
 import type { BalancingMode } from '$lib/components/Selection/balancingMode';
 
 type SelectionError = { error: string };
@@ -30,7 +30,7 @@ interface SubmitParams {
     selectionResultTagName: string;
     queryTagId: string;
     balancingMode: BalancingMode;
-    selectionFilter: SelectionRequest['filter'];
+    selectionFilter: SamplingRequest['filter'];
 }
 
 export function useCreateSelection(params: UseCreateSelectionParams) {
@@ -39,8 +39,8 @@ export function useCreateSelection(params: UseCreateSelectionParams) {
 
     async function performSelection(
         collectionId: string,
-        strategies: SelectionRequest['strategies'],
-        selectionFilter: SelectionRequest['filter'],
+        strategies: SamplingRequest['strategies'],
+        selectionFilter: SamplingRequest['filter'],
         n: number,
         tagName: string
     ): Promise<boolean> {
@@ -49,7 +49,7 @@ export function useCreateSelection(params: UseCreateSelectionParams) {
             path: { collection_id: collectionId },
             body: {
                 n_samples_to_select: n,
-                selection_result_tag_name: tagName,
+                sampling_result_tag_name: tagName,
                 strategies,
                 filter: selectionFilter ?? undefined
             }

--- a/lightly_studio_view/src/lib/hooks/useCreateSelection/useCreateSelection.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSelection/useCreateSelection.ts
@@ -1,5 +1,5 @@
 import {
-    createCombinationSelection,
+    createSampling,
     computeSimilarityMetadata,
     computeTypicalityMetadata
 } from '$lib/api/lightly_studio_local/sdk.gen';
@@ -45,7 +45,7 @@ export function useCreateSelection(params: UseCreateSelectionParams) {
         tagName: string
     ): Promise<boolean> {
         _loadingMessage.set('Creating selection...');
-        const response = await createCombinationSelection({
+        const response = await createSampling({
             path: { collection_id: collectionId },
             body: {
                 n_samples_to_select: n,


### PR DESCRIPTION
## What has changed and why?
We want to use "sampling" for the old mundig selection, and "selection" for things like selection images in the GUI or lasso selection.

## How has it been tested?
Existing tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized terminology from "selection" to "sampling" across the platform.
  * Updated Python API method: `DatasetQuery.selection()` → `DatasetQuery.sampling()`.
  * Result tag naming: `selection_result_tag_name` → `sampling_result_tag_name`.
  * Documentation and UI components updated with consistent "sampling" terminology throughout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->