### PR TITLE
Fix: links in docs are properly colored

### DIFF
--- a/lightly_studio/docs/docs/_static/custom.css
+++ b/lightly_studio/docs/docs/_static/custom.css
@@ -185,6 +185,10 @@ code.doc-symbol-module {
   color: #13a6e6;
 }
 
+.md-content .md-typeset a code {
+  color: inherit;
+}
+
 .md-content .md-typeset > p a:hover,
 .md-content .md-typeset > ul a:hover,
 .md-content .md-typeset > ol a:hover,


### PR DESCRIPTION
## What has changed and why?

- a simple css rule to make sure links are always colored properly to indicate that they are clickable

before
<img width="1217" height="870" alt="image" src="https://github.com/user-attachments/assets/9b1141ea-2f05-4dba-add3-a8b1b96ce9b4" />


after
<img width="1242" height="900" alt="image" src="https://github.com/user-attachments/assets/da7a40dd-cd67-4a0e-8521-61f8644546f3" />



## How has it been tested?

N/A
## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved visual consistency in documentation by enhancing the appearance of code snippets within links, ensuring they now display with proper link styling for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->