### PR TITLE
Add annotation source support to class balancing UI

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte
@@ -1,16 +1,32 @@
 <script lang="ts">
     import * as Select from '$lib/components/ui/select';
 
+    type SourceOption = {
+        id: string;
+        name: string;
+    };
+
     interface Props {
-        /** Names of the annotation sources (collections) to choose from. */
-        sourceNames: string[];
+        /** Annotation sources (collections) to choose from. */
+        sourceOptions?: SourceOption[];
+        /** Backward-compatible list of source names where the value is also the display label. */
+        sourceNames?: string[];
         /** Currently selected source name. */
         selectedSource?: string;
         /** Optional notification when the selection changes (the value also flows out via `bind:selectedSource`). */
         onSelect?: (source: string) => void;
     }
 
-    let { sourceNames, selectedSource = $bindable(), onSelect }: Props = $props();
+    let { sourceOptions, sourceNames, selectedSource = $bindable(), onSelect }: Props = $props();
+
+    const options = $derived(
+        sourceOptions ??
+            sourceNames?.map((name) => ({
+                id: name,
+                name
+            })) ??
+            []
+    );
 </script>
 
 <Select.Root
@@ -22,14 +38,14 @@
     }}
 >
     <Select.Trigger class="w-full" data-testid="annotation-source-trigger">
-        {selectedSource ?? 'Select a source...'}
+        {options.find((source) => source.id === selectedSource)?.name ?? 'Select a source...'}
     </Select.Trigger>
     <Select.Content>
-        {#each sourceNames as name (name)}
+        {#each options as source (source.id)}
             <Select.Item
-                value={name}
-                label={name}
-                data-testid={`annotation-source-option-${name}`}
+                value={source.id}
+                label={source.name}
+                data-testid={`annotation-source-option-${source.name}`}
             />
         {/each}
     </Select.Content>

--- a/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.test.ts
@@ -8,7 +8,10 @@ describe('AnnotationSourceSelect', () => {
     });
 
     const defaultProps = {
-        sourceNames: ['ground_truth', 'predictions'],
+        sourceOptions: [
+            { id: 'ground-truth-id', name: 'ground_truth' },
+            { id: 'predictions-id', name: 'predictions' }
+        ],
         onSelect: vi.fn()
     };
 
@@ -22,7 +25,7 @@ describe('AnnotationSourceSelect', () => {
 
     it('shows the currently selected source', () => {
         render(AnnotationSourceSelect, {
-            props: { ...defaultProps, selectedSource: 'predictions' }
+            props: { ...defaultProps, selectedSource: 'predictions-id' }
         });
 
         expect(screen.getByTestId('annotation-source-trigger')).toHaveTextContent('predictions');
@@ -37,6 +40,6 @@ describe('AnnotationSourceSelect', () => {
             await screen.findByTestId('annotation-source-option-predictions')
         );
 
-        expect(onSelect).toHaveBeenCalledWith('predictions');
+        expect(onSelect).toHaveBeenCalledWith('predictions-id');
     });
 });

--- a/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/BalancingModeSelect.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/BalancingModeSelect.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+    import { Label } from '$lib/components/ui/label';
+    import * as Select from '$lib/components/ui/select';
+    import {
+        BALANCING_MODE_LABELS,
+        type BalancingMode
+    } from '$lib/components/Sampling/balancingMode';
+
+    interface Props {
+        balancingMode: BalancingMode;
+        onBalancingModeChange: (mode: BalancingMode) => void;
+    }
+
+    let { balancingMode, onBalancingModeChange }: Props = $props();
+</script>
+
+<div class="grid grid-cols-4 items-center gap-4">
+    <Label for="balancing-mode" class="text-right text-foreground">Balancing Mode</Label>
+    <Select.Root
+        type="single"
+        name="balancing-mode"
+        value={balancingMode}
+        onValueChange={(value) => onBalancingModeChange(value as BalancingMode)}
+    >
+        <Select.Trigger
+            id="balancing-mode"
+            class="col-span-3"
+            data-testid="sampling-dialog-balancing-mode-select"
+        >
+            {BALANCING_MODE_LABELS[balancingMode]}
+        </Select.Trigger>
+        <Select.Content>
+            <Select.Group>
+                <Select.Item
+                    value="uniform"
+                    label="Uniform"
+                    data-testid="sampling-balancing-mode-uniform"
+                >
+                    Uniform
+                </Select.Item>
+                <Select.Item value="dictionary" label="Dictionary" disabled>
+                    Dictionary (Coming soon)
+                </Select.Item>
+                <Select.Item
+                    value="input"
+                    label="Input"
+                    data-testid="sampling-balancing-mode-input"
+                    disabled
+                >
+                    Input (Coming soon)
+                </Select.Item>
+            </Select.Group>
+        </Select.Content>
+    </Select.Root>
+</div>

--- a/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.svelte
@@ -20,13 +20,18 @@
         onAnnotationSourceChange
     }: Props = $props();
 
-    const sourceNames = $derived(annotationCollections.map((collection) => collection.name));
+    const sourceOptions = $derived(
+        annotationCollections.map((collection) => ({
+            id: collection.collection_id,
+            name: collection.name
+        }))
+    );
 </script>
 
 <BalancingModeSelect {balancingMode} {onBalancingModeChange} />
 
 <AnnotationSourceSelect
-    {sourceNames}
+    {sourceOptions}
     selectedSource={annotationSourceId}
     onSelect={onAnnotationSourceChange}
 />

--- a/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { Label } from '$lib/components/ui/label';
     import * as Select from '$lib/components/ui/select';
+    import type { AnnotationCollectionView } from '$lib/api/lightly_studio_local/types.gen';
     import {
         BALANCING_MODE_LABELS,
         type BalancingMode
@@ -8,10 +9,26 @@
 
     interface Props {
         balancingMode: BalancingMode;
+        annotationCollections: AnnotationCollectionView[];
+        annotationSourceId: string;
         onBalancingModeChange: (mode: BalancingMode) => void;
+        onAnnotationSourceChange: (annotationSourceId: string) => void;
     }
 
-    let { balancingMode, onBalancingModeChange }: Props = $props();
+    let {
+        balancingMode,
+        annotationCollections,
+        annotationSourceId,
+        onBalancingModeChange,
+        onAnnotationSourceChange
+    }: Props = $props();
+
+    const selectedAnnotationSourceName = $derived(
+        annotationSourceId === ''
+            ? 'All annotation sources'
+            : (annotationCollections.find((source) => source.collection_id === annotationSourceId)
+                  ?.name ?? 'Select annotation source')
+    );
 </script>
 
 <div class="grid grid-cols-4 items-center gap-4">
@@ -45,6 +62,47 @@
                     data-testid="sampling-balancing-mode-input"
                     disabled>Input (Coming soon)</Select.Item
                 >
+            </Select.Group>
+        </Select.Content>
+    </Select.Root>
+</div>
+
+<div class="grid grid-cols-4 items-center gap-4">
+    <Label for="annotation-source" class="text-right text-foreground">Annotation Source</Label>
+    <Select.Root
+        type="single"
+        name="annotation-source"
+        value={annotationSourceId}
+        allowDeselect
+        onValueChange={onAnnotationSourceChange}
+    >
+        <Select.Trigger
+            id="annotation-source"
+            class="col-span-3"
+            data-testid="sampling-dialog-annotation-source-select"
+        >
+            {selectedAnnotationSourceName}
+        </Select.Trigger>
+        <Select.Content>
+            <Select.Group>
+                {#if annotationCollections.length === 0}
+                    <div
+                        class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
+                        data-testid="sampling-dialog-no-annotation-sources"
+                    >
+                        No annotation sources available.
+                    </div>
+                {:else}
+                    {#each annotationCollections as source (source.collection_id)}
+                        <Select.Item
+                            value={source.collection_id}
+                            label={source.name}
+                            data-testid={`sampling-annotation-source-${source.collection_id}`}
+                        >
+                            {source.name}
+                        </Select.Item>
+                    {/each}
+                {/if}
             </Select.Group>
         </Select.Content>
     </Select.Root>

--- a/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-    import { Label } from '$lib/components/ui/label';
-    import * as Select from '$lib/components/ui/select';
     import type { AnnotationCollectionView } from '$lib/api/lightly_studio_local/types.gen';
-    import {
-        BALANCING_MODE_LABELS,
-        type BalancingMode
-    } from '$lib/components/Sampling/balancingMode';
+    import { type BalancingMode } from '$lib/components/Sampling/balancingMode';
+    import AnnotationSourceSelect from '$lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte';
+    import BalancingModeSelect from './BalancingModeSelect.svelte';
 
     interface Props {
         balancingMode: BalancingMode;
@@ -23,87 +20,13 @@
         onAnnotationSourceChange
     }: Props = $props();
 
-    const selectedAnnotationSourceName = $derived(
-        annotationSourceId === ''
-            ? 'All annotation sources'
-            : (annotationCollections.find((source) => source.collection_id === annotationSourceId)
-                  ?.name ?? 'Select annotation source')
-    );
+    const sourceNames = $derived(annotationCollections.map((collection) => collection.name));
 </script>
 
-<div class="grid grid-cols-4 items-center gap-4">
-    <Label for="balancing-mode" class="text-right text-foreground">Balancing Mode</Label>
-    <Select.Root
-        type="single"
-        name="balancing-mode"
-        value={balancingMode}
-        onValueChange={(v) => onBalancingModeChange(v as BalancingMode)}
-    >
-        <Select.Trigger
-            id="balancing-mode"
-            class="col-span-3"
-            data-testid="sampling-dialog-balancing-mode-select"
-        >
-            {BALANCING_MODE_LABELS[balancingMode]}
-        </Select.Trigger>
-        <Select.Content>
-            <Select.Group>
-                <Select.Item
-                    value="uniform"
-                    label="Uniform"
-                    data-testid="sampling-balancing-mode-uniform">Uniform</Select.Item
-                >
-                <Select.Item value="dictionary" label="Dictionary" disabled
-                    >Dictionary (Coming soon)</Select.Item
-                >
-                <Select.Item
-                    value="input"
-                    label="Input"
-                    data-testid="sampling-balancing-mode-input"
-                    disabled>Input (Coming soon)</Select.Item
-                >
-            </Select.Group>
-        </Select.Content>
-    </Select.Root>
-</div>
+<BalancingModeSelect {balancingMode} {onBalancingModeChange} />
 
-<div class="grid grid-cols-4 items-center gap-4">
-    <Label for="annotation-source" class="text-right text-foreground">Annotation Source</Label>
-    <Select.Root
-        type="single"
-        name="annotation-source"
-        value={annotationSourceId}
-        allowDeselect
-        onValueChange={onAnnotationSourceChange}
-    >
-        <Select.Trigger
-            id="annotation-source"
-            class="col-span-3"
-            data-testid="sampling-dialog-annotation-source-select"
-        >
-            {selectedAnnotationSourceName}
-        </Select.Trigger>
-        <Select.Content>
-            <Select.Group>
-                {#if annotationCollections.length === 0}
-                    <div
-                        class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
-                        data-testid="sampling-dialog-no-annotation-sources"
-                    >
-                        No annotation sources available.
-                    </div>
-                {:else}
-                    {#each annotationCollections as source (source.collection_id)}
-                        <Select.Item
-                            value={source.collection_id}
-                            label={source.name}
-                            data-testid={`sampling-annotation-source-${source.collection_id}`}
-                        >
-                            {source.name}
-                        </Select.Item>
-                    {/each}
-                {/if}
-            </Select.Group>
-        </Select.Content>
-    </Select.Root>
-</div>
+<AnnotationSourceSelect
+    {sourceNames}
+    selectedSource={annotationSourceId}
+    onSelect={onAnnotationSourceChange}
+/>

--- a/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.test.ts
@@ -9,7 +9,13 @@ describe('ClassBalancingForm', () => {
 
     it('shows the current balancing mode label', () => {
         render(ClassBalancingForm, {
-            props: { balancingMode: 'uniform', onBalancingModeChange: vi.fn() }
+            props: {
+                balancingMode: 'uniform',
+                annotationCollections: [],
+                annotationSourceId: '',
+                onBalancingModeChange: vi.fn(),
+                onAnnotationSourceChange: vi.fn()
+            }
         });
 
         expect(screen.getByTestId('sampling-dialog-balancing-mode-select')).toHaveTextContent(
@@ -19,7 +25,13 @@ describe('ClassBalancingForm', () => {
 
     it('shows the uniform option in the dropdown', async () => {
         render(ClassBalancingForm, {
-            props: { balancingMode: 'uniform', onBalancingModeChange: vi.fn() }
+            props: {
+                balancingMode: 'uniform',
+                annotationCollections: [],
+                annotationSourceId: '',
+                onBalancingModeChange: vi.fn(),
+                onAnnotationSourceChange: vi.fn()
+            }
         });
 
         await fireEvent.keyDown(screen.getByTestId('sampling-dialog-balancing-mode-select'), {
@@ -31,7 +43,13 @@ describe('ClassBalancingForm', () => {
 
     it('shows input balancing mode as disabled and coming soon', async () => {
         render(ClassBalancingForm, {
-            props: { balancingMode: 'uniform', onBalancingModeChange: vi.fn() }
+            props: {
+                balancingMode: 'uniform',
+                annotationCollections: [],
+                annotationSourceId: '',
+                onBalancingModeChange: vi.fn(),
+                onAnnotationSourceChange: vi.fn()
+            }
         });
 
         await fireEvent.keyDown(screen.getByTestId('sampling-dialog-balancing-mode-select'), {

--- a/lightly_studio_view/src/lib/components/Sampling/CreateSampling.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/CreateSampling.test.ts
@@ -10,6 +10,11 @@ type MockTag = {
     kind: 'sample';
 };
 
+type MockAnnotationCollection = {
+    collection_id: string;
+    name: string;
+};
+
 const pageMock = vi.hoisted(() => ({
     params: { collection_id: 'test-collection-id' },
     data: { collection: { sample_type: 'image' as string } }
@@ -20,6 +25,7 @@ vi.mock('$app/state', () => ({
 }));
 
 let tagsStore: Writable<MockTag[]>;
+let annotationCollectionsData: MockAnnotationCollection[];
 const loadTagsMock = vi.fn();
 const setTagSelectedMock = vi.fn();
 
@@ -28,6 +34,12 @@ vi.mock('$lib/hooks/useTags/useTags', () => ({
         tags: tagsStore,
         loadTags: loadTagsMock,
         setTagSelected: setTagSelectedMock
+    })
+}));
+
+vi.mock('$lib/hooks/useAnnotationCollections/useAnnotationCollections', () => ({
+    useAnnotationCollections: () => ({
+        data: annotationCollectionsData
     })
 }));
 
@@ -86,6 +98,10 @@ describe('CreateSamplingDialog', () => {
         tagsStore = writable([
             { tag_id: 'tag-1', name: 'Query Tag', description: null, kind: 'sample' as const }
         ]);
+        annotationCollectionsData = [
+            { collection_id: 'annotation-source-1', name: 'Source 1' },
+            { collection_id: 'annotation-source-2', name: 'Source 2' }
+        ];
         submitMock.mockResolvedValue(undefined);
     });
 
@@ -335,6 +351,39 @@ describe('CreateSamplingDialog', () => {
                 expect.objectContaining({
                     samplingStrategy: 'class_balancing',
                     balancingMode: 'uniform'
+                })
+            );
+        });
+    });
+
+    it('passes the selected annotation source to class balancing sampling', async () => {
+        filteredSampleCountStore.set(100);
+
+        render(CreateSamplingDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('sampling-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('sampling-strategy-class-balancing'));
+
+        await fireEvent.keyDown(screen.getByTestId('sampling-dialog-annotation-source-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(
+            await screen.findByTestId('sampling-annotation-source-annotation-source-2')
+        );
+
+        await fireEvent.input(screen.getByTestId('sampling-dialog-tag-name-input'), {
+            target: { value: 'source-filtered-tag' }
+        });
+        await fireEvent.click(screen.getByTestId('sampling-dialog-submit'));
+
+        await waitFor(() => {
+            expect(submitMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    samplingStrategy: 'class_balancing',
+                    balancingMode: 'uniform',
+                    annotationSourceId: 'annotation-source-2'
                 })
             );
         });

--- a/lightly_studio_view/src/lib/components/Sampling/CreateSampling.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/CreateSampling.test.ts
@@ -366,12 +366,10 @@ describe('CreateSamplingDialog', () => {
         });
         await fireEvent.pointerUp(await screen.findByTestId('sampling-strategy-class-balancing'));
 
-        await fireEvent.keyDown(screen.getByTestId('sampling-dialog-annotation-source-select'), {
+        await fireEvent.keyDown(screen.getByTestId('annotation-source-trigger'), {
             key: 'Enter'
         });
-        await fireEvent.pointerUp(
-            await screen.findByTestId('sampling-annotation-source-annotation-source-2')
-        );
+        await fireEvent.pointerUp(await screen.findByTestId('annotation-source-option-Source 2'));
 
         await fireEvent.input(screen.getByTestId('sampling-dialog-tag-name-input'), {
             target: { value: 'source-filtered-tag' }

--- a/lightly_studio_view/src/lib/components/Sampling/CreateSamplingDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/CreateSamplingDialog.svelte
@@ -4,6 +4,7 @@
     import * as Dialog from '$lib/components/ui/dialog';
     import { Input } from '$lib/components/ui/input';
     import { Label } from '$lib/components/ui/label';
+    import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
     import { useTags } from '$lib/hooks/useTags/useTags';
     import { useSamplingDialog } from '$lib/hooks/useSamplingDialog/useSamplingDialog';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
@@ -24,6 +25,7 @@
     );
 
     const { isSamplingDialogOpen, openSamplingDialog, closeSamplingDialog } = useSamplingDialog();
+    const annotationCollectionsQuery = $derived(useAnnotationCollections({ collectionId }));
 
     const isVideoCollection = $derived(
         page.data.collection?.sample_type === 'video' ||
@@ -35,6 +37,7 @@
     const { filteredSampleCount } = useGlobalStorage();
 
     const currentFilter = $derived(isVideoCollection ? $videoFilter : $imageFilter);
+    const annotationCollections = $derived(annotationCollectionsQuery.data ?? []);
     const samplingFilter = $derived<SamplingRequest['filter']>(
         isVideoCollection
             ? currentFilter
@@ -58,6 +61,7 @@
     let balancingMode = $state<BalancingMode>('uniform');
     let nSamplesToSelect = $state<number>(10);
     let queryTagId = $state('');
+    let annotationSourceId = $state('');
     let samplingResultTagName = $state<string>('');
 
     // Form validation
@@ -109,6 +113,7 @@
             samplingResultTagName,
             queryTagId,
             balancingMode,
+            annotationSourceId,
             samplingFilter
         });
 
@@ -119,6 +124,7 @@
         samplingStrategy = '';
         nSamplesToSelect = 10;
         queryTagId = '';
+        annotationSourceId = '';
         samplingResultTagName = '';
     }
 </script>
@@ -151,7 +157,10 @@
                     {#if samplingStrategy === 'class_balancing'}
                         <ClassBalancingForm
                             {balancingMode}
+                            {annotationCollections}
+                            {annotationSourceId}
                             onBalancingModeChange={(mode) => (balancingMode = mode)}
+                            onAnnotationSourceChange={(sourceId) => (annotationSourceId = sourceId)}
                         />
                     {/if}
 

--- a/lightly_studio_view/src/lib/hooks/useCreateSampling/useCreateSampling.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSampling/useCreateSampling.test.ts
@@ -400,6 +400,49 @@ describe('useCreateSampling', () => {
         expect(computeSimilarityMetadata).not.toHaveBeenCalled();
     });
 
+    it('submit with class_balancing includes annotation source when provided', async () => {
+        vi.mocked(createSampling).mockResolvedValue({ data: {}, error: null } as never);
+        const loadTags = vi.fn().mockResolvedValue(undefined);
+        const setTagSelected = vi.fn();
+        const closeSamplingDialog = vi.fn();
+        const tagsStore = writable([]);
+
+        const { submit } = useCreateSampling({
+            tags: tagsStore,
+            setTagSelected,
+            loadTags,
+            closeSamplingDialog
+        });
+        const result = await submit({
+            collectionId: 'col-1',
+            isSimilaritySupported: true,
+            samplingStrategy: 'class_balancing',
+            nSamplesToSelect: 20,
+            samplingResultTagName: 'balanced-tag',
+            queryTagId: '',
+            balancingMode: 'uniform',
+            annotationSourceId: 'annotation-source-2',
+            samplingFilter: null
+        });
+
+        expect(result).toBe(true);
+        expect(createSampling).toHaveBeenCalledWith({
+            path: { collection_id: 'col-1' },
+            body: {
+                n_samples_to_select: 20,
+                sampling_result_tag_name: 'balanced-tag',
+                strategies: [
+                    {
+                        strategy_name: 'balance',
+                        target_distribution: 'uniform',
+                        annotation_source_id: 'annotation-source-2'
+                    }
+                ],
+                filter: undefined
+            }
+        });
+    });
+
     it('submit with class_balancing and input mode passes input as target_distribution', async () => {
         vi.mocked(createSampling).mockResolvedValue({ data: {}, error: null } as never);
         const loadTags = vi.fn().mockResolvedValue(undefined);

--- a/lightly_studio_view/src/lib/hooks/useCreateSampling/useCreateSampling.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSampling/useCreateSampling.ts
@@ -30,6 +30,7 @@ interface SubmitParams {
     samplingResultTagName: string;
     queryTagId: string;
     balancingMode: BalancingMode;
+    annotationSourceId?: string;
     samplingFilter: SamplingRequest['filter'];
 }
 
@@ -78,6 +79,7 @@ export function useCreateSampling(params: UseCreateSamplingParams) {
             samplingResultTagName,
             queryTagId,
             balancingMode,
+            annotationSourceId,
             samplingFilter
         } = submitParams;
         _isSubmitting.set(true);
@@ -86,7 +88,13 @@ export function useCreateSampling(params: UseCreateSamplingParams) {
             if (samplingStrategy === 'class_balancing') {
                 return await performSampling(
                     collectionId,
-                    [{ strategy_name: 'balance', target_distribution: balancingMode }],
+                    [
+                        {
+                            strategy_name: 'balance',
+                            target_distribution: balancingMode,
+                            annotation_source_id: annotationSourceId || undefined
+                        }
+                    ],
                     samplingFilter,
                     nSamplesToSelect,
                     samplingResultTagName


### PR DESCRIPTION
## What has changed and why?
Class balancing needs a annotation source and there can be multiple. Let the user choose.

## How has it been tested?
Manually and unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added annotation source selection to the class-balancing sampling UI; chosen source is included when submitting a sampling job.
  * Introduced a dedicated balancing-mode selector that displays the current mode and available options.

* **Bug Fixes / Improvements**
  * Clarified balancing-mode UI with disabled "Coming soon" options for unavailable modes; improved form reset after submission.

* **Tests**
  * Updated and added tests to cover annotation source selection and verify it’s sent with class-balancing submissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->