### PR TITLE
bug: select all does not respect active annotation source

### DIFF
--- a/lightly_studio_view/e2e/general/select-all.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/select-all.e2e-test.ts
@@ -45,3 +45,50 @@ test('select all images with label filter via keyboard shortcut', async ({ page,
     // All samples should be selected (use selection pill since not all items are rendered)
     await expect(page.getByText(`${cocoDataset.totalSamples} selected`)).toBeVisible();
 });
+
+test('select all images respects annotation source filter', async ({ page, samplesPage }) => {
+    await expect(samplesPage.getSamples().first()).toBeVisible();
+
+    const sourceCheckboxes = page
+        .getByText('Annotation Sources', { exact: true })
+        .locator('xpath=ancestor::button/following-sibling::*[1]//button[@role="checkbox"]');
+
+    await expect(sourceCheckboxes.first()).toBeVisible({ timeout: 10000 });
+    test.skip(
+        (await sourceCheckboxes.count()) < 2,
+        'requires at least two annotation sources in the E2E dataset'
+    );
+
+    const listResponsePromise = page.waitForResponse(
+        (response) =>
+            response.url().includes('/images/list') &&
+            response.request().method() === 'POST' &&
+            response.status() === 200,
+        { timeout: 10000 }
+    );
+
+    await sourceCheckboxes.first().click();
+    const listResponse = await listResponsePromise;
+    const listRequestBody = listResponse.request().postDataJSON();
+    const expectedCollectionIds =
+        listRequestBody.filters?.sample_filter?.annotations_filter?.collection_ids;
+
+    expect(expectedCollectionIds?.length).toBeGreaterThan(0);
+
+    await page.click('body');
+    const sampleIdsResponsePromise = page.waitForResponse(
+        (response) =>
+            response.url().includes('/images/sample_ids') &&
+            response.request().method() === 'POST' &&
+            response.status() === 200,
+        { timeout: 10000 }
+    );
+    await page.keyboard.press('Control+a');
+    const sampleIdsResponse = await sampleIdsResponsePromise;
+    const sampleIdsRequestBody = sampleIdsResponse.request().postDataJSON();
+
+    expect(sampleIdsRequestBody.filters?.sample_filter?.annotations_filter?.collection_ids).toEqual(
+        expectedCollectionIds
+    );
+    await expect(page.getByText(/\d+ selected/)).toBeVisible();
+});

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -1,14 +1,10 @@
 import { derived, get, writable } from 'svelte/store';
 import { createMetadataFilters } from '../useMetadataFilters/useMetadataFilters';
 import type { ImagesInfiniteParams } from '../useImagesInfinite/useImagesInfinite';
+import { getAnnotationsFilter } from '../useImagesInfinite/getAnnotationsFilter';
 import type { DimensionBounds } from '$lib/services/loadDimensionBounds';
 import { SortDirection } from '$lib/api/lightly_studio_local';
-import type {
-    AnnotationsFilter,
-    ImageFilter,
-    QueryExpr,
-    SampleFilter
-} from '$lib/api/lightly_studio_local';
+import type { ImageFilter, QueryExpr, SampleFilter } from '$lib/api/lightly_studio_local';
 import type { SortExpr } from '../useImagesInfinite/types';
 
 const filterParams = writable<ImagesInfiniteParams>({} as ImagesInfiniteParams);
@@ -65,12 +61,12 @@ const imageFilter = derived(filterParams, ($filterParams): ImageFilter | null =>
         sampleFilter.sample_ids = sampleIds;
     }
 
-    const annotationLabelIds = $filterParams.filters?.annotation_label_ids;
-    if (annotationLabelIds && annotationLabelIds.length > 0) {
-        sampleFilter.annotations_filter = {
-            filter_type: 'annotations',
-            annotation_label_ids: annotationLabelIds
-        } satisfies AnnotationsFilter;
+    const annotationsFilter = getAnnotationsFilter({
+        annotation_label_ids: $filterParams.filters?.annotation_label_ids,
+        collection_ids: $filterParams.filters?.collection_ids
+    });
+    if (annotationsFilter) {
+        sampleFilter.annotations_filter = annotationsFilter;
     }
 
     const tagIds = $filterParams.filters?.tag_ids;


### PR DESCRIPTION
## What has changed and why?

- this PR fixes the issue that annotation source was not considered when using the select all features

## How has it been tested?

- manual test and new e2e test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Select all (Cmd/Ctrl+A) operation now respects active annotation source filters for correct image selection behavior

* **Tests**
  * Added test coverage for select all functionality when annotation source filters are applied

* **Refactor**
  * Improved annotation filter construction to properly handle collection-based filtering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->