### PR TITLE
Add input class balancing option

### DIFF
--- a/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/BalancingModeSelect.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/BalancingModeSelect.svelte
@@ -45,9 +45,8 @@
                     value="input"
                     label="Input"
                     data-testid="sampling-balancing-mode-input"
-                    disabled
                 >
-                    Input (Coming soon)
+                    Input
                 </Select.Item>
             </Select.Group>
         </Select.Content>

--- a/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.svelte
@@ -30,8 +30,13 @@
 
 <BalancingModeSelect {balancingMode} {onBalancingModeChange} />
 
-<AnnotationSourceSelect
-    {sourceOptions}
-    selectedSource={annotationSourceId}
-    onSelect={onAnnotationSourceChange}
-/>
+<div class="grid grid-cols-4 items-center gap-4">
+    <span class="text-right text-foreground">Annotation Source</span>
+    <div class="col-span-3">
+        <AnnotationSourceSelect
+            {sourceOptions}
+            selectedSource={annotationSourceId}
+            onSelect={onAnnotationSourceChange}
+        />
+    </div>
+</div>

--- a/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.test.ts
@@ -41,13 +41,14 @@ describe('ClassBalancingForm', () => {
         expect(await screen.findByTestId('sampling-balancing-mode-uniform')).toBeInTheDocument();
     });
 
-    it('shows input balancing mode as disabled and coming soon', async () => {
+    it('shows input balancing mode as enabled', async () => {
+        const onBalancingModeChange = vi.fn();
         render(ClassBalancingForm, {
             props: {
                 balancingMode: 'uniform',
                 annotationCollections: [],
                 annotationSourceId: '',
-                onBalancingModeChange: vi.fn(),
+                onBalancingModeChange,
                 onAnnotationSourceChange: vi.fn()
             }
         });
@@ -57,7 +58,11 @@ describe('ClassBalancingForm', () => {
         });
 
         const inputOption = await screen.findByTestId('sampling-balancing-mode-input');
-        expect(inputOption).toHaveAttribute('data-disabled');
-        expect(inputOption).toHaveTextContent('Input (Coming soon)');
+        expect(inputOption).not.toHaveAttribute('data-disabled');
+        expect(inputOption).toHaveTextContent('Input');
+
+        await fireEvent.pointerUp(inputOption);
+
+        expect(onBalancingModeChange).toHaveBeenCalledWith('input');
     });
 });

--- a/lightly_studio_view/src/lib/components/Sampling/CreateSampling.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/CreateSampling.test.ts
@@ -387,7 +387,7 @@ describe('CreateSamplingDialog', () => {
         });
     });
 
-    it('shows input balancing mode as disabled and coming soon', async () => {
+    it('shows input balancing mode as enabled', async () => {
         filteredSampleCountStore.set(100);
 
         render(CreateSamplingDialog);
@@ -401,8 +401,8 @@ describe('CreateSamplingDialog', () => {
             key: 'Enter'
         });
         const inputMode = await screen.findByTestId('sampling-balancing-mode-input');
-        expect(inputMode).toHaveAttribute('data-disabled');
-        expect(inputMode).toHaveTextContent('Input (Coming soon)');
+        expect(inputMode).not.toHaveAttribute('data-disabled');
+        expect(inputMode).toHaveTextContent('Input');
     });
 
     it('disables similarity for video collections', async () => {
@@ -458,6 +458,44 @@ describe('CreateSamplingDialog', () => {
         });
         expect(screen.getByTestId('sampling-dialog-strategy-select')).toHaveTextContent(
             'Select strategy'
+        );
+    });
+
+    it('resets the balancing mode to uniform after a successful submission in class-balancing', async () => {
+        submitMock.mockResolvedValue(true);
+        filteredSampleCountStore.set(100);
+
+        render(CreateSamplingDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('sampling-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('sampling-strategy-class-balancing'));
+
+        await fireEvent.keyDown(screen.getByTestId('sampling-dialog-balancing-mode-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('sampling-balancing-mode-input'));
+
+        await fireEvent.input(screen.getByTestId('sampling-dialog-tag-name-input'), {
+            target: { value: 'my-tag' }
+        });
+        await fireEvent.click(screen.getByTestId('sampling-dialog-submit'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('sampling-dialog-tag-name-input')).toHaveValue('');
+        });
+        expect(screen.getByTestId('sampling-dialog-strategy-select')).toHaveTextContent(
+            'Select strategy'
+        );
+
+        // Re-open and select class balancing again to verify it is reset to Uniform
+        await fireEvent.keyDown(screen.getByTestId('sampling-dialog-strategy-select'), {
+            key: 'Enter'
+        });
+        await fireEvent.pointerUp(await screen.findByTestId('sampling-strategy-class-balancing'));
+        expect(screen.getByTestId('sampling-dialog-balancing-mode-select')).toHaveTextContent(
+            'Uniform'
         );
     });
 

--- a/lightly_studio_view/src/lib/components/Sampling/CreateSamplingDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/CreateSamplingDialog.svelte
@@ -122,6 +122,7 @@
 
     function resetForm() {
         samplingStrategy = '';
+        balancingMode = 'uniform';
         nSamplesToSelect = 10;
         queryTagId = '';
         annotationSourceId = '';


### PR DESCRIPTION
## What has changed and why?
Input is one of two class balancing options that are missing.

## How has it been tested?
Manually and unit test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The class-balancing **Input** option in the sampling dialog is now enabled and selectable.
* **Bug Fixes**
  * After submitting sampling, the form now resets more completely; if class balancing is selected again, the balancing mode defaults back to **Uniform**.
* **Style**
  * Improved the class-balancing form layout by presenting **Annotation Source** with a clearer labeled arrangement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->