### PR TITLE
Query from GUI e2e test - happy path

### DIFF
--- a/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
@@ -3,21 +3,13 @@ import { cocoDataset } from './fixtures';
 
 const QUERY = 'segmentation_mask(class_name = "airplane")';
 
-test.describe('query editor — happy path', () => {
-    test('open query editor and verify apply button is enabled', async ({ imagesPage, page }) => {
-        await imagesPage.goto();
-
+test.describe('query editor', () => {
+    test('apply query and verify filtered grid', async ({ samplesPage, page }) => {
         await page.getByTestId('query-filter-add-button').click();
         await expect(page.getByRole('heading', { name: 'Query Filter' })).toBeVisible();
 
-        // On first open: draftValue = default template ≠ lastAppliedValue = null → canApply = true
+        // On first open: The apply button should be enabled.
         await expect(page.getByTestId('query-editor-apply-button')).toBeEnabled();
-    });
-
-    test('apply query and verify filtered grid', async ({ imagesPage, page }) => {
-        await imagesPage.goto();
-        await page.getByTestId('query-filter-add-button').click();
-        await expect(page.getByRole('heading', { name: 'Query Filter' })).toBeVisible();
 
         // Type the query into Monaco
         // Click the editor content area to focus Monaco, then select-all and type
@@ -28,15 +20,14 @@ test.describe('query editor — happy path', () => {
         // Click Apply and wait for the filtered image list response
         const applyButton = page.getByTestId('query-editor-apply-button');
         const refetchPromise = page.waitForResponse(
-            (r) => r.url().includes('/images/list') && r.status() === 200,
-            { timeout: 15_000 }
+            (r) => r.url().includes('/images/list') && r.status() === 200
         );
         await applyButton.click();
         await refetchPromise;
 
         // Verify the grid shows only airplane samples
-        await imagesPage.getSamples().first().waitFor({ state: 'attached', timeout: 10_000 });
-        const sampleCount = await imagesPage.getSamples().count();
+        await samplesPage.getSamples().first().waitFor({ state: 'attached' });
+        const sampleCount = await samplesPage.getSamples().count();
         expect(sampleCount).toBe(cocoDataset.labels.airplane.sampleCount);
 
         // Apply button should be disabled (draft matches applied value)

--- a/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
@@ -14,7 +14,7 @@ test.describe('query editor', () => {
         // Type the query into Monaco
         // Click the editor content area to focus Monaco, then select-all and type
         await page.locator('.monaco-editor .view-lines').first().click();
-        await page.keyboard.press('Meta+a');
+        await page.keyboard.press('ControlOrMeta+a');
         await page.keyboard.type(QUERY);
 
         // Click Apply and wait for the filtered image list response
@@ -26,9 +26,7 @@ test.describe('query editor', () => {
         await refetchPromise;
 
         // Verify the grid shows only airplane samples
-        await samplesPage.getSamples().first().waitFor({ state: 'attached' });
-        const sampleCount = await samplesPage.getSamples().count();
-        expect(sampleCount).toBe(cocoDataset.labels.airplane.sampleCount);
+        await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.labels.airplane.sampleCount);
 
         // Apply button should be disabled (draft matches applied value)
         await expect(applyButton).toBeDisabled();

--- a/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '../utils';
+import { cocoDataset } from './fixtures';
+
+const QUERY = 'segmentation_mask(class_name = "airplane")';
+
+test.describe('query editor — happy path', () => {
+    test('open query editor and verify apply button is enabled', async ({ imagesPage, page }) => {
+        await imagesPage.goto();
+
+        await page.getByTestId('query-filter-add-button').click();
+        await expect(page.getByRole('heading', { name: 'Query Filter' })).toBeVisible();
+
+        // On first open: draftValue = default template ≠ lastAppliedValue = null → canApply = true
+        await expect(page.getByTestId('query-editor-apply-button')).toBeEnabled();
+    });
+
+    test('apply query and verify filtered grid', async ({ imagesPage, page }) => {
+        await imagesPage.goto();
+        await page.getByTestId('query-filter-add-button').click();
+        await expect(page.getByRole('heading', { name: 'Query Filter' })).toBeVisible();
+
+        // Type the query into Monaco
+        // Click the editor content area to focus Monaco, then select-all and type
+        await page.locator('.monaco-editor .view-lines').first().click();
+        await page.keyboard.press('Meta+a');
+        await page.keyboard.type(QUERY);
+
+        // Click Apply and wait for the filtered image list response
+        const applyButton = page.getByTestId('query-editor-apply-button');
+        const refetchPromise = page.waitForResponse(
+            (r) => r.url().includes('/images/list') && r.status() === 200,
+            { timeout: 15_000 }
+        );
+        await applyButton.click();
+        await refetchPromise;
+
+        // Verify the grid shows only airplane samples
+        await imagesPage.getSamples().first().waitFor({ state: 'attached', timeout: 10_000 });
+        const sampleCount = await imagesPage.getSamples().count();
+        expect(sampleCount).toBe(cocoDataset.labels.airplane.sampleCount);
+
+        // Apply button should be disabled (draft matches applied value)
+        await expect(applyButton).toBeDisabled();
+
+        // Filter chip should be visible
+        await expect(page.getByTestId('query-filter-chip')).toBeVisible();
+    });
+});

--- a/lightly_studio_view/e2e/utils.ts
+++ b/lightly_studio_view/e2e/utils.ts
@@ -50,12 +50,6 @@ type Pages = {
     videosPage: VideosPage;
     videoFramesPage: VideoFramesPage;
     videoFrameDetailsPage: VideoFrameDetailsPage;
-    /**
-     * Like samplesPage but does NOT auto-navigate.
-     * Use this when tests need to share in-page state (e.g. Svelte stores)
-     * across multiple test functions via a single goto() call.
-     */
-    imagesPage: SamplesPage;
 };
 
 export const test = base.extend<Pages>({
@@ -126,10 +120,6 @@ export const test = base.extend<Pages>({
     videoFrameDetailsPage: async ({ page }, use) => {
         const videoFrameDetailsPage = new VideoFrameDetailsPage(page);
         await use(videoFrameDetailsPage);
-    },
-
-    imagesPage: async ({ page }, use) => {
-        await use(new SamplesPage(page));
     }
 });
 

--- a/lightly_studio_view/e2e/utils.ts
+++ b/lightly_studio_view/e2e/utils.ts
@@ -50,6 +50,12 @@ type Pages = {
     videosPage: VideosPage;
     videoFramesPage: VideoFramesPage;
     videoFrameDetailsPage: VideoFrameDetailsPage;
+    /**
+     * Like samplesPage but does NOT auto-navigate.
+     * Use this when tests need to share in-page state (e.g. Svelte stores)
+     * across multiple test functions via a single goto() call.
+     */
+    imagesPage: SamplesPage;
 };
 
 export const test = base.extend<Pages>({
@@ -120,6 +126,10 @@ export const test = base.extend<Pages>({
     videoFrameDetailsPage: async ({ page }, use) => {
         const videoFrameDetailsPage = new VideoFrameDetailsPage(page);
         await use(videoFrameDetailsPage);
+    },
+
+    imagesPage: async ({ page }, use) => {
+        await use(new SamplesPage(page));
     }
 });
 

--- a/lightly_studio_view/src/lib/components/QueryControl/QueryControl.svelte
+++ b/lightly_studio_view/src/lib/components/QueryControl/QueryControl.svelte
@@ -26,6 +26,7 @@
 <Segment title="Query">
     {#if lastQueryExpression}
         <FilterChip
+            testId="query-filter-chip"
             checked={!!$imageQueryExpression?.query_expr_str}
             title="Query Filter"
             checkboxLabel={$imageQueryExpression?.query_expr_str
@@ -58,6 +59,7 @@
             variant="outline"
             size="sm"
             class="w-full justify-start gap-2 text-muted-foreground"
+            data-testid="query-filter-add-button"
             onclick={onOpen}
         >
             <Pencil class="h-3.5 w-3.5" />

--- a/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
@@ -84,8 +84,11 @@ AND object_detection(class_name = "person" AND x > 10)
         <div
             class="flex items-center justify-end gap-2 border-b border-[#3c3c3c] bg-[#252526] px-4 py-2"
         >
-            <Button type="button" disabled={readOnly || !canApply} onclick={handleSave}
-                >Apply</Button
+            <Button
+                type="button"
+                disabled={readOnly || !canApply}
+                data-testid="query-editor-apply-button"
+                onclick={handleSave}>Apply</Button
             >
         </div>
     {/if}


### PR DESCRIPTION
## What has changed and why?

Add a query from GUI e2e test for the happy path.

Opens the query editor, types in `segmentation_mask(class_name = "airplane")`, applies, and verifies the expected grid sample count.

Note: A follow-up PR will test also non-happy path.

## How has it been tested?

Ran the test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added comprehensive end-to-end test for the query editor, verifying query filter application and result validation
* Enhanced test infrastructure with improved test identifiers to support automated testing across query control components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->