### PR TITLE
Query editor e2e tests

### DIFF
--- a/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
@@ -51,8 +51,11 @@ test.describe('query filter chip toggle', () => {
         await page.getByRole('checkbox', { name: 'Disable query filter' }).click();
         await disableRefetch;
 
-        // Grid should show the default unfiltered page
-        await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.defaultPageSize);
+        // Grid should show at least one full page of unfiltered results.
+        // (Infinite scroll may load additional pages, so we check ≥ rather than ===.)
+        await expect
+            .poll(() => samplesPage.getSamples().count())
+            .toBeGreaterThanOrEqual(cocoDataset.defaultPageSize);
 
         // Re-check to re-enable the query
         const enableRefetch = page.waitForResponse(
@@ -75,7 +78,8 @@ test.describe('query filter chip toggle', () => {
         // Click the chip body to reopen the editor
         await page
             .getByTestId('query-filter-chip')
-            .getByRole('button', { name: 'Query Filter' })
+            .locator('button:not([role="checkbox"])')
+            .first()
             .click();
         await expect(page.getByRole('heading', { name: 'Query Filter' })).toBeVisible();
 
@@ -104,8 +108,10 @@ test.describe('query filter chip toggle', () => {
         // "Add query filter" button should reappear
         await expect(page.getByTestId('query-filter-add-button')).toBeVisible();
 
-        // Grid should show the default unfiltered page
-        await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.defaultPageSize);
+        // Grid should show at least one full page of unfiltered results
+        await expect
+            .poll(() => samplesPage.getSamples().count())
+            .toBeGreaterThanOrEqual(cocoDataset.defaultPageSize);
     });
 });
 

--- a/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
@@ -3,6 +3,19 @@ import { cocoDataset } from './fixtures';
 
 const QUERY = 'segmentation_mask(class_name = "airplane")';
 
+/** Select-all in Monaco, type a query, click Apply, and wait for the grid to update. */
+async function typeAndApply(page: import('@playwright/test').Page, query: string): Promise<void> {
+    await page.locator('.monaco-editor .view-lines').first().click();
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.type(query);
+
+    const refetchPromise = page.waitForResponse(
+        (r) => r.url().includes('/images/list') && r.status() === 200
+    );
+    await page.getByTestId('query-editor-apply-button').click();
+    await refetchPromise;
+}
+
 test.describe('query editor', () => {
     test('apply query and verify filtered grid', async ({ samplesPage, page }) => {
         await page.getByTestId('query-filter-add-button').click();
@@ -11,27 +24,111 @@ test.describe('query editor', () => {
         // On first open: The apply button should be enabled.
         await expect(page.getByTestId('query-editor-apply-button')).toBeEnabled();
 
-        // Type the query into Monaco
-        // Click the editor content area to focus Monaco, then select-all and type
-        await page.locator('.monaco-editor .view-lines').first().click();
-        await page.keyboard.press('ControlOrMeta+a');
-        await page.keyboard.type(QUERY);
-
-        // Click Apply and wait for the filtered image list response
-        const applyButton = page.getByTestId('query-editor-apply-button');
-        const refetchPromise = page.waitForResponse(
-            (r) => r.url().includes('/images/list') && r.status() === 200
-        );
-        await applyButton.click();
-        await refetchPromise;
+        await typeAndApply(page, QUERY);
 
         // Verify the grid shows only airplane samples
         await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.labels.airplane.sampleCount);
 
         // Apply button should be disabled (draft matches applied value)
-        await expect(applyButton).toBeDisabled();
+        await expect(page.getByTestId('query-editor-apply-button')).toBeDisabled();
 
         // Filter chip should be visible
         await expect(page.getByTestId('query-filter-chip')).toBeVisible();
+    });
+});
+
+test.describe('query filter chip toggle', () => {
+    test('toggling filter chip disables and re-enables query', async ({ samplesPage, page }) => {
+        await page.getByTestId('query-filter-add-button').click();
+        await typeAndApply(page, QUERY);
+        await expect(page.getByTestId('query-filter-chip')).toBeVisible();
+        await page.getByTestId('query-editor-close-button').click();
+
+        // Uncheck the filter chip checkbox to disable the query
+        const disableRefetch = page.waitForResponse(
+            (r) => r.url().includes('/images/list') && r.status() === 200
+        );
+        await page.getByRole('checkbox', { name: 'Disable query filter' }).click();
+        await disableRefetch;
+
+        // Grid should show the default unfiltered page
+        await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.defaultPageSize);
+
+        // Re-check to re-enable the query
+        const enableRefetch = page.waitForResponse(
+            (r) => r.url().includes('/images/list') && r.status() === 200
+        );
+        await page.getByRole('checkbox', { name: 'Enable query filter' }).click();
+        await enableRefetch;
+
+        await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.labels.airplane.sampleCount);
+    });
+
+    test('reopening editor loads existing query with Apply disabled', async ({
+        samplesPage,
+        page
+    }) => {
+        await page.getByTestId('query-filter-add-button').click();
+        await typeAndApply(page, QUERY);
+        await page.getByTestId('query-editor-close-button').click();
+
+        // Click the chip body to reopen the editor
+        await page
+            .getByTestId('query-filter-chip')
+            .getByRole('button', { name: 'Query Filter' })
+            .click();
+        await expect(page.getByRole('heading', { name: 'Query Filter' })).toBeVisible();
+
+        // Editor should contain the previously applied query
+        await expect(page.locator('.monaco-editor .view-lines')).toContainText(QUERY);
+
+        // Apply should be disabled since draft === lastAppliedValue
+        await expect(page.getByTestId('query-editor-apply-button')).toBeDisabled();
+
+        // Grid should still show filtered results
+        await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.labels.airplane.sampleCount);
+    });
+
+    test('clearing filter removes chip and restores grid', async ({ samplesPage, page }) => {
+        await page.getByTestId('query-filter-add-button').click();
+        await typeAndApply(page, QUERY);
+        await page.getByTestId('query-editor-close-button').click();
+
+        // Click the X button to clear the filter
+        const refetchPromise = page.waitForResponse(
+            (r) => r.url().includes('/images/list') && r.status() === 200
+        );
+        await page.getByRole('button', { name: 'Clear query filter' }).click();
+        await refetchPromise;
+
+        // "Add query filter" button should reappear
+        await expect(page.getByTestId('query-filter-add-button')).toBeVisible();
+
+        // Grid should show the default unfiltered page
+        await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.defaultPageSize);
+    });
+});
+
+test.describe('query editor error handling', () => {
+    test('syntax error shows toast and Apply stays enabled', async ({ samplesPage, page }) => {
+        await page.getByTestId('query-filter-add-button').click();
+        await typeAndApply(page, QUERY);
+
+        // Now type an invalid query over the existing one
+        await page.locator('.monaco-editor .view-lines').first().click();
+        await page.keyboard.press('ControlOrMeta+a');
+        await page.keyboard.type('width <');
+
+        const applyButton = page.getByTestId('query-editor-apply-button');
+        await applyButton.click();
+
+        // Error toast should appear
+        await expect(page.getByText('Failed to translate query')).toBeVisible();
+
+        // Apply button should remain enabled (draft still differs from last applied)
+        await expect(applyButton).toBeEnabled();
+
+        // Grid should still show the previously filtered results
+        await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.labels.airplane.sampleCount);
     });
 });

--- a/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
@@ -1,17 +1,20 @@
+import type { Page } from '@playwright/test';
 import { test, expect } from '../utils';
 import { cocoDataset } from './fixtures';
 
 const QUERY = 'segmentation_mask(class_name = "airplane")';
 
+function waitForImageListResponse(page: Page) {
+    return page.waitForResponse((r) => r.url().includes('/images/list') && r.status() === 200);
+}
+
 /** Select-all in Monaco, type a query, click Apply, and wait for the grid to update. */
-async function typeAndApply(page: import('@playwright/test').Page, query: string): Promise<void> {
+async function typeAndApply(page: Page, query: string): Promise<void> {
     await page.locator('.monaco-editor .view-lines').first().click();
     await page.keyboard.press('ControlOrMeta+a');
     await page.keyboard.type(query);
 
-    const refetchPromise = page.waitForResponse(
-        (r) => r.url().includes('/images/list') && r.status() === 200
-    );
+    const refetchPromise = waitForImageListResponse(page);
     await page.getByTestId('query-editor-apply-button').click();
     await refetchPromise;
 }
@@ -35,9 +38,7 @@ test.describe('query editor', () => {
         // Filter chip should be visible
         await expect(page.getByTestId('query-filter-chip')).toBeVisible();
     });
-});
 
-test.describe('query filter chip toggle', () => {
     test('toggling filter chip disables and re-enables query', async ({ samplesPage, page }) => {
         await page.getByTestId('query-filter-add-button').click();
         await typeAndApply(page, QUERY);
@@ -45,9 +46,7 @@ test.describe('query filter chip toggle', () => {
         await page.getByTestId('query-editor-close-button').click();
 
         // Uncheck the filter chip checkbox to disable the query
-        const disableRefetch = page.waitForResponse(
-            (r) => r.url().includes('/images/list') && r.status() === 200
-        );
+        const disableRefetch = waitForImageListResponse(page);
         await page.getByRole('checkbox', { name: 'Disable query filter' }).click();
         await disableRefetch;
 
@@ -58,9 +57,7 @@ test.describe('query filter chip toggle', () => {
             .toBeGreaterThanOrEqual(cocoDataset.defaultPageSize);
 
         // Re-check to re-enable the query
-        const enableRefetch = page.waitForResponse(
-            (r) => r.url().includes('/images/list') && r.status() === 200
-        );
+        const enableRefetch = waitForImageListResponse(page);
         await page.getByRole('checkbox', { name: 'Enable query filter' }).click();
         await enableRefetch;
 
@@ -76,11 +73,7 @@ test.describe('query filter chip toggle', () => {
         await page.getByTestId('query-editor-close-button').click();
 
         // Click the chip body to reopen the editor
-        await page
-            .getByTestId('query-filter-chip')
-            .locator('button:not([role="checkbox"])')
-            .first()
-            .click();
+        await page.getByTestId('query-filter-chip-body').click();
         await expect(page.getByRole('heading', { name: 'Query Filter' })).toBeVisible();
 
         // Editor should contain the previously applied query
@@ -99,9 +92,7 @@ test.describe('query filter chip toggle', () => {
         await page.getByTestId('query-editor-close-button').click();
 
         // Click the X button to clear the filter
-        const refetchPromise = page.waitForResponse(
-            (r) => r.url().includes('/images/list') && r.status() === 200
-        );
+        const refetchPromise = waitForImageListResponse(page);
         await page.getByRole('button', { name: 'Clear query filter' }).click();
         await refetchPromise;
 
@@ -113,9 +104,7 @@ test.describe('query filter chip toggle', () => {
             .poll(() => samplesPage.getSamples().count())
             .toBeGreaterThanOrEqual(cocoDataset.defaultPageSize);
     });
-});
 
-test.describe('query editor error handling', () => {
     test('syntax error shows toast and Apply stays enabled', async ({ samplesPage, page }) => {
         await page.getByTestId('query-filter-add-button').click();
         await typeAndApply(page, QUERY);

--- a/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
@@ -1,10 +1,10 @@
-import type { Page } from '@playwright/test';
+import type { Page, Response } from '@playwright/test';
 import { test, expect } from '../utils';
 import { cocoDataset } from './fixtures';
 
 const QUERY = 'segmentation_mask(class_name = "airplane")';
 
-function waitForImageListResponse(page: Page) {
+function waitForImageListResponse(page: Page): Promise<Response> {
     return page.waitForResponse((r) => r.url().includes('/images/list') && r.status() === 200);
 }
 

--- a/lightly_studio_view/src/lib/components/FilterChip/FilterChip.svelte
+++ b/lightly_studio_view/src/lib/components/FilterChip/FilterChip.svelte
@@ -30,7 +30,12 @@
     <div class="flex items-center gap-2">
         <Checkbox {checked} aria-label={checkboxLabel} {onCheckedChange} />
         {#if onclick}
-            <button type="button" class="min-w-0 flex-1 cursor-pointer text-left" {onclick}>
+            <button
+                type="button"
+                class="min-w-0 flex-1 cursor-pointer text-left"
+                data-testid={testId ? `${testId}-body` : undefined}
+                {onclick}
+            >
                 <div class="truncate text-sm font-medium">{title}</div>
                 {#if subtitle}{@render subtitle()}{/if}
             </button>


### PR DESCRIPTION
## What has changed and why?

Add e2e tests for the query editor feature covering other than the happy path:
- Filter chip interaction
- Syntax error handling

## How has it been tested?

`npx playwright test e2e/general/query-editor.e2e-test.ts` — all 5 tests pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored query editor test suite with centralized helper utilities to improve consistency and reliability of test assertions, patterns, and UI state verification.
  * Enhanced component testability through improved test identifiers for better test coverage and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->