### PR TITLE
show collection name in annotations entries for header menu 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Header menu: show collection name in Annotations entries
+
 ### Deprecated
 
 ### Removed

--- a/lightly_studio_view/src/lib/components/NavigationMenu/utils.test.ts
+++ b/lightly_studio_view/src/lib/components/NavigationMenu/utils.test.ts
@@ -5,7 +5,8 @@ import { SampleType, type CollectionView } from '$lib/api/lightly_studio_local';
 const makeCollection = (
     id: string,
     sampleType: SampleType = SampleType.IMAGE,
-    children?: CollectionView[]
+    children?: CollectionView[],
+    overrides?: Partial<CollectionView>
 ): CollectionView => ({
     collection_id: id,
     dataset_id: 'test-dataset-id',
@@ -13,7 +14,8 @@ const makeCollection = (
     sample_type: sampleType,
     created_at: new Date(),
     updated_at: new Date(),
-    children
+    children,
+    ...overrides
 });
 
 describe('getMenuItem', () => {
@@ -39,6 +41,17 @@ describe('getMenuItem', () => {
             'Group Component Name'
         );
         expect(item.title).toBe('Group Component Name');
+    });
+
+    it('prefixes annotation title with "Annotations:" when groupComponentName is provided', () => {
+        const item = getMenuItem(
+            'dataset-id',
+            undefined,
+            'col-id',
+            SampleType.ANNOTATION,
+            'ground_truth'
+        );
+        expect(item.title).toBe('Annotations: ground_truth');
     });
 
     it('sets isSelected when collectionId matches currentCollectionId', () => {
@@ -140,5 +153,72 @@ describe('buildBreadcrumbLevels', () => {
         expect(sib1.isSelected).toBe(true);
         expect(sib2.id).toBe('image-img-2');
         expect(sib2.isSelected).toBe(false);
+    });
+
+    it('uses annotation name when root has multiple annotation collections', () => {
+        const ann1 = makeCollection('ann-1', SampleType.ANNOTATION, undefined, {
+            name: 'ground_truth',
+            group_component_name: 'gc-1'
+        });
+        const ann2 = makeCollection('ann-2', SampleType.ANNOTATION, undefined, {
+            name: 'predictions',
+            group_component_name: 'gc-2'
+        });
+        const root = makeCollection('root', SampleType.IMAGE, [ann1, ann2]);
+
+        const levels = buildBreadcrumbLevels([root, ann1], root, 'ann-1', 'dataset-id');
+
+        expect(levels[1].selected.title).toBe('Annotations: ground_truth');
+        expect(levels[1].siblings.map((s) => s.title)).toEqual([
+            'Annotations: ground_truth',
+            'Annotations: predictions'
+        ]);
+    });
+
+    it('uses group_component_name when root has a single annotation collection', () => {
+        const ann = makeCollection('ann-1', SampleType.ANNOTATION, undefined, {
+            name: 'ground_truth',
+            group_component_name: 'gc-1'
+        });
+        const root = makeCollection('root', SampleType.IMAGE, [ann]);
+
+        const levels = buildBreadcrumbLevels([root, ann], root, 'ann-1', 'dataset-id');
+
+        expect(levels[1].selected.title).toBe('Annotations: gc-1');
+    });
+
+    it('falls back to default "Annotations" title when single annotation has no group_component_name', () => {
+        const ann = makeCollection('ann-1', SampleType.ANNOTATION, undefined, {
+            name: 'ground_truth'
+        });
+        const root = makeCollection('root', SampleType.IMAGE, [ann]);
+
+        const levels = buildBreadcrumbLevels([root, ann], root, 'ann-1', 'dataset-id');
+
+        expect(levels[1].selected.title).toBe('Annotations');
+    });
+
+    it('keeps group_component_name for non-annotation siblings when multiple annotations exist', () => {
+        const img = makeCollection('img-1', SampleType.IMAGE, undefined, {
+            name: 'img-name',
+            group_component_name: 'Pictures'
+        });
+        const ann1 = makeCollection('ann-1', SampleType.ANNOTATION, undefined, {
+            name: 'ground_truth',
+            group_component_name: 'gc-1'
+        });
+        const ann2 = makeCollection('ann-2', SampleType.ANNOTATION, undefined, {
+            name: 'predictions',
+            group_component_name: 'gc-2'
+        });
+        const root = makeCollection('root', SampleType.GROUP, [img, ann1, ann2]);
+
+        const levels = buildBreadcrumbLevels([root, img], root, 'img-1', 'dataset-id');
+
+        expect(levels[1].siblings.map((s) => s.title)).toEqual([
+            'Pictures',
+            'Annotations: ground_truth',
+            'Annotations: predictions'
+        ]);
     });
 });

--- a/lightly_studio_view/src/lib/components/NavigationMenu/utils.ts
+++ b/lightly_studio_view/src/lib/components/NavigationMenu/utils.ts
@@ -129,6 +129,7 @@ export function buildBreadcrumbLevels(
             currentCollectionId,
             c.collection_id,
             c.sample_type,
+            // For annotation collections, show the collection name to distinguish them if there are several; otherwise, use the group component name or a generic title.
             c.sample_type === SampleType.ANNOTATION && hasSeveralAnnotationCollections
                 ? c.name
                 : c.group_component_name

--- a/lightly_studio_view/src/lib/components/NavigationMenu/utils.ts
+++ b/lightly_studio_view/src/lib/components/NavigationMenu/utils.ts
@@ -42,7 +42,7 @@ export function getMenuItem(
             };
         case SampleType.ANNOTATION:
             return {
-                title: groupComponentName || 'Annotations',
+                title: groupComponentName ? `Annotations: ${groupComponentName}` : 'Annotations',
                 id: elementId,
                 icon: ComponentIcon,
                 href: routeHelpers.toAnnotations(datasetId, collectionType, collectionId),
@@ -120,13 +120,18 @@ export function buildBreadcrumbLevels(
 ): BreadcrumbLevel[] {
     if (!ancestorPath) return [];
 
+    const hasSeveralAnnotationCollections = rootCollection.children
+        ? rootCollection.children.filter((c) => c.sample_type === SampleType.ANNOTATION).length > 1
+        : false;
     const toMenuItem = (c: CollectionView): NavigationMenuItem =>
         getMenuItem(
             datasetId,
             currentCollectionId,
             c.collection_id,
             c.sample_type,
-            c.group_component_name
+            c.sample_type === SampleType.ANNOTATION && hasSeveralAnnotationCollections
+                ? c.name
+                : c.group_component_name
         );
 
     return ancestorPath.map((node, index) => {


### PR DESCRIPTION
## What has changed and why?

This PR introduces showing collection name if we have more than 1 annotation collection. 
It is required to distinct between annotation collections.

## How has it been tested?

Added unit test + tested manually

1. Run the app with several annotation collections  `make -C lightly_studio start-e2e-evaluations`
2. Check the Header
<img width="1116" height="577" alt="Screenshot 2026-05-29 at 12 01 51" src="https://github.com/user-attachments/assets/cab832ae-9930-47b2-8e3e-021d6c340c79" />



## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined annotation labels in header menu and breadcrumbs: when multiple annotation collections exist, entries show the collection name; otherwise they use the provided group name; if missing, they fall back to the plain "Annotations" label.

* **Tests**
  * Expanded coverage for annotation menu and breadcrumb title behaviors.

* **Chores**
  * Updated changelog to note header menu label change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->