### PR TITLE
Ingest color_categories list column in embedding plot (PR 2/2, frontend)

### DIFF
--- a/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
@@ -17,6 +17,7 @@ describe('getCategoryBySelection', () => {
         y: new Float32Array([5.0, 6.0, 7.0, 8.0]),
         fulfils_filter: new Uint8Array([1, 1, 0, 1]),
         color_category: new Uint8Array([1, 1, 0, 1]),
+        color_categories: [[1], [1], [0], [1]],
         sample_id: ['sample1', 'sample2', 'sample3', 'sample4']
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.test.ts
@@ -18,6 +18,7 @@ describe('useArrowData', () => {
             y: [4, 5, 6],
             fulfils_filter: [true, false, true],
             color_category: [1, 2, 0],
+            color_categories: [[1], [2], [0]],
             sample_id: ['a', 'b', 'c']
         };
 
@@ -136,6 +137,7 @@ describe('useArrowData', () => {
             y: [],
             fulfils_filter: [],
             color_category: [],
+            color_categories: [],
             sample_id: []
         });
         expect(get(colorLegend)).toEqual(new Map());
@@ -149,6 +151,7 @@ describe('useArrowData', () => {
             y: [4, 5, 6],
             fulfils_filter: [true, false, true],
             color_category: [1, 2, 0],
+            color_categories: [[1], [2], [0]],
             sample_id: ['a', 'b', 'c']
         };
         const mockTable = {

--- a/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.ts
@@ -1,7 +1,17 @@
 import { tableFromIPC } from 'apache-arrow';
 import { writable, type Writable } from 'svelte/store';
 
-const dataColumns = ['x', 'y', 'fulfils_filter', 'color_category', 'sample_id'] as const;
+// `color_categories` carries every category a sample belongs to (in priority
+// order); `color_category` is the scalar primary still used for rendering. The
+// list column is ingested here for now; resolving it at render time is upcoming.
+const dataColumns = [
+    'x',
+    'y',
+    'fulfils_filter',
+    'color_category',
+    'color_categories',
+    'sample_id'
+] as const;
 type TableColumn = (typeof dataColumns)[number];
 
 export type ArrowData = Record<TableColumn, unknown>;

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -25,6 +25,7 @@ describe('usePlotData', () => {
         y: new Float32Array([5.0, 6.0, 7.0, 8.0]),
         fulfils_filter: new Uint8Array([1, 1, 0, 1]),
         color_category: new Uint8Array([1, 2, 0, 3]),
+        color_categories: [[1], [2], [0], [3]],
         sample_id: ['sample1', 'sample2', 'sample3', 'sample4']
     });
 


### PR DESCRIPTION
## What has changed and why?

Follow-up to PR 1/2 (backend). Reads the new `color_categories` Arrow list column into `ArrowData` so every per-sample category is available on the frontend.

Rendering still uses the scalar `color_category`; resolving the visible category from the list (legend toggling falling back to a secondary category, distinct markers for multi-category samples) is a follow-up.

Caveats:
- Stacked on PR 1/2 — merge that first, as the new column is a required read and will error if the backend isn't yet sending it.
- No visible behavior change yet; this only wires the data through.

## How has it been tested?

- `make static-checks` and PlotPanel `vitest` suites in `lightly_studio_view`.
- Test mocks updated to include the new column.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)