### PR TITLE
LIG-9590: color picker for annotation collections bugfix and enable

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
@@ -27,6 +27,8 @@
         annotation_label_name: string;
         segmentation_mask?: number[] | null;
         object_detection_details?: BoundingBox;
+        /** Optional hex color that overrides label-based color computation. */
+        collectionColor?: string;
     };
 
     type ObjectDetectionAnnotation = {
@@ -34,6 +36,8 @@
         annotation_label_name: string;
         object_detection_details: BoundingBox;
         segmentation_mask?: undefined;
+        /** Optional hex color that overrides label-based color computation. */
+        collectionColor?: string;
     };
 
     type AnnotationCanvasAnnotation = InstanceAnnotation | ObjectDetectionAnnotation;
@@ -104,11 +108,23 @@
 
     const clampAlpha = (value: number): number => Math.max(0, Math.min(value, 1));
 
+    const hexToRgba = (hex: string, colorAlpha: number): [number, number, number, number] => {
+        const r = parseInt(hex.slice(1, 3), 16);
+        const g = parseInt(hex.slice(3, 5), 16);
+        const b = parseInt(hex.slice(5, 7), 16);
+        return [r, g, b, Math.round(clampAlpha(colorAlpha) * 255)];
+    };
+
     const resolveLabelColor = (
         labelName: string,
         colorAlpha: number,
-        customLabelColors: CustomLabelColorMap
+        customLabelColors: CustomLabelColorMap,
+        collectionColor?: string
     ): [number, number, number, number] => {
+        if (collectionColor?.startsWith('#')) {
+            return hexToRgba(collectionColor, colorAlpha);
+        }
+
         const customColor = customLabelColors[labelName];
         if (!customColor) {
             return rgbaParser(getColorByLabel(labelName, colorAlpha).color);
@@ -141,12 +157,13 @@
 
         for (const annotation of annotations) {
             const labelName = annotation.annotation_label_name || 'label';
+            const collectionColor = annotation.collectionColor;
 
             const rle = toCloneableRLE(annotation.segmentation_mask);
             if (rle.length) {
                 masks.push({
                     rle,
-                    color: resolveLabelColor(labelName, alpha, customLabelColors)
+                    color: resolveLabelColor(labelName, alpha, customLabelColors, collectionColor)
                 });
             }
 
@@ -158,7 +175,7 @@
                     y: Math.round(bbox.y),
                     width: Math.round(bbox.width),
                     height: Math.round(bbox.height),
-                    color: resolveLabelColor(labelName, 1, customLabelColors)
+                    color: resolveLabelColor(labelName, 1, customLabelColors, collectionColor)
                 });
             }
         }

--- a/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
@@ -2,7 +2,10 @@
     import Segment from '$lib/components/Segment/Segment.svelte';
     import { SideMenu } from '$lib/components/SideMenu';
     import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
-    import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
+    import {
+        useAnnotationCollectionsFilter,
+        DEFAULT_COLLECTION_COLORS
+    } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
 
     interface Props {
         collectionId: string;
@@ -15,8 +18,14 @@
         (annotationCollectionsQuery.data ?? []).map((c) => ({ id: c.collection_id, name: c.name }))
     );
 
-    const { setSelectedCollectionIds, setCollectionIdToName, selectedCollectionIds } =
-        useAnnotationCollectionsFilter();
+    const {
+        setSelectedCollectionIds,
+        setCollectionIdToName,
+        selectedCollectionIds,
+        collectionIdToColor,
+        setCollectionIdToColor,
+        setCollectionColor
+    } = useAnnotationCollectionsFilter();
 
     let initialized = $state(false);
 
@@ -29,17 +38,30 @@
             setCollectionIdToName(
                 Object.fromEntries(items.map((i: { id: string; name: string }) => [i.id, i.name]))
             );
+            setCollectionIdToColor(
+                Object.fromEntries(
+                    items.map((i, idx) => [
+                        i.id,
+                        DEFAULT_COLLECTION_COLORS[idx % DEFAULT_COLLECTION_COLORS.length]
+                    ])
+                )
+            );
         }
     });
+
+    const itemsWithColors = $derived(
+        items.map((item) => ({ ...item, color: $collectionIdToColor[item.id] }))
+    );
 </script>
 
 {#if isEnabled}
     <Segment title="Annotation Sources">
         <SideMenu
             showColorMarker={$selectedCollectionIds.length > 1}
-            {items}
+            items={itemsWithColors}
             initialSelectedItemsIds={items.map((i) => i.id)}
             onChangeSelectedItems={setSelectedCollectionIds}
+            onColorChange={(id, color) => setCollectionColor(id, color)}
         />
     </Segment>
 {/if}

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.svelte
@@ -40,7 +40,8 @@
     } = $props();
 
     const { customLabelColorsStore } = useCustomLabelColors();
-    const { selectedCollectionIds, collectionIdToName } = useAnnotationCollectionsFilter();
+    const { selectedCollectionIds, collectionIdToName, collectionIdToColor } =
+        useAnnotationCollectionsFilter();
 
     const label = $derived(annotation.annotation_label.annotation_label_name);
 
@@ -53,19 +54,44 @@
 
     const annotationId = $derived(annotation.sample_id);
 
-    const colorText = $derived(getColorByLabel(colorLabel, 1));
+    // Resolve hex color string from collection store or fall back to label-based color.
+    const applyAlphaToColor = (color: string, alpha: number): string => {
+        if (color.startsWith('#')) {
+            const r = parseInt(color.slice(1, 3), 16);
+            const g = parseInt(color.slice(3, 5), 16);
+            const b = parseInt(color.slice(5, 7), 16);
+            return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+        }
+        return withAlpha(color, alpha);
+    };
+
+    // When in multi-collection mode, use the shared collection color; otherwise use label color.
+    const baseColor = $derived.by(() => {
+        if ($selectedCollectionIds.length > 1) {
+            const hexColor = $collectionIdToColor[annotation.annotation_collection_id];
+            if (hexColor) return hexColor;
+        }
+        return $customLabelColorsStore[colorLabel]?.color ?? getColorByLabel(colorLabel, 1).color;
+    });
+
+    const colorText = $derived.by(() => {
+        const color = applyAlphaToColor(baseColor, 1);
+        // Derive a contrast color by inverting the RGB components
+        const rgba = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+        const contrastColor = rgba
+            ? `rgba(${255 - parseInt(rgba[1])}, ${255 - parseInt(rgba[2])}, ${255 - parseInt(rgba[3])}, 1)`
+            : color;
+        return { color, contrastColor };
+    });
 
     const colorStroke = $derived.by(() => {
-        const color =
-            $customLabelColorsStore[colorLabel]?.color ?? getColorByLabel(colorLabel, 1).color;
+        const color = applyAlphaToColor(baseColor, 1);
         if (highlight === 'disabled') return withAlpha(color, 0.1);
         return color;
     });
 
     const colorFill = $derived.by(() => {
-        const color =
-            $customLabelColorsStore[colorLabel]?.color ?? getColorByLabel(colorLabel, 0.4).color;
-
+        const color = applyAlphaToColor(baseColor, 0.4);
         if (highlight === 'disabled') return withAlpha(color, 0.1);
         if (highlight === 'active') return withAlpha(color, 0);
         return color;

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
@@ -28,7 +28,8 @@
 
     const { isHidden } = useHideAnnotations();
     const { showBoundingBoxesForSegmentationStore } = useSettings();
-    const { selectedCollectionIds, collectionIdToName } = useAnnotationCollectionsFilter();
+    const { selectedCollectionIds, collectionIdToName, collectionIdToColor } =
+        useAnnotationCollectionsFilter();
 
     // Normalize backend annotation variants into the smaller canvas render contract.
     const mapToCanvasAnnotation = (
@@ -67,6 +68,7 @@
         const showInstanceSegmentationBoundingBoxes = $showBoundingBoxesForSegmentationStore;
         const selectedIds = $selectedCollectionIds;
         const idToName = $collectionIdToName;
+        const idToColor = $collectionIdToColor;
 
         return sample.annotations
             .filter(
@@ -83,7 +85,12 @@
                 if (!canvas) return null;
                 if (selectedIds.length > 1) {
                     const collectionName = idToName[annotation.annotation_collection_id];
-                    if (collectionName) return { ...canvas, annotation_label_name: collectionName };
+                    const collectionColor = idToColor[annotation.annotation_collection_id];
+                    return {
+                        ...canvas,
+                        annotation_label_name: collectionName ?? canvas.annotation_label_name,
+                        collectionColor
+                    };
                 }
                 return canvas;
             })

--- a/lightly_studio_view/src/lib/components/SideMenu/ColorMarker/ColorMarker.svelte
+++ b/lightly_studio_view/src/lib/components/SideMenu/ColorMarker/ColorMarker.svelte
@@ -4,17 +4,29 @@
 
     interface Props {
         label: string;
+        /** Explicit hex color override; if provided, skips label-based computation. */
+        color?: string;
         markerProps?: HTMLAttributes<HTMLSpanElement>;
     }
 
-    let { label, markerProps }: Props = $props();
+    let { label, color: explicitColor, markerProps }: Props = $props();
 
-    const colorFaded = $derived(computeColorByKey(label, 0.35));
-    const color = $derived(computeColorByKey(label, 1));
+    // Convert hex to rgba with given alpha
+    const hexToRgba = (hex: string, alpha: number) => {
+        const r = parseInt(hex.slice(1, 3), 16);
+        const g = parseInt(hex.slice(3, 5), 16);
+        const b = parseInt(hex.slice(5, 7), 16);
+        return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    };
+
+    const colorFaded = $derived(
+        explicitColor ? hexToRgba(explicitColor, 0.35) : computeColorByKey(label, 0.35).color
+    );
+    const colorBorder = $derived(explicitColor ?? computeColorByKey(label, 1).color);
 </script>
 
 <span
     class="inline-block h-3 w-3 shrink-0 rounded-sm border"
-    style="background-color: {colorFaded.color}; border-color: {color.color};"
+    style="background-color: {colorFaded}; border-color: {colorBorder};"
     {...markerProps}
 ></span>

--- a/lightly_studio_view/src/lib/components/SideMenu/MenuItem/MenuItem.svelte
+++ b/lightly_studio_view/src/lib/components/SideMenu/MenuItem/MenuItem.svelte
@@ -4,6 +4,7 @@
     import type { ComponentProps } from 'svelte';
     import ColorMarker from '../ColorMarker/ColorMarker.svelte';
     import { Typography } from '$lib/components';
+    import { ColorPicker } from '$lib/components/ui/color-picker';
 
     interface Props {
         /** Label text displayed in the menu item; also used as the `title` attribute. */
@@ -12,11 +13,16 @@
         checked: boolean;
         /** When `true`, renders a color swatch before the label text. */
         showColorMarker?: boolean;
+        /** Explicit hex color for the swatch; falls back to label-based computation. */
+        color?: string;
+        /** When provided, the swatch becomes a color picker trigger. */
+        onColorChange?: (color: string) => void;
         /** Callback fired when the checkbox is toggled. */
         onCheckedChange: ComponentProps<typeof Checkbox>['onCheckedChange'];
     }
 
-    let { name, checked, showColorMarker, onCheckedChange }: Props = $props();
+    let { name, checked, showColorMarker, color, onColorChange, onCheckedChange }: Props =
+        $props();
 
     // Stable unique ID for pairing the checkbox and its label
     const menuItemId = $props.id();
@@ -36,7 +42,28 @@
             class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
         >
             {#if showColorMarker}
-                <ColorMarker label={name} markerProps={{ 'data-testid': `color-marker-${name}` }} />
+                {#if onColorChange}
+                    <ColorPicker
+                        initialColor={color}
+                        onChange={(c) => onColorChange(c)}
+                        position="right"
+                    >
+                        <ColorMarker
+                            label={name}
+                            {color}
+                            markerProps={{
+                                'data-testid': `color-marker-${name}`,
+                                class: 'cursor-pointer hover:opacity-80 transition-opacity'
+                            }}
+                        />
+                    </ColorPicker>
+                {:else}
+                    <ColorMarker
+                        label={name}
+                        {color}
+                        markerProps={{ 'data-testid': `color-marker-${name}` }}
+                    />
+                {/if}
             {/if}
             <Typography variant="body1" className="flex-1 truncate">
                 {name}

--- a/lightly_studio_view/src/lib/components/SideMenu/SideMenu/SideMenu.svelte
+++ b/lightly_studio_view/src/lib/components/SideMenu/SideMenu/SideMenu.svelte
@@ -8,6 +8,7 @@
         items: MenuItemType[];
         initialSelectedItemsIds?: string[];
         onChangeSelectedItems: (selectedItemsIds: string[]) => void;
+        onColorChange?: (id: string, color: string) => void;
         containerProps?: HTMLAttributes<HTMLDivElement>;
         showColorMarker?: boolean;
     }
@@ -16,6 +17,7 @@
         items,
         initialSelectedItemsIds,
         onChangeSelectedItems,
+        onColorChange,
         containerProps,
         showColorMarker
     }: SideMenuProps = $props();
@@ -32,12 +34,14 @@
 </script>
 
 <div {...containerProps} class={cn('w-full space-y-2 overflow-hidden', containerProps?.class)}>
-    {#each items as { id, name } (id)}
+    {#each items as { id, name, color } (id)}
         <MenuItem
             {name}
+            {color}
             {showColorMarker}
             checked={selectedItemsIds.includes(id)}
             onCheckedChange={() => handleCheckedChange(id)}
+            onColorChange={onColorChange ? (c) => onColorChange(id, c) : undefined}
         />
     {/each}
 </div>

--- a/lightly_studio_view/src/lib/components/SideMenu/types.ts
+++ b/lightly_studio_view/src/lib/components/SideMenu/types.ts
@@ -1,4 +1,5 @@
 export interface MenuItemType {
     id: string;
     name: string;
+    color?: string;
 }

--- a/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.ts
@@ -1,13 +1,31 @@
 import { writable } from 'svelte/store';
 
+export const DEFAULT_COLLECTION_COLORS = [
+    '#3b82f6', // blue
+    '#ef4444', // red
+    '#22c55e', // green
+    '#f59e0b', // amber
+    '#8b5cf6', // violet
+    '#ec4899', // pink
+    '#14b8a6', // teal
+    '#f97316', // orange
+    '#6366f1', // indigo
+    '#84cc16' // lime
+];
+
 const selectedCollectionIds = writable<string[]>([]);
 const collectionIdToName = writable<Record<string, string>>({});
+const collectionIdToColor = writable<Record<string, string>>({});
 
 export const useAnnotationCollectionsFilter = () => {
     return {
         selectedCollectionIds,
         setSelectedCollectionIds: (ids: string[]) => selectedCollectionIds.set(ids),
         collectionIdToName,
-        setCollectionIdToName: (map: Record<string, string>) => collectionIdToName.set(map)
+        setCollectionIdToName: (map: Record<string, string>) => collectionIdToName.set(map),
+        collectionIdToColor,
+        setCollectionIdToColor: (map: Record<string, string>) => collectionIdToColor.set(map),
+        setCollectionColor: (id: string, color: string) =>
+            collectionIdToColor.update((m) => ({ ...m, [id]: color }))
     };
 };


### PR DESCRIPTION
- Add collectionIdToColor shared store to useAnnotationCollectionsFilter
- Assign default colors (from a distinct hex palette) when collections load
- Fix color mismatch bug: SampleAnnotation and AnnotationCanvas now both use the same shared store color instead of independently hashing the label name
- Add color picker to each item in the Annotation Collections menu (SideMenu)
- ColorMarker now accepts an explicit hex color prop
- MenuItem wraps ColorMarker in ColorPicker when onColorChange is provided
- SampleAnnotations passes collectionColor through to AnnotationCanvas
- AnnotationCanvas uses collectionColor (if present) to override label-based color

## What has changed and why?

(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive color picker to customize colors for each annotation collection.
  * Collection colors now override default label colors across segmentation masks and detection boxes.
  * Multiple collections can be simultaneously displayed with distinct, individually assigned colors for improved visual organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightly-ai/lightly-studio/pull/1264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->