### PR TITLE
Render embedding plot from color_categories with category fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Header menu: show collection name in Annotations entries
+- Embedding plot coloring now supports multiple categories per sample.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Header menu: show collection name in Annotations entries
-- Embedding plot coloring now supports multiple categories per sample.
+- Embedding plot coloring now supports multiple categories per sample, resolving issues with toggling visibility of categories in the legend.
 
 ### Deprecated
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -16,7 +16,6 @@
     import PlotColorByPopover from './PlotColorByPopover/PlotColorByPopover.svelte';
     import { useCategoryVisibility } from './useCategoryVisibility/useCategoryVisibility';
     import { isEqual } from 'lodash-es';
-    import { NOT_FILTERED_CATEGORY } from './plotCategories';
     import { getCategoryColors, getCategoryCount, getLegendEntries } from './plotColorUtils';
     import { page } from '$app/state';
     import { isVideosRoute } from '$lib/routes';
@@ -116,13 +115,14 @@
             arrowData: $arrowData,
             rangeSelection: $rangeSelection,
             highlightedSampleIds: activeSampleIds,
-            hasActiveFilter: hasActiveFilter
+            hasActiveFilter: hasActiveFilter,
+            hiddenCategories: $hiddenCategories
         })
     );
     const categoryCount = $derived.by(() => getCategoryCount($colorLegend));
     const useLabelColors = $derived($selectedColorByType !== 'metadata');
     const categoryColors = $derived.by(() =>
-        getCategoryColors($colorLegend, $hiddenCategories, useLabelColors, $colorBy !== null)
+        getCategoryColors($colorLegend, useLabelColors, $colorBy !== null)
     );
     const legendEntries = $derived.by(() =>
         getLegendEntries($colorLegend, $hiddenCategories, useLabelColors)
@@ -136,8 +136,8 @@
         const filter = isVideos ? $videoFilter : $imageFilter;
         const currentSampleIds = filter?.sample_filter?.sample_ids || [];
         const selectableCount =
-            ($arrowData?.color_category as Uint8Array | undefined)?.reduce((count, category) => {
-                return category !== NOT_FILTERED_CATEGORY ? count + 1 : count;
+            ($arrowData?.fulfils_filter as Uint8Array | undefined)?.reduce((count, fulfils) => {
+                return fulfils !== 0 ? count + 1 : count;
             }, 0) ?? null;
 
         if ($selectedSampleIds.length === 0) {

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
@@ -242,7 +242,7 @@ describe('PlotPanel.svelte', () => {
             x: new Float32Array([1, 2, 3]),
             y: new Float32Array([1, 2, 3]),
             fulfils_filter: new Uint8Array([1, 1, 0]),
-            color_category: new Uint8Array([1, 1, 0]),
+            color_categories: [[2], [2], []],
             sample_id: ['sample-1', 'sample-2', 'sample-3']
         });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
@@ -16,7 +16,7 @@ describe('getCategoryBySelection', () => {
         x: new Float32Array([1.0, 2.0, 3.0, 4.0]),
         y: new Float32Array([5.0, 6.0, 7.0, 8.0]),
         fulfils_filter: new Uint8Array([1, 1, 0, 1]),
-        color_category: new Uint8Array([1, 1, 0, 1]),
+        color_categories: [[2], [2], [], [2]],
         sample_id: ['sample1', 'sample2', 'sample3', 'sample4']
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
@@ -16,7 +16,7 @@ describe('getCategoryBySelection', () => {
         x: new Float32Array([1.0, 2.0, 3.0, 4.0]),
         y: new Float32Array([5.0, 6.0, 7.0, 8.0]),
         fulfils_filter: new Uint8Array([1, 1, 0, 1]),
-        color_categories: [[2], [2], [], [2]],
+        color_categories: [[2, 3], [2], [], [3]],
         sample_id: ['sample1', 'sample2', 'sample3', 'sample4']
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
@@ -34,25 +34,11 @@ describe('plotColorUtils', () => {
             [3, 'Validation']
         ]);
 
-        expect(getCategoryColors(colorLegend, new Set(), true, true)).toEqual([
+        expect(getCategoryColors(colorLegend, true, true)).toEqual([
             NOT_FILTERED_COLOR,
             UNASSIGNED_COLOR,
             getColorByLabel('Train').color,
             getColorByLabel('Validation').color
-        ]);
-    });
-
-    it('renders hidden categories with the unassigned color when colorBy is active', () => {
-        const colorLegend = new Map([
-            [2, 'Train'],
-            [3, 'Validation']
-        ]);
-
-        expect(getCategoryColors(colorLegend, new Set([3]), true, true)).toEqual([
-            NOT_FILTERED_COLOR,
-            UNASSIGNED_COLOR,
-            getColorByLabel('Train').color,
-            UNASSIGNED_COLOR
         ]);
     });
 
@@ -93,27 +79,13 @@ describe('plotColorUtils', () => {
         ]);
     });
 
-    it('returns unassigned color for hidden categories when colorBy is active', () => {
-        const legend = new Map([
-            [0, ''],
-            [1, ''],
-            [2, '']
-        ]);
-        const hiddenCategories = new Set([0, 2]);
-        expect(getCategoryColors(legend, hiddenCategories, false, true)).toEqual([
-            UNASSIGNED_COLOR,
-            UNASSIGNED_COLOR,
-            UNASSIGNED_COLOR
-        ]);
-    });
-
     it('uses unassigned color for category 1 when colorBy is active', () => {
         const colorLegend = new Map([
             [2, 'Train'],
             [3, 'Validation']
         ]);
 
-        expect(getCategoryColors(colorLegend, new Set(), false, true)[1]).toBe(UNASSIGNED_COLOR);
+        expect(getCategoryColors(colorLegend, false, true)[1]).toBe(UNASSIGNED_COLOR);
         expect(getCategoryColors(colorLegend)[1]).toBe(FILTERED_COLOR);
     });
 
@@ -125,8 +97,8 @@ describe('plotColorUtils', () => {
         ]);
 
         const labelColor = getColorByLabel('labelName').color;
-        const defaultColors = getCategoryColors(legend, new Set(), false);
-        const labelColors = getCategoryColors(legend, new Set(), true, true);
+        const defaultColors = getCategoryColors(legend, false);
+        const labelColors = getCategoryColors(legend, true, true);
 
         expect(labelColors).toEqual([NOT_FILTERED_COLOR, UNASSIGNED_COLOR, labelColor]);
         expect(defaultColors[2]).not.toBe(labelColor);

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -64,16 +64,11 @@ export function getCategoryCount(colorLegend?: ReadonlyMap<number, string> | nul
 
 export function getCategoryColors(
     colorLegend?: ReadonlyMap<number, string> | null,
-    hiddenCategories: ReadonlySet<number> = new Set(),
     useLabelColors: boolean = false,
     isColorByActive: boolean = false
 ): string[] {
     const categoryCount = getCategoryCount(colorLegend);
     return Array.from({ length: categoryCount }, (_, category) => {
-        if (hiddenCategories.has(category)) {
-            return isColorByActive ? UNASSIGNED_COLOR : FILTERED_COLOR;
-        }
-
         const label = useLabelColors ? (colorLegend?.get(category) ?? '') : '';
         return getBaseCategoryColor(category, categoryCount, label, isColorByActive);
     });

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { resolveVisibleCategory } from './resolveVisibleCategory';
+
+describe('resolveVisibleCategory', () => {
+    it('returns NOT_FILTERED_CATEGORY (0) when the point does not fulfil the filter', () => {
+        expect(resolveVisibleCategory([2, 3], 0, new Set())).toBe(0);
+    });
+
+    it('returns the first category when none are hidden', () => {
+        expect(resolveVisibleCategory([2, 3], 1, new Set())).toBe(2);
+    });
+
+    it('returns FILTERED_CATEGORY (1) when the point has no categories', () => {
+        expect(resolveVisibleCategory([], 1, new Set())).toBe(1);
+    });
+
+    it('falls back to the next visible category when the first is hidden', () => {
+        expect(resolveVisibleCategory([2, 3], 1, new Set([2]))).toBe(3);
+    });
+
+    it('falls back to FILTERED_CATEGORY (1) when the only category is hidden', () => {
+        expect(resolveVisibleCategory([2], 1, new Set([2]))).toBe(1);
+    });
+
+    it('falls back to FILTERED_CATEGORY (1) when all categories are hidden', () => {
+        expect(resolveVisibleCategory([2, 3], 1, new Set([2, 3]))).toBe(1);
+    });
+
+    it('ignores the filter when resolving a hidden fallback', () => {
+        expect(resolveVisibleCategory([2, 3, 4], 1, new Set([2, 3]))).toBe(4);
+    });
+});

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
@@ -1,12 +1,11 @@
 import { FILTERED_CATEGORY, NOT_FILTERED_CATEGORY } from '../plotCategories';
 
 /**
- * Resolves the category a point should be rendered as, given all categories it belongs to.
- *
- * Mirrors the backend's primary-category logic, with an extra hidden-aware step so a
- * multi-category sample falls back to its next visible category when one is toggled off:
+ * Resolves the category a point is displayed as, given every category it belongs to in
+ * priority order. Hidden categories are skipped so a multi-category point falls back to
+ * its next visible category:
  * - point does not fulfil the filter -> NOT_FILTERED_CATEGORY
- * - otherwise the first category (priority order) that is not hidden
+ * - otherwise the first category that is not hidden
  * - otherwise (no categories, or all hidden) -> FILTERED_CATEGORY (unassigned)
  *
  * @param colorCategories - All categories the point belongs to, in priority order

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
@@ -1,0 +1,32 @@
+import { FILTERED_CATEGORY, NOT_FILTERED_CATEGORY } from '../plotCategories';
+
+/**
+ * Resolves the category a point should be rendered as, given all categories it belongs to.
+ *
+ * Mirrors the backend's primary-category logic, with an extra hidden-aware step so a
+ * multi-category sample falls back to its next visible category when one is toggled off:
+ * - point does not fulfil the filter -> NOT_FILTERED_CATEGORY
+ * - otherwise the first category (priority order) that is not hidden
+ * - otherwise (no categories, or all hidden) -> FILTERED_CATEGORY (unassigned)
+ *
+ * @param colorCategories - All categories the point belongs to, in priority order
+ * @param fulfilsFilter - Whether the point passes the active filter (0 = filtered out)
+ * @param hiddenCategories - Categories currently toggled off in the legend
+ */
+export const resolveVisibleCategory = (
+    colorCategories: number[],
+    fulfilsFilter: number,
+    hiddenCategories: ReadonlySet<number>
+): number => {
+    if (fulfilsFilter === 0) {
+        return NOT_FILTERED_CATEGORY;
+    }
+
+    for (const category of colorCategories) {
+        if (!hiddenCategories.has(category)) {
+            return category;
+        }
+    }
+
+    return FILTERED_CATEGORY;
+};

--- a/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.test.ts
@@ -12,12 +12,25 @@ describe('useArrowData', () => {
         vi.clearAllMocks();
     });
 
+    // Builds a getChild mock where color_categories behaves like an Arrow list<uint8> vector
+    // (read row by row via get/length) and other columns expose a flat toArray().
+    const createGetChild = (columns: Record<string, unknown>, colorCategories: number[][]) =>
+        vi.fn((col: string) => {
+            if (col === 'color_categories') {
+                return {
+                    length: colorCategories.length,
+                    get: (row: number) => colorCategories[row]
+                };
+            }
+            return { toArray: () => columns[col] };
+        });
+
     it('successfully reads Arrow data with all required columns', async () => {
+        const colorCategories = [[1], [2], []];
         const mockData = {
             x: [1, 2, 3],
             y: [4, 5, 6],
             fulfils_filter: [true, false, true],
-            color_category: [1, 2, 0],
             sample_id: ['a', 'b', 'c']
         };
 
@@ -25,9 +38,7 @@ describe('useArrowData', () => {
             schema: {
                 metadata: new Map([['color_legend', '{"1":"Filtered","2":"Train"}']])
             },
-            getChild: vi.fn((col: string) => ({
-                toArray: () => mockData[col as keyof typeof mockData]
-            }))
+            getChild: createGetChild(mockData, colorCategories)
         };
 
         vi.mocked(tableFromIPC).mockResolvedValue(mockTable as unknown as Table);
@@ -39,7 +50,7 @@ describe('useArrowData', () => {
 
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        expect(get(data)).toEqual(mockData);
+        expect(get(data)).toEqual({ ...mockData, color_categories: colorCategories });
         expect(get(colorLegend)).toEqual(
             new Map([
                 [1, 'Filtered'],
@@ -135,7 +146,7 @@ describe('useArrowData', () => {
             x: [],
             y: [],
             fulfils_filter: [],
-            color_category: [],
+            color_categories: [],
             sample_id: []
         });
         expect(get(colorLegend)).toEqual(new Map());
@@ -144,20 +155,18 @@ describe('useArrowData', () => {
 
     it('falls back to an empty color legend when metadata is malformed', async () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const colorCategories = [[1], [2], []];
         const mockData = {
             x: [1, 2, 3],
             y: [4, 5, 6],
             fulfils_filter: [true, false, true],
-            color_category: [1, 2, 0],
             sample_id: ['a', 'b', 'c']
         };
         const mockTable = {
             schema: {
                 metadata: new Map([['color_legend', '{"1":"Filtered"']])
             },
-            getChild: vi.fn((col: string) => ({
-                toArray: () => mockData[col as keyof typeof mockData]
-            }))
+            getChild: createGetChild(mockData, colorCategories)
         };
 
         vi.mocked(tableFromIPC).mockResolvedValue(mockTable as unknown as Table);
@@ -169,7 +178,7 @@ describe('useArrowData', () => {
 
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        expect(get(data)).toEqual(mockData);
+        expect(get(data)).toEqual({ ...mockData, color_categories: colorCategories });
         expect(get(colorLegend)).toEqual(new Map());
         expect(get(error)).toBeUndefined();
         expect(warnSpy).toHaveBeenCalledWith(

--- a/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.test.ts
@@ -14,23 +14,24 @@ describe('useArrowData', () => {
 
     // Builds a getChild mock where color_categories behaves like an Arrow list<uint8> vector
     // (read row by row via get/length) and other columns expose a flat toArray().
-    const createGetChild = (columns: Record<string, unknown>, colorCategories: number[][]) =>
+    const createGetChild = (columns: Record<string, unknown>) =>
         vi.fn((col: string) => {
             if (col === 'color_categories') {
+                const rows = columns[col] as number[][];
                 return {
-                    length: colorCategories.length,
-                    get: (row: number) => colorCategories[row]
+                    length: rows.length,
+                    get: (row: number) => rows[row]
                 };
             }
             return { toArray: () => columns[col] };
         });
 
     it('successfully reads Arrow data with all required columns', async () => {
-        const colorCategories = [[1], [2], []];
         const mockData = {
             x: [1, 2, 3],
             y: [4, 5, 6],
             fulfils_filter: [true, false, true],
+            color_categories: [[1, 2], [2], []],
             sample_id: ['a', 'b', 'c']
         };
 
@@ -38,7 +39,7 @@ describe('useArrowData', () => {
             schema: {
                 metadata: new Map([['color_legend', '{"1":"Filtered","2":"Train"}']])
             },
-            getChild: createGetChild(mockData, colorCategories)
+            getChild: createGetChild(mockData)
         };
 
         vi.mocked(tableFromIPC).mockResolvedValue(mockTable as unknown as Table);
@@ -50,7 +51,7 @@ describe('useArrowData', () => {
 
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        expect(get(data)).toEqual({ ...mockData, color_categories: colorCategories });
+        expect(get(data)).toEqual(mockData);
         expect(get(colorLegend)).toEqual(
             new Map([
                 [1, 'Filtered'],
@@ -155,18 +156,18 @@ describe('useArrowData', () => {
 
     it('falls back to an empty color legend when metadata is malformed', async () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const colorCategories = [[1], [2], []];
         const mockData = {
             x: [1, 2, 3],
             y: [4, 5, 6],
             fulfils_filter: [true, false, true],
+            color_categories: [[1, 2], [2], []],
             sample_id: ['a', 'b', 'c']
         };
         const mockTable = {
             schema: {
                 metadata: new Map([['color_legend', '{"1":"Filtered"']])
             },
-            getChild: createGetChild(mockData, colorCategories)
+            getChild: createGetChild(mockData)
         };
 
         vi.mocked(tableFromIPC).mockResolvedValue(mockTable as unknown as Table);
@@ -178,7 +179,7 @@ describe('useArrowData', () => {
 
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        expect(get(data)).toEqual({ ...mockData, color_categories: colorCategories });
+        expect(get(data)).toEqual(mockData);
         expect(get(colorLegend)).toEqual(new Map());
         expect(get(error)).toBeUndefined();
         expect(warnSpy).toHaveBeenCalledWith(

--- a/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.ts
@@ -1,8 +1,19 @@
-import { tableFromIPC } from 'apache-arrow';
+import { tableFromIPC, type Vector } from 'apache-arrow';
 import { writable, type Writable } from 'svelte/store';
 
-const dataColumns = ['x', 'y', 'fulfils_filter', 'color_category', 'sample_id'] as const;
+const dataColumns = ['x', 'y', 'fulfils_filter', 'color_categories', 'sample_id'] as const;
 type TableColumn = (typeof dataColumns)[number];
+
+// `color_categories` is a list<uint8> column: each row holds all categories a sample belongs
+// to, in priority order. `toArray()` is meant for scalar columns, so we read it row by row
+// into a plain number[][] that the rest of the plot pipeline can index directly.
+const readListColumn = (column: Vector): number[][] => {
+    const rows: number[][] = [];
+    for (let row = 0; row < column.length; row++) {
+        rows.push(Array.from<number>(column.get(row) ?? []));
+    }
+    return rows;
+};
 
 export type ArrowData = Record<TableColumn, unknown>;
 
@@ -57,11 +68,15 @@ export function useArrowData({ blobData }: { blobData: Blob }): UseArrowDataRetu
             }
             const columnData = new Map<TableColumn, unknown>();
             for (const col of dataColumns) {
-                if (!table.getChild(col)) {
+                const child = table.getChild(col);
+                if (!child) {
                     error.set(`Missing required column "${col}" in Arrow data.`);
                     return;
                 }
-                columnData.set(col, table.getChild(col)?.toArray());
+                columnData.set(
+                    col,
+                    col === 'color_categories' ? readListColumn(child) : child.toArray()
+                );
             }
             data.set(Object.fromEntries(columnData) as Record<TableColumn, unknown>);
             colorLegend.set(parseColorLegend(table.schema?.metadata));

--- a/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.ts
@@ -4,9 +4,8 @@ import { writable, type Writable } from 'svelte/store';
 const dataColumns = ['x', 'y', 'fulfils_filter', 'color_categories', 'sample_id'] as const;
 type TableColumn = (typeof dataColumns)[number];
 
-// `color_categories` is a list<uint8> column: each row holds all categories a sample belongs
-// to, in priority order. `toArray()` is meant for scalar columns, so we read it row by row
-// into a plain number[][] that the rest of the plot pipeline can index directly.
+// Reads a list<uint8> column row by row into a plain number[][], where each row holds all
+// the categories a sample belongs to, in priority order.
 const readListColumn = (column: Vector): number[][] => {
     const rows: number[][] = [];
     for (let row = 0; row < column.length; row++) {

--- a/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useArrowData/useArrowData.ts
@@ -1,7 +1,7 @@
 import { tableFromIPC, type Vector } from 'apache-arrow';
 import { writable, type Writable } from 'svelte/store';
 
-const dataColumns = ['x', 'y', 'fulfils_filter', 'color_categories', 'sample_id'] as const;
+const dataColumns = ['x', 'y', 'fulfils_filter', 'color_categories', 'sample_id'];
 type TableColumn = (typeof dataColumns)[number];
 
 // Reads a list<uint8> column row by row into a plain number[][], where each row holds all

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -20,11 +20,13 @@ vi.mock('../getCategoryBySelection/getCategoryBySelection', () => ({
 const { usePlotData } = await import('./usePlotData');
 
 describe('usePlotData', () => {
+    // color_categories + fulfils_filter resolve to the primary categories [1, 2, 0, 3]:
+    // sample1 has no categories (-> unassigned 1), sample3 is filtered out (-> 0).
     const createMockArrowData = (): ArrowData => ({
         x: new Float32Array([1.0, 2.0, 3.0, 4.0]),
         y: new Float32Array([5.0, 6.0, 7.0, 8.0]),
         fulfils_filter: new Uint8Array([1, 1, 0, 1]),
-        color_category: new Uint8Array([1, 2, 0, 3]),
+        color_categories: [[], [2], [], [3]],
         sample_id: ['sample1', 'sample2', 'sample3', 'sample4']
     });
 
@@ -51,9 +53,25 @@ describe('usePlotData', () => {
         expect(data).toEqual({
             x: mockData.x,
             y: mockData.y,
-            category: mockData.color_category
+            category: new Uint8Array([1, 2, 0, 3])
         });
         expect(get(result.selectedSampleIds)).toEqual([]);
+    });
+
+    it('falls back to the next visible category when one is hidden', () => {
+        const mockData = createMockArrowData();
+        // sample2 belongs to categories [2, 3]; sample4 only to [4].
+        mockData.color_categories = [[], [2, 3], [], [4]];
+
+        const result = usePlotData({
+            arrowData: mockData,
+            rangeSelection: null,
+            hiddenCategories: new Set([2, 4])
+        });
+
+        const data = get(result.data) as { category: Uint8Array };
+        // sample2 falls back from hidden 2 to visible 3; sample4's only category is hidden -> unassigned 1.
+        expect(Array.from(data.category)).toEqual([1, 3, 0, 1]);
     });
 
     it('should update categories based on range selection', () => {

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -20,13 +20,14 @@ vi.mock('../getCategoryBySelection/getCategoryBySelection', () => ({
 const { usePlotData } = await import('./usePlotData');
 
 describe('usePlotData', () => {
-    // color_categories + fulfils_filter resolve to the primary categories [1, 2, 0, 3]:
-    // sample1 has no categories (-> unassigned 1), sample3 is filtered out (-> 0).
+    // color_categories + fulfils_filter resolve to categories [1, 2, 0, 3]: sample1 has no
+    // categories (-> unassigned 1), sample2 takes the first of its two categories (2),
+    // sample3 is filtered out (-> 0).
     const createMockArrowData = (): ArrowData => ({
         x: new Float32Array([1.0, 2.0, 3.0, 4.0]),
         y: new Float32Array([5.0, 6.0, 7.0, 8.0]),
         fulfils_filter: new Uint8Array([1, 1, 0, 1]),
-        color_categories: [[], [2], [], [3]],
+        color_categories: [[], [2, 5], [], [3]],
         sample_id: ['sample1', 'sample2', 'sample3', 'sample4']
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
@@ -3,6 +3,7 @@ import { EmbeddingView, type Point } from 'embedding-atlas/svelte';
 import type { ComponentProps } from 'svelte';
 import type { ArrowData } from '../useArrowData/useArrowData';
 import { getCategoryBySelection } from '../getCategoryBySelection/getCategoryBySelection';
+import { resolveVisibleCategory } from '../resolveVisibleCategory/resolveVisibleCategory';
 import { FILTERED_CATEGORY, NOT_FILTERED_CATEGORY } from '../plotCategories';
 
 type PlotColumn = 'x' | 'y' | 'category';
@@ -17,24 +18,50 @@ type UsePlotDataReturn = {
 type Selection = Point[] | null;
 
 /**
+ * Resolves each point's displayed category from its full `color_categories` list, so a
+ * multi-category sample falls back to its next visible category when one is toggled off.
+ */
+function resolveBaseCategories(
+    data: ArrowData,
+    hiddenCategories: ReadonlySet<number>,
+    pointCount: number
+): Uint8Array {
+    const colorCategories = data.color_categories as number[][];
+    const fulfilsFilter = data.fulfils_filter as ArrayLike<number>;
+
+    const category = new Uint8Array(pointCount);
+    for (let index = 0; index < pointCount; index++) {
+        category[index] = resolveVisibleCategory(
+            colorCategories[index],
+            fulfilsFilter[index],
+            hiddenCategories
+        );
+    }
+    return category;
+}
+
+/**
  * Transforms Arrow data into plot-ready format with category assignments based on filters and selections.
  * Applies range selection to categorize points and tracks which sample IDs are selected.
  *
  * @param arrowData - Parsed Arrow data containing x/y coordinates, filter status, and sample IDs
  * @param rangeSelection - Optional polygon selection to further categorize points within the range
  * @param hasActiveFilter - When false, all points start as FILTERED_CATEGORY so range selection still works without a pre-existing filter
+ * @param hiddenCategories - Categories toggled off in the legend; points fall back to their next visible category
  * @returns Object with formatted plot data, error store, and selected sample IDs store
  */
 export function usePlotData({
     arrowData,
     rangeSelection,
     highlightedSampleIds = [],
-    hasActiveFilter = true
+    hasActiveFilter = true,
+    hiddenCategories = new Set()
 }: {
     arrowData: ArrowData;
     rangeSelection: Selection;
     highlightedSampleIds?: string[];
     hasActiveFilter?: boolean;
+    hiddenCategories?: ReadonlySet<number>;
 }): UsePlotDataReturn {
     const error = writable<string | undefined>();
     const plotData = writable<Record<PlotColumn, unknown>>();
@@ -46,9 +73,10 @@ export function usePlotData({
         return { data: plotData, error, selectedSampleIds };
     }
 
+    const pointCount = (data.x as Float32Array).length;
     let category = hasActiveFilter
-        ? (data.color_category as Uint8Array)
-        : new Uint8Array((data.x as Float32Array).length).fill(FILTERED_CATEGORY);
+        ? resolveBaseCategories(data, hiddenCategories, pointCount)
+        : new Uint8Array(pointCount).fill(FILTERED_CATEGORY);
     const sampleIds = data.sample_id as string[];
 
     if (rangeSelection) {

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
@@ -18,29 +18,6 @@ type UsePlotDataReturn = {
 type Selection = Point[] | null;
 
 /**
- * Resolves each point's displayed category from its full `color_categories` list, so a
- * multi-category sample falls back to its next visible category when one is toggled off.
- */
-function resolveBaseCategories(
-    data: ArrowData,
-    hiddenCategories: ReadonlySet<number>,
-    pointCount: number
-): Uint8Array {
-    const colorCategories = data.color_categories as number[][];
-    const fulfilsFilter = data.fulfils_filter as ArrayLike<number>;
-
-    const category = new Uint8Array(pointCount);
-    for (let index = 0; index < pointCount; index++) {
-        category[index] = resolveVisibleCategory(
-            colorCategories[index],
-            fulfilsFilter[index],
-            hiddenCategories
-        );
-    }
-    return category;
-}
-
-/**
  * Transforms Arrow data into plot-ready format with category assignments based on filters and selections.
  * Applies range selection to categorize points and tracks which sample IDs are selected.
  *
@@ -74,9 +51,24 @@ export function usePlotData({
     }
 
     const pointCount = (data.x as Float32Array).length;
-    let category = hasActiveFilter
-        ? resolveBaseCategories(data, hiddenCategories, pointCount)
-        : new Uint8Array(pointCount).fill(FILTERED_CATEGORY);
+    const colorCategories = data.color_categories as number[][];
+    const fulfilsFilter = data.fulfils_filter as ArrayLike<number>;
+
+    // Each point is displayed as its first visible category, so it falls back to the next
+    // one when a category is toggled off. Without an active filter every point starts as
+    // FILTERED_CATEGORY so range selection still works.
+    let category = new Uint8Array(pointCount);
+    if (hasActiveFilter) {
+        for (let index = 0; index < pointCount; index++) {
+            category[index] = resolveVisibleCategory(
+                colorCategories[index],
+                fulfilsFilter[index],
+                hiddenCategories
+            );
+        }
+    } else {
+        category.fill(FILTERED_CATEGORY);
+    }
     const sampleIds = data.sample_id as string[];
 
     if (rangeSelection) {


### PR DESCRIPTION
## What has changed and why?

Based on #1262. 

The backend now sends all categories per sample to the frontend, instead of a single category. Use the new `color_categories` field for rendering.

This fixes a problem, where hiding a category in the legend would hide a sample, even if it had other categories assigned.

Note that each legend toggle now recomputes the per-point category array rather than just the palette; this is the necessary cost of correct fallback.

Follow-ups:
* Clean up the old unused `color_category` code

## How has it been tested?

- Tests
- Manual verification

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plot coloring now supports multiple categories per sample and falls back to the next visible category when some are hidden.

* **Bug Fixes**
  * Fixed legend visibility behavior so hiding categories correctly updates plotted colors and selection counts.

* **Tests**
  * Updated and added tests covering multi-category color data, hidden-category fallbacks, and visible-category resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->