### PR TITLE
Evaluation Run Button: Show only when eval runs are available

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -12,6 +12,7 @@
         compact?: boolean;
         canSelectAll: boolean;
         isImages: boolean;
+        hasEvaluationRuns: boolean;
         hasMediaWithEmbeddings: boolean;
         collectionDatasetId: string;
         onSelectAll: () => Promise<void>;
@@ -28,6 +29,7 @@
         compact = false,
         canSelectAll,
         isImages,
+        hasEvaluationRuns,
         hasMediaWithEmbeddings,
         onSelectAll,
         searchImage,
@@ -72,7 +74,7 @@
                 </Button>
             </Tooltip>
         {/if}
-        {#if isImages}
+        {#if isImages && hasEvaluationRuns}
             <Tooltip
                 content={$showEvaluationRuns ? 'Hide Evaluation Runs' : 'Show Evaluation Runs'}
                 position="bottom"

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -60,6 +60,7 @@ const defaultProps = {
     compact: false,
     canSelectAll: false,
     isImages: false,
+    hasEvaluationRuns: true,
     hasMediaWithEmbeddings: false,
     collectionDatasetId: 'dataset-1',
     onSelectAll: vi.fn().mockResolvedValue(undefined),
@@ -158,9 +159,9 @@ describe('DatasetGridHeader', () => {
         expect(container.querySelector('[data-grid-search-drop-target]')).not.toBeInTheDocument();
     });
 
-    it('shows the evaluation runs toggle for image collections', () => {
+    it('shows the evaluation runs toggle for image collections with evaluations', () => {
         render(DatasetGridHeader, {
-            props: { ...defaultProps, isImages: true }
+            props: { ...defaultProps, isImages: true, hasEvaluationRuns: true }
         });
 
         expect(screen.getByTestId('toggle-evaluation-runs-button')).toBeInTheDocument();
@@ -177,7 +178,7 @@ describe('DatasetGridHeader', () => {
         const { setShowEvaluationRuns } = useGlobalStorage();
 
         render(DatasetGridHeader, {
-            props: { ...defaultProps, isImages: true }
+            props: { ...defaultProps, isImages: true, hasEvaluationRuns: true }
         });
 
         const toggle = screen.getByTestId('toggle-evaluation-runs-button');
@@ -186,6 +187,14 @@ describe('DatasetGridHeader', () => {
 
         await fireEvent.click(toggle);
         expect(setShowEvaluationRuns).toHaveBeenLastCalledWith(false);
+    });
+
+    it('hides the evaluation runs toggle when no evaluations exist', () => {
+        render(DatasetGridHeader, {
+            props: { ...defaultProps, isImages: true, hasEvaluationRuns: false }
+        });
+
+        expect(screen.queryByTestId('toggle-evaluation-runs-button')).not.toBeInTheDocument();
     });
 
     it('hides the embeddings and evaluation runs labels in compact mode', () => {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -405,7 +405,7 @@
                 </PaneResizer>
             {/snippet}
 
-            {#if $activePanel === 'evaluationRuns'}
+            {#if $activePanel === 'evaluationRuns' && hasEvaluationRuns}
                 <PaneGroup direction="horizontal" class="flex-1">
                     <Pane defaultSize={65} minSize={35} class="flex">
                         <div

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -96,6 +96,7 @@
 
     const evaluationRunsQuery = useEvaluationRuns(() => ({ datasetId: collection.dataset_id }));
     const evaluationRuns = $derived(evaluationRunsQuery.data ?? []);
+    const hasEvaluationRuns = $derived(evaluationRuns.length > 0);
 
     const parentCollection = $derived.by(() =>
         retrieveParentCollection($collections, collectionId)
@@ -370,6 +371,7 @@
                     <DatasetGridHeader
                         {canSelectAll}
                         {isImages}
+                        {hasEvaluationRuns}
                         {hasMediaWithEmbeddings}
                         collectionDatasetId={collection.dataset_id}
                         compact={isSidePanelOpen}
@@ -436,6 +438,7 @@
                             <DatasetGridHeader
                                 {canSelectAll}
                                 {isImages}
+                                {hasEvaluationRuns}
                                 {hasMediaWithEmbeddings}
                                 collectionDatasetId={collection.dataset_id}
                                 compact={isSidePanelOpen}


### PR DESCRIPTION
## What has changed and why?

Show the evaluatiuon button in the header only whne evalaution runs are available.

## How has it been tested?

test is updated

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Evaluation toggle now appears only for image collections that have evaluation runs, and the evaluation side panel is hidden when none exist—avoids showing non-functional controls.
* **Tests**
  * UI tests updated to verify the toggle and side panel correctly show or hide based on available evaluation runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->