### PR TITLE
Truncate long plot legend names

### DIFF
--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <div
-    class="absolute bottom-1 left-3 flex max-h-[calc(100%-0.5rem)] flex-col items-start gap-1 overflow-hidden rounded-md border border-white/10 bg-black/60 px-2 py-1 text-xs text-muted-foreground backdrop-blur-sm"
+    class="absolute bottom-1 left-3 flex max-h-[calc(100%-0.5rem)] max-w-48 flex-col items-start gap-1 overflow-hidden rounded-md border border-white/10 bg-black/60 px-2 py-1 text-xs text-muted-foreground backdrop-blur-sm"
     data-testid="plot-legend"
 >
     <div class="flex w-full flex-col gap-1 overflow-y-auto dark:[color-scheme:dark]">
@@ -44,7 +44,7 @@
                 ondblclick={() => onDoubleClickCategory?.(entry.cat)}
             >
                 <span class="legend-dot shrink-0" style={`background-color: ${entry.color}`}></span>
-                <span class="truncate">{entry.label}</span>
+                <span class="min-w-0 truncate" title={entry.label}>{entry.label}</span>
             </button>
         {/each}
         {#if legendEntries.length > 0}


### PR DESCRIPTION
## What has changed and why?

Truncate long plot legend names. Shows the full name on hover.

## How has it been tested?

Manually.

<img width="526" height="487" alt="Screenshot 2026-06-01 at 13 43 12" src="https://github.com/user-attachments/assets/f8d17f30-3e23-4723-995a-ed895b137bf2" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Legend labels now display a tooltip with the full text when you hover over truncated entries, making it easier to view complete label names
  * Legend layout improved with optimized width constraints for better visual balance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->