### PR TITLE
Add strategyInstance helpers

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/index.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/index.ts
@@ -4,5 +4,9 @@ export {
     type ClassBalancingTargetDistributionMode,
     type ClassBalancingTargetRow,
     type ClassBalancingParams,
-    type StrategyParams
+    type StrategyParams,
+    type StrategyInstance,
+    STRATEGY_DEFAULTS,
+    STRATEGY_LABELS
 } from './types';
+export { cloneStrategyParams, createStrategyInstance } from './strategyInstance';

--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyInstance.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyInstance.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { cloneStrategyParams, createStrategyInstance } from './strategyInstance';
-import { STRATEGY_DEFAULTS } from './types';
+import { cloneStrategyParams, createStrategyInstance, STRATEGY_DEFAULTS } from '.';
 
 describe('cloneStrategyParams', () => {
     it('shallow-clones non-class_balancing params', () => {
@@ -44,6 +43,7 @@ describe('createStrategyInstance', () => {
 
         expect(instance.type).toBe('diversity');
         expect(instance.params).toEqual(STRATEGY_DEFAULTS.diversity);
+        expect(instance.params).not.toBe(STRATEGY_DEFAULTS.diversity);
     });
 
     it('sets isExpanded to true', () => {

--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyInstance.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyInstance.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { cloneStrategyParams, createStrategyInstance } from './strategyInstance';
+import { STRATEGY_DEFAULTS } from './types';
+
+describe('cloneStrategyParams', () => {
+    it('shallow-clones non-class_balancing params', () => {
+        const original = { strength: 2 };
+        const clone = cloneStrategyParams('diversity', original);
+
+        expect(clone).toEqual({ strength: 2 });
+        expect(clone).not.toBe(original);
+    });
+
+    it('deep-clones class_balancing target_distribution rows', () => {
+        const original = {
+            target_distribution_mode: 'dictionary' as const,
+            target_distribution: [{ class_name: 'cat', weight: 1 }],
+            strength: 1
+        };
+        const clone = cloneStrategyParams('class_balancing', original);
+
+        expect(clone.target_distribution).toEqual([{ class_name: 'cat', weight: 1 }]);
+        expect(clone.target_distribution).not.toBe(original.target_distribution);
+        expect(clone.target_distribution[0]).not.toBe(original.target_distribution[0]);
+    });
+
+    it('mutation of class_balancing source rows does not affect clone', () => {
+        const original = {
+            target_distribution_mode: 'dictionary' as const,
+            target_distribution: [{ class_name: 'cat', weight: 1 }],
+            strength: 1
+        };
+        const clone = cloneStrategyParams('class_balancing', original);
+
+        original.target_distribution[0].class_name = 'dog';
+
+        expect(clone.target_distribution[0].class_name).toBe('cat');
+    });
+});
+
+describe('createStrategyInstance', () => {
+    it('creates instance with the correct type and default params', () => {
+        const instance = createStrategyInstance('diversity');
+
+        expect(instance.type).toBe('diversity');
+        expect(instance.params).toEqual(STRATEGY_DEFAULTS.diversity);
+    });
+
+    it('sets isExpanded to true', () => {
+        const instance = createStrategyInstance('typicality');
+
+        expect(instance.isExpanded).toBe(true);
+    });
+
+    it('generates a unique id for each call', () => {
+        const a = createStrategyInstance('diversity');
+        const b = createStrategyInstance('diversity');
+
+        expect(a.id).not.toBe(b.id);
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyInstance.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyInstance.ts
@@ -1,0 +1,37 @@
+import {
+    STRATEGY_DEFAULTS,
+    type ClassBalancingParams,
+    type ClassBalancingTargetRow,
+    type StrategyInstance,
+    type StrategyParamsByType,
+    type StrategyType
+} from './types';
+
+function cloneClassBalancingRows(rows: ClassBalancingTargetRow[]): ClassBalancingTargetRow[] {
+    return rows.map((row) => ({ ...row }));
+}
+
+export function cloneStrategyParams<T extends StrategyType>(
+    type: T,
+    params: StrategyParamsByType[T]
+): StrategyParamsByType[T] {
+    if (type === 'class_balancing') {
+        return {
+            ...params,
+            target_distribution: cloneClassBalancingRows(
+                (params as ClassBalancingParams).target_distribution
+            )
+        } as StrategyParamsByType[T];
+    }
+
+    return { ...params };
+}
+
+export function createStrategyInstance(type: StrategyType): StrategyInstance {
+    return {
+        id: crypto.randomUUID(),
+        type,
+        params: cloneStrategyParams(type, STRATEGY_DEFAULTS[type]),
+        isExpanded: true
+    } as StrategyInstance;
+}

--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyInstance.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyInstance.ts
@@ -27,9 +27,21 @@ export function cloneStrategyParams<T extends StrategyType>(
     return { ...params };
 }
 
+let strategyInstanceCounter = 0;
+
+function generateStrategyInstanceId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+
+    const fallback = strategyInstanceCounter;
+    strategyInstanceCounter += 1;
+    return String(fallback);
+}
+
 export function createStrategyInstance(type: StrategyType): StrategyInstance {
     return {
-        id: crypto.randomUUID(),
+        id: generateStrategyInstanceId(),
         type,
         params: cloneStrategyParams(type, STRATEGY_DEFAULTS[type]),
         isExpanded: true

--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/types.ts
@@ -29,7 +29,7 @@ export interface ClassBalancingParams {
     strength: number;
 }
 
-interface StrategyParamsByType {
+export interface StrategyParamsByType {
     diversity: DiversityParams;
     typicality: TypicalityParams;
     similarity: SimilarityParams;
@@ -82,3 +82,15 @@ export const STRATEGY_OPTIONS = [
             'Selects samples to reach a target class distribution using annotation labels. Use to fix class imbalance or enforce custom class proportions.'
     }
 ] satisfies Array<{ type: StrategyType; label: string; description: string }>;
+
+export const STRATEGY_LABELS: Record<StrategyType, string> = Object.fromEntries(
+    STRATEGY_OPTIONS.map((strategy) => [strategy.type, strategy.label])
+) as Record<StrategyType, string>;
+
+export const STRATEGY_DEFAULTS: { [K in StrategyType]: StrategyParamsByType[K] } = {
+    diversity: { strength: 1 },
+    typicality: { strength: 1 },
+    similarity: { query_tag_id: '', strength: 1 },
+    metadata_weighting: { metadata_key: '', strength: 1 },
+    class_balancing: { target_distribution_mode: 'uniform', target_distribution: [], strength: 1 }
+};


### PR DESCRIPTION
## What has changed and why?

Introduces `STRATEGY_DEFAULTS` and `STRATEGY_LABELS` constants, plus `cloneStrategyParams` and    `createStrategyInstance` helpers for initializing and cloning strategy instances in the strategy builder.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Strategy builder now exposes strategy labels and typed defaults, creates new strategy instances with unique IDs and expanded state, and clones parameters to avoid accidental mutations.

* **Tests**
  * Added tests covering parameter cloning behavior and strategy instance creation to ensure defaults, cloning semantics, and uniqueness are reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->