### PR TITLE
Make plot colors more distict for tags

### DIFF
--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -120,9 +120,7 @@
         })
     );
     const categoryCount = $derived.by(() => getCategoryCount($colorLegend));
-    const useLabelColors = $derived(
-        $selectedColorByType !== 'metadata' && $selectedColorByType !== 'tags'
-    );
+    const useLabelColors = $derived($selectedColorByType === 'annotation_label');
     const categoryColors = $derived.by(() =>
         getCategoryColors($colorLegend, useLabelColors, $colorBy !== null)
     );

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -120,7 +120,9 @@
         })
     );
     const categoryCount = $derived.by(() => getCategoryCount($colorLegend));
-    const useLabelColors = $derived($selectedColorByType !== 'metadata');
+    const useLabelColors = $derived(
+        $selectedColorByType !== 'metadata' && $selectedColorByType !== 'tags'
+    );
     const categoryColors = $derived.by(() =>
         getCategoryColors($colorLegend, useLabelColors, $colorBy !== null)
     );


### PR DESCRIPTION
## What has changed and why?

Use discrete colorwheel coloring for tags - it splits the colors equally in the color wheel. Before, color was assigned by hashing the tag name.

## How has it been tested?

Manually.

Before:
<img width="669" height="517" alt="Screenshot 2026-05-29 at 17 39 20 (1)" src="https://github.com/user-attachments/assets/49dc2f90-29cd-4887-8777-b6fc698e433e" />

After:
<img width="795" height="613" alt="Screenshot 2026-06-01 at 18 20 18" src="https://github.com/user-attachments/assets/eb342413-85b2-4e20-bb43-1ce78d956db5" />



## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plots now restrict label-based coloring to annotation labels only. Color palettes and legends for other color modes (such as tags or metadata) are no longer driven by label colors, ensuring correct palette selection and legend entries.
  * This improves visual consistency and prevents incorrect color assignments when switching color-by modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->