### PR TITLE
Improve annotation and plot colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Header menu: show collection name in Annotations entries
 - Embedding plot coloring now supports multiple categories per sample, resolving issues with toggling visibility of categories in the legend.
+- Made annotation and plot colors more distinguishable.
 
 ### Deprecated
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.test.ts
@@ -7,10 +7,10 @@ import { getColorByLabel } from '$lib/utils';
 describe('PlotPanelLegend', () => {
     it('renders the fixed entries and the custom legend list', () => {
         render(PlotPanelLegend, {
-            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'hsl(0, 70%, 55%)'],
+            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'rgb(255, 0, 136)'],
             includedLabel: 'No category',
             legendEntries: [
-                { cat: 2, label: 'metadata.split: train', color: 'hsl(0, 70%, 55%)', hidden: false }
+                { cat: 2, label: 'metadata.split: train', color: 'rgb(255, 0, 136)', hidden: false }
             ]
         });
 
@@ -33,8 +33,8 @@ describe('PlotPanelLegend', () => {
         const onToggleCategory = vi.fn();
 
         render(PlotPanelLegend, {
-            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'hsl(0, 70%, 55%)'],
-            legendEntries: [{ cat: 2, label: 'Train', color: 'hsl(0, 70%, 55%)', hidden: false }],
+            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'rgb(255, 0, 136)'],
+            legendEntries: [{ cat: 2, label: 'Train', color: 'rgb(255, 0, 136)', hidden: false }],
             onToggleCategory
         });
 
@@ -47,8 +47,8 @@ describe('PlotPanelLegend', () => {
         const onDoubleClickCategory = vi.fn();
 
         render(PlotPanelLegend, {
-            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'hsl(0, 70%, 55%)'],
-            legendEntries: [{ cat: 2, label: 'Train', color: 'hsl(0, 70%, 55%)', hidden: false }],
+            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'rgb(255, 0, 136)'],
+            legendEntries: [{ cat: 2, label: 'Train', color: 'rgb(255, 0, 136)', hidden: false }],
             onDoubleClickCategory
         });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
@@ -74,8 +74,8 @@ describe('plotColorUtils', () => {
                 false
             )
         ).toEqual([
-            { cat: 2, label: 'Train', color: 'hsl(0, 70%, 55%)', hidden: false },
-            { cat: 3, label: 'Validation', color: 'hsl(180, 70%, 55%)', hidden: false }
+            { cat: 2, label: 'Train', color: 'rgb(255, 0, 136)', hidden: false },
+            { cat: 3, label: 'Validation', color: 'rgb(0, 193, 150)', hidden: false }
         ]);
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -1,7 +1,8 @@
-import { getColorByLabel } from '$lib/utils';
+import { getColorByLabel, oklchToRgb } from '$lib/utils';
 
-const HSL_SATURATION = 70;
-const HSL_LIGHTNESS = 55;
+const OKLCH_LIGHTNESS = 0.65;
+const OKLCH_CHROMA = 0.3;
+const SINGLE_CATEGORY_HUE = 264;
 const RESERVED_CATEGORY_COUNT = 2;
 
 export const NOT_FILTERED_COLOR = '#9CA3AF';
@@ -23,18 +24,15 @@ function getMaxCategoryFromLegend(colorLegend?: ReadonlyMap<number, string> | nu
     return Math.max(...colorLegend.keys());
 }
 
-function getDiscreteHslColor(index: number, total: number): string {
-    if (total <= 1) {
-        return 'hsl(220, 70%, 55%)';
-    }
-
-    const hue = Math.round((index * 360) / total) % 360;
-    return `hsl(${hue}, ${HSL_SATURATION}%, ${HSL_LIGHTNESS}%)`;
+function getDiscreteOklchColor(index: number, total: number): string {
+    const hue = total <= 1 ? SINGLE_CATEGORY_HUE : ((index * 360) / total) % 360;
+    const { r, g, b } = oklchToRgb(OKLCH_LIGHTNESS, OKLCH_CHROMA, hue);
+    return `rgb(${r}, ${g}, ${b})`;
 }
 
 function getDiscreteCategoryColor(category: number, categoryCount: number): string {
     const totalColoredCategories = Math.max(1, categoryCount - RESERVED_CATEGORY_COUNT);
-    return getDiscreteHslColor(category - RESERVED_CATEGORY_COUNT, totalColoredCategories);
+    return getDiscreteOklchColor(category - RESERVED_CATEGORY_COUNT, totalColoredCategories);
 }
 
 function getBaseCategoryColor(

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -25,8 +25,6 @@ function getMaxCategoryFromLegend(colorLegend?: ReadonlyMap<number, string> | nu
 }
 
 function getDiscreteOklchColor(index: number, total: number): string {
-    // A lone category has no neighbours to space against, so pin it to a fixed
-    // hue instead of the wheel's first slot.
     const { r, g, b } = oklchHueWheelColor({
         index,
         count: total,

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -1,13 +1,13 @@
-import { getColorByLabel, oklchToRgb } from '$lib/utils';
+import { getColorByLabel, oklchHueWheelColor } from '$lib/utils';
 
 const OKLCH_LIGHTNESS = 0.65;
 const OKLCH_CHROMA = 0.3;
-const SINGLE_CATEGORY_HUE = 264;
+
 const RESERVED_CATEGORY_COUNT = 2;
 
-export const NOT_FILTERED_COLOR = '#9CA3AF';
-export const FILTERED_COLOR = '#F59E0B';
-export const UNASSIGNED_COLOR = '#CAAC78';
+export const NOT_FILTERED_COLOR = '#222222';
+export const FILTERED_COLOR = '#FF7220';
+export const UNASSIGNED_COLOR = '#666666';
 
 interface LegendEntry {
     cat: number;
@@ -25,8 +25,14 @@ function getMaxCategoryFromLegend(colorLegend?: ReadonlyMap<number, string> | nu
 }
 
 function getDiscreteOklchColor(index: number, total: number): string {
-    const hue = total <= 1 ? SINGLE_CATEGORY_HUE : ((index * 360) / total) % 360;
-    const { r, g, b } = oklchToRgb(OKLCH_LIGHTNESS, OKLCH_CHROMA, hue);
+    // A lone category has no neighbours to space against, so pin it to a fixed
+    // hue instead of the wheel's first slot.
+    const { r, g, b } = oklchHueWheelColor({
+        index,
+        count: total,
+        lightness: OKLCH_LIGHTNESS,
+        chroma: OKLCH_CHROMA
+    });
     return `rgb(${r}, ${g}, ${b})`;
 }
 

--- a/lightly_studio_view/src/lib/utils/colorConvert.test.ts
+++ b/lightly_studio_view/src/lib/utils/colorConvert.test.ts
@@ -5,7 +5,8 @@ import {
     rgbaFromBytes,
     withAlpha,
     stripAlpha,
-    oklchToRgb
+    oklchToRgb,
+    oklchHueWheelColor
 } from './colorConvert';
 
 describe('hexToRgb', () => {
@@ -83,6 +84,29 @@ describe('oklchToRgb', () => {
             expect(channel).toBeGreaterThanOrEqual(0);
             expect(channel).toBeLessThanOrEqual(255);
         }
+    });
+});
+
+describe('oklchHueWheelColor', () => {
+    test('places index 0 at the start of the hue circle', () => {
+        // Same as oklchToRgb at hue 0 for the given lightness/chroma.
+        expect(oklchHueWheelColor({ index: 0, count: 4, lightness: 0.65, chroma: 0.3 })).toEqual(
+            oklchToRgb(0.65, 0.3, 0)
+        );
+    });
+
+    test('spreads hues evenly: index i sits at i/count around the circle', () => {
+        // index 1 of 4 → hue 90°.
+        expect(oklchHueWheelColor({ index: 1, count: 4, lightness: 0.65, chroma: 0.3 })).toEqual(
+            oklchToRgb(0.65, 0.3, 90)
+        );
+    });
+
+    test('hueOffset rotates the wheel and wraps past 360°', () => {
+        // index 3 of 4 → 270°, +120° offset → 390° wraps to 30°.
+        expect(
+            oklchHueWheelColor({ index: 3, count: 4, lightness: 0.65, chroma: 0.3, hueOffset: 120 })
+        ).toEqual(oklchToRgb(0.65, 0.3, 30));
     });
 });
 

--- a/lightly_studio_view/src/lib/utils/colorConvert.test.ts
+++ b/lightly_studio_view/src/lib/utils/colorConvert.test.ts
@@ -4,7 +4,8 @@ import {
     rgbaToHex,
     rgbaFromBytes,
     withAlpha,
-    stripAlpha
+    stripAlpha,
+    oklchToRgb
 } from './colorConvert';
 
 describe('hexToRgb', () => {
@@ -61,6 +62,27 @@ describe('withAlpha', () => {
 
     test('returns input unchanged when no rgb(a) match is found', () => {
         expect(withAlpha('hsl(0, 100%, 50%)', 0.5)).toBe('hsl(0, 100%, 50%)');
+    });
+});
+
+describe('oklchToRgb', () => {
+    test('maps achromatic OKLCH to neutral sRGB', () => {
+        // Zero chroma at full lightness is white; at zero lightness, black.
+        expect(oklchToRgb(1, 0, 0)).toEqual({ r: 255, g: 255, b: 255 });
+        expect(oklchToRgb(0, 0, 0)).toEqual({ r: 0, g: 0, b: 0 });
+    });
+
+    test('produces an in-gamut hue at the palette lightness/chroma', () => {
+        // Hue 120° at L=0.8, C=0.22 is a yellow-green inside the sRGB gamut.
+        expect(oklchToRgb(0.8, 0.22, 120)).toEqual({ r: 173, g: 208, b: 0 });
+    });
+
+    test('clamps out-of-gamut channels to the 0-255 range', () => {
+        const { r, g, b } = oklchToRgb(0.8, 0.22, 0);
+        for (const channel of [r, g, b]) {
+            expect(channel).toBeGreaterThanOrEqual(0);
+            expect(channel).toBeLessThanOrEqual(255);
+        }
     });
 });
 

--- a/lightly_studio_view/src/lib/utils/colorConvert.ts
+++ b/lightly_studio_view/src/lib/utils/colorConvert.ts
@@ -105,6 +105,9 @@ export function oklchHueWheelColor({
     chroma,
     hueOffset = 0
 }: OklchHueWheelColorParams): RGB {
+    if (index < 0 || index >= count) {
+        throw new RangeError(`index must be in [0, ${count}), got ${index}`);
+    }
     const hue = (hueOffset + (360 * index) / count) % 360;
     return oklchToRgb(lightness, chroma, hue);
 }

--- a/lightly_studio_view/src/lib/utils/colorConvert.ts
+++ b/lightly_studio_view/src/lib/utils/colorConvert.ts
@@ -43,3 +43,43 @@ export function withAlpha(color: string, alpha: number): string {
 export function stripAlpha(color: string): string {
     return color.replace(/rgba?\((\d+,\s*\d+,\s*\d+)(?:,\s*[\d.]+)?\)/, 'rgb($1)');
 }
+
+/** Linear-light sRGB channel → gamma-encoded sRGB channel (IEC 61966-2-1). */
+function linearToGamma(c: number): number {
+    return c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+}
+
+/**
+ * Converts an OKLCH color to 8-bit sRGB.
+ *
+ * @param l Lightness, 0-1.
+ * @param c Chroma, typically 0-0.4.
+ * @param h Hue in degrees, 0-360.
+ *
+ * Channels that fall outside the sRGB gamut are clamped to [0, 255], which can
+ * shift the perceived hue/chroma for highly saturated inputs. Uses Björn
+ * Ottosson's OKLab matrices (https://bottosson.github.io/posts/oklab/).
+ */
+export function oklchToRgb(l: number, c: number, h: number): RGB {
+    const hRad = (h * Math.PI) / 180;
+    const a = c * Math.cos(hRad);
+    const b = c * Math.sin(hRad);
+
+    // OKLab → non-linear LMS → linear LMS (cube).
+    const l_ = l + 0.3963377774 * a + 0.2158037573 * b;
+    const m_ = l - 0.1055613458 * a - 0.0638541728 * b;
+    const s_ = l - 0.0894841775 * a - 1.291485548 * b;
+    const lCube = l_ ** 3;
+    const mCube = m_ ** 3;
+    const sCube = s_ ** 3;
+
+    // Linear LMS → linear sRGB.
+    const rLin = 4.0767416621 * lCube - 3.3077115913 * mCube + 0.2309699292 * sCube;
+    const gLin = -1.2684380046 * lCube + 2.6097574011 * mCube - 0.3413193965 * sCube;
+    const bLin = -0.0041960863 * lCube - 0.7034186147 * mCube + 1.707614701 * sCube;
+
+    const toByte = (channel: number) =>
+        Math.round(Math.max(0, Math.min(1, linearToGamma(channel))) * 255);
+
+    return { r: toByte(rLin), g: toByte(gLin), b: toByte(bLin) };
+}

--- a/lightly_studio_view/src/lib/utils/colorConvert.ts
+++ b/lightly_studio_view/src/lib/utils/colorConvert.ts
@@ -83,3 +83,26 @@ export function oklchToRgb(l: number, c: number, h: number): RGB {
 
     return { r: toByte(rLin), g: toByte(gLin), b: toByte(bLin) };
 }
+
+/**
+ * Returns the sRGB color for the `index`-th of `count` hues spread evenly around
+ * the OKLCH hue circle, at a fixed lightness and chroma. `hueOffset` (degrees)
+ * rotates the whole wheel — pass it to interleave several wheels so their hues
+ * land in each other's gaps.
+ */
+export function oklchHueWheelColor({
+    index,
+    count,
+    lightness,
+    chroma,
+    hueOffset = 0
+}: {
+    index: number;
+    count: number;
+    lightness: number;
+    chroma: number;
+    hueOffset?: number;
+}): RGB {
+    const hue = (hueOffset + (360 * index) / count) % 360;
+    return oklchToRgb(lightness, chroma, hue);
+}

--- a/lightly_studio_view/src/lib/utils/colorConvert.ts
+++ b/lightly_studio_view/src/lib/utils/colorConvert.ts
@@ -4,6 +4,14 @@ export interface RGB {
     b: number;
 }
 
+interface OklchHueWheelColorParams {
+    index: number;
+    count: number;
+    lightness: number;
+    chroma: number;
+    hueOffset?: number;
+}
+
 export function hexToRgb(hex: string): RGB {
     return {
         r: parseInt(hex.slice(1, 3), 16),
@@ -96,13 +104,7 @@ export function oklchHueWheelColor({
     lightness,
     chroma,
     hueOffset = 0
-}: {
-    index: number;
-    count: number;
-    lightness: number;
-    chroma: number;
-    hueOffset?: number;
-}): RGB {
+}: OklchHueWheelColorParams): RGB {
     const hue = (hueOffset + (360 * index) / count) % 360;
     return oklchToRgb(lightness, chroma, hue);
 }

--- a/lightly_studio_view/src/lib/utils/getColorByLabel.test.ts
+++ b/lightly_studio_view/src/lib/utils/getColorByLabel.test.ts
@@ -20,8 +20,8 @@ describe('getColorByLabel', () => {
 
     test('returns an rgba color and an RGB-inverted contrast color', () => {
         expect(getColorByLabel('cat')).toEqual({
-            color: 'rgba(0, 184, 0, 1)',
-            contrastColor: 'rgba(255, 71, 255, 1)'
+            color: 'rgba(60, 225, 93, 1)',
+            contrastColor: 'rgba(195, 30, 162, 1)'
         });
     });
 

--- a/lightly_studio_view/src/lib/utils/getColorByLabel.test.ts
+++ b/lightly_studio_view/src/lib/utils/getColorByLabel.test.ts
@@ -20,14 +20,33 @@ describe('getColorByLabel', () => {
 
     test('returns an rgba color and an RGB-inverted contrast color', () => {
         expect(getColorByLabel('cat')).toEqual({
-            color: 'rgba(60, 225, 93, 1)',
-            contrastColor: 'rgba(195, 30, 162, 1)'
+            color: 'rgba(0, 190, 53, 1)',
+            contrastColor: 'rgba(255, 65, 202, 1)'
         });
     });
 
     test('clamps alpha below 0 to 0 and above 1 to 1', () => {
         expect(getColorByLabel('test', -5).color).toContain(', 0)');
         expect(getColorByLabel('test', 2).color).toContain(', 1)');
+    });
+
+    test('spreads sequential labels across the whole palette', () => {
+        // Regression test for the FNV-1a hash: sequential labels like `class_0`, `class_1`, ...
+        // are spread evenly accross the 32 cpalette colors.
+        const labels = Array.from({ length: 100 }, (_, i) => `class_${i}`);
+
+        const countsByColor = new Map<string, number>();
+        for (const label of labels) {
+            const { color } = getColorByLabel(label);
+            countsByColor.set(color, (countsByColor.get(color) ?? 0) + 1);
+        }
+
+        // Every one of the 32 palette colors should be used.
+        expect(countsByColor.size).toBe(32);
+        // No single color should hoard labels (uniform spread of 100 labels
+        // over 32 colors averages ~3 per color; allow generous headroom for variance).
+        const maxPerColor = Math.max(...countsByColor.values());
+        expect(maxPerColor).toBeLessThanOrEqual(7);
     });
 
     describe('with a custom color override', () => {

--- a/lightly_studio_view/src/lib/utils/getColorByLabel.test.ts
+++ b/lightly_studio_view/src/lib/utils/getColorByLabel.test.ts
@@ -20,8 +20,8 @@ describe('getColorByLabel', () => {
 
     test('returns an rgba color and an RGB-inverted contrast color', () => {
         expect(getColorByLabel('cat')).toEqual({
-            color: 'rgba(0, 0, 255, 1)',
-            contrastColor: 'rgba(255, 255, 0, 1)'
+            color: 'rgba(0, 184, 0, 1)',
+            contrastColor: 'rgba(255, 71, 255, 1)'
         });
     });
 

--- a/lightly_studio_view/src/lib/utils/getColorByLabel.ts
+++ b/lightly_studio_view/src/lib/utils/getColorByLabel.ts
@@ -1,30 +1,27 @@
 import { useCustomLabelColors } from '$lib/hooks/useCustomLabelColors';
-import { hexToRgb } from './colorConvert';
+import { hexToRgb, oklchToRgb } from './colorConvert';
 import { getColorPair } from './getColorPair';
 
-const COLOR_PALETTE: Array<[number, number, number]> = [
-    [255, 0, 0], // Red
-    [0, 255, 0], // Green
-    [0, 0, 255], // Blue
-    [255, 255, 0], // Yellow
-    [255, 0, 255], // Magenta
-    [0, 255, 255], // Cyan
-    [128, 0, 0], // Maroon
-    [0, 128, 0], // Dark Green
-    [0, 0, 128], // Navy
-    [128, 128, 0], // Olive
-    [128, 0, 128], // Purple
-    [0, 128, 128], // Teal
-    [192, 192, 192], // Silver
-    [128, 128, 128], // Gray
-    [255, 165, 0], // Orange
-    [255, 20, 147], // Deep Pink
-    [75, 0, 130], // Indigo
-    [255, 105, 180], // Hot Pink
-    [0, 255, 127], // Spring Green
-    [255, 215, 0], // Gold
-    [255, 69, 0] // Red-Orange
+// 32 perceptually-uniform colors: the union of two equal-hue OKLCH wheels. Each
+// wheel fixes lightness and chroma and sweeps 16 evenly-spaced hues, so colors
+// within a wheel differ only in hue, while the two wheels differ in
+// brightness/saturation. The second wheel is rotated by half a hue step so its
+// hues fall in the first wheel's gaps, spreading all 32 hues evenly around the
+// circle. Generated rather than hand-tuned to keep the spec explicit.
+const COLORS_PER_WHEEL = 16;
+const HUE_STEP = 360 / COLORS_PER_WHEEL;
+const WHEELS: Array<{ lightness: number; chroma: number; hueOffset: number }> = [
+    { lightness: 0.65, chroma: 0.3, hueOffset: 0 },
+    { lightness: 0.8, chroma: 0.22, hueOffset: HUE_STEP / 2 }
 ];
+const COLOR_PALETTE: Array<[number, number, number]> = WHEELS.flatMap(
+    ({ lightness, chroma, hueOffset }) =>
+        Array.from({ length: COLORS_PER_WHEEL }, (_, i) => {
+            const hue = hueOffset + HUE_STEP * i;
+            const { r, g, b } = oklchToRgb(lightness, chroma, hue);
+            return [r, g, b] as [number, number, number];
+        })
+);
 
 export const getColorByLabel = (label: string, alpha: number = 1) => {
     alpha = Math.max(0, Math.min(alpha, 1));
@@ -39,12 +36,11 @@ export const getColorByLabel = (label: string, alpha: number = 1) => {
         }
     }
 
-    // Hash the label into the palette. Indexing matches the previous implementation
-    // (`(|hash| % (palette.length - 1)) + 1` mapped to `palette[index - 1]`), which
-    // uses 20 of the 21 palette entries — preserved here to keep label colors stable.
+    // Hash the label deterministically into the palette so a given label always maps
+    // to the same color across sessions.
     const hash = Array.from(label).reduce((h, char) => (h << 5) - h + char.charCodeAt(0), 0);
-    const index = (Math.abs(hash) % (COLOR_PALETTE.length - 1)) + 1;
-    const [r, g, b] = COLOR_PALETTE[index - 1];
+    const index = Math.abs(hash) % COLOR_PALETTE.length;
+    const [r, g, b] = COLOR_PALETTE[index];
 
     return getColorPair({ r, g, b }, alpha);
 };

--- a/lightly_studio_view/src/lib/utils/getColorByLabel.ts
+++ b/lightly_studio_view/src/lib/utils/getColorByLabel.ts
@@ -28,6 +28,17 @@ const COLOR_PALETTE: Array<[number, number, number]> = WHEELS.flatMap(
         })
 );
 
+// FNV-1a 32-bit hash. Mixes each byte into all 32 bits, so the result distributes
+// well even when reduced modulo a power-of-two table length.
+const fnv1aHash = (value: string) => {
+    let hash = 0x811c9dc5; // FNV-1a 32-bit offset basis
+    for (let i = 0; i < value.length; i++) {
+        hash ^= value.charCodeAt(i);
+        hash = Math.imul(hash, 0x01000193); // FNV-1a 32-bit prime
+    }
+    return hash >>> 0; // coerce to unsigned 32-bit
+};
+
 export const getColorByLabel = (label: string, alpha: number = 1) => {
     alpha = Math.max(0, Math.min(alpha, 1));
 
@@ -43,8 +54,7 @@ export const getColorByLabel = (label: string, alpha: number = 1) => {
 
     // Hash the label deterministically into the palette so a given label always maps
     // to the same color across sessions.
-    const hash = Array.from(label).reduce((h, char) => (h << 5) - h + char.charCodeAt(0), 0);
-    const index = Math.abs(hash) % COLOR_PALETTE.length;
+    const index = fnv1aHash(label) % COLOR_PALETTE.length;
     const [r, g, b] = COLOR_PALETTE[index];
 
     return getColorPair({ r, g, b }, alpha);

--- a/lightly_studio_view/src/lib/utils/getColorByLabel.ts
+++ b/lightly_studio_view/src/lib/utils/getColorByLabel.ts
@@ -1,5 +1,5 @@
 import { useCustomLabelColors } from '$lib/hooks/useCustomLabelColors';
-import { hexToRgb, oklchToRgb } from './colorConvert';
+import { hexToRgb, oklchHueWheelColor } from './colorConvert';
 import { getColorPair } from './getColorPair';
 
 // 32 perceptually-uniform colors: the union of two equal-hue OKLCH wheels. Each
@@ -17,8 +17,13 @@ const WHEELS: Array<{ lightness: number; chroma: number; hueOffset: number }> = 
 const COLOR_PALETTE: Array<[number, number, number]> = WHEELS.flatMap(
     ({ lightness, chroma, hueOffset }) =>
         Array.from({ length: COLORS_PER_WHEEL }, (_, i) => {
-            const hue = hueOffset + HUE_STEP * i;
-            const { r, g, b } = oklchToRgb(lightness, chroma, hue);
+            const { r, g, b } = oklchHueWheelColor({
+                index: i,
+                count: COLORS_PER_WHEEL,
+                lightness,
+                chroma,
+                hueOffset
+            });
             return [r, g, b] as [number, number, number];
         })
 );

--- a/lightly_studio_view/src/lib/utils/index.ts
+++ b/lightly_studio_view/src/lib/utils/index.ts
@@ -28,5 +28,6 @@ export {
     rgbaFromBytes,
     withAlpha,
     stripAlpha,
-    oklchToRgb
+    oklchToRgb,
+    oklchHueWheelColor
 } from './colorConvert';

--- a/lightly_studio_view/src/lib/utils/index.ts
+++ b/lightly_studio_view/src/lib/utils/index.ts
@@ -27,5 +27,6 @@ export {
     rgbaToHex,
     rgbaFromBytes,
     withAlpha,
-    stripAlpha
+    stripAlpha,
+    oklchToRgb
 } from './colorConvert';


### PR DESCRIPTION
## What has changed and why?

Change annotation and plot color palette.

Annotation colors were before taken from a fixed 21-color palette. After, they are taken from a 32-color palette consisting of two 16-color wheels uniformly spaced in the OKLCH color space.

Metadata and tags are as before taken uniformly from a color wheel, the change was only from HSL to OKLCH for better color distinguishability.

Moreover, "exluded by filters" and "no category" colors have been changed to be both on the grayscale.

## How has it been tested?

Manually.

<img width="350" alt="Screenshot 2026-06-02 at 10 31 09" src="https://github.com/user-attachments/assets/7998ee32-b8dc-4928-978c-05946a5c7dba" />
<img width="350"  alt="Screenshot 2026-06-02 at 11 13 07" src="https://github.com/user-attachments/assets/c7b6eb40-18a9-4911-849c-52f7518326a3" />
<img width="350"  alt="Screenshot 2026-06-02 at 11 13 25" src="https://github.com/user-attachments/assets/153946c2-dac1-4f9e-a7f5-2793a6c39261" />
<img width="350"  alt="Screenshot 2026-06-02 at 11 13 40" src="https://github.com/user-attachments/assets/311a491e-3cbb-4966-a292-7ccf269f757e" />
<img width="1434" height="834" alt="Screenshot 2026-06-02 at 11 12 28" src="https://github.com/user-attachments/assets/844cb5db-ef38-4a64-b8fe-9b1fde21f54e" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Annotation, plot, and legend colors were redesigned for stronger distinction and readability; default filtered and unassigned colors updated.
  * Label-assigned and discrete category colors now come from a new evenly distributed palette, so some labels/categories may show different colors.

* **Tests**
  * Unit tests updated and expanded to cover the new color generation and mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->