### PR TITLE
fix: chunk oversized IN-clause selects and deletes to stay under Postgres' parameter limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed deleting large datasets (more than ~65,535 samples) failing on PostgreSQL with
-  `number of parameters must be between 0 and 65535`.
+- Fixed operations on large datasets (more than ~65,535 samples) failing on PostgreSQL with
+  `number of parameters must be between 0 and 65535` — including deleting datasets, tagging,
+  embedding and metadata lookups, and adding large image or video sets.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed operations on large datasets (more than ~65,535 samples) failing on PostgreSQL with
-  `number of parameters must be between 0 and 65535` — including deleting datasets, tagging,
-  embedding and metadata lookups, and adding large image or video sets.
+  `number of parameters must be between 0 and 65535`.
 
 ### Security
 

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotations.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotations.py
@@ -13,6 +13,7 @@ from lightly_studio.resolvers import annotation_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
 )
+from lightly_studio.utils import batching
 
 
 def delete_annotations(
@@ -42,10 +43,8 @@ def delete_annotations(
 
     # Now delete the annotations themselves
     annotation_ids = [annotation.sample_id for annotation in annotations]
-    if annotation_ids:
+    for batch in batching.batched(items=annotation_ids):
         session.exec(
-            delete(AnnotationBaseTable).where(
-                col(AnnotationBaseTable.sample_id).in_(annotation_ids)
-            )
+            delete(AnnotationBaseTable).where(col(AnnotationBaseTable.sample_id).in_(batch))
         )
-        session.commit()
+    session.commit()

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_by_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_by_id.py
@@ -10,6 +10,7 @@ from sqlmodel import Session, col, select
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationBaseTable,
 )
+from lightly_studio.utils import batching
 
 
 def get_by_id(session: Session, annotation_id: UUID) -> AnnotationBaseTable | None:
@@ -31,9 +32,13 @@ def get_by_ids(session: Session, annotation_ids: Sequence[UUID]) -> Sequence[Ann
     Returns:
         A list of annotations matching the provided IDs.
     """
-    results = session.exec(
-        select(AnnotationBaseTable).where(col(AnnotationBaseTable.sample_id).in_(annotation_ids))
-    ).all()
+    results: list[AnnotationBaseTable] = []
+    for batch in batching.batched(items=annotation_ids):
+        results.extend(
+            session.exec(
+                select(AnnotationBaseTable).where(col(AnnotationBaseTable.sample_id).in_(batch))
+            ).all()
+        )
 
     annotation_map = {annotation.sample_id: annotation for annotation in results}
     return [annotation_map[id_] for id_ in annotation_ids if id_ in annotation_map]

--- a/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
@@ -11,6 +11,7 @@ from lightly_studio.models.caption import CaptionCreate, CaptionTable
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.sample import SampleCreate
 from lightly_studio.resolvers import collection_resolver, sample_resolver
+from lightly_studio.utils import batching
 
 
 class CaptionCreateHelper(CaptionCreate):
@@ -66,9 +67,11 @@ def create_many(
 
 def get_by_ids(session: Session, sample_ids: Sequence[UUID]) -> list[CaptionTable]:
     """Retrieve captions by IDs."""
-    results = session.exec(
-        select(CaptionTable).where(col(CaptionTable.sample_id).in_(set(sample_ids)))
-    ).all()
+    results: list[CaptionTable] = []
+    for batch in batching.batched(items=set(sample_ids)):
+        results.extend(
+            session.exec(select(CaptionTable).where(col(CaptionTable.sample_id).in_(batch))).all()
+        )
     # Return samples in the same order as the input IDs
     caption_map = {caption.sample_id: caption for caption in results}
     return [caption_map[id_] for id_ in sample_ids if id_ in caption_map]

--- a/lightly_studio/src/lightly_studio/resolvers/group_resolver/create_many.py
+++ b/lightly_studio/src/lightly_studio/resolvers/group_resolver/create_many.py
@@ -10,6 +10,7 @@ from sqlmodel import Session, col, select
 from lightly_studio.models.group import GroupTable, SampleGroupLinkTable
 from lightly_studio.models.sample import SampleCreate, SampleTable
 from lightly_studio.resolvers import collection_resolver, sample_resolver
+from lightly_studio.utils import batching
 
 
 def create_many(
@@ -81,11 +82,12 @@ def _validate_groups(
 
     # Get sample_id to collection_id mapping
     all_sample_ids = {sid for sample_ids in groups for sid in sample_ids}
-    statement = select(SampleTable.sample_id, SampleTable.collection_id).where(
-        col(SampleTable.sample_id).in_(all_sample_ids)
-    )
-    results = session.exec(statement).all()
-    sample_id_to_collection_id = dict(results)
+    sample_id_to_collection_id: dict[UUID, UUID] = {}
+    for batch in batching.batched(items=all_sample_ids):
+        statement = select(SampleTable.sample_id, SampleTable.collection_id).where(
+            col(SampleTable.sample_id).in_(batch)
+        )
+        sample_id_to_collection_id.update(session.exec(statement).all())
 
     for sample_ids in groups:
         component_ids_in_group = [sample_id_to_collection_id[sid] for sid in sample_ids]

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/filter_new_paths.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/filter_new_paths.py
@@ -8,6 +8,7 @@ from sqlmodel import Session, col, select
 
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
+from lightly_studio.utils import batching
 
 
 def filter_new_paths(
@@ -24,16 +25,18 @@ def filter_new_paths(
         A tuple of (new_paths, existing_paths) where new_paths are file paths
         not yet in the collection and existing_paths are already present.
     """
-    existing_file_paths_abs = set(
-        session.exec(
-            select(col(ImageTable.file_path_abs))
-            .join(SampleTable)
-            .where(
-                col(SampleTable.collection_id) == collection_id,
-                col(ImageTable.file_path_abs).in_(file_paths_abs),
-            )
-        ).all()
-    )
+    existing_file_paths_abs: set[str] = set()
+    for batch in batching.batched(items=file_paths_abs):
+        existing_file_paths_abs.update(
+            session.exec(
+                select(col(ImageTable.file_path_abs))
+                .join(SampleTable)
+                .where(
+                    col(SampleTable.collection_id) == collection_id,
+                    col(ImageTable.file_path_abs).in_(batch),
+                )
+            ).all()
+        )
     file_paths_abs_set = set(file_paths_abs)
     return (
         list(file_paths_abs_set - existing_file_paths_abs),  # paths not in the collection

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_many_by_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_many_by_id.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.image import ImageTable
+from lightly_studio.utils import batching
 
 
 def get_many_by_id(session: Session, sample_ids: list[UUID]) -> list[ImageTable]:
@@ -18,9 +19,11 @@ def get_many_by_id(session: Session, sample_ids: list[UUID]) -> list[ImageTable]
 
     Output order matches the input order.
     """
-    results = session.exec(
-        select(ImageTable).where(col(ImageTable.sample_id).in_(sample_ids))
-    ).all()
+    results: list[ImageTable] = []
+    for batch in batching.batched(items=sample_ids):
+        results.extend(
+            session.exec(select(ImageTable).where(col(ImageTable.sample_id).in_(batch))).all()
+        )
     # Return samples in the same order as the input IDs
     sample_map = {sample.sample_id: sample for sample in results}
     return [sample_map[id_] for id_ in sample_ids if id_ in sample_map]

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_sample_ids_by_paths.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_sample_ids_by_paths.py
@@ -9,6 +9,7 @@ from sqlmodel import Session, col, select
 
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
+from lightly_studio.utils import batching
 
 
 def get_sample_ids_by_paths(
@@ -27,16 +28,15 @@ def get_sample_ids_by_paths(
         A mapping from file_path_abs to sample_id for paths that exist in the collection.
         Paths not found in the collection are omitted from the result.
     """
-    if not file_paths_abs:
-        return {}
-
-    query = (
-        select(col(ImageTable.file_path_abs), col(ImageTable.sample_id))
-        .join(SampleTable)
-        .where(
-            col(SampleTable.collection_id) == collection_id,
-            col(ImageTable.file_path_abs).in_(file_paths_abs),
+    path_to_sample_id: dict[str, UUID] = {}
+    for batch in batching.batched(items=file_paths_abs):
+        query = (
+            select(col(ImageTable.file_path_abs), col(ImageTable.sample_id))
+            .join(SampleTable)
+            .where(
+                col(SampleTable.collection_id) == collection_id,
+                col(ImageTable.file_path_abs).in_(batch),
+            )
         )
-    )
-    results = session.exec(query).all()
-    return dict(results)
+        path_to_sample_id.update(session.exec(query).all())
+    return path_to_sample_id

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/bulk_update_metadata.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/bulk_update_metadata.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.metadata import SampleMetadataTable
+from lightly_studio.utils import batching
 
 
 def bulk_update_metadata(
@@ -31,10 +32,12 @@ def bulk_update_metadata(
 
     # Get all existing metadata rows for the given sample IDs.
     sample_ids = [s[0] for s in sample_metadata]
-    existing_metadata = session.exec(
-        select(SampleMetadataTable).where(col(SampleMetadataTable.sample_id).in_(sample_ids))
-    ).all()
-    sample_id_to_existing_metadata = {meta.sample_id: meta for meta in existing_metadata}
+    sample_id_to_existing_metadata: dict[UUID, SampleMetadataTable] = {}
+    for batch in batching.batched(items=sample_ids):
+        existing_metadata = session.exec(
+            select(SampleMetadataTable).where(col(SampleMetadataTable.sample_id).in_(batch))
+        ).all()
+        sample_id_to_existing_metadata.update({meta.sample_id: meta for meta in existing_metadata})
 
     for sample_id, new_metadata in sample_metadata:
         metadata = sample_id_to_existing_metadata.get(

--- a/lightly_studio/src/lightly_studio/resolvers/sample_embedding_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_embedding_resolver.py
@@ -15,6 +15,7 @@ from lightly_studio.models.sample_embedding import (
     SampleEmbeddingTable,
 )
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
+from lightly_studio.utils import batching
 
 
 def create(session: Session, sample_embedding: SampleEmbeddingCreate) -> SampleEmbeddingTable:
@@ -50,14 +51,16 @@ def get_by_sample_ids(
     Returns:
         List of sample embeddings associated with the provided IDs.
     """
-    string_ids = [str(id_) for id_ in sample_ids]
-    results = list(
-        session.exec(
-            select(SampleEmbeddingTable)
-            .where(cast(SampleEmbeddingTable.sample_id, String).in_(string_ids))
-            .where(SampleEmbeddingTable.embedding_model_id == embedding_model_id)
-        ).all()
-    )
+    results: list[SampleEmbeddingTable] = []
+    for batch in batching.batched(items=sample_ids):
+        string_ids = [str(id_) for id_ in batch]
+        results.extend(
+            session.exec(
+                select(SampleEmbeddingTable)
+                .where(cast(SampleEmbeddingTable.sample_id, String).in_(string_ids))
+                .where(SampleEmbeddingTable.embedding_model_id == embedding_model_id)
+            ).all()
+        )
     # Return embeddings in the same order as the input IDs
     embedding_map = {embedding.sample_id: embedding for embedding in results}
     return [embedding_map[id_] for id_ in sample_ids if id_ in embedding_map]

--- a/lightly_studio/src/lightly_studio/resolvers/sample_resolver/get_many_by_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_resolver/get_many_by_id.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.sample import SampleTable
+from lightly_studio.utils import batching
 
 
 def get_many_by_id(session: Session, sample_ids: list[UUID]) -> list[SampleTable]:
@@ -14,9 +15,11 @@ def get_many_by_id(session: Session, sample_ids: list[UUID]) -> list[SampleTable
 
     Output order matches the input order.
     """
-    results = session.exec(
-        select(SampleTable).where(col(SampleTable.sample_id).in_(sample_ids))
-    ).all()
+    results: list[SampleTable] = []
+    for batch in batching.batched(items=sample_ids):
+        results.extend(
+            session.exec(select(SampleTable).where(col(SampleTable.sample_id).in_(batch))).all()
+        )
     # Return samples in the same order as the input IDs
     sample_map = {sample.sample_id: sample for sample in results}
     return [sample_map[id_] for id_ in sample_ids if id_ in sample_map]

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -12,6 +12,7 @@ from sqlmodel import Session, col, select
 
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
 from lightly_studio.models.tag import TagCreate, TagTable
+from lightly_studio.utils import batching
 
 
 def create(session: Session, tag: TagCreate) -> TagTable:
@@ -192,12 +193,13 @@ def remove_sample_ids_from_tag_id(
     if not tag or not tag.tag_id:
         return None
 
-    session.exec(
-        sqlmodel.delete(SampleTagLinkTable).where(
-            col(SampleTagLinkTable.tag_id) == tag_id,
-            col(SampleTagLinkTable.sample_id).in_(sample_ids),
+    for batch in batching.batched(items=sample_ids):
+        session.exec(
+            sqlmodel.delete(SampleTagLinkTable).where(
+                col(SampleTagLinkTable.tag_id) == tag_id,
+                col(SampleTagLinkTable.sample_id).in_(batch),
+            )
         )
-    )
 
     session.commit()
     session.refresh(tag)

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/filter_new_paths.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/filter_new_paths.py
@@ -8,6 +8,7 @@ from sqlmodel import Session, col, select
 
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.video import VideoTable
+from lightly_studio.utils import batching
 
 
 def filter_new_paths(
@@ -24,16 +25,18 @@ def filter_new_paths(
         A tuple of (new_paths, existing_paths) where new_paths are file paths
         not yet in the collection and existing_paths are already present.
     """
-    existing_file_paths_abs = set(
-        session.exec(
-            select(col(VideoTable.file_path_abs))
-            .join(SampleTable)
-            .where(
-                col(SampleTable.collection_id) == collection_id,
-                col(VideoTable.file_path_abs).in_(file_paths_abs),
-            )
-        ).all()
-    )
+    existing_file_paths_abs: set[str] = set()
+    for batch in batching.batched(items=file_paths_abs):
+        existing_file_paths_abs.update(
+            session.exec(
+                select(col(VideoTable.file_path_abs))
+                .join(SampleTable)
+                .where(
+                    col(SampleTable.collection_id) == collection_id,
+                    col(VideoTable.file_path_abs).in_(batch),
+                )
+            ).all()
+        )
     file_paths_abs_set = set(file_paths_abs)
     return (
         list(file_paths_abs_set - existing_file_paths_abs),  # paths not in the collection

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_many_by_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_many_by_id.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.video import VideoTable
+from lightly_studio.utils import batching
 
 
 def get_many_by_id(session: Session, sample_ids: list[UUID]) -> list[VideoTable]:
@@ -14,9 +15,11 @@ def get_many_by_id(session: Session, sample_ids: list[UUID]) -> list[VideoTable]
 
     Output order matches the input order.
     """
-    results = session.exec(
-        select(VideoTable).where(col(VideoTable.sample_id).in_(sample_ids))
-    ).all()
+    results: list[VideoTable] = []
+    for batch in batching.batched(items=sample_ids):
+        results.extend(
+            session.exec(select(VideoTable).where(col(VideoTable.sample_id).in_(batch))).all()
+        )
     # Return samples in the same order as the input IDs
     sample_map = {sample.sample_id: sample for sample in results}
     return [sample_map[id_] for id_ in sample_ids if id_ in sample_map]

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -34,6 +34,7 @@ from lightly_studio.sampling.sampling_config import (
     MetadataWeightingStrategy,
     SamplingConfig,
 )
+from lightly_studio.utils import batching
 
 EPSILON = 1e-6
 
@@ -311,16 +312,19 @@ def _get_annotations_for_class_balancing(
             )
         )
 
-    annotations_statement = (
-        select(AnnotationBaseTable)
-        .join(
-            SampleTable,
-            col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
+    annotations: list[AnnotationBaseTable] = []
+    for batch in batching.batched(items=parent_sample_ids):
+        annotations_statement = (
+            select(AnnotationBaseTable)
+            .join(
+                SampleTable,
+                col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id),
+            )
+            .where(col(AnnotationBaseTable.parent_sample_id).in_(batch))
+            .where(col(SampleTable.collection_id) == annotation_source_id)
         )
-        .where(col(AnnotationBaseTable.parent_sample_id).in_(parent_sample_ids))
-        .where(col(SampleTable.collection_id) == annotation_source_id)
-    )
-    return list(session.exec(annotations_statement).all())
+        annotations.extend(session.exec(annotations_statement).all())
+    return annotations
 
 
 def _add_strategy_to_mundig(

--- a/lightly_studio/tests/resolvers/image_resolver/test_filter_new_paths.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_filter_new_paths.py
@@ -59,6 +59,23 @@ def test_filter_new_paths(db_session: Session) -> None:
     assert file_paths_old == []
 
 
+def test_filter_new_paths__exceeds_postgres_param_limit(db_session: Session) -> None:
+    # More paths than PostgreSQL's 65,535 single-statement bind-param cap; the chunked
+    # query must not raise. On an empty collection every path is new. (This is the
+    # 163k-image COCO ingestion crash path.)
+    collection = create_collection(session=db_session)
+    file_paths_abs = [f"/p/{i}.png" for i in range(70_000)]
+
+    file_paths_new, file_paths_old = image_resolver.filter_new_paths(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_paths_abs=file_paths_abs,
+    )
+
+    assert len(file_paths_new) == 70_000
+    assert file_paths_old == []
+
+
 def test_filter_new_paths_same_path_different_collections(db_session: Session) -> None:
     """The same file_path_abs can be added to different collections independently."""
     collection_a = create_collection(collection_name="collection_a", session=db_session)

--- a/lightly_studio/tests/resolvers/image_resolver/test_filter_new_paths.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_filter_new_paths.py
@@ -60,7 +60,7 @@ def test_filter_new_paths(db_session: Session) -> None:
 
 
 def test_filter_new_paths__exceeds_postgres_param_limit(db_session: Session) -> None:
-    # More paths than PostgreSQL's 65,535-parameter cap; the chunked query must not raise.
+    # More paths than PostgreSQL's 65,535-parameter cap.
     collection = create_collection(session=db_session)
     file_paths_abs = [f"/p/{i}.png" for i in range(70_000)]
 

--- a/lightly_studio/tests/resolvers/image_resolver/test_filter_new_paths.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_filter_new_paths.py
@@ -60,9 +60,7 @@ def test_filter_new_paths(db_session: Session) -> None:
 
 
 def test_filter_new_paths__exceeds_postgres_param_limit(db_session: Session) -> None:
-    # More paths than PostgreSQL's 65,535 single-statement bind-param cap; the chunked
-    # query must not raise. On an empty collection every path is new. (This is the
-    # 163k-image COCO ingestion crash path.)
+    # More paths than PostgreSQL's 65,535-parameter cap; the chunked query must not raise.
     collection = create_collection(session=db_session)
     file_paths_abs = [f"/p/{i}.png" for i in range(70_000)]
 

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_many_by_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_many_by_id.py
@@ -40,8 +40,6 @@ def test_get_many_by_id(
 
 
 def test_get_many_by_id__exceeds_postgres_param_limit(db_session: Session) -> None:
-    # More ids than PostgreSQL's 65,535 single-statement bind-param cap. The chunked
-    # query must not raise; none match, so the result is empty. (Raises pre-fix under
-    # --postgres; passes on both backends post-fix.)
+    # More ids than PostgreSQL's 65,535-parameter cap; the chunked query must not raise.
     sample_ids = [uuid.uuid4() for _ in range(70_000)]
     assert image_resolver.get_many_by_id(session=db_session, sample_ids=sample_ids) == []

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_many_by_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_many_by_id.py
@@ -1,3 +1,5 @@
+import uuid
+
 from sqlmodel import Session
 
 from lightly_studio.resolvers import (
@@ -35,3 +37,11 @@ def test_get_many_by_id(
     assert len(samples) == 2
     assert samples[0].file_name == "sample1.png"
     assert samples[1].file_name == "sample2.png"
+
+
+def test_get_many_by_id__exceeds_postgres_param_limit(db_session: Session) -> None:
+    # More ids than PostgreSQL's 65,535 single-statement bind-param cap. The chunked
+    # query must not raise; none match, so the result is empty. (Raises pre-fix under
+    # --postgres; passes on both backends post-fix.)
+    sample_ids = [uuid.uuid4() for _ in range(70_000)]
+    assert image_resolver.get_many_by_id(session=db_session, sample_ids=sample_ids) == []

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_many_by_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_many_by_id.py
@@ -40,6 +40,6 @@ def test_get_many_by_id(
 
 
 def test_get_many_by_id__exceeds_postgres_param_limit(db_session: Session) -> None:
-    # More ids than PostgreSQL's 65,535-parameter cap; the chunked query must not raise.
+    # More ids than PostgreSQL's 65,535-parameter cap.
     sample_ids = [uuid.uuid4() for _ in range(70_000)]
     assert image_resolver.get_many_by_id(session=db_session, sample_ids=sample_ids) == []

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -17,7 +17,7 @@ def test_create_tag(db_session: Session) -> None:
 
 
 def test_remove_sample_ids_from_tag_id__exceeds_postgres_param_limit(db_session: Session) -> None:
-    # More sample ids than PostgreSQL's 65,535-parameter cap; the chunked delete must not raise.
+    # More sample ids than PostgreSQL's 65,535-parameter cap.
     collection_id = create_collection(session=db_session).collection_id
     tag = create_tag(session=db_session, collection_id=collection_id, tag_name="t")
     sample_ids = [uuid4() for _ in range(70_000)]

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -16,6 +16,20 @@ def test_create_tag(db_session: Session) -> None:
     assert tag.name == "example_tag"
 
 
+def test_remove_sample_ids_from_tag_id__exceeds_postgres_param_limit(db_session: Session) -> None:
+    # More sample ids than PostgreSQL's 65,535 single-statement bind-param cap; the
+    # chunked delete must not raise. (Raises pre-fix under --postgres.)
+    collection_id = create_collection(session=db_session).collection_id
+    tag = create_tag(session=db_session, collection_id=collection_id, tag_name="t")
+    sample_ids = [uuid4() for _ in range(70_000)]
+
+    result = tag_resolver.remove_sample_ids_from_tag_id(
+        session=db_session, tag_id=tag.tag_id, sample_ids=sample_ids
+    )
+
+    assert result is not None
+
+
 def test_create_tag__unique_tag_name(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -17,8 +17,7 @@ def test_create_tag(db_session: Session) -> None:
 
 
 def test_remove_sample_ids_from_tag_id__exceeds_postgres_param_limit(db_session: Session) -> None:
-    # More sample ids than PostgreSQL's 65,535 single-statement bind-param cap; the
-    # chunked delete must not raise. (Raises pre-fix under --postgres.)
+    # More sample ids than PostgreSQL's 65,535-parameter cap; the chunked delete must not raise.
     collection_id = create_collection(session=db_session).collection_id
     tag = create_tag(session=db_session, collection_id=collection_id, tag_name="t")
     sample_ids = [uuid4() for _ in range(70_000)]


### PR DESCRIPTION
## What has changed and why?

Follow-up to PR #1265. PostgreSQL caps a single statement at 65,535 bind parameters, so passing a dataset-scaling id/path list to a single `WHERE ... IN (...)` fails on large datasets with `number of parameters must be between 0 and 65535`. This chunks the remaining such selects and deletes with `batching.batched(items=...)`, accumulating results across chunks while preserving output order.

Some other queries can't be chunked without changing their semantics, and are left for a follow-up PR.

## How has it been tested?

New unittests use a 70k-element list. 

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented failures when performing operations on very large datasets (≈65k+ items) — fixes across deletion, retrieval, tagging, embeddings, metadata updates, and bulk image/video handling.
* **Tests**
  * Added tests validating correct behavior when input sizes exceed PostgreSQL bind-parameter limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->