### PR TITLE
Add strategy instance validation for strategy builder

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/index.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/index.ts
@@ -10,3 +10,4 @@ export {
     STRATEGY_LABELS
 } from './types';
 export { cloneStrategyParams, createStrategyInstance } from './strategyInstance';
+export { isStrategyInstanceValid } from './strategyValidation';

--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyValidation.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyValidation.test.ts
@@ -1,15 +1,47 @@
 import { describe, expect, it } from 'vitest';
-import { isStrategyInstanceValid } from './strategyValidation';
-import { type StrategyInstance } from './types';
+import { isStrategyInstanceValid, type StrategyInstance } from '.';
+
+const defaultDiversity: StrategyInstance = {
+    id: '1',
+    type: 'diversity',
+    params: { strength: 1 },
+    isExpanded: true
+};
+
+const defaultTypicality: StrategyInstance = {
+    id: '1',
+    type: 'typicality',
+    params: { strength: 1 },
+    isExpanded: true
+};
+
+const defaultSimilarity: StrategyInstance = {
+    id: '1',
+    type: 'similarity',
+    params: { query_tag_id: 'tag-abc', strength: 1 },
+    isExpanded: true
+};
+
+const defaultMetadataWeighting: StrategyInstance = {
+    id: '1',
+    type: 'metadata_weighting',
+    params: { metadata_key: 'sharpness', strength: 1 },
+    isExpanded: true
+};
+
+const defaultClassBalancing: StrategyInstance = {
+    id: '1',
+    type: 'class_balancing',
+    params: { target_distribution_mode: 'uniform', target_distribution: [], strength: 1 },
+    isExpanded: true
+};
 
 describe('isStrategyInstanceValid', () => {
     describe('strength validation', () => {
         it('returns false when strength is 0', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'diversity',
-                params: { strength: 0 },
-                isExpanded: true
+                ...defaultDiversity,
+                params: { strength: 0 }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
@@ -17,10 +49,8 @@ describe('isStrategyInstanceValid', () => {
 
         it('returns true when strength is negative', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'typicality',
-                params: { strength: -1 },
-                isExpanded: true
+                ...defaultTypicality,
+                params: { strength: -1 }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(true);
@@ -28,10 +58,8 @@ describe('isStrategyInstanceValid', () => {
 
         it('returns false when strength is NaN', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'diversity',
-                params: { strength: NaN },
-                isExpanded: true
+                ...defaultDiversity,
+                params: { strength: NaN }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
@@ -39,10 +67,8 @@ describe('isStrategyInstanceValid', () => {
 
         it('returns false when strength is Infinity', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'diversity',
-                params: { strength: Infinity },
-                isExpanded: true
+                ...defaultDiversity,
+                params: { strength: Infinity }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
@@ -51,37 +77,21 @@ describe('isStrategyInstanceValid', () => {
 
     describe('diversity', () => {
         it('returns true when strength is valid', () => {
-            const instance: StrategyInstance = {
-                id: '1',
-                type: 'diversity',
-                params: { strength: 1 },
-                isExpanded: true
-            };
-
-            expect(isStrategyInstanceValid(instance)).toBe(true);
+            expect(isStrategyInstanceValid(defaultDiversity)).toBe(true);
         });
     });
 
     describe('typicality', () => {
         it('returns true when strength is valid', () => {
-            const instance: StrategyInstance = {
-                id: '1',
-                type: 'typicality',
-                params: { strength: 1 },
-                isExpanded: true
-            };
-
-            expect(isStrategyInstanceValid(instance)).toBe(true);
+            expect(isStrategyInstanceValid(defaultTypicality)).toBe(true);
         });
     });
 
     describe('similarity', () => {
         it('returns false when query_tag_id is empty', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'similarity',
-                params: { query_tag_id: '', strength: 1 },
-                isExpanded: true
+                ...defaultSimilarity,
+                params: { ...defaultSimilarity.params, query_tag_id: '' }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
@@ -89,34 +99,23 @@ describe('isStrategyInstanceValid', () => {
 
         it('returns false when query_tag_id is whitespace', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'similarity',
-                params: { query_tag_id: '   ', strength: 1 },
-                isExpanded: true
+                ...defaultSimilarity,
+                params: { ...defaultSimilarity.params, query_tag_id: '   ' }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
         });
 
         it('returns true when query_tag_id is set', () => {
-            const instance: StrategyInstance = {
-                id: '1',
-                type: 'similarity',
-                params: { query_tag_id: 'tag-abc', strength: 1 },
-                isExpanded: true
-            };
-
-            expect(isStrategyInstanceValid(instance)).toBe(true);
+            expect(isStrategyInstanceValid(defaultSimilarity)).toBe(true);
         });
     });
 
     describe('metadata_weighting', () => {
         it('returns false when metadata_key is empty', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'metadata_weighting',
-                params: { metadata_key: '', strength: 1 },
-                isExpanded: true
+                ...defaultMetadataWeighting,
+                params: { ...defaultMetadataWeighting.params, metadata_key: '' }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
@@ -124,49 +123,27 @@ describe('isStrategyInstanceValid', () => {
 
         it('returns false when metadata_key is whitespace', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'metadata_weighting',
-                params: { metadata_key: '   ', strength: 1 },
-                isExpanded: true
+                ...defaultMetadataWeighting,
+                params: { ...defaultMetadataWeighting.params, metadata_key: '   ' }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
         });
 
         it('returns true when metadata_key is set', () => {
-            const instance: StrategyInstance = {
-                id: '1',
-                type: 'metadata_weighting',
-                params: { metadata_key: 'sharpness', strength: 1 },
-                isExpanded: true
-            };
-
-            expect(isStrategyInstanceValid(instance)).toBe(true);
+            expect(isStrategyInstanceValid(defaultMetadataWeighting)).toBe(true);
         });
     });
 
     describe('class_balancing', () => {
         it('returns true for uniform target_distribution_mode regardless of distribution', () => {
-            const instance: StrategyInstance = {
-                id: '1',
-                type: 'class_balancing',
-                params: {
-                    target_distribution_mode: 'uniform',
-                    target_distribution: [],
-                    strength: 1
-                },
-                isExpanded: true
-            };
-
-            expect(isStrategyInstanceValid(instance)).toBe(true);
+            expect(isStrategyInstanceValid(defaultClassBalancing)).toBe(true);
         });
 
         it('returns true for input target_distribution_mode regardless of distribution', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'class_balancing',
-                params: { target_distribution_mode: 'input', target_distribution: [], strength: 1 },
-                isExpanded: true
+                ...defaultClassBalancing,
+                params: { ...defaultClassBalancing.params, target_distribution_mode: 'input' }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(true);
@@ -174,14 +151,12 @@ describe('isStrategyInstanceValid', () => {
 
         it('returns false for dictionary with empty target_distribution', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'class_balancing',
+                ...defaultClassBalancing,
                 params: {
+                    ...defaultClassBalancing.params,
                     target_distribution_mode: 'dictionary',
-                    target_distribution: [],
-                    strength: 1
-                },
-                isExpanded: true
+                    target_distribution: []
+                }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
@@ -189,14 +164,12 @@ describe('isStrategyInstanceValid', () => {
 
         it('returns false for dictionary when a row has an empty class_name', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'class_balancing',
+                ...defaultClassBalancing,
                 params: {
+                    ...defaultClassBalancing.params,
                     target_distribution_mode: 'dictionary',
-                    target_distribution: [{ class_name: '', weight: 1 }],
-                    strength: 1
-                },
-                isExpanded: true
+                    target_distribution: [{ class_name: '', weight: 1 }]
+                }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
@@ -204,14 +177,12 @@ describe('isStrategyInstanceValid', () => {
 
         it('returns false for dictionary when a row has a whitespace class_name', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'class_balancing',
+                ...defaultClassBalancing,
                 params: {
+                    ...defaultClassBalancing.params,
                     target_distribution_mode: 'dictionary',
-                    target_distribution: [{ class_name: '   ', weight: 1 }],
-                    strength: 1
-                },
-                isExpanded: true
+                    target_distribution: [{ class_name: '   ', weight: 1 }]
+                }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
@@ -219,14 +190,12 @@ describe('isStrategyInstanceValid', () => {
 
         it('returns false for dictionary when a row has a non-positive weight', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'class_balancing',
+                ...defaultClassBalancing,
                 params: {
+                    ...defaultClassBalancing.params,
                     target_distribution_mode: 'dictionary',
-                    target_distribution: [{ class_name: 'cat', weight: 0 }],
-                    strength: 1
-                },
-                isExpanded: true
+                    target_distribution: [{ class_name: 'cat', weight: 0 }]
+                }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
@@ -234,17 +203,15 @@ describe('isStrategyInstanceValid', () => {
 
         it('returns true for dictionary with a valid distribution', () => {
             const instance: StrategyInstance = {
-                id: '1',
-                type: 'class_balancing',
+                ...defaultClassBalancing,
                 params: {
+                    ...defaultClassBalancing.params,
                     target_distribution_mode: 'dictionary',
                     target_distribution: [
                         { class_name: 'cat', weight: 2 },
                         { class_name: 'dog', weight: 1 }
-                    ],
-                    strength: 1
-                },
-                isExpanded: true
+                    ]
+                }
             };
 
             expect(isStrategyInstanceValid(instance)).toBe(true);

--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyValidation.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyValidation.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+import { isStrategyInstanceValid } from './strategyValidation';
+import { type StrategyInstance } from './types';
+
+describe('isStrategyInstanceValid', () => {
+    describe('strength validation', () => {
+        it('returns false when strength is 0', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'diversity',
+                params: { strength: 0 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns true when strength is negative', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'typicality',
+                params: { strength: -1 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(true);
+        });
+
+        it('returns false when strength is NaN', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'diversity',
+                params: { strength: NaN },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns false when strength is Infinity', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'diversity',
+                params: { strength: Infinity },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+    });
+
+    describe('diversity', () => {
+        it('returns true when strength is valid', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'diversity',
+                params: { strength: 1 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(true);
+        });
+    });
+
+    describe('typicality', () => {
+        it('returns true when strength is valid', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'typicality',
+                params: { strength: 1 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(true);
+        });
+    });
+
+    describe('similarity', () => {
+        it('returns false when query_tag_id is empty', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'similarity',
+                params: { query_tag_id: '', strength: 1 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns false when query_tag_id is whitespace', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'similarity',
+                params: { query_tag_id: '   ', strength: 1 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns true when query_tag_id is set', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'similarity',
+                params: { query_tag_id: 'tag-abc', strength: 1 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(true);
+        });
+    });
+
+    describe('metadata_weighting', () => {
+        it('returns false when metadata_key is empty', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'metadata_weighting',
+                params: { metadata_key: '', strength: 1 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns false when metadata_key is whitespace', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'metadata_weighting',
+                params: { metadata_key: '   ', strength: 1 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns true when metadata_key is set', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'metadata_weighting',
+                params: { metadata_key: 'sharpness', strength: 1 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(true);
+        });
+    });
+
+    describe('class_balancing', () => {
+        it('returns true for uniform target_distribution_mode regardless of distribution', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'class_balancing',
+                params: {
+                    target_distribution_mode: 'uniform',
+                    target_distribution: [],
+                    strength: 1
+                },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(true);
+        });
+
+        it('returns true for input target_distribution_mode regardless of distribution', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'class_balancing',
+                params: { target_distribution_mode: 'input', target_distribution: [], strength: 1 },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(true);
+        });
+
+        it('returns false for dictionary with empty target_distribution', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'class_balancing',
+                params: {
+                    target_distribution_mode: 'dictionary',
+                    target_distribution: [],
+                    strength: 1
+                },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns false for dictionary when a row has an empty class_name', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'class_balancing',
+                params: {
+                    target_distribution_mode: 'dictionary',
+                    target_distribution: [{ class_name: '', weight: 1 }],
+                    strength: 1
+                },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns false for dictionary when a row has a whitespace class_name', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'class_balancing',
+                params: {
+                    target_distribution_mode: 'dictionary',
+                    target_distribution: [{ class_name: '   ', weight: 1 }],
+                    strength: 1
+                },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns false for dictionary when a row has a non-positive weight', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'class_balancing',
+                params: {
+                    target_distribution_mode: 'dictionary',
+                    target_distribution: [{ class_name: 'cat', weight: 0 }],
+                    strength: 1
+                },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns true for dictionary with a valid distribution', () => {
+            const instance: StrategyInstance = {
+                id: '1',
+                type: 'class_balancing',
+                params: {
+                    target_distribution_mode: 'dictionary',
+                    target_distribution: [
+                        { class_name: 'cat', weight: 2 },
+                        { class_name: 'dog', weight: 1 }
+                    ],
+                    strength: 1
+                },
+                isExpanded: true
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(true);
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyValidation.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyValidation.test.ts
@@ -73,6 +73,15 @@ describe('isStrategyInstanceValid', () => {
 
             expect(isStrategyInstanceValid(instance)).toBe(false);
         });
+
+        it('returns false when strength is -Infinity', () => {
+            const instance: StrategyInstance = {
+                ...defaultDiversity,
+                params: { strength: -Infinity }
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
     });
 
     describe('diversity', () => {
@@ -195,6 +204,45 @@ describe('isStrategyInstanceValid', () => {
                     ...defaultClassBalancing.params,
                     target_distribution_mode: 'dictionary',
                     target_distribution: [{ class_name: 'cat', weight: 0 }]
+                }
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns false for dictionary when a row has a negative weight', () => {
+            const instance: StrategyInstance = {
+                ...defaultClassBalancing,
+                params: {
+                    ...defaultClassBalancing.params,
+                    target_distribution_mode: 'dictionary',
+                    target_distribution: [{ class_name: 'cat', weight: -1 }]
+                }
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns false for dictionary when a row has a NaN weight', () => {
+            const instance: StrategyInstance = {
+                ...defaultClassBalancing,
+                params: {
+                    ...defaultClassBalancing.params,
+                    target_distribution_mode: 'dictionary',
+                    target_distribution: [{ class_name: 'cat', weight: Number.NaN }]
+                }
+            };
+
+            expect(isStrategyInstanceValid(instance)).toBe(false);
+        });
+
+        it('returns false for dictionary when a row has an Infinity weight', () => {
+            const instance: StrategyInstance = {
+                ...defaultClassBalancing,
+                params: {
+                    ...defaultClassBalancing.params,
+                    target_distribution_mode: 'dictionary',
+                    target_distribution: [{ class_name: 'cat', weight: Number.POSITIVE_INFINITY }]
                 }
             };
 

--- a/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyValidation.ts
+++ b/lightly_studio_view/src/lib/hooks/useStrategyBuilder/strategyValidation.ts
@@ -1,0 +1,37 @@
+import { type StrategyInstance } from './types';
+
+function isNonZeroFiniteNumber(value: number): boolean {
+    return Number.isFinite(value) && value !== 0;
+}
+
+function isPositiveNumber(value: number): boolean {
+    return Number.isFinite(value) && value > 0;
+}
+
+export function isStrategyInstanceValid(instance: StrategyInstance): boolean {
+    if (!isNonZeroFiniteNumber(instance.params.strength)) {
+        return false;
+    }
+
+    if (instance.type === 'similarity') {
+        return instance.params.query_tag_id.trim().length > 0;
+    }
+
+    if (instance.type === 'metadata_weighting') {
+        return instance.params.metadata_key.trim().length > 0;
+    }
+
+    if (instance.type === 'class_balancing') {
+        if (instance.params.target_distribution_mode !== 'dictionary') {
+            return true;
+        }
+        return (
+            instance.params.target_distribution.length > 0 &&
+            instance.params.target_distribution.every(
+                (row) => row.class_name.trim().length > 0 && isPositiveNumber(row.weight)
+            )
+        );
+    }
+
+    return true;
+}


### PR DESCRIPTION
## What has changed and why?

Strategy instances need to be validated before submission. Each strategy type has type-specific required fields (e.g., `query_tag_id` for similarity, `metadata_key` for metadata weighting, distribution rows for class balancing in dictionary mode). This PR adds `isStrategyInstanceValid` - a validation function for `StrategyInstance` objects in the strategy builder.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strategy validation now enforces configuration requirements: numeric strength must be a finite non-zero number; required fields must be non-empty for each strategy type; class-balancing distributions must be populated with valid class names and positive weights when using a dictionary mode.
* **Tests**
  * Added comprehensive tests covering validation rules and edge cases (zero, negative, NaN/Infinity, empty/whitespace inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->