### PR TITLE
Show number of samples in sampling dialog more nicely

### DIFF
--- a/lightly_studio_view/src/lib/components/Sampling/CreateSampling.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/CreateSampling.test.ts
@@ -94,7 +94,7 @@ describe('CreateSamplingDialog', () => {
 
         render(CreateSamplingDialog);
 
-        expect(screen.getByText(/Create a sampling of the/)).toBeInTheDocument();
+        expect(screen.getByText(/Sample from the/)).toBeInTheDocument();
         expect(screen.getByText('42 samples')).toBeInTheDocument();
     });
 

--- a/lightly_studio_view/src/lib/components/Sampling/CreateSampling.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/CreateSampling.test.ts
@@ -94,17 +94,22 @@ describe('CreateSamplingDialog', () => {
 
         render(CreateSamplingDialog);
 
-        expect(
-            screen.getByText('Create a subset of the 42 samples fulfilling the current filters.')
-        ).toBeInTheDocument();
+        expect(screen.getByText(/Create a sampling of the/)).toBeInTheDocument();
+        expect(screen.getByText('42 samples')).toBeInTheDocument();
     });
 
-    it('shows the fallback header text when filteredSampleCount is 0', () => {
+    it('uses the singular noun when exactly one sample matches the filters', () => {
+        filteredSampleCountStore.set(1);
+
         render(CreateSamplingDialog);
 
-        expect(
-            screen.getByText('Create a subset of the samples fulfilling the current filters.')
-        ).toBeInTheDocument();
+        expect(screen.getByText('1 sample')).toBeInTheDocument();
+    });
+
+    it('shows the count even when no samples match the filters', () => {
+        render(CreateSamplingDialog);
+
+        expect(screen.getByText('0 samples')).toBeInTheDocument();
     });
 
     it('shows the not enough samples warning when requested count exceeds available', async () => {

--- a/lightly_studio_view/src/lib/components/Sampling/CreateSamplingDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/CreateSamplingDialog.svelte
@@ -76,10 +76,8 @@
         $filteredSampleCount > 0 && nSamplesToSelect > $filteredSampleCount
     );
 
-    const samplingDescription = $derived(
-        $filteredSampleCount > 0
-            ? `Create a subset of the ${$filteredSampleCount} samples fulfilling the current filters.`
-            : 'Create a subset of the samples fulfilling the current filters.'
+    const sampleCountLabel = $derived(
+        `${$filteredSampleCount} ${$filteredSampleCount === 1 ? 'sample' : 'samples'}`
     );
 
     const { isSubmitting, loadingMessage, submit } = useCreateSampling({
@@ -136,7 +134,9 @@
                 <Dialog.Header>
                     <Dialog.Title class="text-foreground">Create Sampling</Dialog.Title>
                     <Dialog.Description class="text-foreground">
-                        {samplingDescription}
+                        Create a sampling of the <strong class="font-semibold text-primary"
+                            >{sampleCountLabel}</strong
+                        > currently matching your filters.
                     </Dialog.Description>
                 </Dialog.Header>
 

--- a/lightly_studio_view/src/lib/components/Sampling/CreateSamplingDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/CreateSamplingDialog.svelte
@@ -134,7 +134,7 @@
                 <Dialog.Header>
                     <Dialog.Title class="text-foreground">Create Sampling</Dialog.Title>
                     <Dialog.Description class="text-foreground">
-                        Create a sampling of the <strong class="font-semibold text-primary"
+                        Sample from the <strong class="font-semibold text-primary"
                             >{sampleCountLabel}</strong
                         > currently matching your filters.
                     </Dialog.Description>


### PR DESCRIPTION
## What has changed and why?

Shows the number of samples in the "Create Sampling" dialog more nicely. Went with using green colour, just using bold does not make it visible enough.

## How has it been tested?
Manually
Screenshots are still using the outdated "Create a sampling of the " instead of "Sample from the"
<img width="392" height="302" alt="image" src="https://github.com/user-attachments/assets/25c0b3c6-e845-4df4-8f3c-706e1dc139d3" />

<img width="407" height="353" alt="image" src="https://github.com/user-attachments/assets/200aa188-fc6d-4fbb-a445-71ef35f0e725" />



## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (too small)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Sampling dialog now displays the sample count explicitly with correct singular/plural forms for 0, 1, and multiple samples.
  * The count is shown inline and emphasized in the dialog description.
  * Dialog header text was adjusted to show a prefix plus a separate, visible sample count rather than a single fallback sentence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->