### PR TITLE
Make top bar overflow to the next row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Grid top bar no longer overflows its container or covers the grid when a side panel is open;
+  it now shrinks with the available width and wraps onto a second line when too narrow.
 - Fixed operations on large datasets (more than ~65,535 samples) failing on PostgreSQL with
   `number of parameters must be between 0 and 65535`.
 

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -206,8 +206,8 @@
     );
 </script>
 
-<div class="flex h-full flex-1">
-    <div class="flex-1">
+<div class="flex h-full min-w-0 flex-1">
+    <div class="min-w-0 flex-1">
         <GridContainer
             itemCount={annotations.length}
             message={{

--- a/lightly_studio_view/src/lib/components/GridHeader/GridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/GridHeader/GridHeader.svelte
@@ -17,10 +17,14 @@
     }: GridHeaderProps = $props();
 </script>
 
-<div class="my-2 flex items-center space-x-4">
-    <div class="flex-1">
-        {@render children?.()}
-    </div>
+<div class="my-2 flex flex-wrap items-center gap-x-4 gap-y-2">
+    {#if children}
+        <div class="min-w-[12rem] flex-1">
+            {@render children()}
+        </div>
+    {:else}
+        <div class="flex-1"></div>
+    {/if}
 
     {@render selectionControls?.()}
     {#if showImageSizeControl}

--- a/lightly_studio_view/src/lib/components/GridHeader/GridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/GridHeader/GridHeader.test.ts
@@ -77,20 +77,18 @@ describe('GridHeader', () => {
         expect(screen.getByLabelText('Zoom out')).toBeInTheDocument();
     });
 
-    it('applies correct CSS classes for layout', () => {
+    it('lays out controls in a flex row that can wrap instead of overflowing', () => {
         const { container } = render(GridHeaderTest, {
             props: {
                 testCase: 'children-only'
             }
         });
 
-        const wrapper = container.querySelector(
-            '.my-2.flex.flex-wrap.items-center.gap-x-4.gap-y-2'
-        );
+        const wrapper = container.querySelector('.flex.flex-wrap');
         expect(wrapper).toBeInTheDocument();
     });
 
-    it('applies flex-1 to children container', () => {
+    it('gives the children region flexible width', () => {
         const { container } = render(GridHeaderTest, {
             props: {
                 testCase: 'children-only'

--- a/lightly_studio_view/src/lib/components/GridHeader/GridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/GridHeader/GridHeader.test.ts
@@ -84,7 +84,9 @@ describe('GridHeader', () => {
             }
         });
 
-        const wrapper = container.querySelector('.my-2.flex.items-center.space-x-4');
+        const wrapper = container.querySelector(
+            '.my-2.flex.flex-wrap.items-center.gap-x-4.gap-y-2'
+        );
         expect(wrapper).toBeInTheDocument();
     });
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -387,7 +387,7 @@
                     <Separator class="mb-4 bg-border-hard" />
                 {/if}
 
-                <div class="flex min-h-0 flex-1">
+                <div class="flex min-h-0 min-w-0 flex-1">
                     {@render children()}
                 </div>
                 {#if isCollectionGrid}
@@ -406,10 +406,10 @@
             {/snippet}
 
             {#if $activePanel === 'evaluationRuns' && hasEvaluationRuns}
-                <PaneGroup direction="horizontal" class="flex-1">
+                <PaneGroup direction="horizontal" class="min-w-0 flex-1">
                     <Pane defaultSize={65} minSize={35} class="flex">
                         <div
-                            class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
+                            class="relative flex min-w-0 flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
                         >
                             {@render mainContent()}
                         </div>
@@ -430,10 +430,10 @@
                 </PaneGroup>
             {:else if $activePanel === 'embeddingPlot' && (isImages || isVideos)}
                 <!-- When plot is shown, use PaneGroup for the main content + plot -->
-                <PaneGroup direction="horizontal" class="flex-1">
+                <PaneGroup direction="horizontal" class="min-w-0 flex-1">
                     <Pane defaultSize={50} minSize={30} class="flex">
                         <div
-                            class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4"
+                            class="relative flex min-w-0 flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4"
                         >
                             <DatasetGridHeader
                                 {canSelectAll}
@@ -471,10 +471,10 @@
                     </Pane>
                 </PaneGroup>
             {:else if $activePanel === 'queryEditor' && isImages}
-                <PaneGroup direction="horizontal" class="flex-1">
+                <PaneGroup direction="horizontal" class="min-w-0 flex-1">
                     <Pane defaultSize={65} minSize={35} class="flex">
                         <div
-                            class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
+                            class="relative flex min-w-0 flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
                         >
                             {@render mainContent()}
                         </div>
@@ -488,7 +488,9 @@
                 </PaneGroup>
             {:else}
                 <!-- Normal layout (no side panel) -->
-                <div class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2">
+                <div
+                    class="relative flex min-w-0 flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
+                >
                     {@render mainContent()}
                 </div>
             {/if}


### PR DESCRIPTION
## What has changed and why?

This is a preparatory PR for making the top bar more compact.

Before, the width of main content was at least the width of the top bar, making the side panel overlap the main content.

This PR fixes the flex layout. It makes the top bar split into rows, though that change should be only temporary.

## How has it been tested?

Manually.

Before:

https://github.com/user-attachments/assets/bbaa4da0-3f91-41de-91b0-81708971083d


After:

https://github.com/user-attachments/assets/5d9a8afa-96da-4c00-bb8d-3f3b87a5cb11


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the grid top bar overflowing or covering content when a side panel is open; it now shrinks to available width and wraps to a second line when constrained. Improved sizing and overflow handling across multi-panel layouts so nested content can shrink and scroll correctly.

* **Tests**
  * Updated component tests to expect a wrapping header layout and flexible children sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->