### PR TITLE
Add StrategyCard component for combination sampling strategy builder

### DIFF
--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.stories.svelte
@@ -13,6 +13,7 @@
                 { tag_id: 'tag-2', name: 'Curated Set' }
             ],
             annotationLabels: ['cat', 'dog', 'bird'],
+            metadataFieldNames: ['sharpness', 'brightness', 'contrast'],
             onRemove: fn(),
             onDuplicate: fn(),
             onUpdate: fn(),

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.stories.svelte
@@ -1,0 +1,101 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import { fn } from 'storybook/test';
+    import StrategyCard from './StrategyCard.svelte';
+
+    const { Story } = defineMeta({
+        title: 'Components/Sampling/StrategyCard',
+        component: StrategyCard,
+        tags: ['autodocs'],
+        args: {
+            tags: [
+                { tag_id: 'tag-1', name: 'Initial Tag' },
+                { tag_id: 'tag-2', name: 'Curated Set' }
+            ],
+            annotationLabels: ['cat', 'dog', 'bird'],
+            onRemove: fn(),
+            onDuplicate: fn(),
+            onUpdate: fn(),
+            onToggleExpand: fn()
+        }
+    });
+</script>
+
+<Story
+    name="Diversity"
+    args={{
+        instance: {
+            id: 'story-1',
+            type: 'diversity',
+            params: { strength: 1 },
+            isExpanded: true
+        }
+    }}
+/>
+
+<Story
+    name="Typicality"
+    args={{
+        instance: {
+            id: 'story-2',
+            type: 'typicality',
+            params: { strength: 1 },
+            isExpanded: true
+        }
+    }}
+/>
+
+<Story
+    name="Similarity"
+    args={{
+        instance: {
+            id: 'story-3',
+            type: 'similarity',
+            params: { query_tag_id: 'tag-1', strength: 1 },
+            isExpanded: true
+        }
+    }}
+/>
+
+<Story
+    name="MetadataWeighting"
+    args={{
+        instance: {
+            id: 'story-4',
+            type: 'metadata_weighting',
+            params: { metadata_key: 'sharpness', strength: 1 },
+            isExpanded: true
+        }
+    }}
+/>
+
+<Story
+    name="ClassBalancing"
+    args={{
+        instance: {
+            id: 'story-5',
+            type: 'class_balancing',
+            params: {
+                annotation_source: 'dictionary',
+                target_distribution: [
+                    { class_name: 'cat', weight: 2 },
+                    { class_name: 'dog', weight: 1 }
+                ],
+                strength: 1
+            },
+            isExpanded: true
+        }
+    }}
+/>
+
+<Story
+    name="Collapsed"
+    args={{
+        instance: {
+            id: 'story-6',
+            type: 'diversity',
+            params: { strength: 1 },
+            isExpanded: false
+        }
+    }}
+/>

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.stories.svelte
@@ -1,7 +1,8 @@
-<script module>
+<script module lang="ts">
     import { defineMeta } from '@storybook/addon-svelte-csf';
     import { fn } from 'storybook/test';
     import StrategyCard from './StrategyCard.svelte';
+    import type { StrategyInstance } from '$lib/hooks/useStrategyBuilder';
 
     const { Story } = defineMeta({
         title: 'Components/Sampling/StrategyCard',
@@ -30,7 +31,7 @@
             type: 'diversity',
             params: { strength: 1 },
             isExpanded: true
-        }
+        } satisfies StrategyInstance
     }}
 />
 
@@ -42,7 +43,7 @@
             type: 'typicality',
             params: { strength: 1 },
             isExpanded: true
-        }
+        } satisfies StrategyInstance
     }}
 />
 
@@ -54,7 +55,7 @@
             type: 'similarity',
             params: { query_tag_id: 'tag-1', strength: 1 },
             isExpanded: true
-        }
+        } satisfies StrategyInstance
     }}
 />
 
@@ -66,7 +67,7 @@
             type: 'metadata_weighting',
             params: { metadata_key: 'sharpness', strength: 1 },
             isExpanded: true
-        }
+        } satisfies StrategyInstance
     }}
 />
 
@@ -77,7 +78,7 @@
             id: 'story-5',
             type: 'class_balancing',
             params: {
-                annotation_source: 'dictionary',
+                target_distribution_mode: 'dictionary',
                 target_distribution: [
                     { class_name: 'cat', weight: 2 },
                     { class_name: 'dog', weight: 1 }
@@ -85,7 +86,7 @@
                 strength: 1
             },
             isExpanded: true
-        }
+        } satisfies StrategyInstance
     }}
 />
 
@@ -97,6 +98,6 @@
             type: 'diversity',
             params: { strength: 1 },
             isExpanded: false
-        }
+        } satisfies StrategyInstance
     }}
 />

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+    import { ChevronDown, ChevronRight, Copy, Trash2 } from '@lucide/svelte';
+    import { Button } from '$lib/components/ui/button';
+
+    import {
+        STRATEGY_LABELS,
+        type MetadataWeightingParams,
+        type SimilarityParams,
+        type StrategyInstance,
+        type StrategyParams,
+        type StrategySummaryTag,
+        type ClassBalancingParams
+    } from '$lib/hooks/useStrategyBuilder';
+    import MetadataWeightingForm from '../forms/MetadataWeightingForm/MetadataWeightingForm.svelte';
+    import SimilarityForm from '../forms/SimilarityForm/SimilarityForm.svelte';
+    import ClassBalancingForm from '../forms/ClassBalancingForm/ClassBalancingForm.svelte';
+    import StrengthField from '../forms/StrengthField/StrengthField.svelte';
+    interface Props {
+        instance: StrategyInstance;
+        tags: StrategySummaryTag[];
+        annotationLabels: string[];
+        onRemove: () => void;
+        onDuplicate: () => void;
+        onUpdate: (params: Partial<StrategyParams>) => void;
+        onToggleExpand: () => void;
+    }
+    let {
+        instance,
+        tags,
+        annotationLabels,
+        onRemove,
+        onDuplicate,
+        onUpdate,
+        onToggleExpand
+    }: Props = $props();
+</script>
+
+<div
+    class="rounded-md border border-border bg-background p-3"
+    data-testid={`strategy-card-${instance.id}`}
+>
+    <div class="flex items-start justify-between gap-3">
+        <button
+            type="button"
+            class="flex min-w-0 flex-1 items-start gap-2 text-left"
+            onclick={onToggleExpand}
+            data-testid={`strategy-card-toggle-${instance.id}`}
+        >
+            {#if instance.isExpanded}
+                <ChevronDown class="mt-0.5 size-4 shrink-0" />
+            {:else}
+                <ChevronRight class="mt-0.5 size-4 shrink-0" />
+            {/if}
+
+            <div class="min-w-0">
+                <p class="truncate text-sm font-medium text-foreground">
+                    {STRATEGY_LABELS[instance.type]}
+                </p>
+            </div>
+        </button>
+
+        <div class="flex shrink-0 gap-1">
+            <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Duplicate strategy"
+                onclick={onDuplicate}
+                data-testid={`strategy-card-duplicate-${instance.id}`}
+            >
+                <Copy class="size-4" />
+            </Button>
+            <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Remove strategy"
+                onclick={onRemove}
+                data-testid={`strategy-card-remove-${instance.id}`}
+            >
+                <Trash2 class="size-4" />
+            </Button>
+        </div>
+    </div>
+
+    {#if instance.isExpanded}
+        <div class="mt-3 border-t border-border pt-3">
+            {#if instance.type === 'diversity'}
+                <StrengthField
+                    strength={instance.params.strength}
+                    id="diversity-strength"
+                    testid="strategy-diversity-strength-input"
+                    onUpdate={(strength) => onUpdate({ strength })}
+                />
+            {:else if instance.type === 'typicality'}
+                <StrengthField
+                    strength={instance.params.strength}
+                    id="typicality-strength"
+                    testid="strategy-typicality-strength-input"
+                    onUpdate={(strength) => onUpdate({ strength })}
+                />
+            {:else if instance.type === 'similarity'}
+                <SimilarityForm params={instance.params as SimilarityParams} {tags} {onUpdate} />
+            {:else if instance.type === 'metadata_weighting'}
+                <MetadataWeightingForm
+                    params={instance.params as MetadataWeightingParams}
+                    {onUpdate}
+                />
+            {:else}
+                <ClassBalancingForm
+                    params={instance.params as ClassBalancingParams}
+                    {annotationLabels}
+                    {onUpdate}
+                />
+            {/if}
+        </div>
+    {/if}
+</div>

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
@@ -90,15 +90,15 @@
             {#if instance.type === 'diversity'}
                 <StrengthField
                     strength={instance.params.strength}
-                    id="diversity-strength"
-                    testid="strategy-diversity-strength-input"
+                    id={`diversity-strength-${instance.id}`}
+                    testid={`strategy-diversity-strength-input-${instance.id}`}
                     onUpdate={(strength) => onUpdate({ strength })}
                 />
             {:else if instance.type === 'typicality'}
                 <StrengthField
                     strength={instance.params.strength}
-                    id="typicality-strength"
-                    testid="strategy-typicality-strength-input"
+                    id={`typicality-strength-${instance.id}`}
+                    testid={`strategy-typicality-strength-input-${instance.id}`}
                     onUpdate={(strength) => onUpdate({ strength })}
                 />
             {:else if instance.type === 'similarity'}

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
@@ -41,19 +41,19 @@
     class="rounded-md border border-border bg-background p-3"
     data-testid={`strategy-card-${instance.id}`}
 >
-    <div class="flex items-start justify-between gap-3">
+    <div class="flex items-center justify-between gap-3">
         <button
             type="button"
-            class="flex min-w-0 flex-1 items-start gap-2 text-left"
+            class="flex min-w-0 flex-1 items-center gap-2 text-left"
             onclick={onToggleExpand}
             data-testid={`strategy-card-toggle-${instance.id}`}
             aria-expanded={instance.isExpanded}
             aria-controls={`strategy-card-content-${instance.id}`}
         >
             {#if instance.isExpanded}
-                <ChevronDown class="mt-0.5 size-4 shrink-0" />
+                <ChevronDown class="size-4 shrink-0" />
             {:else}
-                <ChevronRight class="mt-0.5 size-4 shrink-0" />
+                <ChevronRight class="size-4 shrink-0" />
             {/if}
 
             <div class="min-w-0">

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
@@ -15,6 +15,7 @@
     import SimilarityForm from '../forms/SimilarityForm/SimilarityForm.svelte';
     import ClassBalancingForm from '../forms/ClassBalancingForm/ClassBalancingForm.svelte';
     import StrengthField from '../forms/StrengthField/StrengthField.svelte';
+    import Typography from '$lib/components/Typography/Typography.svelte';
     interface Props {
         instance: StrategyInstance;
         tags: StrategySummaryTag[];
@@ -57,9 +58,13 @@
             {/if}
 
             <div class="min-w-0">
-                <p class="truncate text-sm font-medium text-foreground">
+                <Typography
+                    variant="subtitle2"
+                    component="span"
+                    className="block truncate text-foreground"
+                >
                     {STRATEGY_LABELS[instance.type]}
-                </p>
+                </Typography>
             </div>
         </button>
 

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
@@ -19,6 +19,7 @@
         instance: StrategyInstance;
         tags: StrategySummaryTag[];
         annotationLabels: string[];
+        metadataFieldNames?: string[];
         onRemove: () => void;
         onDuplicate: () => void;
         onUpdate: (params: Partial<StrategyParams>) => void;
@@ -28,6 +29,7 @@
         instance,
         tags,
         annotationLabels,
+        metadataFieldNames = [],
         onRemove,
         onDuplicate,
         onUpdate,
@@ -104,6 +106,7 @@
             {:else if instance.type === 'metadata_weighting'}
                 <MetadataWeightingForm
                     params={instance.params as MetadataWeightingParams}
+                    {metadataFieldNames}
                     {onUpdate}
                 />
             {:else}

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
     import { ChevronDown, ChevronRight, Copy, Trash2 } from '@lucide/svelte';
     import { Button } from '$lib/components/ui/button';
+    import {
+        Collapsible,
+        CollapsibleContent,
+        CollapsibleTrigger
+    } from '$lib/components/ui/collapsible';
 
     import {
         STRATEGY_LABELS,
@@ -42,87 +47,91 @@
     class="rounded-md border border-border bg-background p-3"
     data-testid={`strategy-card-${instance.id}`}
 >
-    <div class="flex items-center justify-between gap-3">
-        <button
-            type="button"
-            class="flex min-w-0 flex-1 items-center gap-2 text-left"
-            onclick={onToggleExpand}
-            data-testid={`strategy-card-toggle-${instance.id}`}
-            aria-expanded={instance.isExpanded}
-            aria-controls={`strategy-card-content-${instance.id}`}
-        >
-            {#if instance.isExpanded}
-                <ChevronDown class="size-4 shrink-0" />
-            {:else}
-                <ChevronRight class="size-4 shrink-0" />
-            {/if}
+    <Collapsible open={instance.isExpanded} onOpenChange={() => onToggleExpand()}>
+        <div class="flex items-center justify-between gap-3">
+            <CollapsibleTrigger
+                class="flex min-w-0 flex-1 items-center gap-2 text-left"
+                data-testid={`strategy-card-toggle-${instance.id}`}
+            >
+                {#if instance.isExpanded}
+                    <ChevronDown class="size-4 shrink-0" />
+                {:else}
+                    <ChevronRight class="size-4 shrink-0" />
+                {/if}
 
-            <div class="min-w-0">
-                <Typography
-                    variant="subtitle2"
-                    component="span"
-                    className="block truncate text-foreground"
+                <div class="min-w-0">
+                    <Typography
+                        variant="subtitle2"
+                        component="span"
+                        className="block truncate text-foreground"
+                    >
+                        {STRATEGY_LABELS[instance.type]}
+                    </Typography>
+                </div>
+            </CollapsibleTrigger>
+
+            <div class="flex shrink-0 gap-1">
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Duplicate strategy"
+                    onclick={onDuplicate}
+                    data-testid={`strategy-card-duplicate-${instance.id}`}
                 >
-                    {STRATEGY_LABELS[instance.type]}
-                </Typography>
+                    <Copy class="size-4" />
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Remove strategy"
+                    onclick={onRemove}
+                    data-testid={`strategy-card-remove-${instance.id}`}
+                >
+                    <Trash2 class="size-4" />
+                </Button>
             </div>
-        </button>
-
-        <div class="flex shrink-0 gap-1">
-            <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label="Duplicate strategy"
-                onclick={onDuplicate}
-                data-testid={`strategy-card-duplicate-${instance.id}`}
-            >
-                <Copy class="size-4" />
-            </Button>
-            <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label="Remove strategy"
-                onclick={onRemove}
-                data-testid={`strategy-card-remove-${instance.id}`}
-            >
-                <Trash2 class="size-4" />
-            </Button>
         </div>
-    </div>
 
-    {#if instance.isExpanded}
-        <div id={`strategy-card-content-${instance.id}`} class="mt-3 border-t border-border pt-3">
-            {#if instance.type === 'diversity'}
-                <StrengthField
-                    strength={instance.params.strength}
-                    id={`diversity-strength-${instance.id}`}
-                    testid={`strategy-diversity-strength-input-${instance.id}`}
-                    onUpdate={(strength) => onUpdate({ strength })}
-                />
-            {:else if instance.type === 'typicality'}
-                <StrengthField
-                    strength={instance.params.strength}
-                    id={`typicality-strength-${instance.id}`}
-                    testid={`strategy-typicality-strength-input-${instance.id}`}
-                    onUpdate={(strength) => onUpdate({ strength })}
-                />
-            {:else if instance.type === 'similarity'}
-                <SimilarityForm params={instance.params as SimilarityParams} {tags} {onUpdate} />
-            {:else if instance.type === 'metadata_weighting'}
-                <MetadataWeightingForm
-                    params={instance.params as MetadataWeightingParams}
-                    {metadataFieldNames}
-                    {onUpdate}
-                />
-            {:else}
-                <ClassBalancingForm
-                    params={instance.params as ClassBalancingParams}
-                    {annotationLabels}
-                    {onUpdate}
-                />
+        <CollapsibleContent forceMount>
+            {#if instance.isExpanded}
+                <div class="mt-3 border-t border-border pt-3">
+                    {#if instance.type === 'diversity'}
+                        <StrengthField
+                            strength={instance.params.strength}
+                            id={`diversity-strength-${instance.id}`}
+                            testid={`strategy-diversity-strength-input-${instance.id}`}
+                            onUpdate={(strength) => onUpdate({ strength })}
+                        />
+                    {:else if instance.type === 'typicality'}
+                        <StrengthField
+                            strength={instance.params.strength}
+                            id={`typicality-strength-${instance.id}`}
+                            testid={`strategy-typicality-strength-input-${instance.id}`}
+                            onUpdate={(strength) => onUpdate({ strength })}
+                        />
+                    {:else if instance.type === 'similarity'}
+                        <SimilarityForm
+                            params={instance.params as SimilarityParams}
+                            {tags}
+                            {onUpdate}
+                        />
+                    {:else if instance.type === 'metadata_weighting'}
+                        <MetadataWeightingForm
+                            params={instance.params as MetadataWeightingParams}
+                            {metadataFieldNames}
+                            {onUpdate}
+                        />
+                    {:else}
+                        <ClassBalancingForm
+                            params={instance.params as ClassBalancingParams}
+                            {annotationLabels}
+                            {onUpdate}
+                        />
+                    {/if}
+                </div>
             {/if}
-        </div>
-    {/if}
+        </CollapsibleContent>
+    </Collapsible>
 </div>

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
@@ -47,6 +47,8 @@
             class="flex min-w-0 flex-1 items-start gap-2 text-left"
             onclick={onToggleExpand}
             data-testid={`strategy-card-toggle-${instance.id}`}
+            aria-expanded={instance.isExpanded}
+            aria-controls={`strategy-card-content-${instance.id}`}
         >
             {#if instance.isExpanded}
                 <ChevronDown class="mt-0.5 size-4 shrink-0" />
@@ -86,7 +88,7 @@
     </div>
 
     {#if instance.isExpanded}
-        <div class="mt-3 border-t border-border pt-3">
+        <div id={`strategy-card-content-${instance.id}`} class="mt-3 border-t border-border pt-3">
             {#if instance.type === 'diversity'}
                 <StrengthField
                     strength={instance.params.strength}

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
@@ -164,7 +164,11 @@ describe('StrategyCard', () => {
             const instance: StrategyInstance = {
                 id: 'abc',
                 type: 'class_balancing',
-                params: { annotation_source: 'uniform', target_distribution: [], strength: 1 },
+                params: {
+                    target_distribution_mode: 'uniform',
+                    target_distribution: [],
+                    strength: 1
+                },
                 isExpanded: true
             };
 

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
@@ -88,7 +88,7 @@ describe('StrategyCard', () => {
             render(StrategyCard, { props: { ...defaultProps, instance } });
 
             expect(
-                screen.queryByTestId('strategy-diversity-strength-input')
+                screen.queryByTestId('strategy-diversity-strength-input-abc')
             ).not.toBeInTheDocument();
         });
     });
@@ -104,7 +104,7 @@ describe('StrategyCard', () => {
 
             render(StrategyCard, { props: { ...defaultProps, instance } });
 
-            expect(screen.getByTestId('strategy-diversity-strength-input')).toBeInTheDocument();
+            expect(screen.getByTestId('strategy-diversity-strength-input-abc')).toBeInTheDocument();
         });
     });
 
@@ -119,7 +119,7 @@ describe('StrategyCard', () => {
 
             render(StrategyCard, { props: { ...defaultProps, instance } });
 
-            expect(screen.getByTestId('strategy-typicality-strength-input')).toBeInTheDocument();
+            expect(screen.getByTestId('strategy-typicality-strength-input-abc')).toBeInTheDocument();
         });
     });
 

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
@@ -1,0 +1,178 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import StrategyCard from './StrategyCard.svelte';
+import type { StrategyInstance } from '$lib/hooks/useStrategyBuilder';
+
+const defaultProps = {
+    tags: [],
+    annotationLabels: [],
+    onRemove: vi.fn(),
+    onDuplicate: vi.fn(),
+    onUpdate: vi.fn(),
+    onToggleExpand: vi.fn()
+};
+
+describe('StrategyCard', () => {
+    describe('header', () => {
+        it('renders the strategy label', () => {
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'diversity',
+                params: { strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, { props: { ...defaultProps, instance } });
+
+            expect(screen.getByText('Diversity')).toBeInTheDocument();
+        });
+
+        it('calls onToggleExpand when the toggle button is clicked', async () => {
+            const onToggleExpand = vi.fn();
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'diversity',
+                params: { strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, { props: { ...defaultProps, onToggleExpand, instance } });
+
+            await fireEvent.click(screen.getByTestId('strategy-card-toggle-abc'));
+
+            expect(onToggleExpand).toHaveBeenCalledOnce();
+        });
+
+        it('calls onDuplicate when the duplicate button is clicked', async () => {
+            const onDuplicate = vi.fn();
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'diversity',
+                params: { strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, { props: { ...defaultProps, onDuplicate, instance } });
+
+            await fireEvent.click(screen.getByTestId('strategy-card-duplicate-abc'));
+
+            expect(onDuplicate).toHaveBeenCalledOnce();
+        });
+
+        it('calls onRemove when the remove button is clicked', async () => {
+            const onRemove = vi.fn();
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'diversity',
+                params: { strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, { props: { ...defaultProps, onRemove, instance } });
+
+            await fireEvent.click(screen.getByTestId('strategy-card-remove-abc'));
+
+            expect(onRemove).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('collapsed state', () => {
+        it('does not render the form when isExpanded is false', () => {
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'diversity',
+                params: { strength: 1 },
+                isExpanded: false
+            };
+
+            render(StrategyCard, { props: { ...defaultProps, instance } });
+
+            expect(
+                screen.queryByTestId('strategy-diversity-strength-input')
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    describe('diversity', () => {
+        it('renders the strength field when expanded', () => {
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'diversity',
+                params: { strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, { props: { ...defaultProps, instance } });
+
+            expect(screen.getByTestId('strategy-diversity-strength-input')).toBeInTheDocument();
+        });
+    });
+
+    describe('typicality', () => {
+        it('renders the strength field when expanded', () => {
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'typicality',
+                params: { strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, { props: { ...defaultProps, instance } });
+
+            expect(screen.getByTestId('strategy-typicality-strength-input')).toBeInTheDocument();
+        });
+    });
+
+    describe('similarity', () => {
+        it('renders the similarity form when expanded', () => {
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'similarity',
+                params: { query_tag_id: '', strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, {
+                props: {
+                    ...defaultProps,
+                    instance,
+                    tags: [{ tag_id: 'tag-1', name: 'Tag One' }]
+                }
+            });
+
+            expect(screen.getByText('Similarity')).toBeInTheDocument();
+        });
+    });
+
+    describe('metadata_weighting', () => {
+        it('renders the metadata weighting form when expanded', () => {
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'metadata_weighting',
+                params: { metadata_key: '', strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, { props: { ...defaultProps, instance } });
+
+            expect(screen.getByText('Metadata Weighting')).toBeInTheDocument();
+        });
+    });
+
+    describe('class_balancing', () => {
+        it('renders the class balancing form when expanded', () => {
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'class_balancing',
+                params: { annotation_source: 'uniform', target_distribution: [], strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, {
+                props: { ...defaultProps, instance, annotationLabels: ['cat', 'dog'] }
+            });
+
+            expect(screen.getByText('Class Balancing')).toBeInTheDocument();
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
@@ -157,6 +157,25 @@ describe('StrategyCard', () => {
 
             expect(screen.getByText('Metadata Weighting')).toBeInTheDocument();
         });
+
+        it('forwards metadataFieldNames to the metadata weighting form', () => {
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'metadata_weighting',
+                params: { metadata_key: '', strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, {
+                props: {
+                    ...defaultProps,
+                    instance,
+                    metadataFieldNames: ['sharpness', 'brightness']
+                }
+            });
+
+            expect(screen.getByTestId('strategy-metadata-key-input')).toBeInTheDocument();
+        });
     });
 
     describe('class_balancing', () => {

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
@@ -119,7 +119,9 @@ describe('StrategyCard', () => {
 
             render(StrategyCard, { props: { ...defaultProps, instance } });
 
-            expect(screen.getByTestId('strategy-typicality-strength-input-abc')).toBeInTheDocument();
+            expect(
+                screen.getByTestId('strategy-typicality-strength-input-abc')
+            ).toBeInTheDocument();
         });
     });
 


### PR DESCRIPTION
## What has changed and why?

Adds StrategyCard, a collapsible card that represents a single strategy in the combination sampling. It displays the strategy name, duplicate and remove actions.

## How has it been tested?

Unit tests + Storybook

<img width="1607" height="169" alt="Screenshot 2026-06-02 at 13 38 15" src="https://github.com/user-attachments/assets/2a27ace2-9eab-4c49-aa5b-28582d6c66c4" />

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expandable strategy cards for sampling with Diversity, Typicality, Similarity, Metadata Weighting, and Class Balancing; supports expand/collapse, duplicate, remove, and type-specific parameter editors.

* **Documentation**
  * Storybook examples demonstrating each strategy variant and expanded/collapsed states.

* **Tests**
  * Test suite covering rendering, header controls (toggle/duplicate/remove), and strategy-specific expanded-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->