### PR TITLE
Reduce backdrop of all overlays from 80 to 50%

### DIFF
--- a/lightly_studio_view/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/lightly_studio_view/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -12,7 +12,7 @@
 <DialogPrimitive.Overlay
 	bind:ref
 	class={cn(
-		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80",
+		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/50",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
## What has changed and why?

Reduce the backdrop of all dialogs from 80% to 50%.

## How has it been tested?
<img width="1440" height="597" alt="image" src="https://github.com/user-attachments/assets/1dafb71b-1e99-4fb0-92a1-da4f31eec185" />
<img width="1446" height="605" alt="image" src="https://github.com/user-attachments/assets/4c26c6d4-52d0-4f20-9945-7d682f8f0578" />

<img width="1448" height="594" alt="image" src="https://github.com/user-attachments/assets/44a0d1c9-74f0-4672-a89a-360b67d3012c" />
<img width="1435" height="592" alt="image" src="https://github.com/user-attachments/assets/55b01a13-2b05-4e7c-bd33-28cfc40bdf29" />
<img width="1447" height="603" alt="image" src="https://github.com/user-attachments/assets/693a812f-394e-4689-9ec9-7f385752559e" />
<img width="1444" height="604" alt="image" src="https://github.com/user-attachments/assets/97c39a76-5962-4c01-9289-de100e5299ba" />



## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (not relevant enough)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted dialog overlay background opacity to be more transparent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->