### PR TITLE
Add strategy API mapping for combination sampling

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/strategyApiMapping.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/strategyApiMapping.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { getMetadataKey, toApiStrategy } from './strategyApiMapping';
+
+describe('getMetadataKey', () => {
+    it('returns typicality-<id> for typicality instances', () => {
+        expect(
+            getMetadataKey({
+                id: 'abc',
+                type: 'typicality',
+                params: { strength: 1 },
+                isExpanded: true
+            })
+        ).toBe('typicality-abc');
+    });
+
+    it('returns similarity-<id> for similarity instances', () => {
+        expect(
+            getMetadataKey({
+                id: 'xyz',
+                type: 'similarity',
+                params: { query_tag_id: 'qt', strength: 1 },
+                isExpanded: true
+            })
+        ).toBe('similarity-xyz');
+    });
+
+    it('returns the metadata_key field for metadata_weighting instances', () => {
+        expect(
+            getMetadataKey({
+                id: 'foo',
+                type: 'metadata_weighting',
+                params: { metadata_key: 'sharpness', strength: 1 },
+                isExpanded: true
+            })
+        ).toBe('sharpness');
+    });
+
+    it('returns empty string for diversity instances', () => {
+        expect(
+            getMetadataKey({
+                id: 'div',
+                type: 'diversity',
+                params: { strength: 1 },
+                isExpanded: true
+            })
+        ).toBe('');
+    });
+
+    it('returns empty string for class_balancing instances', () => {
+        expect(
+            getMetadataKey({
+                id: 'bal',
+                type: 'class_balancing',
+                params: {
+                    target_distribution_mode: 'uniform',
+                    target_distribution: [],
+                    strength: 1
+                },
+                isExpanded: true
+            })
+        ).toBe('');
+    });
+});
+
+describe('toApiStrategy', () => {
+    it('maps diversity to diversity strategy with null embedding model and strength', () => {
+        expect(
+            toApiStrategy({
+                id: 'div-1',
+                type: 'diversity',
+                params: { strength: 2 },
+                isExpanded: true
+            })
+        ).toEqual({ strategy_name: 'diversity', embedding_model_name: null, strength: 2 });
+    });
+
+    it('maps typicality to weights strategy using typicality-<id> as metadata key', () => {
+        expect(
+            toApiStrategy({
+                id: 'typ-1',
+                type: 'typicality',
+                params: { strength: 1.5 },
+                isExpanded: true
+            })
+        ).toEqual({ strategy_name: 'weights', metadata_key: 'typicality-typ-1', strength: 1.5 });
+    });
+
+    it('maps similarity to weights strategy using similarity-<id> as metadata key', () => {
+        expect(
+            toApiStrategy({
+                id: 'sim-1',
+                type: 'similarity',
+                params: { query_tag_id: 'qt-1', strength: 1 },
+                isExpanded: true
+            })
+        ).toEqual({ strategy_name: 'weights', metadata_key: 'similarity-sim-1', strength: 1 });
+    });
+
+    it('maps metadata_weighting to weights strategy using the configured metadata key', () => {
+        expect(
+            toApiStrategy({
+                id: 'mw-1',
+                type: 'metadata_weighting',
+                params: { metadata_key: 'brightness', strength: 3 },
+                isExpanded: true
+            })
+        ).toEqual({ strategy_name: 'weights', metadata_key: 'brightness', strength: 3 });
+    });
+
+    it('maps class_balancing with uniform source to balance strategy with string target_distribution', () => {
+        expect(
+            toApiStrategy({
+                id: 'cb-1',
+                type: 'class_balancing',
+                params: {
+                    target_distribution_mode: 'uniform',
+                    target_distribution: [],
+                    strength: 1
+                },
+                isExpanded: true
+            })
+        ).toEqual({ strategy_name: 'balance', target_distribution: 'uniform', strength: 1 });
+    });
+
+    it('maps class_balancing with input source to balance strategy with string target_distribution', () => {
+        expect(
+            toApiStrategy({
+                id: 'cb-2',
+                type: 'class_balancing',
+                params: { target_distribution_mode: 'input', target_distribution: [], strength: 1 },
+                isExpanded: true
+            })
+        ).toEqual({ strategy_name: 'balance', target_distribution: 'input', strength: 1 });
+    });
+
+    it('maps class_balancing with dictionary source to balance strategy converting rows to object', () => {
+        expect(
+            toApiStrategy({
+                id: 'cb-3',
+                type: 'class_balancing',
+                params: {
+                    target_distribution_mode: 'dictionary',
+                    target_distribution: [
+                        { class_name: 'cat', weight: 2 },
+                        { class_name: 'dog', weight: 1 }
+                    ],
+                    strength: 1
+                },
+                isExpanded: true
+            })
+        ).toEqual({
+            strategy_name: 'balance',
+            target_distribution: { cat: 2, dog: 1 },
+            strength: 1
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/strategyApiMapping.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/strategyApiMapping.test.ts
@@ -1,134 +1,111 @@
 import { describe, expect, it } from 'vitest';
+import type { StrategyInstance } from '$lib/hooks/useStrategyBuilder';
 import { getMetadataKey, toApiStrategy } from './strategyApiMapping';
+
+const defaultDiversity: StrategyInstance = {
+    id: 'div-1',
+    type: 'diversity',
+    params: { strength: 1 },
+    isExpanded: true
+};
+
+const defaultTypicality: StrategyInstance = {
+    id: 'typ-1',
+    type: 'typicality',
+    params: { strength: 1 },
+    isExpanded: true
+};
+
+const defaultSimilarity: StrategyInstance = {
+    id: 'sim-1',
+    type: 'similarity',
+    params: { query_tag_id: 'qt-1', strength: 1 },
+    isExpanded: true
+};
+
+const defaultMetadataWeighting: StrategyInstance = {
+    id: 'mw-1',
+    type: 'metadata_weighting',
+    params: { metadata_key: 'sharpness', strength: 1 },
+    isExpanded: true
+};
+
+const defaultClassBalancing: StrategyInstance = {
+    id: 'cb-1',
+    type: 'class_balancing',
+    params: { target_distribution_mode: 'uniform', target_distribution: [], strength: 1 },
+    isExpanded: true
+};
 
 describe('getMetadataKey', () => {
     it('returns typicality-<id> for typicality instances', () => {
-        expect(
-            getMetadataKey({
-                id: 'abc',
-                type: 'typicality',
-                params: { strength: 1 },
-                isExpanded: true
-            })
-        ).toBe('typicality-abc');
+        expect(getMetadataKey({ ...defaultTypicality, id: 'abc' })).toBe('typicality-abc');
     });
 
     it('returns similarity-<id> for similarity instances', () => {
-        expect(
-            getMetadataKey({
-                id: 'xyz',
-                type: 'similarity',
-                params: { query_tag_id: 'qt', strength: 1 },
-                isExpanded: true
-            })
-        ).toBe('similarity-xyz');
+        expect(getMetadataKey({ ...defaultSimilarity, id: 'xyz' })).toBe('similarity-xyz');
     });
 
     it('returns the metadata_key field for metadata_weighting instances', () => {
-        expect(
-            getMetadataKey({
-                id: 'foo',
-                type: 'metadata_weighting',
-                params: { metadata_key: 'sharpness', strength: 1 },
-                isExpanded: true
-            })
-        ).toBe('sharpness');
+        expect(getMetadataKey(defaultMetadataWeighting)).toBe('sharpness');
     });
 
     it('returns empty string for diversity instances', () => {
-        expect(
-            getMetadataKey({
-                id: 'div',
-                type: 'diversity',
-                params: { strength: 1 },
-                isExpanded: true
-            })
-        ).toBe('');
+        expect(getMetadataKey(defaultDiversity)).toBe('');
     });
 
     it('returns empty string for class_balancing instances', () => {
-        expect(
-            getMetadataKey({
-                id: 'bal',
-                type: 'class_balancing',
-                params: {
-                    target_distribution_mode: 'uniform',
-                    target_distribution: [],
-                    strength: 1
-                },
-                isExpanded: true
-            })
-        ).toBe('');
+        expect(getMetadataKey(defaultClassBalancing)).toBe('');
     });
 });
 
 describe('toApiStrategy', () => {
     it('maps diversity to diversity strategy with null embedding model and strength', () => {
-        expect(
-            toApiStrategy({
-                id: 'div-1',
-                type: 'diversity',
-                params: { strength: 2 },
-                isExpanded: true
-            })
-        ).toEqual({ strategy_name: 'diversity', embedding_model_name: null, strength: 2 });
+        expect(toApiStrategy({ ...defaultDiversity, params: { strength: 2 } })).toEqual({
+            strategy_name: 'diversity',
+            embedding_model_name: null,
+            strength: 2
+        });
     });
 
     it('maps typicality to weights strategy using typicality-<id> as metadata key', () => {
-        expect(
-            toApiStrategy({
-                id: 'typ-1',
-                type: 'typicality',
-                params: { strength: 1.5 },
-                isExpanded: true
-            })
-        ).toEqual({ strategy_name: 'weights', metadata_key: 'typicality-typ-1', strength: 1.5 });
+        expect(toApiStrategy({ ...defaultTypicality, params: { strength: 1.5 } })).toEqual({
+            strategy_name: 'weights',
+            metadata_key: 'typicality-typ-1',
+            strength: 1.5
+        });
     });
 
     it('maps similarity to weights strategy using similarity-<id> as metadata key', () => {
-        expect(
-            toApiStrategy({
-                id: 'sim-1',
-                type: 'similarity',
-                params: { query_tag_id: 'qt-1', strength: 1 },
-                isExpanded: true
-            })
-        ).toEqual({ strategy_name: 'weights', metadata_key: 'similarity-sim-1', strength: 1 });
+        expect(toApiStrategy(defaultSimilarity)).toEqual({
+            strategy_name: 'weights',
+            metadata_key: 'similarity-sim-1',
+            strength: 1
+        });
     });
 
     it('maps metadata_weighting to weights strategy using the configured metadata key', () => {
         expect(
             toApiStrategy({
-                id: 'mw-1',
-                type: 'metadata_weighting',
-                params: { metadata_key: 'brightness', strength: 3 },
-                isExpanded: true
+                ...defaultMetadataWeighting,
+                params: { metadata_key: 'brightness', strength: 3 }
             })
         ).toEqual({ strategy_name: 'weights', metadata_key: 'brightness', strength: 3 });
     });
 
     it('maps class_balancing with uniform source to balance strategy with string target_distribution', () => {
-        expect(
-            toApiStrategy({
-                id: 'cb-1',
-                type: 'class_balancing',
-                params: {
-                    target_distribution_mode: 'uniform',
-                    target_distribution: [],
-                    strength: 1
-                },
-                isExpanded: true
-            })
-        ).toEqual({ strategy_name: 'balance', target_distribution: 'uniform', strength: 1 });
+        expect(toApiStrategy(defaultClassBalancing)).toEqual({
+            strategy_name: 'balance',
+            target_distribution: 'uniform',
+            strength: 1
+        });
     });
 
     it('maps class_balancing with input source to balance strategy with string target_distribution', () => {
         expect(
             toApiStrategy({
-                id: 'cb-2',
-                type: 'class_balancing',
-                params: { target_distribution_mode: 'input', target_distribution: [], strength: 1 },
-                isExpanded: true
+                ...defaultClassBalancing,
+                params: { ...defaultClassBalancing.params, target_distribution_mode: 'input' }
             })
         ).toEqual({ strategy_name: 'balance', target_distribution: 'input', strength: 1 });
     });
@@ -136,8 +113,7 @@ describe('toApiStrategy', () => {
     it('maps class_balancing with dictionary source to balance strategy converting rows to object', () => {
         expect(
             toApiStrategy({
-                id: 'cb-3',
-                type: 'class_balancing',
+                ...defaultClassBalancing,
                 params: {
                     target_distribution_mode: 'dictionary',
                     target_distribution: [
@@ -145,8 +121,7 @@ describe('toApiStrategy', () => {
                         { class_name: 'dog', weight: 1 }
                     ],
                     strength: 1
-                },
-                isExpanded: true
+                }
             })
         ).toEqual({
             strategy_name: 'balance',

--- a/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/strategyApiMapping.ts
+++ b/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/strategyApiMapping.ts
@@ -1,4 +1,4 @@
-import type { SelectionRequest } from '$lib/api/lightly_studio_local/types.gen';
+import type { SamplingRequest } from '$lib/api/lightly_studio_local/types.gen';
 import type { StrategyInstance } from '$lib/hooks/useStrategyBuilder';
 
 export function getMetadataKey(instance: StrategyInstance): string {
@@ -8,7 +8,7 @@ export function getMetadataKey(instance: StrategyInstance): string {
     return '';
 }
 
-export function toApiStrategy(instance: StrategyInstance): SelectionRequest['strategies'][number] {
+export function toApiStrategy(instance: StrategyInstance): SamplingRequest['strategies'][number] {
     if (instance.type === 'diversity') {
         return {
             strategy_name: 'diversity',

--- a/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/strategyApiMapping.ts
+++ b/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/strategyApiMapping.ts
@@ -33,7 +33,7 @@ export function toApiStrategy(instance: StrategyInstance): SamplingRequest['stra
         };
     }
 
-    const target_distribution =
+    const targetDistribution =
         instance.params.target_distribution_mode === 'dictionary'
             ? Object.fromEntries(
                   instance.params.target_distribution.map((row) => [row.class_name, row.weight])
@@ -42,7 +42,7 @@ export function toApiStrategy(instance: StrategyInstance): SamplingRequest['stra
 
     return {
         strategy_name: 'balance',
-        target_distribution,
+        target_distribution: targetDistribution,
         strength: instance.params.strength
     };
 }

--- a/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/strategyApiMapping.ts
+++ b/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/strategyApiMapping.ts
@@ -1,0 +1,48 @@
+import type { SelectionRequest } from '$lib/api/lightly_studio_local/types.gen';
+import type { StrategyInstance } from '$lib/hooks/useStrategyBuilder';
+
+export function getMetadataKey(instance: StrategyInstance): string {
+    if (instance.type === 'typicality') return `typicality-${instance.id}`;
+    if (instance.type === 'similarity') return `similarity-${instance.id}`;
+    if (instance.type === 'metadata_weighting') return instance.params.metadata_key;
+    return '';
+}
+
+export function toApiStrategy(instance: StrategyInstance): SelectionRequest['strategies'][number] {
+    if (instance.type === 'diversity') {
+        return {
+            strategy_name: 'diversity',
+            embedding_model_name: null,
+            strength: instance.params.strength
+        };
+    }
+
+    if (instance.type === 'typicality' || instance.type === 'similarity') {
+        return {
+            strategy_name: 'weights',
+            metadata_key: getMetadataKey(instance),
+            strength: instance.params.strength
+        };
+    }
+
+    if (instance.type === 'metadata_weighting') {
+        return {
+            strategy_name: 'weights',
+            metadata_key: instance.params.metadata_key,
+            strength: instance.params.strength
+        };
+    }
+
+    const target_distribution =
+        instance.params.target_distribution_mode === 'dictionary'
+            ? Object.fromEntries(
+                  instance.params.target_distribution.map((row) => [row.class_name, row.weight])
+              )
+            : instance.params.target_distribution_mode;
+
+    return {
+        strategy_name: 'balance',
+        target_distribution,
+        strength: instance.params.strength
+    };
+}


### PR DESCRIPTION
## What has changed and why?

Adds getMetadataKey and toApiStrategy helpers that convert StrategyInstance objects into the SelectionRequest API shape.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added strategy-to-API mapping for diversity, typicality, similarity, metadata weighting, and class balancing; includes derived metadata key handling and conversion of dictionary-style target distributions for API payloads.

* **Tests**
  * Added tests covering metadata key derivation, mapping of each strategy type to the expected API payload, and class-balancing target distribution conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->