### PR TITLE
[Do not merge] Collapse grid top-bar controls when they would overflow

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -9,7 +9,6 @@
     type SearchImage = { name: string; previewUrl: string };
 
     interface Props {
-        compact?: boolean;
         canSelectAll: boolean;
         isImages: boolean;
         hasEvaluationRuns: boolean;
@@ -26,7 +25,6 @@
     }
 
     const {
-        compact = false,
         canSelectAll,
         isImages,
         hasEvaluationRuns,
@@ -47,12 +45,12 @@
 </script>
 
 <GridHeader>
-    {#snippet selectionControls()}
+    {#snippet selectionControls(compact: boolean)}
         {#if canSelectAll}
-            <GridHeaderSelectAllButton onclick={onSelectAll} />
+            <GridHeaderSelectAllButton onclick={onSelectAll} {compact} />
         {/if}
     {/snippet}
-    {#snippet auxControls()}
+    {#snippet auxControls(compact: boolean)}
         {#if isImages}
             <OrderBy datasetId={collectionDatasetId} />
         {/if}
@@ -62,7 +60,7 @@
                 position="bottom"
             >
                 <Button
-                    class="flex items-center space-x-1"
+                    class="flex shrink-0 items-center space-x-1"
                     data-testid="toggle-plot-button"
                     variant={$showEmbeddingPlot ? 'default' : 'ghost'}
                     onclick={() => setShowEmbeddingPlot(!$showEmbeddingPlot)}
@@ -80,7 +78,7 @@
                 position="bottom"
             >
                 <Button
-                    class="flex items-center space-x-1"
+                    class="flex shrink-0 items-center space-x-1"
                     data-testid="toggle-evaluation-runs-button"
                     variant={$showEvaluationRuns ? 'default' : 'ghost'}
                     onclick={() => setShowEvaluationRuns(!$showEvaluationRuns)}
@@ -94,7 +92,7 @@
         {/if}
     {/snippet}
     {#if hasMediaWithEmbeddings}
-        <div class="relative" role="region" data-grid-search-drop-target>
+        <div class="relative min-w-48" role="region" data-grid-search-drop-target>
             <CollectionSearch
                 image={searchImage}
                 isPending={searchPending}

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -57,7 +57,6 @@ import DatasetGridHeader from './DatasetGridHeader.svelte';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 
 const defaultProps = {
-    compact: false,
     canSelectAll: false,
     isImages: false,
     hasEvaluationRuns: true,
@@ -197,19 +196,21 @@ describe('DatasetGridHeader', () => {
         expect(screen.queryByTestId('toggle-evaluation-runs-button')).not.toBeInTheDocument();
     });
 
-    it('hides the embeddings and evaluation runs labels in compact mode', () => {
+    it('shows the embeddings and evaluation labels when the toolbar is not compact', () => {
+        // Collapsing is driven at runtime by GridHeader's overflow measurement
+        // (ResizeObserver), which jsdom does not exercise, so here the bar stays in its
+        // roomy state and both labels are present.
         render(DatasetGridHeader, {
             props: {
                 ...defaultProps,
-                compact: true,
                 isImages: true,
                 hasMediaWithEmbeddings: true
             }
         });
 
         expect(screen.getByTestId('toggle-plot-button')).toBeInTheDocument();
-        expect(screen.queryByText('Embeddings')).not.toBeInTheDocument();
+        expect(screen.getByText('Embeddings')).toBeInTheDocument();
         expect(screen.getByTestId('toggle-evaluation-runs-button')).toBeInTheDocument();
-        expect(screen.queryByText('Evaluation')).not.toBeInTheDocument();
+        expect(screen.getByText('Evaluation')).toBeInTheDocument();
     });
 });

--- a/lightly_studio_view/src/lib/components/GridHeader/GridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/GridHeader/GridHeader.svelte
@@ -5,8 +5,10 @@
     interface GridHeaderProps {
         showImageSizeControl?: boolean;
         children?: Snippet;
-        selectionControls?: Snippet;
-        auxControls?: Snippet;
+        // The snippets receive whether the toolbar is currently compact, so the
+        // controls they render can drop their text labels when space runs out.
+        selectionControls?: Snippet<[boolean]>;
+        auxControls?: Snippet<[boolean]>;
     }
 
     let {
@@ -15,16 +17,44 @@
         selectionControls,
         auxControls
     }: GridHeaderProps = $props();
+
+    let barEl = $state<HTMLDivElement | null>(null);
+    let compact = $state(false);
+    // The width the toolbar needs to show every control with its labels. It is
+    // captured from scrollWidth while the (expanded) bar is overflowing, then used
+    // as a stable threshold for re-expanding — so toggling compact can't oscillate.
+    let expandedWidth = 0;
+
+    function measure(el: HTMLDivElement) {
+        if (!compact) {
+            // Collapse the moment the full-width layout no longer fits.
+            if (el.scrollWidth > el.clientWidth) {
+                expandedWidth = el.scrollWidth;
+                compact = true;
+            }
+        } else if (expandedWidth > 0 && el.clientWidth >= expandedWidth) {
+            // Re-expand only once the full layout is known to fit again.
+            compact = false;
+        }
+    }
+
+    $effect(() => {
+        const el = barEl;
+        if (!el) return;
+        const observer = new ResizeObserver(() => measure(el));
+        observer.observe(el);
+        return () => observer.disconnect();
+    });
 </script>
 
-<div class="my-2 flex items-center space-x-4">
-    <div class="flex-1">
+<div bind:this={barEl} class="my-2 flex items-center space-x-4">
+    <div class="min-w-0 flex-1">
         {@render children?.()}
     </div>
 
-    {@render selectionControls?.()}
+    {@render selectionControls?.(compact)}
     {#if showImageSizeControl}
-        <ImageSizeControl />
+        <ImageSizeControl {compact} />
     {/if}
-    {@render auxControls?.()}
+    {@render auxControls?.(compact)}
 </div>

--- a/lightly_studio_view/src/lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte
+++ b/lightly_studio_view/src/lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte
@@ -2,7 +2,8 @@
     import { SquareCheck } from '@lucide/svelte';
     import Button from '../ui/button/button.svelte';
 
-    const { onclick }: { onclick: () => Promise<void> } = $props();
+    const { onclick, compact = false }: { onclick: () => Promise<void>; compact?: boolean } =
+        $props();
 </script>
 
 <Button
@@ -14,5 +15,7 @@
     {onclick}
 >
     <SquareCheck class="size-4" />
-    <span>Select all</span>
+    {#if !compact}
+        <span>Select all</span>
+    {/if}
 </Button>

--- a/lightly_studio_view/src/lib/components/ImageSizeControl/ImageSizeControl.svelte
+++ b/lightly_studio_view/src/lib/components/ImageSizeControl/ImageSizeControl.svelte
@@ -3,7 +3,7 @@
     import { throttle } from 'lodash-es';
     import { ZoomIn, ZoomOut } from '@lucide/svelte';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
-    const { min = 1, max = 16 } = $props();
+    const { min = 1, max = 16, compact = false } = $props();
 
     const { updateSampleSize, sampleSize } = useGlobalStorage();
 
@@ -27,7 +27,11 @@
     }
 </script>
 
-<div class="flex w-48 shrink-0 items-center space-x-2 text-diffuse-foreground">
+<!--
+  When the toolbar runs out of room (compact) the slider is dropped and the control
+  collapses to just the zoom-out / zoom-in icon buttons, which still adjust the size.
+-->
+<div class="flex shrink-0 items-center space-x-2 text-diffuse-foreground {compact ? '' : 'w-36'}">
     <button
         onclick={zoomOut}
         disabled={width >= max}
@@ -37,15 +41,17 @@
         <ZoomOut class="h-4 w-4" />
     </button>
 
-    <Slider
-        type="multiple"
-        class="w-full flex-1"
-        value={[sliderValue]}
-        {min}
-        {max}
-        step={1}
-        onValueChange={handleChange}
-    />
+    {#if !compact}
+        <Slider
+            type="multiple"
+            class="w-full flex-1"
+            value={[sliderValue]}
+            {min}
+            {max}
+            step={1}
+            onValueChange={handleChange}
+        />
+    {/if}
 
     <button
         onclick={zoomIn}

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
@@ -41,7 +41,7 @@
     };
 </script>
 
-<div class="flex items-center gap-1">
+<div class="flex shrink-0 items-center gap-1">
     <Select.Root type="single" value={selectValue} allowDeselect onValueChange={handleValueChange}>
         <Select.Trigger
             class="h-8 w-[100px] min-w-20 gap-1 px-2.5 text-xs font-normal"

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -304,8 +304,6 @@
     const isCollectionGrid = $derived(
         isImages || isAnnotations || isVideos || isVideoFrames || isGroups
     );
-
-    const isSidePanelOpen = $derived($activePanel !== 'none');
 </script>
 
 <div class="flex-none">
@@ -374,7 +372,6 @@
                         {hasEvaluationRuns}
                         {hasMediaWithEmbeddings}
                         collectionDatasetId={collection.dataset_id}
-                        compact={isSidePanelOpen}
                         onSelectAll={selectAllHandle.handleSelectAll}
                         searchImage={$searchImage}
                         searchPending={$searchPending}
@@ -409,7 +406,7 @@
                 <PaneGroup direction="horizontal" class="flex-1">
                     <Pane defaultSize={65} minSize={35} class="flex">
                         <div
-                            class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
+                            class="relative flex min-w-0 flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
                         >
                             {@render mainContent()}
                         </div>
@@ -433,7 +430,7 @@
                 <PaneGroup direction="horizontal" class="flex-1">
                     <Pane defaultSize={50} minSize={30} class="flex">
                         <div
-                            class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4"
+                            class="relative flex min-w-0 flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4"
                         >
                             <DatasetGridHeader
                                 {canSelectAll}
@@ -441,7 +438,6 @@
                                 {hasEvaluationRuns}
                                 {hasMediaWithEmbeddings}
                                 collectionDatasetId={collection.dataset_id}
-                                compact={isSidePanelOpen}
                                 onSelectAll={selectAllHandle.handleSelectAll}
                                 searchImage={$searchImage}
                                 searchPending={$searchPending}
@@ -474,7 +470,7 @@
                 <PaneGroup direction="horizontal" class="flex-1">
                     <Pane defaultSize={65} minSize={35} class="flex">
                         <div
-                            class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
+                            class="relative flex min-w-0 flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
                         >
                             {@render mainContent()}
                         </div>
@@ -488,7 +484,9 @@
                 </PaneGroup>
             {:else}
                 <!-- Normal layout (no side panel) -->
-                <div class="relative flex flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2">
+                <div
+                    class="relative flex min-w-0 flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
+                >
                     {@render mainContent()}
                 </div>
             {/if}

--- a/lightly_studio_view/src/setupTests.ts
+++ b/lightly_studio_view/src/setupTests.ts
@@ -20,6 +20,16 @@ vi.mock('$env/static/public', () => ({
     PUBLIC_LIGHTLY_STUDIO_API_URL: 'http://mock-url.com/api'
 }));
 
+// jsdom does not implement ResizeObserver; components that observe element size
+// (e.g. GridHeader's overflow detection) need a no-op stand-in to render in tests.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as unknown as typeof ResizeObserver;
+}
+
 Object.defineProperty(Element.prototype, 'animate', {
     writable: true,
     value: vi.fn().mockImplementation(() => {


### PR DESCRIPTION
## What has changed and why?

The grid top bar got cramped when space was tight (e.g. a side panel open or a narrow viewport): controls were pushed off and the area scrolled instead of adapting.

The toolbar now measures its own width and, when the controls would overflow, collapses them to icon-only — text labels (Select all, Embeddings, Evaluation) drop and the zoom slider is replaced by its +/- buttons. As the bar widens again, everything is restored. Detection is overflow-based (a ResizeObserver with a cached full-width threshold so it can't oscillate), not fixed breakpoints.

This also adds `min-w-0` to the toolbar's card wrappers so the bar is genuinely width-constrained; without it the page just scrolls and no collapse can ever trigger.

Caveat: the `min-w-0` changes touch the shared flex/overflow layout of the collection view — worth a sanity check that other panel/grid layouts still behave.

## How has it been tested?

- Component tests for the affected toolbar components pass; `make static-checks` is clean.
- Verified manually in the running app across viewport widths: controls collapse exactly when they would overflow and restore on widening, with no flicker at the threshold.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)