### PR TITLE
Add computeStrategyMetadata function for combination sampling

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/computeStrategyMetadata.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/computeStrategyMetadata.test.ts
@@ -16,6 +16,12 @@ vi.mock('svelte-sonner', () => ({
 
 const { toast } = await import('svelte-sonner');
 
+const defaultParams = {
+    collectionId: 'col-1',
+    isVideoCollection: false,
+    onProgress: vi.fn()
+};
+
 describe('computeStrategyMetadata', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -26,14 +32,13 @@ describe('computeStrategyMetadata', () => {
         const onProgress = vi.fn();
 
         const result = await computeStrategyMetadata({
+            ...defaultParams,
             instance: {
                 id: 'typ-1',
                 type: 'typicality',
                 params: { strength: 1 },
                 isExpanded: true
             },
-            collectionId: 'col-1',
-            isVideoCollection: false,
             onProgress
         });
 
@@ -50,14 +55,13 @@ describe('computeStrategyMetadata', () => {
         const onProgress = vi.fn();
 
         const result = await computeStrategyMetadata({
+            ...defaultParams,
             instance: {
                 id: 'sim-1',
                 type: 'similarity',
                 params: { query_tag_id: 'qtag-1', strength: 1 },
                 isExpanded: true
             },
-            collectionId: 'col-1',
-            isVideoCollection: false,
             onProgress
         });
 
@@ -73,23 +77,22 @@ describe('computeStrategyMetadata', () => {
         const onProgress = vi.fn();
 
         const r1 = await computeStrategyMetadata({
+            ...defaultParams,
             instance: { id: 'd', type: 'diversity', params: { strength: 1 }, isExpanded: true },
-            collectionId: 'col-1',
-            isVideoCollection: false,
             onProgress
         });
         const r2 = await computeStrategyMetadata({
+            ...defaultParams,
             instance: {
                 id: 'm',
                 type: 'metadata_weighting',
                 params: { metadata_key: 'k', strength: 1 },
                 isExpanded: true
             },
-            collectionId: 'col-1',
-            isVideoCollection: false,
             onProgress
         });
         const r3 = await computeStrategyMetadata({
+            ...defaultParams,
             instance: {
                 id: 'b',
                 type: 'class_balancing',
@@ -100,8 +103,6 @@ describe('computeStrategyMetadata', () => {
                 },
                 isExpanded: true
             },
-            collectionId: 'col-1',
-            isVideoCollection: false,
             onProgress
         });
 
@@ -120,15 +121,8 @@ describe('computeStrategyMetadata', () => {
         } as never);
 
         const result = await computeStrategyMetadata({
-            instance: {
-                id: 'typ-2',
-                type: 'typicality',
-                params: { strength: 1 },
-                isExpanded: true
-            },
-            collectionId: 'col-1',
-            isVideoCollection: false,
-            onProgress: vi.fn()
+            ...defaultParams,
+            instance: { id: 'typ-2', type: 'typicality', params: { strength: 1 }, isExpanded: true }
         });
 
         expect(result).toBe(false);
@@ -144,15 +138,13 @@ describe('computeStrategyMetadata', () => {
         } as never);
 
         const result = await computeStrategyMetadata({
+            ...defaultParams,
             instance: {
                 id: 'sim-2',
                 type: 'similarity',
                 params: { query_tag_id: 'qt', strength: 1 },
                 isExpanded: true
-            },
-            collectionId: 'col-1',
-            isVideoCollection: false,
-            onProgress: vi.fn()
+            }
         });
 
         expect(result).toBe(false);
@@ -163,15 +155,14 @@ describe('computeStrategyMetadata', () => {
 
     it('blocks similarity on video collections without calling the API', async () => {
         const result = await computeStrategyMetadata({
+            ...defaultParams,
             instance: {
                 id: 'sim-3',
                 type: 'similarity',
                 params: { query_tag_id: 'qt', strength: 1 },
                 isExpanded: true
             },
-            collectionId: 'col-1',
-            isVideoCollection: true,
-            onProgress: vi.fn()
+            isVideoCollection: true
         });
 
         expect(result).toBe(false);

--- a/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/computeStrategyMetadata.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/computeStrategyMetadata.test.ts
@@ -1,0 +1,183 @@
+import {
+    computeSimilarityMetadata,
+    computeTypicalityMetadata
+} from '$lib/api/lightly_studio_local/sdk.gen';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computeStrategyMetadata } from './computeStrategyMetadata';
+
+vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
+    computeSimilarityMetadata: vi.fn(),
+    computeTypicalityMetadata: vi.fn()
+}));
+
+vi.mock('svelte-sonner', () => ({
+    toast: { error: vi.fn(), success: vi.fn() }
+}));
+
+const { toast } = await import('svelte-sonner');
+
+describe('computeStrategyMetadata', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('calls computeTypicalityMetadata with the unique instance key and reports progress', async () => {
+        vi.mocked(computeTypicalityMetadata).mockResolvedValue({ data: {}, error: null } as never);
+        const onProgress = vi.fn();
+
+        const result = await computeStrategyMetadata({
+            instance: {
+                id: 'typ-1',
+                type: 'typicality',
+                params: { strength: 1 },
+                isExpanded: true
+            },
+            collectionId: 'col-1',
+            isVideoCollection: false,
+            onProgress
+        });
+
+        expect(result).toBe(true);
+        expect(onProgress).toHaveBeenCalledWith('Computing typicality metadata...');
+        expect(computeTypicalityMetadata).toHaveBeenCalledWith({
+            path: { collection_id: 'col-1' },
+            body: { embedding_model_name: null, metadata_name: 'typicality-typ-1' }
+        });
+    });
+
+    it('calls computeSimilarityMetadata with the query tag id and unique instance key', async () => {
+        vi.mocked(computeSimilarityMetadata).mockResolvedValue({ data: {}, error: null } as never);
+        const onProgress = vi.fn();
+
+        const result = await computeStrategyMetadata({
+            instance: {
+                id: 'sim-1',
+                type: 'similarity',
+                params: { query_tag_id: 'qtag-1', strength: 1 },
+                isExpanded: true
+            },
+            collectionId: 'col-1',
+            isVideoCollection: false,
+            onProgress
+        });
+
+        expect(result).toBe(true);
+        expect(onProgress).toHaveBeenCalledWith('Computing similarity metadata...');
+        expect(computeSimilarityMetadata).toHaveBeenCalledWith({
+            path: { collection_id: 'col-1', query_tag_id: 'qtag-1' },
+            body: { embedding_model_name: null, metadata_name: 'similarity-sim-1' }
+        });
+    });
+
+    it('returns true without calling any API for diversity, metadata_weighting, and class_balancing', async () => {
+        const onProgress = vi.fn();
+
+        const r1 = await computeStrategyMetadata({
+            instance: { id: 'd', type: 'diversity', params: { strength: 1 }, isExpanded: true },
+            collectionId: 'col-1',
+            isVideoCollection: false,
+            onProgress
+        });
+        const r2 = await computeStrategyMetadata({
+            instance: {
+                id: 'm',
+                type: 'metadata_weighting',
+                params: { metadata_key: 'k', strength: 1 },
+                isExpanded: true
+            },
+            collectionId: 'col-1',
+            isVideoCollection: false,
+            onProgress
+        });
+        const r3 = await computeStrategyMetadata({
+            instance: {
+                id: 'b',
+                type: 'class_balancing',
+                params: {
+                    target_distribution_mode: 'uniform',
+                    target_distribution: [],
+                    strength: 1
+                },
+                isExpanded: true
+            },
+            collectionId: 'col-1',
+            isVideoCollection: false,
+            onProgress
+        });
+
+        expect(r1).toBe(true);
+        expect(r2).toBe(true);
+        expect(r3).toBe(true);
+        expect(computeTypicalityMetadata).not.toHaveBeenCalled();
+        expect(computeSimilarityMetadata).not.toHaveBeenCalled();
+        expect(onProgress).not.toHaveBeenCalled();
+    });
+
+    it('returns false and toasts error when typicality API fails', async () => {
+        vi.mocked(computeTypicalityMetadata).mockResolvedValue({
+            data: undefined,
+            error: { error: 'Embedding not found' }
+        } as never);
+
+        const result = await computeStrategyMetadata({
+            instance: {
+                id: 'typ-2',
+                type: 'typicality',
+                params: { strength: 1 },
+                isExpanded: true
+            },
+            collectionId: 'col-1',
+            isVideoCollection: false,
+            onProgress: vi.fn()
+        });
+
+        expect(result).toBe(false);
+        expect(toast.error).toHaveBeenCalledWith(
+            'Failed to compute typicality metadata: Embedding not found'
+        );
+    });
+
+    it('returns false and toasts error when similarity API fails', async () => {
+        vi.mocked(computeSimilarityMetadata).mockResolvedValue({
+            data: undefined,
+            error: { error: 'Tag not found' }
+        } as never);
+
+        const result = await computeStrategyMetadata({
+            instance: {
+                id: 'sim-2',
+                type: 'similarity',
+                params: { query_tag_id: 'qt', strength: 1 },
+                isExpanded: true
+            },
+            collectionId: 'col-1',
+            isVideoCollection: false,
+            onProgress: vi.fn()
+        });
+
+        expect(result).toBe(false);
+        expect(toast.error).toHaveBeenCalledWith(
+            'Failed to compute similarity metadata: Tag not found'
+        );
+    });
+
+    it('blocks similarity on video collections without calling the API', async () => {
+        const result = await computeStrategyMetadata({
+            instance: {
+                id: 'sim-3',
+                type: 'similarity',
+                params: { query_tag_id: 'qt', strength: 1 },
+                isExpanded: true
+            },
+            collectionId: 'col-1',
+            isVideoCollection: true,
+            onProgress: vi.fn()
+        });
+
+        expect(result).toBe(false);
+        expect(computeSimilarityMetadata).not.toHaveBeenCalled();
+        expect(toast.error).toHaveBeenCalledWith(
+            'Similarity is only available for image collections.'
+        );
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/computeStrategyMetadata.ts
+++ b/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/computeStrategyMetadata.ts
@@ -1,0 +1,68 @@
+import {
+    computeSimilarityMetadata,
+    computeTypicalityMetadata
+} from '$lib/api/lightly_studio_local/sdk.gen';
+import type { StrategyInstance } from '$lib/hooks/useStrategyBuilder';
+import { toast } from 'svelte-sonner';
+import { getMetadataKey } from './strategyApiMapping';
+
+interface SelectionError {
+    error: string;
+}
+
+interface ComputeStrategyMetadataParams {
+    instance: StrategyInstance;
+    collectionId: string;
+    isVideoCollection: boolean;
+    onProgress: (message: string) => void;
+}
+
+export async function computeStrategyMetadata(
+    params: ComputeStrategyMetadataParams
+): Promise<boolean> {
+    const { instance, collectionId, isVideoCollection, onProgress } = params;
+    if (instance.type === 'typicality') {
+        onProgress('Computing typicality metadata...');
+        const response = await computeTypicalityMetadata({
+            path: { collection_id: collectionId },
+            body: {
+                embedding_model_name: null,
+                metadata_name: getMetadataKey(instance)
+            }
+        });
+        if (response.error) {
+            toast.error(
+                'Failed to compute typicality metadata: ' +
+                    ((response.error as SelectionError).error ?? 'Unknown error')
+            );
+            return false;
+        }
+    }
+
+    if (instance.type === 'similarity') {
+        if (isVideoCollection) {
+            toast.error('Similarity is only available for image collections.');
+            return false;
+        }
+        onProgress('Computing similarity metadata...');
+        const response = await computeSimilarityMetadata({
+            path: {
+                collection_id: collectionId,
+                query_tag_id: instance.params.query_tag_id
+            },
+            body: {
+                embedding_model_name: null,
+                metadata_name: getMetadataKey(instance)
+            }
+        });
+        if (response.error) {
+            toast.error(
+                'Failed to compute similarity metadata: ' +
+                    ((response.error as SelectionError).error ?? 'Unknown error')
+            );
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/computeStrategyMetadata.ts
+++ b/lightly_studio_view/src/lib/hooks/useSubmitCombinationSelection/computeStrategyMetadata.ts
@@ -10,6 +10,13 @@ interface SelectionError {
     error: string;
 }
 
+function handleComputeError(response: { error: unknown }, prefix: string): boolean {
+    if (!response.error) return false;
+    const detail = (response.error as SelectionError).error ?? 'Unknown error';
+    toast.error(`${prefix}: ${detail}`);
+    return true;
+}
+
 interface ComputeStrategyMetadataParams {
     instance: StrategyInstance;
     collectionId: string;
@@ -30,13 +37,7 @@ export async function computeStrategyMetadata(
                 metadata_name: getMetadataKey(instance)
             }
         });
-        if (response.error) {
-            toast.error(
-                'Failed to compute typicality metadata: ' +
-                    ((response.error as SelectionError).error ?? 'Unknown error')
-            );
-            return false;
-        }
+        if (handleComputeError(response, 'Failed to compute typicality metadata')) return false;
     }
 
     if (instance.type === 'similarity') {
@@ -55,13 +56,7 @@ export async function computeStrategyMetadata(
                 metadata_name: getMetadataKey(instance)
             }
         });
-        if (response.error) {
-            toast.error(
-                'Failed to compute similarity metadata: ' +
-                    ((response.error as SelectionError).error ?? 'Unknown error')
-            );
-            return false;
-        }
+        if (handleComputeError(response, 'Failed to compute similarity metadata')) return false;
     }
 
     return true;


### PR DESCRIPTION
## What has changed and why?

Extracts metadata computation logic for typicality and similarity strategy instances into a dedicated helper.

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added strategy metadata computation with progress feedback and user-facing error toasts for typicality and similarity workflows.
  * Similarity operations are blocked for video collections with a clear notification.

* **Bug Fixes**
  * Centralized API error reporting to surface meaningful error details to users.

* **Tests**
  * Added tests covering all strategy types, success/failure paths, progress reporting, and video-collection constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->