### PR TITLE
feat: introduce shared Select component

### DIFF
--- a/lightly_studio_view/src/lib/components/Select/Select.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Select/Select.stories.svelte
@@ -1,0 +1,178 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import { fn } from 'storybook/test';
+    import { Crosshair, Plus, Sigma, Target, TrendingUp } from '@lucide/svelte';
+    import { Button } from '$lib/components';
+    import Select from './Select.svelte';
+
+    const DEMO_ITEMS = [
+        { value: 'accuracy', label: 'Accuracy' },
+        { value: 'precision', label: 'Precision' },
+        { value: 'recall', label: 'Recall' },
+        { value: 'f1', label: 'F1 Score' }
+    ];
+
+    const DEMO_ITEMS_WITH_ICONS = [
+        { value: 'accuracy', label: 'Accuracy', icon: Target },
+        { value: 'precision', label: 'Precision', icon: Crosshair },
+        { value: 'recall', label: 'Recall', icon: TrendingUp },
+        { value: 'f1', label: 'F1 Score', icon: Sigma }
+    ];
+
+    const { Story } = defineMeta({
+        title: 'Components/Primitives/Select',
+        component: Select,
+        tags: ['autodocs'],
+        parameters: {
+            layout: 'centered'
+        },
+        argTypes: {
+            items: {
+                description:
+                    'List of items to render. Mutually exclusive with the `children` slot.',
+                control: 'object'
+            },
+            value: {
+                description: 'Currently selected value.',
+                control: 'select',
+                options: ['', 'accuracy', 'precision', 'recall', 'f1']
+            },
+            placeholder: {
+                description: 'Placeholder text shown when nothing is selected.',
+                control: 'text',
+                table: {
+                    type: { summary: 'string' },
+                    defaultValue: { summary: 'Select…' }
+                }
+            },
+            allowDeselect: {
+                description: 'Allow clearing the current selection.',
+                control: 'boolean',
+                table: {
+                    type: { summary: 'boolean' },
+                    defaultValue: { summary: 'false' }
+                }
+            },
+            disabled: {
+                description: 'Whether the select is disabled.',
+                control: 'boolean',
+                table: {
+                    type: { summary: 'boolean' },
+                    defaultValue: { summary: 'false' }
+                }
+            },
+            size: {
+                description: 'Trigger size. Heights align with the Button primitive.',
+                control: 'select',
+                options: ['sm', 'md', 'lg'],
+                table: {
+                    type: { summary: "'sm' | 'md' | 'lg'" },
+                    defaultValue: { summary: 'md' }
+                }
+            },
+            class: {
+                description: 'Additional class names for the trigger button.',
+                control: 'text'
+            },
+            testId: {
+                description: '`data-testid` for the trigger element.',
+                control: 'text'
+            },
+            onValueChange: {
+                description: 'Called when the selected value changes.',
+                control: false
+            },
+            children: {
+                description:
+                    'Advanced slot: provide custom `Select.Item` / `Select.Group` markup. When provided, `items` is ignored.',
+                control: false
+            }
+        }
+    });
+</script>
+
+<Story
+    name="NoSelection"
+    args={{
+        items: DEMO_ITEMS,
+        placeholder: 'Pick a metric…',
+        onValueChange: fn()
+    }}
+/>
+
+<Story
+    name="PreSelected"
+    args={{
+        items: DEMO_ITEMS,
+        value: 'precision',
+        placeholder: 'Pick a metric…',
+        onValueChange: fn()
+    }}
+/>
+
+<Story
+    name="WithDeselect"
+    args={{
+        items: DEMO_ITEMS,
+        value: 'recall',
+        allowDeselect: true,
+        placeholder: 'Pick a metric…',
+        onValueChange: fn()
+    }}
+/>
+
+<Story
+    name="WithButton"
+    args={{
+        items: DEMO_ITEMS,
+        value: 'precision',
+        placeholder: 'Pick a metric…',
+        onValueChange: fn()
+    }}
+>
+    {#snippet template(args)}
+        <div class="flex items-center gap-2">
+            <Select {...args} />
+            <Button variant="ghost" icon={Plus} vari buttonProps={{ onclick: fn() }}
+                >Add metric</Button
+            >
+        </div>
+    {/snippet}
+</Story>
+
+<Story
+    name="Sizes"
+    args={{
+        items: DEMO_ITEMS,
+        value: 'precision',
+        placeholder: 'Pick a metric…',
+        onValueChange: fn()
+    }}
+>
+    {#snippet template(args)}
+        <div class="flex items-center gap-2">
+            <Select {...args} size="sm" />
+            <Select {...args} size="md" />
+            <Select {...args} size="lg" />
+        </div>
+    {/snippet}
+</Story>
+
+<Story
+    name="WithIcons"
+    args={{
+        items: DEMO_ITEMS_WITH_ICONS,
+        value: 'precision',
+        placeholder: 'Pick a metric…',
+        onValueChange: fn()
+    }}
+/>
+
+<Story
+    name="WithIconsNoSelection"
+    args={{
+        items: DEMO_ITEMS_WITH_ICONS,
+        placeholder: 'Pick a metric…',
+        onValueChange: fn()
+    }}
+/>

--- a/lightly_studio_view/src/lib/components/Select/Select.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Select/Select.stories.svelte
@@ -133,9 +133,7 @@
     {#snippet template(args)}
         <div class="flex items-center gap-2">
             <Select {...args} />
-            <Button variant="ghost" icon={Plus} vari buttonProps={{ onclick: fn() }}
-                >Add metric</Button
-            >
+            <Button variant="ghost" icon={Plus} buttonProps={{ onclick: fn() }}>Add metric</Button>
         </div>
     {/snippet}
 </Story>

--- a/lightly_studio_view/src/lib/components/Select/Select.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Select/Select.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
     import { defineMeta } from '@storybook/addon-svelte-csf';
     import { fn } from 'storybook/test';
     import { Crosshair, Plus, Sigma, Target, TrendingUp } from '@lucide/svelte';

--- a/lightly_studio_view/src/lib/components/Select/Select.svelte
+++ b/lightly_studio_view/src/lib/components/Select/Select.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+    import type { Component, Snippet } from 'svelte';
+    import type { IconProps } from '@lucide/svelte';
+    import * as SelectPrimitive from '$lib/components/ui/select';
+    import { cn } from '$lib/utils/shadcn';
+
+    export interface SelectItem {
+        value: string;
+        label: string;
+        /** Optional Lucide icon rendered before the label, in both the trigger and dropdown. */
+        icon?: Component<IconProps>;
+        testId?: string;
+    }
+
+    export type SelectSize = 'sm' | 'md' | 'lg';
+
+    interface Props {
+        /** List of items to render. Mutually exclusive with `children` slot. */
+        items?: SelectItem[];
+        /** Currently selected value. */
+        value?: string;
+        /** Placeholder text shown when nothing is selected. */
+        placeholder?: string;
+        /** Allow clearing the current selection. */
+        allowDeselect?: boolean;
+        /** Whether the select is disabled. */
+        disabled?: boolean;
+        /** Whether the dropdown is open. Bindable for external control. */
+        open?: boolean;
+        /** Trigger size. Heights align with the Button primitive. */
+        size?: SelectSize;
+        /** Additional class names for the trigger button. */
+        class?: string;
+        /** `data-testid` for the trigger element. */
+        testId?: string;
+        /** Called when the selected value changes. */
+        onValueChange?: (value: string) => void;
+        /**
+         * Advanced slot: provide custom `Select.Item` / `Select.Group` markup.
+         * When provided, `items` prop is ignored.
+         */
+        children?: Snippet;
+    }
+
+    let {
+        items,
+        value = $bindable(undefined),
+        placeholder = 'Select…',
+        allowDeselect = false,
+        disabled = false,
+        open = $bindable(false),
+        size = 'md',
+        class: className,
+        testId,
+        onValueChange,
+        children
+    }: Props = $props();
+
+    const triggerSizeClass: Record<SelectSize, string> = {
+        sm: 'h-9 text-xs',
+        md: 'h-10 text-sm',
+        lg: 'h-11 text-base'
+    };
+
+    const itemSizeClass: Record<SelectSize, string> = {
+        sm: 'py-1 text-xs',
+        md: 'py-1.5 text-sm',
+        lg: 'py-2 text-base'
+    };
+
+    const iconSizeClass: Record<SelectSize, string> = {
+        sm: 'size-3.5',
+        md: 'size-4',
+        lg: 'size-5'
+    };
+
+    const findItem = (v: string | undefined) =>
+        v === undefined ? undefined : items?.find((i) => i.value === v);
+
+    const handleValueChange = (v: string) => {
+        value = v;
+        onValueChange?.(v);
+    };
+</script>
+
+<SelectPrimitive.Root
+    type="single"
+    {value}
+    {allowDeselect}
+    {disabled}
+    bind:open
+    onValueChange={handleValueChange}
+>
+    <SelectPrimitive.Trigger
+        data-testid={testId}
+        class={cn(
+            // Ghost-style: no border, no background, height matches the Button primitive
+            'm-0 flex items-center gap-2 rounded-md border-0 bg-transparent pr-2 font-normal',
+            triggerSizeClass[size],
+            'text-foreground hover:bg-accent hover:text-accent-foreground',
+            'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            'data-[placeholder]:text-muted-foreground',
+            className
+        )}
+    >
+        {@const selectedItem = findItem(value)}
+        {#if selectedItem?.icon}
+            {@const TriggerIcon = selectedItem.icon}
+            <TriggerIcon class={cn(iconSizeClass[size], 'shrink-0')} />
+        {/if}
+        <span class="truncate">{value ? (selectedItem?.label ?? value) : placeholder}</span>
+    </SelectPrimitive.Trigger>
+
+    <SelectPrimitive.Content>
+        {#if children}
+            {@render children()}
+        {:else if items}
+            {#each items as item (item.value)}
+                <SelectPrimitive.Item
+                    value={item.value}
+                    label={item.label}
+                    data-testid={item.testId}
+                    class={cn('gap-2', itemSizeClass[size])}
+                >
+                    {#if item.icon}
+                        {@const ItemIcon = item.icon}
+                        <ItemIcon class={cn(iconSizeClass[size], 'shrink-0')} />
+                    {/if}
+                    {item.label}
+                </SelectPrimitive.Item>
+            {/each}
+        {/if}
+    </SelectPrimitive.Content>
+</SelectPrimitive.Root>

--- a/lightly_studio_view/src/lib/components/Select/Select.svelte
+++ b/lightly_studio_view/src/lib/components/Select/Select.svelte
@@ -86,6 +86,7 @@
 <SelectPrimitive.Root
     type="single"
     {value}
+    {items}
     {allowDeselect}
     {disabled}
     bind:open

--- a/lightly_studio_view/src/lib/components/Select/Select.test.ts
+++ b/lightly_studio_view/src/lib/components/Select/Select.test.ts
@@ -1,15 +1,27 @@
-import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
 import { Crosshair, Target } from '@lucide/svelte';
 import '@testing-library/jest-dom';
 import Select, { type SelectItem } from './Select.svelte';
 
 // bits-ui Select uses pointer-capture and scrollIntoView APIs that jsdom doesn't implement.
+const originalHasPointerCapture = Element.prototype.hasPointerCapture;
+const originalSetPointerCapture = Element.prototype.setPointerCapture;
+const originalReleasePointerCapture = Element.prototype.releasePointerCapture;
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
 beforeAll(() => {
     Element.prototype.hasPointerCapture = vi.fn(() => false);
     Element.prototype.setPointerCapture = vi.fn();
     Element.prototype.releasePointerCapture = vi.fn();
     Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterAll(() => {
+    Element.prototype.hasPointerCapture = originalHasPointerCapture;
+    Element.prototype.setPointerCapture = originalSetPointerCapture;
+    Element.prototype.releasePointerCapture = originalReleasePointerCapture;
+    Element.prototype.scrollIntoView = originalScrollIntoView;
 });
 
 const ITEMS: SelectItem[] = [
@@ -79,7 +91,6 @@ describe('Select', () => {
 
         const trigger = container.querySelector(triggerSelector);
         expect(trigger?.className).toContain('custom-class');
-        expect(trigger?.className).toContain('rounded-md');
     });
 
     describe('icon', () => {

--- a/lightly_studio_view/src/lib/components/Select/Select.test.ts
+++ b/lightly_studio_view/src/lib/components/Select/Select.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { Crosshair, Target } from '@lucide/svelte';
+import '@testing-library/jest-dom';
+import Select, { type SelectItem } from './Select.svelte';
+
+// bits-ui Select uses pointer-capture and scrollIntoView APIs that jsdom doesn't implement.
+beforeAll(() => {
+    Element.prototype.hasPointerCapture = vi.fn(() => false);
+    Element.prototype.setPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+    Element.prototype.scrollIntoView = vi.fn();
+});
+
+const ITEMS: SelectItem[] = [
+    { value: 'accuracy', label: 'Accuracy' },
+    { value: 'precision', label: 'Precision' },
+    { value: 'recall', label: 'Recall' }
+];
+
+const ITEMS_WITH_ICONS: SelectItem[] = [
+    { value: 'accuracy', label: 'Accuracy', icon: Target },
+    { value: 'precision', label: 'Precision', icon: Crosshair },
+    { value: 'recall', label: 'Recall' }
+];
+
+const triggerSelector = 'button[data-select-trigger]';
+
+describe('Select', () => {
+    it('renders the placeholder when no value is selected', () => {
+        const { container } = render(Select, {
+            props: { items: ITEMS, placeholder: 'Pick a metric' }
+        });
+
+        const trigger = container.querySelector(triggerSelector);
+        expect(trigger).toBeInTheDocument();
+        expect(trigger).toHaveTextContent('Pick a metric');
+    });
+
+    it('renders the matching item label when a value is selected', () => {
+        const { container } = render(Select, {
+            props: { items: ITEMS, value: 'precision' }
+        });
+
+        expect(container.querySelector(triggerSelector)).toHaveTextContent('Precision');
+    });
+
+    it('falls back to the raw value when no matching item exists', () => {
+        const { container } = render(Select, {
+            props: { items: ITEMS, value: 'unknown' }
+        });
+
+        expect(container.querySelector(triggerSelector)).toHaveTextContent('unknown');
+    });
+
+    it('forwards the testId to the trigger element', () => {
+        const { container } = render(Select, {
+            props: { items: ITEMS, testId: 'metric-select' }
+        });
+
+        expect(container.querySelector(triggerSelector)).toHaveAttribute(
+            'data-testid',
+            'metric-select'
+        );
+    });
+
+    it('disables the trigger when disabled is true', () => {
+        const { container } = render(Select, {
+            props: { items: ITEMS, disabled: true }
+        });
+
+        expect(container.querySelector(triggerSelector)).toBeDisabled();
+    });
+
+    it('merges custom class names with the default classes', () => {
+        const { container } = render(Select, {
+            props: { items: ITEMS, class: 'custom-class' }
+        });
+
+        const trigger = container.querySelector(triggerSelector);
+        expect(trigger?.className).toContain('custom-class');
+        expect(trigger?.className).toContain('rounded-md');
+    });
+
+    describe('icon', () => {
+        it('renders the selected item icon in the trigger', () => {
+            const { container } = render(Select, {
+                props: { items: ITEMS_WITH_ICONS, value: 'accuracy' }
+            });
+
+            const icon = container.querySelector(`${triggerSelector} > svg`);
+            expect(icon).toBeInTheDocument();
+            expect(icon).toHaveClass('size-4');
+        });
+
+        it('renders an icon matching the selected value when multiple items have icons', () => {
+            const { container } = render(Select, {
+                props: { items: ITEMS_WITH_ICONS, value: 'precision' }
+            });
+
+            const icon = container.querySelector(`${triggerSelector} > svg`);
+            expect(icon).toBeInTheDocument();
+            // Lucide adds a `lucide-<name>` class so we can assert which icon mounted
+            expect(icon?.getAttribute('class')).toContain('lucide-crosshair');
+        });
+
+        it.each([
+            ['sm', 'size-3.5'],
+            ['md', 'size-4'],
+            ['lg', 'size-5']
+        ] as const)('scales the trigger icon to %s', (size, sizeClass) => {
+            const { container } = render(Select, {
+                props: { items: ITEMS_WITH_ICONS, value: 'accuracy', size }
+            });
+
+            const icon = container.querySelector(`${triggerSelector} > svg`);
+            expect(icon).toBeInTheDocument();
+            expect(icon?.getAttribute('class')).toContain(sizeClass);
+        });
+
+        it.each([
+            ['sm', 'size-3.5'],
+            ['md', 'size-4'],
+            ['lg', 'size-5']
+        ] as const)('scales dropdown item icons to %s', (size, sizeClass) => {
+            const { baseElement } = render(Select, {
+                props: { items: ITEMS_WITH_ICONS, size, open: true }
+            });
+
+            const itemIcons = baseElement.querySelectorAll('[data-select-item] > svg');
+            expect(itemIcons.length).toBeGreaterThan(0);
+            itemIcons.forEach((icon) => {
+                expect(icon.getAttribute('class')).toContain(sizeClass);
+            });
+        });
+    });
+
+    describe('size', () => {
+        it('defaults to md (h-10)', () => {
+            const { container } = render(Select, { props: { items: ITEMS } });
+
+            const trigger = container.querySelector(triggerSelector);
+            expect(trigger?.className).toContain('h-10');
+            expect(trigger?.className).toContain('text-sm');
+        });
+
+        it.each([
+            ['sm', 'h-9', 'text-xs'],
+            ['md', 'h-10', 'text-sm'],
+            ['lg', 'h-11', 'text-base']
+        ] as const)(
+            'applies the %s size classes to the trigger',
+            (size, heightClass, textClass) => {
+                const { container } = render(Select, {
+                    props: { items: ITEMS, size }
+                });
+
+                const trigger = container.querySelector(triggerSelector);
+                expect(trigger?.className).toContain(heightClass);
+                expect(trigger?.className).toContain(textClass);
+            }
+        );
+
+        it.each([
+            ['sm', 'py-1', 'text-xs'],
+            ['md', 'py-1.5', 'text-sm'],
+            ['lg', 'py-2', 'text-base']
+        ] as const)(
+            'applies the %s size classes to dropdown items',
+            (size, paddingClass, textClass) => {
+                const { baseElement } = render(Select, {
+                    props: { items: ITEMS, size, open: true }
+                });
+
+                const items = baseElement.querySelectorAll('[data-select-item]');
+                expect(items.length).toBe(ITEMS.length);
+                items.forEach((item) => {
+                    expect(item.className).toContain(paddingClass);
+                    expect(item.className).toContain(textClass);
+                });
+            }
+        );
+    });
+});

--- a/lightly_studio_view/src/lib/components/Select/index.ts
+++ b/lightly_studio_view/src/lib/components/Select/index.ts
@@ -1,0 +1,2 @@
+export { default as Select } from './Select.svelte';
+export type { SelectItem, SelectSize } from './Select.svelte';


### PR DESCRIPTION
## What has changed and why?

This PR introduces shared Select component to  provide functionality of selecting item from the list. 
It will replace varios select-like custom variations across the app

## How has it been tested?

By the tests and storybook story
<img width="1291" height="733" alt="Screenshot 2026-06-03 at 10 55 23" src="https://github.com/user-attachments/assets/e5c5d269-929a-418c-b63a-e91ed9f7905b" />
<img width="1316" height="868" alt="Screenshot 2026-06-03 at 10 55 10" src="https://github.com/user-attachments/assets/c6a5e9dc-5cab-446c-a1a6-f1079e7d6eba" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Select component with icon support, three sizes (sm/md/lg), optional deselect, disabled state, placeholder, and customizable trigger styling.

* **Documentation**
  * Added interactive Storybook examples showcasing no-selection, preselected, deselect, button-adjacent, sizes, and icon variants.

* **Tests**
  * Added unit tests covering placeholder/label rendering, icon display/scaling, size-specific styles, testId forwarding, disabled state, and class merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->