### PR TITLE
feat: replace all select usages with shared select component

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte
@@ -1,22 +1,27 @@
 <script lang="ts">
     import { Select } from '$lib/components/Select';
 
-    interface Props {
-        /** Names of the annotation sources (collections) to choose from. */
-        sourceNames: string[];
-        /** Currently selected source name. */
-        selectedSource?: string;
-        /** Optional notification when the selection changes (the value also flows out via `bind:selectedSource`). */
-        onSelect?: (source: string) => void;
+    interface SourceOption {
+        id: string;
+        name: string;
     }
 
-    let { sourceNames, selectedSource = $bindable(), onSelect }: Props = $props();
+    interface Props {
+        /** Annotation sources (collections) to choose from. */
+        sourceOptions: SourceOption[];
+        /** Currently selected source id. */
+        selectedSource?: string;
+        /** Optional notification when the selection changes (the value also flows out via `bind:selectedSource`). */
+        onSelect?: (sourceId: string) => void;
+    }
+
+    let { sourceOptions, selectedSource = $bindable(), onSelect }: Props = $props();
 
     const items = $derived(
-        sourceNames.map((name) => ({
-            value: name,
-            label: name,
-            testId: `annotation-source-option-${name}`
+        sourceOptions.map((option) => ({
+            value: option.id,
+            label: option.name,
+            testId: `annotation-source-option-${option.name}`
         }))
     );
 </script>

--- a/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte
@@ -1,52 +1,34 @@
 <script lang="ts">
-    import * as Select from '$lib/components/ui/select';
-
-    type SourceOption = {
-        id: string;
-        name: string;
-    };
+    import { Select } from '$lib/components/Select';
 
     interface Props {
-        /** Annotation sources (collections) to choose from. */
-        sourceOptions?: SourceOption[];
-        /** Backward-compatible list of source names where the value is also the display label. */
-        sourceNames?: string[];
+        /** Names of the annotation sources (collections) to choose from. */
+        sourceNames: string[];
         /** Currently selected source name. */
         selectedSource?: string;
         /** Optional notification when the selection changes (the value also flows out via `bind:selectedSource`). */
         onSelect?: (source: string) => void;
     }
 
-    let { sourceOptions, sourceNames, selectedSource = $bindable(), onSelect }: Props = $props();
+    let { sourceNames, selectedSource = $bindable(), onSelect }: Props = $props();
 
-    const options = $derived(
-        sourceOptions ??
-            sourceNames?.map((name) => ({
-                id: name,
-                name
-            })) ??
-            []
+    const items = $derived(
+        sourceNames.map((name) => ({
+            value: name,
+            label: name,
+            testId: `annotation-source-option-${name}`
+        }))
     );
 </script>
 
-<Select.Root
-    type="single"
+<Select
+    {items}
     value={selectedSource}
+    placeholder="Select a source..."
+    class="w-full"
+    testId="annotation-source-trigger"
     onValueChange={(value) => {
         selectedSource = value;
         onSelect?.(value);
     }}
->
-    <Select.Trigger class="w-full" data-testid="annotation-source-trigger">
-        {options.find((source) => source.id === selectedSource)?.name ?? 'Select a source...'}
-    </Select.Trigger>
-    <Select.Content>
-        {#each options as source (source.id)}
-            <Select.Item
-                value={source.id}
-                label={source.name}
-                data-testid={`annotation-source-option-${source.name}`}
-            />
-        {/each}
-    </Select.Content>
-</Select.Root>
+/>

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -3,7 +3,12 @@
     import FormField from '$lib/components/FormField/FormField.svelte';
     import { Checkbox } from '$lib/components';
     import { Button } from '$lib/components/ui';
-    import * as Select from '$lib/components/ui/select/index.js';
+    import {
+        Select,
+        SelectMenuItem,
+        SelectMenuGroup,
+        SelectMenuGroupHeading
+    } from '$lib/components/Select';
     import * as Tabs from '$lib/components/ui/tabs/index.js';
     import { useTags } from '$lib/hooks/useTags/useTags';
     import { exportCollection } from '$lib/services/exportCollection';
@@ -157,59 +162,62 @@
                 <Tabs.Root bind:value={exportType} class="w-full">
                     <!-- TODO(lukas 3/2026): Consider constructing this by iterating over exportTypeLabels-->
                     <FormField label="Export Type">
-                        <Select.Root type="single" bind:value={exportType}>
-                            <Select.Trigger class="w-full" data-testid="export-type-select">
-                                {exportTypeTriggerContent}
-                            </Select.Trigger>
-                            <Select.Content>
+                        <Select
+                            value={exportType}
+                            triggerLabel={exportTypeTriggerContent}
+                            class="w-full"
+                            testId="export-type-select"
+                            onValueChange={(v) => (exportType = v as typeof exportType)}
+                        >
+                            {#snippet children()}
                                 {#if isVideoCollection}
-                                    <Select.Item
+                                    <SelectMenuItem
                                         value="youtube_vis_segmentation"
                                         label="YouTube-VIS Video Segmentation Masks"
-                                        >YouTube-VIS Video Segmentation Masks</Select.Item
+                                        >YouTube-VIS Video Segmentation Masks</SelectMenuItem
                                     >
                                 {:else}
-                                    <Select.Item value="samples" label="Image Filenames"
-                                        >Image Filenames</Select.Item
+                                    <SelectMenuItem value="samples" label="Image Filenames"
+                                        >Image Filenames</SelectMenuItem
                                     >
-                                    <Select.Item
+                                    <SelectMenuItem
                                         value="object_detections"
                                         label="Image Object Detections"
-                                        >Image Object Detections</Select.Item
+                                        >Image Object Detections</SelectMenuItem
                                     >
-                                    <Select.Item
+                                    <SelectMenuItem
                                         value="segmentation"
                                         label="Image Segmentation Mask (COCO)"
-                                        >Image Segmentation Mask (COCO)</Select.Item
+                                        >Image Segmentation Mask (COCO)</SelectMenuItem
                                     >
-                                    <Select.Item
+                                    <SelectMenuItem
                                         value="semantic_segmentations"
                                         label="Image Segmentation Mask (PASCAL VOC)"
-                                        >Image Segmentation Mask (PASCAL VOC)</Select.Item
+                                        >Image Segmentation Mask (PASCAL VOC)</SelectMenuItem
                                     >
-                                    <Select.Item value="captions" label="Image Captions"
-                                        >Image Captions</Select.Item
+                                    <SelectMenuItem value="captions" label="Image Captions"
+                                        >Image Captions</SelectMenuItem
                                     >
                                 {/if}
-                            </Select.Content>
-                        </Select.Root>
+                            {/snippet}
+                        </Select>
                     </FormField>
 
                     <!-- Samples tab -->
 
                     <Tabs.Content value="samples" class="pt-2">
                         <FormField label="Tag">
-                            <Select.Root
-                                type="single"
-                                name="tagIdToExport"
-                                bind:value={tagIdToExport}
+                            <Select
+                                value={tagIdToExport}
+                                triggerLabel={triggerContent}
+                                class="w-full"
+                                onValueChange={(v) => (tagIdToExport = v)}
                             >
-                                <Select.Trigger class="w-full">
-                                    {triggerContent}
-                                </Select.Trigger>
-                                <Select.Content>
-                                    <Select.Group>
-                                        <Select.GroupHeading>Annotation tags</Select.GroupHeading>
+                                {#snippet children()}
+                                    <SelectMenuGroup>
+                                        <SelectMenuGroupHeading
+                                            >Annotation tags</SelectMenuGroupHeading
+                                        >
                                         {#if $tags.filter((tag) => tag.kind === 'annotation').length === 0}
                                             <div
                                                 class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
@@ -218,13 +226,13 @@
                                             </div>
                                         {/if}
                                         {#each $tags.filter((tag) => tag.kind === 'annotation') as annotationTag}
-                                            <Select.Item
+                                            <SelectMenuItem
                                                 value={annotationTag.tag_id}
                                                 label={annotationTag.name}
-                                                >{annotationTag.name}</Select.Item
+                                                >{annotationTag.name}</SelectMenuItem
                                             >
                                         {/each}
-                                        <Select.GroupHeading>Sample tags</Select.GroupHeading>
+                                        <SelectMenuGroupHeading>Sample tags</SelectMenuGroupHeading>
                                         {#if $tags.filter((tag) => tag.kind === 'sample').length === 0}
                                             <div
                                                 class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
@@ -233,14 +241,15 @@
                                             </div>
                                         {/if}
                                         {#each $tags.filter((tag) => tag.kind === 'sample') as sampleTag}
-                                            <Select.Item
+                                            <SelectMenuItem
                                                 value={sampleTag.tag_id}
-                                                label={sampleTag.name}>{sampleTag.name}</Select.Item
+                                                label={sampleTag.name}
+                                                >{sampleTag.name}</SelectMenuItem
                                             >
                                         {/each}
-                                    </Select.Group>
-                                </Select.Content>
-                            </Select.Root>
+                                    </SelectMenuGroup>
+                                {/snippet}
+                            </Select>
                         </FormField>
 
                         <div class="my-4">

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
@@ -5,7 +5,7 @@
     import { Tooltip } from '$lib/components/ui/tooltip';
     import { Button } from '$lib/components';
     import { Checkbox, Alert } from '$lib/components';
-    import * as Select from '$lib/components/ui/select';
+    import { Select } from '$lib/components/Select';
     import * as Dialog from '$lib/components/ui/dialog';
     import { Tabs, TabsContent, TabsList, TabsTrigger } from '$lib/components/ui/tabs';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
@@ -72,8 +72,6 @@
         [classifiersSelected, classifiers],
         ([$sel, $list]) => $sel.size > 0 && $list.length > 0
     );
-
-    const triggerContent = derived(exportType, ($type) => $type || 'Select export type');
 
     // Sort classifiers alphabetically by name
     const sortedClassifiers = derived(classifiers, ($classifiers) => {
@@ -406,21 +404,13 @@
                     <label for="exportType" class="text-sm font-medium"
                         >Select the export type for the classifier.</label
                     >
-                    <Select.Root type="single" name="exportType" bind:value={$exportType}>
-                        <Select.Trigger class="w-full">
-                            {$triggerContent}
-                        </Select.Trigger>
-                        <Select.Content>
-                            <Select.Group>
-                                <Select.GroupHeading>Export Types</Select.GroupHeading>
-                                {#each exportOptions as value (value)}
-                                    <Select.Item {value} label={value}>
-                                        {value}
-                                    </Select.Item>
-                                {/each}
-                            </Select.Group>
-                        </Select.Content>
-                    </Select.Root>
+                    <Select
+                        items={exportOptions.map((v) => ({ value: v, label: v }))}
+                        value={$exportType}
+                        placeholder="Select export type"
+                        class="w-full"
+                        onValueChange={(v) => exportType.set(v as typeof $exportType)}
+                    />
                 </div>
 
                 <Button buttonProps={{ onclick: () => handleExportWithType(), class: 'flex-1' }}>

--- a/lightly_studio_view/src/lib/components/Header/Menu.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Menu.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
-    import { Button } from '$lib/components/ui/button';
-    import { Popover, PopoverContent, PopoverTrigger } from '$lib/components/ui/popover';
+    import { Select, type SelectItem } from '$lib/components/Select';
     import { useClassifiersMenu } from '$lib/hooks/useClassifiers/useClassifiersMenu';
     import { useSamplingDialog } from '$lib/hooks/useSamplingDialog/useSamplingDialog';
     import { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
     import { useSettingsDialog } from '$lib/hooks/useSettingsDialog/useSettingsDialog';
     import { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
     import {
-        ChevronDown,
-        ChevronRight,
         Puzzle as PuzzleIcon,
         Download as DownloadIcon,
         Settings as SettingsIcon,
@@ -40,15 +37,7 @@
     const { openSettingsDialog } = useSettingsDialog();
     const { openOperatorsDialog } = useOperatorsDialog();
 
-    let isMenuOpen = $state(false);
-
-    type MenuIcon = typeof BrainCircuitIcon;
-    type MenuItem = {
-        icon: MenuIcon;
-        label: string;
-        onSelect: () => void;
-        testId: string;
-    };
+    type MenuAction = SelectItem & { onSelect: () => void };
 
     const hasClassifier = $derived(isImages && hasEmbeddings);
     const hasSampling = $derived(isImages || isVideos);
@@ -60,92 +49,78 @@
 
     const isEditor = $derived(hasMinimumRole(user?.role, 'editor'));
 
-    const menuItems = $derived.by<MenuItem[]>(() => {
-        const items: MenuItem[] = [];
+    const menuActions = $derived.by<MenuAction[]>(() => {
+        const items: MenuAction[] = [];
 
         if (hasClassifier && isEditor) {
             items.push({
-                icon: BrainCircuitIcon,
+                value: 'menu-classifiers',
                 label: 'Few Shot Classifier',
-                onSelect: openClassifiersMenu,
-                testId: 'menu-classifiers'
+                icon: BrainCircuitIcon,
+                testId: 'menu-classifiers',
+                onSelect: openClassifiersMenu
             });
         }
 
         if (hasSampling && isEditor) {
             items.push({
-                icon: WandSparklesIcon,
+                value: 'menu-sampling',
                 label: 'Sampling',
-                onSelect: openSamplingDialog,
-                testId: 'menu-sampling'
+                icon: WandSparklesIcon,
+                testId: 'menu-sampling',
+                onSelect: openSamplingDialog
             });
         }
 
         if (isEditor) {
             items.push({
-                icon: PuzzleIcon,
+                value: 'menu-operators',
                 label: 'Plugins',
-                onSelect: openOperatorsDialog,
-                testId: 'menu-operators'
+                icon: PuzzleIcon,
+                testId: 'menu-operators',
+                onSelect: openOperatorsDialog
             });
         }
 
         if (hasExport) {
             items.push({
-                icon: DownloadIcon,
+                value: 'menu-export',
                 label: 'Export',
-                onSelect: openExportDialog,
-                testId: 'menu-export'
+                icon: DownloadIcon,
+                testId: 'menu-export',
+                onSelect: openExportDialog
             });
         }
 
         if (isEditor) {
             items.push({
-                icon: SettingsIcon,
+                value: 'menu-settings',
                 label: 'Settings',
-                onSelect: openSettingsDialog,
-                testId: 'menu-settings'
+                icon: SettingsIcon,
+                testId: 'menu-settings',
+                onSelect: openSettingsDialog
             });
         }
 
         return items;
     });
 
-    function handle(callback: () => void) {
-        isMenuOpen = false;
-        callback();
-    }
+    let selectedValue = $state<string | undefined>(undefined);
+
+    const handleValueChange = (value: string) => {
+        const action = menuActions.find((item) => item.value === value);
+        selectedValue = undefined;
+        action?.onSelect();
+    };
 </script>
 
-{#if menuItems.length > 0}
-    <Popover bind:open={isMenuOpen}>
-        <PopoverTrigger>
-            <Button
-                variant="ghost"
-                class="nav-button flex items-center space-x-2"
-                data-testid="menu-trigger"
-            >
-                <span>Menu</span>
-                <ChevronDown class="size-4" />
-            </Button>
-        </PopoverTrigger>
-        <PopoverContent class="w-64 p-2">
-            <div class="flex flex-col">
-                {#each menuItems as item (item.testId)}
-                    <button
-                        type="button"
-                        class="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        onclick={() => handle(item.onSelect)}
-                        data-testid={item.testId}
-                    >
-                        <div class="flex items-center gap-2">
-                            <item.icon class="size-4 text-muted-foreground" />
-                            <span>{item.label}</span>
-                        </div>
-                        <ChevronRight class="size-4 text-muted-foreground" />
-                    </button>
-                {/each}
-            </div>
-        </PopoverContent>
-    </Popover>
+{#if menuActions.length > 0}
+    <Select
+        bind:value={selectedValue}
+        triggerLabel="Menu"
+        items={menuActions}
+        onValueChange={handleValueChange}
+        class="nav-button w-[100px]"
+        testId="menu-trigger"
+    />
 {/if}

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
@@ -2,7 +2,7 @@
     import { SortDirection } from '$lib/api/lightly_studio_local';
     import { useOrderBy } from '$lib/hooks/useOrderBy/useOrderBy';
     import { useGlobalStorage } from '$lib/hooks';
-    import * as Select from '$lib/components/ui/select';
+    import { Select, type SelectItem } from '$lib/components/Select';
     import { Button } from '$lib/components/ui/button';
     import { ArrowDown, ArrowUp } from '@lucide/svelte';
 
@@ -34,6 +34,17 @@
         return idx >= 0 ? String(idx) : '';
     });
 
+    const sortItems = $derived<SelectItem[]>(
+        $allSortFields.map((field, i) => ({
+            value: String(i),
+            label: field.label,
+            testId:
+                field.source === 'evaluation_metric'
+                    ? `sort-field-${field.evaluation_run_name}-${field.metric_name}`
+                    : `sort-field-${field.value}`
+        }))
+    );
+
     const handleValueChange = (value: string) => {
         if (value === '') {
             const idx = $allSortFields.findIndex((field) => $isFieldSelected(field));
@@ -46,33 +57,18 @@
 </script>
 
 <div class="flex items-center gap-1">
-    <Select.Root
-        type="single"
+    <Select
+        items={sortItems}
         value={selectValue}
+        triggerLabel={$selectedLabel ?? undefined}
         allowDeselect
         onValueChange={handleValueChange}
         disabled={isSimilaritySearchActive}
-    >
-        <Select.Trigger
-            class="h-8 w-[100px] min-w-20 gap-1 px-2.5 text-xs font-normal"
-            data-testid="sort-by-trigger"
-        >
-            <span class="truncate">{$selectedLabel ?? 'Sort by'}</span>
-        </Select.Trigger>
-        <Select.Content class="max-h-64">
-            {#each $allSortFields as field, i}
-                <Select.Item
-                    value={String(i)}
-                    label={field.label}
-                    data-testid={field.source === 'evaluation_metric'
-                        ? `sort-field-${field.evaluation_run_name}-${field.metric_name}`
-                        : `sort-field-${field.value}`}
-                >
-                    {field.label}
-                </Select.Item>
-            {/each}
-        </Select.Content>
-    </Select.Root>
+        placeholder="Sort by"
+        size="xs"
+        class="w-[100px] min-w-20"
+        testId="sort-by-trigger"
+    />
 
     <Button
         variant="ghost"

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Palette } from '@lucide/svelte';
-    import * as Select from '$lib/components/ui/select';
+    import { Select, SelectMenuItem } from '$lib/components/Select';
     import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
     import { usePlotColorByType } from './usePlotColorByType/usePlotColorByType';
 
@@ -57,6 +57,7 @@
         });
         return idx >= 0 ? String(idx) : NO_COLOR_BY;
     });
+
     const triggerLabel = $derived.by(() => {
         if (selectedKey) {
             return `metadata.${selectedKey}`;
@@ -93,23 +94,26 @@
     };
 </script>
 
-<Select.Root type="single" value={selectValue} allowDeselect onValueChange={handleValueChange}>
-    <Select.Trigger class="h-8 w-48 gap-2 px-2.5" data-testid="plot-color-by-button">
-        <div class="flex min-w-0 items-center gap-2">
-            <Palette class="h-4 w-4 shrink-0" />
-            <span class="truncate">{triggerLabel}</span>
-        </div>
-    </Select.Trigger>
-    <Select.Content class="max-h-64" data-testid="plot-color-by-options">
+<Select
+    icon={Palette}
+    {triggerLabel}
+    value={selectValue}
+    allowDeselect
+    onValueChange={handleValueChange}
+    size="xs"
+    class="w-48"
+    testId="plot-color-by-button"
+>
+    {#snippet children()}
         {#if colorByOptions.length === 0}
             <p class="px-2 py-1.5 text-sm text-muted-foreground">Nothing to color by</p>
         {:else}
-            <Select.Item value={NO_COLOR_BY} label="No coloring">No coloring</Select.Item>
+            <SelectMenuItem value={NO_COLOR_BY} label="No coloring">No coloring</SelectMenuItem>
             {#each colorByOptions as option, i (option.type === 'metadata' ? `metadata:${option.fieldName}` : `type:${option.type}`)}
-                <Select.Item value={String(i)} label={option.label}>
+                <SelectMenuItem value={String(i)} label={option.label}>
                     {option.label}
-                </Select.Item>
+                </SelectMenuItem>
             {/each}
         {/if}
-    </Select.Content>
-</Select.Root>
+    {/snippet}
+</Select>

--- a/lightly_studio_view/src/lib/components/Sampling/AddStrategyButton.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/AddStrategyButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { Plus } from '@lucide/svelte';
     import { Portal } from 'bits-ui';
-    import * as Select from '$lib/components/ui/select';
+    import { Select, SelectMenuItem } from '$lib/components/Select';
     import { STRATEGY_OPTIONS, type StrategyType } from '$lib/hooks/useStrategyBuilder';
 
     interface Props {
@@ -47,8 +47,11 @@
     );
 </script>
 
-<Select.Root
-    type="single"
+<Select
+    icon={Plus}
+    triggerLabel="Add strategy"
+    class="w-full"
+    testId="add-strategy-button"
     onValueChange={(v) => {
         if (v) onAdd(v as StrategyType);
     }}
@@ -56,11 +59,7 @@
         if (!open) handleMouseLeave();
     }}
 >
-    <Select.Trigger class="w-full" data-testid="add-strategy-button">
-        <Plus class="mr-2 size-4" />
-        <span class="mr-2">Add strategy</span>
-    </Select.Trigger>
-    <Select.Content>
+    {#snippet children()}
         {#each STRATEGY_OPTIONS as strategy (strategy.type)}
             {@const disabledReason = getDisabledReason(strategy.type)}
             <div
@@ -71,7 +70,7 @@
                     handleMouseEnter(strategy.type, e.currentTarget as HTMLElement)}
                 onmouseleave={handleMouseLeave}
             >
-                <Select.Item
+                <SelectMenuItem
                     value={strategy.type}
                     label={strategy.label}
                     disabled={!!disabledReason}
@@ -91,8 +90,8 @@
                 </span>
             </div>
         {/each}
-    </Select.Content>
-</Select.Root>
+    {/snippet}
+</Select>
 
 {#if hoveredType && tooltipRect && hoveredStrategy}
     <Portal>

--- a/lightly_studio_view/src/lib/components/Sampling/SimilarityForm/SimilarityForm.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/SimilarityForm/SimilarityForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Label } from '$lib/components/ui/label';
-    import * as Select from '$lib/components/ui/select';
+    import { Select, SelectMenuItem } from '$lib/components/Select';
 
     interface Tag {
         tag_id: string;
@@ -22,31 +22,32 @@
 
 <div class="grid grid-cols-4 items-center gap-4">
     <Label for="query-tag" class="text-right text-foreground">Query Tag</Label>
-    <Select.Root type="single" name="query-tag" value={queryTagId} onValueChange={onQueryTagChange}>
-        <Select.Trigger class="col-span-3" data-testid="sampling-dialog-query-tag-select">
-            {selectedQueryTagName}
-        </Select.Trigger>
-        <Select.Content>
-            <Select.Group>
-                {#if tags.length === 0}
-                    <div
-                        class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
-                        data-testid="sampling-dialog-no-query-tags"
+    <Select
+        value={queryTagId}
+        triggerLabel={selectedQueryTagName}
+        class="col-span-3"
+        testId="sampling-dialog-query-tag-select"
+        onValueChange={onQueryTagChange}
+    >
+        {#snippet children()}
+            {#if tags.length === 0}
+                <div
+                    class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
+                    data-testid="sampling-dialog-no-query-tags"
+                >
+                    No sample tags available.
+                </div>
+            {:else}
+                {#each tags as tag (tag.tag_id)}
+                    <SelectMenuItem
+                        value={tag.tag_id}
+                        label={tag.name}
+                        data-testid={`sampling-query-tag-${tag.tag_id}`}
                     >
-                        No sample tags available.
-                    </div>
-                {:else}
-                    {#each tags as tag (tag.tag_id)}
-                        <Select.Item
-                            value={tag.tag_id}
-                            label={tag.name}
-                            data-testid={`sampling-query-tag-${tag.tag_id}`}
-                        >
-                            {tag.name}
-                        </Select.Item>
-                    {/each}
-                {/if}
-            </Select.Group>
-        </Select.Content>
-    </Select.Root>
+                        {tag.name}
+                    </SelectMenuItem>
+                {/each}
+            {/if}
+        {/snippet}
+    </Select>
 </div>

--- a/lightly_studio_view/src/lib/components/Sampling/StrategySelect/StrategySelect.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategySelect/StrategySelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Label } from '$lib/components/ui/label';
-    import * as Select from '$lib/components/ui/select';
+    import { Select, type SelectItem } from '$lib/components/Select';
 
     type Strategy = 'diversity' | 'typicality' | 'similarity' | 'class_balancing' | '';
 
@@ -10,7 +10,9 @@
         onValueChange: (value: Strategy) => void;
     }
 
-    const STRATEGIES: { value: Strategy; label: string; testId: string }[] = [
+    let { value, isSimilaritySupported, onValueChange }: Props = $props();
+
+    const items = $derived<SelectItem[]>([
         { value: 'diversity', label: 'Diversity', testId: 'sampling-strategy-diversity' },
         { value: 'typicality', label: 'Typicality', testId: 'sampling-strategy-typicality' },
         {
@@ -18,41 +20,23 @@
             label: 'Class Balancing',
             testId: 'sampling-strategy-class-balancing'
         },
-        { value: 'similarity', label: 'Similarity', testId: 'sampling-strategy-similarity' }
-    ];
-
-    const STRATEGY_LABELS = Object.fromEntries(STRATEGIES.map((s) => [s.value, s.label]));
-
-    let { value, isSimilaritySupported, onValueChange }: Props = $props();
+        {
+            value: 'similarity',
+            label: 'Similarity',
+            testId: 'sampling-strategy-similarity',
+            disabled: !isSimilaritySupported
+        }
+    ]);
 </script>
 
 <div class="grid grid-cols-4 items-center gap-4">
     <Label for="strategy" class="text-right text-foreground">Strategy</Label>
-    <Select.Root
-        type="single"
-        name="strategy"
+    <Select
+        {items}
         {value}
+        placeholder="Select strategy"
+        class="col-span-3"
+        testId="sampling-dialog-strategy-select"
         onValueChange={(v) => onValueChange(v as Strategy)}
-    >
-        <Select.Trigger
-            id="strategy"
-            class="col-span-3"
-            data-testid="sampling-dialog-strategy-select"
-        >
-            {STRATEGY_LABELS[value] ?? 'Select strategy'}
-        </Select.Trigger>
-        <Select.Content>
-            <Select.Group>
-                {#each STRATEGIES as strategy}
-                    <Select.Item
-                        value={strategy.value}
-                        label={strategy.label}
-                        data-testid={strategy.testId}
-                        disabled={strategy.value === 'similarity' && !isSimilaritySupported}
-                        >{strategy.label}</Select.Item
-                    >
-                {/each}
-            </Select.Group>
-        </Select.Content>
-    </Select.Root>
+    />
 </div>

--- a/lightly_studio_view/src/lib/components/Sampling/StrategySelect/StrategySelect.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategySelect/StrategySelect.svelte
@@ -37,6 +37,7 @@
         placeholder="Select strategy"
         class="col-span-3"
         testId="sampling-dialog-strategy-select"
+        selectProps={{ id: 'strategy' }}
         onValueChange={(v) => onValueChange(v as Strategy)}
     />
 </div>

--- a/lightly_studio_view/src/lib/components/Sampling/forms/ClassBalancingForm/AnnotationSource/AnnotationSource.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/forms/ClassBalancingForm/AnnotationSource/AnnotationSource.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Label } from '$lib/components/ui/label';
-    import * as Select from '$lib/components/ui/select';
+    import { Select } from '$lib/components/Select';
     import FieldTooltip from '$lib/components/FieldTooltip/FieldTooltip.svelte';
     import type { ClassBalancingTargetDistributionMode } from '$lib/hooks/useStrategyBuilder';
 
@@ -11,14 +11,15 @@
 
     let { targetDistributionMode, onUpdate }: Props = $props();
 
-    const TARGET_DISTRIBUTION_MODE_OPTIONS: {
-        value: ClassBalancingTargetDistributionMode;
-        label: string;
-    }[] = [
-        { value: 'uniform', label: 'Uniform' },
-        { value: 'input', label: 'Input' },
-        { value: 'dictionary', label: 'Dictionary' }
-    ];
+    const items = [
+        { value: 'uniform', label: 'Uniform', testId: 'class-balancing-annotation-source-uniform' },
+        { value: 'input', label: 'Input', testId: 'class-balancing-annotation-source-input' },
+        {
+            value: 'dictionary',
+            label: 'Dictionary',
+            testId: 'class-balancing-annotation-source-dictionary'
+        }
+    ] satisfies { value: ClassBalancingTargetDistributionMode; label: string; testId: string }[];
 </script>
 
 <div class="grid gap-2">
@@ -26,27 +27,11 @@
         <Label>Target distribution</Label>
         <FieldTooltip content="The target class distribution to optimize toward." />
     </div>
-    <Select.Root
-        type="single"
+    <Select
+        {items}
         value={targetDistributionMode}
+        class="w-full"
+        testId="class-balancing-annotation-source"
         onValueChange={(value) => onUpdate(value as ClassBalancingTargetDistributionMode)}
-    >
-        <Select.Trigger class="w-full" data-testid="class-balancing-annotation-source">
-            {TARGET_DISTRIBUTION_MODE_OPTIONS.find((o) => o.value === targetDistributionMode)
-                ?.label}
-        </Select.Trigger>
-        <Select.Content>
-            <Select.Group>
-                {#each TARGET_DISTRIBUTION_MODE_OPTIONS as option (option.value)}
-                    <Select.Item
-                        value={option.value}
-                        label={option.label}
-                        data-testid={`class-balancing-annotation-source-${option.value}`}
-                    >
-                        {option.label}
-                    </Select.Item>
-                {/each}
-            </Select.Group>
-        </Select.Content>
-    </Select.Root>
+    />
 </div>

--- a/lightly_studio_view/src/lib/components/Sampling/forms/ClassBalancingForm/TargetDistribution/TargetDistribution.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/forms/ClassBalancingForm/TargetDistribution/TargetDistribution.svelte
@@ -3,7 +3,7 @@
     import { Button } from '$lib/components/ui/button';
     import { Input } from '$lib/components/ui/input';
     import { Label } from '$lib/components/ui/label';
-    import * as Select from '$lib/components/ui/select';
+    import { Select, type SelectItem } from '$lib/components/Select';
     import FieldTooltip from '$lib/components/FieldTooltip/FieldTooltip.svelte';
     import type { ClassBalancingTargetRow } from '$lib/hooks/useStrategyBuilder';
 
@@ -58,29 +58,20 @@
     {/if}
 
     {#each targetDistribution as row, index (index)}
+        {@const rowItems = annotationLabels.map<SelectItem>((label) => ({
+            value: label,
+            label,
+            testId: `class-balancing-class-name-${index}-${label}`
+        }))}
         <div class="grid grid-cols-[1fr_120px_auto] gap-2">
-            <Select.Root
-                type="single"
+            <Select
+                items={rowItems}
                 value={row.class_name}
+                placeholder="Select class"
+                class="w-full"
+                testId={`class-balancing-class-name-${index}`}
                 onValueChange={(value) => updateRow(index, { class_name: value })}
-            >
-                <Select.Trigger class="w-full" data-testid={`class-balancing-class-name-${index}`}>
-                    {row.class_name || 'Select class'}
-                </Select.Trigger>
-                <Select.Content>
-                    <Select.Group>
-                        {#each annotationLabels as label (label)}
-                            <Select.Item
-                                value={label}
-                                {label}
-                                data-testid={`class-balancing-class-name-${index}-${label}`}
-                            >
-                                {label}
-                            </Select.Item>
-                        {/each}
-                    </Select.Group>
-                </Select.Content>
-            </Select.Root>
+            />
             <Input
                 type="number"
                 min="0"

--- a/lightly_studio_view/src/lib/components/Sampling/forms/MetadataWeightingForm/MetadataKeySelect.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/forms/MetadataWeightingForm/MetadataKeySelect.svelte
@@ -1,24 +1,21 @@
 <script lang="ts">
-    import * as Select from '$lib/components/ui/select';
+    import { Select } from '$lib/components/Select';
+
     interface Props {
         value: string;
         fieldNames: string[];
         onValueChange: (value: string) => void;
     }
     let { value, fieldNames, onValueChange }: Props = $props();
+
+    const items = $derived(fieldNames.map((name) => ({ value: name, label: name })));
 </script>
 
-<Select.Root type="single" name="metadata-weighting-key" {value} {onValueChange}>
-    <Select.Trigger class="w-full" data-testid="strategy-metadata-key-input">
-        {value || 'Select a metadata field'}
-    </Select.Trigger>
-    <Select.Content>
-        <Select.Group>
-            {#each fieldNames as fieldName (fieldName)}
-                <Select.Item value={fieldName} label={fieldName}>
-                    {fieldName}
-                </Select.Item>
-            {/each}
-        </Select.Group>
-    </Select.Content>
-</Select.Root>
+<Select
+    {items}
+    {value}
+    {onValueChange}
+    placeholder="Select a metadata field"
+    class="w-full"
+    testId="strategy-metadata-key-input"
+/>

--- a/lightly_studio_view/src/lib/components/Sampling/forms/SimilarityForm/SimilarityForm.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/forms/SimilarityForm/SimilarityForm.svelte
@@ -29,6 +29,7 @@
             triggerLabel={selectedQueryTagName}
             class="w-full"
             testId="similarity-query-tag-select"
+            selectProps={{ id: 'similarity-query-tag' }}
             onValueChange={(queryTagId) => onUpdate({ query_tag_id: queryTagId })}
         >
             {#snippet children()}

--- a/lightly_studio_view/src/lib/components/Sampling/forms/SimilarityForm/SimilarityForm.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/forms/SimilarityForm/SimilarityForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Label } from '$lib/components/ui/label';
-    import * as Select from '$lib/components/ui/select';
+    import { Select, SelectMenuItem } from '$lib/components/Select';
     import FieldTooltip from '$lib/components/FieldTooltip/FieldTooltip.svelte';
     import type { SimilarityParams, StrategySummaryTag } from '$lib/hooks/useStrategyBuilder';
     import StrengthField from '../StrengthField/StrengthField.svelte';
@@ -24,42 +24,34 @@
                 content="Samples in this tag serve as the similarity reference. The strategy selects samples most similar to them."
             />
         </div>
-        <Select.Root
-            type="single"
-            name="similarity-query-tag"
+        <Select
             value={params.query_tag_id}
+            triggerLabel={selectedQueryTagName}
+            class="w-full"
+            testId="similarity-query-tag-select"
             onValueChange={(queryTagId) => onUpdate({ query_tag_id: queryTagId })}
         >
-            <Select.Trigger
-                id="similarity-query-tag"
-                class="w-full"
-                data-testid="similarity-query-tag-select"
-            >
-                {selectedQueryTagName}
-            </Select.Trigger>
-            <Select.Content>
-                <Select.Group>
-                    {#if tags.length === 0}
-                        <div
-                            class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
-                            data-testid="similarity-no-query-tags"
+            {#snippet children()}
+                {#if tags.length === 0}
+                    <div
+                        class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
+                        data-testid="similarity-no-query-tags"
+                    >
+                        No sample tags available.
+                    </div>
+                {:else}
+                    {#each tags as tag (tag.tag_id)}
+                        <SelectMenuItem
+                            value={tag.tag_id}
+                            label={tag.name}
+                            data-testid={`similarity-query-tag-${tag.tag_id}`}
                         >
-                            No sample tags available.
-                        </div>
-                    {:else}
-                        {#each tags as tag (tag.tag_id)}
-                            <Select.Item
-                                value={tag.tag_id}
-                                label={tag.name}
-                                data-testid={`similarity-query-tag-${tag.tag_id}`}
-                            >
-                                {tag.name}
-                            </Select.Item>
-                        {/each}
-                    {/if}
-                </Select.Group>
-            </Select.Content>
-        </Select.Root>
+                            {tag.name}
+                        </SelectMenuItem>
+                    {/each}
+                {/if}
+            {/snippet}
+        </Select>
     </div>
 
     <StrengthField

--- a/lightly_studio_view/src/lib/components/Select/Select.svelte
+++ b/lightly_studio_view/src/lib/components/Select/Select.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
     import type { Component, Snippet } from 'svelte';
+    import { Select as SelectBits, type WithoutChild } from 'bits-ui';
     import type { IconProps } from '@lucide/svelte';
     import * as SelectPrimitive from '$lib/components/ui/select';
     import { cn } from '$lib/utils/shadcn';
+
+    type SelectTriggerProps = Omit<
+        WithoutChild<SelectBits.TriggerProps>,
+        'class' | 'data-testid' | 'ref'
+    >;
 
     export interface SelectItem {
         value: string;
@@ -39,6 +45,8 @@
         class?: string;
         /** `data-testid` for the trigger element. */
         testId?: string;
+        /** Additional attributes forwarded to the trigger button (e.g. `id` for `<Label for>`). */
+        selectProps?: SelectTriggerProps;
         /** Called when the selected value changes. */
         onValueChange?: (value: string) => void;
         /** Called when the dropdown open state changes. */
@@ -62,6 +70,7 @@
         size = 'md',
         class: className,
         testId,
+        selectProps,
         onValueChange,
         onOpenChange,
         children
@@ -108,6 +117,7 @@
     {onOpenChange}
 >
     <SelectPrimitive.Trigger
+        {...selectProps}
         data-testid={testId}
         class={cn(
             // Ghost-style: no border, no background, height matches the Button primitive

--- a/lightly_studio_view/src/lib/components/Select/Select.svelte
+++ b/lightly_studio_view/src/lib/components/Select/Select.svelte
@@ -9,10 +9,12 @@
         label: string;
         /** Optional Lucide icon rendered before the label, in both the trigger and dropdown. */
         icon?: Component<IconProps>;
+        /** Disable this item in the dropdown. */
+        disabled?: boolean;
         testId?: string;
     }
 
-    export type SelectSize = 'sm' | 'md' | 'lg';
+    export type SelectSize = 'xs' | 'sm' | 'md' | 'lg';
 
     interface Props {
         /** List of items to render. Mutually exclusive with `children` slot. */
@@ -21,6 +23,10 @@
         value?: string;
         /** Placeholder text shown when nothing is selected. */
         placeholder?: string;
+        /** Fixed label shown in the trigger instead of the selected value's label. */
+        triggerLabel?: string;
+        /** Icon rendered in the trigger, irrespective of the current selection. */
+        icon?: Component<IconProps>;
         /** Allow clearing the current selection. */
         allowDeselect?: boolean;
         /** Whether the select is disabled. */
@@ -35,6 +41,8 @@
         testId?: string;
         /** Called when the selected value changes. */
         onValueChange?: (value: string) => void;
+        /** Called when the dropdown open state changes. */
+        onOpenChange?: (open: boolean) => void;
         /**
          * Advanced slot: provide custom `Select.Item` / `Select.Group` markup.
          * When provided, `items` prop is ignored.
@@ -46,6 +54,8 @@
         items,
         value = $bindable(undefined),
         placeholder = 'Select…',
+        triggerLabel,
+        icon: TriggerIconProp,
         allowDeselect = false,
         disabled = false,
         open = $bindable(false),
@@ -53,22 +63,26 @@
         class: className,
         testId,
         onValueChange,
+        onOpenChange,
         children
     }: Props = $props();
 
     const triggerSizeClass: Record<SelectSize, string> = {
+        xs: 'h-8 text-xs',
         sm: 'h-9 text-xs',
         md: 'h-10 text-sm',
         lg: 'h-11 text-base'
     };
 
     const itemSizeClass: Record<SelectSize, string> = {
+        xs: 'py-1 text-xs',
         sm: 'py-1 text-xs',
         md: 'py-1.5 text-sm',
         lg: 'py-2 text-base'
     };
 
     const iconSizeClass: Record<SelectSize, string> = {
+        xs: 'size-3.5',
         sm: 'size-3.5',
         md: 'size-4',
         lg: 'size-5'
@@ -91,6 +105,7 @@
     {disabled}
     bind:open
     onValueChange={handleValueChange}
+    {onOpenChange}
 >
     <SelectPrimitive.Trigger
         data-testid={testId}
@@ -106,11 +121,13 @@
         )}
     >
         {@const selectedItem = findItem(value)}
-        {#if selectedItem?.icon}
-            {@const TriggerIcon = selectedItem.icon}
+        {@const TriggerIcon = TriggerIconProp ?? selectedItem?.icon}
+        {#if TriggerIcon}
             <TriggerIcon class={cn(iconSizeClass[size], 'shrink-0')} />
         {/if}
-        <span class="truncate">{value ? (selectedItem?.label ?? value) : placeholder}</span>
+        <span class="truncate"
+            >{triggerLabel ?? (value ? (selectedItem?.label ?? value) : placeholder)}</span
+        >
     </SelectPrimitive.Trigger>
 
     <SelectPrimitive.Content>
@@ -121,6 +138,7 @@
                 <SelectPrimitive.Item
                     value={item.value}
                     label={item.label}
+                    disabled={item.disabled}
                     data-testid={item.testId}
                     class={cn('gap-2', itemSizeClass[size])}
                 >

--- a/lightly_studio_view/src/lib/components/Select/Select.test.ts
+++ b/lightly_studio_view/src/lib/components/Select/Select.test.ts
@@ -76,6 +76,14 @@ describe('Select', () => {
         );
     });
 
+    it('forwards selectProps attributes (e.g. id) to the trigger element', () => {
+        const { container } = render(Select, {
+            props: { items: ITEMS, selectProps: { id: 'metric-trigger' } }
+        });
+
+        expect(container.querySelector(triggerSelector)).toHaveAttribute('id', 'metric-trigger');
+    });
+
     it('disables the trigger when disabled is true', () => {
         const { container } = render(Select, {
             props: { items: ITEMS, disabled: true }

--- a/lightly_studio_view/src/lib/components/Select/index.ts
+++ b/lightly_studio_view/src/lib/components/Select/index.ts
@@ -1,2 +1,7 @@
 export { default as Select } from './Select.svelte';
 export type { SelectItem, SelectSize } from './Select.svelte';
+export {
+    Item as SelectMenuItem,
+    Group as SelectMenuGroup,
+    GroupHeading as SelectMenuGroupHeading
+} from '$lib/components/ui/select';

--- a/lightly_studio_view/src/lib/components/SelectClassDialog/SelectClassDialog.svelte
+++ b/lightly_studio_view/src/lib/components/SelectClassDialog/SelectClassDialog.svelte
@@ -26,6 +26,10 @@
     // Only let the user pick a source when there is more than one to choose between.
     const showSourceSelect = $derived(sourceNames.length > 1);
 
+    // AnnotationSourceSelect expects {id, name}; when callers identify sources by
+    // name alone, the id and name are the same value.
+    const sourceOptions = $derived(sourceNames.map((name) => ({ id: name, name })));
+
     let selectedItem = $state<ListItem | undefined>(undefined);
     // Track close origin so the onOpenChange(false) that fires when we set
     // open = false from handleConfirm does not also invoke onCancel.
@@ -74,7 +78,7 @@
         {#if showSourceSelect}
             <div class="space-y-1 py-2">
                 <span class="text-sm text-muted-foreground">Annotation source</span>
-                <AnnotationSourceSelect {sourceNames} bind:selectedSource />
+                <AnnotationSourceSelect {sourceOptions} bind:selectedSource />
             </div>
         {/if}
 

--- a/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { Button } from '$lib/components/ui/button';
     import * as Dialog from '$lib/components/ui/dialog';
-    import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
+    import { Select } from '$lib/components/Select';
     import { Switch } from '$lib/components/ui/switch';
     import { useSettings } from '$lib/hooks/useSettings';
     import { useSettingsDialog } from '$lib/hooks/useSettingsDialog/useSettingsDialog';
@@ -96,25 +96,16 @@
                     <div class="space-y-4">
                         <h3 class="text-lg font-medium text-foreground">Display Settings</h3>
                         <SettingsFieldRow id="grid-view-rendering" label="Grid View Rendering">
-                            <div class="relative">
-                                <Select
-                                    type="single"
-                                    value={dialogState.gridViewRendering}
-                                    onValueChange={(v) =>
-                                        (dialogState.gridViewRendering =
-                                            v as typeof dialogState.gridViewRendering)}
-                                >
-                                    <SelectTrigger id="grid-view-rendering">
-                                        {dialogState.gridViewRendering === 'cover'
-                                            ? 'Cover'
-                                            : 'Contain'}
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="cover">Cover</SelectItem>
-                                        <SelectItem value="contain">Contain</SelectItem>
-                                    </SelectContent>
-                                </Select>
-                            </div>
+                            <Select
+                                items={[
+                                    { value: 'cover', label: 'Cover' },
+                                    { value: 'contain', label: 'Contain' }
+                                ]}
+                                value={dialogState.gridViewRendering}
+                                onValueChange={(v) =>
+                                    (dialogState.gridViewRendering =
+                                        v as typeof dialogState.gridViewRendering)}
+                            />
                         </SettingsFieldRow>
                         <SettingsFieldRow
                             id="show-sample-filenames"
@@ -130,25 +121,16 @@
                             id="grid-view-thumbnail-quality"
                             label="Thumbnail Quality in Grid View"
                         >
-                            <div class="relative">
-                                <Select
-                                    type="single"
-                                    value={dialogState.gridViewThumbnailQuality}
-                                    onValueChange={(v) =>
-                                        (dialogState.gridViewThumbnailQuality =
-                                            v as typeof dialogState.gridViewThumbnailQuality)}
-                                >
-                                    <SelectTrigger id="grid-view-thumbnail-quality">
-                                        {dialogState.gridViewThumbnailQuality === 'high'
-                                            ? 'High'
-                                            : 'Original'}
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="raw">Original</SelectItem>
-                                        <SelectItem value="high">High</SelectItem>
-                                    </SelectContent>
-                                </Select>
-                            </div>
+                            <Select
+                                items={[
+                                    { value: 'raw', label: 'Original' },
+                                    { value: 'high', label: 'High' }
+                                ]}
+                                value={dialogState.gridViewThumbnailQuality}
+                                onValueChange={(v) =>
+                                    (dialogState.gridViewThumbnailQuality =
+                                        v as typeof dialogState.gridViewThumbnailQuality)}
+                            />
                         </SettingsFieldRow>
                     </div>
 

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -1,5 +1,7 @@
 export { default as Alert } from '$lib/components/Alert/index.svelte';
 export { default as Button } from '$lib/components/Button/Button.svelte';
+export { Select } from '$lib/components/Select';
+export type { SelectItem, SelectSize } from '$lib/components/Select';
 export { default as AnnotationsGrid } from '$lib/components/AnnotationsGrid/AnnotationsGrid.svelte';
 export { default as AnnotationsGridItem } from '$lib/components/AnnotationsGrid/AnnotationsGridItem/AnnotationsGridItem.svelte';
 export { default as Card } from '$lib/components/Card/Card.svelte';


### PR DESCRIPTION
## What has changed and why?

This PR replaces custom styled select components with shared Select component with consistent view and behaviour

## How has it been tested?
By tests and visual check of all touched parts
<img width="1768" height="987" alt="Screenshot 2026-06-03 at 14 06 59" src="https://github.com/user-attachments/assets/71d44bfc-0d4f-4ab4-9e0d-8244b9a92385" />



<img width="766" height="362" alt="Screenshot 2026-06-03 at 14 00 32" src="https://github.com/user-attachments/assets/7043436b-bb87-4253-bfd7-7f81a75aad20" />
<img width="695" height="958" alt="Screenshot 2026-06-03 at 14 00 26" src="https://github.com/user-attachments/assets/2cc84a06-6c1f-47a0-883a-a86d5a654ada" />
<img width="841" height="651" alt="Screenshot 2026-06-03 at 14 00 18" src="https://github.com/user-attachments/assets/acab9022-a5e3-423b-a82c-87275834bef5" />



## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified dropdowns across the app to a single, consistent Select UI for smoother, more predictable interactions and clearer placeholders/triggers.
  * Menus and action lists now use the unified Select trigger for consistent behavior.

* **New Features**
  * Select gains disabled options, an extra-small size, optional fixed trigger labels, and an open/close callback for finer control.

* **Quality**
  * Improved test coverage and test identifiers for more reliable UI testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->