### PR TITLE
feat: align styles for tags input

### DIFF
--- a/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
@@ -83,7 +83,6 @@
             oninput={handleInput}
             onfocus={handleFocus}
             onblur={handleBlur}
-            class="disabled:opacity-60"
             disabled={busy}
         />
     </div>

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
@@ -83,7 +83,7 @@
             oninput={handleInput}
             onfocus={handleFocus}
             onblur={handleBlur}
-            class="h-8 text-xs disabled:opacity-60"
+            class="disabled:opacity-60"
             disabled={busy}
         />
     </div>


### PR DESCRIPTION
## What has changed and why?

Make input for tags selection look similar to search embedding input

## How has it been tested?

By visual check
<img width="1327" height="485" alt="Screenshot 2026-06-03 at 14 20 36" src="https://github.com/user-attachments/assets/80aa6ee0-a6af-4349-990c-2011bec744bb" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted input field styling in the tag assignment interface: removed fixed height and smaller font settings, altering the input's displayed height and typography while preserving the disabled-state opacity for consistent disabled appearance. This results in a slightly larger, more legible input field in the tag assignment workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->