### PR TITLE
feat: align "select all" with other controls in app

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -11,11 +11,13 @@
     interface Props {
         compact?: boolean;
         canSelectAll: boolean;
+        isSelectionActive: boolean;
         isImages: boolean;
         hasEvaluationRuns: boolean;
         hasMediaWithEmbeddings: boolean;
         collectionDatasetId: string;
         onSelectAll: () => Promise<void>;
+        onDeselectAll: () => void;
         searchImage: SearchImage | undefined;
         searchPending: boolean;
         initialQueryText: string;
@@ -28,10 +30,12 @@
     const {
         compact = false,
         canSelectAll,
+        isSelectionActive,
         isImages,
         hasEvaluationRuns,
         hasMediaWithEmbeddings,
         onSelectAll,
+        onDeselectAll,
         searchImage,
         searchPending,
         initialQueryText,
@@ -49,7 +53,7 @@
 <GridHeader>
     {#snippet selectionControls()}
         {#if canSelectAll}
-            <GridHeaderSelectAllButton onclick={onSelectAll} />
+            <GridHeaderSelectAllButton checked={isSelectionActive} {onSelectAll} {onDeselectAll} />
         {/if}
     {/snippet}
     {#snippet auxControls()}

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -59,11 +59,13 @@ import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 const defaultProps = {
     compact: false,
     canSelectAll: false,
+    isSelectionActive: false,
     isImages: false,
     hasEvaluationRuns: true,
     hasMediaWithEmbeddings: false,
     collectionDatasetId: 'dataset-1',
     onSelectAll: vi.fn().mockResolvedValue(undefined),
+    onDeselectAll: vi.fn(),
     searchImage: undefined,
     searchPending: false,
     initialQueryText: '',
@@ -80,6 +82,7 @@ describe('DatasetGridHeader', () => {
         (storage.setShowEmbeddingPlot as ReturnType<typeof vi.fn>).mockClear();
         (storage.setShowEvaluationRuns as ReturnType<typeof vi.fn>).mockClear();
         defaultProps.onSelectAll.mockClear();
+        defaultProps.onDeselectAll.mockClear();
     });
 
     it('renders the select-all button when canSelectAll is true', async () => {
@@ -98,6 +101,17 @@ describe('DatasetGridHeader', () => {
         render(DatasetGridHeader, { props: { ...defaultProps, canSelectAll: false } });
 
         expect(screen.queryByTestId('select-all-button')).not.toBeInTheDocument();
+    });
+
+    it('calls onDeselectAll when the select-all checkbox is toggled off', async () => {
+        render(DatasetGridHeader, {
+            props: { ...defaultProps, canSelectAll: true, isSelectionActive: true }
+        });
+
+        const checkbox = screen.getByTestId('select-all-button');
+        await fireEvent.click(checkbox);
+        expect(defaultProps.onDeselectAll).toHaveBeenCalledTimes(1);
+        expect(defaultProps.onSelectAll).not.toHaveBeenCalled();
     });
 
     it('renders the OrderBy control only for image collections', () => {

--- a/lightly_studio_view/src/lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte
+++ b/lightly_studio_view/src/lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte
@@ -1,18 +1,36 @@
 <script lang="ts">
-    import { SquareCheck } from '@lucide/svelte';
-    import Button from '../ui/button/button.svelte';
+    import { Checkbox } from '$lib/components/ui/checkbox';
+    import { Label } from '$lib/components/ui/label';
 
-    const { onclick }: { onclick: () => Promise<void> } = $props();
+    interface Props {
+        checked: boolean;
+        onSelectAll: () => Promise<void>;
+        onDeselectAll: () => void;
+    }
+
+    const { checked, onSelectAll, onDeselectAll }: Props = $props();
+
+    const handleCheckedChange = (next: boolean) => {
+        if (next) {
+            void onSelectAll();
+        } else {
+            onDeselectAll();
+        }
+    };
 </script>
 
-<Button
-    class="h-8 shrink-0 gap-1.5 px-2 text-diffuse-foreground hover:bg-background hover:text-foreground"
-    data-testid="select-all-button"
-    variant="ghost"
-    aria-label="Select all"
-    title="Select all"
-    {onclick}
->
-    <SquareCheck class="size-4" />
-    <span>Select all</span>
-</Button>
+<div class="flex h-8 shrink-0 items-center gap-2 px-2">
+    <Checkbox
+        id="select-all-checkbox"
+        {checked}
+        onCheckedChange={handleCheckedChange}
+        data-testid="select-all-button"
+        aria-label={checked ? 'Deselect all' : 'Select all'}
+    />
+    <Label
+        for="select-all-checkbox"
+        class="cursor-pointer text-sm font-normal text-diffuse-foreground hover:text-foreground"
+    >
+        Select all
+    </Label>
+</div>

--- a/lightly_studio_view/src/lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.test.ts
+++ b/lightly_studio_view/src/lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.test.ts
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import GridHeaderSelectAllButton from './GridHeaderSelectAllButton.svelte';
+
+describe('GridHeaderSelectAllButton', () => {
+    const buildProps = (overrides: Partial<Parameters<typeof render>[1]['props']> = {}) => ({
+        checked: false,
+        onSelectAll: vi.fn().mockResolvedValue(undefined),
+        onDeselectAll: vi.fn(),
+        ...overrides
+    });
+
+    it('renders the checkbox unchecked with "Select all" label by default', () => {
+        render(GridHeaderSelectAllButton, { props: buildProps() });
+
+        const checkbox = screen.getByTestId('select-all-button');
+        expect(checkbox).toBeInTheDocument();
+        expect(checkbox).toHaveAttribute('aria-checked', 'false');
+        expect(checkbox).toHaveAttribute('aria-label', 'Select all');
+        expect(screen.getByText('Select all')).toBeInTheDocument();
+    });
+
+    it('renders the checkbox checked when checked=true', () => {
+        render(GridHeaderSelectAllButton, { props: buildProps({ checked: true }) });
+
+        const checkbox = screen.getByTestId('select-all-button');
+        expect(checkbox).toHaveAttribute('aria-checked', 'true');
+        expect(checkbox).toHaveAttribute('aria-label', 'Deselect all');
+    });
+
+    it('calls onSelectAll when toggled on', async () => {
+        const props = buildProps();
+        render(GridHeaderSelectAllButton, { props });
+
+        await fireEvent.click(screen.getByTestId('select-all-button'));
+
+        expect(props.onSelectAll).toHaveBeenCalledTimes(1);
+        expect(props.onDeselectAll).not.toHaveBeenCalled();
+    });
+
+    it('calls onDeselectAll when toggled off', async () => {
+        const props = buildProps({ checked: true });
+        render(GridHeaderSelectAllButton, { props });
+
+        await fireEvent.click(screen.getByTestId('select-all-button'));
+
+        expect(props.onDeselectAll).toHaveBeenCalledTimes(1);
+        expect(props.onSelectAll).not.toHaveBeenCalled();
+    });
+
+    it('clicking the label also toggles the checkbox', async () => {
+        const props = buildProps();
+        render(GridHeaderSelectAllButton, { props });
+
+        await fireEvent.click(screen.getByText('Select all'));
+
+        expect(props.onSelectAll).toHaveBeenCalledTimes(1);
+    });
+});

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -370,12 +370,14 @@
                 {#if isCollectionGrid}
                     <DatasetGridHeader
                         {canSelectAll}
+                        isSelectionActive={$selectedCount > 0}
                         {isImages}
                         {hasEvaluationRuns}
                         {hasMediaWithEmbeddings}
                         collectionDatasetId={collection.dataset_id}
                         compact={isSidePanelOpen}
                         onSelectAll={selectAllHandle.handleSelectAll}
+                        onDeselectAll={clearSelection}
                         searchImage={$searchImage}
                         searchPending={$searchPending}
                         initialQueryText={$textEmbedding?.queryText ?? ''}
@@ -437,12 +439,14 @@
                         >
                             <DatasetGridHeader
                                 {canSelectAll}
+                                isSelectionActive={$selectedCount > 0}
                                 {isImages}
                                 {hasEvaluationRuns}
                                 {hasMediaWithEmbeddings}
                                 collectionDatasetId={collection.dataset_id}
                                 compact={isSidePanelOpen}
                                 onSelectAll={selectAllHandle.handleSelectAll}
+                                onDeselectAll={clearSelection}
                                 searchImage={$searchImage}
                                 searchPending={$searchPending}
                                 initialQueryText={$textEmbedding?.queryText ?? ''}


### PR DESCRIPTION
## What has changed and why?

This PR adjusts "select all" to behave as element with checkbox should work, including unselecting



## How has it been tested?

Added a test + visual checks
<img width="1800" height="1024" alt="Screenshot 2026-06-03 at 15 09 12" src="https://github.com/user-attachments/assets/6bf691a8-78f4-4097-b0de-63714e1bfa93" />
<img width="1782" height="1011" alt="Screenshot 2026-06-03 at 15 09 06" src="https://github.com/user-attachments/assets/7940aff6-37ce-40fe-b6f7-c6fda50dcc49" />

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select-all control redesigned as a checkbox with explicit checked state and toggled aria labels.
  * Deselect-all action added so selections can be cleared from the header.
  * Header now reflects active selection state across dataset views/layouts.

* **Tests**
  * Added tests covering checkbox checked/unchecked rendering and select/deselect interactions, plus header wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->