### PR TITLE
feat: introduce iconAfter for Button

### DIFF
--- a/lightly_studio_view/src/lib/components/Button/Button.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Button/Button.stories.svelte
@@ -1,7 +1,7 @@
 <script module>
     import { defineMeta } from '@storybook/addon-svelte-csf';
     import { fn } from 'storybook/test';
-    import { Pencil, Plus } from '@lucide/svelte';
+    import { ChevronDown, Pencil, Plus } from '@lucide/svelte';
     import Button from './Button.svelte';
 
     const { Story } = defineMeta({
@@ -39,6 +39,14 @@
                 description: 'Lucide icon component rendered before the label.',
                 control: false
             },
+            iconAfter: {
+                description: 'Lucide icon component rendered after the label.',
+                control: false
+            },
+            iconAfterClass: {
+                description: 'Additional class applied to the trailing icon (merged with `size-4`).',
+                control: 'text'
+            },
             buttonProps: {
                 description:
                     'Props forwarded to the underlying shadcn button element (e.g. `onclick`, `disabled`, `title`, `type`, `class`).',
@@ -61,6 +69,10 @@
 
 <Story name="With Icon" args={{ icon: Pencil, buttonProps: { onclick: fn() } }}>
     Edit Annotations
+</Story>
+
+<Story name="With Icon After" args={{ iconAfter: ChevronDown, buttonProps: { onclick: fn() } }}>
+    Open menu
 </Story>
 
 <Story

--- a/lightly_studio_view/src/lib/components/Button/Button.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Button/Button.stories.svelte
@@ -44,7 +44,8 @@
                 control: false
             },
             iconAfterClass: {
-                description: 'Additional class applied to the trailing icon (merged with `size-4`).',
+                description:
+                    'Additional class applied to the trailing icon (merged with `size-4`).',
                 control: 'text'
             },
             buttonProps: {

--- a/lightly_studio_view/src/lib/components/Button/Button.svelte
+++ b/lightly_studio_view/src/lib/components/Button/Button.svelte
@@ -13,6 +13,10 @@
     interface BaseProps {
         /** Lucide icon component rendered before the label. */
         icon?: Component<IconProps>;
+        /** Lucide icon component rendered after the label. */
+        iconAfter?: Component<IconProps>;
+        /** Additional class applied to the trailing icon (merged with `size-4`). */
+        iconAfterClass?: string;
         /**
          * Visual style of the button. One of:
          * `default` | `destructive` | `outline` | `secondary` | `ghost` | `link`.
@@ -48,6 +52,8 @@
 
     let {
         icon: Icon,
+        iconAfter: IconAfter,
+        iconAfterClass,
         variant = 'ghost',
         buttonProps = {},
         collapseAt = 'never',
@@ -86,6 +92,9 @@
     {/if}
     {#if children}
         <span class={labelCollapseClass[collapseAt]}>{@render children()}</span>
+    {/if}
+    {#if IconAfter}
+        <IconAfter class={cn('size-4', iconAfterClass)} />
     {/if}
     {#if isPending}
         <span

--- a/lightly_studio_view/src/lib/components/Button/Button.test.ts
+++ b/lightly_studio_view/src/lib/components/Button/Button.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { Pencil } from '@lucide/svelte';
+import { ChevronDown, Pencil } from '@lucide/svelte';
 import '@testing-library/jest-dom';
 import ButtonTestWrapper from './ButtonTestWrapper.test.svelte';
 
@@ -33,6 +33,38 @@ describe('Button', () => {
 
         expect(container.querySelector('button')).toBeInTheDocument();
         expect(container.querySelector(labelSelector)).toBeNull();
+    });
+
+    it('renders the trailing icon after the label when iconAfter is provided', () => {
+        const { container } = render(ButtonTestWrapper, {
+            props: { label: 'Open', iconAfter: ChevronDown }
+        });
+
+        const children = Array.from(container.querySelector('button')?.children ?? []);
+        const labelIndex = children.findIndex((el) => el.tagName === 'SPAN');
+        const svgIndex = children.findIndex((el) => el.tagName === 'svg' || el.tagName === 'SVG');
+        expect(labelIndex).toBeGreaterThan(-1);
+        expect(svgIndex).toBeGreaterThan(labelIndex);
+        expect(children[svgIndex]).toHaveClass('size-4');
+    });
+
+    it('renders both leading and trailing icons when both are provided', () => {
+        const { container } = render(ButtonTestWrapper, {
+            props: { label: 'Open', icon: Pencil, iconAfter: ChevronDown }
+        });
+
+        const svgs = container.querySelectorAll(iconSelector);
+        expect(svgs.length).toBe(2);
+    });
+
+    it('merges iconAfterClass with the default size class on the trailing icon', () => {
+        const { container } = render(ButtonTestWrapper, {
+            props: { label: 'Open', iconAfter: ChevronDown, iconAfterClass: 'rotate-180' }
+        });
+
+        const svg = container.querySelector('button > svg:last-of-type');
+        expect(svg?.getAttribute('class')).toContain('size-4');
+        expect(svg?.getAttribute('class')).toContain('rotate-180');
     });
 
     it('applies the variant passed through to the underlying button', () => {

--- a/lightly_studio_view/src/lib/components/Button/ButtonTestWrapper.test.svelte
+++ b/lightly_studio_view/src/lib/components/Button/ButtonTestWrapper.test.svelte
@@ -9,6 +9,8 @@
     let {
         label,
         icon,
+        iconAfter,
+        iconAfterClass,
         variant,
         buttonProps,
         collapseAt,
@@ -17,6 +19,8 @@
     }: {
         label?: string;
         icon?: Component<IconProps>;
+        iconAfter?: Component<IconProps>;
+        iconAfterClass?: string;
         variant?: ButtonVariant;
         buttonProps?: ButtonProps;
         collapseAt?: CollapseAt;
@@ -26,12 +30,23 @@
 </script>
 
 {#if label !== undefined}
-    <Button {icon} {variant} {buttonProps} {collapseAt} {isPending} {ariaLabel}>
+    <Button
+        {icon}
+        {iconAfter}
+        {iconAfterClass}
+        {variant}
+        {buttonProps}
+        {collapseAt}
+        {isPending}
+        {ariaLabel}
+    >
         {label}
     </Button>
 {:else}
     <Button
         {icon}
+        {iconAfter}
+        {iconAfterClass}
         {variant}
         {buttonProps}
         {collapseAt}

--- a/lightly_studio_view/src/lib/components/MenuItem/MenuItem.svelte
+++ b/lightly_studio_view/src/lib/components/MenuItem/MenuItem.svelte
@@ -21,6 +21,11 @@
 >
     <Button
         icon={item.icon}
+        iconAfter={hasSiblings ? ChevronDown : undefined}
+        iconAfterClass={cn(
+            'shrink-0 opacity-60 transition-transform duration-200',
+            open && 'rotate-180'
+        )}
         buttonProps={{
             href: item.href,
             'data-testid': `navigation-menu-${item.title.toLowerCase()}`,
@@ -28,14 +33,6 @@
         }}
     >
         {item.title}
-        {#if hasSiblings}
-            <ChevronDown
-                class={cn(
-                    'size-4 shrink-0 opacity-60 transition-transform duration-200',
-                    open && 'rotate-180'
-                )}
-            />
-        {/if}
     </Button>
 
     {#if hasSiblings && open}


### PR DESCRIPTION
## What has changed and why?
We need to be able to render icon after the label within the button

THis PR introduced optional property iconAfter and fixes issue with menu with hard coded icon in label

## How has it been tested?

By additional test and visually
<img width="1312" height="600" alt="Screenshot 2026-06-03 at 15 27 40" src="https://github.com/user-attachments/assets/43d0bf01-1fa5-4b8c-96a2-9093b11e8519" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Button now supports trailing icons displayed after button text, with optional custom styling for the trailing icon
  * Menu items use the trailing-icon support to show dropdown indicators and rotate when open

* **Tests**
  * Added tests covering trailing-icon rendering, coexisting leading+trailing icons, and custom trailing-icon class merging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->