### PR TITLE
Add plugin executing overlay with expected delay message

### DIFF
--- a/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
@@ -26,6 +26,7 @@
     import type { SampleType } from '$lib/api/lightly_studio_local';
     import { useTags } from '$lib/hooks/useTags/useTags';
     import { useQueryClient } from '@tanstack/svelte-query';
+    import { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
 
     interface Props {
         operatorMetadata: RegisteredOperatorMetadata | null;
@@ -55,6 +56,7 @@
     );
 
     const queryClient = useQueryClient();
+    const { setPluginExecuting } = useOperatorsDialog();
 
     const collectionId = $page.params.collection_id;
 
@@ -123,6 +125,7 @@
         }
 
         isExecuting = true;
+        setPluginExecuting(true);
         executionError = undefined;
         executionSuccess = undefined;
 
@@ -157,6 +160,7 @@
             toast.error('Operator execution failed', { description: message });
         } finally {
             isExecuting = false;
+            setPluginExecuting(false);
         }
     }
 

--- a/lightly_studio_view/src/lib/components/PluginExecutingOverlay/PluginExecutingOverlay.svelte
+++ b/lightly_studio_view/src/lib/components/PluginExecutingOverlay/PluginExecutingOverlay.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import Spinner from '$lib/components/Spinner/Spinner.svelte';
+    import { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
+
+    const { isPluginExecuting } = useOperatorsDialog();
+</script>
+
+{#if $isPluginExecuting}
+    <div
+        class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50"
+        aria-modal="true"
+        role="dialog"
+        aria-label="Plugin executing"
+    >
+        <div class="flex flex-col items-center gap-4 rounded-lg bg-background p-8 shadow-lg">
+            <Spinner size="large" />
+            <p class="text-sm text-foreground">
+                Plugin executing. This might take up to several minutes…
+            </p>
+        </div>
+    </div>
+{/if}

--- a/lightly_studio_view/src/lib/components/PluginExecutingOverlay/PluginExecutingOverlay.svelte
+++ b/lightly_studio_view/src/lib/components/PluginExecutingOverlay/PluginExecutingOverlay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import Spinner from '$lib/components/Spinner/Spinner.svelte';
-    import { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
+    import { useOperatorsDialog } from '$lib/hooks';
 
     const { isPluginExecuting } = useOperatorsDialog();
 </script>

--- a/lightly_studio_view/src/lib/components/PluginExecutingOverlay/PluginExecutingOverlay.test.ts
+++ b/lightly_studio_view/src/lib/components/PluginExecutingOverlay/PluginExecutingOverlay.test.ts
@@ -1,0 +1,35 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import PluginExecutingOverlay from './PluginExecutingOverlay.svelte';
+import { useOperatorsDialog } from '$lib/hooks';
+
+const { setPluginExecuting } = useOperatorsDialog();
+
+describe('PluginExecutingOverlay', () => {
+    afterEach(() => {
+        setPluginExecuting(false);
+        document.body.innerHTML = '';
+    });
+
+    it('is hidden when plugin is not executing', () => {
+        render(PluginExecutingOverlay);
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('shows the overlay while plugin is executing', async () => {
+        render(PluginExecutingOverlay);
+        setPluginExecuting(true);
+        await screen.findByRole('dialog');
+        expect(
+            screen.getByText('Plugin executing. This might take up to several minutes…')
+        ).toBeInTheDocument();
+    });
+
+    it('hides the overlay after execution completes', async () => {
+        render(PluginExecutingOverlay);
+        setPluginExecuting(true);
+        await screen.findByRole('dialog');
+        setPluginExecuting(false);
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+});

--- a/lightly_studio_view/src/lib/components/PluginExecutingOverlay/index.ts
+++ b/lightly_studio_view/src/lib/components/PluginExecutingOverlay/index.ts
@@ -1,0 +1,1 @@
+export { default as PluginExecutingOverlay } from './PluginExecutingOverlay.svelte';

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -37,3 +37,4 @@ export { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotatio
 export { useSegmentationMaskPreview } from '$lib/hooks/useSegmentationMaskPreview';
 export { useCreateSampling } from '$lib/hooks/useCreateSampling/useCreateSampling';
 export { useColorPicker } from '$lib/hooks/useColorPicker/useColorPicker.svelte';
+export { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';

--- a/lightly_studio_view/src/lib/hooks/useOperatorsDialog/useOperatorsDialog.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorsDialog/useOperatorsDialog.ts
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store';
 
 const isOperatorsDialogOpen = writable(false);
+const isPluginExecuting = writable(false);
 
 export function useOperatorsDialog() {
     const openOperatorsDialog = () => {
@@ -11,9 +12,15 @@ export function useOperatorsDialog() {
         isOperatorsDialogOpen.set(false);
     };
 
+    const setPluginExecuting = (executing: boolean) => {
+        isPluginExecuting.set(executing);
+    };
+
     return {
         isOperatorsDialogOpen,
+        isPluginExecuting,
         openOperatorsDialog,
-        closeOperatorsDialog
+        closeOperatorsDialog,
+        setPluginExecuting
     };
 }

--- a/lightly_studio_view/src/routes/+layout.svelte
+++ b/lightly_studio_view/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
     import '../app.css';
     import { Toaster } from 'svelte-sonner';
     import { client } from '$lib/api/lightly_studio_local/client.gen';
+    import PluginExecutingOverlay from '$lib/components/PluginExecutingOverlay/PluginExecutingOverlay.svelte';
 
     interface ApiErrorWithStatus {
         error?: string;
@@ -53,5 +54,6 @@
     <div class="flex h-full w-full flex-col">
         {@render children()}
         <Toaster richColors />
+        <PluginExecutingOverlay />
     </div>
 </QueryClientProvider>

--- a/lightly_studio_view/src/routes/+layout.svelte
+++ b/lightly_studio_view/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
     import '../app.css';
     import { Toaster } from 'svelte-sonner';
     import { client } from '$lib/api/lightly_studio_local/client.gen';
-    import PluginExecutingOverlay from '$lib/components/PluginExecutingOverlay/PluginExecutingOverlay.svelte';
+    import { PluginExecutingOverlay } from '$lib/components/PluginExecutingOverlay';
 
     interface ApiErrorWithStatus {
         error?: string;


### PR DESCRIPTION
## What has changed and why?

Adds a PluginExecutingOverlay component that renders a full-screen modal with a spinner and the message "Plugin executing. This might take up to several minutes…" while an operator is running.

## How has it been tested?

- Open the Operators dialog, configure and execute an operator.
- Verify the overlay appears immediately after clicking Execute and disappears once execution completes.

<img width="1903" height="933" alt="Screenshot 2026-06-03 at 10 12 33" src="https://github.com/user-attachments/assets/b739bdfb-3825-42e4-bad0-f64f9891f652" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-screen overlay added that displays a spinner and message while plugins run, and is rendered in the app layout.
  * Operator dialog now triggers and clears the plugin-executing state so the overlay appears during execution.

* **Tests**
  * Added tests verifying the overlay shows while execution is active and hides afterward.

* **Chores**
  * Hook re-exported to make the plugin-executing state available across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->