### PR TITLE
Make top bar icon spacing consistent

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -69,7 +69,7 @@
                 position="bottom"
             >
                 <Button
-                    class="flex items-center space-x-1"
+                    class="h-8 gap-1.5 px-2"
                     data-testid="toggle-plot-button"
                     variant={$showEmbeddingPlot ? 'default' : 'ghost'}
                     aria-label="Embeddings"
@@ -88,7 +88,7 @@
                 position="bottom"
             >
                 <Button
-                    class="flex items-center space-x-1"
+                    class="h-8 gap-1.5 px-2"
                     data-testid="toggle-evaluation-runs-button"
                     variant={$showEvaluationRuns ? 'default' : 'ghost'}
                     aria-label="Evaluation"

--- a/lightly_studio_view/src/lib/components/ImageSizeControl/ImageSizeControl.svelte
+++ b/lightly_studio_view/src/lib/components/ImageSizeControl/ImageSizeControl.svelte
@@ -34,7 +34,12 @@
     }
 </script>
 
-<div class="flex shrink-0 items-center space-x-2 text-diffuse-foreground" class:w-40={!compact}>
+<div
+    class="flex shrink-0 items-center text-diffuse-foreground"
+    class:w-40={!compact}
+    class:space-x-2={!compact}
+    class:space-x-4={compact}
+>
     <button
         onclick={zoomOut}
         disabled={width >= max}

--- a/lightly_studio_view/src/lib/components/ImageSizeControl/ImageSizeControl.svelte
+++ b/lightly_studio_view/src/lib/components/ImageSizeControl/ImageSizeControl.svelte
@@ -36,7 +36,7 @@
 
 <div
     class="flex shrink-0 items-center text-diffuse-foreground"
-    class:w-40={!compact}
+    class:w-36={!compact}
     class:space-x-2={!compact}
     class:space-x-4={compact}
 >


### PR DESCRIPTION
## What has changed and why?

Adjusted inconsistent spacing between the top bar controls. Note that a proper fix is to use the same components for everything - in progress by Kondrat.

## How has it been tested?

Manually. Tested both the normal and compact mode.

<img width="1035" height="233" alt="Screenshot 2026-06-03 at 17 37 03" src="https://github.com/user-attachments/assets/4279a211-1510-4209-b0be-ec3f191e6947" />
<img width="794" height="191" alt="Screenshot 2026-06-03 at 17 37 14" src="https://github.com/user-attachments/assets/4250b3fc-81be-4fe5-af7a-eed706df3598" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined toggle button spacing and sizing for dataset controls
  * Improved responsive layout for image size controls to better adapt to compact view modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->