### PR TITLE
Update Quick Start Examples

### DIFF
--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -70,7 +70,7 @@ directly use your own image, video, or YOLO/COCO dataset.
         dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
 
         # Indexes the dataset, creates embeddings and stores everything in the database.
-        dataset = ls.ImageDataset.create()
+        dataset = ls.ImageDataset.load_or_create()
         dataset.add_images_from_path(
             path=f"{dataset_path}/coco_subset_128_images/images",
         )
@@ -94,7 +94,7 @@ directly use your own image, video, or YOLO/COCO dataset.
         dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
 
         # Create a dataset and populate it with videos.
-        dataset = ls.VideoDataset.create()
+        dataset = ls.VideoDataset.load_or_create()
         dataset.add_videos_from_path(path=f"{dataset_path}/youtube_vis_50_videos/train/videos")
 
         # Start the UI server.
@@ -114,7 +114,7 @@ directly use your own image, video, or YOLO/COCO dataset.
         # Download the example dataset (will be skipped if it already exists)
         dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
 
-        dataset = ls.ImageDataset.create()
+        dataset = ls.ImageDataset.load_or_create()
         dataset.add_samples_from_yolo(
             data_yaml=f"{dataset_path}/road_signs_yolo/data.yaml",
         )
@@ -135,7 +135,7 @@ directly use your own image, video, or YOLO/COCO dataset.
         # Download the example dataset (will be skipped if it already exists)
         dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
 
-        dataset = ls.ImageDataset.create()
+        dataset = ls.ImageDataset.load_or_create()
         dataset.add_samples_from_coco(
             annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
             images_path=f"{dataset_path}/coco_subset_128_images/images",


### PR DESCRIPTION
## What has changed and why?

Use the load_or_create in the quickstart examples to make them rerunable. Other examples were not changed (e.g. in docs/docs/dataset_setup/image_dataset.md), as there the methods are getting introduced at some point. And using them earlier would break the storyline.

## How has it been tested?

make serve

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Quickstart code examples with revised snippets for dataset creation and indexing. Changes applied to Image Folder, Video Folder, YOLO Object Detection, and COCO Segmentation Mask examples. Documentation now consistently reflects the current method for dataset operations across all supported types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->