### PR TITLE
Do not clean for build-dirty Makefile target

### DIFF
--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -50,7 +50,7 @@ endif
 
 # Fast build: skips npm ci, nvm install, and langium generate in the frontend.
 .PHONY: build-dirty
-build-dirty: clean build-dirty-lightly_studio_view
+build-dirty: build-dirty-lightly_studio_view
 	@echo "Building a distribution package..."
 	uv build
 


### PR DESCRIPTION
## What has changed and why?

Do not clean for build-dirty Makefile target. This allows to reuse an already built database lightly_studio.db.

## How has it been tested?

Manually.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the dirty build process to skip the clean step, improving build speed during development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->