### PR TITLE
Add ImageDataset.add_annotations_from_pascal_voc_segmentations

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -259,6 +259,32 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             )
         _log_missing_images(annotation_source=annotation_source, missing_paths=missing)
 
+    def add_annotations_from_pascal_voc_segmentations(
+        self,
+        masks_path: PathLike,
+        images_root: PathLike,
+        class_id_to_name: Mapping[int, str],
+        annotation_source: str,
+    ) -> None:
+        """Attach Pascal VOC semantic segmentation masks to images already in the dataset.
+
+        Args:
+            masks_path: Path to the folder containing the segmentation masks.
+            images_root: Root path used for matching image filenames.
+            class_id_to_name: Mapping from class IDs to class names.
+            annotation_source: Name of the annotation source.
+        """
+        label_input = PascalVOCSemanticSegmentationInput.from_dirs(
+            images_dir=images_root,
+            masks_dir=masks_path,
+            class_id_to_name=class_id_to_name,
+        )
+        self.add_annotations_from_labelformat(
+            input_labels=label_input,
+            images_root=images_root,
+            annotation_source=annotation_source,
+        )
+
     def add_samples_from_labelformat(
         self,
         input_labels: ObjectDetectionInput | InstanceSegmentationInput,

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -274,6 +274,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             class_id_to_name: Mapping from class IDs to class names.
             annotation_source: Name of the annotation source.
         """
+        images_root = _normalize_input_path(path=images_root)
+        masks_path = _normalize_input_path(path=masks_path)
+
         label_input = PascalVOCSemanticSegmentationInput.from_dirs(
             images_dir=images_root,
             masks_dir=masks_path,

--- a/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pytest
 import yaml
 from PIL import Image
@@ -45,6 +46,11 @@ def _create_sample_images(image_paths: list[Path]) -> None:
     for image_path in image_paths:
         image_path.parent.mkdir(parents=True, exist_ok=True)
         Image.new("RGB", (10, 10)).save(image_path)
+
+
+def _create_mask(mask_path: Path, mask: np.ndarray) -> None:
+    mask_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(mask).save(mask_path)
 
 
 def _setup_dataset_with_images(tmp_path: Path, file_names: list[str]) -> tuple[ImageDataset, Path]:
@@ -230,3 +236,84 @@ class TestDataset:
             parent_collection_id=dataset.collection_id,
         )
         assert len(result.annotations) == 2
+
+    def test_add_annotations_from_pascal_voc_segmentations__appends_to_existing_images(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        dataset, images_path = _setup_dataset_with_images(tmp_path, ["image1.jpg", "image2.jpg"])
+        masks_path = tmp_path / "masks"
+        # image1 contains both background and "cat" pixels -> 2 annotations.
+        mask1 = np.zeros((10, 10), dtype=np.uint8)
+        mask1[0, 0] = 1
+        _create_mask(masks_path / "image1.png", mask1)
+        # image2 contains only background -> 1 annotation.
+        _create_mask(masks_path / "image2.png", np.zeros((10, 10), dtype=np.uint8))
+
+        dataset.add_annotations_from_pascal_voc_segmentations(
+            masks_path=masks_path,
+            images_root=images_path,
+            class_id_to_name={0: "bg", 1: "cat"},
+            annotation_source="ground_truth",
+        )
+
+        result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="ground_truth",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(result.annotations) == 3
+
+        cov_id = collection_resolver.get_or_create_child_collection(
+            session=dataset.session,
+            collection_id=dataset.collection_id,
+            sample_type=SampleType.ANNOTATION,
+            name="ground_truth",
+        )
+        covered = set(
+            annotation_collection_coverage_resolver.list_by_collection_id(
+                session=dataset.session, annotation_collection_id=cov_id
+            )
+        )
+        assert covered == {s.sample_id for s in dataset}
+
+    def test_add_annotations_from_pascal_voc_segmentations__warns_on_missing_images(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # Only image1 is added to the dataset.
+        images_path = tmp_path / "images"
+        images_path.mkdir()
+        _create_sample_images([images_path / "image1.jpg"])
+        dataset = ImageDataset.create(name="test_dataset")
+        dataset.add_images_from_path(path=images_path, embed=False)
+
+        # image2 exists on disk with a mask but was never added to the dataset.
+        _create_sample_images([images_path / "image2.jpg"])
+        masks_path = tmp_path / "masks"
+        _create_mask(masks_path / "image1.png", np.zeros((10, 10), dtype=np.uint8))
+        _create_mask(masks_path / "image2.png", np.zeros((10, 10), dtype=np.uint8))
+
+        with caplog.at_level(logging.WARNING):
+            dataset.add_annotations_from_pascal_voc_segmentations(
+                masks_path=masks_path,
+                images_root=images_path,
+                class_id_to_name={0: "bg"},
+                annotation_source="gt",
+            )
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "skipped 1 annotation" in r.getMessage() and "image2.jpg" in r.getMessage()
+            for r in warnings
+        )
+
+        result = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="gt",
+            parent_collection_id=dataset.collection_id,
+        )
+        assert len(result.annotations) == 1

--- a/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
@@ -8,6 +8,7 @@ from typing import Any
 import numpy as np
 import pytest
 import yaml
+from numpy.typing import NDArray
 from PIL import Image
 
 from lightly_studio import ImageDataset
@@ -48,7 +49,7 @@ def _create_sample_images(image_paths: list[Path]) -> None:
         Image.new("RGB", (10, 10)).save(image_path)
 
 
-def _create_mask(mask_path: Path, mask: np.ndarray) -> None:
+def _create_mask(mask_path: Path, mask: NDArray[np.uint8]) -> None:
     mask_path.parent.mkdir(parents=True, exist_ok=True)
     Image.fromarray(mask).save(mask_path)
 


### PR DESCRIPTION
## What has changed and why?

Added ImageDataset.add_annotations_from_pascal_voc_segmentations to easily add sem segmentation annotations from multiple sources to existing images. 

## How has it been tested?

New tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import Pascal VOC semantic segmentation masks and attach them to images already in a dataset; skips and logs a warning for masks that don't match any dataset image.
* **Tests**
  * Added tests covering successful import and the skip-with-warning behavior for unmatched masks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->