### PR TITLE
Group classifications by source

### DIFF
--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSourceGroup/SampleDetailsAnnotationSourceGroup.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSourceGroup/SampleDetailsAnnotationSourceGroup.svelte
@@ -14,12 +14,21 @@
         name: string;
         count: number;
         showColorMarker: boolean;
-        allHidden: boolean;
-        onToggleVisibility: (e: MouseEvent) => void;
+        /** When omitted, the visibility eye is hidden (e.g. for classifications, which
+         * are not drawn on the canvas and so cannot be toggled). */
+        allHidden?: boolean;
+        onToggleVisibility?: (e: MouseEvent) => void;
         children: Snippet;
     }
 
-    let { name, count, showColorMarker, allHidden, onToggleVisibility, children }: Props = $props();
+    let {
+        name,
+        count,
+        showColorMarker,
+        allHidden = false,
+        onToggleVisibility,
+        children
+    }: Props = $props();
 
     let open = $state(true);
 
@@ -42,34 +51,36 @@
                 />
             </div>
         </CollapsibleTrigger>
-        <div class="flex shrink-0 items-center">
-            {#if allHidden}
-                <Tooltip content="Show all annotations from this source">
-                    <button
-                        type="button"
-                        aria-label="Show all annotations from this source"
-                        class="flex items-center"
-                        onclick={onToggleVisibility}
-                    >
-                        <EyeOff
-                            data-testid="source-group-eye-off"
-                            class="size-4 text-muted-foreground"
-                        />
-                    </button>
-                </Tooltip>
-            {:else}
-                <Tooltip content="Hide all annotations from this source">
-                    <button
-                        type="button"
-                        aria-label="Hide all annotations from this source"
-                        class="flex items-center"
-                        onclick={onToggleVisibility}
-                    >
-                        <Eye data-testid="source-group-eye" class="size-4" />
-                    </button>
-                </Tooltip>
-            {/if}
-        </div>
+        {#if onToggleVisibility}
+            <div class="flex shrink-0 items-center">
+                {#if allHidden}
+                    <Tooltip content="Show all annotations from this source">
+                        <button
+                            type="button"
+                            aria-label="Show all annotations from this source"
+                            class="flex items-center"
+                            onclick={onToggleVisibility}
+                        >
+                            <EyeOff
+                                data-testid="source-group-eye-off"
+                                class="size-4 text-muted-foreground"
+                            />
+                        </button>
+                    </Tooltip>
+                {:else}
+                    <Tooltip content="Hide all annotations from this source">
+                        <button
+                            type="button"
+                            aria-label="Hide all annotations from this source"
+                            class="flex items-center"
+                            onclick={onToggleVisibility}
+                        >
+                            <Eye data-testid="source-group-eye" class="size-4" />
+                        </button>
+                    </Tooltip>
+                {/if}
+            </div>
+        {/if}
     </div>
     <CollapsibleContent forceMount>
         {#if open}

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSourceGroup/SampleDetailsAnnotationSourceGroup.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSourceGroup/SampleDetailsAnnotationSourceGroup.test.ts
@@ -23,6 +23,7 @@ const defaultProps = {
 const propsWithoutEye = {
     name: 'Ground truth',
     count: 3,
+    sampleId: 'sample-1',
     showColorMarker: true,
     children
 };

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSourceGroup/SampleDetailsAnnotationSourceGroup.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSourceGroup/SampleDetailsAnnotationSourceGroup.test.ts
@@ -17,6 +17,15 @@ const defaultProps = {
     children
 };
 
+// Classifications reuse the group without a visibility toggle: omitting
+// onToggleVisibility hides the eye entirely.
+const propsWithoutEye = {
+    name: 'Ground truth',
+    count: 3,
+    showColorMarker: true,
+    children
+};
+
 describe('SampleDetailsAnnotationSourceGroup', () => {
     it('renders the source name, annotation count and children', () => {
         render(SampleDetailsAnnotationSourceGroup, { props: defaultProps });
@@ -72,6 +81,21 @@ describe('SampleDetailsAnnotationSourceGroup', () => {
         await user.click(screen.getByTestId('source-group-eye'));
 
         expect(onToggleVisibility).toHaveBeenCalledOnce();
+        expect(screen.getByTestId('group-content')).toBeInTheDocument();
+    });
+
+    it('hides the visibility eye when onToggleVisibility is omitted', () => {
+        render(SampleDetailsAnnotationSourceGroup, { props: propsWithoutEye });
+
+        expect(screen.queryByTestId('source-group-eye')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('source-group-eye-off')).not.toBeInTheDocument();
+    });
+
+    it('still renders the name, count and children without the eye', () => {
+        render(SampleDetailsAnnotationSourceGroup, { props: propsWithoutEye });
+
+        expect(screen.getByText('Ground truth')).toBeInTheDocument();
+        expect(screen.getByText('3')).toBeInTheDocument();
         expect(screen.getByTestId('group-content')).toBeInTheDocument();
     });
 });

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { AnnotationType, type AnnotationView } from '$lib/api/lightly_studio_local';
-    import { Segment } from '$lib/components';
+    import { SampleDetailsAnnotationSourceGroup, Segment } from '$lib/components';
     import LabelNotFound from '$lib/components/LabelNotFound/LabelNotFound.svelte';
     import SelectList from '$lib/components/SelectList/SelectList.svelte';
     import { getSelectionItems } from '$lib/components/SelectList/getSelectionItems';
@@ -8,6 +8,8 @@
     import { addAnnotationCreateToUndoStack } from '$lib/services/addAnnotationCreateToUndoStack';
     import { addAnnotationDeleteToUndoStack } from '$lib/services/addAnnotationDeleteToUndoStack';
     import { addAnnotationLabelChangeToUndoStack } from '$lib/services/addAnnotationLabelChangeToUndoStack';
+    import { useAnnotationCollections } from '$lib/hooks';
+    import { groupAnnotationsBySource } from '../SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.helpers';
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
     import { useCreateAnnotation } from '$lib/hooks/useCreateAnnotation/useCreateAnnotation';
     import { useCreateLabel } from '$lib/hooks/useCreateLabel/useCreateLabel';
@@ -55,6 +57,13 @@
                   )
             : [];
     });
+
+    const annotationCollectionsQuery = useAnnotationCollections({ collectionId });
+    const annotationSources = $derived(annotationCollectionsQuery.data ?? []);
+    const isGrouped = $derived(annotationSources.length > 1);
+    const sourceGroups = $derived(
+        isGrouped ? groupAnnotationsBySource(classificationAnnotations, annotationSources) : []
+    );
 
     const handleDeleteAnnotation = async (annotationId: string) => {
         if (!annotationLabels.data) return;
@@ -177,61 +186,83 @@
     });
 </script>
 
+{#snippet classificationRow(annotation: AnnotationView)}
+    <div
+        class="flex w-full items-center justify-between gap-2 rounded-sm bg-card px-4 py-3 text-left"
+        data-annotation-id={annotation.sample_id}
+    >
+        <span class="flex min-w-0 flex-1 flex-col gap-1">
+            <span class="min-w-0 text-sm font-medium">
+                {#if $isEditingMode}
+                    <SelectList
+                        {items}
+                        selectedItem={items.find(
+                            (i) => i.value === getLabelValue(annotation)?.value
+                        )}
+                        name="classification-label"
+                        placeholder="Select or create a class"
+                        className="w-full min-w-0"
+                        contentClassName="w-full min-w-0"
+                        onSelect={async (item) => {
+                            await updateClassificationLabel(annotation, item.value);
+                        }}
+                    >
+                        {#snippet notFound({ inputValue })}
+                            <LabelNotFound label={inputValue} />
+                        {/snippet}
+                    </SelectList>
+                {:else}
+                    <span class="block min-w-0 truncate">
+                        {annotation.annotation_label.annotation_label_name}
+                    </span>
+                    {#if annotation.object_track_number != null}
+                        <span class="shrink-0 font-mono text-xs opacity-80"
+                            >#{annotation.object_track_number}</span
+                        >
+                    {/if}
+                {/if}
+            </span>
+        </span>
+        <div class="flex shrink-0 items-center gap-3">
+            {#if $isEditingMode}
+                <button
+                    type="button"
+                    onclick={(e) => {
+                        e.stopPropagation();
+                        handleDeleteAnnotation(annotation.sample_id);
+                    }}
+                >
+                    <Trash2 class="size-6" />
+                </button>
+            {/if}
+        </div>
+    </div>
+{/snippet}
+
 <Segment title="Classification">
     <div class="flex flex-col gap-3 space-y-4">
         <div class="flex flex-col gap-2">
-            {#each classificationAnnotations as annotation}
-                <div
-                    class="flex w-full items-center justify-between gap-2 rounded-sm bg-card px-4 py-3 text-left"
-                    data-annotation-id={annotation.sample_id}
-                >
-                    <span class="flex min-w-0 flex-1 flex-col gap-1">
-                        <span class="min-w-0 text-sm font-medium">
-                            {#if $isEditingMode}
-                                <SelectList
-                                    {items}
-                                    selectedItem={items.find(
-                                        (i) => i.value === getLabelValue(annotation)?.value
-                                    )}
-                                    name="classification-label"
-                                    placeholder="Select or create a class"
-                                    className="w-full min-w-0"
-                                    contentClassName="w-full min-w-0"
-                                    onSelect={async (item) => {
-                                        await updateClassificationLabel(annotation, item.value);
-                                    }}
-                                >
-                                    {#snippet notFound({ inputValue })}
-                                        <LabelNotFound label={inputValue} />
-                                    {/snippet}
-                                </SelectList>
-                            {:else}
-                                <span class="block min-w-0 truncate">
-                                    {annotation.annotation_label.annotation_label_name}
-                                </span>
-                                {#if annotation.object_track_number != null}
-                                    <span class="shrink-0 font-mono text-xs opacity-80"
-                                        >#{annotation.object_track_number}</span
-                                    >
-                                {/if}
-                            {/if}
-                        </span>
-                    </span>
-                    <div class="flex shrink-0 items-center gap-3">
-                        {#if $isEditingMode}
-                            <button
-                                type="button"
-                                onclick={(e) => {
-                                    e.stopPropagation();
-                                    handleDeleteAnnotation(annotation.sample_id);
-                                }}
-                            >
-                                <Trash2 class="size-6" />
-                            </button>
-                        {/if}
-                    </div>
+            {#if isGrouped}
+                <div class="flex flex-col gap-3">
+                    {#each sourceGroups as group (group.id)}
+                        <SampleDetailsAnnotationSourceGroup
+                            name={group.name}
+                            count={group.annotations.length}
+                            showColorMarker={true}
+                        >
+                            <div class="flex flex-col gap-2">
+                                {#each group.annotations as annotation (annotation.sample_id)}
+                                    {@render classificationRow(annotation)}
+                                {/each}
+                            </div>
+                        </SampleDetailsAnnotationSourceGroup>
+                    {/each}
                 </div>
-            {/each}
+            {:else}
+                {#each classificationAnnotations as annotation (annotation.sample_id)}
+                    {@render classificationRow(annotation)}
+                {/each}
+            {/if}
             {#if $isEditingMode}
                 {#each draftClassifications as draftId (draftId)}
                     <div

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -8,8 +8,12 @@
     import { addAnnotationCreateToUndoStack } from '$lib/services/addAnnotationCreateToUndoStack';
     import { addAnnotationDeleteToUndoStack } from '$lib/services/addAnnotationDeleteToUndoStack';
     import { addAnnotationLabelChangeToUndoStack } from '$lib/services/addAnnotationLabelChangeToUndoStack';
-    import { useAnnotationCollections } from '$lib/hooks';
-    import { groupAnnotationsBySource } from '../SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.helpers';
+    import { useAnnotationCollections, useAnnotationCollectionsFilter } from '$lib/hooks';
+    import {
+        areAllAnnotationsHidden,
+        computeSeededHiddenIds,
+        groupAnnotationsBySource
+    } from '../SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.helpers';
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
     import { useCreateAnnotation } from '$lib/hooks/useCreateAnnotation/useCreateAnnotation';
     import { useCreateLabel } from '$lib/hooks/useCreateLabel/useCreateLabel';
@@ -59,10 +63,17 @@
     });
 
     const annotationCollectionsQuery = useAnnotationCollections({ collectionId });
+    const { selectedCollectionIds } = useAnnotationCollectionsFilter();
     const annotationSources = $derived(annotationCollectionsQuery.data ?? []);
     const isGrouped = $derived(annotationSources.length > 1);
     const sourceGroups = $derived(
         isGrouped ? groupAnnotationsBySource(classificationAnnotations, annotationSources) : []
+    );
+
+    // Hidden set implied by the grid filter, as a derived so it's readable at mount (unlike
+    // the effect-written `annotationsIdsToHide`); drives the seed and the initial collapse.
+    const seededHiddenIds = $derived(
+        computeSeededHiddenIds(classificationAnnotations, $selectedCollectionIds, annotationSources)
     );
 
     const handleDeleteAnnotation = async (annotationId: string) => {
@@ -248,6 +259,11 @@
                         <SampleDetailsAnnotationSourceGroup
                             name={group.name}
                             count={group.annotations.length}
+                            {sampleId}
+                            initiallyOpen={!areAllAnnotationsHidden(
+                                group.annotations,
+                                seededHiddenIds
+                            )}
                             showColorMarker={true}
                         >
                             <div class="flex flex-col gap-2">

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    // TODO (Mihnea, 06/2026): Refactor this component, as it is way past the 100-line guideline.
     import { AnnotationType, type AnnotationView } from '$lib/api/lightly_studio_local';
     import { SampleDetailsAnnotationSourceGroup, Segment } from '$lib/components';
     import LabelNotFound from '$lib/components/LabelNotFound/LabelNotFound.svelte';
@@ -238,6 +239,7 @@
             {#if $isEditingMode}
                 <button
                     type="button"
+                    aria-label="Delete classification"
                     onclick={(e) => {
                         e.stopPropagation();
                         handleDeleteAnnotation(annotation.sample_id);

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -1,0 +1,163 @@
+import type { AnnotationView } from '$lib/api/lightly_studio_local';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SampleDetailsClassificationSegment from './SampleDetailsClassificationSegment.svelte';
+
+const mocks = vi.hoisted(() => ({
+    collections: [] as { collection_id: string; name: string }[],
+    isEditingMode: undefined as unknown as { set: (value: boolean) => void }
+}));
+
+vi.mock('$app/state', () => ({
+    page: { params: { dataset_id: 'dataset-1' } }
+}));
+
+// The classification segment imports useAnnotationCollections through the `$lib/hooks`
+// barrel; mocking the underlying module replaces the barrel re-export too.
+vi.mock('$lib/hooks/useAnnotationCollections/useAnnotationCollections', () => ({
+    useAnnotationCollections: vi.fn(() => ({ data: mocks.collections }))
+}));
+
+vi.mock('$lib/hooks/useGlobalStorage', async () => {
+    const { writable } = await import('svelte/store');
+    const isEditingMode = writable(false);
+    mocks.isEditingMode = isEditingMode;
+    return {
+        useGlobalStorage: () => ({
+            isEditingMode,
+            addReversibleAction: vi.fn()
+        })
+    };
+});
+
+vi.mock('$lib/hooks/useAnnotationLabels/useAnnotationLabels', () => ({
+    useAnnotationLabels: vi.fn(() => ({ data: [] }))
+}));
+
+vi.mock('$lib/hooks/useCreateAnnotation/useCreateAnnotation', () => ({
+    useCreateAnnotation: vi.fn(() => ({ createAnnotation: vi.fn() }))
+}));
+
+vi.mock('$lib/hooks/useDeleteAnnotation/useDeleteAnnotation', () => ({
+    useDeleteAnnotation: vi.fn(() => ({ deleteAnnotation: vi.fn() }))
+}));
+
+vi.mock('$lib/hooks/useCreateLabel/useCreateLabel', () => ({
+    useCreateLabel: vi.fn(() => ({ createLabel: vi.fn() }))
+}));
+
+vi.mock('$lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation', () => ({
+    useUpdateAnnotationsMutation: vi.fn(() => ({ updateAnnotations: vi.fn() }))
+}));
+
+vi.mock('$lib/hooks/useCollection/useCollection', () => ({
+    useCollectionWithChildren: vi.fn(() => ({ refetch: vi.fn() }))
+}));
+
+vi.mock('svelte-sonner', () => ({
+    toast: { success: vi.fn(), error: vi.fn() }
+}));
+
+const groundTruthSource = { collection_id: 'source-gt', name: 'Ground truth' };
+const predictionsSource = { collection_id: 'source-pred', name: 'Predictions' };
+
+const createClassification = (
+    sampleId: string,
+    sourceId: string,
+    labelName: string
+): AnnotationView =>
+    ({
+        parent_sample_id: 'parent-sample-1',
+        sample_id: sampleId,
+        annotation_collection_id: sourceId,
+        annotation_type: 'classification',
+        annotation_label: { annotation_label_name: labelName },
+        created_at: new Date('1970-01-01T00:00:00.000Z')
+    }) satisfies AnnotationView;
+
+const defaultProps = {
+    collectionId: 'collection-1',
+    sampleId: 'sample-1',
+    annotations: [] as AnnotationView[],
+    refetch: vi.fn()
+};
+
+describe('SampleDetailsClassificationSegment', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.collections = [];
+        mocks.isEditingMode.set(false);
+    });
+
+    it('renders a flat list without source groups for a single source', () => {
+        mocks.collections = [groundTruthSource];
+        const annotations = [
+            createClassification('c1', groundTruthSource.collection_id, 'bird'),
+            createClassification('c2', groundTruthSource.collection_id, 'cat')
+        ];
+
+        render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+        expect(screen.queryByTestId('annotation-source-group-header')).not.toBeInTheDocument();
+        expect(screen.getByText('bird')).toBeInTheDocument();
+        expect(screen.getByText('cat')).toBeInTheDocument();
+    });
+
+    it('groups classifications under one header per source for multiple sources', () => {
+        mocks.collections = [groundTruthSource, predictionsSource];
+        const annotations = [
+            createClassification('c1', groundTruthSource.collection_id, 'cat'),
+            createClassification('c2', predictionsSource.collection_id, 'zebra'),
+            createClassification('c3', groundTruthSource.collection_id, 'dog')
+        ];
+
+        render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+        const headers = screen.getAllByTestId('annotation-source-group-header');
+        expect(headers).toHaveLength(2);
+        expect(headers[0]).toHaveTextContent(groundTruthSource.name);
+        expect(headers[0]).toHaveTextContent('2');
+        expect(headers[1]).toHaveTextContent(predictionsSource.name);
+        expect(headers[1]).toHaveTextContent('1');
+        expect(screen.getByText('zebra')).toBeInTheDocument();
+    });
+
+    it('never shows the visibility eye on classification groups', () => {
+        mocks.collections = [groundTruthSource, predictionsSource];
+        const annotations = [
+            createClassification('c1', groundTruthSource.collection_id, 'cat'),
+            createClassification('c2', predictionsSource.collection_id, 'zebra')
+        ];
+
+        render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+        expect(screen.getAllByTestId('annotation-source-group-header')).toHaveLength(2);
+        expect(screen.queryByTestId('source-group-eye')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('source-group-eye-off')).not.toBeInTheDocument();
+    });
+
+    it('renders editable rows inside groups with a single add button below', async () => {
+        const user = userEvent.setup();
+        mocks.isEditingMode.set(true);
+        mocks.collections = [groundTruthSource, predictionsSource];
+        const annotations = [
+            createClassification('c1', groundTruthSource.collection_id, 'cat'),
+            createClassification('c2', predictionsSource.collection_id, 'zebra'),
+            createClassification('c3', groundTruthSource.collection_id, 'dog')
+        ];
+
+        render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+        expect(screen.getAllByTestId('annotation-source-group-header')).toHaveLength(2);
+        // One editable row per classification, rendered inside the groups.
+        expect(screen.getAllByTestId('select-list-trigger')).toHaveLength(3);
+        // The add button is rendered once, below the groups (not duplicated per group).
+        expect(screen.getAllByTestId('add-classification-button')).toHaveLength(1);
+
+        // Adding a draft renders an extra row without duplicating the add button.
+        await user.click(screen.getByTestId('add-classification-button'));
+        expect(screen.getAllByTestId('select-list-trigger')).toHaveLength(4);
+        expect(screen.getAllByTestId('add-classification-button')).toHaveLength(1);
+    });
+});

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -6,6 +6,7 @@ import SampleDetailsClassificationSegment from './SampleDetailsClassificationSeg
 
 const mocks = vi.hoisted(() => ({
     collections: [] as { collection_id: string; name: string }[],
+    selectedCollectionIds: [] as string[],
     isEditingMode: undefined as unknown as { set: (value: boolean) => void }
 }));
 
@@ -18,6 +19,16 @@ vi.mock('$app/state', () => ({
 vi.mock('$lib/hooks/useAnnotationCollections/useAnnotationCollections', () => ({
     useAnnotationCollections: vi.fn(() => ({ data: mocks.collections }))
 }));
+
+// Drives the grid-filter seeded collapse: sources missing from the selection start collapsed.
+vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter', async () => {
+    const { readable } = await import('svelte/store');
+    return {
+        useAnnotationCollectionsFilter: vi.fn(() => ({
+            selectedCollectionIds: readable(mocks.selectedCollectionIds)
+        }))
+    };
+});
 
 vi.mock('$lib/hooks/useGlobalStorage', async () => {
     const { writable } = await import('svelte/store');
@@ -87,6 +98,7 @@ describe('SampleDetailsClassificationSegment', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mocks.collections = [];
+        mocks.selectedCollectionIds = [];
         mocks.isEditingMode.set(false);
     });
 
@@ -135,6 +147,41 @@ describe('SampleDetailsClassificationSegment', () => {
         expect(screen.getAllByTestId('annotation-source-group-header')).toHaveLength(2);
         expect(screen.queryByTestId('source-group-eye')).not.toBeInTheDocument();
         expect(screen.queryByTestId('source-group-eye-off')).not.toBeInTheDocument();
+    });
+
+    it('collapses a source left unselected on the grid', () => {
+        mocks.collections = [groundTruthSource, predictionsSource];
+        mocks.selectedCollectionIds = [groundTruthSource.collection_id];
+        const annotations = [
+            createClassification('c1', groundTruthSource.collection_id, 'cat'),
+            createClassification('c2', predictionsSource.collection_id, 'zebra')
+        ];
+
+        render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+        // Both headers render, but the unselected Predictions group starts collapsed,
+        // hiding its classifications; the selected Ground truth group stays expanded.
+        expect(screen.getAllByTestId('annotation-source-group-header')).toHaveLength(2);
+        expect(screen.getByText('cat')).toBeInTheDocument();
+        expect(screen.queryByText('zebra')).not.toBeInTheDocument();
+    });
+
+    it('expands a collapsed source when its header is clicked', async () => {
+        const user = userEvent.setup();
+        mocks.collections = [groundTruthSource, predictionsSource];
+        mocks.selectedCollectionIds = [groundTruthSource.collection_id];
+        const annotations = [
+            createClassification('c1', groundTruthSource.collection_id, 'cat'),
+            createClassification('c2', predictionsSource.collection_id, 'zebra')
+        ];
+
+        render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+        expect(screen.queryByText('zebra')).not.toBeInTheDocument();
+
+        await user.click(screen.getByText(predictionsSource.name));
+
+        expect(screen.getByText('zebra')).toBeInTheDocument();
     });
 
     it('renders editable rows inside groups with a single add button below', async () => {

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -197,14 +197,14 @@ describe('SampleDetailsClassificationSegment', () => {
         render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
 
         expect(screen.getAllByTestId('annotation-source-group-header')).toHaveLength(2);
-        // One editable row per classification, rendered inside the groups.
-        expect(screen.getAllByTestId('select-list-trigger')).toHaveLength(3);
+        // One editable combobox per classification, rendered inside the groups.
+        expect(screen.getAllByRole('combobox')).toHaveLength(3);
         // The add button is rendered once, below the groups (not duplicated per group).
         expect(screen.getAllByTestId('add-classification-button')).toHaveLength(1);
 
-        // Adding a draft renders an extra row without duplicating the add button.
+        // Adding a draft renders an extra editable row without duplicating the add button.
         await user.click(screen.getByTestId('add-classification-button'));
-        expect(screen.getAllByTestId('select-list-trigger')).toHaveLength(4);
+        expect(screen.getAllByRole('combobox')).toHaveLength(4);
         expect(screen.getAllByTestId('add-classification-button')).toHaveLength(1);
     });
 });


### PR DESCRIPTION
## What has changed and why?

Extends the current implementation to also group classifications by source


https://github.com/user-attachments/assets/ca29e755-b72b-4150-9942-e6196fdad1f6



## How has it been tested?

Manually + new tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Classification annotations now group by source when multiple sources exist, with per-source headers and counts.

* **Improvements**
  * Visibility (“eye”) controls are shown only when applicable, reducing UI clutter; source groups can be collapsed/expanded while preserving state.
  * Editing flows render rows consistently and keep a single add-row control.

* **Tests**
  * New tests cover grouping, conditional visibility, collapse/expand behavior, and edit/add-row interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->