### PR TITLE
fix css hack to adjust button sise

### DIFF
--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -307,21 +307,23 @@
                 bind:this={plotContainer}
             >
                 {#if $plotData && width >= MIN_RENDER_SIZE && height >= MIN_RENDER_SIZE}
-                    <EmbeddingView
-                        class="h-full w-full"
-                        config={embeddingConfig}
-                        {width}
-                        {height}
-                        {categoryCount}
-                        data={$plotData}
-                        {categoryColors}
-                        tooltip={null}
-                        theme={embeddingTheme}
-                        {onRangeSelection}
-                        {onViewportState}
-                        {viewportState}
-                        rangeSelection={$rangeSelection}
-                    />
+                    <div class="embedding-view h-full w-full">
+                        <EmbeddingView
+                            config={embeddingConfig}
+                            {width}
+                            {height}
+                            {categoryCount}
+                            data={$plotData}
+                            {categoryColors}
+                            tooltip={null}
+                            theme={embeddingTheme}
+                            {onRangeSelection}
+                            {onViewportState}
+                            {viewportState}
+                            rangeSelection={$rangeSelection}
+                        />
+                    </div>
+
                     <PlotPanelLegend
                         {categoryColors}
                         {includedLabel}
@@ -374,15 +376,15 @@
 <svelte:window onmouseup={handleMouseUp} onkeydown={onWindowKeyDown} />
 
 <style>
-    :global(.embedding-plot-wrapper button) {
+    :global(.embedding-view button) {
         width: 20px !important;
         height: 20px !important;
     }
-    :global(.embedding-plot-wrapper button svg) {
+    :global(.embedding-view button svg) {
         width: 18px !important;
         height: 18px !important;
     }
-    :global(.embedding-plot-wrapper div[style*='bottom: 0px'][style*='position: absolute']) {
+    :global(.embedding-view div[style*='bottom: 0px'][style*='position: absolute']) {
         font-size: 15px !important;
         height: 25px !important;
         line-height: 25px !important;


### PR DESCRIPTION
## What has changed and why?

Styles were applied for all buttons including labels for annotations

## How has it been tested?

VIsual check

1. Run app
2. Open image grid
3. Open embedding plot
4. Choose "annotations" at the bottom of the plot
5. You should see the list of colored annotation labels 
<img width="1239" height="1238" alt="Screenshot 2026-06-04 at 18 25 50" src="https://github.com/user-attachments/assets/1fa920e0-437a-4208-9b25-b93c92f33c57" />

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the internal layout structure of the plot panel component for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->