### PR TITLE
Show Label if Multi Source

### DIFF
--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotation/SampleDetailsAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotation/SampleDetailsAnnotation.svelte
@@ -85,7 +85,7 @@
         >
             <SampleAnnotation
                 {annotation}
-                showLabel={$showAnnotationTextLabelsStore}
+                showLabel={$showAnnotationTextLabelsStore || colorBySource}
                 {showBoundingBox}
                 imageWidth={sample.width}
                 constraintBox={{


### PR DESCRIPTION
## What has changed and why?

Toggle the label visibility when mutliple sources are visble. this enhances the information, since all labels are using the same color.

One source:
<img width="1438" height="604" alt="image" src="https://github.com/user-attachments/assets/a40172c7-e216-4acf-9c93-31925937d9e6" />


Multiple sources:
<img width="1448" height="634" alt="image" src="https://github.com/user-attachments/assets/d127fc5a-8387-471b-a7ae-d55acfe2edef" />


## How has it been tested?

Local

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
