### PR TITLE
Show Confidence in Label and side panel

### DIFF
--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.svelte
@@ -131,6 +131,7 @@
             {colorText}
             {label}
             trackId={annotation.object_track_number}
+            confidence={annotation.confidence}
         />
     {/if}
 

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.test.ts
@@ -103,6 +103,31 @@ describe('SampleAnnotation', () => {
         expect(screen.getByTestId('svg-annotation-text')).toHaveTextContent('person');
     });
 
+    it('appends confidence to the canvas label when confidence is set', () => {
+        render(SampleAnnotation, {
+            props: {
+                annotation: { ...createObjectDetectionAnnotation(), confidence: 0.87 },
+                imageWidth: 100,
+                showLabel: true
+            }
+        });
+
+        expect(screen.getByTestId('svg-annotation-text')).toHaveTextContent('car (0.87)');
+    });
+
+    it('does not show confidence in the canvas label when confidence is null', () => {
+        render(SampleAnnotation, {
+            props: {
+                annotation: { ...createObjectDetectionAnnotation(), confidence: null },
+                imageWidth: 100,
+                showLabel: true
+            }
+        });
+
+        expect(screen.getByTestId('svg-annotation-text')).toHaveTextContent('car');
+        expect(screen.getByTestId('svg-annotation-text')).not.toHaveTextContent('(');
+    });
+
     it('keeps object-detection label visible when bounding boxes are hidden', () => {
         render(SampleAnnotation, {
             props: {

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationLabel/SampleAnnotationLabel.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationLabel/SampleAnnotationLabel.svelte
@@ -6,7 +6,8 @@
         label,
         fontSize = 14,
         isPrediction = false,
-        trackId = null
+        trackId = null,
+        confidence = null
     }: {
         coordinates: [number, number];
         colorText: ReturnType<typeof getColorByLabel>;
@@ -15,10 +16,12 @@
         boxGap?: number;
         isPrediction?: boolean;
         trackId?: number | null;
+        confidence?: number | null;
     } = $props();
     const displayLabel = $derived.by(() => {
         const base = isPrediction ? `${label} (pred)` : label;
-        return trackId != null ? `${base} #${trackId}` : base;
+        const withTrack = trackId != null ? `${base} #${trackId}` : base;
+        return confidence != null ? `${withTrack} (${confidence.toFixed(2)})` : withTrack;
     });
     const [x, y] = $derived(coordinates);
     let textElement: SVGTextElement | null = $state(null);

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationLabel/SampleAnnotationLabel.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationLabel/SampleAnnotationLabel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { getColorByLabel } from '$lib/utils';
+    import { formatConfidence, getColorByLabel } from '$lib/utils';
     const {
         coordinates,
         colorText,
@@ -21,7 +21,8 @@
     const displayLabel = $derived.by(() => {
         const base = isPrediction ? `${label} (pred)` : label;
         const withTrack = trackId != null ? `${base} #${trackId}` : base;
-        return confidence != null ? `${withTrack} (${confidence.toFixed(2)})` : withTrack;
+        const formattedConfidence = formatConfidence(confidence);
+        return formattedConfidence ? `${withTrack} (${formattedConfidence})` : withTrack;
     });
     const [x, y] = $derived(coordinates);
     let textElement: SVGTextElement | null = $state(null);

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationLabel/SampleAnnotationLabel.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationLabel/SampleAnnotationLabel.svelte
@@ -1,14 +1,7 @@
 <script lang="ts">
     import { formatConfidence, getColorByLabel } from '$lib/utils';
-    const {
-        coordinates,
-        colorText,
-        label,
-        fontSize = 14,
-        isPrediction = false,
-        trackId = null,
-        confidence = null
-    }: {
+
+    interface Props {
         coordinates: [number, number];
         colorText: ReturnType<typeof getColorByLabel>;
         label: string;
@@ -17,7 +10,17 @@
         isPrediction?: boolean;
         trackId?: number | null;
         confidence?: number | null;
-    } = $props();
+    }
+
+    const {
+        coordinates,
+        colorText,
+        label,
+        fontSize = 14,
+        isPrediction = false,
+        trackId = null,
+        confidence = null
+    }: Props = $props();
     const displayLabel = $derived.by(() => {
         const base = isPrediction ? `${label} (pred)` : label;
         const withTrack = trackId != null ? `${base} #${trackId}` : base;

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -227,6 +227,11 @@
                     <span class="block min-w-0 truncate">
                         {annotation.annotation_label.annotation_label_name}
                     </span>
+                    {#if annotation.confidence != null}
+                        <span class="text-xs text-muted-foreground"
+                            >Confidence: {annotation.confidence.toFixed(2)}</span
+                        >
+                    {/if}
                     {#if annotation.object_track_number != null}
                         <span class="shrink-0 font-mono text-xs opacity-80"
                             >#{annotation.object_track_number}</span

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -5,7 +5,7 @@
     import LabelNotFound from '$lib/components/LabelNotFound/LabelNotFound.svelte';
     import SelectList from '$lib/components/SelectList/SelectList.svelte';
     import { getSelectionItems } from '$lib/components/SelectList/getSelectionItems';
-    import { cn } from '$lib/utils';
+    import { cn, formatConfidence } from '$lib/utils';
     import { addAnnotationCreateToUndoStack } from '$lib/services/addAnnotationCreateToUndoStack';
     import { addAnnotationDeleteToUndoStack } from '$lib/services/addAnnotationDeleteToUndoStack';
     import { addAnnotationLabelChangeToUndoStack } from '$lib/services/addAnnotationLabelChangeToUndoStack';
@@ -228,8 +228,9 @@
                         {annotation.annotation_label.annotation_label_name}
                     </span>
                     {#if annotation.confidence != null}
+                        {@const formattedConfidence = formatConfidence(annotation.confidence)}
                         <span class="text-xs text-muted-foreground"
-                            >Confidence: {annotation.confidence.toFixed(2)}</span
+                            >Confidence: {formattedConfidence}</span
                         >
                     {/if}
                     {#if annotation.object_track_number != null}

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -76,7 +76,8 @@ const predictionsSource = { collection_id: 'source-pred', name: 'Predictions' };
 const createClassification = (
     sampleId: string,
     sourceId: string,
-    labelName: string
+    labelName: string,
+    confidence?: number | null
 ): AnnotationView =>
     ({
         parent_sample_id: 'parent-sample-1',
@@ -84,7 +85,8 @@ const createClassification = (
         annotation_collection_id: sourceId,
         annotation_type: 'classification',
         annotation_label: { annotation_label_name: labelName },
-        created_at: new Date('1970-01-01T00:00:00.000Z')
+        created_at: new Date('1970-01-01T00:00:00.000Z'),
+        confidence
     }) satisfies AnnotationView;
 
 const defaultProps = {
@@ -182,6 +184,30 @@ describe('SampleDetailsClassificationSegment', () => {
         await user.click(screen.getByText(predictionsSource.name));
 
         expect(screen.getByText('zebra')).toBeInTheDocument();
+    });
+
+    it('shows confidence value when present', () => {
+        mocks.collections = [groundTruthSource];
+        const annotations = [
+            createClassification('c1', groundTruthSource.collection_id, 'bird', 0.95)
+        ];
+
+        render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+        expect(screen.getByText('bird')).toBeInTheDocument();
+        expect(screen.getByText('Confidence: 0.95')).toBeInTheDocument();
+    });
+
+    it('does not show confidence line when confidence is null', () => {
+        mocks.collections = [groundTruthSource];
+        const annotations = [
+            createClassification('c1', groundTruthSource.collection_id, 'bird', null)
+        ];
+
+        render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+        expect(screen.getByText('bird')).toBeInTheDocument();
+        expect(screen.queryByText(/Confidence:/)).not.toBeInTheDocument();
     });
 
     it('renders editable rows inside groups with a single add button below', async () => {

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { cn } from '$lib/utils';
+    import { cn, formatConfidence } from '$lib/utils';
     import { page } from '$app/state';
     import SelectList from '$lib/components/SelectList/SelectList.svelte';
     import { getSelectionItems } from '$lib/components/SelectList/getSelectionItems';
@@ -198,8 +198,11 @@
                                 >
                                     <span class="truncate">{annotationLabelName}</span>
                                     {#if annotation.confidence != null}
+                                        {@const formattedConfidence = formatConfidence(
+                                            annotation.confidence
+                                        )}
                                         <span class="text-xs text-muted-foreground"
-                                            >Confidence: {annotation.confidence.toFixed(2)}</span
+                                            >Confidence: {formattedConfidence}</span
                                         >
                                     {/if}
                                 </div>

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
@@ -197,6 +197,11 @@
                                     class="flex w-full min-w-0 flex-1 flex-col gap-1 overflow-hidden"
                                 >
                                     <span class="truncate">{annotationLabelName}</span>
+                                    {#if annotation.confidence != null}
+                                        <span class="text-xs text-muted-foreground"
+                                            >Confidence: {annotation.confidence.toFixed(2)}</span
+                                        >
+                                    {/if}
                                 </div>
                             {/if}
                         </div>

--- a/lightly_studio_view/src/lib/utils/formatter.test.ts
+++ b/lightly_studio_view/src/lib/utils/formatter.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { formatConfidence } from './formatter';
+
+describe('formatConfidence', () => {
+    it('formats confidence with two decimal places', () => {
+        expect(formatConfidence(0.876)).toBe('0.88');
+    });
+
+    it('returns null for missing confidence', () => {
+        expect(formatConfidence(null)).toBeNull();
+        expect(formatConfidence(undefined)).toBeNull();
+    });
+});

--- a/lightly_studio_view/src/lib/utils/formatter.ts
+++ b/lightly_studio_view/src/lib/utils/formatter.ts
@@ -15,6 +15,14 @@ export const formatFloat2 = (num: number): string => {
     return formatFloat(num, 2);
 };
 
+export const formatConfidence = (confidence?: number | null): string | null => {
+    if (confidence == null) {
+        return null;
+    }
+
+    return formatFloat2(confidence);
+};
+
 /**
  * Format a metadata value for display
  * @param value - The metadata value to format


### PR DESCRIPTION
## What has changed and why?

Shwoing the confidence values if available in the label overlay(if shown), and the right side panel.

<img width="1460" height="638" alt="image" src="https://github.com/user-attachments/assets/9573f895-5542-42e3-9606-4dfa9bd82ac1" />

<img width="1458" height="641" alt="image" src="https://github.com/user-attachments/assets/ff39cf40-68f6-4a71-a58f-6f01db56015b" />


## How has it been tested?

unit tests are added

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Annotation confidence values now display throughout the application, including in sample annotations on the canvas, classification details, and annotation information panels. Confidence values are formatted consistently as decimal numbers.

* **Tests**
  * Added comprehensive test coverage to verify confidence value formatting and display across annotation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->