### PR TITLE
Fix Run Selected Classifiers button layout

### DIFF
--- a/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
@@ -15,15 +15,7 @@
     import { useClassifiersMenu } from '$lib/hooks/useClassifiers/useClassifiersMenu';
     import { useQueryClient } from '@tanstack/svelte-query';
     import { readAnnotationLabelsOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
-    import {
-        Network as NetworkIcon,
-        Pencil,
-        Download,
-        Upload,
-        Play,
-        LoaderCircle as Loader2,
-        Info
-    } from '@lucide/svelte';
+    import { Network as NetworkIcon, Pencil, Download, Upload, Play, Info } from '@lucide/svelte';
     import { useImageAnnotationCountsQueryKey } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
 
     const exportOptions: ClassifierExportType[] = ['sklearn', 'lightly'];
@@ -346,19 +338,17 @@
                                             </Tooltip>
                                         </div>
                                         <Button
+                                            icon={Play}
+                                            isPending={$isLoading}
                                             buttonProps={{
                                                 onclick: runClassifier,
                                                 disabled: !$isApplyButtonEnabled,
                                                 class: 'w-full'
                                             }}
                                         >
-                                            {#if $isLoading}
-                                                <Loader2 class="mr-2 size-4 animate-spin" />
-                                                Running Classifiers...
-                                            {:else}
-                                                <Play class="mr-2 size-4" />
-                                                Run Selected Classifiers
-                                            {/if}
+                                            {$isLoading
+                                                ? 'Running Classifiers...'
+                                                : 'Run Selected Classifiers'}
                                         </Button>
                                     </div>
                                 {:else}


### PR DESCRIPTION
## What has changed and why?

Fix Run Selected Classifiers button layout. Use the button properties instead of custom code.

## How has it been tested?

Manually.

Before
<img width="546" height="489" alt="Screenshot 2026-06-05 at 10 24 41" src="https://github.com/user-attachments/assets/db8674d0-2879-4bca-886b-da48836bcf8e" />

After
<img width="524" height="551" alt="Screenshot 2026-06-05 at 10 43 10" src="https://github.com/user-attachments/assets/65c6d76b-d733-4bd6-b10e-234636808c3e" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Enhanced the loading state indicator on the "Run Selected Classifiers" button with improved visual feedback during classifier execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->