### PR TITLE
Hide strategy tooltip when sampling dropdown closes

### DIFF
--- a/lightly_studio_view/src/lib/components/Sampling/AddStrategyButton.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/AddStrategyButton.svelte
@@ -17,6 +17,7 @@
         onAdd
     }: Props = $props();
 
+    let isOpen = $state(false);
     let hoveredType = $state<StrategyType | null>(null);
     let tooltipRect = $state<DOMRect | null>(null);
     // wrapper element refs used to position the tooltip on keyboard highlight
@@ -56,6 +57,7 @@
         if (v) onAdd(v as StrategyType);
     }}
     onOpenChange={(open) => {
+        isOpen = open;
         if (!open) handleMouseLeave();
     }}
 >
@@ -93,7 +95,7 @@
     {/snippet}
 </Select>
 
-{#if hoveredType && tooltipRect && hoveredStrategy}
+{#if isOpen && hoveredType && tooltipRect && hoveredStrategy}
     <Portal>
         <div
             id="strategy-tooltip-{hoveredType}"


### PR DESCRIPTION
## What has changed and why?

Gate the strategy tooltip on the dropdown's open state so it disappears when the dropdown closes.

## How has it been tested?

Manual test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tooltip display behavior in the strategy selection dropdown to only appear when the dropdown is open, preventing tooltips from displaying at inappropriate times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->