### PR TITLE
Make annotation details left panel scrollable

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationDetailsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationDetailsPanel.svelte
@@ -60,7 +60,7 @@
 <Card className="h-full">
     <CardContent className="h-full flex flex-col">
         <div
-            class="flex h-full min-h-0 flex-col space-y-4 overflow-hidden dark:[color-scheme:dark]"
+            class="flex h-full min-h-0 flex-col space-y-4 overflow-y-auto dark:[color-scheme:dark]"
         >
             <SegmentTags
                 {tags}


### PR DESCRIPTION
## What has changed and why?

Allows the annotation details content to scroll vertically when it overflows.

https://github.com/user-attachments/assets/43f9c235-10c1-46b0-9052-c2e3b315d1ef

## How has it been tested?

Manual test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertical scrolling in the Annotation Details panel to properly handle and display content that exceeds the panel's visible area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->