### PR TITLE
Add link to documentation and description on plugin page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Show plugin description and a link to documentation when no plugins are available.
+
 ### Changed
 
 ### Deprecated

--- a/lightly_studio_view/src/lib/components/Operator/OperatorsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/OperatorsMenu.svelte
@@ -121,10 +121,9 @@
                     <div class="p-4 text-sm text-muted-foreground">
                         <p>No plugins available.</p>
                         <p class="mt-2">
-                            LightlyStudio can be customized with plugins. You can write your own
-                            plugins to import or export data in custom formats, or to run operations
-                            such as model-assisted annotation on individual images or the full
-                            dataset.
+                            Extend LightlyStudio with plugins. Install ready-made plugins or build
+                            your own to import/export data, run model-assisted annotation, and
+                            automate workflows.
                         </p>
                     </div>
                 {:else}

--- a/lightly_studio_view/src/lib/components/Operator/OperatorsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/OperatorsMenu.svelte
@@ -118,7 +118,15 @@
                         <span>{errorMessage}</span>
                     </div>
                 {:else if operators.length === 0}
-                    <div class="p-4 text-sm text-muted-foreground">No plugins available.</div>
+                    <div class="p-4 text-sm text-muted-foreground">
+                        <p>No plugins available.</p>
+                        <p class="mt-2">
+                            LightlyStudio can be customized with plugins. You can write your own
+                            plugins to import or export data in custom formats, or to run operations
+                            such as model-assisted annotation on individual images or the full
+                            dataset.
+                        </p>
+                    </div>
                 {:else}
                     <ul class="divide-y divide-border">
                         {#each applicableOperators as operator}
@@ -160,6 +168,16 @@
                     {/if}
                 {/if}
             </div>
+            <Dialog.Footer class="px-4 pb-4">
+                <a
+                    href="https://docs.lightly.ai/studio/concepts_and_tools/plugins/"
+                    target="_blank"
+                    rel="noreferrer"
+                    class="mr-auto self-center text-xs text-muted-foreground underline-offset-4 hover:underline"
+                >
+                    Learn more about plugins →
+                </a>
+            </Dialog.Footer>
         </Dialog.Content>
     </Dialog.Portal>
 </Dialog.Root>


### PR DESCRIPTION
## What has changed and why?

- Adds a footer link to the plugin documentation.
- When no plugins are available, a descriptive paragraph explains what plugins are for.

<img width="646" height="351" alt="Screenshot 2026-06-09 at 10 48 08" src="https://github.com/user-attachments/assets/9d987634-d4a6-46ee-af08-4719c1ed573b" />

## How has it been tested?

Manual test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the empty-plugins UI: expanded a single-line notice into a multi-paragraph explanation outlining plugin customization and example capabilities (data import/export, model-assisted annotation, workflow automation).
  * Added a prominent "Learn more about plugins" external documentation link in the operators dialog footer for quick access to plugin guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->