### PR TITLE
Reorder quickstart examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,88 @@ LightlyStudio is a browser app that runs on your own computer. Use it in two sim
 Get started with one of these example workflows:
 
 <details open>
+<summary><strong>Evaluate object detection predictions on a COCO dataset</strong></summary>
+
+Create a file named `example_coco_od_evaluation.py`:
+
+```python
+import lightly_studio as ls
+from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
+from lightly_studio.evaluation.image_dataset_evaluate import ObjectDetectionEvaluationConfig
+
+
+# Download the example dataset (will be skipped if it already exists)
+dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
+
+images_path = f"{dataset_path}/coco_subset_128_images/images"
+evaluation_config = ObjectDetectionEvaluationConfig(
+    iou_threshold=0.5,
+    classwise=True,
+)
+
+dataset = ls.ImageDataset.load_or_create()
+dataset.add_images_from_path(path=images_path)
+# Add ground truth annotations
+dataset.add_annotations_from_coco(
+    annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
+    images_root=images_path,
+    annotation_source="ground_truth",
+)
+# Add predictions annotations
+dataset.add_annotations_from_coco(
+    annotations_json=f"{dataset_path}/coco_subset_128_images/predictions_train2017.json",
+    images_root=images_path,
+    annotation_source="predictions",
+)
+# Optional: tag a subset of samples to run the evaluation on.
+dataset.query()[:10].add_tag("evaluated_samples")
+# Create query for tagged samples
+tagged_evaluation_query = dataset.query().match(ImageSampleField.tags.contains("evaluated_samples"))
+
+dataset.evaluate(query=tagged_evaluation_query).object_detection(
+    name="od_evaluation",
+    gt_annotation_source="ground_truth",
+    pred_annotation_source="predictions",
+    config=evaluation_config,
+)
+
+ls.start_gui()
+```
+</details>
+
+<details>
+<summary><strong>Index a COCO dataset</strong></summary>
+
+Create a file named `example_coco.py`:
+
+```python
+import lightly_studio as ls
+
+# Download the example dataset (will be skipped if it already exists)
+dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
+
+dataset = ls.ImageDataset.load_or_create()
+dataset.add_samples_from_coco(
+    annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
+    images_path=f"{dataset_path}/coco_subset_128_images/images",
+)
+# Optional: tag a subset of samples to filter them in the GUI. 
+dataset.query()[:10].add_tag("sample_subset")
+
+ls.start_gui()
+```
+
+Run `python example_coco.py` and open the printed URL to inspect images with their annotations.
+
+To import COCO segmentation masks instead of object detections, set:
+
+```python
+annotation_type=ls.AnnotationType.SEGMENTATION_MASK
+```
+
+</details>
+
+<details>
 <summary><strong>Index a YOLO dataset</strong></summary>
 
 Create a file named `example_yolo.py`:
@@ -122,36 +204,6 @@ ls.start_gui()
 ```
 
 Run `python example_yolo.py` and open the printed URL to inspect images with their annotations.
-
-</details>
-
-<details>
-<summary><strong>Index a COCO dataset</strong></summary>
-
-Create a file named `example_coco.py`:
-
-```python
-import lightly_studio as ls
-
-# Download the example dataset (will be skipped if it already exists)
-dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
-
-dataset = ls.ImageDataset.load_or_create()
-dataset.add_samples_from_coco(
-    annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
-    images_path=f"{dataset_path}/coco_subset_128_images/images",
-)
-
-ls.start_gui()
-```
-
-Run `python example_coco.py` and open the printed URL to inspect images with their annotations.
-
-To import COCO segmentation masks instead of object detections, set:
-
-```python
-annotation_type=ls.AnnotationType.SEGMENTATION_MASK
-```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -103,32 +103,6 @@ LightlyStudio is a browser app that runs on your own computer. Use it in two sim
 Get started with one of these example workflows:
 
 <details open>
-<summary><strong>Index a folder of images for curation and labeling</strong></summary>
-
-Create a file named `example_image.py`:
-
-```python
-import lightly_studio as ls
-
-# Download the example dataset (will be skipped if it already exists)
-dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
-
-# Index the images, create embeddings, and store everything in the local database.
-dataset = ls.ImageDataset.load_or_create()
-dataset.add_images_from_path(
-    path=f"{dataset_path}/coco_subset_128_images/images",
-)
-
-# Start the UI server on localhost:8001.
-# Pass `host` and `port` parameters to customize it.
-ls.start_gui()
-```
-
-Run `python example_image.py` and open the printed URL in your browser.
-
-</details>
-
-<details>
 <summary><strong>Index a YOLO dataset</strong></summary>
 
 Create a file named `example_yolo.py`:
@@ -212,6 +186,31 @@ from google.colab import output
 
 output.serve_kernel_port_as_iframe(server.port, width=1000, height=800)
 ```
+</details>
+
+<details>
+<summary><strong>Index a folder of images for curation and labeling</strong></summary>
+
+Create a file named `example_image.py`:
+
+```python
+import lightly_studio as ls
+
+# Download the example dataset (will be skipped if it already exists)
+dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
+
+# Index the images, create embeddings, and store everything in the local database.
+dataset = ls.ImageDataset.load_or_create()
+dataset.add_images_from_path(
+    path=f"{dataset_path}/coco_subset_128_images/images",
+)
+
+# Start the UI server on localhost:8001.
+# Pass `host` and `port` parameters to customize it.
+ls.start_gui()
+```
+
+Run `python example_image.py` and open the printed URL in your browser.
 
 </details>
 

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -59,7 +59,7 @@ The library is OS-independent and works on Windows, Linux, and macOS.
 The examples below download the required example data the first time you run them. You can also
 directly use your own image, video, or YOLO/COCO dataset.
 
-=== "COCO Segmentation Mask"
+=== "COCO Object Detection"
 
     1. Create a file named `example_coco.py` with the following contents:
 
@@ -73,7 +73,6 @@ directly use your own image, video, or YOLO/COCO dataset.
         dataset.add_samples_from_coco(
             annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
             images_path=f"{dataset_path}/coco_subset_128_images/images",
-            annotation_type=ls.AnnotationType.SEGMENTATION_MASK,
         )
         # Optional: tag a subset of samples to filter them in the GUI. 
         dataset.query()[:10].add_tag("sample_subset")

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -59,6 +59,50 @@ The library is OS-independent and works on Windows, Linux, and macOS.
 The examples below download the required example data the first time you run them. You can also
 directly use your own image, video, or YOLO/COCO dataset.
 
+=== "YOLO Object Detection"
+
+    1. Create a file named `example_yolo.py` with the following contents:
+
+        ```python title="example_yolo.py"
+        import lightly_studio as ls
+
+        # Download the example dataset (will be skipped if it already exists)
+        dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
+
+        dataset = ls.ImageDataset.load_or_create()
+        dataset.add_samples_from_yolo(
+            data_yaml=f"{dataset_path}/road_signs_yolo/data.yaml",
+        )
+
+        ls.start_gui()
+        ```
+
+    1. Run `python example_yolo.py` in your terminal.
+    1. Click on the printed URL to open the app in your browser.
+
+=== "COCO Segmentation Mask"
+
+    1. Create a file named `example_coco.py` with the following contents:
+
+        ```python title="example_coco.py"
+        import lightly_studio as ls
+
+        # Download the example dataset (will be skipped if it already exists)
+        dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
+
+        dataset = ls.ImageDataset.load_or_create()
+        dataset.add_samples_from_coco(
+            annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
+            images_path=f"{dataset_path}/coco_subset_128_images/images",
+            annotation_type=ls.AnnotationType.SEGMENTATION_MASK,
+        )
+
+        ls.start_gui()
+        ```
+
+    1. Run `python example_coco.py` in your terminal.
+    1. Click on the printed URL to open the app in your browser.
+
 === "Image Folder"
 
     1. Create a file named `example_image.py` with the following contents:
@@ -102,50 +146,6 @@ directly use your own image, video, or YOLO/COCO dataset.
         ```
 
     1. Run `python example_video.py` in your terminal.
-    1. Click on the printed URL to open the app in your browser.
-
-=== "YOLO Object Detection"
-
-    1. Create a file named `example_yolo.py` with the following contents:
-
-        ```python title="example_yolo.py"
-        import lightly_studio as ls
-
-        # Download the example dataset (will be skipped if it already exists)
-        dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
-
-        dataset = ls.ImageDataset.load_or_create()
-        dataset.add_samples_from_yolo(
-            data_yaml=f"{dataset_path}/road_signs_yolo/data.yaml",
-        )
-
-        ls.start_gui()
-        ```
-
-    1. Run `python example_yolo.py` in your terminal.
-    1. Click on the printed URL to open the app in your browser.
-
-=== "COCO Segmentation Mask"
-
-    1. Create a file named `example_coco.py` with the following contents:
-
-        ```python title="example_coco.py"
-        import lightly_studio as ls
-
-        # Download the example dataset (will be skipped if it already exists)
-        dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
-
-        dataset = ls.ImageDataset.load_or_create()
-        dataset.add_samples_from_coco(
-            annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
-            images_path=f"{dataset_path}/coco_subset_128_images/images",
-            annotation_type=ls.AnnotationType.SEGMENTATION_MASK,
-        )
-
-        ls.start_gui()
-        ```
-
-    1. Run `python example_coco.py` in your terminal.
     1. Click on the printed URL to open the app in your browser.
 
 !!! tip

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -59,6 +59,31 @@ The library is OS-independent and works on Windows, Linux, and macOS.
 The examples below download the required example data the first time you run them. You can also
 directly use your own image, video, or YOLO/COCO dataset.
 
+=== "COCO Segmentation Mask"
+
+    1. Create a file named `example_coco.py` with the following contents:
+
+        ```python title="example_coco.py"
+        import lightly_studio as ls
+
+        # Download the example dataset (will be skipped if it already exists)
+        dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
+
+        dataset = ls.ImageDataset.load_or_create()
+        dataset.add_samples_from_coco(
+            annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
+            images_path=f"{dataset_path}/coco_subset_128_images/images",
+            annotation_type=ls.AnnotationType.SEGMENTATION_MASK,
+        )
+        # Optional: tag a subset of samples to filter them in the GUI. 
+        dataset.query()[:10].add_tag("sample_subset")
+
+        ls.start_gui()
+        ```
+
+    1. Run `python example_coco.py` in your terminal.
+    1. Click on the printed URL to open the app in your browser.
+
 === "YOLO Object Detection"
 
     1. Create a file named `example_yolo.py` with the following contents:
@@ -78,29 +103,6 @@ directly use your own image, video, or YOLO/COCO dataset.
         ```
 
     1. Run `python example_yolo.py` in your terminal.
-    1. Click on the printed URL to open the app in your browser.
-
-=== "COCO Segmentation Mask"
-
-    1. Create a file named `example_coco.py` with the following contents:
-
-        ```python title="example_coco.py"
-        import lightly_studio as ls
-
-        # Download the example dataset (will be skipped if it already exists)
-        dataset_path = ls.utils.download_example_dataset(download_dir="dataset_examples")
-
-        dataset = ls.ImageDataset.load_or_create()
-        dataset.add_samples_from_coco(
-            annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
-            images_path=f"{dataset_path}/coco_subset_128_images/images",
-            annotation_type=ls.AnnotationType.SEGMENTATION_MASK,
-        )
-
-        ls.start_gui()
-        ```
-
-    1. Run `python example_coco.py` in your terminal.
     1. Click on the printed URL to open the app in your browser.
 
 === "Image Folder"


### PR DESCRIPTION
## What has changed and why?

Reorder quickstart examples so the user's first contact will be a annotated dataset. 

## How has it been tested?
<img width="1250" height="924" alt="image" src="https://github.com/user-attachments/assets/ed402c6d-4826-40d7-9d43-85e3f781bc80" />
<img width="985" height="1123" alt="image" src="https://github.com/user-attachments/assets/b8560a42-d54f-44f6-a5fa-6f714e3f88e6" />




## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized Quickstart examples for clearer flow; COCO object-detection placed first, YOLO second, image-folder moved after notebooks
  * Made COCO evaluation the initially highlighted workflow
  * Separated image-folder workflow into its own section with runnable instructions
  * Updated indexing examples and added an optional GUI tagging step for initial samples
  * Standardized Python snippet formatting and adjusted ordering of “run / click URL” steps across examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->