### PR TITLE
Always show selection checkbox on grid items

### DIFF
--- a/lightly_studio_view/src/lib/components/GridItem/GridItemTag.svelte
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItemTag.svelte
@@ -7,7 +7,7 @@
 
     const { user } = useAuth();
 
-    const shouldRenderTag = $derived(isSelected && hasMinimumRole(user?.role, 'labeler'));
+    const shouldRenderTag = $derived(hasMinimumRole(user?.role, 'labeler'));
 </script>
 
 {#if shouldRenderTag}
@@ -16,6 +16,6 @@
         data-testid="grid-item-tag"
         inert
     >
-        <SelectableBox onSelect={() => undefined} isSelected={true} />
+        <SelectableBox onSelect={() => undefined} {isSelected} />
     </div>
 {/if}

--- a/lightly_studio_view/src/lib/components/GridItem/GridItemTag.test.ts
+++ b/lightly_studio_view/src/lib/components/GridItem/GridItemTag.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import GridItemTag from './GridItemTag.svelte';
+import * as useAuthModule from '$lib/hooks/useAuth/useAuth';
+
+vi.mock('$lib/hooks/useAuth/useAuth');
+
+const defaultProps = { isSelected: false };
+
+describe('GridItemTag', () => {
+    it('shows checkbox for unselected item when user has labeler role', () => {
+        vi.mocked(useAuthModule.default).mockReturnValue({
+            user: { role: 'labeler', email: 'labeler@example.com', username: 'labeler' },
+            token: 'mock-token',
+            isAuthenticated: true
+        });
+
+        render(GridItemTag, { props: defaultProps });
+
+        expect(screen.getByTestId('grid-item-tag')).toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).not.toBeChecked();
+    });
+
+    it('shows checked checkbox for selected item when user has labeler role', () => {
+        vi.mocked(useAuthModule.default).mockReturnValue({
+            user: { role: 'labeler', email: 'labeler@example.com', username: 'labeler' },
+            token: 'mock-token',
+            isAuthenticated: true
+        });
+
+        render(GridItemTag, { props: { ...defaultProps, isSelected: true } });
+
+        expect(screen.getByTestId('grid-item-tag')).toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('does not show checkbox for viewer role', () => {
+        vi.mocked(useAuthModule.default).mockReturnValue({
+            user: { role: 'viewer', email: 'viewer@example.com', username: 'viewer' },
+            token: 'mock-token',
+            isAuthenticated: true
+        });
+
+        render(GridItemTag, { props: defaultProps });
+
+        expect(screen.queryByTestId('grid-item-tag')).not.toBeInTheDocument();
+    });
+
+    it('shows checkbox in OSS mode (no role)', () => {
+        vi.mocked(useAuthModule.default).mockReturnValue({
+            user: undefined,
+            token: undefined,
+            isAuthenticated: false
+        });
+
+        render(GridItemTag, { props: defaultProps });
+
+        expect(screen.getByTestId('grid-item-tag')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## What has changed and why?

The checkbox is always rendered for labelers, showing an unchecked state on unselected items.

<img width="1524" height="527" alt="Screenshot 2026-06-10 at 09 30 40" src="https://github.com/user-attachments/assets/bcf74984-a4f0-4bf6-bb56-d32116bdff66" />

## How has it been tested?

Manual test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tag visibility now correctly follows role-based permissions for authenticated users.
  * Selection state is accurately reflected in tag visuals.

* **Tests**
  * Added tests covering tag rendering and selection behavior across authentication roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->