### PR TITLE
Display confidence in annotation detail panel

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationMetadata/AnnotationMetadata.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationMetadata/AnnotationMetadata.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import Segment from '$lib/components/Segment/Segment.svelte';
     import { isClassificationAnnotation } from '$lib/services/types';
-    import { formatInteger } from '$lib/utils';
+    import { formatConfidence, formatInteger } from '$lib/utils';
     import { getBoundingBox } from '$lib/components/SampleAnnotation/utils';
     import { ANNOTATION_TYPES } from '$lib/constants';
     import { page } from '$app/state';
@@ -52,6 +52,18 @@
                     value: formatInteger(Math.round(width)) + 'px'
                 },
                 ...annotationsMetadata
+            ];
+        }
+
+        const formattedConfidence = formatConfidence(annotation.confidence);
+        if (formattedConfidence != null) {
+            annotationsMetadata = [
+                ...annotationsMetadata,
+                {
+                    id: 'confidence',
+                    label: 'Confidence:',
+                    value: formattedConfidence
+                }
             ];
         }
 


### PR DESCRIPTION
## What has changed and why?

Shows the annotation's confidence value in the annotation detail metadata panel.

## How has it been tested?

Manually verified in the annotation detail panel; `formatConfidence` is covered by existing unit tests.

<img width="1140" height="731" alt="Screenshot 2026-06-10 at 14 46 14" src="https://github.com/user-attachments/assets/72ce7eb9-fb68-4b8a-ae6a-d3eadbae4d86" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Annotation details panel now displays confidence scores for annotations when available, providing users with additional quality metrics alongside existing metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->