### PR TITLE
Add CI for docs build

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -174,3 +174,35 @@ jobs:
         env:
           UV_PYTHON: ${{ matrix.python }}
         run: make test
+
+  check-docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      # Authenticate to download dev versions of lightly-mundig.
+      - name: Authenticate with GCP
+        uses: 'google-github-actions/auth@v3'
+        with:
+          project_id: boris-250909
+          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
+
+      - name: Set Up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.8.17"
+          enable-cache: true
+
+      - name: Set Up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.9"
+
+      # `make docs` checks broken links.
+      - name: Build docs
+        working-directory: lightly_studio/docs
+        run: make docs

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -202,6 +202,12 @@ jobs:
         with:
           python-version: "3.9"
 
+      # Installs the Artifact Registry keyring so uv can sync lightly-mundig
+      # even when it is pinned to an internal (non-public) version.
+      - name: Install LightlyStudio dependencies
+        working-directory: lightly_studio
+        run: make install-optional-deps
+
       # `make docs` checks broken links.
       - name: Build docs
         working-directory: lightly_studio/docs

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -202,8 +202,7 @@ jobs:
         with:
           python-version: "3.9"
 
-      # Installs the Artifact Registry keyring so uv can sync lightly-mundig
-      # even when it is pinned to an internal (non-public) version.
+      # Installs keyring to download dev versions of lightly-mundig.
       - name: Install LightlyStudio dependencies
         working-directory: lightly_studio
         run: make install-optional-deps

--- a/lightly_studio/docs/Makefile
+++ b/lightly_studio/docs/Makefile
@@ -1,10 +1,12 @@
 ### Documentation
 
 # Build docs for the current version.
+# `--strict` turns the validation warnings configured in mkdocs.yml (broken
+# anchors/links, pages missing from nav) into build errors.
 .PHONY: docs
 docs:
 	@echo "📚 Building documentation..."
-	uv run --group=docs mkdocs build --clean
+	uv run --group=docs mkdocs build --clean --strict
 
 .PHONY: serve
 serve:

--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -1,5 +1,0 @@
-# Embeddings
-
-Embeddings are vector representations of your samples computed by a neural network. Embeddings are visualized in the UI, and they power advanced features like similarity search, sampling or few-shot classification. LightlyStudio automatically embeds samples when they are added to a dataset. 
-
-More details on how to work with embeddings will be added soon.

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -79,9 +79,7 @@ nav:
       - AWS S3: enterprise/cloud_storage/aws.md
 
 # Promote link/nav checks from INFO to WARNING so that `mkdocs build --strict`
-# turns them into build errors (see the Makefile `docs` target). This prevents
-# broken anchors, broken links, and pages missing from the nav from being
-# added accidentally.
+# turns them into build errors (see the Makefile `docs` target).
 validation:
   omitted_files: warn
   absolute_links: warn

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -78,6 +78,19 @@ nav:
       - enterprise/cloud_storage/index.md
       - AWS S3: enterprise/cloud_storage/aws.md
 
+# Promote link/nav checks from INFO to WARNING so that `mkdocs build --strict`
+# turns them into build errors (see the Makefile `docs` target). This prevents
+# broken anchors, broken links, and pages missing from the nav from being
+# added accidentally.
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+  nav:
+    omitted_files: warn
+    not_found: warn
+
 extra_css:
   - _static/custom.css
 


### PR DESCRIPTION
## What has changed and why?

Add a CI job inside the `test_and_release.yml`.

The job checks that the docs do not have any broken anchors, broken links, or pages missing from the navigation.

## How has it been tested?

* The CI failed with an unlinked page
* Locally `make docs` fails on broken link

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Stricter site validation: link, anchor and navigation issues now fail documentation builds to catch broken or missing pages.
  * The embeddings documentation page content was removed/cleared; site navigation may reflect that change.

* **Chores**
  * Automated documentation build and validation added to CI to ensure docs integrity before release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->