### PR TITLE
Add confidence and annotations source fields to the Langium grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - When sorting the image grid by a numeric field, the field value is now shown as an overlay on each sample.
-- Query editor now supports annotation `source` and `confidence` fields in queries.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - When sorting the image grid by a numeric field, the field value is now shown as an overlay on each sample.
+- Query editor now supports annotation `source` and `confidence` fields in queries.
 
 ### Changed
 

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query-schema.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query-schema.ts
@@ -65,6 +65,16 @@ export const SCOPES: Record<Scope, ScopeDoc> = {
                 type: 'string',
                 description: 'Annotation class of the detection.'
             },
+            {
+                name: 'source',
+                type: 'string',
+                description: 'Annotation source collection name.'
+            },
+            {
+                name: 'confidence',
+                type: 'float',
+                description: 'Detection confidence score.'
+            },
             { name: 'x', type: 'int', description: 'Top-left X coordinate of the bounding box.' },
             { name: 'y', type: 'int', description: 'Top-left Y coordinate of the bounding box.' },
             { name: 'width', type: 'int', description: 'Bounding box width in pixels.' },
@@ -80,6 +90,16 @@ export const SCOPES: Record<Scope, ScopeDoc> = {
                 name: 'class_name',
                 type: 'string',
                 description: 'Annotation class of the classification.'
+            },
+            {
+                name: 'source',
+                type: 'string',
+                description: 'Annotation source collection name.'
+            },
+            {
+                name: 'confidence',
+                type: 'float',
+                description: 'Classification confidence score.'
             }
         ]
     },
@@ -93,6 +113,16 @@ export const SCOPES: Record<Scope, ScopeDoc> = {
                 name: 'class_name',
                 type: 'string',
                 description: 'Annotation class of the segmentation mask.'
+            },
+            {
+                name: 'source',
+                type: 'string',
+                description: 'Annotation source collection name.'
+            },
+            {
+                name: 'confidence',
+                type: 'float',
+                description: 'Segmentation confidence score.'
             },
             { name: 'x', type: 'int', description: 'Top-left X coordinate of the mask bounds.' },
             { name: 'y', type: 'int', description: 'Top-left Y coordinate of the mask bounds.' },
@@ -120,7 +150,7 @@ export const TOP_LEVEL_KEYWORDS: KeywordDoc[] = [
     {
         name: 'object_detection',
         description: 'Filter on detections inside an image.',
-        insertText: 'object_detection(${1:condition})'
+        insertText: 'object_detection(${1:class_name = "..."})'
     },
     {
         name: 'classification',

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
@@ -99,10 +99,14 @@ ObjectDetectionUnary returns Expression:
 
 ObjectDetectionComparison returns ComparisonExpression:
   ObjectDetectionIntFieldReference {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=IntLiteral
+   | ObjectDetectionFloatFieldReference {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=NumericLiteral
    | ObjectDetectionStringFieldReference {ComparisonExpression.left=current} operator=('=' | '!=') right=StringLiteral;
 
 ObjectDetectionIntFieldReference returns FieldReference:
   {FieldReference} member=ObjectDetectionIntFieldName;
+
+ObjectDetectionFloatFieldReference returns FieldReference:
+  {FieldReference} member=ObjectDetectionFloatFieldName;
 
 ObjectDetectionStringFieldReference returns FieldReference:
   {FieldReference} member=ObjectDetectionStringFieldName;
@@ -122,10 +126,14 @@ ClassificationUnary returns Expression:
     | ClassificationComparison;
 
 ClassificationComparison returns ComparisonExpression:
-  ClassificationFieldReference {ComparisonExpression.left=current} operator=('=' | '!=') right=StringLiteral;
+  ClassificationFieldReference {ComparisonExpression.left=current} operator=('=' | '!=') right=StringLiteral
+   | ClassificationFloatFieldReference {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=NumericLiteral;
 
 ClassificationFieldReference returns Expression:
   {FieldReference} member=CLASS_NAME;
+
+ClassificationFloatFieldReference returns FieldReference:
+  {FieldReference} member=ClassificationFloatFieldName;
 
 SegmentationMask returns Expression:
   SegmentationMaskOr;
@@ -143,10 +151,14 @@ SegmentationMaskUnary returns Expression:
 
 SegmentationMaskComparison returns ComparisonExpression:
   SegmentationMaskIntFieldReference {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=IntLiteral
+   | SegmentationMaskFloatFieldReference {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=NumericLiteral
    | SegmentationMaskStringFieldReference {ComparisonExpression.left=current} operator=('=' | '!=') right=StringLiteral;
 
 SegmentationMaskIntFieldReference returns FieldReference:
   {FieldReference} member=SegmentationMaskIntFieldName;
+
+SegmentationMaskFloatFieldReference returns FieldReference:
+  {FieldReference} member=SegmentationMaskFloatFieldName;
 
 SegmentationMaskStringFieldReference returns FieldReference:
   {FieldReference} member=SegmentationMaskStringFieldName;
@@ -164,6 +176,7 @@ terminal WIDTH returns string: /\bwidth\b/;
 terminal CLASS_NAME returns string: /\bclass_name\b/;
 terminal X_COORD returns string: /\bx\b/;
 terminal Y_COORD returns string: /\by\b/;
+terminal CONFIDENCE returns string: /\bconfidence\b/;
 
 ImageIntFieldName returns string:
   HEIGHT | WIDTH;
@@ -189,11 +202,20 @@ VideoStringFieldName returns string:
 ObjectDetectionIntFieldName returns string:
   HEIGHT | WIDTH | X_COORD | Y_COORD;
 
+ObjectDetectionFloatFieldName returns string:
+  CONFIDENCE;
+
 ObjectDetectionStringFieldName returns string:
   CLASS_NAME;
 
+ClassificationFloatFieldName returns string:
+  CONFIDENCE;
+
 SegmentationMaskIntFieldName returns string:
   HEIGHT | WIDTH | X_COORD | Y_COORD;
+
+SegmentationMaskFloatFieldName returns string:
+  CONFIDENCE;
 
 SegmentationMaskStringFieldName returns string:
   CLASS_NAME;

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/lightly-query.langium
@@ -126,11 +126,11 @@ ClassificationUnary returns Expression:
     | ClassificationComparison;
 
 ClassificationComparison returns ComparisonExpression:
-  ClassificationFieldReference {ComparisonExpression.left=current} operator=('=' | '!=') right=StringLiteral
+  ClassificationStringFieldReference {ComparisonExpression.left=current} operator=('=' | '!=') right=StringLiteral
    | ClassificationFloatFieldReference {ComparisonExpression.left=current} operator=('=' | '!=' | '<' | '>' | '<=' | '>=') right=NumericLiteral;
 
-ClassificationFieldReference returns Expression:
-  {FieldReference} member=CLASS_NAME;
+ClassificationStringFieldReference returns FieldReference:
+  {FieldReference} member=ClassificationStringFieldName;
 
 ClassificationFloatFieldReference returns FieldReference:
   {FieldReference} member=ClassificationFloatFieldName;
@@ -174,6 +174,7 @@ TagInExpression returns Expression:
 terminal HEIGHT returns string: /\bheight\b/;
 terminal WIDTH returns string: /\bwidth\b/;
 terminal CLASS_NAME returns string: /\bclass_name\b/;
+terminal SOURCE returns string: /\bsource\b/;
 terminal X_COORD returns string: /\bx\b/;
 terminal Y_COORD returns string: /\by\b/;
 terminal CONFIDENCE returns string: /\bconfidence\b/;
@@ -206,10 +207,13 @@ ObjectDetectionFloatFieldName returns string:
   CONFIDENCE;
 
 ObjectDetectionStringFieldName returns string:
-  CLASS_NAME;
+  CLASS_NAME | SOURCE;
 
 ClassificationFloatFieldName returns string:
   CONFIDENCE;
+
+ClassificationStringFieldName returns string:
+  CLASS_NAME | SOURCE;
 
 SegmentationMaskIntFieldName returns string:
   HEIGHT | WIDTH | X_COORD | Y_COORD;
@@ -218,7 +222,7 @@ SegmentationMaskFloatFieldName returns string:
   CONFIDENCE;
 
 SegmentationMaskStringFieldName returns string:
-  CLASS_NAME;
+  CLASS_NAME | SOURCE;
 
 NumericLiteral returns Expression:
   IntLiteral | FloatLiteral;

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -102,6 +102,13 @@ const int = (table: string, name: string, operator: OrdOp, value: number): Match
     value
 });
 
+const float = (table: string, name: string, operator: OrdOp, value: number): MatchExpr => ({
+    type: 'ordinal_float_expr',
+    field: { table, name },
+    operator,
+    value
+});
+
 const str = (table: string, name: string, operator: EqOp, value: string): MatchExpr => ({
     type: 'string_expr',
     field: { table, name },
@@ -228,6 +235,11 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
         source: 'object_detection(height <= 120)',
         expected: query(objectDetection(int('object_detection', 'height', '<=', 120)))
     },
+    {
+        name: 'object detection confidence greater than',
+        source: 'object_detection(confidence > 0.5)',
+        expected: query(objectDetection(float('object_detection', 'confidence', '>', 0.5)))
+    },
 
     /* Classification expression */
     {
@@ -236,9 +248,19 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
         expected: query(classification(str('classification', 'class_name', '==', 'cat')))
     },
     {
+        name: 'classification confidence greater than',
+        source: 'classification(confidence > 0.9)',
+        expected: query(classification(float('classification', 'confidence', '>', 0.9)))
+    },
+    {
         name: 'segmentation class_name',
         source: 'segmentation_mask(class_name = "cat")',
         expected: query(segmentationMask(str('segmentation_mask', 'class_name', '==', 'cat')))
+    },
+    {
+        name: 'segmentation confidence greater than',
+        source: 'segmentation_mask(confidence > 0.9)',
+        expected: query(segmentationMask(float('segmentation_mask', 'confidence', '>', 0.9)))
     },
     {
         name: 'segmentation x inequality',

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.test.ts
@@ -240,12 +240,22 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
         source: 'object_detection(confidence > 0.5)',
         expected: query(objectDetection(float('object_detection', 'confidence', '>', 0.5)))
     },
+    {
+        name: 'object detection annotation source equality',
+        source: 'object_detection(source = "predictions")',
+        expected: query(objectDetection(str('object_detection', 'source', '==', 'predictions')))
+    },
 
     /* Classification expression */
     {
         name: 'classification class_name',
         source: 'classification(class_name = "cat")',
         expected: query(classification(str('classification', 'class_name', '==', 'cat')))
+    },
+    {
+        name: 'classification annotation source equality',
+        source: 'classification(source = "ground_truth")',
+        expected: query(classification(str('classification', 'source', '==', 'ground_truth')))
     },
     {
         name: 'classification confidence greater than',
@@ -261,6 +271,11 @@ const TRANSLATION_TEST_CASES: TranslationTestCase[] = [
         name: 'segmentation confidence greater than',
         source: 'segmentation_mask(confidence > 0.9)',
         expected: query(segmentationMask(float('segmentation_mask', 'confidence', '>', 0.9)))
+    },
+    {
+        name: 'segmentation annotation source equality',
+        source: 'segmentation_mask(source = "predictions")',
+        expected: query(segmentationMask(str('segmentation_mask', 'source', '==', 'predictions')))
     },
     {
         name: 'segmentation x inequality',

--- a/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/language/query-expr-translation.ts
@@ -18,8 +18,11 @@ import {
     isNumberLiteral,
     isObjectDetectionIntFieldName,
     isObjectDetectionStringFieldName,
+    isObjectDetectionFloatFieldName,
+    isClassificationFloatFieldName,
     isSegmentationMaskIntFieldName,
     isSegmentationMaskStringFieldName,
+    isSegmentationMaskFloatFieldName,
     isStringLiteral,
     isTagInExpression,
     isVideoEqualityFloatFieldName,
@@ -256,6 +259,14 @@ function visitComparisonExpression(
                         value: right.value
                     };
                 }
+                if (isObjectDetectionFloatFieldName(fieldName)) {
+                    return {
+                        type: 'ordinal_float_expr',
+                        field: { table, name: fieldName },
+                        operator: toOrdinalComparisonOperator(expr.operator),
+                        value: right.value
+                    };
+                }
                 break;
             case 'segmentation_mask':
                 if (isSegmentationMaskIntFieldName(fieldName)) {
@@ -266,9 +277,24 @@ function visitComparisonExpression(
                         value: right.value
                     };
                 }
+                if (isSegmentationMaskFloatFieldName(fieldName)) {
+                    return {
+                        type: 'ordinal_float_expr',
+                        field: { table, name: fieldName },
+                        operator: toOrdinalComparisonOperator(expr.operator),
+                        value: right.value
+                    };
+                }
                 break;
             case 'classification':
-                // This is a placeholder in case a field is added later. The code throws later.
+                if (isClassificationFloatFieldName(fieldName)) {
+                    return {
+                        type: 'ordinal_float_expr',
+                        field: { table, name: fieldName },
+                        operator: toOrdinalComparisonOperator(expr.operator),
+                        value: right.value
+                    };
+                }
                 break;
         }
     }

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/completionAdapter/completionAdapterEnrichWithSchemaDocs.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/completionAdapter/completionAdapterEnrichWithSchemaDocs.test.ts
@@ -23,6 +23,25 @@ describe('enrichWithSchemaDocs', () => {
         });
     });
 
+    it('enriches annotation source and confidence fields in annotation scopes', async () => {
+        const { enrichWithSchemaDocs } = await import('./completionAdapterEnrichWithSchemaDocs');
+
+        const sourceResult = enrichWithSchemaDocs({ label: 'source' } as never, 'classification');
+        expect(sourceResult.detail).toBe('Classification.source: string');
+        expect(sourceResult.documentation).toEqual({
+            value: 'Annotation source collection name.'
+        });
+
+        const confidenceResult = enrichWithSchemaDocs(
+            { label: 'confidence' } as never,
+            'object_detection'
+        );
+        expect(confidenceResult.detail).toBe('ObjectDetection.confidence: float');
+        expect(confidenceResult.documentation).toEqual({
+            value: 'Detection confidence score.'
+        });
+    });
+
     it('returns unchanged item for unknown label', async () => {
         const { enrichWithSchemaDocs } = await import('./completionAdapterEnrichWithSchemaDocs');
         const item = { label: 'unknown' };

--- a/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/useSyntaxCompletion.test.ts
+++ b/lightly_studio_view/src/lib/components/QueryEditor/useLightlyQueryLanguage/useSyntaxCompletion.test.ts
@@ -453,6 +453,21 @@ describe('useSyntaxCompletion', () => {
         });
     });
 
+    it('suggests source and confidence in annotation scopes', async () => {
+        const { provideCompletionItems } = await loadAndAttach([]);
+        const result = await provideCompletionItems(
+            makeModel('object_detection(') as never,
+            { lineNumber: 1, column: 18 } as never
+        );
+
+        const labels = result.suggestions.map((suggestion) =>
+            typeof suggestion.label === 'string' ? suggestion.label : suggestion.label.label
+        );
+
+        expect(labels).toContain('source');
+        expect(labels).toContain('confidence');
+    });
+
     it('resolves field scope from cursor context (segmentation_mask)', async () => {
         const { provideCompletionItems } = await loadAndAttach([
             { label: 'class_name', kind: LspCompletionItemKind.Field }


### PR DESCRIPTION
## What has changed and why?
These fields are needed for model evaluation.

Note that this is not yet plugged to the backend. Adding these fields to the query changes nothing.

## How has it been tested?
Ran query editor locally

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query editor now supports `source` and `confidence` annotation fields across object detection, classification, and segmentation mask scopes.

* **Tests**
  * Added test coverage for new annotation fields and syntax completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->