### PR TITLE
Add AnnotationSourceField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Show plugin description and a link to documentation when no plugins are available.
 - When sorting the image grid by a numeric field, the field value is now shown as an overlay on each sample.
-- Query editor now supports annotation `source` and `confidence` fields in queries.
+- Query editor now supports annotation `source` field in queries.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Show plugin description and a link to documentation when no plugins are available.
 - When sorting the image grid by a numeric field, the field value is now shown as an overlay on each sample.
+- Query editor now supports annotation `source` and `confidence` fields in queries.
 
 ### Changed
 

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_expression.py
@@ -17,8 +17,6 @@ from lightly_studio.models.sample import SampleTable
 T = TypeVar("T")
 
 
-# Ignore PLW1641 because `==` and `!=` create query conditions here, so these
-# classes do not need normal hash behavior.
 @dataclass
 class RelationshipMatchExpression(MatchExpression, Generic[T]):
     """Evaluates a match expression against a related table using the SQLAlchemy `.has()` operator.
@@ -57,10 +55,10 @@ class RelationshipMatchExpression(MatchExpression, Generic[T]):
         return self.relationship.has(self.criterion.get())
 
 
-class AnnotationSourceField:
+# Ignore PLW1641 because `==` and `!=` create query conditions here, so these
+# classes do not need normal hash behavior.
+class AnnotationSourceField:  # noqa: PLW1641
     """Queryable annotation source field."""
-
-    __hash__ = object.__hash__
 
     def __eq__(self, other: str) -> MatchExpression:  # type: ignore[override]
         """Return a match expression for a source name equality check."""

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_expression.py
@@ -7,8 +7,12 @@ from typing import Generic, TypeVar
 
 from sqlalchemy import ColumnElement
 from sqlalchemy.orm import Mapped
+from sqlmodel import col
 
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.sample import SampleTable
 
 T = TypeVar("T")
 
@@ -51,3 +55,32 @@ class RelationshipMatchExpression(MatchExpression, Generic[T]):
     def get(self) -> ColumnElement[bool]:
         """Get the relationship match expression."""
         return self.relationship.has(self.criterion.get())
+
+
+class AnnotationSourceField:
+    """Queryable annotation source field."""
+
+    __hash__ = object.__hash__
+
+    def __eq__(self, other: str) -> MatchExpression:  # type: ignore[override]
+        """Return a match expression for a source name equality check."""
+        return AnnotationSourceMatchExpression(source_name=other)
+
+    def __ne__(self, other: str) -> MatchExpression:  # type: ignore[override]
+        """Return a match expression for a source name inequality check."""
+        return AnnotationSourceMatchExpression(source_name=other, negate=True)
+
+
+@dataclass
+class AnnotationSourceMatchExpression(MatchExpression):
+    """Evaluates an annotation source comparison against the owning collection."""
+
+    source_name: str
+    negate: bool = False
+
+    def get(self) -> ColumnElement[bool]:
+        """Get the annotation source match expression."""
+        expr = AnnotationBaseTable.sample.has(
+            SampleTable.collection.has(col(CollectionTable.name) == self.source_name)
+        )
+        return ~expr if self.negate else expr

--- a/lightly_studio/src/lightly_studio/core/dataset_query/classification_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/classification_expression.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from sqlalchemy import ColumnElement, and_
 from sqlmodel import col
 
+from lightly_studio.core.dataset_query.annotation_expression import AnnotationSourceField
 from lightly_studio.core.dataset_query.boolean_expression import AND
 from lightly_studio.core.dataset_query.foreign_field import ForeignComparableField
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
@@ -25,6 +26,7 @@ class ClassificationField:
         column=col(AnnotationLabelTable.annotation_label_name),
         relationship=AnnotationBaseTable.annotation_label,
     )
+    source = AnnotationSourceField()
 
 
 class ClassificationQuery:

--- a/lightly_studio/src/lightly_studio/core/dataset_query/object_detection_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/object_detection_expression.py
@@ -9,6 +9,7 @@ from sqlalchemy import ColumnElement, and_
 from sqlmodel import col
 from typing_extensions import TypeVar
 
+from lightly_studio.core.dataset_query.annotation_expression import AnnotationSourceField
 from lightly_studio.core.dataset_query.boolean_expression import AND
 from lightly_studio.core.dataset_query.foreign_field import (
     ForeignComparableField,
@@ -49,6 +50,7 @@ class ObjectDetectionField:
         column=col(AnnotationLabelTable.annotation_label_name),
         relationship=AnnotationBaseTable.annotation_label,
     )
+    source = AnnotationSourceField()
     # TODO(lukas, 4/2026): add confidence
 
 

--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -92,8 +92,11 @@ _STRING_FIELDS: dict[tuple[str, str], _EqualityField[str]] = {
     ("video", "file_name"): VideoSampleField.file_name,
     ("video", "file_path_abs"): VideoSampleField.file_path_abs,
     ("classification", "class_name"): ClassificationField.class_name,
+    ("classification", "source"): ClassificationField.source,
     ("object_detection", "class_name"): ObjectDetectionField.class_name,
+    ("object_detection", "source"): ObjectDetectionField.source,
     ("segmentation_mask", "class_name"): SegmentationMaskField.class_name,
+    ("segmentation_mask", "source"): SegmentationMaskField.source,
 }
 
 _INTEGER_FIELDS: dict[tuple[str, str], _OrdinalField[int]] = {

--- a/lightly_studio/src/lightly_studio/core/dataset_query/segmentation_mask_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/segmentation_mask_expression.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from sqlalchemy import ColumnElement, and_
 from sqlmodel import col
 
+from lightly_studio.core.dataset_query.annotation_expression import AnnotationSourceField
 from lightly_studio.core.dataset_query.boolean_expression import AND
 from lightly_studio.core.dataset_query.foreign_field import (
     ForeignComparableField,
@@ -45,6 +46,7 @@ class SegmentationMaskField:
         column=col(AnnotationLabelTable.annotation_label_name),
         relationship=AnnotationBaseTable.annotation_label,
     )
+    source = AnnotationSourceField()
 
 
 class SegmentationMaskQuery:

--- a/lightly_studio/src/lightly_studio/models/collection.py
+++ b/lightly_studio/src/lightly_studio/models/collection.py
@@ -57,10 +57,6 @@ class CollectionTable(CollectionBase, table=True):
         back_populates="parent",
         sa_relationship_kwargs={"lazy": "select"},
     )
-    samples: list["SampleTable"] = Relationship(
-        back_populates="collection",
-        sa_relationship_kwargs={"lazy": "select"},
-    )
     # TODO(lukas, 3/2026): add a relationship to DatasetTable
 
 
@@ -117,6 +113,3 @@ class AnnotationCollectionView(SQLModel):
 
     collection_id: UUID
     name: str
-
-
-from lightly_studio.models.sample import SampleTable  # noqa: E402

--- a/lightly_studio/src/lightly_studio/models/collection.py
+++ b/lightly_studio/src/lightly_studio/models/collection.py
@@ -57,6 +57,10 @@ class CollectionTable(CollectionBase, table=True):
         back_populates="parent",
         sa_relationship_kwargs={"lazy": "select"},
     )
+    samples: list["SampleTable"] = Relationship(
+        back_populates="collection",
+        sa_relationship_kwargs={"lazy": "select"},
+    )
     # TODO(lukas, 3/2026): add a relationship to DatasetTable
 
 
@@ -113,3 +117,6 @@ class AnnotationCollectionView(SQLModel):
 
     collection_id: UUID
     name: str
+
+
+from lightly_studio.models.sample import SampleTable  # noqa: E402

--- a/lightly_studio/src/lightly_studio/models/sample.py
+++ b/lightly_studio/src/lightly_studio/models/sample.py
@@ -53,8 +53,10 @@ class SampleTable(SampleBase, table=True):
         },
     )
     collection: Mapped["CollectionTable"] = Relationship(
-        back_populates="samples",
-        sa_relationship_kwargs={"lazy": "select"},
+        sa_relationship_kwargs={
+            "lazy": "select",
+            "foreign_keys": "[SampleTable.collection_id]",
+        },
     )
     captions: Mapped[list["CaptionTable"]] = Relationship(
         back_populates="parent_sample",

--- a/lightly_studio/src/lightly_studio/models/sample.py
+++ b/lightly_studio/src/lightly_studio/models/sample.py
@@ -52,6 +52,10 @@ class SampleTable(SampleBase, table=True):
             "foreign_keys": "[AnnotationBaseTable.parent_sample_id]",
         },
     )
+    collection: Mapped["CollectionTable"] = Relationship(
+        back_populates="samples",
+        sa_relationship_kwargs={"lazy": "select"},
+    )
     captions: Mapped[list["CaptionTable"]] = Relationship(
         back_populates="parent_sample",
         sa_relationship_kwargs={
@@ -142,6 +146,7 @@ from lightly_studio.models.annotation.annotation_base import (  # noqa: E402
     AnnotationView,
 )
 from lightly_studio.models.caption import CaptionTable, CaptionView  # noqa: E402
+from lightly_studio.models.collection import CollectionTable  # noqa: E402
 from lightly_studio.models.metadata import (  # noqa: E402
     SampleMetadataTable,
     SampleMetadataView,

--- a/lightly_studio/tests/core/dataset_query/test_query_translation.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation.py
@@ -205,6 +205,18 @@ def test_to_match_expression__classification_match() -> None:
     assert "annotation_label_name = 'cat'" in sql
 
 
+def test_to_match_expression__classification_source() -> None:
+    expr = ClassificationMatchExpr(
+        subexpr=StringExpr(
+            field=FieldRef(table="classification", name="source"),
+            operator=EqualityComparisonOperator.EQ,
+            value="ground_truth",
+        )
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "collection.name = 'ground_truth'" in sql
+
+
 def test_to_match_expression__object_detection_match() -> None:
     subexpr = IntegerExpr(
         field=FieldRef(table="object_detection", name="width"),
@@ -218,6 +230,18 @@ def test_to_match_expression__object_detection_match() -> None:
     assert "object_detection_annotation.width > 50" in sql
 
 
+def test_to_match_expression__object_detection_source() -> None:
+    expr = ObjectDetectionMatchExpr(
+        subexpr=StringExpr(
+            field=FieldRef(table="object_detection", name="source"),
+            operator=EqualityComparisonOperator.EQ,
+            value="predictions",
+        )
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "collection.name = 'predictions'" in sql
+
+
 def test_to_match_expression__segmentation_mask_match() -> None:
     subexpr = StringExpr(
         field=FieldRef(table="segmentation_mask", name="class_name"),
@@ -229,6 +253,18 @@ def test_to_match_expression__segmentation_mask_match() -> None:
     assert "exists" in sql
     assert "annotation_type = 'segmentation_mask'" in sql
     assert "annotation_label_name = 'person'" in sql
+
+
+def test_to_match_expression__segmentation_mask_source() -> None:
+    expr = SegmentationMaskMatchExpr(
+        subexpr=StringExpr(
+            field=FieldRef(table="segmentation_mask", name="source"),
+            operator=EqualityComparisonOperator.EQ,
+            value="ground_truth",
+        )
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "collection.name = 'ground_truth'" in sql
 
 
 def test_to_match_expression__and() -> None:

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
@@ -156,7 +156,7 @@ def test_to_match_expression__classification_source(db_session: Session) -> None
     dataset = create_collection(session=db_session)
     cid = dataset.collection_id
     image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/cat.jpg")
-    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/dog.jpg")
+    image2 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/dog.jpg")
 
     label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="cat")
     create_annotation(
@@ -166,6 +166,14 @@ def test_to_match_expression__classification_source(db_session: Session) -> None
         annotation_label_id=label.annotation_label_id,
         annotation_type=AnnotationType.CLASSIFICATION,
         annotation_collection_name="ground_truth",
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image2.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_collection_name="predictions",
     )
 
     expr = ClassificationMatchExpr(

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
@@ -152,6 +152,35 @@ def test_to_match_expression__classification_match(db_session: Session) -> None:
     assert [r.sample_id for r in results] == [image1.sample_id]
 
 
+def test_to_match_expression__classification_source(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/cat.jpg")
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/dog.jpg")
+
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="cat")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_collection_name="ground_truth",
+    )
+
+    expr = ClassificationMatchExpr(
+        subexpr=StringExpr(
+            field=FieldRef(table="classification", name="source"),
+            operator=EqualityComparisonOperator.EQ,
+            value="ground_truth",
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [image1.sample_id]
+
+
 def test_to_match_expression__object_detection_match(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     cid = dataset.collection_id
@@ -189,6 +218,36 @@ def test_to_match_expression__object_detection_match(db_session: Session) -> Non
     assert [r.sample_id for r in results] == [image1.sample_id]
 
 
+def test_to_match_expression__object_detection_source(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/1.jpg")
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/2.jpg")
+
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="person")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_collection_name="predictions",
+        annotation_data={"x": 0, "y": 0, "width": 100, "height": 100},
+    )
+
+    expr = ObjectDetectionMatchExpr(
+        subexpr=StringExpr(
+            field=FieldRef(table="object_detection", name="source"),
+            operator=EqualityComparisonOperator.EQ,
+            value="predictions",
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [image1.sample_id]
+
+
 def test_to_match_expression__segmentation_mask_match(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     cid = dataset.collection_id
@@ -209,6 +268,35 @@ def test_to_match_expression__segmentation_mask_match(db_session: Session) -> No
             field=FieldRef(table="segmentation_mask", name="class_name"),
             operator=EqualityComparisonOperator.EQ,
             value="person",
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [image1.sample_id]
+
+
+def test_to_match_expression__segmentation_mask_source(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/1.jpg")
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/2.jpg")
+
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="person")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.SEGMENTATION_MASK,
+        annotation_collection_name="ground_truth",
+    )
+
+    expr = SegmentationMaskMatchExpr(
+        subexpr=StringExpr(
+            field=FieldRef(table="segmentation_mask", name="source"),
+            operator=EqualityComparisonOperator.EQ,
+            value="ground_truth",
         )
     )
     match = query_translation.to_match_expression(expr)


### PR DESCRIPTION
## What has changed and why?
And also hook it to the database. This makes annotation source querying actually possible.

## How has it been tested?
Added tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queries can now filter classifications, object detections, and segmentation masks by annotation source, enabling searches scoped to specific annotation collections.

* **Tests**
  * Added unit and database integration tests validating annotation-source filtering across all supported annotation types.

* **Documentation**
  * CHANGELOG updated to note annotation source support in the query editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->