### PR TITLE
Fix: Explain 'add query filter' in GUI better with tooltip and other text

### DIFF
--- a/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
@@ -22,7 +22,7 @@ async function typeAndApply(page: Page, query: string): Promise<void> {
 test.describe('query editor', () => {
     test('apply query and verify filtered grid', async ({ samplesPage, page }) => {
         await page.getByTestId('query-filter-add-button').click();
-        await expect(page.getByRole('heading', { name: 'Query Filter' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Advanced filters' })).toBeVisible();
 
         // On first open: The apply button should be enabled.
         await expect(page.getByTestId('query-editor-apply-button')).toBeEnabled();
@@ -47,7 +47,7 @@ test.describe('query editor', () => {
 
         // Uncheck the filter chip checkbox to disable the query
         const disableRefetch = waitForImageListResponse(page);
-        await page.getByRole('checkbox', { name: 'Disable query filter' }).click();
+        await page.getByRole('checkbox', { name: 'Disable advanced filters' }).click();
         await disableRefetch;
 
         // Grid should show at least one full page of unfiltered results.
@@ -58,7 +58,7 @@ test.describe('query editor', () => {
 
         // Re-check to re-enable the query
         const enableRefetch = waitForImageListResponse(page);
-        await page.getByRole('checkbox', { name: 'Enable query filter' }).click();
+        await page.getByRole('checkbox', { name: 'Enable advanced filters' }).click();
         await enableRefetch;
 
         await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.labels.airplane.sampleCount);
@@ -74,7 +74,7 @@ test.describe('query editor', () => {
 
         // Click the chip body to reopen the editor
         await page.getByTestId('query-filter-chip-body').click();
-        await expect(page.getByRole('heading', { name: 'Query Filter' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Advanced filters' })).toBeVisible();
 
         // Editor should contain the previously applied query
         await expect(page.locator('.monaco-editor .view-lines')).toContainText(QUERY);
@@ -93,10 +93,10 @@ test.describe('query editor', () => {
 
         // Click the X button to clear the filter
         const refetchPromise = waitForImageListResponse(page);
-        await page.getByRole('button', { name: 'Clear query filter' }).click();
+        await page.getByRole('button', { name: 'Clear advanced filters' }).click();
         await refetchPromise;
 
-        // "Add query filter" button should reappear
+        // "Create advanced filters" button should reappear
         await expect(page.getByTestId('query-filter-add-button')).toBeVisible();
 
         // Grid should show at least one full page of unfiltered results

--- a/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/query-editor.e2e-test.ts
@@ -22,7 +22,11 @@ async function typeAndApply(page: Page, query: string): Promise<void> {
 test.describe('query editor', () => {
     test('apply query and verify filtered grid', async ({ samplesPage, page }) => {
         await page.getByTestId('query-filter-add-button').click();
-        await expect(page.getByRole('heading', { name: 'Advanced filters' })).toBeVisible();
+        await expect(
+            page
+                .getByTestId('query-editor-panel')
+                .getByRole('heading', { name: 'Advanced filters' })
+        ).toBeVisible();
 
         // On first open: The apply button should be enabled.
         await expect(page.getByTestId('query-editor-apply-button')).toBeEnabled();
@@ -74,7 +78,11 @@ test.describe('query editor', () => {
 
         // Click the chip body to reopen the editor
         await page.getByTestId('query-filter-chip-body').click();
-        await expect(page.getByRole('heading', { name: 'Advanced filters' })).toBeVisible();
+        await expect(
+            page
+                .getByTestId('query-editor-panel')
+                .getByRole('heading', { name: 'Advanced filters' })
+        ).toBeVisible();
 
         // Editor should contain the previously applied query
         await expect(page.locator('.monaco-editor .view-lines')).toContainText(QUERY);

--- a/lightly_studio_view/src/lib/components/QueryControl/QueryControl.svelte
+++ b/lightly_studio_view/src/lib/components/QueryControl/QueryControl.svelte
@@ -2,11 +2,12 @@
     import { Button } from '$lib/components';
     import FilterChip from '$lib/components/FilterChip/FilterChip.svelte';
     import Segment from '$lib/components/Segment/Segment.svelte';
+    import Tooltip from '$lib/components/ui/tooltip/tooltip.svelte';
     import {
         useImageFilters,
         type QueryExpression
     } from '$lib/hooks/useImageFilters/useImageFilters';
-    import { Pencil } from '@lucide/svelte';
+    import { ListFilterPlus } from '@lucide/svelte';
 
     interface Props {
         onOpen: () => void;
@@ -23,15 +24,15 @@
     });
 </script>
 
-<Segment title="Query">
+<Segment title="Advanced filters">
     {#if lastQueryExpression}
         <FilterChip
             testId="query-filter-chip"
             checked={!!$imageQueryExpression?.query_expr_str}
-            title="Query Filter"
+            title="Advanced filters"
             checkboxLabel={$imageQueryExpression?.query_expr_str
-                ? 'Disable query filter'
-                : 'Enable query filter'}
+                ? 'Disable advanced filters'
+                : 'Enable advanced filters'}
             onCheckedChange={(v) => {
                 if (v) {
                     updateQueryExpr(lastQueryExpression!);
@@ -55,16 +56,22 @@
             {/snippet}
         </FilterChip>
     {:else}
-        <Button
-            icon={Pencil}
-            variant="outline"
-            buttonProps={{
-                onclick: onOpen,
-                'data-testid': 'query-filter-add-button',
-                class: 'w-full'
-            }}
+        <Tooltip
+            content="Write a query to filter with conditions the simple filters can't express: e.g. images that contain both a cat AND a dog. Combine annotation classes, image properties, and tags with AND, OR, and NOT."
+            position="right"
+            triggerClass="block w-full"
         >
-            Add query filter
-        </Button>
+            <Button
+                icon={ListFilterPlus}
+                variant="outline"
+                buttonProps={{
+                    onclick: onOpen,
+                    'data-testid': 'query-filter-add-button',
+                    class: 'w-full'
+                }}
+            >
+                Create advanced filters
+            </Button>
+        </Tooltip>
     {/if}
 </Segment>

--- a/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
@@ -30,7 +30,10 @@
     };
 </script>
 
-<div class="flex h-full min-w-0 flex-1 flex-col rounded-[1vw] bg-card p-4">
+<div
+    class="flex h-full min-w-0 flex-1 flex-col rounded-[1vw] bg-card p-4"
+    data-testid="query-editor-panel"
+>
     <div class="mb-3 min-w-0">
         <div class="flex items-center justify-between">
             <Typography variant="h5" component="h2" className="text-foreground"

--- a/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditorPanel/QueryEditorPanel.svelte
@@ -34,13 +34,13 @@
     <div class="mb-3 min-w-0">
         <div class="flex items-center justify-between">
             <Typography variant="h5" component="h2" className="text-foreground"
-                >Query Filter</Typography
+                >Advanced filters</Typography
             >
             <Button
                 variant="ghost"
                 size="icon"
                 onclick={onClose}
-                aria-label="Close query filter panel"
+                aria-label="Close advanced filters panel"
                 class="h-8 w-8"
                 data-testid="query-editor-close-button"
             >


### PR DESCRIPTION
## What has changed and why?

To improve the UX of the advanced query filtering system we want to better explain what it does. The old button was not very helpful. And there was no tooltip.

Changes
- rename button and change icon (before it was the pencil icon)
- add tooltip


Old:
<img width="585" height="374" alt="image" src="https://github.com/user-attachments/assets/a63548f1-d116-45f0-9730-993e124d0a42" />

New:

https://github.com/user-attachments/assets/717d5f7b-c2ea-46bb-91a6-dd70d7daa787



## How has it been tested?

- updated e2e test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Renamed "Query Filter" to "Advanced filters" across panel headers, buttons, chip labels, and control text; updated button label to "Create advanced filters" and added tooltip helper content.
* **Tests**
  * Updated end-to-end tests and UI assertions to reflect the renamed "Advanced filters" wording and the new enable/disable/clear control labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->