### PR TITLE
Fix undo for semantic segmentation annotation creation

### DIFF
--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect.test.ts
@@ -110,6 +110,12 @@ vi.mock('$lib/hooks/useSegmentationMaskBrush', () => ({
     useSegmentationMaskBrush: useSegmentationMaskBrushMock
 }));
 
+vi.mock('$lib/hooks/useDeleteAnnotation/useDeleteAnnotation', () => ({
+    useDeleteAnnotation: () => ({
+        deleteAnnotation: vi.fn()
+    })
+}));
+
 const baseProps = {
     collectionId: 'collection-1',
     brushRadius: 5,

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect/SampleSegmentationMaskRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect/SampleSegmentationMaskRect.svelte
@@ -15,9 +15,9 @@
         useSegmentationMaskPreview,
         useAnnotationLabels,
         useAnnotation,
-        useAnnotationLabelContext
+        useAnnotationLabelContext,
+        useDeleteAnnotation
     } from '$lib/hooks';
-    import { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
     import { page } from '$app/state';
     import type { PendingChange } from '../pendingChange';
     import SampleAnnotationRect from '../SampleAnnotationRect/SampleAnnotationRect.svelte';

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect/SampleSegmentationMaskRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect/SampleSegmentationMaskRect.svelte
@@ -17,6 +17,7 @@
         useAnnotation,
         useAnnotationLabelContext
     } from '$lib/hooks';
+    import { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
     import { page } from '$app/state';
     import type { PendingChange } from '../pendingChange';
     import SampleAnnotationRect from '../SampleAnnotationRect/SampleAnnotationRect.svelte';
@@ -58,6 +59,8 @@
         setAnnotationId
     } = useAnnotationLabelContext();
 
+    const { deleteAnnotation } = useDeleteAnnotation({ collectionId });
+
     const labels = useAnnotationLabels(() => ({ collectionId }));
 
     const activeAnnotationId = $derived.by(() => {
@@ -94,6 +97,7 @@
             sample,
             annotations: sample.annotations,
             refetch,
+            deleteAnnotation,
             requestLabel,
             onAnnotationCreated: () => {
                 // Only refresh root collection if there were no annotations before

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -40,3 +40,4 @@ export { useCreateSampling } from '$lib/hooks/useCreateSampling/useCreateSamplin
 export { useColorPicker } from '$lib/hooks/useColorPicker/useColorPicker.svelte';
 export { useSubmitCombinationSelection } from '$lib/hooks/useSubmitCombinationSelection/useSubmitCombinationSelection';
 export { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
+export { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';

--- a/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.test.ts
@@ -5,6 +5,7 @@ import type { AnnotationLabelContext } from '$lib/contexts/SampleDetailsAnnotati
 
 import { useSegmentationMaskBrush } from './useSegmentationMaskBrush';
 import { useGlobalStorage } from './useGlobalStorage';
+import { useReversibleActions } from './useReversibleActions';
 import {
     computeBoundingBoxFromMask,
     encodeBinaryMaskToRLE
@@ -69,10 +70,6 @@ vi.mock('$lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation', 
     useUpdateAnnotationsMutation: () => ({ updateAnnotations })
 }));
 
-vi.mock('$lib/hooks/useDeleteAnnotation/useDeleteAnnotation', () => ({
-    useDeleteAnnotation: () => ({ deleteAnnotation })
-}));
-
 vi.mock('$lib/hooks/useCreateLabel/useCreateLabel', () => ({
     useCreateLabel: () => ({ createLabel })
 }));
@@ -94,6 +91,7 @@ const sample = { width: 100, height: 100 };
 
 describe('useSegmentationMaskBrush', () => {
     beforeEach(() => {
+        useGlobalStorage().clearReversibleActions();
         annotationLabelContext.isDrawing = true;
         annotationLabelContext.annotationId = null;
         annotationLabelContext.annotationLabel = null;
@@ -126,7 +124,8 @@ describe('useSegmentationMaskBrush', () => {
             datasetId,
             sampleId: 's1',
             sample,
-            refetch
+            refetch,
+            deleteAnnotation
         });
 
         await finishBrush(mask, null, []);
@@ -148,7 +147,8 @@ describe('useSegmentationMaskBrush', () => {
             datasetId,
             sampleId: 's1',
             sample,
-            refetch
+            refetch,
+            deleteAnnotation
         });
 
         await finishBrush(mask, null, []);
@@ -173,7 +173,8 @@ describe('useSegmentationMaskBrush', () => {
             datasetId,
             sampleId: 's1',
             sample,
-            refetch
+            refetch,
+            deleteAnnotation
         });
 
         await finishBrush(mask, selectedAnnotation, [], updateAnnotation);
@@ -202,7 +203,8 @@ describe('useSegmentationMaskBrush', () => {
             datasetId,
             sampleId: 's1',
             sample,
-            refetch
+            refetch,
+            deleteAnnotation
         });
 
         await finishBrush(mask, selectedAnnotation, [], updateAnnotation, new Set(['locked-id']));
@@ -225,7 +227,8 @@ describe('useSegmentationMaskBrush', () => {
             datasetId,
             sampleId: 's1',
             sample,
-            refetch
+            refetch,
+            deleteAnnotation
         });
 
         await finishBrush(mask, selectedAnnotation, [], updateAnnotation, new Set(['locked-id']));
@@ -252,7 +255,8 @@ describe('useSegmentationMaskBrush', () => {
             datasetId,
             sampleId: 's1',
             sample,
-            refetch
+            refetch,
+            deleteAnnotation
         });
 
         await finishBrush(mask, null, labels);
@@ -281,7 +285,8 @@ describe('useSegmentationMaskBrush', () => {
             datasetId,
             sampleId: 's1',
             sample,
-            refetch
+            refetch,
+            deleteAnnotation
         });
 
         await finishBrush(mask, null, []);
@@ -308,7 +313,8 @@ describe('useSegmentationMaskBrush', () => {
             datasetId,
             sampleId: 's1',
             sample,
-            refetch
+            refetch,
+            deleteAnnotation
         });
 
         await finishBrush(mask, null, labels);
@@ -333,6 +339,7 @@ describe('useSegmentationMaskBrush', () => {
             sampleId: 's1',
             sample,
             refetch,
+            deleteAnnotation,
             requestLabel
         });
 
@@ -361,7 +368,8 @@ describe('useSegmentationMaskBrush', () => {
             datasetId,
             sampleId: 's1',
             sample,
-            refetch
+            refetch,
+            deleteAnnotation
         });
 
         await finishBrush(mask, null, labels);
@@ -381,7 +389,8 @@ describe('useSegmentationMaskBrush', () => {
             datasetId,
             sampleId: 's1',
             sample,
-            refetch
+            refetch,
+            deleteAnnotation
         });
 
         await finishBrush(mask, null, []);
@@ -393,5 +402,108 @@ describe('useSegmentationMaskBrush', () => {
 
         expect(createAnnotation).toHaveBeenCalled();
         expect(refetch).toHaveBeenCalled();
+    });
+
+    it('adds a create-annotation undo action to the stack when a new annotation is created with a brush stroke', async () => {
+        const { reversibleActions } = useReversibleActions();
+
+        annotationLabelContext.annotationLabel = 'car';
+        const refetch = vi.fn();
+
+        const { finishBrush } = useSegmentationMaskBrush({
+            collectionId: 'c1',
+            datasetId,
+            sampleId: 's1',
+            sample,
+            refetch,
+            deleteAnnotation
+        });
+
+        await finishBrush(mask, null, [
+            { annotation_label_id: 'car-label-id', annotation_label_name: 'car' }
+        ]);
+
+        const actions = get(reversibleActions);
+        expect(actions).toHaveLength(1);
+        expect(actions[0].groupId).toBe('annotation-create');
+        expect(actions[0].description).toBe('Undo create annotation');
+    });
+
+    it('places create-annotation undo below stroke-update undo after a second stroke on the newly created annotation', async () => {
+        const { reversibleActions } = useReversibleActions();
+
+        annotationLabelContext.annotationLabel = 'car';
+        const refetch = vi.fn();
+        const updateAnnotation = vi.fn().mockResolvedValue(undefined);
+
+        const { finishBrush } = useSegmentationMaskBrush({
+            collectionId: 'c1',
+            datasetId,
+            sampleId: 's1',
+            sample,
+            refetch,
+            deleteAnnotation
+        });
+
+        // First stroke: creates the annotation (no selected annotation)
+        await finishBrush(mask, null, [
+            { annotation_label_id: 'car-label-id', annotation_label_name: 'car' }
+        ]);
+
+        // Simulate the user starting a new stroke (onpointerdown sets isDrawing back to true)
+        annotationLabelContext.isDrawing = true;
+
+        // Second stroke: updates the newly created annotation
+        const createdAnnotation = {
+            sample_id: 'new-annotation-id',
+            annotation_type: 'segmentation_mask',
+            segmentation_details: {
+                segmentation_mask: [1, 2, 3]
+            }
+        } as AnnotationView;
+        await finishBrush(
+            mask,
+            createdAnnotation,
+            [{ annotation_label_id: 'car-label-id', annotation_label_name: 'car' }],
+            updateAnnotation
+        );
+
+        const actions = get(reversibleActions);
+        expect(actions).toHaveLength(2);
+        // Most recent action (update stroke) must be first so it is undone first
+        expect(actions[0].groupId).toBe('bbox-change-annotation-details');
+        // Annotation creation must be second so it is undone after all strokes are reverted
+        expect(actions[1].groupId).toBe('annotation-create');
+    });
+
+    it('calls deleteAnnotation with the annotation id when the create undo action is executed', async () => {
+        const { reversibleActions, executeReversibleAction } = useReversibleActions();
+
+        annotationLabelContext.annotationLabel = 'car';
+        const refetch = vi.fn();
+        deleteAnnotation.mockResolvedValue(undefined);
+
+        const { finishBrush } = useSegmentationMaskBrush({
+            collectionId: 'c1',
+            datasetId,
+            sampleId: 's1',
+            sample,
+            refetch,
+            deleteAnnotation
+        });
+
+        await finishBrush(mask, null, [
+            { annotation_label_id: 'car-label-id', annotation_label_name: 'car' }
+        ]);
+
+        // After creating the annotation, annotationId is set to the new annotation's id.
+        expect(annotationLabelContext.annotationId).toBe('new-annotation-id');
+
+        const actions = get(reversibleActions);
+        await executeReversibleAction(actions[0].id);
+
+        expect(deleteAnnotation).toHaveBeenCalledWith('new-annotation-id');
+        expect(get(reversibleActions)).toHaveLength(0);
+        expect(annotationLabelContext.annotationId).toBeNull();
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.ts
+++ b/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.ts
@@ -11,7 +11,6 @@ import type { BoundingBox } from '$lib/types';
 import { toast } from 'svelte-sonner';
 import { useGlobalStorage } from './useGlobalStorage';
 import { addAnnotationCreateToUndoStack } from '$lib/services/addAnnotationCreateToUndoStack';
-import { useDeleteAnnotation } from './useDeleteAnnotation/useDeleteAnnotation';
 import { useUpdateAnnotationsMutation } from './useUpdateAnnotationsMutation/useUpdateAnnotationsMutation';
 import { applySegmentationMaskConstraints } from '$lib/utils/segmentationOverlap';
 import { restoreOverriddenSegmentationAnnotationsForUndo } from '$lib/services/restoreOverriddenSegmentationAnnotationsForUndo';
@@ -23,6 +22,7 @@ export function useSegmentationMaskBrush({
     sample,
     annotations = [],
     refetch,
+    deleteAnnotation,
     onAnnotationCreated,
     requestLabel
 }: {
@@ -32,6 +32,9 @@ export function useSegmentationMaskBrush({
     sample: { width: number; height: number };
     annotations?: AnnotationView[];
     refetch: () => void;
+    /** Must be a stable reference (not recreated on re-renders) to ensure undo closures
+     *  call the live mutation rather than a disposed one. */
+    deleteAnnotation: (annotationId: string) => Promise<void>;
     onAnnotationCreated?: () => void;
     /** Called when no label is currently selected. Should show a class-picker and resolve with
      *  the chosen class, or null if the user cancelled. */
@@ -40,9 +43,6 @@ export function useSegmentationMaskBrush({
     const { createLabel } = useCreateLabel({ collectionId });
     const { createAnnotation } = useCreateAnnotation({ collectionId });
     const { addReversibleAction, updateLastAnnotationLabel } = useGlobalStorage();
-    const { deleteAnnotation } = useDeleteAnnotation({
-        collectionId
-    });
     const {
         context: annotationLabelContext,
         setIsDrawing,
@@ -126,6 +126,7 @@ export function useSegmentationMaskBrush({
         if (selectedAnnotation) {
             try {
                 if (!updateAnnotation) return;
+
                 await updateAnnotation({
                     annotation_id: selectedAnnotation.sample_id!,
                     collection_id: collectionId,
@@ -180,7 +181,8 @@ export function useSegmentationMaskBrush({
             addReversibleAction,
             deleteAnnotation,
             refetch,
-            onUndo: restoreOverriddenAnnotations
+            onUndo: restoreOverriddenAnnotations,
+            onDelete: () => setAnnotationId(null)
         });
 
         setAnnotationType('segmentation_mask');

--- a/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.ts
+++ b/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.ts
@@ -182,7 +182,11 @@ export function useSegmentationMaskBrush({
             deleteAnnotation,
             refetch,
             onUndo: restoreOverriddenAnnotations,
-            onDelete: () => setAnnotationId(null)
+            onDelete: () => {
+                if (annotationLabelContext.annotationId === newAnnotation.sample_id) {
+                    setAnnotationId(null);
+                }
+            }
         });
 
         setAnnotationType('segmentation_mask');

--- a/lightly_studio_view/src/lib/services/addAnnotationCreateToUndoStack.ts
+++ b/lightly_studio_view/src/lib/services/addAnnotationCreateToUndoStack.ts
@@ -8,17 +8,22 @@ export const addAnnotationCreateToUndoStack = ({
     addReversibleAction,
     deleteAnnotation,
     refetch,
-    onUndo
+    onUndo,
+    onDelete
 }: {
     annotation: AnnotationView;
     addReversibleAction: (action: ReversibleAction) => void;
     deleteAnnotation: (annotationId: string) => Promise<void>;
     refetch: () => void;
     onUndo?: ReversibleActionCallback;
+    /** Called after deletion succeeds, before refetch. Use to clean up UI state
+     *  (e.g. clear the selected annotation ID from context). */
+    onDelete?: ReversibleActionCallback;
 }) => {
     const execute = async () => {
         await deleteAnnotation(annotation.sample_id);
         await onUndo?.();
+        await onDelete?.();
         refetch();
     };
 


### PR DESCRIPTION
## What has changed and why?

When undoing a freshly created segmentation annotation, the selected annotation ID in the context was not cleared. This left the UI in a stale state. The `deleteAnnotation` is now passed into `useSegmentationMaskBrush` as a prop instead of being created inside it. This ensures the undo action always calls the correct

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Segmentation brush now supports deleting annotations as part of the draw/preview flow.
  * Undo/redo for segmentation annotations improved: creation and subsequent edits undo in correct order, and undoing a deletion clears the selection/state as expected.

* **Tests**
  * Expanded tests for undo and deletion workflows, including undo ordering and state reset after deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->