### PR TITLE
Add: Tooltip for annotation lock

### DIFF
--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
@@ -216,7 +216,9 @@
                     <div class="flex shrink-0 gap-3">
                         {#if $isEditingMode && annotation.annotation_type != 'object_detection'}
                             {#if isLocked}
-                                <Tooltip content="Unlock annotation">
+                                <Tooltip
+                                    content="Unlock annotation. Allows new brush strokes to paint over this mask again."
+                                >
                                     <Lock
                                         class="size-4 text-muted-foreground"
                                         onclick={(e) => {
@@ -226,7 +228,9 @@
                                     />
                                 </Tooltip>
                             {:else}
-                                <Tooltip content="Lock annotation">
+                                <Tooltip
+                                    content="Lock annotation. Locked masks are protected: new brush strokes won't paint over or modify them."
+                                >
                                     <Unlock
                                         class="size-4"
                                         onclick={(e) => {


### PR DESCRIPTION
## What has changed and why?

- Simple change that adds a tooltip for the annotation lock feature

Video showing the new tooltip:

https://github.com/user-attachments/assets/aa89bd5d-aa97-48b0-a892-50a6b3c0d7ec
 
## How has it been tested?

Manual testing

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced tooltip text for annotation lock/unlock controls in editing mode. Unlock tooltip now clarifies that unlocking allows new brush strokes to paint over the mask. Lock tooltip now clarifies that locked masks are protected from new brush strokes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->