### PR TITLE
Update embedding-atlas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed embedding rendering for users without WebGPU by updating `embedding-atlas` from `0.10.0` to `0.21.0`.
+
 ### Security
 
 ## \[1.0.0\] - 2026-06-05

--- a/lightly_studio_view/package-lock.json
+++ b/lightly_studio_view/package-lock.json
@@ -20,7 +20,7 @@
         "d3-transition": "^3.0.1",
         "d3-zoom": "^3.0.0",
         "echarts": "^6.0.0",
-        "embedding-atlas": "^0.10.0",
+        "embedding-atlas": "^0.21.0",
         "langium": "^4.2.2",
         "lodash-es": "^4.17.22",
         "monaco-editor": "^0.55.1",
@@ -5656,9 +5656,9 @@
       "license": "ISC"
     },
     "node_modules/embedding-atlas": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/embedding-atlas/-/embedding-atlas-0.10.0.tgz",
-      "integrity": "sha512-Pjd9cmyDNi1fIrrJ8h0kr2cokIlXM4HvjxD/NqzoFNVcrCzluv01wPEUWrelE0z4lb3cyB9LsA7m4liQp4/ZzQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/embedding-atlas/-/embedding-atlas-0.21.0.tgz",
+      "integrity": "sha512-cjBkZiurZagyGGzKJmpJ8YaZlB6ZbM0mtEp4N1V5HTJArH8VJQWNNqxR1v0k0fpQZaByoLvT37kI972sr/Vawg==",
       "license": "MIT",
       "peerDependencies": {
         "@uwdata/mosaic-core": ">=0.19.0",

--- a/lightly_studio_view/package.json
+++ b/lightly_studio_view/package.json
@@ -88,7 +88,7 @@
     "d3-transition": "^3.0.1",
     "d3-zoom": "^3.0.0",
     "echarts": "^6.0.0",
-    "embedding-atlas": "^0.10.0",
+    "embedding-atlas": "^0.21.0",
     "langium": "^4.2.2",
     "lodash-es": "^4.17.22",
     "monaco-editor": "^0.55.1",


### PR DESCRIPTION
## What has changed and why?

Bumps `embedding-atlas` from `0.10.0` to `0.21.0` to fix broken embedding rendering on Linux machines.

## How has it been tested?

Manual test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed embedding rendering on systems without WebGPU to ensure visualizations display reliably.
* **Chores**
  * Updated the visualization/embedding library to a newer compatible release for improved stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->