### PR TITLE
Remove outdated Linux/Firefox note for embedding plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Removed outdated documentation note recommending Firefox on Linux for embedding plots.
 - Fixed embedding rendering for users without WebGPU by updating `embedding-atlas` from `0.10.0` to `0.21.0`.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed outdated documentation note recommending Firefox on Linux for embedding plots.
+
 ### Security
 
 ## \[1.0.0\] - 2026-06-05

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -162,10 +162,6 @@ directly use your own image, video, or YOLO/COCO dataset.
    your browser (by default `http://localhost:8001`).
 -  Images and videos are streamed from their original local folder or remote storage for display in the UI.
 
-!!! note "For Linux Users"
-    We recommend using Firefox for the best experience with embedding plots, as other browsers might
-    not render them correctly.
-
 ## Feature Overview
 
 ### Datasets


### PR DESCRIPTION
## What has changed and why?

The docs previously recommended Firefox on Linux for embedding plots as a workaround for rendering issues. This note is now outdated.

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Firefox browser recommendation for Linux users regarding plot embedding from documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->