### PR TITLE
Add NullableNumericalField for `confidence` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Show plugin description and a link to documentation when no plugins are available.
 - When sorting the image grid by a numeric field, the field value is now shown as an overlay on each sample.
-- Query editor now supports annotation `source` field in queries.
+- Query editor now supports annotation `source` and `confidence` fields in queries.
 
 ### Changed
 

--- a/lightly_studio/src/lightly_studio/core/dataset_query/classification_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/classification_expression.py
@@ -9,6 +9,7 @@ from sqlmodel import col
 
 from lightly_studio.core.dataset_query.annotation_expression import AnnotationSourceField
 from lightly_studio.core.dataset_query.boolean_expression import AND
+from lightly_studio.core.dataset_query.field import NullableOrdinalField
 from lightly_studio.core.dataset_query.foreign_field import ForeignComparableField
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
 from lightly_studio.models.annotation.annotation_base import (
@@ -27,6 +28,7 @@ class ClassificationField:
         relationship=AnnotationBaseTable.annotation_label,
     )
     source = AnnotationSourceField()
+    confidence = NullableOrdinalField(col(AnnotationBaseTable.confidence))
 
 
 class ClassificationQuery:

--- a/lightly_studio/src/lightly_studio/core/dataset_query/field.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/field.py
@@ -78,7 +78,44 @@ class OrdinalField(Field, Generic[T]):  # noqa: PLW1641
         return OrdinalFieldExpression(field=self, operator="!=", value=other)
 
 
+class NullableOrdinalField(Field, Generic[T]):  # noqa: PLW1641
+    """Generic field for nullable ordinal values that support comparison operations."""
+
+    def __init__(self, column: Mapped[T | None]) -> None:
+        """Initialize the nullable ordinal field with a database column."""
+        self._column = column
+
+    def get_sqlmodel_field(self) -> Mapped[T | None]:
+        """Get the nullable ordinal database column or property."""
+        return self._column
+
+    def __gt__(self, other: T) -> OrdinalFieldExpression[T]:
+        """Create a greater-than expression."""
+        return OrdinalFieldExpression(field=self, operator=">", value=other)
+
+    def __lt__(self, other: T) -> OrdinalFieldExpression[T]:
+        """Create a less-than expression."""
+        return OrdinalFieldExpression(field=self, operator="<", value=other)
+
+    def __ge__(self, other: T) -> OrdinalFieldExpression[T]:
+        """Create a greater-than-or-equal expression."""
+        return OrdinalFieldExpression(field=self, operator=">=", value=other)
+
+    def __le__(self, other: T) -> OrdinalFieldExpression[T]:
+        """Create a less-than-or-equal expression."""
+        return OrdinalFieldExpression(field=self, operator="<=", value=other)
+
+    def __eq__(self, other: T) -> OrdinalFieldExpression[T]:  # type: ignore[override]
+        """Create an equality expression."""
+        return OrdinalFieldExpression(field=self, operator="==", value=other)
+
+    def __ne__(self, other: T) -> OrdinalFieldExpression[T]:  # type: ignore[override]
+        """Create a not-equal expression."""
+        return OrdinalFieldExpression(field=self, operator="!=", value=other)
+
+
 NumericalField = OrdinalField[Union[float, int]]
+NullableNumericalField = NullableOrdinalField[Union[float, int]]
 DatetimeField = OrdinalField[datetime]
 
 

--- a/lightly_studio/src/lightly_studio/core/dataset_query/field_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/field_expression.py
@@ -14,6 +14,7 @@ from lightly_studio.core.dataset_query.match_expression import MatchExpression
 if TYPE_CHECKING:
     from lightly_studio.core.dataset_query.field import (
         ComparableField,
+        NullableOrdinalField,
         OrdinalField,
     )
 
@@ -36,7 +37,7 @@ OrdinalOperator = Literal[">", "<", "==", ">=", "<=", "!="]
 class OrdinalFieldExpression(MatchExpression, Generic[T]):
     """Generic expression for ordinal field comparisons."""
 
-    field: OrdinalField[T]
+    field: OrdinalField[T] | NullableOrdinalField[T]
     operator: OrdinalOperator
     value: T
 
@@ -45,7 +46,7 @@ class OrdinalFieldExpression(MatchExpression, Generic[T]):
         table_property = self.field.get_sqlmodel_field()
         operations: dict[
             OrdinalOperator,
-            Callable[[Mapped[T], T], ColumnElement[bool]],
+            Callable[[Mapped[T] | Mapped[T | None], T], ColumnElement[bool]],
         ] = {
             "<": lambda tp, v: tp < v,
             "<=": lambda tp, v: tp <= v,

--- a/lightly_studio/src/lightly_studio/core/dataset_query/object_detection_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/object_detection_expression.py
@@ -11,6 +11,7 @@ from typing_extensions import TypeVar
 
 from lightly_studio.core.dataset_query.annotation_expression import AnnotationSourceField
 from lightly_studio.core.dataset_query.boolean_expression import AND
+from lightly_studio.core.dataset_query.field import NullableOrdinalField
 from lightly_studio.core.dataset_query.foreign_field import (
     ForeignComparableField,
     ForeignNumericalField,
@@ -51,7 +52,7 @@ class ObjectDetectionField:
         relationship=AnnotationBaseTable.annotation_label,
     )
     source = AnnotationSourceField()
-    # TODO(lukas, 4/2026): add confidence
+    confidence = NullableOrdinalField(col(AnnotationBaseTable.confidence))
 
 
 class ObjectDetectionQuery:

--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -122,6 +122,20 @@ _ORDINAL_FLOAT_FIELDS: dict[tuple[str, str], _OrdinalField[Number]] = {
     ("video", "fps"): VideoSampleField.fps,
 }
 
+# Annotation confidence is stored in a nullable column, but still supports
+# ordinal numeric comparisons in the query language.
+_ORDINAL_NULLABLE_FLOAT_FIELDS: dict[tuple[str, str], _OrdinalField[Number]] = {
+    ("classification", "confidence"): ClassificationField.confidence,
+    ("object_detection", "confidence"): ObjectDetectionField.confidence,
+    ("segmentation_mask", "confidence"): SegmentationMaskField.confidence,
+}
+# We can merge ordinal fields with nullable, as NULL values fail any comparison in SQL, so it just
+# works as expected.
+_ALL_ORDINAL_FLOAT_FIELDS: dict[tuple[str, str], _OrdinalField[Number]] = {
+    **_ORDINAL_FLOAT_FIELDS,
+    **_ORDINAL_NULLABLE_FLOAT_FIELDS,
+}
+
 _EQUALITY_FLOAT_FIELDS: dict[tuple[str, str], _EqualityField[Number]] = {
     ("video", "duration_s"): VideoSampleField.duration_s,
 }
@@ -242,7 +256,11 @@ def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 C9
         )
     if isinstance(expr, OrdinalFloatExpr):
         return _apply_ordinal_operator(
-            field=_lookup(mapping=_ORDINAL_FLOAT_FIELDS, field=expr.field, type_="ordinal float"),
+            field=_lookup(
+                mapping=_ALL_ORDINAL_FLOAT_FIELDS,
+                field=expr.field,
+                type_="ordinal float",
+            ),
             operator=expr.operator,
             value=expr.value,
         )

--- a/lightly_studio/src/lightly_studio/core/dataset_query/segmentation_mask_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/segmentation_mask_expression.py
@@ -9,6 +9,7 @@ from sqlmodel import col
 
 from lightly_studio.core.dataset_query.annotation_expression import AnnotationSourceField
 from lightly_studio.core.dataset_query.boolean_expression import AND
+from lightly_studio.core.dataset_query.field import NullableOrdinalField
 from lightly_studio.core.dataset_query.foreign_field import (
     ForeignComparableField,
     ForeignNumericalField,
@@ -47,6 +48,7 @@ class SegmentationMaskField:
         relationship=AnnotationBaseTable.annotation_label,
     )
     source = AnnotationSourceField()
+    confidence = NullableOrdinalField(col(AnnotationBaseTable.confidence))
 
 
 class SegmentationMaskQuery:

--- a/lightly_studio/tests/core/dataset_query/test_field_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_field_expression.py
@@ -137,7 +137,7 @@ class TestDatetimeFieldExpression:
         assert "where image.created_at <= '2024-06-15 10:30:00+00:00'" in sql
 
 
-class TestNullableNumericalFieldExpression:
+class TestNullableNumericalField:
     def test_apply__greater_equal(self) -> None:
         query = select(AnnotationBaseTable)
         confidence_field = NullableNumericalField(col(AnnotationBaseTable.confidence))

--- a/lightly_studio/tests/core/dataset_query/test_field_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_field_expression.py
@@ -4,8 +4,9 @@ from datetime import datetime, timezone
 from typing import cast
 
 import pytest
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 
+from lightly_studio.core.dataset_query.field import NullableNumericalField
 from lightly_studio.core.dataset_query.field_expression import (
     ComparableFieldExpression,
     ComparisonOperator,
@@ -14,9 +15,15 @@ from lightly_studio.core.dataset_query.field_expression import (
     OrdinalOperator,
 )
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
-from tests.helpers_resolvers import create_collection, create_image
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
 
 
 class TestNumericalFieldExpression:
@@ -128,6 +135,50 @@ class TestDatetimeFieldExpression:
 
         sql = str(returned_query.compile(compile_kwargs={"literal_binds": True})).lower()
         assert "where image.created_at <= '2024-06-15 10:30:00+00:00'" in sql
+
+
+class TestNullableNumericalFieldExpression:
+    def test_apply__greater_equal(self) -> None:
+        query = select(AnnotationBaseTable)
+        confidence_field = NullableNumericalField(col(AnnotationBaseTable.confidence))
+
+        expr = confidence_field >= 0.7
+        returned_query = query.where(expr.get())
+
+        sql = str(returned_query.compile(compile_kwargs={"literal_binds": True})).lower()
+        assert "where annotation_base.confidence >= 0.7" in sql
+
+    def test_operators__null_does_not_match(self, db_session: Session) -> None:
+        dataset = create_collection(session=db_session)
+        image = create_image(
+            session=db_session,
+            collection_id=dataset.collection_id,
+            file_path_abs="/path/to/test.jpg",
+            width=200,
+            height=100,
+        )
+        label = create_annotation_label(
+            session=db_session,
+            root_collection_id=dataset.collection_id,
+            label_name="cat",
+        )
+        create_annotation(
+            session=db_session,
+            collection_id=dataset.collection_id,
+            sample_id=image.sample_id,
+            annotation_label_id=label.annotation_label_id,
+            annotation_type=AnnotationType.CLASSIFICATION,
+        )
+
+        confidence_field = NullableNumericalField(col(AnnotationBaseTable.confidence))
+        query = select(AnnotationBaseTable).where(
+            AnnotationBaseTable.parent_sample_id == image.sample_id
+        )
+
+        result_query = query.where((confidence_field >= 0.7).get())
+        results = db_session.exec(result_query).all()
+
+        assert results == []
 
 
 class TestStringFieldExpression:

--- a/lightly_studio/tests/core/dataset_query/test_query_translation.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation.py
@@ -217,6 +217,18 @@ def test_to_match_expression__classification_source() -> None:
     assert "collection.name = 'ground_truth'" in sql
 
 
+def test_to_match_expression__classification_confidence() -> None:
+    expr = ClassificationMatchExpr(
+        subexpr=OrdinalFloatExpr(
+            field=FieldRef(table="classification", name="confidence"),
+            operator=OrdinalComparisonOperator.GTE,
+            value=0.7,
+        )
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "annotation_base.confidence >= 0.7" in sql
+
+
 def test_to_match_expression__object_detection_match() -> None:
     subexpr = IntegerExpr(
         field=FieldRef(table="object_detection", name="width"),
@@ -242,6 +254,18 @@ def test_to_match_expression__object_detection_source() -> None:
     assert "collection.name = 'predictions'" in sql
 
 
+def test_to_match_expression__object_detection_confidence() -> None:
+    expr = ObjectDetectionMatchExpr(
+        subexpr=OrdinalFloatExpr(
+            field=FieldRef(table="object_detection", name="confidence"),
+            operator=OrdinalComparisonOperator.GT,
+            value=0.9,
+        )
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "annotation_base.confidence > 0.9" in sql
+
+
 def test_to_match_expression__segmentation_mask_match() -> None:
     subexpr = StringExpr(
         field=FieldRef(table="segmentation_mask", name="class_name"),
@@ -265,6 +289,18 @@ def test_to_match_expression__segmentation_mask_source() -> None:
     )
     sql = _to_sql(query_translation.to_match_expression(expr))
     assert "collection.name = 'ground_truth'" in sql
+
+
+def test_to_match_expression__segmentation_mask_confidence() -> None:
+    expr = SegmentationMaskMatchExpr(
+        subexpr=OrdinalFloatExpr(
+            field=FieldRef(table="segmentation_mask", name="confidence"),
+            operator=OrdinalComparisonOperator.LTE,
+            value=0.5,
+        )
+    )
+    sql = _to_sql(query_translation.to_match_expression(expr))
+    assert "annotation_base.confidence <= 0.5" in sql
 
 
 def test_to_match_expression__and() -> None:

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__database.py
@@ -25,6 +25,7 @@ from lightly_studio.models.query_expr import (
     NotExpr,
     ObjectDetectionMatchExpr,
     OrdinalComparisonOperator,
+    OrdinalFloatExpr,
     OrExpr,
     SegmentationMaskMatchExpr,
     StringExpr,
@@ -189,6 +190,100 @@ def test_to_match_expression__classification_source(db_session: Session) -> None
     assert [r.sample_id for r in results] == [image1.sample_id]
 
 
+def test_to_match_expression__classification_confidence(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/cat.jpg")
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/dog.jpg")
+
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="cat")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={"confidence": 0.8},
+    )
+
+    expr = ClassificationMatchExpr(
+        subexpr=OrdinalFloatExpr(
+            field=FieldRef(table="classification", name="confidence"),
+            operator=OrdinalComparisonOperator.GTE,
+            value=0.7,
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [image1.sample_id]
+
+
+def test_to_match_expression__classification_confidence_no_match(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/cat.jpg")
+
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="cat")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_data={"confidence": 0.8},
+    )
+
+    expr = ClassificationMatchExpr(
+        subexpr=OrdinalFloatExpr(
+            field=FieldRef(table="classification", name="confidence"),
+            operator=OrdinalComparisonOperator.LT,
+            value=0.7,
+        )
+    )
+
+    results = (
+        DatasetQuery(dataset=dataset, session=db_session)
+        .match(query_translation.to_match_expression(expr))
+        .to_list()
+    )
+
+    assert results == []
+
+
+def test_to_match_expression__classification_confidence_none_no_match(
+    db_session: Session,
+) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/cat.jpg")
+
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="cat")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+
+    expr = ClassificationMatchExpr(
+        subexpr=OrdinalFloatExpr(
+            field=FieldRef(table="classification", name="confidence"),
+            operator=OrdinalComparisonOperator.GTE,
+            value=0.7,
+        )
+    )
+
+    results = (
+        DatasetQuery(dataset=dataset, session=db_session)
+        .match(query_translation.to_match_expression(expr))
+        .to_list()
+    )
+
+    assert results == []
+
+
 def test_to_match_expression__object_detection_match(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     cid = dataset.collection_id
@@ -256,6 +351,67 @@ def test_to_match_expression__object_detection_source(db_session: Session) -> No
     assert [r.sample_id for r in results] == [image1.sample_id]
 
 
+def test_to_match_expression__object_detection_confidence(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/1.jpg")
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/2.jpg")
+
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="person")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_data={"x": 0, "y": 0, "width": 100, "height": 100, "confidence": 0.95},
+    )
+
+    expr = ObjectDetectionMatchExpr(
+        subexpr=OrdinalFloatExpr(
+            field=FieldRef(table="object_detection", name="confidence"),
+            operator=OrdinalComparisonOperator.GT,
+            value=0.9,
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [image1.sample_id]
+
+
+def test_to_match_expression__object_detection_confidence_no_match(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/1.jpg")
+
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="person")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+        annotation_data={"x": 0, "y": 0, "width": 100, "height": 100, "confidence": 0.95},
+    )
+
+    expr = ObjectDetectionMatchExpr(
+        subexpr=OrdinalFloatExpr(
+            field=FieldRef(table="object_detection", name="confidence"),
+            operator=OrdinalComparisonOperator.GT,
+            value=0.99,
+        )
+    )
+
+    results = (
+        DatasetQuery(dataset=dataset, session=db_session)
+        .match(query_translation.to_match_expression(expr))
+        .to_list()
+    )
+
+    assert results == []
+
+
 def test_to_match_expression__segmentation_mask_match(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     cid = dataset.collection_id
@@ -305,6 +461,35 @@ def test_to_match_expression__segmentation_mask_source(db_session: Session) -> N
             field=FieldRef(table="segmentation_mask", name="source"),
             operator=EqualityComparisonOperator.EQ,
             value="ground_truth",
+        )
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [r.sample_id for r in results] == [image1.sample_id]
+
+
+def test_to_match_expression__segmentation_mask_confidence(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    cid = dataset.collection_id
+    image1 = create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/1.jpg")
+    create_image(session=db_session, collection_id=cid, file_path_abs="/path/to/2.jpg")
+
+    label = create_annotation_label(session=db_session, root_collection_id=cid, label_name="person")
+    create_annotation(
+        session=db_session,
+        collection_id=cid,
+        sample_id=image1.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.SEGMENTATION_MASK,
+        annotation_data={"confidence": 0.4},
+    )
+
+    expr = SegmentationMaskMatchExpr(
+        subexpr=OrdinalFloatExpr(
+            field=FieldRef(table="segmentation_mask", name="confidence"),
+            operator=OrdinalComparisonOperator.LTE,
+            value=0.5,
         )
     )
     match = query_translation.to_match_expression(expr)


### PR DESCRIPTION
## What has changed and why?
Note that we can't use the existing NumericalField, as it's only for float or int but not for `float | int | None`, i.e. an optional number.

## How has it been tested?
Added tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query editor now supports filtering by annotation confidence for classification, object detection, and segmentation masks (including nullable/optional confidence).

* **Tests**
  * Added unit and integration database tests validating confidence-based query translation and runtime filtering, including handling of null confidence values.

* **Documentation**
  * Updated changelog to document confidence field support in the query editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->