### PR TITLE
Limit diversity strategy to one per sampling combination

### DIFF
--- a/lightly_studio_view/src/lib/components/Sampling/AddStrategyButton.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/AddStrategyButton.svelte
@@ -5,12 +5,14 @@
     import { STRATEGY_OPTIONS, type StrategyType } from '$lib/hooks/useStrategyBuilder';
 
     interface Props {
+        diversityDisabledReason?: string;
         similarityDisabledReason?: string;
         metadataWeightingDisabledReason?: string;
         classBalancingDisabledReason?: string;
         onAdd: (type: StrategyType) => void;
     }
     let {
+        diversityDisabledReason,
         similarityDisabledReason,
         metadataWeightingDisabledReason,
         classBalancingDisabledReason,
@@ -24,6 +26,7 @@
     let itemRefs: Partial<Record<StrategyType, HTMLElement>> = {};
 
     function getDisabledReason(type: StrategyType): string | undefined {
+        if (type === 'diversity') return diversityDisabledReason;
         if (type === 'similarity') return similarityDisabledReason;
         if (type === 'metadata_weighting') return metadataWeightingDisabledReason;
         if (type === 'class_balancing') return classBalancingDisabledReason;

--- a/lightly_studio_view/src/lib/components/Sampling/AddStrategyButton.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/AddStrategyButton.svelte
@@ -20,6 +20,7 @@
     }: Props = $props();
 
     let isOpen = $state(false);
+    let selectedValue = $state<string | undefined>(undefined);
     let hoveredType = $state<StrategyType | null>(null);
     let tooltipRect = $state<DOMRect | null>(null);
     // wrapper element refs used to position the tooltip on keyboard highlight
@@ -56,8 +57,12 @@
     triggerLabel="Add strategy"
     class="w-full"
     testId="add-strategy-button"
+    bind:value={selectedValue}
     onValueChange={(v) => {
-        if (v) onAdd(v as StrategyType);
+        if (v) {
+            onAdd(v as StrategyType);
+            selectedValue = undefined;
+        }
     }}
     onOpenChange={(open) => {
         isOpen = open;

--- a/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.svelte
@@ -106,6 +106,7 @@
                                         annotationLabels={strategyOptions.annotationLabels}
                                         annotationSourceOptions={strategyOptions.annotationSourceOptions}
                                         metadataFieldNames={strategyOptions.metadataFieldNames}
+                                        isDuplicateDisabled={instance.type === 'diversity'}
                                         onRemove={() => removeStrategy(instance.id)}
                                         onDuplicate={() => duplicateStrategy(instance.id)}
                                         onUpdate={(params) => updateParams(instance.id, params)}

--- a/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.svelte
@@ -33,6 +33,10 @@
 
     const strategyOptions = useStrategyOptions(() => collectionId);
 
+    // TODO: Update once there are multiple embedding models - currently only one diversity
+    // strategy is supported since all samples share a single embedding space.
+    const hasDiversity = $derived($instances.some((i) => i.type === 'diversity'));
+
     const {
         tags,
         nSamplesToSelect,
@@ -74,6 +78,9 @@
                     <div class="grid gap-4 py-4">
                         <div class="w-full">
                             <AddStrategyButton
+                                diversityDisabledReason={hasDiversity
+                                    ? 'Only one diversity strategy can be added per selection.'
+                                    : undefined}
                                 similarityDisabledReason={isVideoCollection
                                     ? 'Not available for video collections. Similarity selection requires image embeddings.'
                                     : $tags.length === 0

--- a/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.svelte
@@ -33,7 +33,7 @@
 
     const strategyOptions = useStrategyOptions(() => collectionId);
 
-    // TODO: Update once there are multiple embedding models - currently only one diversity
+    // TODO(Leonardo, 06/2026): Update once there are multiple embedding models - currently only one diversity
     // strategy is supported since all samples share a single embedding space.
     const hasDiversity = $derived($instances.some((i) => i.type === 'diversity'));
 

--- a/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.test.ts
@@ -367,6 +367,18 @@ describe('SamplingCombinationDialog', () => {
         expect(screen.getByTestId('selection-dialog-submit')).toHaveTextContent('Creating...');
     });
 
+    it('disables the duplicate button on a diversity strategy card', async () => {
+        filteredSampleCountStore.set(100);
+
+        render(SamplingCombinationDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('add-strategy-button'), { key: 'Enter' });
+        await fireEvent.pointerUp(await screen.findByTestId('add-strategy-diversity'));
+
+        const duplicateButton = await screen.findByTestId(/strategy-card-duplicate-/);
+        expect(duplicateButton).toBeDisabled();
+    });
+
     it('disables diversity in the add strategy menu after one diversity strategy has been added', async () => {
         filteredSampleCountStore.set(100);
 

--- a/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.test.ts
@@ -367,6 +367,21 @@ describe('SamplingCombinationDialog', () => {
         expect(screen.getByTestId('selection-dialog-submit')).toHaveTextContent('Creating...');
     });
 
+    it('disables diversity in the add strategy menu after one diversity strategy has been added', async () => {
+        filteredSampleCountStore.set(100);
+
+        render(SamplingCombinationDialog);
+
+        await fireEvent.keyDown(screen.getByTestId('add-strategy-button'), { key: 'Enter' });
+        await fireEvent.pointerUp(await screen.findByTestId('add-strategy-diversity'));
+
+        await fireEvent.keyDown(screen.getByTestId('add-strategy-button'), { key: 'Enter' });
+
+        expect(await screen.findByTestId('add-strategy-diversity')).toHaveAttribute(
+            'data-disabled'
+        );
+    });
+
     it('disables metadata weighting when only non-numeric metadata fields are present', async () => {
         metadataInfoStore = readable([{ name: 'label', type: 'string' }]);
 

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
@@ -27,6 +27,7 @@
         annotationLabels: string[];
         annotationSourceOptions?: { id: string; name: string }[];
         metadataFieldNames?: string[];
+        isDuplicateDisabled?: boolean;
         onRemove: () => void;
         onDuplicate: () => void;
         onUpdate: (params: Partial<StrategyParams>) => void;
@@ -38,6 +39,7 @@
         annotationLabels,
         annotationSourceOptions = [],
         metadataFieldNames = [],
+        isDuplicateDisabled = false,
         onRemove,
         onDuplicate,
         onUpdate,
@@ -79,6 +81,7 @@
                     size="icon"
                     aria-label="Duplicate strategy"
                     onclick={onDuplicate}
+                    disabled={isDuplicateDisabled}
                     data-testid={`strategy-card-duplicate-${instance.id}`}
                 >
                     <Copy class="size-4" />

--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.test.ts
@@ -63,6 +63,21 @@ describe('StrategyCard', () => {
             expect(onDuplicate).toHaveBeenCalledOnce();
         });
 
+        it('disables the duplicate button when isDuplicateDisabled is true', () => {
+            const instance: StrategyInstance = {
+                id: 'abc',
+                type: 'diversity',
+                params: { strength: 1 },
+                isExpanded: true
+            };
+
+            render(StrategyCard, {
+                props: { ...defaultProps, instance, isDuplicateDisabled: true }
+            });
+
+            expect(screen.getByTestId('strategy-card-duplicate-abc')).toBeDisabled();
+        });
+
         it('calls onRemove when the remove button is clicked', async () => {
             const onRemove = vi.fn();
             const instance: StrategyInstance = {


### PR DESCRIPTION
## What has changed and why?

Disables the **Diversity** option in `AddStrategyButton` once a diversity strategy has already been added to the combination. Only one embedding space is available per collection, so adding multiple diversity strategies would be redundant and confusing.

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent adding more than one diversity strategy — the add menu item is disabled with a displayed reason; duplicate controls on diversity strategy cards are also disabled.
  * Add action now requires a selected value and clears the selection after adding, avoiding stale selections.

* **Tests**
  * Added unit tests verifying the add-menu disables the diversity option when one exists and that the duplicate button is disabled for diversity strategy cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->