### PR TITLE
Object Embeddings Frontend Prototype: Text Search and Embedding Plot

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -64,17 +64,23 @@ class AnnotationQueryParamsModel(BaseModel):
     pagination: PaginatedWithCursor
     annotation_label_ids: list[UUID] | None = None
     tag_ids: list[UUID] | None = None
+    sample_ids: list[UUID] | None = None
+    text_embedding: list[float] | None = None
 
 
 def _get_annotation_query_params(
     pagination: Annotated[PaginatedWithCursor, Depends()],
     annotation_label_ids: Annotated[list[UUID] | None, Query()] = None,
     tag_ids: Annotated[list[UUID] | None, Query()] = None,
+    sample_ids: Annotated[list[UUID] | None, Query()] = None,
+    text_embedding: Annotated[list[float] | None, Query()] = None,
 ) -> AnnotationQueryParamsModel:
     return AnnotationQueryParamsModel(
         pagination=pagination,
         annotation_label_ids=annotation_label_ids,
         tag_ids=tag_ids,
+        sample_ids=sample_ids,
+        text_embedding=text_embedding,
     )
 
 
@@ -149,8 +155,10 @@ def read_annotations_with_payload(
             collection_ids=[collection_id],
             annotation_label_ids=params.annotation_label_ids,
             tag_ids=params.tag_ids,
+            sample_ids=params.sample_ids,
         ),
         collection_id=collection_id,
+        text_embedding=params.text_embedding,
     )
 
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/annotations.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/annotations.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from collections import defaultdict
 from uuid import UUID
 
-from sqlmodel import Session
+from sqlmodel import Session, col, select
 
+from lightly_studio import db_array
 from lightly_studio.api.routes.api.embedding_coloring import coloring_helpers
 from lightly_studio.api.routes.api.embedding_coloring.coloring_helpers import DiscreteColorScale
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.resolvers import annotation_label_resolver, annotation_resolver
 
 
@@ -50,6 +52,17 @@ def build_annotation_color_maps(
     for ann in annotations:
         if ann.annotation_label_id in requested:
             sample_to_labels[ann.parent_sample_id].add(ann.annotation_label_id)
+
+    # LIG-9521 prototype: when the colored samples are annotations themselves (annotation
+    # collection), each sample carries its own label rather than labels of child annotations.
+    own_annotations = session.exec(
+        select(AnnotationBaseTable).where(
+            db_array.in_array(column=col(AnnotationBaseTable.sample_id), values=sample_ids)
+        )
+    ).all()
+    for ann in own_annotations:
+        if ann.annotation_label_id in requested:
+            sample_to_labels[ann.sample_id].add(ann.annotation_label_id)
 
     ordered_label_ids = coloring_helpers.order_values_by_frequency(
         sample_to_values=sample_to_labels,

--- a/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
@@ -16,7 +16,13 @@ from sqlmodel import select
 from lightly_studio.api.routes.api.embedding_coloring import ColorBy, build_color_data
 from lightly_studio.db_manager import SessionDep
 from lightly_studio.models.embedding_model import EmbeddingModelTable
-from lightly_studio.resolvers import image_resolver, twodim_embedding_resolver, video_resolver
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    image_resolver,
+    twodim_embedding_resolver,
+    video_resolver,
+)
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
 
@@ -26,7 +32,7 @@ embeddings2d_router = APIRouter()
 class GetEmbeddings2DRequest(BaseModel):
     """Request body for retrieving 2D embeddings."""
 
-    filters: ImageFilter | VideoFilter = Field(
+    filters: ImageFilter | VideoFilter | AnnotationsFilter = Field(
         description="Filter parameters identifying matching samples"
     )
     color_by: ColorBy | None = None
@@ -119,7 +125,7 @@ def get_2d_embeddings(
 def _get_matching_sample_ids(
     session: SessionDep,
     collection_id: UUID,
-    filters: ImageFilter | VideoFilter,
+    filters: ImageFilter | VideoFilter | AnnotationsFilter,
 ) -> set[UUID]:
     """Get the set of sample IDs that match the given filters.
 
@@ -131,6 +137,14 @@ def _get_matching_sample_ids(
     Returns:
         Set of sample IDs that match the filters.
     """
+    if isinstance(filters, AnnotationsFilter):
+        return set(
+            annotation_resolver.get_sample_ids(
+                session=session,
+                collection_id=collection_id,
+                filters=filters,
+            )
+        )
     if isinstance(filters, VideoFilter):
         return video_resolver.get_sample_ids(
             session=session,

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from uuid import UUID
 
 import fsspec
+import numpy as np
 from fsspec.implementations.local import LocalFileSystem
 from labelformat.formats import (
     COCOInstanceSegmentationInput,
@@ -22,7 +23,7 @@ from labelformat.model.instance_segmentation import (
 from labelformat.model.object_detection import (
     ObjectDetectionInput,
 )
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from lightly_studio.core.dataset import BaseSampleDataset
 from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
@@ -32,10 +33,14 @@ from lightly_studio.dataset import fsspec_lister
 from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
 from lightly_studio.evaluation.image_dataset_evaluate import ImageDatasetEvaluate
 from lightly_studio.export.image_dataset_export import ImageDatasetExport
-from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
 from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingCreate
 from lightly_studio.resolvers import (
+    collection_resolver,
     image_resolver,
+    sample_embedding_resolver,
     tag_resolver,
 )
 from lightly_studio.type_definitions import PathLike
@@ -435,6 +440,12 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             embed=embed,
         )
 
+        if embed:
+            _generate_fake_annotation_embeddings(
+                session=self.session,
+                root_collection_id=self.collection_id,
+            )
+
     def add_samples_from_pascal_voc_segmentations(
         self,
         images_path: PathLike,
@@ -609,6 +620,100 @@ def _postprocess_created_images(
             collection_id=collection_id,
             sample_ids=sample_ids,
         )
+
+
+# LIG-9521 prototype: per-dimension noise std for fake annotation embeddings. With
+# 512-dim unit-norm image embeddings this gives a noise vector of norm ~0.23, enough
+# to spread annotations of the same image apart without destroying cluster structure.
+_FAKE_ANNOTATION_EMBEDDING_NOISE_STD = 0.01
+
+
+def _generate_fake_annotation_embeddings(
+    session: Session,
+    root_collection_id: UUID,
+) -> None:
+    """Generate fake embeddings for annotation samples (LIG-9521 prototype).
+
+    Each annotation gets its parent image's embedding plus gaussian noise, normalized
+    to unit length. Also registers the parent collection's embedding model for each
+    annotation collection so text search and the 2D embedding plot work there.
+    """
+    embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
+    parent_model_id = embedding_manager.load_or_get_default_model(
+        session=session, collection_id=root_collection_id
+    )
+    if parent_model_id is None:
+        return
+    generator = embedding_manager._models[parent_model_id]  # noqa: SLF001
+
+    annotation_collections = collection_resolver.get_annotation_collections(
+        session=session, parent_collection_id=root_collection_id
+    )
+    rng = np.random.default_rng(seed=0)
+    for annotation_collection in annotation_collections:
+        annotation_model = embedding_manager.register_embedding_model(
+            session=session,
+            collection_id=annotation_collection.collection_id,
+            embedding_generator=generator,
+            set_as_default=True,
+        )
+
+        rows = session.exec(
+            select(AnnotationBaseTable.sample_id, AnnotationBaseTable.parent_sample_id)
+            .join(SampleTable, SampleTable.sample_id == AnnotationBaseTable.sample_id)
+            .where(SampleTable.collection_id == annotation_collection.collection_id)
+        ).all()
+        annotation_ids = [annotation_id for annotation_id, _ in rows]
+        already_embedded_ids = {
+            embedding.sample_id
+            for embedding in sample_embedding_resolver.get_by_sample_ids(
+                session=session,
+                sample_ids=annotation_ids,
+                embedding_model_id=annotation_model.embedding_model_id,
+            )
+        }
+        pairs = [
+            (annotation_id, parent_id)
+            for annotation_id, parent_id in rows
+            if annotation_id not in already_embedded_ids
+        ]
+        if not pairs:
+            continue
+
+        parent_ids = list({parent_id for _, parent_id in pairs})
+        parent_embeddings = {
+            embedding.sample_id: embedding.embedding
+            for embedding in sample_embedding_resolver.get_by_sample_ids(
+                session=session,
+                sample_ids=parent_ids,
+                embedding_model_id=parent_model_id,
+            )
+        }
+
+        fake_embeddings = []
+        for annotation_id, parent_id in pairs:
+            parent_embedding = parent_embeddings.get(parent_id)
+            if parent_embedding is None:
+                continue
+            noisy = parent_embedding + rng.normal(
+                0.0, _FAKE_ANNOTATION_EMBEDDING_NOISE_STD, size=parent_embedding.shape
+            )
+            noisy /= np.linalg.norm(noisy)
+            fake_embeddings.append(
+                SampleEmbeddingCreate(
+                    sample_id=annotation_id,
+                    embedding_model_id=annotation_model.embedding_model_id,
+                    embedding=noisy.astype(np.float32),
+                )
+            )
+        if fake_embeddings:
+            sample_embedding_resolver.create_many(
+                session=session, sample_embeddings=fake_embeddings
+            )
+            logger.info(
+                f"Stored {len(fake_embeddings)} fake annotation embeddings for "
+                f"collection '{annotation_collection.name}'."
+            )
 
 
 def _normalize_input_path(path: PathLike) -> PathLike:

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -359,7 +359,9 @@ def _store_embeddings(
 
 def _load_embedding_generator_from_env(sample_type: SampleType) -> EmbeddingGenerator | None:
     """Load the embedding generator based on environment variable configuration."""
-    if sample_type == SampleType.IMAGE:
+    # LIG-9521 prototype: annotation collections use the image embedding model so that
+    # text search and the embedding plot work for (fake) annotation embeddings.
+    if sample_type in (SampleType.IMAGE, SampleType.ANNOTATION):
         return _load_image_embedding_generator_from_env()
     if sample_type == SampleType.VIDEO:
         return _load_video_embedding_generator()

--- a/lightly_studio/src/lightly_studio/examples/example_coco.py
+++ b/lightly_studio/src/lightly_studio/examples/example_coco.py
@@ -7,14 +7,19 @@ from environs import Env
 import lightly_studio as ls
 from lightly_studio import db_manager
 from lightly_studio.models.tag import TagCreate
-from lightly_studio.resolvers import annotation_resolver, collection_resolver, tag_resolver
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    collection_resolver,
+    metadata_resolver,
+    tag_resolver,
+)
 
 # Read environment variables
 env = Env()
 env.read_env()
 
 # Cleanup an existing database
-db_manager.connect(cleanup_existing=True)
+db_manager.connect(db_file="coco.db", cleanup_existing=True)
 
 # Define data paths
 annotations_json = env.path("EXAMPLES_COCO_JSON_PATH", "/path/to/your/dataset/annotations.json")
@@ -28,7 +33,10 @@ dataset.add_samples_from_coco(
     annotation_type=ls.AnnotationType.SEGMENTATION_MASK,
 )
 
-# LIG-9521 prototype: create two annotation tags with random annotations each.
+# LIG-9521 prototype: create two annotation tags with random annotations each, and give
+# every annotation exactly one metadata["tag"] value derived from its tag membership
+# ("no tag", "random-200", "random-400", "random-both"). Dummy data for testing
+# metadata colouring in the embedding plot.
 rng = random.Random(0)
 annotation_collections = collection_resolver.get_annotation_collections(
     session=dataset.session, parent_collection_id=dataset.collection_id
@@ -39,7 +47,10 @@ for annotation_collection in annotation_collections:
             session=dataset.session, collection_id=annotation_collection.collection_id
         )
     )
+    tagged_ids_by_name: dict[str, set] = {}
     for tag_name, tag_size in [("random-200", 200), ("random-400", 400)]:
+        tagged_ids = rng.sample(annotation_sample_ids, min(tag_size, len(annotation_sample_ids)))
+        tagged_ids_by_name[tag_name] = set(tagged_ids)
         tag = tag_resolver.create(
             session=dataset.session,
             tag=TagCreate(
@@ -51,9 +62,24 @@ for annotation_collection in annotation_collections:
         tag_resolver.add_sample_ids_to_tag_id(
             session=dataset.session,
             tag_id=tag.tag_id,
-            sample_ids=rng.sample(
-                annotation_sample_ids, min(tag_size, len(annotation_sample_ids))
-            ),
+            sample_ids=tagged_ids,
         )
+
+    sample_metadata = []
+    for sample_id in annotation_sample_ids:
+        in_200 = sample_id in tagged_ids_by_name["random-200"]
+        in_400 = sample_id in tagged_ids_by_name["random-400"]
+        if in_200 and in_400:
+            metadata_tag = "random-both"
+        elif in_200:
+            metadata_tag = "random-200"
+        elif in_400:
+            metadata_tag = "random-400"
+        else:
+            metadata_tag = "no tag"
+        sample_metadata.append((sample_id, {"tag": metadata_tag}))
+    metadata_resolver.bulk_update_metadata(
+        session=dataset.session, sample_metadata=sample_metadata
+    )
 
 ls.start_gui()

--- a/lightly_studio/src/lightly_studio/examples/example_coco.py
+++ b/lightly_studio/src/lightly_studio/examples/example_coco.py
@@ -1,9 +1,13 @@
 """Example of how to add samples in coco format to a dataset."""
 
+import random
+
 from environs import Env
 
 import lightly_studio as ls
 from lightly_studio import db_manager
+from lightly_studio.models.tag import TagCreate
+from lightly_studio.resolvers import annotation_resolver, collection_resolver, tag_resolver
 
 # Read environment variables
 env = Env()
@@ -23,5 +27,33 @@ dataset.add_samples_from_coco(
     images_path=images_path,
     annotation_type=ls.AnnotationType.SEGMENTATION_MASK,
 )
+
+# LIG-9521 prototype: create two annotation tags with random annotations each.
+rng = random.Random(0)
+annotation_collections = collection_resolver.get_annotation_collections(
+    session=dataset.session, parent_collection_id=dataset.collection_id
+)
+for annotation_collection in annotation_collections:
+    annotation_sample_ids = sorted(
+        annotation_resolver.get_sample_ids(
+            session=dataset.session, collection_id=annotation_collection.collection_id
+        )
+    )
+    for tag_name, tag_size in [("random-200", 200), ("random-400", 400)]:
+        tag = tag_resolver.create(
+            session=dataset.session,
+            tag=TagCreate(
+                name=tag_name,
+                collection_id=annotation_collection.collection_id,
+                kind="annotation",
+            ),
+        )
+        tag_resolver.add_sample_ids_to_tag_id(
+            session=dataset.session,
+            tag_id=tag.tag_id,
+            sample_ids=rng.sample(
+                annotation_sample_ids, min(tag_size, len(annotation_sample_ids))
+            ),
+        )
 
 ls.start_gui()

--- a/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
+++ b/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
@@ -251,6 +251,8 @@ class AnnotationWithPayloadView(BaseModel):
     parent_sample_type: SampleType
     annotation: AnnotationView
     parent_sample_data: Union[ImageAnnotationView, VideoFrameAnnotationView]
+    # LIG-9521 prototype: set when results are ordered by embedding similarity.
+    similarity_score: Optional[float] = None
 
 
 class AnnotationWithPayloadAndCountView(BaseModel):

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_with_payload.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_with_payload.py
@@ -30,6 +30,7 @@ from lightly_studio.resolvers.annotations.annotations_filter import (
 )
 from lightly_studio.resolvers.similarity_utils import (
     apply_similarity_join,
+    distance_to_similarity,
     get_distance_expression,
 )
 
@@ -71,8 +72,9 @@ def get_all_with_payload(
     embedding_model_id, distance_expr = get_distance_expression(
         session=session, collection_id=collection_id, text_embedding=text_embedding
     )
+    has_similarity = distance_expr is not None and embedding_model_id is not None
     similarity_order_by = []
-    if distance_expr is not None and embedding_model_id is not None:
+    if has_similarity:
         base_query = apply_similarity_join(
             query=base_query,
             sample_id_column=col(AnnotationBaseTable.sample_id),
@@ -86,6 +88,8 @@ def get_all_with_payload(
         col(AnnotationBaseTable.created_at).asc(),
         col(AnnotationBaseTable.sample_id).asc(),
     )
+    if has_similarity:
+        annotations_query = annotations_query.add_columns(distance_expr)
 
     total_count_query = select(func.count()).select_from(base_query.subquery())
     total_count = session.exec(total_count_query).one()
@@ -99,17 +103,27 @@ def get_all_with_payload(
 
     rows = session.exec(annotations_query).all()
 
-    return AnnotationWithPayloadAndCountView(
-        total_count=total_count,
-        next_cursor=next_cursor,
-        annotations=[
+    annotation_views = []
+    for row in rows:
+        if has_similarity:
+            annotation, payload, distance = row
+            similarity_score = distance_to_similarity(distance)
+        else:
+            annotation, payload = row
+            similarity_score = None
+        annotation_views.append(
             AnnotationWithPayloadView(
                 parent_sample_type=sample_type,
                 annotation=AnnotationView.from_annotation_table(annotation=annotation),
                 parent_sample_data=_serialize_annotation_payload(payload=payload),
+                similarity_score=similarity_score,
             )
-            for annotation, payload in rows
-        ],
+        )
+
+    return AnnotationWithPayloadAndCountView(
+        total_count=total_count,
+        next_cursor=next_cursor,
+        annotations=annotation_views,
     )
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_with_payload.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_with_payload.py
@@ -28,6 +28,10 @@ from lightly_studio.resolvers import collection_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
 )
+from lightly_studio.resolvers.similarity_utils import (
+    apply_similarity_join,
+    get_distance_expression,
+)
 
 
 def get_all_with_payload(
@@ -35,6 +39,7 @@ def get_all_with_payload(
     collection_id: UUID,
     pagination: Paginated | None = None,
     filters: AnnotationsFilter | None = None,
+    text_embedding: list[float] | None = None,
 ) -> AnnotationWithPayloadAndCountView:
     """Get all annotations with payload from the database.
 
@@ -43,6 +48,8 @@ def get_all_with_payload(
         pagination: Optional pagination parameters
         filters: Optional filters to apply to the query
         collection_id: ID of the collection to get annotations for
+        text_embedding: Optional embedding; when given, annotations are ordered by
+            cosine distance of their embedding to it.
 
     Returns:
         List of annotations matching the filters with payload
@@ -61,7 +68,20 @@ def get_all_with_payload(
     if filters:
         base_query = filters.apply(base_query)
 
+    embedding_model_id, distance_expr = get_distance_expression(
+        session=session, collection_id=collection_id, text_embedding=text_embedding
+    )
+    similarity_order_by = []
+    if distance_expr is not None and embedding_model_id is not None:
+        base_query = apply_similarity_join(
+            query=base_query,
+            sample_id_column=col(AnnotationBaseTable.sample_id),
+            embedding_model_id=embedding_model_id,
+        )
+        similarity_order_by = [distance_expr]
+
     annotations_query = base_query.order_by(
+        *similarity_order_by,
         *_extra_order_by(sample_type=sample_type),
         col(AnnotationBaseTable.created_at).asc(),
         col(AnnotationBaseTable.sample_id).asc(),

--- a/lightly_studio/src/lightly_studio/resolvers/annotations/annotations_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotations/annotations_filter.py
@@ -29,6 +29,9 @@ class AnnotationsFilter(BaseModel):
         default=None, description="List of annotation label UUIDs"
     )
     tag_ids: list[UUID] | None = Field(default=None, description="List of tag UUIDs")
+    sample_ids: list[UUID] | None = Field(
+        default=None, description="List of annotation sample UUIDs to restrict to"
+    )
 
     def apply(
         self,
@@ -88,6 +91,15 @@ class AnnotationsFilter(BaseModel):
                 db_array.in_array(
                     column=col(annotation_sample.collection_id),
                     values=self.collection_ids,
+                )
+            )
+
+        # Filter by annotation sample ids (e.g. embedding plot selection)
+        if self.sample_ids:
+            query = query.where(
+                db_array.in_array(
+                    column=col(annotation_sample.sample_id),
+                    values=self.sample_ids,
                 )
             )
 

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationImageGridItem/AnnotationImageGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationImageGridItem/AnnotationImageGridItem.svelte
@@ -13,6 +13,7 @@
         cachedCollectionVersion: string;
         showLabel: boolean;
         selected?: boolean;
+        onCropImageUrlChange?: (annotationId: string, url: string | null) => void;
     };
 
     let {
@@ -22,7 +23,8 @@
         image,
         cachedCollectionVersion = '',
         showLabel = true,
-        selected = false
+        selected = false,
+        onCropImageUrlChange
     }: Props = $props();
 
     const { getCollectionVersion } = useGlobalStorage();
@@ -84,5 +86,6 @@
         {containerWidth}
         {showLabel}
         {selected}
+        {onCropImageUrlChange}
     />
 {/if}

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
@@ -86,6 +86,61 @@
     // Calculate values for use in template
     const xOffset = $derived(getXOffset());
     const yOffset = $derived(getYOffset());
+
+    // Render the visible window (padded bbox crop) into a canvas and use the result as
+    // the <img> source, so the browser's native right-click "Copy image" copies exactly
+    // the crop instead of the whole parent image (see PR #556 for images).
+    let cropImageUrl = $state<string | null>(null);
+
+    $effect(() => {
+        const sourceUrl = sample.url;
+        const sampleWidth = sample.width;
+        const sampleHeight = sample.height;
+        const windowWidth = containerWidth / scale;
+        const windowHeight = containerHeight / scale;
+        const windowX = -xOffset / scale;
+        const windowY = -yOffset / scale;
+        if (!sourceUrl) return;
+
+        let cancelled = false;
+        let objectUrl: string | null = null;
+        const imageElement = new Image();
+        // The thumbnail may be served cross-origin (dev server); without this the
+        // canvas would be tainted and toBlob would throw.
+        imageElement.crossOrigin = 'anonymous';
+        imageElement.onload = () => {
+            if (cancelled) return;
+            // The thumbnail can be downscaled relative to the original image size the
+            // crop geometry is expressed in.
+            const resolutionX = imageElement.naturalWidth / sampleWidth;
+            const resolutionY = imageElement.naturalHeight / sampleHeight;
+            const canvas = document.createElement('canvas');
+            canvas.width = Math.max(1, Math.round(windowWidth * resolutionX));
+            canvas.height = Math.max(1, Math.round(windowHeight * resolutionY));
+            const context = canvas.getContext('2d');
+            if (!context) return;
+            context.fillStyle = '#000';
+            context.fillRect(0, 0, canvas.width, canvas.height);
+            context.drawImage(
+                imageElement,
+                -windowX * resolutionX,
+                -windowY * resolutionY,
+                imageElement.naturalWidth,
+                imageElement.naturalHeight
+            );
+            canvas.toBlob((blob) => {
+                if (!blob || cancelled) return;
+                objectUrl = URL.createObjectURL(blob);
+                cropImageUrl = objectUrl;
+            }, 'image/png');
+        };
+        imageElement.src = sourceUrl;
+
+        return () => {
+            cancelled = true;
+            if (objectUrl) URL.revokeObjectURL(objectUrl);
+        };
+    });
 </script>
 
 {#if sample}
@@ -95,14 +150,27 @@
         style={`
         width: ${containerWidth}px;
         height: ${containerHeight}px;
-        background-image: url("${sample.url}");
-        background-position: ${xOffset}px ${yOffset}px;
-        background-size: ${sample.width * scale}px ${sample.height * scale}px;
-        background-repeat: no-repeat;
     `}
     >
+        <!-- Real <img> instead of a CSS background so the browser's native
+             right-click "Copy image" works; the source is the canvas-rendered
+             crop so only the crop gets copied (see PR #556 for images). -->
+        {#if cropImageUrl}
+            <img
+                src={cropImageUrl}
+                alt=""
+                draggable="false"
+                class="crop-image"
+                style={`
+                left: 0;
+                top: 0;
+                width: ${containerWidth}px;
+                height: ${containerHeight}px;
+            `}
+            />
+        {/if}
         <div
-            class="annotation-box"
+            class="annotation-box pointer-events-none"
             class:invisible={$isHidden}
             style={`
             left: ${(containerWidth - annotationWidth * scale) / 2}px;
@@ -155,6 +223,11 @@
     .crop {
         position: relative;
         overflow: hidden;
+    }
+
+    .crop-image {
+        position: absolute;
+        max-width: none;
     }
 
     .annotation-box {

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
@@ -17,6 +17,9 @@
             url: string;
         };
         selected?: boolean;
+        // LIG-9521 prototype: reports the generated crop blob URL so the grid can use
+        // it as drag-to-search payload.
+        onCropImageUrlChange?: (annotationId: string, url: string | null) => void;
     };
 
     let {
@@ -25,7 +28,8 @@
         containerHeight,
         sample,
         showLabel = true,
-        selected = false
+        selected = false,
+        onCropImageUrlChange
     }: Props = $props();
 
     const padding = 20;
@@ -92,6 +96,12 @@
     // the crop instead of the whole parent image (see PR #556 for images).
     let cropImageUrl = $state<string | null>(null);
 
+    // Captured by value at init: props are lazy getters, and reading `annotation` during
+    // effect cleanup would re-evaluate `annotations[index]` in the grid against an
+    // already-shrunken array (crash on filter changes). The id is constant per instance —
+    // the {#key} wrapper in the grid remounts this component when it changes.
+    const annotationId = annotation.sample_id;
+
     $effect(() => {
         const sourceUrl = sample.url;
         const sampleWidth = sample.width;
@@ -132,13 +142,17 @@
                 if (!blob || cancelled) return;
                 objectUrl = URL.createObjectURL(blob);
                 cropImageUrl = objectUrl;
+                onCropImageUrlChange?.(annotationId, objectUrl);
             }, 'image/png');
         };
         imageElement.src = sourceUrl;
 
         return () => {
             cancelled = true;
-            if (objectUrl) URL.revokeObjectURL(objectUrl);
+            if (objectUrl) {
+                URL.revokeObjectURL(objectUrl);
+                onCropImageUrlChange?.(annotationId, null);
+            }
         };
     });
 </script>

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -59,6 +59,17 @@
     const { annotationPlotSampleIds } = useAnnotationPlotSelection();
     const plotSelectedAnnotationIds = $derived($annotationPlotSampleIds);
 
+    // LIG-9521 prototype: crop blob URLs reported by the tiles, used as the
+    // drag-to-search payload (mirrors the images grid dragData).
+    let cropImageUrlByAnnotationId = $state<Record<string, string>>({});
+    function handleCropImageUrlChange(annotationId: string, url: string | null) {
+        if (url) {
+            cropImageUrlByAnnotationId[annotationId] = url;
+        } else {
+            delete cropImageUrlByAnnotationId[annotationId];
+        }
+    }
+
     afterNavigate(() => {
         clearReversibleActions();
     });
@@ -266,6 +277,16 @@
                                     dataTestId="annotation-grid-item"
                                     tag={false}
                                     ariaLabel={`Edit annotation: ${annotations[index].annotation.sample_id}`}
+                                    dragData={cropImageUrlByAnnotationId[
+                                        annotations[index].annotation.sample_id
+                                    ]
+                                        ? {
+                                              url: cropImageUrlByAnnotationId[
+                                                  annotations[index].annotation.sample_id
+                                              ],
+                                              fileName: `${annotations[index].annotation.annotation_label.annotation_label_name}-crop.png`
+                                          }
+                                        : undefined}
                                     onSelect={(event) =>
                                         handleGridItemSelect(
                                             event,
@@ -306,6 +327,7 @@
                                             selected={$pickedAnnotationIds[collection_id]?.has(
                                                 annotations[index].annotation.sample_id
                                             )}
+                                            onCropImageUrlChange={handleCropImageUrlChange}
                                         />
                                     </div>
                                 </GridItem>

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -2,6 +2,7 @@
     import { AnnotationsGridItem, SelectableBox } from '$lib/components';
     import { useSelectedAnnotationsFilter } from '$lib/hooks/useAnnotationsFilter/useAnnotationsFilter';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+    import { useAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
     import { useSettings } from '$lib/hooks/useSettings';
     import { useTags } from '$lib/hooks/useTags/useTags';
     import { routeHelpers } from '$lib/routes';
@@ -50,8 +51,13 @@
         getCollectionVersion,
         setfilteredAnnotationCount,
         addReversibleAction,
-        clearReversibleActions
+        clearReversibleActions,
+        textEmbedding
     } = useGlobalStorage();
+
+    // LIG-9521 prototype: the embedding plot lasso selection on the annotations route.
+    const { annotationPlotSampleIds } = useAnnotationPlotSelection();
+    const plotSelectedAnnotationIds = $derived($annotationPlotSampleIds);
 
     afterNavigate(() => {
         clearReversibleActions();
@@ -73,7 +79,11 @@
         query: {
             annotation_label_ids:
                 $selectedAnnotationFilterIds.length > 0 ? $selectedAnnotationFilterIds : undefined,
-            tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined
+            tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined,
+            // LIG-9521 prototype: embedding plot selection + embedding text search.
+            sample_ids:
+                plotSelectedAnnotationIds.length > 0 ? plotSelectedAnnotationIds : undefined,
+            text_embedding: $textEmbedding?.embedding ?? undefined
         }
     });
 
@@ -88,7 +98,10 @@
         collectionId: collection_id
     });
     let infiniteLoaderIdentifier = $derived(
-        $selectedAnnotationFilterIds.join(',') + Array.from($tagsSelected).join(',')
+        $selectedAnnotationFilterIds.join(',') +
+            Array.from($tagsSelected).join(',') +
+            plotSelectedAnnotationIds.join(',') +
+            ($textEmbedding ? `search:${$textEmbedding.queryText}` : '')
     );
 
     const filterHash = $derived(infiniteLoaderIdentifier);

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGridItem/AnnotationsGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGridItem/AnnotationsGridItem.svelte
@@ -16,6 +16,7 @@
         cachedCollectionVersion: string;
         showLabel: boolean;
         selected?: boolean;
+        onCropImageUrlChange?: (annotationId: string, url: string | null) => void;
     };
 
     let {
@@ -24,7 +25,8 @@
         height,
         cachedCollectionVersion = '',
         showLabel = true,
-        selected = false
+        selected = false,
+        onCropImageUrlChange
     }: Props = $props();
 </script>
 
@@ -37,6 +39,7 @@
         {cachedCollectionVersion}
         {showLabel}
         {selected}
+        {onCropImageUrlChange}
     />
 {:else if annotationWithPayload.parent_sample_type == SampleType.VIDEO_FRAME || annotationWithPayload.parent_sample_type == SampleType.VIDEO}
     <AnnotationVideoFrameGridItem

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGridItem/AnnotationsGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGridItem/AnnotationsGridItem.svelte
@@ -5,6 +5,7 @@
         type ImageAnnotationView,
         type VideoFrameAnnotationView
     } from '$lib/api/lightly_studio_local';
+    import { getSimilarityColor } from '$lib/utils';
     import AnnotationImageGridItem from '../AnnotationImageGridItem/AnnotationImageGridItem.svelte';
     import AnnotationVideoFrameGridItem from '../AnnotationVideoFrameGridItem/AnnotationVideoFrameGridItem.svelte';
 
@@ -46,4 +47,16 @@
         {showLabel}
         {selected}
     />
+{/if}
+
+{#if annotationWithPayload.similarity_score !== undefined && annotationWithPayload.similarity_score !== null}
+    <div
+        class="absolute bottom-1 right-1 z-10 box-border flex h-5 items-center rounded bg-black/60 px-1.5 text-xs font-medium text-white backdrop-blur-sm"
+    >
+        <span
+            class="mr-1.5 block h-2 w-2 rounded-full"
+            style="background-color: {getSimilarityColor(annotationWithPayload.similarity_score)}"
+        ></span>
+        {annotationWithPayload.similarity_score.toFixed(2)}
+    </div>
 {/if}

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import FilterChip from '$lib/components/FilterChip/FilterChip.svelte';
     import Segment from '$lib/components/Segment/Segment.svelte';
+    import { useEmbeddingFilterForAnnotations } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
     import { useEmbeddingFilterForImages } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForImages';
     import { useEmbeddingFilterForVideos } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForVideos';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
@@ -10,15 +11,34 @@
         collectionIdStore: Readable<string>;
         isVideos: boolean;
         isImages: boolean;
+        isAnnotations?: boolean;
     };
 
-    let { collectionIdStore, isVideos, isImages }: Props = $props();
+    let { collectionIdStore, isVideos, isImages, isAnnotations = false }: Props = $props();
 
     const { setRangeSelectionForCollection } = useGlobalStorage();
 
-    const embeddingFilter = isVideos
-        ? useEmbeddingFilterForVideos(collectionIdStore, setRangeSelectionForCollection)
-        : useEmbeddingFilterForImages(collectionIdStore, setRangeSelectionForCollection);
+    // Instantiate all variants once and pick reactively: this component lives in the
+    // layout, which persists when switching between the images/annotations tabs.
+    const imagesEmbeddingFilter = useEmbeddingFilterForImages(
+        collectionIdStore,
+        setRangeSelectionForCollection
+    );
+    const videosEmbeddingFilter = useEmbeddingFilterForVideos(
+        collectionIdStore,
+        setRangeSelectionForCollection
+    );
+    const annotationsEmbeddingFilter = useEmbeddingFilterForAnnotations(
+        collectionIdStore,
+        setRangeSelectionForCollection
+    );
+    const embeddingFilter = $derived(
+        isAnnotations
+            ? annotationsEmbeddingFilter
+            : isVideos
+              ? videosEmbeddingFilter
+              : imagesEmbeddingFilter
+    );
 
     const plotFilterCountStore = $derived(embeddingFilter.effectiveCount);
     const isPlotFilterAppliedStore = $derived(embeddingFilter.isVisible);
@@ -31,10 +51,14 @@
         embeddingFilter.clearFilter();
     };
 
-    const plotFilterItemLabel = $derived(isVideos ? 'video' : 'image');
+    const plotFilterItemLabel = $derived(
+        isAnnotations ? 'annotation' : isVideos ? 'video' : 'image'
+    );
     const isPlotFilterApplied = $derived($isPlotFilterAppliedStore);
     const plotFilterCount = $derived($plotFilterCountStore);
-    const hasPlotFilterContext = $derived((isImages || isVideos) && plotFilterCount > 0);
+    const hasPlotFilterContext = $derived(
+        (isImages || isVideos || isAnnotations) && plotFilterCount > 0
+    );
 </script>
 
 {#if hasPlotFilterContext}

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -10,6 +10,7 @@
     import { useEmbeddings } from '$lib/hooks/useEmbeddings/useEmbeddings';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
     import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
+    import { useAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
     import { useArrowData } from './useArrowData/useArrowData';
     import { usePlotData } from './usePlotData/usePlotData';
     import PlotPanelLegend from './PlotPanelLegend.svelte';
@@ -19,11 +20,12 @@
     import { getCategoryColors, getCategoryCount, getLegendEntries } from './plotColorUtils';
     import { INCLUDED_BY_FILTERS_LABEL, NO_CATEGORY_LABEL } from './plotCategories';
     import { page } from '$app/state';
-    import { isVideosRoute } from '$lib/routes';
+    import { isAnnotationsRoute, isVideosRoute } from '$lib/routes';
     import { usePlotColorByType } from './PlotColorByPopover/usePlotColorByType/usePlotColorByType';
     import { useTags } from '$lib/hooks/useTags/useTags';
     import { usePlotColorBy } from './usePlotColorBy/usePlotColorBy';
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
+    import { useSelectedAnnotationsFilter } from '$lib/hooks/useAnnotationsFilter/useAnnotationsFilter';
     import { writable } from 'svelte/store';
 
     const collectionId = page.params.collection_id;
@@ -40,22 +42,42 @@
 
     // Detect if we're on the videos route
     const isVideos = $derived(isVideosRoute(page.route?.id ?? null));
+    // LIG-9521 prototype: the plot also works on the annotations route.
+    const isAnnotations = $derived(isAnnotationsRoute(page.route?.id ?? null));
 
     // Use appropriate filter hook based on route
     const imageFilters = useImageFilters();
     const videoFilters = useVideoFilters();
+    const { annotationPlotSampleIds, updateSampleIds: updateAnnotationPlotSampleIds } =
+        useAnnotationPlotSelection();
 
     const updateSampleIds = $derived(
-        isVideos ? videoFilters.updateSampleIds : imageFilters.updateSampleIds
+        isAnnotations
+            ? updateAnnotationPlotSampleIds
+            : isVideos
+              ? videoFilters.updateSampleIds
+              : imageFilters.updateSampleIds
     );
     const imageFilter = $derived(isVideos ? null : imageFilters.imageFilter);
     const videoFilter = $derived(isVideos ? videoFilters.videoFilter : null);
     const activeSampleIds = $derived(
-        (isVideos ? $videoFilter : $imageFilter)?.sample_filter?.sample_ids ?? []
+        isAnnotations
+            ? $annotationPlotSampleIds
+            : ((isVideos ? $videoFilter : $imageFilter)?.sample_filter?.sample_ids ?? [])
     );
+
+    // LIG-9521 prototype: the active annotation label/tag filter, mirroring what the
+    // annotations grid applies.
+    const { annotationFilter: selectedAnnotationsFilter } =
+        useSelectedAnnotationsFilter(collectionId);
 
     // Prepare filter for embeddings API - use VideoFilter for videos, ImageFilter for images
     const filter = $derived.by(() => {
+        // LIG-9521 prototype: on the annotations route, send the active annotation
+        // label/tag filter (or an empty annotations filter so all points count as included).
+        if (isAnnotations) {
+            return $selectedAnnotationsFilter ?? { filter_type: 'annotations' as const };
+        }
         const currentFilter = isVideos ? $videoFilter : $imageFilter;
         if (!currentFilter) return null;
 
@@ -73,7 +95,12 @@
     });
 
     const { selectedColorByType } = usePlotColorByType(collectionId);
-    const { tags } = useTags({ collection_id: collectionId, kind: ['sample'] });
+    // LIG-9521 prototype: annotation samples carry annotation-kind tags. Captured once
+    // at mount, like collectionId above.
+    const { tags } = useTags({
+        collection_id: collectionId,
+        kind: isAnnotationsRoute(page.route?.id ?? null) ? ['annotation'] : ['sample']
+    });
     const annotationLabelsQuery = useAnnotationLabels(() => ({ collectionId }));
     const annotationLabels = writable<{ annotation_label_id: string }[]>([]);
     $effect(() => {
@@ -138,8 +165,9 @@
             return;
         }
 
-        const filter = isVideos ? $videoFilter : $imageFilter;
-        const currentSampleIds = filter?.sample_filter?.sample_ids || [];
+        const currentSampleIds = isAnnotations
+            ? $annotationPlotSampleIds
+            : ((isVideos ? $videoFilter : $imageFilter)?.sample_filter?.sample_ids ?? []);
         const selectableCount =
             ($arrowData?.fulfils_filter as Uint8Array | undefined)?.reduce((count, fulfils) => {
                 return fulfils !== 0 ? count + 1 : count;

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.ts
@@ -1,0 +1,26 @@
+import { writable, type Readable } from 'svelte/store';
+import { useFilterVisibility } from './useFilterVisibility';
+
+// LIG-9521 prototype: the embedding plot lasso selection on the annotations route.
+// Kept separate from the image/video filter stores so it does not pollute them.
+const annotationPlotSampleIds = writable<string[]>([]);
+
+export function useAnnotationPlotSelection() {
+    return {
+        annotationPlotSampleIds,
+        updateSampleIds: (ids: string[]) => annotationPlotSampleIds.set(ids)
+    };
+}
+
+export function useEmbeddingFilterForAnnotations(
+    collectionId: Readable<string>,
+    setRangeSelectionForCollection: (collectionId: string, selection: null) => void
+) {
+    const { updateSampleIds } = useAnnotationPlotSelection();
+    return useFilterVisibility(
+        collectionId,
+        annotationPlotSampleIds,
+        updateSampleIds,
+        setRangeSelectionForCollection
+    );
+}

--- a/lightly_studio_view/src/lib/hooks/useEmbeddings/useEmbeddings.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddings/useEmbeddings.ts
@@ -1,5 +1,6 @@
 import { get2dEmbeddingsOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
 import type {
+    AnnotationsFilter,
     GetEmbeddings2dRequest,
     ImageFilter,
     VideoFilter
@@ -11,7 +12,7 @@ type EmbeddingsColorBy = GetEmbeddings2dRequest['color_by'];
 
 export function useEmbeddings(
     collectionId: string,
-    filters: ImageFilter | VideoFilter | null,
+    filters: ImageFilter | VideoFilter | AnnotationsFilter | null,
     colorBy: EmbeddingsColorBy = null
 ) {
     return createQuery(() =>

--- a/lightly_studio_view/src/lib/hooks/useSelectAll/useSelectAll.ts
+++ b/lightly_studio_view/src/lib/hooks/useSelectAll/useSelectAll.ts
@@ -7,6 +7,7 @@ import { useVideoFilters, buildVideoFilter } from '$lib/hooks/useVideoFilters/us
 import { useFramesFilter } from '$lib/hooks/useFramesFilter/useFramesFilter';
 import { getFrameFilter } from '$lib/hooks/useFramesFilter/frameFilter';
 import { useSelectedAnnotationsFilter } from '$lib/hooks/useAnnotationsFilter/useAnnotationsFilter';
+import { useAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
 import { fetchSampleIdsForImages } from './fetchSampleIdsForImages';
 import { fetchSampleIdsForVideos } from './fetchSampleIdsForVideos';
 import { fetchSampleIdsForVideoFrames } from './fetchSampleIdsForVideoFrames';
@@ -18,6 +19,7 @@ export function useSelectAll(collectionId: string, gridType: GridType) {
     const { filterParams: videoFilterParams } = useVideoFilters();
     const { filterParams: frameFilterParams } = useFramesFilter();
     const { annotationFilter } = useSelectedAnnotationsFilter(collectionId);
+    const { annotationPlotSampleIds } = useAnnotationPlotSelection();
 
     let isLoading = false;
 
@@ -35,8 +37,20 @@ export function useSelectAll(collectionId: string, gridType: GridType) {
                     collectionId,
                     getFrameFilter(get(frameFilterParams))
                 );
-            case 'annotations':
-                return fetchSampleIdsForAnnotations(collectionId, get(annotationFilter));
+            case 'annotations': {
+                // LIG-9521 prototype: include the embedding plot selection so select-all
+                // only selects the filtered annotations (mirrors imageFilter.sample_filter).
+                const plotSampleIds = get(annotationPlotSampleIds);
+                const filter =
+                    plotSampleIds.length > 0
+                        ? {
+                              ...get(annotationFilter),
+                              filter_type: 'annotations' as const,
+                              sample_ids: plotSampleIds
+                          }
+                        : get(annotationFilter);
+                return fetchSampleIdsForAnnotations(collectionId, filter);
+            }
             default:
                 return [];
         }

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -204,7 +204,10 @@
 
     const hasEmbeddingsQuery = useHasEmbeddings(() => ({ collectionId }));
     const hasEmbeddings = $derived(!!hasEmbeddingsQuery.data);
-    const hasMediaWithEmbeddings = $derived((isImages || isVideos) && hasEmbeddings);
+    // LIG-9521 prototype: annotations have (fake) embeddings too.
+    const hasMediaWithEmbeddings = $derived(
+        (isImages || isVideos || isAnnotations) && hasEmbeddings
+    );
 
     const { metadataValues } = $derived.by(() => useMetadataFilters(collectionId));
     const { dimensionsValues } = useDimensions(collectionIdStore);
@@ -345,6 +348,7 @@
                                 {collectionIdStore}
                                 {isVideos}
                                 {isImages}
+                                {isAnnotations}
                             />
                             {#if isImages}
                                 <AnnotationCollectionsMenu {collectionId} />
@@ -427,7 +431,7 @@
                         {/await}
                     </Pane>
                 </PaneGroup>
-            {:else if $activePanel === 'embeddingPlot' && (isImages || isVideos)}
+            {:else if $activePanel === 'embeddingPlot' && (isImages || isVideos || isAnnotations)}
                 <!-- When plot is shown, use PaneGroup for the main content + plot -->
                 <PaneGroup direction="horizontal" class="min-w-0 flex-1">
                     <Pane defaultSize={50} minSize={30} class="flex">
@@ -466,7 +470,11 @@
 
                     <Pane defaultSize={50} minSize={30} class="flex min-h-0 flex-col">
                         {#await import('$lib/components/PlotPanel/PlotPanel.svelte') then { default: PlotPanel }}
-                            <PlotPanel />
+                            <!-- LIG-9521 prototype: PlotPanel captures collectionId at mount;
+                                 remount it when switching collections (e.g. images <-> annotations tab). -->
+                            {#key collectionId}
+                                <PlotPanel />
+                            {/key}
                         {/await}
                     </Pane>
                 </PaneGroup>


### PR DESCRIPTION
## What has changed and why?

Functional prototype of the frontend for annotation embeddings, using them for text search and the embedding plot.

### Backend

Adapted `lightly_studio/src/lightly_studio/examples/example_coco.py` to:

- Generate embeddings linked to annotation samples.
- Generate some random tags.
- Generate some random categorical metadata.

### Frontend

- Added text search for annotations.
- Added an embedding plot for annotations.

## How to review

Test it yourself: check out the branch, build, and run `example_coco.py`. Then see what works for annotations.

## Screenshot

<img width="1822" height="1067" alt="image" src="https://github.com/user-attachments/assets/3b5e1442-4c5b-4db2-83ce-89996ed79871" />

## How has it been tested?

These following features work on the annotations tab. Partly AI-generated list. 
All of this has been checked manually.

### General

- [x] The search bar and the Embeddings button are available on the annotations tab.
- [x] The embedding plot shows one point per annotation (900 for the COCO subset).
- [x] The images tab behaves exactly as before.

### Similarity search

- [x] Typing a text query (e.g. "sports") reorders the annotation grid by similarity.
- [x] Each search result tile shows its similarity score badge.
- [x] Right-click → "Copy image" on an annotation tile copies only the crop, which can be pasted into the search for image similarity search.
- [x] Uploading or pasting an image file into the search ranks annotations by image similarity.
- [x] Dragging an annotation tile onto the search bar triggers image similarity search.
- [x] Clearing the search (X) restores the default grid order and removes the score badges.
- [x] A query typed on one tab carries over to the other tab (search state is shared). _Design decision, happy to rethink it._
- [x] Scrolling deep through search results paginates without duplicates or gaps.
- [x] Text search combined with a label / tag / plot-selection filter keeps ordering, badges and counts consistent.
- [x] Annotation details prev/next navigation follows the similarity order.
- [ FAILING] Annotation image to annotation search should give a score of 1.0 for the same image. Atm, this fails. This might be due to the way the embeddings are calculated in the backend. Fix it in the full version.
- [FAILING] Annotation image to annotation search combined with embedding plot lasso selection works. Atm, this fails and the loading of annotations in the grid errors out.

### Filtering

- [x] Filtering by annotation class updates the embedding plot and greys out non-matching plot points ("Excluded by filters").
- [x] Filtering by annotation tags filters the embedding plot.
- [x] A lasso/rectangle selection in the plot filters the grid and shows an "Embedding Plot Filter: N annotations" chip in the sidebar; clearing it restores the grid.
- [x] With no filters active, no points are "Excluded by filters" — also after switching between the images and annotations tabs with the plot open.
- [x] A plot selection on the annotations tab does not leak into the image filters (and vice versa).
- [x] Select-all (Ctrl+A) with an active plot-selection filter selects only the filtered annotations.
- [x] The "Embedding Plot Filter" chip checkbox hides the filter and re-enabling it restores the selection.
- [x] Tagging or relabeling the plot-selected annotations acts only on the filtered set.

### Embedding plot colouring

- [x] Colouring by annotation class gives each class its own colour with a legend (not everything "No category").
- [x] Colouring by tags colours the tagged annotations (random-200 / random-400) with a legend.
- [x] Colouring by the metadata field "tag" gives each value its own colour (no tag / random-200 / random-400 / random-both).
- [x] Legend interactions work: click hides a category, double-click solos one.

## Conscious limitations / out of scope

- Few-shot classifier is not available for annotations.
- Sampling is not available for annotations.

### Other limitations

- Annotations created or edited in the GUI get no fake embeddings (only generated at COCO load), so they are invisible to search / plot — deferred to a follow-up issue on embedding computation and update policy.
- Multiple annotation sources / switching annotation collections is untested (COCO has only one).
- Restarting the GUI on an existing DB without re-running the load does nothing.
- Video-frame annotations are not supported (image parents only).
