### PR TITLE
Deep copy rework

### DIFF
--- a/lightly_studio/pytest.ini
+++ b/lightly_studio/pytest.ini
@@ -2,6 +2,9 @@
 pythonpath = src
 python_files = test_*.py
 
+markers =
+    postgres_only: run the test only on the Postgres backend (skipped under DuckDB)
+
 filterwarnings =
     ignore::UserWarning
     ignore::FutureWarning:mobileclip

--- a/lightly_studio/src/lightly_studio/db_manager.py
+++ b/lightly_studio/src/lightly_studio/db_manager.py
@@ -258,6 +258,27 @@ def get_backend() -> DatabaseBackend:
     return get_engine().backend
 
 
+def require_postgres_backend(session: Session) -> None:
+    """Raise unless ``session`` is bound to a PostgreSQL backend.
+
+    Some operations (dataset deep-copy and delete) are enterprise-only and are
+    implemented with PostgreSQL-specific set-based SQL; they are not supported on
+    DuckDB. The check uses the session's bind rather than the global engine so it
+    is correct in tests, which run on per-test engines that are not registered
+    globally.
+
+    Raises:
+        NotImplementedError: If the session is not bound to PostgreSQL.
+    """
+    bind = session.get_bind()
+    dialect_name = bind.dialect.name if bind is not None else None
+    if dialect_name != DatabaseBackend.POSTGRESQL.value:
+        raise NotImplementedError(
+            "This operation is only supported on the PostgreSQL backend. "
+            f"Current backend: {dialect_name or 'unknown'}."
+        )
+
+
 def _initialize_postgres_schema(
     engine: Engine,
     engine_url: str,

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -261,10 +261,11 @@ def _copy_table(
     # Every declared foreign key must be remapped; an unmapped one would be copied verbatim
     # and point back at the source dataset. Catches a new FK column on a copied table.
     unmapped_fk_columns = {c.name for c in table.columns if c.foreign_keys} - set(overrides)
-    assert not unmapped_fk_columns, (
-        f"{table.name}: foreign-key column(s) {sorted(unmapped_fk_columns)} are not in "
-        "`overrides`; add them so they are remapped to the copied dataset."
-    )
+    if unmapped_fk_columns:
+        raise RuntimeError(
+            f"{table.name}: foreign-key column(s) {sorted(unmapped_fk_columns)} are not in "
+            "`overrides`; add them so they are remapped to the copied dataset."
+        )
     columns = list(table.columns)
     select_exprs = [
         (

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -12,9 +12,10 @@ bounded and large (1M-10M sample) datasets are handled by the database.
 This is enterprise-only and PostgreSQL-only (it relies on ``gen_random_uuid()``,
 temporary tables, and statement-end FK checks). DuckDB is not supported.
 
-Adding an FK column to an existing table requires adding it to that table's ``overrides``
-dict below, otherwise it would be copied verbatim and still point at the source dataset.
-``verify_table_coverage`` only guards new *tables*, not new *columns*.
+New columns are copied verbatim automatically; a new *foreign-key* column must be added to
+its table's ``overrides`` dict so it is remapped to the copied dataset. ``_copy_table``
+asserts that every declared FK column is remapped (fails fast otherwise), and
+``verify_table_coverage`` separately guards against new *tables*.
 """
 
 from __future__ import annotations
@@ -213,6 +214,14 @@ def _create_id_map(
     ``ON COMMIT DROP`` ties the table's lifetime to the surrounding transaction, so it is
     released on commit and never leaks onto a pooled connection. The primary key on
     ``old_id`` keeps the downstream joins fast on large datasets.
+
+    Args:
+        session: Database session.
+        source_table: Table to map ids for; also determines the temp table name.
+        id_column: Primary-key column whose values become ``old_id``.
+        where_sql: SQL predicate selecting the in-scope rows. An internal constant; any
+            values are bound through ``params``.
+        params: Bind parameters referenced by ``where_sql``.
     """
     map_name = f"deep_copy_map_{source_table}"
     session.execute(
@@ -235,12 +244,28 @@ def _copy_table(
 ) -> None:
     """Emit ``INSERT INTO target (cols) SELECT <override|verbatim per col> FROM ...``.
 
-    Column names come from ``_table(target).columns`` so new columns are copied
-    verbatim automatically. For each column an ``overrides`` expression is selected if
-    present, otherwise the source column is copied as-is. Names and select expressions are
-    built from the same ordered column list, so they align positionally.
+    Column names come from the target table so new columns are copied verbatim
+    automatically. For each column an ``overrides`` expression is selected if present,
+    otherwise the source column is copied as-is. Names and select expressions are built
+    from the same ordered column list, so they align positionally.
+
+    Args:
+        session: Database session.
+        target: SQLModel table class to insert into.
+        source: Aliased source table to select from (exposes ``.c``).
+        from_clause: ``source`` joined to the map tables needed for the remaps.
+        overrides: Column name -> expression to select instead of the verbatim source
+            column (FK/PK remaps, fresh ``gen_random_uuid()`` ids, regenerated timestamps).
     """
-    columns = list(_table(target).columns)
+    table = _table(target)
+    # Every declared foreign key must be remapped; an unmapped one would be copied verbatim
+    # and point back at the source dataset. Catches a new FK column on a copied table.
+    unmapped_fk_columns = {c.name for c in table.columns if c.foreign_keys} - set(overrides)
+    assert not unmapped_fk_columns, (
+        f"{table.name}: foreign-key column(s) {sorted(unmapped_fk_columns)} are not in "
+        "`overrides`; add them so they are remapped to the copied dataset."
+    )
+    columns = list(table.columns)
     select_exprs = [
         (
             overrides[column.name].label(column.name)
@@ -250,11 +275,17 @@ def _copy_table(
         for column in columns
     ]
     statement = sa_select(*select_exprs).select_from(from_clause)
-    session.exec(insert(_table(target)).from_select([c.name for c in columns], statement))
+    session.exec(insert(table).from_select([c.name for c in columns], statement))
 
 
 def _map(name: str, alias: str | None = None) -> Any:
-    """Return a lightweight clause for a temporary map table (columns old_id, new_id)."""
+    """Return a lightweight clause for a temporary map table (columns old_id, new_id).
+
+    Args:
+        name: Temp map table name.
+        alias: Optional alias, needed when the same map table is joined more than once in
+            a single statement.
+    """
     handle = sa_table(name, sa_column("old_id"), sa_column("new_id"))
     return handle.alias(alias) if alias is not None else handle
 
@@ -275,6 +306,13 @@ def _copy_collections(
 
     The single multi-row insert satisfies the self-referential ``parent_collection_id``
     FK because PostgreSQL checks it at statement end, once all rows are present.
+
+    Args:
+        session: Database session.
+        new_dataset_id: Dataset id the copied collections belong to.
+        copy_name: New name for the root collection.
+        old_root_name: Name of the source root, used to derive child names.
+        now: Timestamp for the copied collections' created_at/updated_at.
     """
     src = _table(CollectionTable).alias("src")
     map_collection = _map(_MAP_COLLECTION)

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -1,25 +1,41 @@
-"""Deep copy resolver for collections."""
+"""Deep copy resolver for collections (PostgreSQL, set-based).
+
+Copies an entire dataset (collections, samples, annotations, embeddings, metadata,
+tags, groups, evaluation data, and link tables) into a new dataset with fresh UUIDs.
+
+The copy runs entirely server-side: for every entity whose new id is referenced by
+other tables we build a temporary ``(old_id, new_id)`` mapping table via
+``gen_random_uuid()``, then copy each table with a single ``INSERT ... SELECT`` that
+joins the maps to remap foreign keys. No rows are materialized in Python, so memory is
+bounded and large (1M-10M sample) datasets are handled by the database.
+
+This is enterprise-only and PostgreSQL-only (it relies on ``gen_random_uuid()``,
+temporary tables, and statement-end FK checks). DuckDB is not supported.
+
+Adding an FK column to an existing table requires adding it to that table's ``overrides``
+dict below, otherwise it would be copied verbatim and still point at the source dataset.
+``verify_table_coverage`` only guards new *tables*, not new *columns*.
+"""
 
 from __future__ import annotations
 
-import copy
-from dataclasses import dataclass, field
-from typing import Any, TypeVar
+from datetime import datetime, timezone
+from typing import Any, cast
 from uuid import UUID, uuid4
 
+from sqlalchemy import Table, case, func, insert, literal, text
+from sqlalchemy import column as sa_column
+from sqlalchemy import select as sa_select
+from sqlalchemy import table as sa_table
 from sqlmodel import Session, SQLModel, col, select
 
-from lightly_studio import db_array
-from lightly_studio.models.annotation.annotation_base import (
-    AnnotationBaseTable,
-)
+from lightly_studio import db_manager
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation.object_detection import (
     ObjectDetectionAnnotationTable,
 )
 from lightly_studio.models.annotation.object_track import ObjectTrackTable
-from lightly_studio.models.annotation.segmentation import (
-    SegmentationAnnotationTable,
-)
+from lightly_studio.models.annotation.segmentation import SegmentationAnnotationTable
 from lightly_studio.models.annotation_collection_coverage import (
     AnnotationCollectionCoverageTable,
 )
@@ -28,7 +44,9 @@ from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.dataset import DatasetTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
-from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
+from lightly_studio.models.evaluation_annotation_metric import (
+    EvaluationAnnotationMetricTable,
+)
 from lightly_studio.models.evaluation_run import EvaluationRunTable
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricTable
 from lightly_studio.models.group import GroupTable, SampleGroupLinkTable
@@ -41,24 +59,15 @@ from lightly_studio.models.video import VideoFrameTable, VideoTable
 from lightly_studio.resolvers import dataset_resolver
 from lightly_studio.resolvers.dataset_resolver import table_coverage_utils
 
-T = TypeVar("T", bound=SQLModel)
-
-# Fields to exclude when copying - these have default_factory and should be regenerated.
-_EXCLUDE_ON_COPY: set[str] = {"created_at", "updated_at"}
-
-
-@dataclass
-class DeepCopyContext:
-    """Holds ID mappings (old ID -> new ID) during deep copy operation."""
-
-    collection_map: dict[UUID, UUID] = field(default_factory=dict)
-    sample_map: dict[UUID, UUID] = field(default_factory=dict)
-    tag_map: dict[UUID, UUID] = field(default_factory=dict)
-    object_track_map: dict[UUID, UUID] = field(default_factory=dict)
-    annotation_label_map: dict[UUID, UUID] = field(default_factory=dict)
-    embedding_model_map: dict[UUID, UUID] = field(default_factory=dict)
-    evaluation_run_map: dict[UUID, UUID] = field(default_factory=dict)
-    new_dataset_id: UUID | None = None
+# Names of the temporary (old_id -> new_id) mapping tables, one per entity whose new id
+# is referenced by other tables.
+_MAP_COLLECTION = "deep_copy_map_collection"
+_MAP_SAMPLE = "deep_copy_map_sample"
+_MAP_TAG = "deep_copy_map_tag"
+_MAP_OBJECT_TRACK = "deep_copy_map_object_track"
+_MAP_ANNOTATION_LABEL = "deep_copy_map_annotation_label"
+_MAP_EMBEDDING_MODEL = "deep_copy_map_embedding_model"
+_MAP_EVALUATION_RUN = "deep_copy_map_evaluation_run"
 
 
 def deep_copy(
@@ -68,662 +77,663 @@ def deep_copy(
 ) -> CollectionTable:
     """Deep copy a dataset with all related entities.
 
-    This performs a complete deep copy of a dataset, creating new UUIDs for all
-    entities while preserving relationships through ID remapping.
-
     Args:
-        session: Database session.
+        session: Database session (must be bound to PostgreSQL).
         dataset_id: Dataset ID to copy.
-        copy_name: Name for the new dataset.
+        copy_name: Name for the new root collection.
 
     Returns:
         The newly created root collection.
     """
-    # If this fails, a new table was added. Update deep_copy to handle it, then update this count.
+    db_manager.require_postgres_backend(session)
+    # If this fails, a new table was added. Update deep_copy to handle it, then update
+    # the count in table_coverage_utils.
     table_coverage_utils.verify_table_coverage()
-    ctx = DeepCopyContext()
 
-    # 1. Create new dataset entry.
     new_dataset_id = uuid4()
-    ctx.new_dataset_id = new_dataset_id
-    # TODO(lukas, 03/2026): `copy_name` should be stored in DatasetTable
-    db_dataset = DatasetTable(
-        dataset_id=new_dataset_id,
-    )
-    session.add(db_dataset)
-    session.flush([db_dataset])
+    now = datetime.now(timezone.utc)
 
-    # 2. Copy collection hierarchy.
+    # The hierarchy gives the root collection name, needed to derive copied names.
     hierarchy = dataset_resolver.get_hierarchy(session=session, dataset_id=dataset_id)
-    root = _copy_collections(
+    old_root_name = hierarchy[0].name
+
+    # 1. New dataset row (parents must exist before their FK children).
+    session.exec(insert(_table(DatasetTable)).values(dataset_id=new_dataset_id))
+
+    # 2. Build the id maps. The 7 entities below have new ids referenced by other tables.
+    _build_id_maps(session=session, old_dataset_id=dataset_id)
+
+    # 3. Copy each table with a single INSERT ... SELECT, in FK dependency order
+    #    (parents before children; PostgreSQL checks FKs at statement end).
+    _copy_collections(
         session=session,
-        hierarchy=hierarchy,
+        new_dataset_id=new_dataset_id,
         copy_name=copy_name,
-        ctx=ctx,
-        dataset_id=new_dataset_id,
+        old_root_name=old_root_name,
+        now=now,
     )
+    _copy_tags(session=session, now=now)
+    _copy_object_tracks(session=session, new_dataset_id=new_dataset_id)
+    _copy_annotation_labels(session=session, new_dataset_id=new_dataset_id)
+    _copy_embedding_models(session=session, now=now)
+    _copy_samples(session=session, now=now)
+    _copy_evaluation_runs(session=session, now=now)
 
-    # 3. Copy collection-scoped entities.
-    old_collection_ids = list(ctx.collection_map.keys())
-    _copy_tags(session=session, old_collection_ids=old_collection_ids, ctx=ctx)
-    _copy_object_tracks(
-        session=session,
-        old_dataset_id=dataset_id,
-        ctx=ctx,
-    )
-    _copy_annotation_labels(
-        session=session,
-        old_dataset_id=dataset_id,
-        ctx=ctx,
-    )
-    _copy_embedding_models(session=session, old_collection_ids=old_collection_ids, ctx=ctx)
-    _copy_evaluation_runs(session=session, old_dataset_id=dataset_id, ctx=ctx)
-    _copy_samples(session=session, old_collection_ids=old_collection_ids, ctx=ctx)
-    session.flush()
+    _copy_images(session=session, now=now)
+    _copy_videos(session=session)
+    _copy_video_frames(session=session)
+    _copy_groups(session=session)
+    _copy_captions(session=session, now=now)
+    _copy_annotations(session=session, now=now)
+    _copy_annotation_details(session=session, detail_table=ObjectDetectionAnnotationTable)
+    _copy_annotation_details(session=session, detail_table=SegmentationAnnotationTable)
 
-    # 4. Copy type-specific sample tables.
-    old_sample_ids = list(ctx.sample_map.keys())
-    _copy_images(session=session, old_sample_ids=old_sample_ids, ctx=ctx)
-    _copy_videos(session=session, old_sample_ids=old_sample_ids, ctx=ctx)
-    _copy_video_frames(session=session, old_sample_ids=old_sample_ids, ctx=ctx)
-    _copy_groups(session=session, old_sample_ids=old_sample_ids, ctx=ctx)
-    _copy_captions(session=session, old_sample_ids=old_sample_ids, ctx=ctx)
-    _copy_annotations(session=session, old_sample_ids=old_sample_ids, ctx=ctx)
-    session.flush()
+    _copy_sample_embeddings(session=session)
+    _copy_metadata(session=session, now=now)
+    _copy_evaluation_sample_metrics(session=session)
+    _copy_evaluation_annotation_metrics(session=session)
 
-    # 5. Copy sample attachments.
-    _copy_metadata(session=session, old_sample_ids=old_sample_ids, ctx=ctx)
-    _copy_embeddings(session=session, old_sample_ids=old_sample_ids, ctx=ctx)
-    _copy_evaluation_sample_metrics(session=session, ctx=ctx)
-    _copy_evaluation_annotation_metrics(session=session, ctx=ctx)
-    session.flush()
+    _copy_sample_tag_links(session=session)
+    _copy_sample_group_links(session=session)
+    _copy_annotation_collection_coverage(session=session)
 
-    # 6. Copy link tables.
-    _copy_sample_tag_links(session=session, old_sample_ids=old_sample_ids, ctx=ctx)
-    _copy_sample_group_links(session=session, old_sample_ids=old_sample_ids, ctx=ctx)
-    _copy_annotation_collection_coverage(session=session, ctx=ctx)
-
+    # Commit so the ON COMMIT DROP map tables are released and a subsequent deep_copy in
+    # the same session can recreate them.
     session.commit()
 
-    return root
+    return session.exec(
+        select(CollectionTable).where(
+            CollectionTable.dataset_id == new_dataset_id,
+            col(CollectionTable.parent_collection_id).is_(None),
+        )
+    ).one()
+
+
+def _build_id_maps(session: Session, old_dataset_id: UUID) -> None:
+    """Create the temporary (old_id -> new_id) mapping tables for the dataset."""
+    dataset_params = {"old_dataset_id": old_dataset_id}
+    in_collection_map = f"collection_id IN (SELECT old_id FROM {_MAP_COLLECTION})"
+
+    _create_id_map(
+        session=session,
+        source_table="collection",
+        id_column="collection_id",
+        where_sql="dataset_id = :old_dataset_id",
+        params=dataset_params,
+    )
+    _create_id_map(
+        session=session,
+        source_table="sample",
+        id_column="sample_id",
+        where_sql=in_collection_map,
+    )
+    _create_id_map(
+        session=session,
+        source_table="tag",
+        id_column="tag_id",
+        where_sql=in_collection_map,
+    )
+    _create_id_map(
+        session=session,
+        source_table="object_track",
+        id_column="object_track_id",
+        where_sql="dataset_id = :old_dataset_id",
+        params=dataset_params,
+    )
+    _create_id_map(
+        session=session,
+        source_table="annotation_label",
+        id_column="annotation_label_id",
+        where_sql="dataset_id = :old_dataset_id",
+        params=dataset_params,
+    )
+    _create_id_map(
+        session=session,
+        source_table="embedding_model",
+        id_column="embedding_model_id",
+        where_sql=in_collection_map,
+    )
+    _create_id_map(
+        session=session,
+        source_table="evaluation_run",
+        id_column="id",
+        where_sql=f"gt_annotation_collection_id IN (SELECT old_id FROM {_MAP_COLLECTION})",
+    )
+
+
+def _create_id_map(
+    session: Session,
+    source_table: str,
+    id_column: str,
+    where_sql: str,
+    params: dict[str, Any] | None = None,
+) -> None:
+    """Create a temporary ``(old_id, new_id)`` table for in-scope rows of a source table.
+
+    ``ON COMMIT DROP`` ties the table's lifetime to the surrounding transaction, so it is
+    released on commit and never leaks onto a pooled connection. The primary key on
+    ``old_id`` keeps the downstream joins fast on large datasets.
+    """
+    map_name = f"deep_copy_map_{source_table}"
+    session.execute(
+        text(
+            f"CREATE TEMPORARY TABLE {map_name} ON COMMIT DROP AS "
+            f"SELECT {id_column} AS old_id, gen_random_uuid() AS new_id "
+            f"FROM {source_table} WHERE {where_sql}"
+        ),
+        params or {},
+    )
+    session.execute(text(f"ALTER TABLE {map_name} ADD PRIMARY KEY (old_id)"))
+
+
+def _copy_table(
+    session: Session,
+    target: type[SQLModel],
+    source: Any,
+    from_clause: Any,
+    overrides: dict[str, Any],
+) -> None:
+    """Emit ``INSERT INTO target (cols) SELECT <override|verbatim per col> FROM ...``.
+
+    Column names come from ``_table(target).columns`` so new columns are copied
+    verbatim automatically. For each column an ``overrides`` expression is selected if
+    present, otherwise the source column is copied as-is. Names and select expressions are
+    built from the same ordered column list, so they align positionally.
+    """
+    columns = list(_table(target).columns)
+    select_exprs = [
+        (
+            overrides[column.name].label(column.name)
+            if column.name in overrides
+            else source.c[column.name]
+        )
+        for column in columns
+    ]
+    statement = sa_select(*select_exprs).select_from(from_clause)
+    session.exec(insert(_table(target)).from_select([c.name for c in columns], statement))
+
+
+def _map(name: str, alias: str | None = None) -> Any:
+    """Return a lightweight clause for a temporary map table (columns old_id, new_id)."""
+    handle = sa_table(name, sa_column("old_id"), sa_column("new_id"))
+    return handle.alias(alias) if alias is not None else handle
+
+
+def _table(model: type[SQLModel]) -> Table:
+    """Return the SQLAlchemy ``Table`` backing a SQLModel table class."""
+    return cast(Table, model.__table__)  # type: ignore[attr-defined]
 
 
 def _copy_collections(
     session: Session,
-    hierarchy: list[CollectionTable],
+    new_dataset_id: UUID,
     copy_name: str,
-    ctx: DeepCopyContext,
-    dataset_id: UUID,
-) -> CollectionTable:
-    """Copy collection hierarchy, maintaining parent-child relationships."""
-    root: CollectionTable | None = None
-    old_root_name = hierarchy[0].name
-
-    # Generate new UUIDs for all collections and build the mapping.
-    ctx.collection_map = {old_coll.collection_id: uuid4() for old_coll in hierarchy}
-
-    # Insert the copied collections one by one.
-    for old_coll in hierarchy:
-        new_id = ctx.collection_map[old_coll.collection_id]
-
-        # Derive new name by replacing root prefix.
-        if old_coll.name == old_root_name:
-            derived_name = copy_name
-        else:
-            derived_name = old_coll.name.replace(old_root_name, copy_name, 1)
-
-        # Remap parent_collection_id if it exists.
-        new_parent_id = None
-        if old_coll.parent_collection_id is not None:
-            new_parent_id = ctx.collection_map[old_coll.parent_collection_id]
-
-        new_coll = _copy_with_updates(
-            old_coll,
-            {
-                "collection_id": new_id,
-                "dataset_id": dataset_id,
-                "name": derived_name,
-                "parent_collection_id": new_parent_id,
-            },
-        )
-        session.add(new_coll)
-        session.flush()  # Flush each collection so it's visible for FK checks.
-
-        # Keep track of the new root collection.
-        # The root is the first collection in the hierarchy argument.
-        if root is None:
-            root = new_coll
-
-    assert root is not None
-    return root
-
-
-def _copy_samples(
-    session: Session,
-    old_collection_ids: list[UUID],
-    ctx: DeepCopyContext,
+    old_root_name: str,
+    now: datetime,
 ) -> None:
-    """Copy all samples, remapping collection_id to new collections."""
-    # TODO (Mihnea, 01/2026): Handle large collections with batching if needed.
-    samples = session.exec(
-        select(SampleTable).where(
-            db_array.in_array(column=col(SampleTable.collection_id), values=old_collection_ids)
-        )
-    ).all()
+    """Copy the collection hierarchy, remapping parent links and deriving names.
 
-    for old_sample in samples:
-        new_id = uuid4()
-        ctx.sample_map[old_sample.sample_id] = new_id
-
-        new_sample = _copy_with_updates(
-            old_sample,
-            {
-                "sample_id": new_id,
-                "collection_id": ctx.collection_map[old_sample.collection_id],
-            },
-        )
-        session.add(new_sample)
-
-
-def _copy_tags(
-    session: Session,
-    old_collection_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy tags, remapping collection_id."""
-    tags = session.exec(
-        select(TagTable).where(
-            db_array.in_array(column=col(TagTable.collection_id), values=old_collection_ids)
-        )
-    ).all()
-
-    for old_tag in tags:
-        new_id = uuid4()
-        ctx.tag_map[old_tag.tag_id] = new_id
-
-        new_tag = _copy_with_updates(
-            old_tag,
-            {
-                "tag_id": new_id,
-                "collection_id": ctx.collection_map[old_tag.collection_id],
-            },
-        )
-        session.add(new_tag)
-
-
-def _copy_annotation_labels(
-    session: Session,
-    old_dataset_id: UUID,
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy annotation labels belonging to a dataset."""
-    labels = session.exec(
-        select(AnnotationLabelTable).where(AnnotationLabelTable.dataset_id == old_dataset_id)
-    ).all()
-
-    for old_label in labels:
-        new_id = uuid4()
-        ctx.annotation_label_map[old_label.annotation_label_id] = new_id
-
-        new_label = _copy_with_updates(
-            old_label,
-            {"annotation_label_id": new_id, "dataset_id": ctx.new_dataset_id},
-        )
-        session.add(new_label)
-
-
-def _copy_embedding_models(
-    session: Session,
-    old_collection_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy embedding models, remapping collection_id."""
-    models = session.exec(
-        select(EmbeddingModelTable).where(
-            db_array.in_array(
-                column=col(EmbeddingModelTable.collection_id), values=old_collection_ids
-            )
-        )
-    ).all()
-
-    for old_model in models:
-        new_id = uuid4()
-        ctx.embedding_model_map[old_model.embedding_model_id] = new_id
-
-        new_model = _copy_with_updates(
-            old_model,
-            {
-                "embedding_model_id": new_id,
-                "collection_id": ctx.collection_map[old_model.collection_id],
-            },
-        )
-        session.add(new_model)
-
-
-def _copy_videos(
-    session: Session,
-    old_sample_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy video records, remapping sample_id."""
-    videos = session.exec(
-        select(VideoTable).where(
-            db_array.in_array(column=col(VideoTable.sample_id), values=old_sample_ids)
-        )
-    ).all()
-
-    for old_video in videos:
-        new_video = _copy_with_updates(
-            old_video,
-            {"sample_id": ctx.sample_map[old_video.sample_id]},
-        )
-        session.add(new_video)
-
-
-def _copy_video_frames(
-    session: Session,
-    old_sample_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy video frames, remapping both sample_id and parent_sample_id."""
-    frames = session.exec(
-        select(VideoFrameTable).where(
-            db_array.in_array(column=col(VideoFrameTable.sample_id), values=old_sample_ids)
-        )
-    ).all()
-
-    for old_frame in frames:
-        new_frame = _copy_with_updates(
-            old_frame,
-            {
-                "sample_id": ctx.sample_map[old_frame.sample_id],
-                "parent_sample_id": ctx.sample_map[old_frame.parent_sample_id],
-            },
-        )
-        session.add(new_frame)
-
-
-def _copy_images(
-    session: Session,
-    old_sample_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy image records, remapping sample_id."""
-    images = session.exec(
-        select(ImageTable).where(
-            db_array.in_array(column=col(ImageTable.sample_id), values=old_sample_ids)
-        )
-    ).all()
-
-    for old_image in images:
-        new_image = _copy_with_updates(
-            old_image,
-            {"sample_id": ctx.sample_map[old_image.sample_id]},
-        )
-        session.add(new_image)
-
-
-def _copy_groups(
-    session: Session,
-    old_sample_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy group records."""
-    groups = session.exec(
-        select(GroupTable).where(
-            db_array.in_array(column=col(GroupTable.sample_id), values=old_sample_ids)
-        )
-    ).all()
-
-    for old_group in groups:
-        new_group = _copy_with_updates(
-            old_group,
-            {"sample_id": ctx.sample_map[old_group.sample_id]},
-        )
-        session.add(new_group)
-
-
-def _copy_captions(
-    session: Session,
-    old_sample_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy captions, remapping sample_id and parent_sample_id."""
-    captions = session.exec(
-        select(CaptionTable).where(
-            db_array.in_array(column=col(CaptionTable.sample_id), values=old_sample_ids)
-        )
-    ).all()
-
-    for old_caption in captions:
-        new_caption = _copy_with_updates(
-            old_caption,
-            {
-                "sample_id": ctx.sample_map[old_caption.sample_id],
-                "parent_sample_id": ctx.sample_map[old_caption.parent_sample_id],
-            },
-        )
-        session.add(new_caption)
-
-
-def _copy_object_tracks(
-    session: Session,
-    old_dataset_id: UUID,
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy object tracks, remapping dataset ID."""
-    tracks = session.exec(
-        select(ObjectTrackTable).where(col(ObjectTrackTable.dataset_id) == old_dataset_id)
-    ).all()
-
-    for old_track in tracks:
-        new_track_id = uuid4()
-        ctx.object_track_map[old_track.object_track_id] = new_track_id
-        new_track = _copy_with_updates(
-            old_track,
-            {
-                "object_track_id": new_track_id,
-                "object_track_number": old_track.object_track_number,
-                "dataset_id": ctx.new_dataset_id,
-            },
-        )
-        session.add(new_track)
-
-
-def _copy_annotations(
-    session: Session,
-    old_sample_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy annotations with their detail tables."""
-    annotations = session.exec(
-        select(AnnotationBaseTable).where(
-            db_array.in_array(column=col(AnnotationBaseTable.sample_id), values=old_sample_ids)
-        )
-    ).all()
-
-    for old_ann in annotations:
-        new_sample_id = ctx.sample_map[old_ann.sample_id]
-        new_object_track_id = (
-            ctx.object_track_map[old_ann.object_track_id]
-            if old_ann.object_track_id is not None
-            else None
-        )
-
-        new_ann = _copy_with_updates(
-            old_ann,
-            {
-                "sample_id": new_sample_id,
-                "annotation_label_id": ctx.annotation_label_map[old_ann.annotation_label_id],
-                "parent_sample_id": ctx.sample_map[old_ann.parent_sample_id],
-                "object_track_id": new_object_track_id,
-            },
-        )
-        session.add(new_ann)
-
-    # Go over detail annotation tables to copy bboxes and segmentation mask.
-    for detail_table in (ObjectDetectionAnnotationTable, SegmentationAnnotationTable):
-        old_details = session.exec(
-            select(detail_table).where(
-                db_array.in_array(column=col(detail_table.sample_id), values=old_sample_ids)
-            )
-        ).all()
-        for old_detail in old_details:
-            session.add(
-                _copy_with_updates(
-                    old_detail,
-                    # Both tables contain sample_id, thus the mypy error is wrong.
-                    {"sample_id": ctx.sample_map[old_detail.sample_id]},  # type: ignore[attr-defined]
-                )
-            )
-
-
-def _copy_metadata(
-    session: Session,
-    old_sample_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy sample metadata."""
-    metadata_records = session.exec(
-        select(SampleMetadataTable).where(
-            db_array.in_array(column=col(SampleMetadataTable.sample_id), values=old_sample_ids)
-        )
-    ).all()
-
-    for old_meta in metadata_records:
-        new_meta = _copy_with_updates(
-            old_meta,
-            {
-                "custom_metadata_id": uuid4(),
-                "sample_id": ctx.sample_map[old_meta.sample_id],
-            },
-        )
-        session.add(new_meta)
-
-
-def _copy_embeddings(
-    session: Session,
-    old_sample_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy sample embeddings, remapping sample_id and embedding_model_id."""
-    embeddings = session.exec(
-        select(SampleEmbeddingTable).where(
-            db_array.in_array(column=col(SampleEmbeddingTable.sample_id), values=old_sample_ids)
-        )
-    ).all()
-
-    for old_emb in embeddings:
-        assert old_emb.embedding_model_id in ctx.embedding_model_map, (
-            f"Embedding references model {old_emb.embedding_model_id} not in copied dataset"
-        )
-        new_emb = _copy_with_updates(
-            old_emb,
-            {
-                "sample_id": ctx.sample_map[old_emb.sample_id],
-                "embedding_model_id": ctx.embedding_model_map[old_emb.embedding_model_id],
-            },
-        )
-        session.add(new_emb)
-
-
-def _copy_sample_tag_links(
-    session: Session,
-    old_sample_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy sample-tag links."""
-    links = session.exec(
-        select(SampleTagLinkTable).where(
-            db_array.in_array(column=col(SampleTagLinkTable.sample_id), values=old_sample_ids)
-        )
-    ).all()
-
-    for old_link in links:
-        if (
-            old_link.sample_id is not None
-            and old_link.tag_id is not None
-            and old_link.tag_id in ctx.tag_map
-        ):
-            new_link = SampleTagLinkTable(
-                sample_id=ctx.sample_map[old_link.sample_id],
-                tag_id=ctx.tag_map[old_link.tag_id],
-            )
-            session.add(new_link)
-
-
-def _copy_sample_group_links(
-    session: Session,
-    old_sample_ids: list[UUID],
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy sample-group links."""
-    links = session.exec(
-        select(SampleGroupLinkTable).where(
-            db_array.in_array(column=col(SampleGroupLinkTable.sample_id), values=old_sample_ids)
-        )
-    ).all()
-
-    for old_link in links:
-        if old_link.parent_sample_id in ctx.sample_map:
-            new_link = SampleGroupLinkTable(
-                sample_id=ctx.sample_map[old_link.sample_id],
-                parent_sample_id=ctx.sample_map[old_link.parent_sample_id],
-            )
-            session.add(new_link)
-
-
-def _copy_evaluation_runs(
-    session: Session,
-    old_dataset_id: UUID,
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy evaluation runs, remapping both collection FKs."""
-    runs = session.exec(
-        select(EvaluationRunTable)
-        .join(
-            CollectionTable,
-            col(EvaluationRunTable.gt_annotation_collection_id)
-            == col(CollectionTable.collection_id),
-        )
-        .where(col(CollectionTable.dataset_id) == old_dataset_id)
-    ).all()
-
-    for old_run in runs:
-        new_run_id = uuid4()
-        ctx.evaluation_run_map[old_run.id] = new_run_id
-        new_run = _copy_with_updates(
-            old_run,
-            {
-                "id": new_run_id,
-                "gt_annotation_collection_id": ctx.collection_map[
-                    old_run.gt_annotation_collection_id
-                ],
-                "pred_annotation_collection_id": ctx.collection_map[
-                    old_run.pred_annotation_collection_id
-                ],
-            },
-        )
-        session.add(new_run)
-
-
-def _copy_evaluation_sample_metrics(
-    session: Session,
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy evaluation sample metrics, remapping evaluation_run_id and sample_id."""
-    if not ctx.evaluation_run_map:
-        return
-    old_run_ids = list(ctx.evaluation_run_map.keys())
-    metrics = session.exec(
-        select(EvaluationSampleMetricTable).where(
-            db_array.in_array(
-                column=col(EvaluationSampleMetricTable.evaluation_run_id), values=old_run_ids
-            )
-        )
-    ).all()
-
-    for old_metric in metrics:
-        new_metric = _copy_with_updates(
-            old_metric,
-            {
-                "evaluation_run_id": ctx.evaluation_run_map[old_metric.evaluation_run_id],
-                "sample_id": ctx.sample_map[old_metric.sample_id],
-            },
-        )
-        session.add(new_metric)
-
-
-def _copy_evaluation_annotation_metrics(
-    session: Session,
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy evaluation annotation metrics, remapping run, sample, and annotation IDs."""
-    if not ctx.evaluation_run_map:
-        return
-    old_run_ids = list(ctx.evaluation_run_map.keys())
-    metrics = session.exec(
-        select(EvaluationAnnotationMetricTable).where(
-            db_array.in_array(
-                column=col(EvaluationAnnotationMetricTable.evaluation_run_id), values=old_run_ids
-            )
-        )
-    ).all()
-
-    for old_metric in metrics:
-        new_metric = _copy_with_updates(
-            old_metric,
-            {
-                "id": uuid4(),
-                "evaluation_run_id": ctx.evaluation_run_map[old_metric.evaluation_run_id],
-                "sample_id": ctx.sample_map[old_metric.sample_id],
-                "pred_annotation_id": (
-                    ctx.sample_map[old_metric.pred_annotation_id]
-                    if old_metric.pred_annotation_id is not None
-                    else None
-                ),
-                "gt_annotation_id": (
-                    ctx.sample_map[old_metric.gt_annotation_id]
-                    if old_metric.gt_annotation_id is not None
-                    else None
-                ),
-            },
-        )
-        session.add(new_metric)
-
-
-def _copy_annotation_collection_coverage(
-    session: Session,
-    ctx: DeepCopyContext,
-) -> None:
-    """Copy annotation collection coverage rows, remapping collection and sample IDs."""
-    if not ctx.collection_map:
-        return
-    old_collection_ids = list(ctx.collection_map.keys())
-    rows = session.exec(
-        select(AnnotationCollectionCoverageTable).where(
-            db_array.in_array(
-                column=col(AnnotationCollectionCoverageTable.annotation_collection_id),
-                values=old_collection_ids,
-            )
-        )
-    ).all()
-
-    for old_row in rows:
-        new_row = AnnotationCollectionCoverageTable(
-            annotation_collection_id=ctx.collection_map[old_row.annotation_collection_id],
-            parent_sample_id=ctx.sample_map[old_row.parent_sample_id],
-        )
-        session.add(new_row)
-
-
-def _copy_with_updates(
-    entity: T,
-    updates: dict[str, Any],
-    deep: bool = False,
-    exclude: set[str] | None = None,
-) -> T:
-    """Create a copy of an entity with specified field updates.
-
-    Uses model_dump() to extract field values, then reconstructs a new instance.
-    This ensures new fields added to models are automatically included in copies.
-
-    Args:
-        entity: Source entity to copy.
-        updates: Fields to override (e.g., remapped IDs).
-        deep: If True, apply copy.deepcopy() after model_dump(). Only needed
-            for non-JSON mutable fields; JSON-typed fields are already
-            deep copied by Pydantic's serialization.
-        exclude: Fields to exclude from copy. Excluded fields will use model defaults.
-                 Defaults to _EXCLUDE_ON_COPY (created_at, updated_at).
-
-    Returns:
-        New instance of the same type with updates applied.
+    The single multi-row insert satisfies the self-referential ``parent_collection_id``
+    FK because PostgreSQL checks it at statement end, once all rows are present.
     """
-    if exclude is None:
-        exclude = _EXCLUDE_ON_COPY
-    data = entity.model_dump(exclude=exclude)
-    if deep:
-        data = copy.deepcopy(data)
-    data.update(updates)
-    return type(entity)(**data)
+    src = _table(CollectionTable).alias("src")
+    map_collection = _map(_MAP_COLLECTION)
+    map_parent = _map(_MAP_COLLECTION, alias="map_parent")
+
+    # Replace the first occurrence of the old root name with copy_name, leaving names
+    # that do not contain it unchanged. Equivalent to the previous
+    # name.replace(old_root_name, copy_name, 1); for the root (name == old_root_name)
+    # this yields copy_name.
+    root_pos = func.strpos(src.c["name"], literal(old_root_name))
+    name_expr = case(
+        (root_pos == 0, src.c["name"]),
+        else_=func.left(src.c["name"], root_pos - 1)
+        .concat(literal(copy_name))
+        .concat(func.substr(src.c["name"], root_pos + func.length(literal(old_root_name)))),
+    )
+    from_clause = src.join(
+        map_collection, map_collection.c.old_id == src.c["collection_id"]
+    ).outerjoin(map_parent, map_parent.c.old_id == src.c["parent_collection_id"])
+    overrides = {
+        "collection_id": map_collection.c.new_id,
+        "dataset_id": literal(new_dataset_id),
+        "parent_collection_id": map_parent.c.new_id,
+        "name": name_expr,
+        "created_at": literal(now),
+        "updated_at": literal(now),
+    }
+    _copy_table(
+        session=session,
+        target=CollectionTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_samples(session: Session, now: datetime) -> None:
+    """Copy samples, remapping collection_id."""
+    src = _table(SampleTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    map_collection = _map(_MAP_COLLECTION)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"]).join(
+        map_collection, map_collection.c.old_id == src.c["collection_id"]
+    )
+    overrides = {
+        "sample_id": map_sample.c.new_id,
+        "collection_id": map_collection.c.new_id,
+        "created_at": literal(now),
+        "updated_at": literal(now),
+    }
+    _copy_table(
+        session=session,
+        target=SampleTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_tags(session: Session, now: datetime) -> None:
+    """Copy tags, remapping collection_id."""
+    src = _table(TagTable).alias("src")
+    map_tag = _map(_MAP_TAG)
+    map_collection = _map(_MAP_COLLECTION)
+    from_clause = src.join(map_tag, map_tag.c.old_id == src.c["tag_id"]).join(
+        map_collection, map_collection.c.old_id == src.c["collection_id"]
+    )
+    overrides = {
+        "tag_id": map_tag.c.new_id,
+        "collection_id": map_collection.c.new_id,
+        "created_at": literal(now),
+        "updated_at": literal(now),
+    }
+    _copy_table(
+        session=session,
+        target=TagTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_object_tracks(session: Session, new_dataset_id: UUID) -> None:
+    """Copy object tracks, remapping dataset_id."""
+    src = _table(ObjectTrackTable).alias("src")
+    map_track = _map(_MAP_OBJECT_TRACK)
+    from_clause = src.join(map_track, map_track.c.old_id == src.c["object_track_id"])
+    overrides = {
+        "object_track_id": map_track.c.new_id,
+        "dataset_id": literal(new_dataset_id),
+    }
+    _copy_table(
+        session=session,
+        target=ObjectTrackTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_annotation_labels(session: Session, new_dataset_id: UUID) -> None:
+    """Copy annotation labels, remapping dataset_id.
+
+    ``created_at`` is copied verbatim (it is a VARCHAR column, so regenerating a datetime
+    literal would not match the stored representation).
+    """
+    src = _table(AnnotationLabelTable).alias("src")
+    map_label = _map(_MAP_ANNOTATION_LABEL)
+    from_clause = src.join(map_label, map_label.c.old_id == src.c["annotation_label_id"])
+    overrides = {
+        "annotation_label_id": map_label.c.new_id,
+        "dataset_id": literal(new_dataset_id),
+    }
+    _copy_table(
+        session=session,
+        target=AnnotationLabelTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_embedding_models(session: Session, now: datetime) -> None:
+    """Copy embedding models, remapping collection_id."""
+    src = _table(EmbeddingModelTable).alias("src")
+    map_model = _map(_MAP_EMBEDDING_MODEL)
+    map_collection = _map(_MAP_COLLECTION)
+    from_clause = src.join(map_model, map_model.c.old_id == src.c["embedding_model_id"]).join(
+        map_collection, map_collection.c.old_id == src.c["collection_id"]
+    )
+    overrides = {
+        "embedding_model_id": map_model.c.new_id,
+        "collection_id": map_collection.c.new_id,
+        "created_at": literal(now),
+    }
+    _copy_table(
+        session=session,
+        target=EmbeddingModelTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_evaluation_runs(session: Session, now: datetime) -> None:
+    """Copy evaluation runs, remapping both collection FKs."""
+    src = _table(EvaluationRunTable).alias("src")
+    map_run = _map(_MAP_EVALUATION_RUN)
+    map_gt = _map(_MAP_COLLECTION, alias="map_gt")
+    map_pred = _map(_MAP_COLLECTION, alias="map_pred")
+    from_clause = (
+        src.join(map_run, map_run.c.old_id == src.c["id"])
+        .join(map_gt, map_gt.c.old_id == src.c["gt_annotation_collection_id"])
+        .join(map_pred, map_pred.c.old_id == src.c["pred_annotation_collection_id"])
+    )
+    overrides = {
+        "id": map_run.c.new_id,
+        "gt_annotation_collection_id": map_gt.c.new_id,
+        "pred_annotation_collection_id": map_pred.c.new_id,
+        "created_at": literal(now),
+    }
+    _copy_table(
+        session=session,
+        target=EvaluationRunTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_images(session: Session, now: datetime) -> None:
+    """Copy images, remapping sample_id."""
+    src = _table(ImageTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"])
+    overrides = {
+        "sample_id": map_sample.c.new_id,
+        "created_at": literal(now),
+        "updated_at": literal(now),
+    }
+    _copy_table(
+        session=session,
+        target=ImageTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_videos(session: Session) -> None:
+    """Copy videos, remapping sample_id."""
+    src = _table(VideoTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"])
+    overrides = {"sample_id": map_sample.c.new_id}
+    _copy_table(
+        session=session,
+        target=VideoTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_video_frames(session: Session) -> None:
+    """Copy video frames, remapping sample_id and parent_sample_id."""
+    src = _table(VideoFrameTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    map_parent = _map(_MAP_SAMPLE, alias="map_parent")
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"]).join(
+        map_parent, map_parent.c.old_id == src.c["parent_sample_id"]
+    )
+    overrides = {
+        "sample_id": map_sample.c.new_id,
+        "parent_sample_id": map_parent.c.new_id,
+    }
+    _copy_table(
+        session=session,
+        target=VideoFrameTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_groups(session: Session) -> None:
+    """Copy groups, remapping sample_id."""
+    src = _table(GroupTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"])
+    overrides = {"sample_id": map_sample.c.new_id}
+    _copy_table(
+        session=session,
+        target=GroupTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_captions(session: Session, now: datetime) -> None:
+    """Copy captions, remapping sample_id and parent_sample_id."""
+    src = _table(CaptionTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    map_parent = _map(_MAP_SAMPLE, alias="map_parent")
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"]).join(
+        map_parent, map_parent.c.old_id == src.c["parent_sample_id"]
+    )
+    overrides = {
+        "sample_id": map_sample.c.new_id,
+        "parent_sample_id": map_parent.c.new_id,
+        "created_at": literal(now),
+    }
+    _copy_table(
+        session=session,
+        target=CaptionTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_annotations(session: Session, now: datetime) -> None:
+    """Copy annotation_base, remapping sample, label, and (nullable) object track FKs."""
+    src = _table(AnnotationBaseTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    map_parent = _map(_MAP_SAMPLE, alias="map_parent")
+    map_label = _map(_MAP_ANNOTATION_LABEL)
+    map_track = _map(_MAP_OBJECT_TRACK)
+    from_clause = (
+        src.join(map_sample, map_sample.c.old_id == src.c["sample_id"])
+        .join(map_parent, map_parent.c.old_id == src.c["parent_sample_id"])
+        .join(map_label, map_label.c.old_id == src.c["annotation_label_id"])
+        .outerjoin(map_track, map_track.c.old_id == src.c["object_track_id"])
+    )
+    overrides = {
+        "sample_id": map_sample.c.new_id,
+        "parent_sample_id": map_parent.c.new_id,
+        "annotation_label_id": map_label.c.new_id,
+        "object_track_id": map_track.c.new_id,
+        "created_at": literal(now),
+    }
+    _copy_table(
+        session=session,
+        target=AnnotationBaseTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_annotation_details(session: Session, detail_table: type[SQLModel]) -> None:
+    """Copy an annotation detail table (object detection / segmentation), remapping sample_id."""
+    src = _table(detail_table).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"])
+    overrides = {"sample_id": map_sample.c.new_id}
+    _copy_table(
+        session=session,
+        target=detail_table,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_sample_embeddings(session: Session) -> None:
+    """Copy sample embeddings, remapping sample_id and embedding_model_id.
+
+    The pgvector ``embedding`` column is copied verbatim, server-side. The inner join on
+    the embedding-model map drops any embedding whose model is not part of the dataset.
+    """
+    src = _table(SampleEmbeddingTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    map_model = _map(_MAP_EMBEDDING_MODEL)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"]).join(
+        map_model, map_model.c.old_id == src.c["embedding_model_id"]
+    )
+    overrides = {
+        "sample_id": map_sample.c.new_id,
+        "embedding_model_id": map_model.c.new_id,
+    }
+    _copy_table(
+        session=session,
+        target=SampleEmbeddingTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_metadata(session: Session, now: datetime) -> None:
+    """Copy sample metadata with a fresh custom_metadata_id, remapping sample_id."""
+    src = _table(SampleMetadataTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"])
+    overrides = {
+        "custom_metadata_id": func.gen_random_uuid(),
+        "sample_id": map_sample.c.new_id,
+        "created_at": literal(now),
+        "updated_at": literal(now),
+    }
+    _copy_table(
+        session=session,
+        target=SampleMetadataTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_evaluation_sample_metrics(session: Session) -> None:
+    """Copy evaluation sample metrics, remapping evaluation_run_id and sample_id."""
+    src = _table(EvaluationSampleMetricTable).alias("src")
+    map_run = _map(_MAP_EVALUATION_RUN)
+    map_sample = _map(_MAP_SAMPLE)
+    from_clause = src.join(map_run, map_run.c.old_id == src.c["evaluation_run_id"]).join(
+        map_sample, map_sample.c.old_id == src.c["sample_id"]
+    )
+    overrides = {
+        "evaluation_run_id": map_run.c.new_id,
+        "sample_id": map_sample.c.new_id,
+    }
+    _copy_table(
+        session=session,
+        target=EvaluationSampleMetricTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_evaluation_annotation_metrics(session: Session) -> None:
+    """Copy evaluation annotation metrics, remapping run/sample and nullable annotation FKs."""
+    src = _table(EvaluationAnnotationMetricTable).alias("src")
+    map_run = _map(_MAP_EVALUATION_RUN)
+    map_sample = _map(_MAP_SAMPLE)
+    map_pred = _map(_MAP_SAMPLE, alias="map_pred")
+    map_gt = _map(_MAP_SAMPLE, alias="map_gt")
+    from_clause = (
+        src.join(map_run, map_run.c.old_id == src.c["evaluation_run_id"])
+        .join(map_sample, map_sample.c.old_id == src.c["sample_id"])
+        .outerjoin(map_pred, map_pred.c.old_id == src.c["pred_annotation_id"])
+        .outerjoin(map_gt, map_gt.c.old_id == src.c["gt_annotation_id"])
+    )
+    overrides = {
+        "id": func.gen_random_uuid(),
+        "evaluation_run_id": map_run.c.new_id,
+        "sample_id": map_sample.c.new_id,
+        "pred_annotation_id": map_pred.c.new_id,
+        "gt_annotation_id": map_gt.c.new_id,
+    }
+    _copy_table(
+        session=session,
+        target=EvaluationAnnotationMetricTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_sample_tag_links(session: Session) -> None:
+    """Copy sample-tag links. Inner joins drop links whose tag is out of scope."""
+    src = _table(SampleTagLinkTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    map_tag = _map(_MAP_TAG)
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"]).join(
+        map_tag, map_tag.c.old_id == src.c["tag_id"]
+    )
+    overrides = {
+        "sample_id": map_sample.c.new_id,
+        "tag_id": map_tag.c.new_id,
+    }
+    _copy_table(
+        session=session,
+        target=SampleTagLinkTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_sample_group_links(session: Session) -> None:
+    """Copy sample-group links, remapping sample_id and parent_sample_id."""
+    src = _table(SampleGroupLinkTable).alias("src")
+    map_sample = _map(_MAP_SAMPLE)
+    map_parent = _map(_MAP_SAMPLE, alias="map_parent")
+    from_clause = src.join(map_sample, map_sample.c.old_id == src.c["sample_id"]).join(
+        map_parent, map_parent.c.old_id == src.c["parent_sample_id"]
+    )
+    overrides = {
+        "sample_id": map_sample.c.new_id,
+        "parent_sample_id": map_parent.c.new_id,
+    }
+    _copy_table(
+        session=session,
+        target=SampleGroupLinkTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_annotation_collection_coverage(session: Session) -> None:
+    """Copy annotation collection coverage rows, remapping collection and sample ids."""
+    src = _table(AnnotationCollectionCoverageTable).alias("src")
+    map_collection = _map(_MAP_COLLECTION)
+    map_sample = _map(_MAP_SAMPLE)
+    from_clause = src.join(
+        map_collection, map_collection.c.old_id == src.c["annotation_collection_id"]
+    ).join(map_sample, map_sample.c.old_id == src.c["parent_sample_id"])
+    overrides = {
+        "annotation_collection_id": map_collection.c.new_id,
+        "parent_sample_id": map_sample.c.new_id,
+    }
+    _copy_table(
+        session=session,
+        target=AnnotationCollectionCoverageTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -81,10 +81,10 @@ def deep_copy(
     Args:
         session: Database session (must be bound to PostgreSQL).
         dataset_id: Dataset ID to copy.
-        copy_name: Name for the new root collection.
+        copy_name: Name for the new dataset.
 
     Returns:
-        The newly created root collection.
+        The newly created dataset.
     """
     db_manager.require_postgres_backend(session)
     # If this fails, a new table was added. Update deep_copy to handle it, then update
@@ -94,7 +94,7 @@ def deep_copy(
     new_dataset_id = uuid4()
     now = datetime.now(timezone.utc)
 
-    # The hierarchy gives the root collection name, needed to derive copied names.
+    # The hierarchy gives the root collection name that's needed to derive copied names.
     hierarchy = dataset_resolver.get_hierarchy(session=session, dataset_id=dataset_id)
     old_root_name = hierarchy[0].name
 
@@ -319,9 +319,7 @@ def _copy_collections(
     map_parent = _map(_MAP_COLLECTION, alias="map_parent")
 
     # Replace the first occurrence of the old root name with copy_name, leaving names
-    # that do not contain it unchanged. Equivalent to the previous
-    # name.replace(old_root_name, copy_name, 1); for the root (name == old_root_name)
-    # this yields copy_name.
+    # that do not contain it unchanged.
     root_pos = func.strpos(src.c["name"], literal(old_root_name))
     name_expr = case(
         (root_pos == 0, src.c["name"]),

--- a/lightly_studio/tests/api/routes/api/test_collection.py
+++ b/lightly_studio/tests/api/routes/api/test_collection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 from sqlmodel import Session
@@ -246,6 +247,7 @@ def test_has_embeddings(
     mock_get_model.assert_called_once_with(session=db_session, collection_id=col_id)
 
 
+@pytest.mark.postgres_only  # Deep copying is enterprise-only (PostgreSQL-backed).
 def test_deep_copy__success(test_client: TestClient, db_session: Session) -> None:
     """Test successful deep copy of a collection."""
     collection = create_collection(session=db_session, collection_name="original")

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -57,6 +57,19 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip postgres_only tests unless the suite runs with --postgres.
+
+    The ``postgres_only`` marker is registered in ``pytest.ini``.
+    """
+    if config.getoption("--postgres"):
+        return
+    skip_marker = pytest.mark.skip(reason="postgres_only: skipped under DuckDB")
+    for item in items:
+        if "postgres_only" in item.keywords:
+            item.add_marker(skip_marker)
+
+
 def _truncate_tables(session: Session) -> None:
     """Truncate all tables in the database to reset state between tests.
 

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -44,6 +44,9 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
 )
 
+# Deep copying is enterprise-only and PostgreSQL-backed; skip on the default DuckDB run.
+pytestmark = pytest.mark.postgres_only
+
 
 def test_deep_copy__empty_collection(db_session: Session) -> None:
     # Arrange


### PR DESCRIPTION
## What has changed and why?

Reworks the deep copy dataset functionality. Initially, it loaded all data into Python, which introduced heavy per-row operations (e.g., `modei_dump` conversions, ORM reconstructions) and unbounded memory. This PR reworks the deep copy functionality, by removing the "Python layer" entirely - everything happens at the DB layer:
- the previous mapping context (Python dicts holding old_id -> new_id mappings) was replaced with temp tables + joins
- the row by row approach was switched to a set-based approach (i.e., on single insert statement copies an entire table in a single operation)
- deep copy is now Postgres-only and raises on DuckDB (this is enterprise-only functionality anyway so it's fine)

Note: tests currently fail - will be fixed once https://github.com/lightly-ai/lightly-studio/pull/1402 gets merged 

## How to review
Considering this is a rework, focus only on the additions - I left some comments on the previous code pointing out the migrated logic (Python -> SQL)

## How has it been tested?

Manually + tests still pass (new PR for this)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Rewrote dataset deep-copy to execute server-side using set-based operations for improved performance and scalability.
* **Bug Fixes**
  * Added a PostgreSQL-backend check up front to fail early when deep-copy is attempted on unsupported backends.
* **Tests**
  * Introduced a `postgres_only` test marker and updated the test runner to automatically skip these tests unless running with PostgreSQL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->