### PR TITLE
Add annotation_source to ImageDataset.add_samples_from*

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -304,7 +304,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
-            annotation_source: Optional name of the annotation source to add the annotations
+            annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
         """
@@ -340,7 +340,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             input_split: The split to load (e.g., 'train', 'val', 'test').
                 If None, all available splits will be loaded and assigned a corresponding tag.
             embed: If True, generate embeddings for the newly added samples.
-            annotation_source: Optional name of the annotation source to add the annotations
+            annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
         """
@@ -412,7 +412,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
-            annotation_source: Optional name of the annotation source to add the annotations
+            annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
         """
@@ -472,7 +472,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
-            annotation_source: Optional name of the annotation source to add the annotations
+            annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
         """
@@ -517,7 +517,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
-            annotation_source: Optional name of the annotation source to add the annotations
+            annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
         """

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -294,6 +294,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         images_path: PathLike,
         split: str | None = None,
         embed: bool = True,
+        annotation_source: str | None = None,
     ) -> None:
         """Load a dataset from a labelformat object and store in database.
 
@@ -303,6 +304,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
+            annotation_source: Optional name of the annotation source to add the annotations
+                to. Reusing the same source name appends to that source. If `None`,
+                a default source is used.
         """
         images_path = Path(images_path).absolute()
 
@@ -311,6 +315,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             root_collection_id=self.collection_id,
             input_labels=input_labels,
             images_path=images_path,
+            collection_name=annotation_source,
         )
 
         _postprocess_created_images(
@@ -326,6 +331,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         data_yaml: PathLike,
         input_split: str | None = None,
         embed: bool = True,
+        annotation_source: str | None = None,
     ) -> None:
         """Load a dataset in YOLO format and store in DB.
 
@@ -334,6 +340,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             input_split: The split to load (e.g., 'train', 'val', 'test').
                 If None, all available splits will be loaded and assigned a corresponding tag.
             embed: If True, generate embeddings for the newly added samples.
+            annotation_source: Optional name of the annotation source to add the annotations
+                to. Reusing the same source name appends to that source. If `None`,
+                a default source is used.
         """
         data_yaml = Path(data_yaml).absolute()
 
@@ -361,6 +370,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
                 root_collection_id=self.collection_id,
                 input_labels=label_input,
                 images_path=images_path,
+                collection_name=annotation_source,
             )
 
             # Tag samples with split name
@@ -383,13 +393,14 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             embed=embed,
         )
 
-    def add_samples_from_coco(
+    def add_samples_from_coco(  # noqa: PLR0913
         self,
         annotations_json: PathLike,
         images_path: PathLike,
         annotation_type: AnnotationType = AnnotationType.OBJECT_DETECTION,
         split: str | None = None,
         embed: bool = True,
+        annotation_source: str | None = None,
     ) -> None:
         """Load a dataset in COCO Object Detection format and store in DB.
 
@@ -401,6 +412,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
+            annotation_source: Optional name of the annotation source to add the annotations
+                to. Reusing the same source name appends to that source. If `None`,
+                a default source is used.
         """
         images_path = _normalize_input_path(path=images_path)
         fs, fs_path = fsspec.core.url_to_fs(url=annotations_json)
@@ -425,6 +439,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             root_collection_id=self.collection_id,
             input_labels=label_input,
             images_path=images_path,
+            collection_name=annotation_source,
         )
 
         _postprocess_created_images(
@@ -435,13 +450,14 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             embed=embed,
         )
 
-    def add_samples_from_pascal_voc_segmentations(
+    def add_samples_from_pascal_voc_segmentations(  # noqa: PLR0913
         self,
         images_path: PathLike,
         masks_path: PathLike,
         class_id_to_name: Mapping[int, str],
         split: str | None = None,
         embed: bool = True,
+        annotation_source: str | None = None,
     ) -> None:
         """Load a Pascal VOC segmentation dataset and store in DB.
 
@@ -456,6 +472,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
+            annotation_source: Optional name of the annotation source to add the annotations
+                to. Reusing the same source name appends to that source. If `None`,
+                a default source is used.
         """
         images_path = _normalize_input_path(path=images_path)
         masks_path = _normalize_input_path(path=masks_path)
@@ -471,6 +490,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             root_collection_id=self.collection_id,
             input_labels=label_input,
             images_path=images_path,
+            collection_name=annotation_source,
         )
 
         _postprocess_created_images(
@@ -487,6 +507,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         images_rel_path: str = "../images",
         split: str | None = None,
         embed: bool = True,
+        annotation_source: str | None = None,
     ) -> None:
         """Load a dataset in Lightly format and store in DB.
 
@@ -496,6 +517,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
+            annotation_source: Optional name of the annotation source to add the annotations
+                to. Reusing the same source name appends to that source. If `None`,
+                a default source is used.
         """
         input_folder = Path(input_folder).absolute()
 
@@ -510,6 +534,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             root_collection_id=self.collection_id,
             input_labels=label_input,
             images_path=images_path,
+            collection_name=annotation_source,
         )
 
         _postprocess_created_images(

--- a/lightly_studio/tests/core/image/test_image_dataset__coco.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__coco.py
@@ -15,6 +15,7 @@ from lightly_studio.models.annotation.object_detection import ObjectDetectionAnn
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import (
     annotation_collection_coverage_resolver,
+    annotation_resolver,
     collection_resolver,
 )
 
@@ -510,9 +511,12 @@ class TestDataset:
             annotation_source="ground_truth",
         )
 
-        annotations = [a for sample in dataset for a in sample.annotations]
+        annotations = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="ground_truth",
+            parent_collection_id=dataset.collection_id,
+        ).annotations
         assert len(annotations) == 2
-        assert all(a.annotation_source == "ground_truth" for a in annotations)
 
     def test_add_samples_from_coco__default_annotation_source(
         self,
@@ -531,9 +535,12 @@ class TestDataset:
             embed=False,
         )
 
-        annotations = [a for sample in dataset for a in sample.annotations]
+        annotations = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="annotation",
+            parent_collection_id=dataset.collection_id,
+        ).annotations
         assert len(annotations) == 2
-        assert all(a.annotation_source == "annotation" for a in annotations)
 
     def test_add_samples_from_coco__relative_local_images_path_normalized_to_absolute(
         self,

--- a/lightly_studio/tests/core/image/test_image_dataset__coco.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__coco.py
@@ -492,6 +492,49 @@ class TestDataset:
         )
         assert covered == {s.sample_id for s in samples}
 
+    def test_add_samples_from_coco__annotation_source(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(json.dumps(get_coco_annotation_dict_valid()))
+        images_path = _create_valid_samples(tmp_path)
+
+        dataset = ImageDataset.create(name="test_dataset")
+        dataset.add_samples_from_coco(
+            annotations_json=annotations_path,
+            images_path=images_path,
+            annotation_type=AnnotationType.OBJECT_DETECTION,
+            embed=False,
+            annotation_source="ground_truth",
+        )
+
+        annotations = [a for sample in dataset for a in sample.annotations]
+        assert len(annotations) == 2
+        assert all(a.annotation_source == "ground_truth" for a in annotations)
+
+    def test_add_samples_from_coco__default_annotation_source(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(json.dumps(get_coco_annotation_dict_valid()))
+        images_path = _create_valid_samples(tmp_path)
+
+        dataset = ImageDataset.create(name="test_dataset")
+        dataset.add_samples_from_coco(
+            annotations_json=annotations_path,
+            images_path=images_path,
+            annotation_type=AnnotationType.OBJECT_DETECTION,
+            embed=False,
+        )
+
+        annotations = [a for sample in dataset for a in sample.annotations]
+        assert len(annotations) == 2
+        assert all(a.annotation_source == "annotation" for a in annotations)
+
     def test_add_samples_from_coco__relative_local_images_path_normalized_to_absolute(
         self,
         patch_collection: None,  # noqa: ARG002


### PR DESCRIPTION
## What has changed and why?

Allow passing the annotation source in all methods that load annotations.

## How has it been tested?

Added new test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dataset import now accepts an optional annotation source so annotations imported from YOLO, COCO, Pascal VOC segmentations, Lightly, and labelformat can be tagged with a specified source for clearer organization and reuse.

* **Tests**
  * Added tests ensuring annotation source is assigned correctly during COCO imports and validating the default source when omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->