### PR TITLE
Add annotation_source to Sample.add_annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show plugin description and a link to documentation when no plugins are available.
 - When sorting the image grid by a numeric field, the field value is now shown as an overlay on each sample.
 - Query editor now supports annotation `source` and `confidence` fields in queries.
+- Python SDK: `annotation_source` parameter on `ImageDataset.add_samples_from*` methods and
+  `Sample.add_annotation` / `add_annotations` to import or add annotations to a named source.
+- Python SDK: `Annotation.annotation_source` property to read the annotation source name.
 
 ### Changed
 

--- a/lightly_studio/src/lightly_studio/core/annotation/annotation.py
+++ b/lightly_studio/src/lightly_studio/core/annotation/annotation.py
@@ -43,3 +43,8 @@ class Annotation:
     def class_name(self) -> str:
         """Annotation class name."""
         return self.annotation_base.annotation_label.annotation_label_name
+
+    @property
+    def annotation_source(self) -> str:
+        """Name of the annotation source this annotation belongs to."""
+        return self.annotation_base.sample.collection.name

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -304,7 +304,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
-            annotation_source: Optional name of the annotation source to add the annotations
+            annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
         """
@@ -340,7 +340,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             input_split: The split to load (e.g., 'train', 'val', 'test').
                 If None, all available splits will be loaded and assigned a corresponding tag.
             embed: If True, generate embeddings for the newly added samples.
-            annotation_source: Optional name of the annotation source to add the annotations
+            annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
         """
@@ -412,7 +412,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
-            annotation_source: Optional name of the annotation source to add the annotations
+            annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
         """
@@ -472,7 +472,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
-            annotation_source: Optional name of the annotation source to add the annotations
+            annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
         """
@@ -517,7 +517,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
-            annotation_source: Optional name of the annotation source to add the annotations
+            annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
         """

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -294,6 +294,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         images_path: PathLike,
         split: str | None = None,
         embed: bool = True,
+        annotation_source: str | None = None,
     ) -> None:
         """Load a dataset from a labelformat object and store in database.
 
@@ -303,6 +304,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
+            annotation_source: Optional name of the annotation source to add the annotations
+                to. Reusing the same source name appends to that source. If `None`,
+                a default source is used.
         """
         images_path = Path(images_path).absolute()
 
@@ -311,6 +315,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             root_collection_id=self.collection_id,
             input_labels=input_labels,
             images_path=images_path,
+            collection_name=annotation_source,
         )
 
         _postprocess_created_images(
@@ -326,6 +331,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         data_yaml: PathLike,
         input_split: str | None = None,
         embed: bool = True,
+        annotation_source: str | None = None,
     ) -> None:
         """Load a dataset in YOLO format and store in DB.
 
@@ -334,6 +340,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             input_split: The split to load (e.g., 'train', 'val', 'test').
                 If None, all available splits will be loaded and assigned a corresponding tag.
             embed: If True, generate embeddings for the newly added samples.
+            annotation_source: Optional name of the annotation source to add the annotations
+                to. Reusing the same source name appends to that source. If `None`,
+                a default source is used.
         """
         data_yaml = Path(data_yaml).absolute()
 
@@ -361,6 +370,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
                 root_collection_id=self.collection_id,
                 input_labels=label_input,
                 images_path=images_path,
+                collection_name=annotation_source,
             )
 
             # Tag samples with split name
@@ -383,13 +393,14 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             embed=embed,
         )
 
-    def add_samples_from_coco(
+    def add_samples_from_coco(  # noqa: PLR0913
         self,
         annotations_json: PathLike,
         images_path: PathLike,
         annotation_type: AnnotationType = AnnotationType.OBJECT_DETECTION,
         split: str | None = None,
         embed: bool = True,
+        annotation_source: str | None = None,
     ) -> None:
         """Load a dataset in COCO Object Detection format and store in DB.
 
@@ -401,6 +412,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
+            annotation_source: Optional name of the annotation source to add the annotations
+                to. Reusing the same source name appends to that source. If `None`,
+                a default source is used.
         """
         images_path = _normalize_input_path(path=images_path)
         fs, fs_path = fsspec.core.url_to_fs(url=annotations_json)
@@ -425,6 +439,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             root_collection_id=self.collection_id,
             input_labels=label_input,
             images_path=images_path,
+            collection_name=annotation_source,
         )
 
         _postprocess_created_images(
@@ -435,13 +450,14 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             embed=embed,
         )
 
-    def add_samples_from_pascal_voc_segmentations(
+    def add_samples_from_pascal_voc_segmentations(  # noqa: PLR0913
         self,
         images_path: PathLike,
         masks_path: PathLike,
         class_id_to_name: Mapping[int, str],
         split: str | None = None,
         embed: bool = True,
+        annotation_source: str | None = None,
     ) -> None:
         """Load a Pascal VOC segmentation dataset and store in DB.
 
@@ -456,6 +472,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
+            annotation_source: Optional name of the annotation source to add the annotations
+                to. Reusing the same source name appends to that source. If `None`,
+                a default source is used.
         """
         images_path = _normalize_input_path(path=images_path)
         masks_path = _normalize_input_path(path=masks_path)
@@ -471,6 +490,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             root_collection_id=self.collection_id,
             input_labels=label_input,
             images_path=images_path,
+            collection_name=annotation_source,
         )
 
         _postprocess_created_images(
@@ -487,6 +507,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         images_rel_path: str = "../images",
         split: str | None = None,
         embed: bool = True,
+        annotation_source: str | None = None,
     ) -> None:
         """Load a dataset in Lightly format and store in DB.
 
@@ -496,6 +517,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             split: Optional split name to tag samples (e.g., 'train', 'val').
                 If provided, all samples will be tagged with this name.
             embed: If True, generate embeddings for the newly added samples.
+            annotation_source: Optional name of the annotation source to add the annotations
+                to. Reusing the same source name appends to that source. If `None`,
+                a default source is used.
         """
         input_folder = Path(input_folder).absolute()
 
@@ -510,6 +534,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             root_collection_id=self.collection_id,
             input_labels=label_input,
             images_path=images_path,
+            collection_name=annotation_source,
         )
 
         _postprocess_created_images(

--- a/lightly_studio/src/lightly_studio/core/sample.py
+++ b/lightly_studio/src/lightly_studio/core/sample.py
@@ -259,19 +259,29 @@ class Sample(ABC):
                 annotations.append(Annotation(annotation_base=annotation))
         return annotations
 
-    def add_annotation(self, annotation: CreateAnnotation) -> None:
+    def add_annotation(
+        self, annotation: CreateAnnotation, annotation_source: str | None = None
+    ) -> None:
         """Add an annotation to this sample.
 
         Args:
             annotation: The annotation to add.
+            annotation_source: Name of the annotation source to add the annotation to.
+                Reusing the same source name appends to that source. If `None`, a
+                default source is used.
         """
-        self.add_annotations(annotations=[annotation])
+        self.add_annotations(annotations=[annotation], annotation_source=annotation_source)
 
-    def add_annotations(self, annotations: Iterable[CreateAnnotation]) -> None:
+    def add_annotations(
+        self, annotations: Iterable[CreateAnnotation], annotation_source: str | None = None
+    ) -> None:
         """Add annotations to this sample.
 
         Args:
             annotations: The annotations to add.
+            annotation_source: Name of the annotation source to add the annotations to.
+                Reusing the same source name appends to that source. If `None`, a
+                default source is used.
         """
         session = self.get_object_session()
         collection = collection_resolver.get_by_id(
@@ -293,6 +303,7 @@ class Sample(ABC):
             session=session,
             parent_collection_id=self.collection_id,
             annotations=annotation_creates,
+            collection_name=annotation_source,
         )
 
     def delete_annotation(self, annotation: Annotation) -> None:

--- a/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__add_annotations.py
@@ -86,6 +86,11 @@ class TestDataset:
         )
         assert len(result.annotations) == 2
 
+        # The annotation source is readable on each annotation.
+        sample_annotations = [a for sample in dataset for a in sample.annotations]
+        assert len(sample_annotations) == 2
+        assert all(a.annotation_source == "ground_truth" for a in sample_annotations)
+
         cov_id = collection_resolver.get_or_create_child_collection(
             session=dataset.session,
             collection_id=dataset.collection_id,

--- a/lightly_studio/tests/core/image/test_image_dataset__coco.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__coco.py
@@ -15,7 +15,6 @@ from lightly_studio.models.annotation.object_detection import ObjectDetectionAnn
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import (
     annotation_collection_coverage_resolver,
-    annotation_resolver,
     collection_resolver,
 )
 
@@ -511,12 +510,9 @@ class TestDataset:
             annotation_source="ground_truth",
         )
 
-        annotations = annotation_resolver.get_all_by_collection_name(
-            session=dataset.session,
-            collection_name="ground_truth",
-            parent_collection_id=dataset.collection_id,
-        ).annotations
+        annotations = [a for sample in dataset for a in sample.annotations]
         assert len(annotations) == 2
+        assert all(a.annotation_source == "ground_truth" for a in annotations)
 
     def test_add_samples_from_coco__default_annotation_source(
         self,
@@ -535,12 +531,9 @@ class TestDataset:
             embed=False,
         )
 
-        annotations = annotation_resolver.get_all_by_collection_name(
-            session=dataset.session,
-            collection_name="annotation",
-            parent_collection_id=dataset.collection_id,
-        ).annotations
+        annotations = [a for sample in dataset for a in sample.annotations]
         assert len(annotations) == 2
+        assert all(a.annotation_source == "annotation" for a in annotations)
 
     def test_add_samples_from_coco__relative_local_images_path_normalized_to_absolute(
         self,

--- a/lightly_studio/tests/core/image/test_image_dataset__coco.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__coco.py
@@ -15,7 +15,6 @@ from lightly_studio.models.annotation.object_detection import ObjectDetectionAnn
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import (
     annotation_collection_coverage_resolver,
-    annotation_resolver,
     collection_resolver,
 )
 

--- a/lightly_studio/tests/core/image/test_image_dataset__coco.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__coco.py
@@ -15,6 +15,7 @@ from lightly_studio.models.annotation.object_detection import ObjectDetectionAnn
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import (
     annotation_collection_coverage_resolver,
+    annotation_resolver,
     collection_resolver,
 )
 
@@ -510,9 +511,12 @@ class TestDataset:
             annotation_source="ground_truth",
         )
 
-        annotations = [a for sample in dataset for a in sample.annotations]
+        annotations = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="ground_truth",
+            parent_collection_id=dataset.collection_id,
+        ).annotations
         assert len(annotations) == 2
-        assert all(a.annotation_source == "ground_truth" for a in annotations)
 
     def test_add_samples_from_coco__default_annotation_source(
         self,
@@ -531,9 +535,12 @@ class TestDataset:
             embed=False,
         )
 
-        annotations = [a for sample in dataset for a in sample.annotations]
+        annotations = annotation_resolver.get_all_by_collection_name(
+            session=dataset.session,
+            collection_name="annotation",
+            parent_collection_id=dataset.collection_id,
+        ).annotations
         assert len(annotations) == 2
-        assert all(a.annotation_source == "annotation" for a in annotations)
 
     def test_add_samples_from_coco__relative_local_images_path_normalized_to_absolute(
         self,

--- a/lightly_studio/tests/core/image/test_image_dataset__coco.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__coco.py
@@ -492,6 +492,49 @@ class TestDataset:
         )
         assert covered == {s.sample_id for s in samples}
 
+    def test_add_samples_from_coco__annotation_source(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(json.dumps(get_coco_annotation_dict_valid()))
+        images_path = _create_valid_samples(tmp_path)
+
+        dataset = ImageDataset.create(name="test_dataset")
+        dataset.add_samples_from_coco(
+            annotations_json=annotations_path,
+            images_path=images_path,
+            annotation_type=AnnotationType.OBJECT_DETECTION,
+            embed=False,
+            annotation_source="ground_truth",
+        )
+
+        annotations = [a for sample in dataset for a in sample.annotations]
+        assert len(annotations) == 2
+        assert all(a.annotation_source == "ground_truth" for a in annotations)
+
+    def test_add_samples_from_coco__default_annotation_source(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        annotations_path = tmp_path / "annotations.json"
+        annotations_path.write_text(json.dumps(get_coco_annotation_dict_valid()))
+        images_path = _create_valid_samples(tmp_path)
+
+        dataset = ImageDataset.create(name="test_dataset")
+        dataset.add_samples_from_coco(
+            annotations_json=annotations_path,
+            images_path=images_path,
+            annotation_type=AnnotationType.OBJECT_DETECTION,
+            embed=False,
+        )
+
+        annotations = [a for sample in dataset for a in sample.annotations]
+        assert len(annotations) == 2
+        assert all(a.annotation_source == "annotation" for a in annotations)
+
     def test_add_samples_from_coco__relative_local_images_path_normalized_to_absolute(
         self,
         patch_collection: None,  # noqa: ARG002

--- a/lightly_studio/tests/core/image/test_image_sample.py
+++ b/lightly_studio/tests/core/image/test_image_sample.py
@@ -559,6 +559,60 @@ class TestImageSample:
         assert dog_ann.width == 30
         assert dog_ann.height == 40
 
+    def test_add_annotation__annotation_source(
+        self,
+        db_session: Session,
+    ) -> None:
+        collection = create_collection(session=db_session)
+        image_table = create_image(
+            session=db_session,
+            collection_id=collection.collection_id,
+        )
+        image = ImageSample(inner=image_table)
+
+        # Add annotations with and without an explicit annotation source.
+        image.add_annotation(CreateClassification(class_name="cat", confidence=0.75))
+        image.add_annotation(
+            CreateClassification(class_name="dog", confidence=0.9),
+            annotation_source="model-v1",
+        )
+
+        annotations = image.annotations
+        assert len(annotations) == 2
+        cat_ann = next(a for a in annotations if a.class_name == "cat")
+        dog_ann = next(a for a in annotations if a.class_name == "dog")
+
+        # Without an explicit source, the default source is used.
+        assert cat_ann.annotation_source == "annotation"
+        assert cat_ann.confidence == pytest.approx(0.75)
+        assert dog_ann.annotation_source == "model-v1"
+        assert dog_ann.confidence == pytest.approx(0.9)
+
+    def test_add_annotations__annotation_source_appends(
+        self,
+        db_session: Session,
+    ) -> None:
+        collection = create_collection(session=db_session)
+        image_table = create_image(
+            session=db_session,
+            collection_id=collection.collection_id,
+        )
+        image = ImageSample(inner=image_table)
+
+        # Reusing the same source name appends to the same source.
+        image.add_annotations(
+            [CreateClassification(class_name="cat")],
+            annotation_source="model-v1",
+        )
+        image.add_annotations(
+            [CreateObjectDetection(class_name="dog", x=10, y=20, width=30, height=40)],
+            annotation_source="model-v1",
+        )
+
+        annotations = image.annotations
+        assert len(annotations) == 2
+        assert all(a.annotation_source == "model-v1" for a in annotations)
+
     def test_delete_annotation(
         self,
         db_session: Session,


### PR DESCRIPTION
## What has changed and why?

- Add `annotation_source` parameter to `Sample.add_annotation` and `Sample.add_annotations` for python api annotation creation.
- Add `Annotation.annotation_source` to read the source name from an existing annotation.

## How has it been tested?

updated tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `annotation_source` parameter to annotation import and creation methods, allowing you to specify and track the source of annotations
  * Added `annotation_source` property to read the source name of an annotation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->