### PR TITLE
Skip deep copy tests on DuckDB

### DIFF
--- a/lightly_studio/pytest.ini
+++ b/lightly_studio/pytest.ini
@@ -2,6 +2,9 @@
 pythonpath = src
 python_files = test_*.py
 
+markers =
+    postgres_only: run the test only on the Postgres backend (skipped under DuckDB)
+
 filterwarnings =
     ignore::UserWarning
     ignore::FutureWarning:mobileclip

--- a/lightly_studio/tests/api/routes/api/test_collection.py
+++ b/lightly_studio/tests/api/routes/api/test_collection.py
@@ -247,7 +247,7 @@ def test_has_embeddings(
     mock_get_model.assert_called_once_with(session=db_session, collection_id=col_id)
 
 
-@pytest.mark.postgres_only  # deep_copy is enterprise-only (PostgreSQL-backed).
+@pytest.mark.postgres_only  # Deep copying is enterprise-only (PostgreSQL-backed).
 def test_deep_copy__success(test_client: TestClient, db_session: Session) -> None:
     """Test successful deep copy of a collection."""
     collection = create_collection(session=db_session, collection_name="original")

--- a/lightly_studio/tests/api/routes/api/test_collection.py
+++ b/lightly_studio/tests/api/routes/api/test_collection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 from sqlmodel import Session
@@ -246,6 +247,7 @@ def test_has_embeddings(
     mock_get_model.assert_called_once_with(session=db_session, collection_id=col_id)
 
 
+@pytest.mark.postgres_only  # deep_copy is enterprise-only (PostgreSQL-backed).
 def test_deep_copy__success(test_client: TestClient, db_session: Session) -> None:
     """Test successful deep copy of a collection."""
     collection = create_collection(session=db_session, collection_name="original")

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -64,16 +64,11 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def pytest_configure(config: pytest.Config) -> None:
-    """Register custom markers for database backend selection."""
-    config.addinivalue_line(
-        "markers",
-        "postgres_only: run the test only on the Postgres backend (skipped under DuckDB)",
-    )
-
-
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Skip postgres_only tests unless the suite runs with --postgres."""
+    """Skip postgres_only tests unless the suite runs with --postgres.
+
+    The ``postgres_only`` marker is registered in ``pytest.ini``.
+    """
     if config.getoption("--postgres"):
         return
     skip_marker = pytest.mark.skip(reason="postgres_only: skipped under DuckDB")

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -20,10 +20,7 @@ from lightly_studio.api import features
 from lightly_studio.api.app import app
 from lightly_studio.dataset import embedding_manager
 from lightly_studio.dataset.embedding_generator import RandomEmbeddingGenerator
-from lightly_studio.dataset.embedding_manager import (
-    EmbeddingManager,
-    EmbeddingManagerProvider,
-)
+from lightly_studio.dataset.embedding_manager import EmbeddingManager, EmbeddingManagerProvider
 from lightly_studio.db_manager import DatabaseEngine
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationBaseTable,
@@ -34,11 +31,7 @@ from lightly_studio.models.annotation_label import (
     AnnotationLabelCreate,
     AnnotationLabelTable,
 )
-from lightly_studio.models.collection import (
-    CollectionCreate,
-    CollectionTable,
-    SampleType,
-)
+from lightly_studio.models.collection import CollectionCreate, CollectionTable, SampleType
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.tag import TagCreate, TagTable

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -34,11 +34,7 @@ from lightly_studio.models.annotation_label import (
     AnnotationLabelCreate,
     AnnotationLabelTable,
 )
-from lightly_studio.models.collection import (
-    CollectionCreate,
-    CollectionTable,
-    SampleType,
-)
+from lightly_studio.models.collection import CollectionCreate, CollectionTable, SampleType
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.tag import TagCreate, TagTable

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -20,7 +20,10 @@ from lightly_studio.api import features
 from lightly_studio.api.app import app
 from lightly_studio.dataset import embedding_manager
 from lightly_studio.dataset.embedding_generator import RandomEmbeddingGenerator
-from lightly_studio.dataset.embedding_manager import EmbeddingManager, EmbeddingManagerProvider
+from lightly_studio.dataset.embedding_manager import (
+    EmbeddingManager,
+    EmbeddingManagerProvider,
+)
 from lightly_studio.db_manager import DatabaseEngine
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationBaseTable,
@@ -31,7 +34,11 @@ from lightly_studio.models.annotation_label import (
     AnnotationLabelCreate,
     AnnotationLabelTable,
 )
-from lightly_studio.models.collection import CollectionCreate, CollectionTable, SampleType
+from lightly_studio.models.collection import (
+    CollectionCreate,
+    CollectionTable,
+    SampleType,
+)
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.tag import TagCreate, TagTable
@@ -55,6 +62,24 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Run tests against a Postgres container instead of in-memory DuckDB.",
     )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom markers for database backend selection."""
+    config.addinivalue_line(
+        "markers",
+        "postgres_only: run the test only on the Postgres backend (skipped under DuckDB)",
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip postgres_only tests unless the suite runs with --postgres."""
+    if config.getoption("--postgres"):
+        return
+    skip_marker = pytest.mark.skip(reason="postgres_only: skipped under DuckDB")
+    for item in items:
+        if "postgres_only" in item.keywords:
+            item.add_marker(skip_marker)
 
 
 def _truncate_tables(session: Session) -> None:

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -44,6 +44,9 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
 )
 
+# deep_copy is enterprise-only and PostgreSQL-backed; skip on the default DuckDB run.
+pytestmark = pytest.mark.postgres_only
+
 
 def test_deep_copy__empty_collection(db_session: Session) -> None:
     # Arrange

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -44,7 +44,7 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
 )
 
-# deep_copy is enterprise-only and PostgreSQL-backed; skip on the default DuckDB run.
+# Deep copying is enterprise-only and PostgreSQL-backed; skip on the default DuckDB run.
 pytestmark = pytest.mark.postgres_only
 
 


### PR DESCRIPTION
## What has changed and why?

Reintroduces the `postgres_only` Pytest marker and skips the deep copy tests on DuckDB.

## How has it been tested?

Tests pass

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
