### PR TITLE
Prevent negative strength values for diversity and class-balancing strategies

### DIFF
--- a/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/StrategyCard/StrategyCard.svelte
@@ -104,6 +104,7 @@
                             strength={instance.params.strength}
                             id={`diversity-strength-${instance.id}`}
                             testid={`strategy-diversity-strength-input-${instance.id}`}
+                            min={0}
                             onUpdate={(strength) => onUpdate({ strength })}
                         />
                     {:else if instance.type === 'typicality'}

--- a/lightly_studio_view/src/lib/components/Sampling/forms/ClassBalancingForm/ClassBalancingForm.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/forms/ClassBalancingForm/ClassBalancingForm.svelte
@@ -47,6 +47,7 @@
         strength={params.strength}
         id={`class-balancing-strength-${instanceId}`}
         testid={`strategy-class-balancing-strength-input-${instanceId}`}
+        min={0}
         onUpdate={(strength) => onUpdate({ strength })}
     />
     {#if params.target_distribution_mode === 'dictionary'}

--- a/lightly_studio_view/src/lib/components/Sampling/forms/StrengthField/StrengthField.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/forms/StrengthField/StrengthField.svelte
@@ -29,7 +29,7 @@
         {id}
         type="number"
         step="0.1"
-        min={min}
+        {min}
         value={strength}
         oninput={(event) => {
             const raw = (event.currentTarget as HTMLInputElement).value;

--- a/lightly_studio_view/src/lib/components/Sampling/forms/StrengthField/StrengthField.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/forms/StrengthField/StrengthField.svelte
@@ -7,28 +7,35 @@
         strength: number;
         id: string;
         testid: string;
+        min?: number;
         onUpdate: (strength: number) => void;
     }
 
-    let { strength, id, testid, onUpdate }: Props = $props();
+    let { strength, id, testid, min, onUpdate }: Props = $props();
+
+    const tooltipContent = $derived(
+        min !== undefined && min >= 0
+            ? 'Relative weight of this strategy in the combination. A strength of 2 gives this strategy twice the influence of one with strength 1.'
+            : 'Relative weight of this strategy in the combination. A strength of 2 gives this strategy twice the influence of one with strength 1. Negative values invert the scoring direction.'
+    );
 </script>
 
 <div class="grid gap-2">
     <div class="flex items-center gap-1.5">
         <Label for={id}>Strength</Label>
-        <FieldTooltip
-            content="Relative weight of this strategy in the combination. A strength of 2 gives this strategy twice the influence of one with strength 1. Negative values invert the scoring direction."
-        />
+        <FieldTooltip content={tooltipContent} />
     </div>
     <Input
         {id}
         type="number"
         step="0.1"
+        min={min}
         value={strength}
         oninput={(event) => {
             const raw = (event.currentTarget as HTMLInputElement).value;
             const parsed = Number(raw);
-            if (raw !== '' && !Number.isNaN(parsed)) onUpdate(parsed);
+            if (raw !== '' && !Number.isNaN(parsed) && (min === undefined || parsed >= min))
+                onUpdate(parsed);
         }}
         data-testid={testid}
         class="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"

--- a/lightly_studio_view/src/lib/components/Sampling/forms/StrengthField/StrengthField.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/forms/StrengthField/StrengthField.svelte
@@ -13,10 +13,10 @@
 
     let { strength, id, testid, min, onUpdate }: Props = $props();
 
+    const negativeValuesAllowed = $derived(min === undefined || min < 0);
     const tooltipContent = $derived(
-        min !== undefined && min >= 0
-            ? 'Relative weight of this strategy in the combination. A strength of 2 gives this strategy twice the influence of one with strength 1.'
-            : 'Relative weight of this strategy in the combination. A strength of 2 gives this strategy twice the influence of one with strength 1. Negative values invert the scoring direction.'
+        'Relative weight of this strategy in the combination. A strength of 2 gives this strategy twice the influence of one with strength 1.' +
+            (negativeValuesAllowed ? ' Negative values invert the scoring direction.' : '')
     );
 </script>
 
@@ -34,8 +34,9 @@
         oninput={(event) => {
             const raw = (event.currentTarget as HTMLInputElement).value;
             const parsed = Number(raw);
-            if (raw !== '' && !Number.isNaN(parsed) && (min === undefined || parsed >= min))
-                onUpdate(parsed);
+            const isNumberInput = raw !== '' && !Number.isNaN(parsed);
+            const isAboveMin = min === undefined || parsed >= min;
+            if (isNumberInput && isAboveMin) onUpdate(parsed);
         }}
         data-testid={testid}
         class="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"

--- a/lightly_studio_view/src/lib/components/Sampling/forms/StrengthField/StrengthField.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/forms/StrengthField/StrengthField.test.ts
@@ -72,4 +72,79 @@ describe('StrengthField', () => {
 
         expect(onUpdate).not.toHaveBeenCalled();
     });
+
+    it('does not call onUpdate with a negative value when min is 0', async () => {
+        const onUpdate = vi.fn();
+
+        render(StrengthField, {
+            props: {
+                strength: 1,
+                id: 'test-strength',
+                testid: 'test-strength-input',
+                min: 0,
+                onUpdate
+            }
+        });
+
+        await fireEvent.input(screen.getByTestId('test-strength-input'), {
+            target: { value: '-1' }
+        });
+
+        expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    it('calls onUpdate with a non-negative value when min is 0', async () => {
+        const onUpdate = vi.fn();
+
+        render(StrengthField, {
+            props: {
+                strength: 1,
+                id: 'test-strength',
+                testid: 'test-strength-input',
+                min: 0,
+                onUpdate
+            }
+        });
+
+        await fireEvent.input(screen.getByTestId('test-strength-input'), {
+            target: { value: '2' }
+        });
+
+        expect(onUpdate).toHaveBeenCalledWith(2);
+    });
+
+    it('shows tooltip mentioning negative values when min is not set', async () => {
+        render(StrengthField, {
+            props: {
+                strength: 1,
+                id: 'test-strength',
+                testid: 'test-strength-input',
+                onUpdate: vi.fn()
+            }
+        });
+
+        await fireEvent.mouseEnter(screen.getByRole('button', { name: 'More information' }));
+
+        expect(screen.getByRole('tooltip')).toHaveTextContent(
+            'Negative values invert the scoring direction.'
+        );
+    });
+
+    it('shows tooltip without negative values mention when min is 0', async () => {
+        render(StrengthField, {
+            props: {
+                strength: 1,
+                id: 'test-strength',
+                testid: 'test-strength-input',
+                min: 0,
+                onUpdate: vi.fn()
+            }
+        });
+
+        await fireEvent.mouseEnter(screen.getByRole('button', { name: 'More information' }));
+
+        expect(screen.getByRole('tooltip')).not.toHaveTextContent(
+            'Negative values invert the scoring direction.'
+        );
+    });
 });


### PR DESCRIPTION
## What has changed and why?

Added an optional `min` prop to `StrengthField`. The `min={0}` is passed for diversity and class balancing strategies, preventing negative strength values from being applied.

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strength inputs for diversity and class‑balancing sampling now enforce a minimum of 0 to prevent negative values.

* **New Features**
  * Strength field accepts an optional minimum constraint and updates its help text to omit the “negative inverts scoring” note when non‑negative only.

* **Tests**
  * Added tests verifying input validation and tooltip content when a minimum is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->