### PR TITLE
Run unit tests conditionally on directory changes

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -37,10 +37,14 @@ jobs:
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
+            # static-checks runs `mypy .` / `ruff check` over the whole tree,
+            # so every Python dir it lints belongs here, not just src/tests.
             backend:
               - '.github/workflows/test_and_release.yml'
               - 'lightly_studio/src/**'
               - 'lightly_studio/tests/**'
+              - 'lightly_studio/e2e-tests/**'
+              - 'lightly_studio/dataset_examples/**'
               - 'lightly_studio/pyproject.toml'
               - 'lightly_studio/uv.lock'
               - 'lightly_studio/ruff.toml'

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -16,8 +16,111 @@ concurrency:
 
   
 jobs:
+  # Detects which areas of the repo changed so downstream jobs can skip work
+  # that the change can't affect (e.g. a docs-only PR skips the test jobs).
+  # The required status check is `Unit Success Check`, not these jobs, so the
+  # test jobs are free to be skipped without stranding the merge queue.
+  detect:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Detect which areas changed
+        id: filter
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+
+
+          def write_outputs(**areas):
+              with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+                  for name, changed in areas.items():
+                      out.write(f"{name}={'true' if changed else 'false'}\n")
+
+
+          def run_all(reason):
+              # Fail safe: when in doubt, run everything rather than risk
+              # skipping a job the change actually affects.
+              print(f"{reason}; running all jobs (fail-safe).")
+              write_outputs(backend=True, frontend=True, docs=True)
+              sys.exit(0)
+
+
+          # Resolve the base/head pair to diff from the event payload. Reading
+          # the payload file avoids interpolating workflow expressions here.
+          event = os.environ["GITHUB_EVENT_NAME"]
+          with open(os.environ["GITHUB_EVENT_PATH"]) as fh:
+              payload = json.load(fh)
+
+          if event == "pull_request":
+              base = payload["pull_request"]["base"]["sha"]
+              head = payload["pull_request"]["head"]["sha"]
+          elif event == "merge_group":
+              base = payload["merge_group"]["base_sha"]
+              head = payload["merge_group"]["head_sha"]
+          else:
+              # push to main, workflow_dispatch, etc.: nothing to diff against.
+              run_all(f"Event {event!r} has no base to diff")
+
+          try:
+              subprocess.run(
+                  ["git", "fetch", "--no-tags", "--depth=1", "origin", base, head],
+                  check=True,
+                  capture_output=True,
+              )
+              files = subprocess.run(
+                  ["git", "diff", "--name-only", base, head],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              ).stdout.split()
+          except subprocess.CalledProcessError:
+              run_all(f"Could not diff {base}..{head}")
+
+          print("Changed files:", *files, sep="\n")
+
+          # Each area lists the path patterns whose changes require its jobs.
+          WORKFLOW = r"^\.github/workflows/test_and_release\.yml$"
+          BACKEND = [
+              r"^lightly_studio/(src|tests)/",
+              r"^lightly_studio/(pyproject\.toml|uv\.lock|ruff\.toml|pytest\.ini|Makefile|alembic\.ini)$",
+              WORKFLOW,
+          ]
+          FRONTEND = [
+              r"^lightly_studio_view/",
+              WORKFLOW,
+          ]
+          DOCS = [
+              r"\.md$",
+              r"^lightly_studio/docs/",
+              r"^ai_guidelines/",
+          ]
+
+          def any_changed(patterns):
+              return any(re.search(p, f) for p in patterns for f in files)
+
+          backend = any_changed(BACKEND)
+          frontend = any_changed(FRONTEND)
+          docs = any_changed(DOCS)
+
+          write_outputs(backend=backend, frontend=frontend, docs=docs)
+          print(f"Result: backend={backend} frontend={frontend} docs={docs}")
+          PY
+
   check-python:
     name: Static Checks Python
+    needs: detect
+    if: needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -53,6 +156,10 @@ jobs:
 
   check-typescript:
     name: Static Checks Typescript
+    needs: detect
+    # Schema/version files are exported from the backend, so backend changes
+    # can affect the generated TypeScript too.
+    if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -102,6 +209,9 @@ jobs:
 
   test-unit:
     name: Unit (${{ matrix.python }}, ${{ matrix.database }})
+    needs: detect
+    # The matrix runs Python unit tests (backend) and view tests (frontend).
+    if: needs.detect.outputs.backend == 'true' || needs.detect.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -177,6 +287,10 @@ jobs:
 
   check-docs:
     name: Build Docs
+    needs: detect
+    # API reference is generated from backend docstrings, so backend changes
+    # can break the docs build / link checks too.
+    if: needs.detect.outputs.docs == 'true' || needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -211,3 +325,58 @@ jobs:
       - name: Build docs
         working-directory: lightly_studio/docs
         run: make docs
+
+  # Single required status check for this workflow. It always runs, so the
+  # gated jobs above can be skipped (on e.g. docs-only changes) without
+  # stranding the merge queue. Configure the branch ruleset to require
+  # `Unit Success Check` instead of the individual job names.
+  unit-success:
+    name: Unit Success Check
+    runs-on: ubuntu-latest
+    needs:
+      - detect
+      - check-python
+      - check-typescript
+      - test-unit
+      - check-docs
+    if: always()
+    steps:
+      - name: Verify required jobs
+        env:
+          DETECT: ${{ needs.detect.result }}
+          PYTHON_CHECKS: ${{ needs.check-python.result }}
+          TYPESCRIPT_CHECKS: ${{ needs.check-typescript.result }}
+          UNIT_TESTS: ${{ needs.test-unit.result }}
+          DOCS: ${{ needs.check-docs.result }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import sys
+
+          # If change detection itself failed, every gated job was skipped for
+          # the wrong reason. Fail safe rather than report a green gate.
+          detect = os.environ["DETECT"]
+          if detect != "success":
+              sys.exit(f"::error::Change detection did not succeed (result={detect}); failing the gate.")
+
+          # A gated job is fine if it passed or was deliberately skipped.
+          # Anything else (failure, cancelled, timed_out) fails the gate.
+          gated = {
+              "Static Checks Python": os.environ["PYTHON_CHECKS"],
+              "Static Checks Typescript": os.environ["TYPESCRIPT_CHECKS"],
+              "Unit tests": os.environ["UNIT_TESTS"],
+              "Build Docs": os.environ["DOCS"],
+          }
+          allowed = {"success", "skipped"}
+
+          for name, result in gated.items():
+              print(f"{name}: {result}")
+
+          failed = {name: result for name, result in gated.items() if result not in allowed}
+          if failed:
+              for name, result in failed.items():
+                  print(f"::error::Required job '{name}' finished with result '{result}'.")
+              sys.exit(1)
+
+          print("All required jobs passed or were skipped.")
+          PY

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -16,7 +16,6 @@ concurrency:
 
   
 jobs:
-  # Lets downstream jobs skip work a change can't affect (e.g. docs-only PRs).
   detect:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -27,7 +26,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend || 'true' }}
       docs: ${{ steps.filter.outputs.docs || 'true' }}
     steps:
-      - name: Checkout Code # Needed for merge_group; PRs use the API.
+      - name: Checkout Code # Needed for merge_group event
         uses: actions/checkout@v6
 
       - name: Filter changed paths
@@ -37,8 +36,8 @@ jobs:
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
-            # static-checks runs `mypy .` / `ruff check` over the whole tree,
-            # so every Python dir it lints belongs here, not just src/tests.
+            # List paths in `lightly_studio/` to exclude triggering on docs.
+            # E2E tests and examples are included for static checks.
             backend:
               - '.github/workflows/test_and_release.yml'
               - 'lightly_studio/src/**'

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -267,7 +267,7 @@ jobs:
   # The single required status check: always runs, so gated jobs can be skipped
   # without stranding the merge queue. Require this in the branch ruleset.
   unit-success:
-    name: Unit Success Check
+    name: CI Success Check
     runs-on: ubuntu-latest
     needs:
       - detect

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -16,106 +16,43 @@ concurrency:
 
   
 jobs:
-  # Detects which areas of the repo changed so downstream jobs can skip work
-  # that the change can't affect (e.g. a docs-only PR skips the test jobs).
-  # The required status check is `Unit Success Check`, not these jobs, so the
-  # test jobs are free to be skipped without stranding the merge queue.
+  # Lets downstream jobs skip work a change can't affect (e.g. docs-only PRs).
   detect:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-      docs: ${{ steps.filter.outputs.docs }}
+      # Empty when the filter is skipped (non-PR/MG events), so `|| 'true'`
+      # runs everything. A real 'false' is non-empty and preserved.
+      backend: ${{ steps.filter.outputs.backend || 'true' }}
+      frontend: ${{ steps.filter.outputs.frontend || 'true' }}
+      docs: ${{ steps.filter.outputs.docs || 'true' }}
     steps:
-      - name: Checkout Code
+      - name: Checkout Code # Needed for merge_group; PRs use the API.
         uses: actions/checkout@v6
 
-      - name: Detect which areas changed
+      - name: Filter changed paths
         id: filter
-        run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import re
-          import subprocess
-          import sys
-
-
-          def write_outputs(**areas):
-              with open(os.environ["GITHUB_OUTPUT"], "a") as out:
-                  for name, changed in areas.items():
-                      out.write(f"{name}={'true' if changed else 'false'}\n")
-
-
-          def run_all(reason):
-              # Fail safe: when in doubt, run everything rather than risk
-              # skipping a job the change actually affects.
-              print(f"{reason}; running all jobs (fail-safe).")
-              write_outputs(backend=True, frontend=True, docs=True)
-              sys.exit(0)
-
-
-          # Resolve the base/head pair to diff from the event payload. Reading
-          # the payload file avoids interpolating workflow expressions here.
-          event = os.environ["GITHUB_EVENT_NAME"]
-          with open(os.environ["GITHUB_EVENT_PATH"]) as fh:
-              payload = json.load(fh)
-
-          if event == "pull_request":
-              base = payload["pull_request"]["base"]["sha"]
-              head = payload["pull_request"]["head"]["sha"]
-          elif event == "merge_group":
-              base = payload["merge_group"]["base_sha"]
-              head = payload["merge_group"]["head_sha"]
-          else:
-              # push to main, workflow_dispatch, etc.: nothing to diff against.
-              run_all(f"Event {event!r} has no base to diff")
-
-          try:
-              subprocess.run(
-                  ["git", "fetch", "--no-tags", "--depth=1", "origin", base, head],
-                  check=True,
-                  capture_output=True,
-              )
-              files = subprocess.run(
-                  ["git", "diff", "--name-only", base, head],
-                  check=True,
-                  capture_output=True,
-                  text=True,
-              ).stdout.split()
-          except subprocess.CalledProcessError:
-              run_all(f"Could not diff {base}..{head}")
-
-          print("Changed files:", *files, sep="\n")
-
-          # Each area lists the path patterns whose changes require its jobs.
-          WORKFLOW = r"^\.github/workflows/test_and_release\.yml$"
-          BACKEND = [
-              r"^lightly_studio/(src|tests)/",
-              r"^lightly_studio/(pyproject\.toml|uv\.lock|ruff\.toml|pytest\.ini|Makefile|alembic\.ini)$",
-              WORKFLOW,
-          ]
-          FRONTEND = [
-              r"^lightly_studio_view/",
-              WORKFLOW,
-          ]
-          DOCS = [
-              r"\.md$",
-              r"^lightly_studio/docs/",
-              r"^ai_guidelines/",
-          ]
-
-          def any_changed(patterns):
-              return any(re.search(p, f) for p in patterns for f in files)
-
-          backend = any_changed(BACKEND)
-          frontend = any_changed(FRONTEND)
-          docs = any_changed(DOCS)
-
-          write_outputs(backend=backend, frontend=frontend, docs=docs)
-          print(f"Result: backend={backend} frontend={frontend} docs={docs}")
-          PY
+        # Other events have no base to diff; they fall back to running all jobs.
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            backend:
+              - '.github/workflows/test_and_release.yml'
+              - 'lightly_studio/src/**'
+              - 'lightly_studio/tests/**'
+              - 'lightly_studio/pyproject.toml'
+              - 'lightly_studio/uv.lock'
+              - 'lightly_studio/ruff.toml'
+              - 'lightly_studio/pytest.ini'
+              - 'lightly_studio/Makefile'
+              - 'lightly_studio/alembic.ini'
+            frontend:
+              - '.github/workflows/test_and_release.yml'
+              - 'lightly_studio_view/**'
+            docs:
+              - '.github/workflows/test_and_release.yml'
+              - 'lightly_studio/docs/**'
 
   check-python:
     name: Static Checks Python
@@ -157,8 +94,7 @@ jobs:
   check-typescript:
     name: Static Checks Typescript
     needs: detect
-    # Schema/version files are exported from the backend, so backend changes
-    # can affect the generated TypeScript too.
+    # Backend changes can alter the exported schema/version, hence the generated TS.
     if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -210,7 +146,7 @@ jobs:
   test-unit:
     name: Unit (${{ matrix.python }}, ${{ matrix.database }})
     needs: detect
-    # The matrix runs Python unit tests (backend) and view tests (frontend).
+    # Matrix runs Python unit tests (backend) and view tests (frontend).
     if: needs.detect.outputs.backend == 'true' || needs.detect.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -288,8 +224,7 @@ jobs:
   check-docs:
     name: Build Docs
     needs: detect
-    # API reference is generated from backend docstrings, so backend changes
-    # can break the docs build / link checks too.
+    # API reference is generated from backend docstrings.
     if: needs.detect.outputs.docs == 'true' || needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -326,10 +261,8 @@ jobs:
         working-directory: lightly_studio/docs
         run: make docs
 
-  # Single required status check for this workflow. It always runs, so the
-  # gated jobs above can be skipped (on e.g. docs-only changes) without
-  # stranding the merge queue. Configure the branch ruleset to require
-  # `Unit Success Check` instead of the individual job names.
+  # The single required status check: always runs, so gated jobs can be skipped
+  # without stranding the merge queue. Require this in the branch ruleset.
   unit-success:
     name: Unit Success Check
     runs-on: ubuntu-latest
@@ -353,14 +286,12 @@ jobs:
           import os
           import sys
 
-          # If change detection itself failed, every gated job was skipped for
-          # the wrong reason. Fail safe rather than report a green gate.
+          # If detection failed, jobs were skipped for the wrong reason.
           detect = os.environ["DETECT"]
           if detect != "success":
               sys.exit(f"::error::Change detection did not succeed (result={detect}); failing the gate.")
 
-          # A gated job is fine if it passed or was deliberately skipped.
-          # Anything else (failure, cancelled, timed_out) fails the gate.
+          # A gated job is fine only if it passed or was skipped.
           gated = {
               "Static Checks Python": os.environ["PYTHON_CHECKS"],
               "Static Checks Typescript": os.environ["TYPESCRIPT_CHECKS"],


### PR DESCRIPTION
## What has changed and why?

Skips test jobs that a change can't affect.

This PR introduces dependency on the 3rd party `dorny/paths-filter` action for action detection. It is a popular action with an MIT license. The check works specifically also for merge queues.

Note that the Docs check before was omitted from required checks in GitHub settings (by mistake), this PR will make it required.

Note: A change of required checks from multiple jobs to the single `Unit Success Check` is needed before merging.

## How has it been tested?

* This PR's own CI run.
* For merge queue, we'll need to test live

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline efficiency by running checks only when relevant parts of the codebase change.
  * Added an always-on merge validation gate that ensures required checks either succeed or are skipped before allowing merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->