### PR TITLE
Fix: Add hint about how to add annotations to the GUI

### DIFF
--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
@@ -30,7 +30,7 @@
                     rel="noreferrer"
                     class="text-primary underline-offset-4 hover:underline"
                 >
-                    Add annotations manually or import them from code.
+                    Label samples directly in Studio or import annotations from code.
                 </a>
             </p>
         {:else}

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
@@ -23,14 +23,14 @@
     <div class="width-full space-y-2 overflow-hidden">
         {#if $annotationFilterRows.length === 0}
             <p class="text-sm text-diffuse-foreground">
-                No annotations.
+                No annotations yet.
                 <a
-                    href="https://docs.lightly.ai/studio/dataset_setup/image_dataset/"
+                    href="https://docs.lightly.ai/studio/concepts_and_tools/annotations"
                     target="_blank"
                     rel="noreferrer"
                     class="text-primary underline-offset-4 hover:underline"
                 >
-                    Learn how to add annotations.
+                    Add annotations manually or import them from code.
                 </a>
             </p>
         {:else}

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
@@ -30,7 +30,7 @@
                     rel="noreferrer"
                     class="text-primary underline-offset-4 hover:underline"
                 >
-                    Label samples directly in Studio or import annotations from code.
+                    Label samples directly in LightlyStudio or import annotations from code.
                 </a>
             </p>
         {:else}

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
@@ -21,43 +21,59 @@
 
 <Segment title="Annotation Classes">
     <div class="width-full space-y-2 overflow-hidden">
-        {#each $annotationFilterRows as { label_name, current_count, total_count, selected } (label_name)}
-            <div class="width-full flex items-center space-x-2" title={label_name}>
-                <Checkbox
-                    id={label_name}
-                    checked={selected}
-                    aria-labelledby={`${label_name}-label`}
-                    onCheckedChange={() => onToggleAnnotationFilter(label_name)}
-                />
-
-                <Label
-                    id={`${label_name}-label`}
-                    for={label_name}
-                    data-testid="labels-menu-item"
-                    class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        {#if $annotationFilterRows.length === 0}
+            <p class="text-sm text-diffuse-foreground">
+                No annotations.
+                <a
+                    href="https://docs.lightly.ai/studio/dataset_setup/image_dataset/"
+                    target="_blank"
+                    rel="noreferrer"
+                    class="text-primary underline-offset-4 hover:underline"
                 >
-                    {#if $selectedCollectionIds.length < 2}
-                        <AnnotationColorLegend
-                            labelName={label_name}
-                            className="h-3 w-3"
-                            {selected}
-                        />
-                    {/if}
-                    <p
-                        class="flex-1 truncate text-base font-normal"
-                        data-testid="label-menu-label-name"
+                    Learn how to add annotations.
+                </a>
+            </p>
+        {:else}
+            {#each $annotationFilterRows as { label_name, current_count, total_count, selected } (label_name)}
+                <div class="width-full flex items-center space-x-2" title={label_name}>
+                    <Checkbox
+                        id={label_name}
+                        checked={selected}
+                        aria-labelledby={`${label_name}-label`}
+                        onCheckedChange={() => onToggleAnnotationFilter(label_name)}
+                    />
+
+                    <Label
+                        id={`${label_name}-label`}
+                        for={label_name}
+                        data-testid="labels-menu-item"
+                        class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                     >
-                        {label_name}
-                    </p>
-                    {#if current_count}
-                        <span
-                            class="text-sm text-diffuse-foreground"
-                            data-testid="label-menu-label-count"
-                            >{formatInteger(current_count)} of {formatInteger(total_count)}</span
+                        {#if $selectedCollectionIds.length < 2}
+                            <AnnotationColorLegend
+                                labelName={label_name}
+                                className="h-3 w-3"
+                                {selected}
+                            />
+                        {/if}
+                        <p
+                            class="flex-1 truncate text-base font-normal"
+                            data-testid="label-menu-label-name"
                         >
-                    {/if}
-                </Label>
-            </div>
-        {/each}
+                            {label_name}
+                        </p>
+                        {#if current_count}
+                            <span
+                                class="text-sm text-diffuse-foreground"
+                                data-testid="label-menu-label-count"
+                                >{formatInteger(current_count)} of {formatInteger(
+                                    total_count
+                                )}</span
+                            >
+                        {/if}
+                    </Label>
+                </div>
+            {/each}
+        {/if}
     </div>
 </Segment>


### PR DESCRIPTION
## What has changed and why?

If the user starts the GUI without any annotations we now link to the docs with a hint: https://docs.lightly.ai/studio/concepts_and_tools/annotations/

Before:
<img width="1015" height="775" alt="image" src="https://github.com/user-attachments/assets/b6206f71-06bf-491a-99e4-e934bfb9dfb6" />

After:
<img width="1084" height="767" alt="image" src="https://github.com/user-attachments/assets/fab0d5c3-0ff7-405f-8bf1-3ceada3fbd7b" />


## How has it been tested?

- Manual testing as this is only a frontend change. Tested the link.
## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Labels menu now shows an empty-state message (“No annotations yet.”) when there are no annotations, including a link to documentation for guidance. When annotations exist, the labels list (checkboxes, counts, and existing accessibility/test hooks) remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->