### PR TITLE
Apply query filter to embedding plot coloring and other features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed embedding rendering for users without WebGPU by updating `embedding-atlas` from `0.10.0` to `0.21.0`.
-- The embedding plot now greys out samples excluded by the query filter, matching the image grid.
+- The query filter is now applied consistently across features that use the image filter, such as the embedding plot, sampling, and select-all.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed embedding rendering for users without WebGPU by updating `embedding-atlas` from `0.10.0` to `0.21.0`.
+- The embedding plot now greys out samples excluded by the query filter, matching the image grid.
 
 ### Security
 

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
@@ -57,20 +57,14 @@ describe('useImageFilters', () => {
     });
 
     describe('imageFilter query expression', () => {
-        it('includes query_expr in sample_filter when a query expression is set', () => {
+        it('includes query_expr when set and omits it when toggled off', () => {
             const { imageFilter, updateFilterParams, updateQueryExpr } = useImageFilters();
             updateFilterParams(normalFilterParams);
-            updateQueryExpr({ query_expr: queryExpr, query_expr_str: 'caption == cat' });
 
+            updateQueryExpr({ query_expr: queryExpr, query_expr_str: 'caption == cat' });
             expect(get(imageFilter)?.sample_filter?.query_expr).toEqual(queryExpr);
-        });
 
-        it('omits query_expr when the query expression is toggled off', () => {
-            const { imageFilter, updateFilterParams, updateQueryExpr } = useImageFilters();
-            updateFilterParams(normalFilterParams);
-            updateQueryExpr({ query_expr: queryExpr, query_expr_str: 'caption == cat' });
             updateQueryExpr(undefined);
-
             expect(get(imageFilter)?.sample_filter?.query_expr).toBeUndefined();
         });
     });

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 import { useImageFilters } from './useImageFilters';
-import type { SortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
+import type { QueryExpr, SortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
 import { SortDirection } from '$lib/api/lightly_studio_local/types.gen';
+
+const queryExpr = {
+    match_expr: { type: 'string_expr', field_name: 'caption', value: 'cat' }
+} as unknown as QueryExpr;
+
+const normalFilterParams = {
+    collection_id: 'collection-1',
+    mode: 'normal'
+} as Parameters<ReturnType<typeof useImageFilters>['updateFilterParams']>[0];
 
 vi.mock('../useMetadataFilters/useMetadataFilters', () => ({
     createMetadataFilters: vi.fn(() => [])
@@ -11,8 +20,9 @@ vi.mock('../useMetadataFilters/useMetadataFilters', () => ({
 describe('useImageFilters', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        const { updateFilterParams } = useImageFilters();
+        const { updateFilterParams, updateQueryExpr } = useImageFilters();
         updateFilterParams({} as Parameters<typeof updateFilterParams>[0]);
+        updateQueryExpr(undefined);
     });
 
     describe('updateSortBy', () => {
@@ -38,6 +48,25 @@ describe('useImageFilters', () => {
             updateSortBy(null);
 
             expect(get(imageSortBy)).toBeNull();
+        });
+    });
+
+    describe('imageFilter query expression', () => {
+        it('includes query_expr in sample_filter when a query expression is set', () => {
+            const { imageFilter, updateFilterParams, updateQueryExpr } = useImageFilters();
+            updateFilterParams(normalFilterParams);
+            updateQueryExpr({ query_expr: queryExpr, query_expr_str: 'caption == cat' });
+
+            expect(get(imageFilter)?.sample_filter?.query_expr).toEqual(queryExpr);
+        });
+
+        it('omits query_expr when the query expression is toggled off', () => {
+            const { imageFilter, updateFilterParams, updateQueryExpr } = useImageFilters();
+            updateFilterParams(normalFilterParams);
+            updateQueryExpr({ query_expr: queryExpr, query_expr_str: 'caption == cat' });
+            updateQueryExpr(undefined);
+
+            expect(get(imageFilter)?.sample_filter?.query_expr).toBeUndefined();
         });
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
@@ -5,8 +5,13 @@ import type { QueryExpr, SortFieldExpr } from '$lib/api/lightly_studio_local/typ
 import { SortDirection } from '$lib/api/lightly_studio_local/types.gen';
 
 const queryExpr = {
-    match_expr: { type: 'string_expr', field_name: 'caption', value: 'cat' }
-} as unknown as QueryExpr;
+    match_expr: {
+        type: 'string_expr',
+        field: { table: 'image', name: 'caption' },
+        operator: '==',
+        value: 'cat'
+    }
+} satisfies QueryExpr;
 
 const normalFilterParams = {
     collection_id: 'collection-1',

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -37,67 +37,74 @@ const extractDimensions = (dimensions?: DimensionBounds) => {
     };
 };
 
-const imageFilter = derived(filterParams, ($filterParams): ImageFilter | null => {
-    if (!$filterParams?.collection_id || !$filterParams?.mode) {
-        return null;
-    }
-
-    if ($filterParams.mode === 'classifier') {
-        return null;
-    }
-
-    const filters: ImageFilter = {
-        filter_type: 'image'
-    };
-
-    const { width, height } = extractDimensions($filterParams.filters?.dimensions);
-    if (width) {
-        filters.width = width;
-    }
-    if (height) {
-        filters.height = height;
-    }
-
-    const sampleFilter: SampleFilter = {};
-
-    const sampleIds = $filterParams.filters?.sample_ids;
-    if (sampleIds && sampleIds.length > 0) {
-        sampleFilter.sample_ids = sampleIds;
-    }
-
-    const annotationLabelIds = $filterParams.filters?.annotation_label_ids;
-    if (annotationLabelIds && annotationLabelIds.length > 0) {
-        sampleFilter.annotations_filter = {
-            filter_type: 'annotations',
-            annotation_label_ids: annotationLabelIds
-        } satisfies AnnotationsFilter;
-    }
-
-    const tagIds = $filterParams.filters?.tag_ids;
-    if (tagIds && tagIds.length > 0) {
-        sampleFilter.tag_ids = tagIds;
-    }
-
-    if ($filterParams.metadata_values) {
-        const metadataFilters = createMetadataFilters($filterParams.metadata_values);
-        if (metadataFilters.length > 0) {
-            sampleFilter.metadata_filters = metadataFilters;
-        }
-    }
-
-    if (Object.keys(sampleFilter).length > 0) {
-        filters.sample_filter = sampleFilter;
-    }
-
-    return Object.keys(filters).length > 0 ? filters : null;
-});
-
 export interface QueryExpression {
     query_expr: QueryExpr;
     query_expr_str: string;
 }
 
 const imageQueryExpression = writable<QueryExpression | null>({} as QueryExpression);
+
+const imageFilter = derived(
+    [filterParams, imageQueryExpression],
+    ([$filterParams, $imageQueryExpression]): ImageFilter | null => {
+        if (!$filterParams?.collection_id || !$filterParams?.mode) {
+            return null;
+        }
+
+        if ($filterParams.mode === 'classifier') {
+            return null;
+        }
+
+        const filters: ImageFilter = {
+            filter_type: 'image'
+        };
+
+        const { width, height } = extractDimensions($filterParams.filters?.dimensions);
+        if (width) {
+            filters.width = width;
+        }
+        if (height) {
+            filters.height = height;
+        }
+
+        const sampleFilter: SampleFilter = {};
+
+        const sampleIds = $filterParams.filters?.sample_ids;
+        if (sampleIds && sampleIds.length > 0) {
+            sampleFilter.sample_ids = sampleIds;
+        }
+
+        const annotationLabelIds = $filterParams.filters?.annotation_label_ids;
+        if (annotationLabelIds && annotationLabelIds.length > 0) {
+            sampleFilter.annotations_filter = {
+                filter_type: 'annotations',
+                annotation_label_ids: annotationLabelIds
+            } satisfies AnnotationsFilter;
+        }
+
+        const tagIds = $filterParams.filters?.tag_ids;
+        if (tagIds && tagIds.length > 0) {
+            sampleFilter.tag_ids = tagIds;
+        }
+
+        if ($filterParams.metadata_values) {
+            const metadataFilters = createMetadataFilters($filterParams.metadata_values);
+            if (metadataFilters.length > 0) {
+                sampleFilter.metadata_filters = metadataFilters;
+            }
+        }
+
+        if ($imageQueryExpression?.query_expr) {
+            sampleFilter.query_expr = $imageQueryExpression.query_expr;
+        }
+
+        if (Object.keys(sampleFilter).length > 0) {
+            filters.sample_filter = sampleFilter;
+        }
+
+        return Object.keys(filters).length > 0 ? filters : null;
+    }
+);
 
 const imageSortBy = writable<SortExpr[] | null>([
     {

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -42,7 +42,7 @@ export interface QueryExpression {
     query_expr_str: string;
 }
 
-const imageQueryExpression = writable<QueryExpression | null>({} as QueryExpression);
+const imageQueryExpression = writable<QueryExpression | null>(null);
 
 const imageFilter = derived(
     [filterParams, imageQueryExpression],


### PR DESCRIPTION
## What has changed and why?

The query filter was not passed to all consumers of `imageFilter` (plot, sampling, select-all, adjacent navigation, operator context). Note that image grid path is independent, so there is no double-application.

Out of scope: videos have no query-filter UI, so they are unaffected.

## How has it been tested?

- Frontend `make static-checks` passes.
- Added unit tests covering that `query_expr` is included when the query filter is set and omitted when toggled off.
- Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Query filters are now applied consistently across image-filter-dependent features, including the embedding plot, image sampling, and select-all operations.
  * Improved query-expression handling in image filtering so it’s applied when set and removed when cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->