### PR TITLE
Fixing the annotation source dropdown

### DIFF
--- a/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.svelte
@@ -3,6 +3,7 @@
     import { type BalancingMode } from '$lib/components/Sampling/balancingMode';
     import AnnotationSourceSelect from '$lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte';
     import BalancingModeSelect from './BalancingModeSelect.svelte';
+    import { Label } from '$lib/components/ui/label';
 
     interface Props {
         balancingMode: BalancingMode;
@@ -30,8 +31,14 @@
 
 <BalancingModeSelect {balancingMode} {onBalancingModeChange} />
 
-<AnnotationSourceSelect
-    {sourceOptions}
-    selectedSource={annotationSourceId}
-    onSelect={onAnnotationSourceChange}
-/>
+<div class="grid grid-cols-4 items-center gap-4">
+    <Label for="annotation-source" class="text-right text-foreground">Annotation Source</Label>
+    <div class="col-span-3">
+        <AnnotationSourceSelect
+            id="annotation-source"
+            {sourceOptions}
+            selectedSource={annotationSourceId}
+            onSelect={onAnnotationSourceChange}
+        />
+    </div>
+</div>

--- a/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/ClassBalancingForm/ClassBalancingForm.test.ts
@@ -60,4 +60,24 @@ describe('ClassBalancingForm', () => {
         expect(inputOption).toHaveAttribute('data-disabled');
         expect(inputOption).toHaveTextContent('Input (Coming soon)');
     });
+
+    it('wires the annotation source label to the select trigger', () => {
+        render(ClassBalancingForm, {
+            props: {
+                balancingMode: 'uniform',
+                annotationCollections: [
+                    {
+                        collection_id: 'annotation-source-1',
+                        name: 'Ground Truth'
+                    }
+                ],
+                annotationSourceId: 'annotation-source-1',
+                onBalancingModeChange: vi.fn(),
+                onAnnotationSourceChange: vi.fn()
+            }
+        });
+
+        const trigger = screen.getByTestId('annotation-source-trigger');
+        expect(screen.getByLabelText('Annotation Source')).toBe(trigger);
+    });
 });


### PR DESCRIPTION
## What has changed and why?
It should only take up one column.

## How has it been tested?
Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the Class Balancing form layout with a responsive grid and clearer “Annotation Source” labeling aligned with the corresponding selector.

* **Tests**
  * Added a unit test to confirm the form renders correctly with provided collection data and that the “Annotation Source” label is properly connected to the selector trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->