### PR TITLE
Simplify order of strategies hint

### DIFF
--- a/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/SamplingCombinationDialog.svelte
@@ -115,8 +115,7 @@
                                 {/each}
                                 <span class="flex items-center gap-1 text-xs text-muted-foreground">
                                     <Info class="size-3 shrink-0" />
-                                    Strategies are scored and combined simultaneously using their strength
-                                    weights - the order shown here does not affect the result.
+                                    The order of strategies does not affect the result.
                                 </span>
                             </div>
                         {/if}


### PR DESCRIPTION
## What has changed and why?

Simplifies the strategies order hint text since it is slightly redundant with the strength field tooltips.

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated helper text in the Sampling dialog to clarify that the order of strategies does not affect the final results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->