### PR TITLE
Extract frontend tests into a parallel CI job

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -146,11 +146,11 @@ jobs:
         working-directory: lightly_studio_view
         run: make static-checks
 
-  test-unit:
-    name: Unit (${{ matrix.python }}, ${{ matrix.database }})
+  test-backend:
+    name: Backend (${{ matrix.python }}, ${{ matrix.database }})
     needs: detect
-    # Matrix runs Python unit tests (backend) and view tests (frontend).
-    if: needs.detect.outputs.backend == 'true' || needs.detect.outputs.frontend == 'true'
+    # Matrix runs the Python backend unit tests. View tests live in `test-frontend`.
+    if: needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -158,21 +158,15 @@ jobs:
         include:
           # Postgres is only tested on 3.14 because PostgreSQL dialect/driver
           # behavior doesn't vary by Python version.
-          # View tests (lightly_studio_view) run only once because they are
-          # independent of the Python version.
-          # TODO(Mihnea, 03/2026): Extract view tests to a separate job.
           - python: "3.9"
             database: DuckDB
             make_target: test
-            run_view_tests: false
           - python: "3.14"
             database: DuckDB
             make_target: test
-            run_view_tests: true
           - python: "3.14"
             database: Postgres
             make_target: test-postgres
-            run_view_tests: false
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -217,11 +211,62 @@ jobs:
           UV_PYTHON: ${{ matrix.python }}
         run: make ${{ matrix.make_target }}
 
-      - name: Run Tests for lightly_studio_view
-        if: matrix.run_view_tests
+  test-frontend:
+    name: Frontend Tests
+    needs: detect
+    # View tests are Python-version independent, so they run in a single job
+    # instead of across the backend matrix. Backend changes can alter the
+    # exported schema (and thus the generated API client), hence `backend` too.
+    if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      # Authenticate to download dev versions of lightly-mundig.
+      - name: Authenticate with GCP
+        uses: 'google-github-actions/auth@v3'
+        with:
+          project_id: boris-250909
+          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
+
+      - name: Set Up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.9"
+
+      - name: Set Up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.8.17"
+          python-version: "3.9"
+          enable-cache: true
+
+      - name: Install LightlyStudio dependencies
+        working-directory: lightly_studio
+        run: make install-optional-deps
+
+      # The view test suite imports the generated API client, which is built
+      # from the backend's exported schema.
+      - name: Export schema and generate version file from backend
+        working-directory: lightly_studio
+        run: |
+          make export-schema
+          make export-version
+
+      - name: Install dependencies
         working-directory: lightly_studio_view
-        env:
-          UV_PYTHON: ${{ matrix.python }}
+        run: make install
+
+      # Generates the Langium and API-client sources the unit tests import.
+      - name: Build app
+        working-directory: lightly_studio_view
+        run: make build
+
+      - name: Run Tests for lightly_studio_view
+        working-directory: lightly_studio_view
         run: make test
 
   check-docs:
@@ -273,7 +318,8 @@ jobs:
       - detect
       - check-python
       - check-typescript
-      - test-unit
+      - test-backend
+      - test-frontend
       - check-docs
     if: always()
     steps:
@@ -282,7 +328,8 @@ jobs:
           DETECT: ${{ needs.detect.result }}
           PYTHON_CHECKS: ${{ needs.check-python.result }}
           TYPESCRIPT_CHECKS: ${{ needs.check-typescript.result }}
-          UNIT_TESTS: ${{ needs.test-unit.result }}
+          BACKEND_TESTS: ${{ needs.test-backend.result }}
+          FRONTEND_TESTS: ${{ needs.test-frontend.result }}
           DOCS: ${{ needs.check-docs.result }}
         run: |
           python3 - <<'PY'
@@ -298,7 +345,8 @@ jobs:
           gated = {
               "Static Checks Python": os.environ["PYTHON_CHECKS"],
               "Static Checks Typescript": os.environ["TYPESCRIPT_CHECKS"],
-              "Unit tests": os.environ["UNIT_TESTS"],
+              "Backend tests": os.environ["BACKEND_TESTS"],
+              "Frontend tests": os.environ["FRONTEND_TESTS"],
               "Build Docs": os.environ["DOCS"],
           }
           allowed = {"success", "skipped"}


### PR DESCRIPTION
## What has changed and why?

The view (frontend) test suite was bolted onto the longest backend matrix leg (3.14/DuckDB), running back-to-back after the Python tests and making that job the long pole (~11m) on the Unit Test critical path. This moves the view tests into a dedicated `test-frontend` job that runs in parallel, and slims the backend matrix down to backend-only. The new ceiling becomes the slowest remaining job (~8m46s, the 3.9 backend leg).

Caveats:
- `test-frontend` still needs the backend Python/uv setup: the view tests import the generated API client, which is built from the backend's exported OpenAPI schema. So the job reproduces the same schema-export → install → build chain that `Static Checks Typescript` already uses.
- That setup chain is now duplicated across two jobs. Left as-is intentionally — it's stable boilerplate across only two call sites; a composite action would add more plumbing than it saves at this scale.

## How has it been tested?

CI on this PR. The new `test-frontend` job runs the same `make test` that previously executed inside the backend matrix leg, with the equivalent setup.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)