### PR TITLE
Parallelize backend DuckDB tests

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -252,8 +252,7 @@ jobs:
           make export-schema
           make export-version
 
-      # `make build` installs deps (build: install) and generates the Langium
-      # and API-client sources the unit tests import.
+      # `make build` installs deps (build: install) before building.
       - name: Build app
         working-directory: lightly_studio_view
         run: make build

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -255,11 +255,8 @@ jobs:
           make export-schema
           make export-version
 
-      - name: Install dependencies
-        working-directory: lightly_studio_view
-        run: make install
-
-      # Generates the Langium and API-client sources the unit tests import.
+      # `make build` installs deps (build: install) and generates the Langium
+      # and API-client sources the unit tests import.
       - name: Build app
         working-directory: lightly_studio_view
         run: make build

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -146,11 +146,11 @@ jobs:
         working-directory: lightly_studio_view
         run: make static-checks
 
-  test-unit:
-    name: Unit (${{ matrix.python }}, ${{ matrix.database }})
+  test-backend:
+    name: Backend (${{ matrix.python }}, ${{ matrix.database }})
     needs: detect
-    # Matrix runs Python unit tests (backend) and view tests (frontend).
-    if: needs.detect.outputs.backend == 'true' || needs.detect.outputs.frontend == 'true'
+    # Matrix runs the Python backend unit tests. View tests live in `test-frontend`.
+    if: needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -158,21 +158,15 @@ jobs:
         include:
           # Postgres is only tested on 3.14 because PostgreSQL dialect/driver
           # behavior doesn't vary by Python version.
-          # View tests (lightly_studio_view) run only once because they are
-          # independent of the Python version.
-          # TODO(Mihnea, 03/2026): Extract view tests to a separate job.
           - python: "3.9"
             database: DuckDB
             make_target: test
-            run_view_tests: false
           - python: "3.14"
             database: DuckDB
             make_target: test
-            run_view_tests: true
           - python: "3.14"
             database: Postgres
             make_target: test-postgres
-            run_view_tests: false
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -217,11 +211,62 @@ jobs:
           UV_PYTHON: ${{ matrix.python }}
         run: make ${{ matrix.make_target }}
 
-      - name: Run Tests for lightly_studio_view
-        if: matrix.run_view_tests
+  test-frontend:
+    name: Frontend Tests
+    needs: detect
+    # View tests are Python-version independent, so they run in a single job
+    # instead of across the backend matrix. Backend changes can alter the
+    # exported schema (and thus the generated API client), hence `backend` too.
+    if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      # Authenticate to download dev versions of lightly-mundig.
+      - name: Authenticate with GCP
+        uses: 'google-github-actions/auth@v3'
+        with:
+          project_id: boris-250909
+          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
+
+      - name: Set Up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.9"
+
+      - name: Set Up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.8.17"
+          python-version: "3.9"
+          enable-cache: true
+
+      - name: Install LightlyStudio dependencies
+        working-directory: lightly_studio
+        run: make install-optional-deps
+
+      # The view test suite imports the generated API client, which is built
+      # from the backend's exported schema.
+      - name: Export schema and generate version file from backend
+        working-directory: lightly_studio
+        run: |
+          make export-schema
+          make export-version
+
+      - name: Install dependencies
         working-directory: lightly_studio_view
-        env:
-          UV_PYTHON: ${{ matrix.python }}
+        run: make install
+
+      # Generates the Langium and API-client sources the unit tests import.
+      - name: Build app
+        working-directory: lightly_studio_view
+        run: make build
+
+      - name: Run Tests for lightly_studio_view
+        working-directory: lightly_studio_view
         run: make test
 
   check-docs:
@@ -273,7 +318,8 @@ jobs:
       - detect
       - check-python
       - check-typescript
-      - test-unit
+      - test-backend
+      - test-frontend
       - check-docs
     if: always()
     steps:
@@ -282,7 +328,8 @@ jobs:
           DETECT: ${{ needs.detect.result }}
           PYTHON_CHECKS: ${{ needs.check-python.result }}
           TYPESCRIPT_CHECKS: ${{ needs.check-typescript.result }}
-          UNIT_TESTS: ${{ needs.test-unit.result }}
+          BACKEND_TESTS: ${{ needs.test-backend.result }}
+          FRONTEND_TESTS: ${{ needs.test-frontend.result }}
           DOCS: ${{ needs.check-docs.result }}
         run: |
           python3 - <<'PY'
@@ -298,7 +345,8 @@ jobs:
           gated = {
               "Static Checks Python": os.environ["PYTHON_CHECKS"],
               "Static Checks Typescript": os.environ["TYPESCRIPT_CHECKS"],
-              "Unit tests": os.environ["UNIT_TESTS"],
+              "Backend tests": os.environ["BACKEND_TESTS"],
+              "Frontend tests": os.environ["FRONTEND_TESTS"],
               "Build Docs": os.environ["DOCS"],
           }
           allowed = {"success", "skipped"}

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -134,14 +134,11 @@ jobs:
           make export-schema
           make export-version
 
-      - name: Install dependencies
-        working-directory: lightly_studio_view
-        run:  make install
-      
+      # `make build` installs deps (build: install) before building.
       - name: Build app to get svelte types
         working-directory: lightly_studio_view
         run:  make build
-      
+
       - name: Make static checks
         working-directory: lightly_studio_view
         run: make static-checks

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -149,7 +149,6 @@ jobs:
   test-backend:
     name: Backend (${{ matrix.python }}, ${{ matrix.database }})
     needs: detect
-    # Matrix runs the Python backend unit tests. View tests live in `test-frontend`.
     if: needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     strategy:

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -175,7 +175,7 @@ start-example:
 .PHONY: test
 test: build
 	@echo "Running tests..."
-	PYTHONPATH=$(PWD) uv run pytest -n 2
+	PYTHONPATH=$(PWD) uv run pytest -n 3
 
 .PHONY: test-ci
 test-ci:

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -175,7 +175,7 @@ start-example:
 .PHONY: test
 test: build
 	@echo "Running tests..."
-	PYTHONPATH=$(PWD) uv run pytest
+	PYTHONPATH=$(PWD) uv run pytest -n auto
 
 .PHONY: test-ci
 test-ci:

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -175,7 +175,7 @@ start-example:
 .PHONY: test
 test: build
 	@echo "Running tests..."
-	PYTHONPATH=$(PWD) uv run pytest -n 3
+	PYTHONPATH=$(PWD) uv run pytest -n auto
 
 .PHONY: test-ci
 test-ci:

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -175,7 +175,7 @@ start-example:
 .PHONY: test
 test: build
 	@echo "Running tests..."
-	PYTHONPATH=$(PWD) uv run pytest -n auto
+	PYTHONPATH=$(PWD) uv run pytest -n 2
 
 .PHONY: test-ci
 test-ci:


### PR DESCRIPTION
## What has changed and why?

Run python tests in parallel with DuckDB. Saves 2-3min for these CI workflows.

The CI machines have 4 cores. Using `-n auto` resolving to 4, checked that with 2 and 3 workers we are slower.

Note:
* Overall time decreases from 8-9min to 6min
* The time spent in pytest decreases from 335s/288s to 190s/175s for py3.9/py3.14
* The change is not applied to Postgres tests, the current setup is not thread-safe

This change leaves "Backend (3.14, Postgres)" the bottleneck CI test (excluding e2e) at 8min.

## How has it been tested?

Observed the CI.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
