### PR TITLE
Split general e2e tests into two shards

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -407,8 +407,7 @@ jobs:
         with:
           name: performance-metrics-${{ matrix.name }}
           path: lightly_studio_view/performance-metrics.json
-          # Only the shard that happens to run the performance test produces this file;
-          # the other general/videos shards legitimately have nothing to upload.
+          # Only the shard running the performance test produces this file.
           if-no-files-found: ignore
 
       - name: Create e2e success marker

--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -159,16 +159,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: General
+          - name: General 1/2
             index_script: index_general.py
             playwright_project: general
-            success_marker: .e2e-success-general
-            success_key: e2e-success-general
-            artifact_name: Playwright Report (General)
+            shard: "1/2"
+            success_marker: .e2e-success-general-1
+            success_key: e2e-success-general-1
+            artifact_name: Playwright Report (General 1)
+            postgres: false
+          - name: General 2/2
+            index_script: index_general.py
+            playwright_project: general
+            shard: "2/2"
+            success_marker: .e2e-success-general-2
+            success_key: e2e-success-general-2
+            artifact_name: Playwright Report (General 2)
             postgres: false
           - name: Videos
             index_script: index_video.py
             playwright_project: videos
+            shard: "1/1"
             success_marker: .e2e-success-videos
             success_key: e2e-success-videos
             artifact_name: Playwright Report (Videos)
@@ -176,20 +186,31 @@ jobs:
           - name: Groups
             index_script: index_groups.py
             playwright_project: groups
+            shard: "1/1"
             success_marker: .e2e-success-groups
             success_key: e2e-success-groups
             artifact_name: Playwright Report (Groups)
             postgres: false
-          - name: General Postgres
+          - name: General Postgres 1/2
             index_script: index_general.py
             playwright_project: general
-            success_marker: .e2e-success-general-postgres
-            success_key: e2e-success-general-postgres
-            artifact_name: Playwright Report (General Postgres)
+            shard: "1/2"
+            success_marker: .e2e-success-general-postgres-1
+            success_key: e2e-success-general-postgres-1
+            artifact_name: Playwright Report (General Postgres 1)
+            postgres: true
+          - name: General Postgres 2/2
+            index_script: index_general.py
+            playwright_project: general
+            shard: "2/2"
+            success_marker: .e2e-success-general-postgres-2
+            success_key: e2e-success-general-postgres-2
+            artifact_name: Playwright Report (General Postgres 2)
             postgres: true
           - name: Videos Postgres
             index_script: index_video.py
             playwright_project: videos
+            shard: "1/1"
             success_marker: .e2e-success-videos-postgres
             success_key: e2e-success-videos-postgres
             artifact_name: Playwright Report (Videos Postgres)
@@ -345,8 +366,13 @@ jobs:
       - name: Run end-to-end tests for indexed dataset
         if: steps.cache-success.outputs.cache-hit != 'true'
         working-directory: lightly_studio_view
-        run: npx playwright test --reporter=html --trace=on --project=${{ matrix.playwright_project }}
-        timeout-minutes: 10
+        run: >-
+          npx playwright test
+          --reporter=html
+          --trace=on
+          --project=${{ matrix.playwright_project }}
+          --shard=${{ matrix.shard }}
+        timeout-minutes: 6
 
       - name: Generate performance summary
         if: steps.cache-success.outputs.cache-hit != 'true' && (matrix.playwright_project == 'general' || matrix.playwright_project == 'videos')

--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: General 1/2
+          - name: General 1 of 2
             index_script: index_general.py
             playwright_project: general
             shard: "1/2"
@@ -167,7 +167,7 @@ jobs:
             success_key: e2e-success-general-1
             artifact_name: Playwright Report (General 1)
             postgres: false
-          - name: General 2/2
+          - name: General 2 of 2
             index_script: index_general.py
             playwright_project: general
             shard: "2/2"
@@ -191,7 +191,7 @@ jobs:
             success_key: e2e-success-groups
             artifact_name: Playwright Report (Groups)
             postgres: false
-          - name: General Postgres 1/2
+          - name: General Postgres 1 of 2
             index_script: index_general.py
             playwright_project: general
             shard: "1/2"
@@ -199,7 +199,7 @@ jobs:
             success_key: e2e-success-general-postgres-1
             artifact_name: Playwright Report (General Postgres 1)
             postgres: true
-          - name: General Postgres 2/2
+          - name: General Postgres 2 of 2
             index_script: index_general.py
             playwright_project: general
             shard: "2/2"
@@ -407,7 +407,9 @@ jobs:
         with:
           name: performance-metrics-${{ matrix.name }}
           path: lightly_studio_view/performance-metrics.json
-          if-no-files-found: warn
+          # Only the shard that happens to run the performance test produces this file;
+          # the other general/videos shards legitimately have nothing to upload.
+          if-no-files-found: ignore
 
       - name: Create e2e success marker
         if: steps.cache-success.outputs.cache-hit != 'true'

--- a/lightly_studio_view/e2e/pages/sample-details-page.ts
+++ b/lightly_studio_view/e2e/pages/sample-details-page.ts
@@ -67,7 +67,11 @@ export class SampleDetailsPage {
     }
 
     getAnnotationBoxByLabel(label: string) {
-        return this.page.locator(`[data-testid="selectable-svg-group"] [data-label="${label}"]`);
+        // Match `data-annotation-label` (always rendered), not the `data-label` text overlay that
+        // only appears when the "show annotation text labels" setting is on.
+        return this.page.locator(
+            `[data-testid="selectable-svg-group"] [data-annotation-label="${label}"] [data-testid="annotation_box"]`
+        );
     }
 
     async setLabel(label: string) {


### PR DESCRIPTION
## What has changed and why?

The general e2e suite was the CI bottleneck. Both the `General` (DuckDB) and `General Postgres` matrix jobs ran the full suite serially at ~10-11 min each, and test execution accounted for ~77% of that time.

Each is now split into two parallel shards using Playwright's `--shard` flag, dropping the critical path to ~6.5 min. The `shard` field is required on every matrix entry; unsharded suites (Videos, Groups) use `1/1`.

Note:
- Sharding is whole-file (config has `workers: 1`, no `fullyParallel`), so files are never split mid-way.
- Balance is by file count, not duration, so the split is roughly 55/45 rather than exactly even.

## How has it been tested?

Manually checked the CI runs on this PR.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution efficiency with optimized shard configuration
  * Enhanced reliability of annotation element detection in tests
  * Adjusted performance metrics collection for sharded test environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->