### PR TITLE
Fix Select trigger layout and add variant prop

### DIFF
--- a/lightly_studio_view/src/lib/components/Header/Menu.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Menu.svelte
@@ -122,6 +122,7 @@
         hideSelectionMarker
         itemsAsLinks
         onValueChange={handleValueChange}
+        variant="ghost"
         class="nav-button w-[100px]"
         testId="menu-trigger"
     />

--- a/lightly_studio_view/src/lib/components/MenuItem/MenuItem.svelte
+++ b/lightly_studio_view/src/lib/components/MenuItem/MenuItem.svelte
@@ -39,6 +39,7 @@
         onValueChange={handleValueChange}
         hideSelectionMarker
         itemsAsLinks
+        variant="ghost"
         class={cn(item.isSelected && 'bg-accent')}
         testId={`navigation-menu-${item.title.toLowerCase()}`}
     />

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
@@ -66,6 +66,7 @@
         disabled={isSimilaritySearchActive}
         placeholder="Sort by"
         size="xs"
+        variant="ghost"
         class="w-[100px] min-w-20"
         testId="sort-by-trigger"
     />

--- a/lightly_studio_view/src/lib/components/Select/Select.svelte
+++ b/lightly_studio_view/src/lib/components/Select/Select.svelte
@@ -23,6 +23,7 @@
     }
 
     export type SelectSize = 'xs' | 'sm' | 'md' | 'lg';
+    export type SelectVariant = 'default' | 'ghost';
 
     interface Props {
         /** List of items to render. Mutually exclusive with `children` slot. */
@@ -43,6 +44,8 @@
         open?: boolean;
         /** Trigger size. Heights align with the Button primitive. */
         size?: SelectSize;
+        /** Visual style of the trigger. `'default'` shows a bordered input; `'ghost'` is borderless. */
+        variant?: SelectVariant;
         /** Skip reserving the left padding for the selection check marker on items. */
         hideSelectionMarker?: boolean;
         /** Render items as links (uses pointer cursor instead of the default select caret). */
@@ -74,6 +77,7 @@
         disabled = false,
         open = $bindable(false),
         size = 'md',
+        variant = 'default',
         hideSelectionMarker = false,
         itemsAsLinks = false,
         class: className,
@@ -128,8 +132,9 @@
         {...selectProps}
         data-testid={testId}
         class={cn(
-            // Ghost-style: no border, no background, height matches the Button primitive
-            'm-0 flex items-center gap-2 rounded-md border-0 bg-transparent pr-2 font-normal',
+            'm-0 flex items-center justify-start gap-2 rounded-md font-normal [&>svg:last-child]:ml-auto [&>svg:last-child]:shrink-0',
+            variant === 'default' && 'border border-input bg-background px-3',
+            variant === 'ghost' && 'border-0 bg-transparent pr-2',
             triggerSizeClass[size],
             'text-foreground hover:bg-accent hover:text-accent-foreground',
             'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',

--- a/lightly_studio_view/src/lib/components/Select/Select.svelte
+++ b/lightly_studio_view/src/lib/components/Select/Select.svelte
@@ -23,7 +23,7 @@
     }
 
     export type SelectSize = 'xs' | 'sm' | 'md' | 'lg';
-    export type SelectVariant = 'default' | 'ghost';
+    type SelectVariant = 'default' | 'ghost';
 
     interface Props {
         /** List of items to render. Mutually exclusive with `children` slot. */


### PR DESCRIPTION
## What has changed and why?

Adds a default variant to the Select component with proper border and background styles, and fixes the trigger layout so the chevron icon is right-aligned.

<img width="1611" height="945" alt="Screenshot 2026-06-16 at 09 03 41" src="https://github.com/user-attachments/assets/86077234-218e-48aa-8004-642dde4285c3" />
<img width="807" height="546" alt="Screenshot 2026-06-16 at 09 03 48" src="https://github.com/user-attachments/assets/d8468237-deb1-40e7-9e11-13b71f1b6891" />

## How has it been tested?

Manual tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Introduced a variant-based styling system for select controls.
  * Updated menu trigger, menu items, and order-by selectors to use the **ghost** visual variant, aligning their appearance for a more consistent and refined interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->