### PR TITLE
Parallelise backend Postgres tests

### DIFF
--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -185,7 +185,7 @@ test-ci:
 .PHONY: test-postgres
 test-postgres: build
 	@echo "Running tests against Postgres..."
-	uv run pytest --postgres -n auto
+	uv run pytest --postgres -n 3
 
 # Alembic loads lightly_studio package code that expects dist_lightly_studio_view_app.
 .PHONY: mock-webapp-dist

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -185,7 +185,7 @@ test-ci:
 .PHONY: test-postgres
 test-postgres: build
 	@echo "Running tests against Postgres..."
-	uv run pytest --postgres
+	uv run pytest --postgres -n 2
 
 # Alembic loads lightly_studio package code that expects dist_lightly_studio_view_app.
 .PHONY: mock-webapp-dist

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -185,7 +185,7 @@ test-ci:
 .PHONY: test-postgres
 test-postgres: build
 	@echo "Running tests against Postgres..."
-	uv run pytest --postgres -n 3
+	uv run pytest --postgres -n auto
 
 # Alembic loads lightly_studio package code that expects dist_lightly_studio_view_app.
 .PHONY: mock-webapp-dist

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -185,7 +185,7 @@ test-ci:
 .PHONY: test-postgres
 test-postgres: build
 	@echo "Running tests against Postgres..."
-	uv run pytest --postgres -n 2
+	uv run pytest --postgres -n 3
 
 # Alembic loads lightly_studio package code that expects dist_lightly_studio_view_app.
 .PHONY: mock-webapp-dist


### PR DESCRIPTION
## What has changed and why?

Parallelise backend Postgres tests.

The change is simpler than expected, it suffices to call pytest with `-n 3`:
* We create a test-session-scoped db fixture, it starts a testcontainer
* Pytest runs shards in separate processes, every process creates its own container

Note that we could optimise in the future to spawn only one container with postgres, and use multiple databases inside.

## How has it been tested?

Ran CI with `-n2`, `-n3` and `-n auto` (equivalent to 4). The `-n 3` version was equally fast to `-n auto`, assuming one core is occupied (perhaps by the postgres container management). The pytest runtime is down from 232s to 135s, i.e. 97s faster.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Postgres E2E tests now execute with parallelization enabled, running 3 concurrent test workers for faster test suite execution and improved development feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->