### PR TITLE
Persist enforce coloring by class setting

### DIFF
--- a/lightly_studio/src/lightly_studio/migrations/versions/1781760000_7e8b0d6c9a12_add_enforce_coloring_by_class_setting.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1781760000_7e8b0d6c9a12_add_enforce_coloring_by_class_setting.py
@@ -1,0 +1,37 @@
+"""add_enforce_coloring_by_class_setting.
+
+Revision ID: 7e8b0d6c9a12
+Revises: dc6fddd82c1c
+Create Date: 2026-06-18 09:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7e8b0d6c9a12"
+down_revision: Union[str, Sequence[str], None] = "dc6fddd82c1c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "setting",
+        sa.Column(
+            "enforce_coloring_by_class",
+            sa.Boolean(),
+            server_default=sa.false(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("setting", "enforce_coloring_by_class")

--- a/lightly_studio/src/lightly_studio/models/settings.py
+++ b/lightly_studio/src/lightly_studio/models/settings.py
@@ -56,6 +56,10 @@ class SettingBase(SQLModel):
         description="Controls whether to show annotation bounding boxes for segmentation",
     )
 
+    enforce_coloring_by_class: bool = Field(
+        description="Controls whether annotations are always colored by class",
+    )
+
     # Toolbar shortcuts
     key_toolbar_selection: str = Field(
         description="Key to activate the selection tool in the toolbar",
@@ -103,6 +107,9 @@ class SettingDefaults(SettingBase):
     )
     show_bounding_boxes_for_segmentation: bool = Field(
         default=True,
+    )
+    enforce_coloring_by_class: bool = Field(
+        default=False,
     )
     key_toolbar_selection: str = Field(
         default="s",

--- a/lightly_studio/src/lightly_studio/resolvers/settings_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/settings_resolver.py
@@ -68,6 +68,9 @@ def set_settings(session: Session, settings: SettingView) -> SettingView:
         settings.show_bounding_boxes_for_segmentation
     )
 
+    # Update annotation coloring enforcement
+    current_settings.enforce_coloring_by_class = settings.enforce_coloring_by_class
+
     session.commit()
     session.refresh(current_settings)
 

--- a/lightly_studio/tests/resolvers/test_settings_resolver.py
+++ b/lightly_studio/tests/resolvers/test_settings_resolver.py
@@ -24,6 +24,7 @@ def test_get_settings_creates_default_settings(
     assert settings.show_annotation_text_labels is False
     assert settings.show_sample_filenames is False
     assert settings.show_bounding_boxes_for_segmentation is True
+    assert settings.enforce_coloring_by_class is False
     assert settings.key_toolbar_brush == "r"
     assert settings.key_toolbar_eraser == "x"
 
@@ -48,6 +49,7 @@ def test_set_settings_updates_grid_view_rendering(
         show_annotation_text_labels=current_settings.show_annotation_text_labels,
         show_sample_filenames=False,
         show_bounding_boxes_for_segmentation=False,
+        enforce_coloring_by_class=True,
         key_toolbar_selection="d",
         key_toolbar_drag="s",
         key_toolbar_bounding_box="m",
@@ -68,6 +70,7 @@ def test_set_settings_updates_grid_view_rendering(
         updated_settings.show_annotation_text_labels == current_settings.show_annotation_text_labels
     )
     assert updated_settings.show_bounding_boxes_for_segmentation is False
+    assert updated_settings.enforce_coloring_by_class is True
     assert updated_settings.key_toolbar_selection == "d"
     assert updated_settings.key_toolbar_drag == "s"
     assert updated_settings.key_toolbar_bounding_box == "m"
@@ -83,5 +86,6 @@ def test_set_settings_updates_grid_view_rendering(
     assert settings.key_go_back == current_settings.key_go_back
     assert settings.show_annotation_text_labels == current_settings.show_annotation_text_labels
     assert settings.show_bounding_boxes_for_segmentation is False
+    assert settings.enforce_coloring_by_class is True
     assert settings.key_toolbar_brush == "r"
     assert settings.key_toolbar_eraser == "x"

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.test.ts
@@ -39,6 +39,7 @@ vi.mock('$lib/hooks/useSettings', async () => {
         show_annotation_text_labels: false,
         show_sample_filenames: true,
         show_bounding_boxes_for_segmentation: true,
+        enforce_coloring_by_class: false,
         created_at: new Date('1970-01-01T00:00:00.000Z'),
         updated_at: new Date('1970-01-01T00:00:00.000Z'),
         key_toolbar_selection: 's',

--- a/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Settings/SettingsDialog.svelte
@@ -157,6 +157,16 @@
                                 disabled={dialogState.isSaving}
                             />
                         </SettingsFieldRow>
+                        <SettingsFieldRow
+                            id="enforce-coloring-by-class"
+                            label="Enforce Coloring by Class"
+                        >
+                            <Switch
+                                id="enforce-coloring-by-class"
+                                bind:checked={dialogState.enforceColoringByClass}
+                                disabled={dialogState.isSaving}
+                            />
+                        </SettingsFieldRow>
                     </div>
                 </div>
 

--- a/lightly_studio_view/src/lib/components/Settings/SettingsDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/Settings/SettingsDialog.test.ts
@@ -17,6 +17,7 @@ vi.mock('$lib/hooks/useSettings', () => {
         show_annotation_text_labels: false,
         show_sample_filenames: true,
         show_bounding_boxes_for_segmentation: true,
+        enforce_coloring_by_class: false,
         key_toolbar_selection: 's',
         key_toolbar_drag: 'd',
         key_toolbar_bounding_box: 'b',
@@ -118,6 +119,24 @@ describe('SettingsDialog', () => {
         );
     });
 
+    it('should show and save the enforce coloring by class switch', async () => {
+        render(SettingsDialog);
+        await openDialog();
+
+        const toggle = screen.getByRole('switch', { name: 'Enforce Coloring by Class' });
+        expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+        await fireEvent.click(toggle);
+        await fireEvent.click(screen.getByText('Save Changes'));
+
+        const { saveSettings } = useSettings();
+        expect(saveSettings).toHaveBeenCalledWith(
+            expect.objectContaining({
+                enforce_coloring_by_class: true
+            })
+        );
+    });
+
     it('should save all initial settings unchanged when no edits are made', async () => {
         render(SettingsDialog);
         await openDialog();
@@ -134,6 +153,7 @@ describe('SettingsDialog', () => {
             show_annotation_text_labels: false,
             show_sample_filenames: true,
             show_bounding_boxes_for_segmentation: true,
+            enforce_coloring_by_class: false,
             key_toolbar_selection: 's',
             key_toolbar_drag: 'd',
             key_toolbar_bounding_box: 'b',

--- a/lightly_studio_view/src/lib/components/Settings/settingsDialogState.svelte.ts
+++ b/lightly_studio_view/src/lib/components/Settings/settingsDialogState.svelte.ts
@@ -27,6 +27,7 @@ interface SettingsDialogFormState {
     showAnnotationTextLabels: boolean;
     showSampleFilenames: boolean;
     showBoundingBoxesForSegmentation: boolean;
+    enforceColoringByClass: boolean;
 }
 
 interface ShortcutKeyboardEvent {
@@ -51,7 +52,8 @@ export function createSettingsDialogFormState(settings: SettingView): SettingsDi
         gridViewThumbnailQuality: settings.grid_view_thumbnail_quality,
         showAnnotationTextLabels: settings.show_annotation_text_labels,
         showSampleFilenames: settings.show_sample_filenames,
-        showBoundingBoxesForSegmentation: settings.show_bounding_boxes_for_segmentation
+        showBoundingBoxesForSegmentation: settings.show_bounding_boxes_for_segmentation,
+        enforceColoringByClass: settings.enforce_coloring_by_class
     };
 }
 
@@ -67,6 +69,7 @@ export function createSettingsSavePayload(
         show_annotation_text_labels: formState.showAnnotationTextLabels,
         show_sample_filenames: formState.showSampleFilenames,
         show_bounding_boxes_for_segmentation: formState.showBoundingBoxesForSegmentation,
+        enforce_coloring_by_class: formState.enforceColoringByClass,
         key_toolbar_selection: formState.shortcutSettings.keyToolbarSelection,
         key_toolbar_drag: formState.shortcutSettings.keyToolbarDrag,
         key_toolbar_bounding_box: formState.shortcutSettings.keyToolbarBoundingBox,
@@ -115,6 +118,7 @@ export class SettingsDialogState {
     showAnnotationTextLabels = $state(false);
     showSampleFilenames = $state(false);
     showBoundingBoxesForSegmentation = $state(true);
+    enforceColoringByClass = $state(false);
     recordingShortcut: ShortcutSettingKey | null = $state(null);
     isSaving = $state(false);
 
@@ -127,6 +131,7 @@ export class SettingsDialogState {
         this.showAnnotationTextLabels = formState.showAnnotationTextLabels;
         this.showSampleFilenames = formState.showSampleFilenames;
         this.showBoundingBoxesForSegmentation = formState.showBoundingBoxesForSegmentation;
+        this.enforceColoringByClass = formState.enforceColoringByClass;
     }
 
     startRecording(key: ShortcutSettingKey): void {
@@ -154,7 +159,8 @@ export class SettingsDialogState {
             gridViewThumbnailQuality: this.gridViewThumbnailQuality,
             showAnnotationTextLabels: this.showAnnotationTextLabels,
             showSampleFilenames: this.showSampleFilenames,
-            showBoundingBoxesForSegmentation: this.showBoundingBoxesForSegmentation
+            showBoundingBoxesForSegmentation: this.showBoundingBoxesForSegmentation,
+            enforceColoringByClass: this.enforceColoringByClass
         });
     }
 }

--- a/lightly_studio_view/src/lib/components/Settings/settingsDialogState.test.ts
+++ b/lightly_studio_view/src/lib/components/Settings/settingsDialogState.test.ts
@@ -19,6 +19,7 @@ const TEST_SETTINGS: SettingView = {
     show_annotation_text_labels: false,
     show_sample_filenames: false,
     show_bounding_boxes_for_segmentation: true,
+    enforce_coloring_by_class: false,
     created_at: new Date(),
     updated_at: new Date(),
     key_toolbar_selection: 's',
@@ -47,7 +48,8 @@ describe('createSettingsDialogFormState', () => {
             gridViewThumbnailQuality: 'raw',
             showAnnotationTextLabels: false,
             showSampleFilenames: false,
-            showBoundingBoxesForSegmentation: true
+            showBoundingBoxesForSegmentation: true,
+            enforceColoringByClass: false
         });
     });
 });
@@ -71,7 +73,8 @@ describe('createSettingsSavePayload', () => {
                 gridViewThumbnailQuality: 'high',
                 showAnnotationTextLabels: true,
                 showSampleFilenames: true,
-                showBoundingBoxesForSegmentation: false
+                showBoundingBoxesForSegmentation: false,
+                enforceColoringByClass: true
             })
         ).toEqual({
             key_hide_annotations: 'h',
@@ -82,6 +85,7 @@ describe('createSettingsSavePayload', () => {
             show_annotation_text_labels: true,
             show_sample_filenames: true,
             show_bounding_boxes_for_segmentation: false,
+            enforce_coloring_by_class: true,
             key_toolbar_selection: 'a',
             key_toolbar_drag: 'g',
             key_toolbar_bounding_box: 'q',
@@ -117,7 +121,8 @@ describe('SettingsDialogState', () => {
             ...TEST_SETTINGS,
             key_hide_annotations: 'h',
             grid_view_sample_rendering: 'cover',
-            show_annotation_text_labels: true
+            show_annotation_text_labels: true,
+            enforce_coloring_by_class: true
         };
 
         state.hydrate(customSettings);
@@ -125,6 +130,7 @@ describe('SettingsDialogState', () => {
         expect(state.shortcuts.hideAnnotations).toBe('h');
         expect(state.gridViewRendering).toBe('cover');
         expect(state.showAnnotationTextLabels).toBe(true);
+        expect(state.enforceColoringByClass).toBe(true);
     });
 
     it('clears recording state on clearRecording', () => {
@@ -170,6 +176,7 @@ describe('SettingsDialogState', () => {
         state.hydrate(TEST_SETTINGS);
         state.shortcuts.hideAnnotations = 'z';
         state.showSampleFilenames = true;
+        state.enforceColoringByClass = true;
 
         const payload = state.getSavePayload();
 
@@ -177,6 +184,7 @@ describe('SettingsDialogState', () => {
             expect.objectContaining({
                 key_hide_annotations: 'z',
                 show_sample_filenames: true,
+                enforce_coloring_by_class: true,
                 key_go_back: 'Escape',
                 grid_view_sample_rendering: 'contain'
             })

--- a/lightly_studio_view/src/lib/hooks/useSettings.ts
+++ b/lightly_studio_view/src/lib/hooks/useSettings.ts
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS: SettingView = {
     show_annotation_text_labels: false,
     show_sample_filenames: false,
     show_bounding_boxes_for_segmentation: true,
+    enforce_coloring_by_class: false,
     created_at: new Date(),
     updated_at: new Date(),
     key_toolbar_selection: 's',
@@ -50,6 +51,11 @@ const showSampleFilenamesStore = derived(
 const showBoundingBoxesForSegmentationStore = derived(
     settingsStore,
     ($settings) => $settings.show_bounding_boxes_for_segmentation
+);
+
+const enforceColoringByClassStore = derived(
+    settingsStore,
+    ($settings) => $settings.enforce_coloring_by_class
 );
 
 const gridViewThumbnailQualityStore = derived(
@@ -155,6 +161,7 @@ export function useSettings() {
         showAnnotationTextLabelsStore,
         showSampleFilenamesStore,
         showBoundingBoxesForSegmentationStore,
+        enforceColoringByClassStore,
         gridViewThumbnailQualityStore,
 
         // Functions


### PR DESCRIPTION
## What has changed and why?

Adding enforce coloring by class to the settings.

## How has it been tested?

tests are updated.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Enforce Coloring by Class" toggle to the Settings dialog, allowing users to control color assignment behavior based on classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->