### PR TITLE
Resolve evaluation sample metrics by run name

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/evaluation_metric_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/evaluation_metric_expression.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from uuid import UUID
 
-from sqlalchemy import ColumnElement, Select, exists, select
-from sqlmodel import col
+from sqlalchemy import ColumnElement, Select, exists
+from sqlmodel import col, select
 
 from lightly_studio.core.dataset_query.field_expression import OrdinalOperator
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
+from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.evaluation_run import EvaluationRunTable
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricTable
 from lightly_studio.models.sample import SampleTable
 
@@ -18,18 +19,17 @@ class EvaluationMetricField:  # noqa: PLW1641
     """Queryable per-sample metric field from an evaluation run.
 
     Example:
-        ``EvaluationMetricField(evaluation_run_id=run.id, metric_name="miou") < 0.3``
+        ``EvaluationMetricField(run_name="run1", metric_name="miou") < 0.3``
     """
 
-    def __init__(self, evaluation_run_id: UUID, metric_name: str) -> None:
+    def __init__(self, run_name: str, metric_name: str) -> None:
         """Initialize a queryable metric reference."""
-        # TODO(lukas 6/2026): consider using the run name instead.
-        self.evaluation_run_id = evaluation_run_id
+        self.run_name = run_name
         self.metric_name = metric_name
 
     def _expression(self, other: float | int, operator: OrdinalOperator) -> MatchExpression:
         return EvaluationMetricMatchExpression(
-            evaluation_run_id=self.evaluation_run_id,
+            run_name=self.run_name,
             metric_name=self.metric_name,
             operator=operator,
             value=other,
@@ -64,7 +64,7 @@ class EvaluationMetricField:  # noqa: PLW1641
 class EvaluationMetricMatchExpression(MatchExpression):
     """Correlated EXISTS filter against evaluation sample metrics."""
 
-    evaluation_run_id: UUID
+    run_name: str
     metric_name: str
     operator: OrdinalOperator
     value: float | int
@@ -84,8 +84,17 @@ class EvaluationMetricMatchExpression(MatchExpression):
             select(1)
             .select_from(EvaluationSampleMetricTable)
             .where(col(EvaluationSampleMetricTable.sample_id) == col(SampleTable.sample_id))
-            .where(col(EvaluationSampleMetricTable.evaluation_run_id) == self.evaluation_run_id)
             .where(col(EvaluationSampleMetricTable.metric_name) == self.metric_name)
+            .join(
+                EvaluationRunTable,
+                col(EvaluationSampleMetricTable.evaluation_run_id) == col(EvaluationRunTable.id),
+            )
+            .where(col(EvaluationRunTable.name) == self.run_name)
+            .where(col(EvaluationRunTable.dataset_id) == col(CollectionTable.dataset_id))
+            .join(
+                CollectionTable,
+                col(CollectionTable.collection_id) == col(SampleTable.collection_id),
+            )
             .where(operations[self.operator])
         )
         return exists(subquery)

--- a/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
@@ -15,10 +15,12 @@ from typing_extensions import Self, TypeVar
 
 from lightly_studio.core.dataset_query.field import Field
 from lightly_studio.database import db_json
+from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricTable
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.metadata import SampleMetadataTable
+from lightly_studio.models.sample import SampleTable
 
 T = TypeVar("T", default=ImageTable)
 # Preserves the query type so apply_joins works on both SelectOfScalar (apply)
@@ -197,6 +199,7 @@ class OrderByEvaluationMetricField(OrderByExpression):
         # reference distinct value columns — avoiding ambiguous/duplicate SQL.
         self._run_alias = aliased(EvaluationRunTable)
         self._metric_alias = aliased(EvaluationSampleMetricTable)
+        self._collection_alias = aliased(CollectionTable)
 
     def _order_value_expression(self) -> ColumnElement[Any]:
         """Return the evaluation metric value column from the per-instance alias."""
@@ -205,8 +208,14 @@ class OrderByEvaluationMetricField(OrderByExpression):
     def apply_joins(self, query: SelectT) -> SelectT:
         """Left-outer-join evaluation run and sample-metric tables."""
         query = query.outerjoin(
+            self._collection_alias,
+            col(self._collection_alias.collection_id) == col(SampleTable.collection_id),
+        ).outerjoin(
             self._run_alias,
-            col(self._run_alias.name) == self.evaluation_run_name,
+            and_(
+                col(self._run_alias.name) == self.evaluation_run_name,
+                col(self._run_alias.dataset_id) == col(self._collection_alias.dataset_id),
+            ),
         )
         return query.outerjoin(
             self._metric_alias,

--- a/lightly_studio/tests/core/dataset_query/test_dataset_query__order_by.py
+++ b/lightly_studio/tests/core/dataset_query/test_dataset_query__order_by.py
@@ -5,7 +5,14 @@ from sqlmodel import Session
 
 from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
-from lightly_studio.core.dataset_query.order_by import OrderByField
+from lightly_studio.core.dataset_query.order_by import OrderByEvaluationMetricField, OrderByField
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
+from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
+from lightly_studio.resolvers import (
+    evaluation_run_resolver,
+    evaluation_sample_metric_resolver,
+)
 from tests.helpers_resolvers import create_collection, create_image
 
 
@@ -109,3 +116,100 @@ class TestDatasetQueryOrderBy:
             ValueError, match="order_by\\(\\) can only be called once per DatasetQuery instance"
         ):
             query.order_by(OrderByField(ImageSampleField.file_name).desc())
+
+    def test_order_by__evaluation_metric_scopes_run_name_to_dataset(
+        self, db_session: Session
+    ) -> None:
+        """Test ordering by evaluation metric when another dataset has a run with same name."""
+        dataset = create_collection(session=db_session)
+        image_a = create_image(
+            session=db_session,
+            collection_id=dataset.collection_id,
+            file_path_abs="/path/to/a.jpg",
+        )
+        image_b = create_image(
+            session=db_session,
+            collection_id=dataset.collection_id,
+            file_path_abs="/path/to/b.jpg",
+        )
+        gt_collection = create_collection(
+            session=db_session,
+            parent_collection_id=dataset.collection_id,
+            sample_type=SampleType.ANNOTATION,
+        )
+        pred_collection = create_collection(
+            session=db_session,
+            parent_collection_id=dataset.collection_id,
+            sample_type=SampleType.ANNOTATION,
+        )
+        run = evaluation_run_resolver.create(
+            session=db_session,
+            evaluation_run_input=EvaluationRunCreate(
+                name="run1",
+                gt_annotation_collection_id=gt_collection.collection_id,
+                dataset_id=gt_collection.dataset_id,
+                pred_annotation_collection_id=pred_collection.collection_id,
+                task_type=EvaluationTaskType.OBJECT_DETECTION,
+            ),
+        )
+
+        other_dataset = create_collection(session=db_session)
+        other_image = create_image(
+            session=db_session,
+            collection_id=other_dataset.collection_id,
+            file_path_abs="/path/to/other.jpg",
+        )
+        other_gt_collection = create_collection(
+            session=db_session,
+            parent_collection_id=other_dataset.collection_id,
+            sample_type=SampleType.ANNOTATION,
+        )
+        other_pred_collection = create_collection(
+            session=db_session,
+            parent_collection_id=other_dataset.collection_id,
+            sample_type=SampleType.ANNOTATION,
+        )
+        other_run = evaluation_run_resolver.create(
+            session=db_session,
+            evaluation_run_input=EvaluationRunCreate(
+                name="run1",
+                gt_annotation_collection_id=other_gt_collection.collection_id,
+                dataset_id=other_gt_collection.dataset_id,
+                pred_annotation_collection_id=other_pred_collection.collection_id,
+                task_type=EvaluationTaskType.OBJECT_DETECTION,
+            ),
+        )
+        evaluation_sample_metric_resolver.create_many(
+            session=db_session,
+            records=[
+                EvaluationSampleMetricCreate(
+                    evaluation_run_id=run.id,
+                    sample_id=image_a.sample_id,
+                    metric_name="score",
+                    value=0.9,
+                ),
+                EvaluationSampleMetricCreate(
+                    evaluation_run_id=run.id,
+                    sample_id=image_b.sample_id,
+                    metric_name="score",
+                    value=0.1,
+                ),
+                EvaluationSampleMetricCreate(
+                    evaluation_run_id=other_run.id,
+                    sample_id=other_image.sample_id,
+                    metric_name="score",
+                    value=0.0,
+                ),
+            ],
+        )
+
+        result_samples = (
+            DatasetQuery(dataset=dataset, session=db_session)
+            .order_by(OrderByEvaluationMetricField("run1", "score"))
+            .to_list()
+        )
+
+        assert [sample.sample_id for sample in result_samples] == [
+            image_b.sample_id,
+            image_a.sample_id,
+        ]

--- a/lightly_studio/tests/core/dataset_query/test_evaluation_metric_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_evaluation_metric_expression.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from uuid import uuid4
-
 import pytest
 from sqlmodel import Session, select
 
@@ -22,21 +20,22 @@ from lightly_studio.resolvers import (
 from tests.helpers_resolvers import create_collection, create_image
 
 
-def test_evaluation_metric_field__sql() -> None:
+def test_evaluation_metric_field__sql_scopes_run_to_sample_dataset() -> None:
     query = (
         select(ImageTable)
         .join(ImageTable.sample)
-        .where((EvaluationMetricField(evaluation_run_id=uuid4(), metric_name="score") >= 0.5).get())
+        .where((EvaluationMetricField(run_name="run1", metric_name="score") >= 0.5).get())
     )
     sql = str(query.compile(compile_kwargs={"literal_binds": True})).lower()
 
     assert "exists (select 1" in sql
     assert "from evaluation_sample_metric" in sql
-    assert "join evaluation_run" not in sql
-    assert "from evaluation_run" not in sql
-    assert ", sample" not in sql
-    assert "join sample" in sql
-    assert "evaluation_sample_metric.evaluation_run_id =" in sql
+    assert "join evaluation_run" in sql
+    assert "join collection" in sql
+    assert "evaluation_sample_metric.sample_id = sample.sample_id" in sql
+    assert "collection.collection_id = sample.collection_id" in sql
+    assert "evaluation_run.name = 'run1'" in sql
+    assert "evaluation_run.dataset_id = collection.dataset_id" in sql
     assert "evaluation_sample_metric.metric_name = 'score'" in sql
     assert "evaluation_sample_metric.value >= 0.5" in sql
 
@@ -45,27 +44,27 @@ def test_evaluation_metric_field__sql() -> None:
     ("expression", "expected_sql"),
     [
         (
-            EvaluationMetricField(evaluation_run_id=uuid4(), metric_name="score") > 0.5,
+            EvaluationMetricField(run_name="run1", metric_name="score") > 0.5,
             "evaluation_sample_metric.value > 0.5",
         ),
         (
-            EvaluationMetricField(evaluation_run_id=uuid4(), metric_name="score") >= 0.5,
+            EvaluationMetricField(run_name="run1", metric_name="score") >= 0.5,
             "evaluation_sample_metric.value >= 0.5",
         ),
         (
-            EvaluationMetricField(evaluation_run_id=uuid4(), metric_name="score") < 0.5,
+            EvaluationMetricField(run_name="run1", metric_name="score") < 0.5,
             "evaluation_sample_metric.value < 0.5",
         ),
         (
-            EvaluationMetricField(evaluation_run_id=uuid4(), metric_name="score") <= 0.5,
+            EvaluationMetricField(run_name="run1", metric_name="score") <= 0.5,
             "evaluation_sample_metric.value <= 0.5",
         ),
         (
-            EvaluationMetricField(evaluation_run_id=uuid4(), metric_name="score") == 0.5,
+            EvaluationMetricField(run_name="run1", metric_name="score") == 0.5,
             "evaluation_sample_metric.value = 0.5",
         ),
         (
-            EvaluationMetricField(evaluation_run_id=uuid4(), metric_name="score") != 0.5,
+            EvaluationMetricField(run_name="run1", metric_name="score") != 0.5,
             "evaluation_sample_metric.value != 0.5",
         ),
     ],
@@ -126,7 +125,100 @@ def test_evaluation_metric_field__filters_matching_samples(db_session: Session) 
 
     results = (
         DatasetQuery(dataset=dataset, session=db_session)
-        .match(EvaluationMetricField(evaluation_run_id=run.id, metric_name="score") > 0.5)
+        .match(EvaluationMetricField(run_name="run1", metric_name="score") > 0.5)
+        .to_list()
+    )
+
+    assert [result.sample_id for result in results] == [image_b.sample_id]
+
+
+def test_evaluation_metric_field__scopes_run_name_to_dataset(db_session: Session) -> None:
+    """Test filtering when another dataset has a run with the same name."""
+    dataset = create_collection(session=db_session)
+    image_a = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/a.jpg",
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/b.jpg",
+    )
+    gt_collection = create_collection(
+        session=db_session,
+        parent_collection_id=dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        parent_collection_id=dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run1",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            dataset_id=gt_collection.dataset_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+
+    other_dataset = create_collection(session=db_session)
+    other_image = create_image(
+        session=db_session,
+        collection_id=other_dataset.collection_id,
+        file_path_abs="/path/to/other.jpg",
+    )
+    other_gt_collection = create_collection(
+        session=db_session,
+        parent_collection_id=other_dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    other_pred_collection = create_collection(
+        session=db_session,
+        parent_collection_id=other_dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    other_run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run1",
+            gt_annotation_collection_id=other_gt_collection.collection_id,
+            dataset_id=other_gt_collection.dataset_id,
+            pred_annotation_collection_id=other_pred_collection.collection_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    evaluation_sample_metric_resolver.create_many(
+        session=db_session,
+        records=[
+            EvaluationSampleMetricCreate(
+                evaluation_run_id=run.id,
+                sample_id=image_a.sample_id,
+                metric_name="score",
+                value=0.9,
+            ),
+            EvaluationSampleMetricCreate(
+                evaluation_run_id=run.id,
+                sample_id=image_b.sample_id,
+                metric_name="score",
+                value=0.1,
+            ),
+            EvaluationSampleMetricCreate(
+                evaluation_run_id=other_run.id,
+                sample_id=other_image.sample_id,
+                metric_name="score",
+                value=0.0,
+            ),
+        ],
+    )
+
+    results = (
+        DatasetQuery(dataset=dataset, session=db_session)
+        .match(EvaluationMetricField(run_name="run1", metric_name="score") < 0.5)
         .to_list()
     )
 


### PR DESCRIPTION
## What has changed and why?
The query in GUI will be used by humans who will refer to the run by its name.

## How has it been tested?
Added tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Evaluation metrics can now be filtered and referenced by evaluation run name (instead of relying solely on evaluation run ID).
  * Metric-based ordering now correctly scopes results to the dataset associated with the specified run name.

* **Bug Fixes**
  * Run-name filtering is dataset-safe: identical run names in different datasets no longer affect each other’s results.

* **Tests**
  * Updated and added SQL and integration tests to validate run-name scoping and metric ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->