### PR TITLE
Extract shared build_sample_ids_query resolver

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
@@ -31,6 +31,7 @@ from lightly_studio.resolvers.annotation_resolver.get_by_id_with_payload import 
     get_by_id_with_payload,
 )
 from lightly_studio.resolvers.annotation_resolver.get_sample_ids import (
+    build_sample_ids_query,
     get_sample_ids,
 )
 from lightly_studio.resolvers.annotation_resolver.update_annotation_label import (
@@ -44,6 +45,7 @@ from lightly_studio.resolvers.annotation_resolver.update_segmentation_mask impor
 )
 
 __all__ = [
+    "build_sample_ids_query",
     "create_many",
     "delete_annotation",
     "delete_annotations",

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_sample_ids.py
@@ -18,9 +18,6 @@ def build_sample_ids_query(
 ) -> SelectOfScalar[UUID]:
     """Build the query selecting distinct annotation sample ids for a collection.
 
-    Returned un-executed so callers can either run it (see :func:`get_sample_ids`)
-    or embed it as the ``SELECT`` of an ``INSERT … SELECT``.
-
     Args:
         collection_id: The ID of the collection to scope results to.
         filters: The annotation filters to apply.
@@ -50,4 +47,5 @@ def get_sample_ids(
     Returns:
         Set of annotation sample ids matching the given filters.
     """
-    return set(session.exec(build_sample_ids_query(collection_id, filters)).all())
+    query = build_sample_ids_query(collection_id=collection_id, filters=filters)
+    return set(session.exec(query).all())

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_sample_ids.py
@@ -5,10 +5,34 @@ from __future__ import annotations
 from uuid import UUID
 
 from sqlmodel import Session, col, select
+from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+
+
+def build_sample_ids_query(
+    collection_id: UUID,
+    filters: AnnotationsFilter | None = None,
+) -> SelectOfScalar[UUID]:
+    """Build the query selecting distinct annotation sample ids for a collection.
+
+    Returned un-executed so callers can either run it (see :func:`get_sample_ids`)
+    or embed it as the ``SELECT`` of an ``INSERT … SELECT``.
+
+    Args:
+        collection_id: The ID of the collection to scope results to.
+        filters: The annotation filters to apply.
+
+    Returns:
+        A query selecting the distinct annotation sample ids matching the filters.
+    """
+    query = select(AnnotationBaseTable.sample_id).join(AnnotationBaseTable.sample)
+    query = query.where(col(SampleTable.collection_id) == collection_id)
+    if filters is not None:
+        query = filters.apply(query)
+    return query.distinct()
 
 
 def get_sample_ids(
@@ -26,10 +50,4 @@ def get_sample_ids(
     Returns:
         Set of annotation sample ids matching the given filters.
     """
-    query = select(AnnotationBaseTable.sample_id).join(AnnotationBaseTable.sample)
-    query = query.where(col(SampleTable.collection_id) == collection_id)
-    if filters is not None:
-        query = filters.apply(query)
-    sample_ids = session.exec(query.distinct()).all()
-
-    return set(sample_ids)
+    return set(session.exec(build_sample_ids_query(collection_id, filters)).all())

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/__init__.py
@@ -13,13 +13,17 @@ from lightly_studio.resolvers.image_resolver.get_all_by_collection_id import (
 from lightly_studio.resolvers.image_resolver.get_by_id import get_by_id
 from lightly_studio.resolvers.image_resolver.get_dimension_bounds import get_dimension_bounds
 from lightly_studio.resolvers.image_resolver.get_many_by_id import get_many_by_id
-from lightly_studio.resolvers.image_resolver.get_sample_ids import get_sample_ids
+from lightly_studio.resolvers.image_resolver.get_sample_ids import (
+    build_sample_ids_query,
+    get_sample_ids,
+)
 from lightly_studio.resolvers.image_resolver.get_sample_ids_by_paths import (
     get_sample_ids_by_paths,
 )
 from lightly_studio.resolvers.image_resolver.get_samples_excluding import get_samples_excluding
 
 __all__ = [
+    "build_sample_ids_query",
     "count_image_annotations_by_collection",
     "create_many",
     "delete",

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_sample_ids.py
@@ -5,10 +5,34 @@ from __future__ import annotations
 from uuid import UUID
 
 from sqlmodel import Session, col, select
+from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.resolvers.image_filter import ImageFilter
+
+
+def build_sample_ids_query(
+    collection_id: UUID,
+    filters: ImageFilter | None = None,
+) -> SelectOfScalar[UUID]:
+    """Build the query selecting distinct sample ids for a given collection.
+
+    Returned un-executed so callers can either run it (see :func:`get_sample_ids`)
+    or embed it as the ``SELECT`` of an ``INSERT … SELECT``.
+
+    Args:
+        collection_id: The ID of the collection to scope results to.
+        filters: The image filters to apply.
+
+    Returns:
+        A query selecting the distinct sample ids matching the given filters.
+    """
+    query = select(ImageTable.sample_id).join(ImageTable.sample)
+    query = query.where(col(SampleTable.collection_id) == collection_id)
+    if filters is not None:
+        query = filters.apply(query)
+    return query.distinct()
 
 
 def get_sample_ids(
@@ -26,10 +50,4 @@ def get_sample_ids(
     Returns:
         List of sample ids matching the given filters.
     """
-    query = select(ImageTable.sample_id).join(ImageTable.sample)
-    query = query.where(col(SampleTable.collection_id) == collection_id)
-    if filters is not None:
-        query = filters.apply(query)
-    sample_ids = session.exec(query.distinct()).all()
-
-    return set(sample_ids)
+    return set(session.exec(build_sample_ids_query(collection_id, filters)).all())

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_sample_ids.py
@@ -18,9 +18,6 @@ def build_sample_ids_query(
 ) -> SelectOfScalar[UUID]:
     """Build the query selecting distinct sample ids for a given collection.
 
-    Returned un-executed so callers can either run it (see :func:`get_sample_ids`)
-    or embed it as the ``SELECT`` of an ``INSERT … SELECT``.
-
     Args:
         collection_id: The ID of the collection to scope results to.
         filters: The image filters to apply.
@@ -50,4 +47,5 @@ def get_sample_ids(
     Returns:
         List of sample ids matching the given filters.
     """
-    return set(session.exec(build_sample_ids_query(collection_id, filters)).all())
+    query = build_sample_ids_query(collection_id=collection_id, filters=filters)
+    return set(session.exec(query).all())

--- a/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/__init__.py
@@ -14,6 +14,7 @@ from lightly_studio.resolvers.video_frame_resolver.get_by_id import (
     get_by_id,
 )
 from lightly_studio.resolvers.video_frame_resolver.get_sample_ids import (
+    build_sample_ids_query,
     get_sample_ids,
 )
 from lightly_studio.resolvers.video_frame_resolver.get_table_fields_bounds import (
@@ -28,6 +29,7 @@ from lightly_studio.resolvers.video_frame_resolver.video_frame_adjacent_filter i
 
 __all__ = [
     "VideoFrameAdjacentFilter",
+    "build_sample_ids_query",
     "create_many",
     "get_adjacent_video_frames",
     "get_all_by_collection_id",

--- a/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/get_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/get_sample_ids.py
@@ -5,10 +5,36 @@ from __future__ import annotations
 from uuid import UUID
 
 from sqlmodel import Session, col, select
+from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.video import VideoFrameTable
 from lightly_studio.resolvers.video_frame_resolver.video_frame_filter import VideoFrameFilter
+
+
+def build_sample_ids_query(
+    collection_id: UUID,
+    filters: VideoFrameFilter | None = None,
+) -> SelectOfScalar[UUID]:
+    """Build the query selecting distinct sample ids for a given collection.
+
+    Returned un-executed so callers can either run it (see :func:`get_sample_ids`)
+    or embed it as the ``SELECT`` of an ``INSERT … SELECT``.
+
+    Args:
+        collection_id: The ID of the collection to scope results to.
+        filters: The video frame filters to apply.
+
+    Returns:
+        A query selecting the distinct sample ids matching the given filters.
+    """
+    query = (
+        select(VideoFrameTable.sample_id).join(VideoFrameTable.sample).join(VideoFrameTable.video)
+    )
+    query = query.where(col(SampleTable.collection_id) == collection_id)
+    if filters is not None:
+        query = filters.apply(query)
+    return query.distinct()
 
 
 def get_sample_ids(
@@ -26,12 +52,4 @@ def get_sample_ids(
     Returns:
         Set of sample ids matching the given filters.
     """
-    query = (
-        select(VideoFrameTable.sample_id).join(VideoFrameTable.sample).join(VideoFrameTable.video)
-    )
-    query = query.where(col(SampleTable.collection_id) == collection_id)
-    if filters is not None:
-        query = filters.apply(query)
-    sample_ids = session.exec(query.distinct()).all()
-
-    return set(sample_ids)
+    return set(session.exec(build_sample_ids_query(collection_id, filters)).all())

--- a/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/get_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/get_sample_ids.py
@@ -18,9 +18,6 @@ def build_sample_ids_query(
 ) -> SelectOfScalar[UUID]:
     """Build the query selecting distinct sample ids for a given collection.
 
-    Returned un-executed so callers can either run it (see :func:`get_sample_ids`)
-    or embed it as the ``SELECT`` of an ``INSERT … SELECT``.
-
     Args:
         collection_id: The ID of the collection to scope results to.
         filters: The video frame filters to apply.
@@ -52,4 +49,5 @@ def get_sample_ids(
     Returns:
         Set of sample ids matching the given filters.
     """
-    return set(session.exec(build_sample_ids_query(collection_id, filters)).all())
+    query = build_sample_ids_query(collection_id=collection_id, filters=filters)
+    return set(session.exec(query).all())

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/__init__.py
@@ -12,13 +12,17 @@ from lightly_studio.resolvers.video_resolver.get_all_by_collection_id import (
 )
 from lightly_studio.resolvers.video_resolver.get_by_id import get_by_id
 from lightly_studio.resolvers.video_resolver.get_many_by_id import get_many_by_id
-from lightly_studio.resolvers.video_resolver.get_sample_ids import get_sample_ids
+from lightly_studio.resolvers.video_resolver.get_sample_ids import (
+    build_sample_ids_query,
+    get_sample_ids,
+)
 from lightly_studio.resolvers.video_resolver.get_table_fields_bounds import (
     get_table_fields_bounds,
 )
 from lightly_studio.resolvers.video_resolver.get_view_by_id import get_view_by_id
 
 __all__ = [
+    "build_sample_ids_query",
     "count_video_frame_annotations_by_video_collection",
     "create_many",
     "filter_new_paths",

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_sample_ids.py
@@ -18,9 +18,6 @@ def build_sample_ids_query(
 ) -> SelectOfScalar[UUID]:
     """Build the query selecting distinct sample ids for a given collection.
 
-    Returned un-executed so callers can either run it (see :func:`get_sample_ids`)
-    or embed it as the ``SELECT`` of an ``INSERT … SELECT``.
-
     Args:
         collection_id: The ID of the collection to scope results to.
         filters: The video filters to apply.
@@ -50,4 +47,5 @@ def get_sample_ids(
     Returns:
         List of sample ids matching the given filters.
     """
-    return set(session.exec(build_sample_ids_query(collection_id, filters)).all())
+    query = build_sample_ids_query(collection_id=collection_id, filters=filters)
+    return set(session.exec(query).all())

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_sample_ids.py
@@ -5,10 +5,34 @@ from __future__ import annotations
 from uuid import UUID
 
 from sqlmodel import Session, col, select
+from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.video import VideoTable
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
+
+
+def build_sample_ids_query(
+    collection_id: UUID,
+    filters: VideoFilter | None = None,
+) -> SelectOfScalar[UUID]:
+    """Build the query selecting distinct sample ids for a given collection.
+
+    Returned un-executed so callers can either run it (see :func:`get_sample_ids`)
+    or embed it as the ``SELECT`` of an ``INSERT … SELECT``.
+
+    Args:
+        collection_id: The ID of the collection to scope results to.
+        filters: The video filters to apply.
+
+    Returns:
+        A query selecting the distinct sample ids matching the given filters.
+    """
+    query = select(VideoTable.sample_id).join(VideoTable.sample)
+    query = query.where(col(SampleTable.collection_id) == collection_id)
+    if filters is not None:
+        query = filters.apply(query)
+    return query.distinct()
 
 
 def get_sample_ids(
@@ -26,10 +50,4 @@ def get_sample_ids(
     Returns:
         List of sample ids matching the given filters.
     """
-    query = select(VideoTable.sample_id).join(VideoTable.sample)
-    query = query.where(col(SampleTable.collection_id) == collection_id)
-    if filters is not None:
-        query = filters.apply(query)
-    sample_ids = session.exec(query.distinct()).all()
-
-    return set(sample_ids)
+    return set(session.exec(build_sample_ids_query(collection_id, filters)).all())

--- a/lightly_studio/tests/resolvers/annotations/test_get_sample_ids.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_sample_ids.py
@@ -88,3 +88,31 @@ def test_get_sample_ids_with_label_filter(db_session: Session) -> None:
         ),
     )
     assert filtered_ids == {annotation.sample_id}
+
+
+def test_build_sample_ids_query(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    sample = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/sample.png",
+    )
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+    )
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=sample.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    query = annotation_resolver.build_sample_ids_query(collection_id=annotation_collection_id)
+    assert set(db_session.exec(query).all()) == {annotation.sample_id}

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_sample_ids.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_sample_ids.py
@@ -40,3 +40,31 @@ def test_get_sample_ids(db_session: Session) -> None:
         ),
     )
     assert filtered_sample_ids == {created_images[1].sample_id}
+
+
+def test_build_sample_ids_query(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.IMAGE)
+    other_collection = create_collection(session=db_session, sample_type=SampleType.IMAGE)
+
+    created_images = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[
+            ImageStub(path="/path/to/small.jpg", width=100, height=100),
+            ImageStub(path="/path/to/large.jpg", width=800, height=800),
+        ],
+    )
+    create_images(
+        db_session=db_session,
+        collection_id=other_collection.collection_id,
+        images=[ImageStub(path="/path/to/other.jpg", width=800, height=800)],
+    )
+
+    query = image_resolver.build_sample_ids_query(collection_id=collection.collection_id)
+    assert set(db_session.exec(query).all()) == {img.sample_id for img in created_images}
+
+    filtered_query = image_resolver.build_sample_ids_query(
+        collection_id=collection.collection_id,
+        filters=ImageFilter(width=FilterDimensions(min=500)),
+    )
+    assert set(db_session.exec(filtered_query).all()) == {created_images[1].sample_id}

--- a/lightly_studio/tests/resolvers/video/video_frame_resolver/test_get_sample_ids.py
+++ b/lightly_studio/tests/resolvers/video/video_frame_resolver/test_get_sample_ids.py
@@ -45,3 +45,24 @@ def test_get_sample_ids_with_video_id_filter(db_session: Session) -> None:
         filters=VideoFrameFilter(video_id=video1.video_sample_id),
     )
     assert filtered_ids == set(video1.frame_sample_ids)
+
+
+def test_build_sample_ids_query(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+
+    video1 = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/path/to/video1.mp4", duration_s=1.0, fps=1),
+    )
+    create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/path/to/video2.mp4", duration_s=1.0, fps=1),
+    )
+
+    query = video_frame_resolver.build_sample_ids_query(
+        collection_id=video1.video_frames_collection_id,
+        filters=VideoFrameFilter(video_id=video1.video_sample_id),
+    )
+    assert set(db_session.exec(query).all()) == set(video1.frame_sample_ids)

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_get_sample_ids.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_get_sample_ids.py
@@ -42,3 +42,31 @@ def test_get_sample_ids(db_session: Session) -> None:
         ),
     )
     assert filtered_sample_ids == {created_video_ids[1]}
+
+
+def test_build_sample_ids_query(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    other_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+
+    created_video_ids = create_videos(
+        session=db_session,
+        collection_id=collection.collection_id,
+        videos=[
+            VideoStub(path="/path/to/small.mp4", width=100, height=100),
+            VideoStub(path="/path/to/large.mp4", width=800, height=800),
+        ],
+    )
+    create_videos(
+        session=db_session,
+        collection_id=other_collection.collection_id,
+        videos=[VideoStub(path="/path/to/other.mp4", width=800, height=800)],
+    )
+
+    query = video_resolver.build_sample_ids_query(collection_id=collection.collection_id)
+    assert set(db_session.exec(query).all()) == set(created_video_ids)
+
+    filtered_query = video_resolver.build_sample_ids_query(
+        collection_id=collection.collection_id,
+        filters=VideoFilter(width=FilterDimensions(min=500)),
+    )
+    assert set(db_session.exec(filtered_query).all()) == {created_video_ids[1]}


### PR DESCRIPTION
## What has changed and why?

PR2 towards tagging large amounts of samples.

Extracts a shared `build_sample_ids_query` from the four `get_sample_ids` resolvers (image, video, video frame, annotation), which now wrap it.

Returning the query un-executed lets a follow-up PR embed it as the `SELECT` of an `INSERT … SELECT`, tagging select-all results inside the DB without shipping IDs over the wire. Behavior-preserving; also removes the prior quadruplication.

## How has it been tested?

`make static-checks` and the affected resolver tests pass, including a new direct builder test per grid.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Extracted query construction logic into dedicated helper functions for sample ID retrieval across annotation, image, video frame, and video resolvers, improving code maintainability and reusability.

* **Tests**
  * Added comprehensive test coverage for query builder functions to validate correct filtering behavior and query execution across all resolver types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->