### PR TITLE
Centralize effective annotation coloring mode

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
@@ -35,10 +35,10 @@
 {#if isEnabled}
     <Segment title="Annotation Sources">
         <SideMenu
-            showColorMarker={resolveEffectiveColorBySource(
-                $selectedCollectionIds.length > 1,
-                $enforceColoringByClassStore
-            )}
+            showColorMarker={resolveEffectiveColorBySource({
+                multipleSourcesVisible: $selectedCollectionIds.length > 1,
+                enforceColoringByClass: $enforceColoringByClassStore
+            })}
             enableColorPicker
             {items}
             selectedItemsIds={$selectedCollectionIds}

--- a/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
@@ -3,6 +3,8 @@
     import { SideMenu } from '$lib/components/SideMenu';
     import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
     import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
+    import { useSettings } from '$lib/hooks/useSettings';
+    import { resolveEffectiveColorBySource } from '$lib/utils';
 
     interface Props {
         collectionId: string;
@@ -17,6 +19,7 @@
 
     const { setSelectedCollectionIds, selectedCollectionIds, seedSelectionIfNeeded } =
         useAnnotationCollectionsFilter();
+    const { enforceColoringByClassStore } = useSettings();
 
     const isEnabled = $derived(items.length > 1);
 
@@ -32,7 +35,10 @@
 {#if isEnabled}
     <Segment title="Annotation Sources">
         <SideMenu
-            showColorMarker={$selectedCollectionIds.length > 1}
+            showColorMarker={resolveEffectiveColorBySource(
+                $selectedCollectionIds.length > 1,
+                $enforceColoringByClassStore
+            )}
             enableColorPicker
             {items}
             selectedItemsIds={$selectedCollectionIds}

--- a/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.test.ts
@@ -7,7 +7,8 @@ const mocks = vi.hoisted(() => ({
     collections: [] as { collection_id: string; name: string }[],
     selectedCollectionIds: null as unknown as Writable<string[]>,
     setSelectedCollectionIds: vi.fn(),
-    seedSelectionIfNeeded: vi.fn()
+    seedSelectionIfNeeded: vi.fn(),
+    enforceColoringByClassStore: null as unknown as Writable<boolean>
 }));
 
 vi.mock('$lib/hooks/useAnnotationCollections/useAnnotationCollections', () => ({
@@ -29,6 +30,16 @@ vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilte
     };
 });
 
+vi.mock('$lib/hooks/useSettings', async () => {
+    const { writable } = await import('svelte/store');
+    mocks.enforceColoringByClassStore = writable<boolean>(false);
+    return {
+        useSettings: vi.fn(() => ({
+            enforceColoringByClassStore: mocks.enforceColoringByClassStore
+        }))
+    };
+});
+
 describe('AnnotationCollectionsMenu', () => {
     const defaultProps = { collectionId: 'col-1' };
 
@@ -36,6 +47,7 @@ describe('AnnotationCollectionsMenu', () => {
         vi.clearAllMocks();
         mocks.collections = [];
         mocks.selectedCollectionIds.set([]);
+        mocks.enforceColoringByClassStore.set(false);
     });
 
     it('renders nothing when there are no collections', () => {
@@ -94,6 +106,32 @@ describe('AnnotationCollectionsMenu', () => {
         await screen.getAllByRole('checkbox')[0].click();
 
         expect(mocks.setSelectedCollectionIds).toHaveBeenLastCalledWith(['c2']);
+    });
+
+    it('shows color markers when multiple sources are selected and enforce coloring by class is disabled', () => {
+        mocks.collections = [
+            { collection_id: 'c1', name: 'Dogs' },
+            { collection_id: 'c2', name: 'Cats' }
+        ];
+        mocks.selectedCollectionIds.set(['c1', 'c2']);
+        mocks.enforceColoringByClassStore.set(false);
+        render(AnnotationCollectionsMenu, defaultProps);
+
+        expect(screen.getByTestId('color-marker-Dogs')).toBeInTheDocument();
+        expect(screen.getByTestId('color-marker-Cats')).toBeInTheDocument();
+    });
+
+    it('hides color markers when multiple sources are selected and enforce coloring by class is enabled', () => {
+        mocks.collections = [
+            { collection_id: 'c1', name: 'Dogs' },
+            { collection_id: 'c2', name: 'Cats' }
+        ];
+        mocks.selectedCollectionIds.set(['c1', 'c2']);
+        mocks.enforceColoringByClassStore.set(true);
+        render(AnnotationCollectionsMenu, defaultProps);
+
+        expect(screen.queryByTestId('color-marker-Dogs')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('color-marker-Cats')).not.toBeInTheDocument();
     });
 
     it('calls setSelectedCollectionIds with empty array when all collections are deselected', async () => {

--- a/lightly_studio_view/src/lib/components/AnnotationColorLegend/AnnotationColorLegend.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationColorLegend/AnnotationColorLegend.svelte
@@ -6,11 +6,13 @@
     const {
         labelName,
         className,
-        selected = false
+        selected = false,
+        testId
     }: {
         labelName: string;
         className: string;
         selected: boolean;
+        testId?: string;
     } = $props();
 
     const { setCustomColor, getCustomColor, hasCustomColor, customLabelColorsStore } =
@@ -52,7 +54,7 @@
     });
 </script>
 
-<div class="color-picker-container">
+<div class="color-picker-container" data-testid={testId}>
     <ColorPicker
         initialColor={getInitialColor(labelName)}
         initialAlpha={getInitialAlpha(labelName)}

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
@@ -13,10 +13,10 @@
     const { enforceColoringByClassStore } = useSettings();
 
     const showClassColorLegend = $derived(
-        !resolveEffectiveColorBySource(
-            $selectedCollectionIds.length > 1,
-            $enforceColoringByClassStore
-        )
+        !resolveEffectiveColorBySource({
+            multipleSourcesVisible: $selectedCollectionIds.length > 1,
+            enforceColoringByClass: $enforceColoringByClassStore
+        })
     );
 
     let {
@@ -59,13 +59,12 @@
                         class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                     >
                         {#if showClassColorLegend}
-                            <div data-testid="label-color-legend">
-                                <AnnotationColorLegend
-                                    labelName={label_name}
-                                    className="h-3 w-3"
-                                    {selected}
-                                />
-                            </div>
+                            <AnnotationColorLegend
+                                labelName={label_name}
+                                className="h-3 w-3"
+                                {selected}
+                                testId="label-color-legend"
+                            />
                         {/if}
                         <p
                             class="flex-1 truncate text-base font-normal"

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
@@ -3,12 +3,14 @@
     import { Checkbox } from '$lib/components/ui/checkbox/index.js';
     import { Label } from '$lib/components/ui/label/index.js';
     import type { Annotation } from '$lib/types';
-    import { formatInteger } from '$lib/utils';
+    import { formatInteger, resolveEffectiveColorBySource } from '$lib/utils';
     import { type Readable } from 'svelte/store';
     import AnnotationColorLegend from '../AnnotationColorLegend/AnnotationColorLegend.svelte';
     import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
+    import { useSettings } from '$lib/hooks/useSettings';
 
     const { selectedCollectionIds } = useAnnotationCollectionsFilter();
+    const { enforceColoringByClassStore } = useSettings();
 
     let {
         annotationFilterRows,
@@ -49,7 +51,7 @@
                         data-testid="labels-menu-item"
                         class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                     >
-                        {#if $selectedCollectionIds.length < 2}
+                        {#if !resolveEffectiveColorBySource($selectedCollectionIds.length > 1, $enforceColoringByClassStore)}
                             <AnnotationColorLegend
                                 labelName={label_name}
                                 className="h-3 w-3"

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
@@ -12,6 +12,13 @@
     const { selectedCollectionIds } = useAnnotationCollectionsFilter();
     const { enforceColoringByClassStore } = useSettings();
 
+    const showClassColorLegend = $derived(
+        !resolveEffectiveColorBySource(
+            $selectedCollectionIds.length > 1,
+            $enforceColoringByClassStore
+        )
+    );
+
     let {
         annotationFilterRows,
         onToggleAnnotationFilter
@@ -51,12 +58,14 @@
                         data-testid="labels-menu-item"
                         class="flex min-w-0 flex-1 cursor-pointer items-center space-x-2 text-nowrap peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                     >
-                        {#if !resolveEffectiveColorBySource($selectedCollectionIds.length > 1, $enforceColoringByClassStore)}
-                            <AnnotationColorLegend
-                                labelName={label_name}
-                                className="h-3 w-3"
-                                {selected}
-                            />
+                        {#if showClassColorLegend}
+                            <div data-testid="label-color-legend">
+                                <AnnotationColorLegend
+                                    labelName={label_name}
+                                    className="h-3 w-3"
+                                    {selected}
+                                />
+                            </div>
                         {/if}
                         <p
                             class="flex-1 truncate text-base font-normal"

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.test.ts
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/svelte';
+import { writable, type Writable } from 'svelte/store';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import LabelsMenu from './LabelsMenu.svelte';
+import type { Annotation } from '$lib/types';
+
+const mocks = vi.hoisted(() => ({
+    selectedCollectionIds: null as unknown as Writable<string[]>,
+    enforceColoringByClassStore: null as unknown as Writable<boolean>
+}));
+
+vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter', async () => {
+    const { writable } = await import('svelte/store');
+    mocks.selectedCollectionIds = writable<string[]>([]);
+    return {
+        useAnnotationCollectionsFilter: () => ({
+            selectedCollectionIds: mocks.selectedCollectionIds
+        })
+    };
+});
+
+vi.mock('$lib/hooks/useSettings', async () => {
+    const { writable } = await import('svelte/store');
+    mocks.enforceColoringByClassStore = writable<boolean>(false);
+    return {
+        useSettings: () => ({
+            enforceColoringByClassStore: mocks.enforceColoringByClassStore
+        })
+    };
+});
+
+vi.mock('$lib/hooks/useCustomLabelColors', async () => {
+    const { writable } = await import('svelte/store');
+    return {
+        useCustomLabelColors: () => ({
+            customLabelColorsStore: writable({}),
+            colorVersion: writable(0),
+            getCustomColor: () => undefined,
+            setCustomColor: vi.fn(),
+            hasCustomColor: () => false,
+            deleteCustomColor: vi.fn(),
+            clearCustomColors: vi.fn()
+        })
+    };
+});
+
+describe('LabelsMenu', () => {
+    const twoLabels = writable<Annotation[]>([
+        { label_name: 'car', current_count: 1, total_count: 1, selected: true },
+        { label_name: 'person', current_count: 1, total_count: 1, selected: true }
+    ]);
+    const defaultProps = {
+        annotationFilterRows: twoLabels,
+        onToggleAnnotationFilter: vi.fn()
+    };
+
+    beforeEach(() => {
+        mocks.selectedCollectionIds.set([]);
+        mocks.enforceColoringByClassStore.set(false);
+    });
+
+    it('shows class color legends when only one source is selected', () => {
+        mocks.selectedCollectionIds.set(['col-a']);
+        render(LabelsMenu, defaultProps);
+        expect(document.querySelectorAll('.color-picker-container').length).toBe(2);
+    });
+
+    it('hides class color legends when multiple sources are selected and enforce is disabled', () => {
+        mocks.selectedCollectionIds.set(['col-a', 'col-b']);
+        mocks.enforceColoringByClassStore.set(false);
+        render(LabelsMenu, defaultProps);
+        expect(document.querySelectorAll('.color-picker-container').length).toBe(0);
+    });
+
+    it('shows class color legends when multiple sources are selected and enforce is enabled', () => {
+        mocks.selectedCollectionIds.set(['col-a', 'col-b']);
+        mocks.enforceColoringByClassStore.set(true);
+        render(LabelsMenu, defaultProps);
+        expect(document.querySelectorAll('.color-picker-container').length).toBe(2);
+    });
+
+    it('renders a row for each annotation label', () => {
+        render(LabelsMenu, defaultProps);
+        expect(screen.getAllByTestId('labels-menu-item')).toHaveLength(2);
+        expect(screen.getByText('car')).toBeInTheDocument();
+        expect(screen.getByText('person')).toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.test.ts
@@ -62,21 +62,21 @@ describe('LabelsMenu', () => {
     it('shows class color legends when only one source is selected', () => {
         mocks.selectedCollectionIds.set(['col-a']);
         render(LabelsMenu, defaultProps);
-        expect(document.querySelectorAll('.color-picker-container').length).toBe(2);
+        expect(screen.getAllByTestId('label-color-legend')).toHaveLength(2);
     });
 
     it('hides class color legends when multiple sources are selected and enforce is disabled', () => {
         mocks.selectedCollectionIds.set(['col-a', 'col-b']);
         mocks.enforceColoringByClassStore.set(false);
         render(LabelsMenu, defaultProps);
-        expect(document.querySelectorAll('.color-picker-container').length).toBe(0);
+        expect(screen.queryByTestId('label-color-legend')).not.toBeInTheDocument();
     });
 
     it('shows class color legends when multiple sources are selected and enforce is enabled', () => {
         mocks.selectedCollectionIds.set(['col-a', 'col-b']);
         mocks.enforceColoringByClassStore.set(true);
         render(LabelsMenu, defaultProps);
-        expect(document.querySelectorAll('.color-picker-container').length).toBe(2);
+        expect(screen.getAllByTestId('label-color-legend')).toHaveLength(2);
     });
 
     it('renders a row for each annotation label', () => {

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
@@ -2,6 +2,7 @@
     import { useHideAnnotations } from '$lib/hooks/useHideAnnotations';
     import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
     import { useSettings } from '$lib/hooks/useSettings';
+    import { resolveEffectiveColorBySource } from '$lib/utils';
     import { onMount, type ComponentProps } from 'svelte';
     import type { AnnotationView } from '$lib/api/lightly_studio_local';
     import { AnnotationCanvas } from '$lib/components';
@@ -25,8 +26,6 @@
         sample: SampleView;
         objectFit?: SampleImageObjectFit;
     } = $props();
-
-    import { resolveEffectiveColorBySource } from '$lib/utils';
 
     const { isHidden } = useHideAnnotations();
     const { showBoundingBoxesForSegmentationStore, enforceColoringByClassStore } = useSettings();

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
@@ -26,8 +26,10 @@
         objectFit?: SampleImageObjectFit;
     } = $props();
 
+    import { resolveEffectiveColorBySource } from '$lib/utils';
+
     const { isHidden } = useHideAnnotations();
-    const { showBoundingBoxesForSegmentationStore } = useSettings();
+    const { showBoundingBoxesForSegmentationStore, enforceColoringByClassStore } = useSettings();
     const { selectedCollectionIds, collectionIdToName } = useAnnotationCollectionsFilter();
 
     // Normalize backend annotation variants into the smaller canvas render contract.
@@ -67,6 +69,10 @@
         const showInstanceSegmentationBoundingBoxes = $showBoundingBoxesForSegmentationStore;
         const selectedIds = $selectedCollectionIds;
         const idToName = $collectionIdToName;
+        const colorBySource = resolveEffectiveColorBySource(
+            selectedIds.length > 1,
+            $enforceColoringByClassStore
+        );
 
         return sample.annotations
             .filter(
@@ -81,7 +87,7 @@
                     showInstanceSegmentationBoundingBoxes
                 );
                 if (!canvas) return null;
-                if (selectedIds.length > 1) {
+                if (colorBySource) {
                     const collectionName = idToName[annotation.annotation_collection_id];
                     if (collectionName) return { ...canvas, annotation_label_name: collectionName };
                 }

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
@@ -68,10 +68,10 @@
         const showInstanceSegmentationBoundingBoxes = $showBoundingBoxesForSegmentationStore;
         const selectedIds = $selectedCollectionIds;
         const idToName = $collectionIdToName;
-        const colorBySource = resolveEffectiveColorBySource(
-            selectedIds.length > 1,
-            $enforceColoringByClassStore
-        );
+        const colorBySource = resolveEffectiveColorBySource({
+            multipleSourcesVisible: selectedIds.length > 1,
+            enforceColoringByClass: $enforceColoringByClassStore
+        });
 
         return sample.annotations
             .filter(

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.test.ts
@@ -4,6 +4,8 @@ import type { Readable, Writable } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import SampleAnnotations from './index.svelte';
 import { useSettings } from '$lib/hooks/useSettings';
+import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
+import * as utils from '$lib/utils';
 
 type UseSettingsReturn = ReturnType<typeof useSettings>;
 type SettingsStoreValue =
@@ -14,15 +16,19 @@ type ShowBoundingBoxesForSegmentationValue =
         : never;
 type MockedUseSettingsStoreSlice = Pick<
     UseSettingsReturn,
-    'settingsStore' | 'showBoundingBoxesForSegmentationStore'
+    'settingsStore' | 'showBoundingBoxesForSegmentationStore' | 'enforceColoringByClassStore'
 >;
 type MockUseSettingsControls = {
     setShowBoundingBoxesForSegmentation: (value: ShowBoundingBoxesForSegmentationValue) => void;
+    setEnforceColoringByClass: (value: boolean) => void;
 };
 
 const mockUseSettingsControls: MockUseSettingsControls = vi.hoisted(() => ({
     setShowBoundingBoxesForSegmentation: () => {
         throw new Error('showBoundingBoxesForSegmentationStore is not initialized');
+    },
+    setEnforceColoringByClass: () => {
+        throw new Error('enforceColoringByClassStore is not initialized');
     }
 }));
 
@@ -51,14 +57,19 @@ vi.mock('$lib/hooks/useSettings', async () => {
     });
     const showBoundingBoxesForSegmentationStore =
         writable<ShowBoundingBoxesForSegmentationValue>(true);
+    const enforceColoringByClassStore = writable<boolean>(false);
 
     mockUseSettingsControls.setShowBoundingBoxesForSegmentation = (value) => {
         showBoundingBoxesForSegmentationStore.set(value);
     };
+    mockUseSettingsControls.setEnforceColoringByClass = (value) => {
+        enforceColoringByClassStore.set(value);
+    };
 
     const mockedUseSettingsStoreSlice: MockedUseSettingsStoreSlice = {
         settingsStore,
-        showBoundingBoxesForSegmentationStore
+        showBoundingBoxesForSegmentationStore,
+        enforceColoringByClassStore
     };
 
     return {
@@ -127,6 +138,10 @@ const setShowBoundingBoxesForSegmentation = (value: ShowBoundingBoxesForSegmenta
     mockUseSettingsControls.setShowBoundingBoxesForSegmentation(value);
 };
 
+const setEnforceColoringByClass = (value: boolean) => {
+    mockUseSettingsControls.setEnforceColoringByClass(value);
+};
+
 describe('SampleAnnotations', () => {
     let mockContext: Mock2dContext;
 
@@ -188,6 +203,76 @@ describe('SampleAnnotations', () => {
         await waitFor(() => {
             expect(hasStrokeRectCall(mockContext, 10, 21, 30, 41)).toBe(true);
             expect(hasStrokeRectCall(mockContext, 2, 3, 4, 5)).toBe(true);
+        });
+    });
+
+    describe('enforceColoringByClass setting', () => {
+        const { setSelectedCollectionIds, setCollectionIdToName } =
+            useAnnotationCollectionsFilter();
+
+        const createTwoSourceSample = (): ComponentProps<typeof SampleAnnotations>['sample'] =>
+            ({
+                width: 100,
+                height: 80,
+                annotations: [
+                    {
+                        sample_id: 'obj-src-a',
+                        annotation_collection_id: 'col-a',
+                        annotation_type: 'object_detection',
+                        annotation_label: { annotation_label_name: 'car' },
+                        object_detection_details: { x: 1, y: 1, width: 10, height: 10 }
+                    },
+                    {
+                        sample_id: 'obj-src-b',
+                        annotation_collection_id: 'col-b',
+                        annotation_type: 'object_detection',
+                        annotation_label: { annotation_label_name: 'car' },
+                        object_detection_details: { x: 20, y: 20, width: 10, height: 10 }
+                    }
+                ]
+            }) as ComponentProps<typeof SampleAnnotations>['sample'];
+
+        afterEach(() => {
+            setSelectedCollectionIds([]);
+            setCollectionIdToName({});
+            setEnforceColoringByClass(false);
+        });
+
+        it('colors by source name when multiple sources are selected and enforce is disabled', async () => {
+            const colorByLabelSpy = vi.spyOn(utils, 'getColorByLabel');
+
+            setSelectedCollectionIds(['col-a', 'col-b']);
+            setCollectionIdToName({ 'col-a': 'GroundTruth', 'col-b': 'Predictions' });
+            setEnforceColoringByClass(false);
+
+            render(SampleAnnotations, { props: { sample: createTwoSourceSample() } });
+
+            await waitFor(() => {
+                const calledNames = colorByLabelSpy.mock.calls.map(([name]) => name);
+                expect(calledNames).toContain('GroundTruth');
+                expect(calledNames).toContain('Predictions');
+            });
+
+            colorByLabelSpy.mockRestore();
+        });
+
+        it('colors by class when multiple sources are selected and enforce is enabled', async () => {
+            const colorByLabelSpy = vi.spyOn(utils, 'getColorByLabel');
+
+            setSelectedCollectionIds(['col-a', 'col-b']);
+            setCollectionIdToName({ 'col-a': 'GroundTruth', 'col-b': 'Predictions' });
+            setEnforceColoringByClass(true);
+
+            render(SampleAnnotations, { props: { sample: createTwoSourceSample() } });
+
+            await waitFor(() => {
+                const calledNames = colorByLabelSpy.mock.calls.map(([name]) => name);
+                expect(calledNames).toContain('car');
+                expect(calledNames).not.toContain('GroundTruth');
+                expect(calledNames).not.toContain('Predictions');
+            });
+
+            colorByLabelSpy.mockRestore();
         });
     });
 });

--- a/lightly_studio_view/src/lib/utils/index.ts
+++ b/lightly_studio_view/src/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './triggerDownloadBlob';
+export * from './resolveEffectiveColorBySource';
 export * from './groupAnnotationLabels';
 export * from './countVisibleSources';
 export * from './getColorByLabel';

--- a/lightly_studio_view/src/lib/utils/resolveEffectiveColorBySource.test.ts
+++ b/lightly_studio_view/src/lib/utils/resolveEffectiveColorBySource.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { resolveEffectiveColorBySource } from './resolveEffectiveColorBySource';
+
+describe('resolveEffectiveColorBySource', () => {
+    it('returns true when multiple sources are visible and enforce is disabled', () => {
+        expect(resolveEffectiveColorBySource(true, false)).toBe(true);
+    });
+
+    it('returns false when only one source is visible and enforce is disabled', () => {
+        expect(resolveEffectiveColorBySource(false, false)).toBe(false);
+    });
+
+    it('returns false when enforce is enabled and multiple sources are visible', () => {
+        expect(resolveEffectiveColorBySource(true, true)).toBe(false);
+    });
+
+    it('returns false when enforce is enabled and only one source is visible', () => {
+        expect(resolveEffectiveColorBySource(false, true)).toBe(false);
+    });
+});

--- a/lightly_studio_view/src/lib/utils/resolveEffectiveColorBySource.test.ts
+++ b/lightly_studio_view/src/lib/utils/resolveEffectiveColorBySource.test.ts
@@ -3,18 +3,38 @@ import { resolveEffectiveColorBySource } from './resolveEffectiveColorBySource';
 
 describe('resolveEffectiveColorBySource', () => {
     it('returns true when multiple sources are visible and enforce is disabled', () => {
-        expect(resolveEffectiveColorBySource(true, false)).toBe(true);
+        expect(
+            resolveEffectiveColorBySource({
+                multipleSourcesVisible: true,
+                enforceColoringByClass: false
+            })
+        ).toBe(true);
     });
 
     it('returns false when only one source is visible and enforce is disabled', () => {
-        expect(resolveEffectiveColorBySource(false, false)).toBe(false);
+        expect(
+            resolveEffectiveColorBySource({
+                multipleSourcesVisible: false,
+                enforceColoringByClass: false
+            })
+        ).toBe(false);
     });
 
     it('returns false when enforce is enabled and multiple sources are visible', () => {
-        expect(resolveEffectiveColorBySource(true, true)).toBe(false);
+        expect(
+            resolveEffectiveColorBySource({
+                multipleSourcesVisible: true,
+                enforceColoringByClass: true
+            })
+        ).toBe(false);
     });
 
     it('returns false when enforce is enabled and only one source is visible', () => {
-        expect(resolveEffectiveColorBySource(false, true)).toBe(false);
+        expect(
+            resolveEffectiveColorBySource({
+                multipleSourcesVisible: false,
+                enforceColoringByClass: true
+            })
+        ).toBe(false);
     });
 });

--- a/lightly_studio_view/src/lib/utils/resolveEffectiveColorBySource.ts
+++ b/lightly_studio_view/src/lib/utils/resolveEffectiveColorBySource.ts
@@ -1,0 +1,13 @@
+/**
+ * Resolves whether annotations should be colored by source.
+ *
+ * When enforceColoringByClass is true, class colors always win regardless of how many
+ * sources are visible.
+ */
+export const resolveEffectiveColorBySource = (
+    multipleSourcesVisible: boolean,
+    enforceColoringByClass: boolean
+): boolean => {
+    if (enforceColoringByClass) return false;
+    return multipleSourcesVisible;
+};

--- a/lightly_studio_view/src/lib/utils/resolveEffectiveColorBySource.ts
+++ b/lightly_studio_view/src/lib/utils/resolveEffectiveColorBySource.ts
@@ -4,10 +4,13 @@
  * When enforceColoringByClass is true, class colors always win regardless of how many
  * sources are visible.
  */
-export const resolveEffectiveColorBySource = (
-    multipleSourcesVisible: boolean,
-    enforceColoringByClass: boolean
-): boolean => {
+export const resolveEffectiveColorBySource = ({
+    multipleSourcesVisible,
+    enforceColoringByClass
+}: {
+    multipleSourcesVisible: boolean;
+    enforceColoringByClass: boolean;
+}): boolean => {
     if (enforceColoringByClass) return false;
     return multipleSourcesVisible;
 };


### PR DESCRIPTION
## Summary

This PR introduces a single, reusable decision function — `resolveEffectiveColorBySource` — as the canonical path for resolving whether annotations should be colored by source or by class. When **Enforce Coloring by Class** is enabled, the function always returns false regardless of how many sources are visible, overriding the existing multi-source heuristic. When the setting is off, existing behavior is preserved.

The function is applied to three places in the grid view:

- **Grid overlay coloring** (`SampleAnnotations`) — bounding boxes and segmentation masks on image thumbnails now color by class when enforcement is on, instead of by source.
- **Annotation Sources filter** (`AnnotationCollectionsMenu`) — source color markers in the filter panel are hidden when enforcement is on, since the source colors are no longer semantically meaningful.
- **Annotation Classes filter** (`LabelsMenu`) — class color legends, which were previously hidden whenever multiple sources were selected, now reappear when enforcement is on, reflecting the active coloring mode.

## Still pending (covered in follow-up PRs)

The following rendering paths still contain their own inline source-coloring decisions and have not yet been wired to `resolveEffectiveColorBySource`:

- **Image detail view overlays** — object-detection boxes, segmentation masks, and annotation text labels rendered in the full-size image detail view.
- **Side panel annotation rows** — color markers on individual annotation rows in the detail-view side panel.
- **Side panel source group headers** — color markers on source group headers in the detail-view side panel.
- **Classification pills and classification rows** — source vs. class coloring in the classification UI.
- **Video frame annotation overlays** — object-detection and segmentation overlays during video playback.

## Test plan

- [x] Toggle **Enforce Coloring by Class** in Settings with two annotation sources active in the grid view and confirm bounding box colors on thumbnails switch between source-based and class-based.
- [x] Confirm source color dots in the Annotation Sources filter panel disappear when enforcement is on.
- [x] Confirm class color swatches in the Annotation Classes filter panel reappear when enforcement is on.
- [x] `resolveEffectiveColorBySource` unit tests cover all four input combinations.
- [ ] `SampleAnnotations`, `AnnotationCollectionsMenu`, and `LabelsMenu` component tests cover both enforce-on and enforce-off cases with multiple sources.
- [ ] Full test suite passes (`224 test files, 1683 tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “enforce coloring by class” setting to control how annotation colors are assigned (class-based when enabled; source-based only when multiple sources are shown and enforcement is off).
* **UI Updates**
  * Updated annotation color markers and the label color legend visibility/behavior to reflect the new setting and multi-source selection rules.
* **Bug Fixes**
  * Corrected sample annotation coloring so label-to-color mapping matches the setting and current source selection.
* **Tests**
  * Expanded coverage for the setting-driven rendering and color behavior, including new utility tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->