### PR TITLE
Endpoint to tag samples defined by a filter

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Union
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel
-from pydantic import Field as PydanticField
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field
 from sqlmodel.sql.expression import SelectOfScalar
@@ -38,6 +37,7 @@ from lightly_studio.resolvers import (
     video_resolver,
 )
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers.grid_filter import GridFilter
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.video_frame_resolver.video_frame_filter import VideoFrameFilter
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
@@ -203,14 +203,6 @@ def add_sample_ids_to_tag_id(
     return True
 
 
-# The ``filter_type`` discriminator selects both the source table to tag from and the
-# allowed tag kind. Same union as in services/sample_services/sample_adjacents_service.py.
-GridFilter = Annotated[
-    Union[ImageFilter, VideoFilter, VideoFrameFilter, AnnotationsFilter],
-    PydanticField(discriminator="filter_type"),
-]
-
-
 class TagByFilterBody(BaseModel):
     """Body for tagging every sample a grid filter matches.
 
@@ -223,7 +215,7 @@ class TagByFilterBody(BaseModel):
 
 
 def _build_sample_ids_query(
-    grid_filter: ImageFilter | VideoFilter | VideoFrameFilter | AnnotationsFilter,
+    grid_filter: GridFilter,
     collection_id: UUID,
 ) -> SelectOfScalar[UUID]:
     """Dispatch a grid filter to its resolver's ``build_sample_ids_query``."""
@@ -245,7 +237,7 @@ def _build_sample_ids_query(
 
 
 def _expected_tag_kind(
-    grid_filter: ImageFilter | VideoFilter | VideoFrameFilter | AnnotationsFilter,
+    grid_filter: GridFilter,
 ) -> TagKind:
     """Return the tag kind a grid may write: annotations grid ⇒ annotation, else sample."""
     return "annotation" if isinstance(grid_filter, AnnotationsFilter) else "sample"

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -196,19 +196,13 @@ def add_sample_ids_to_tag_id(
 class TagByFilterBody(BaseModel):
     """Body for tagging every sample a grid filter matches.
 
-    ``filter`` is required because the source table is dispatched on its
-    ``filter_type``. "Whole collection" is a typed-but-empty filter, e.g.
-    ``{"filter_type": "image"}``.
+    ``filter`` has no default: its ``filter_type`` tells the server which grid
+    (images, videos, video frames, annotations) to read from, so the caller
+    must always supply it. To tag a whole collection, send a filter with only
+    the type and no predicates, e.g. ``{"filter_type": "image"}``.
     """
 
     filter: GridFilter
-
-
-def _expected_tag_kind(
-    grid_filter: GridFilter,
-) -> TagKind:
-    """Return the tag kind a grid may write: annotations grid ⇒ annotation, else sample."""
-    return "annotation" if isinstance(grid_filter, AnnotationsFilter) else "sample"
 
 
 @tag_router.post(
@@ -224,7 +218,7 @@ def add_samples_to_tag_by_filter(
     tag_id: Annotated[UUID, Path(title="Tag Id")],
     body: TagByFilterBody,
 ) -> bool:
-    """Tag every sample a grid filter matches via a server-side ``INSERT … SELECT``.
+    """Tag every sample a grid filter matches.
 
     No sample ids cross the wire. Idempotent on re-run.
     """
@@ -279,3 +273,10 @@ def remove_thing_ids_to_tag_id(
         session=session, tag_id=tag_id, sample_ids=sample_ids
     )
     return True
+
+
+def _expected_tag_kind(
+    grid_filter: GridFilter,
+) -> TagKind:
+    """Return the tag kind a grid may write: annotations grid ⇒ annotation, else sample."""
+    return "annotation" if isinstance(grid_filter, AnnotationsFilter) else "sample"

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Union
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel
+from pydantic import Field as PydanticField
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field
+from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_BAD_REQUEST,
     HTTP_STATUS_CONFLICT,
     HTTP_STATUS_CREATED,
     HTTP_STATUS_NOT_FOUND,
@@ -22,11 +25,22 @@ from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.tag import (
     TagCreate,
     TagCreateBody,
+    TagKind,
     TagRenameBody,
     TagTable,
     TagView,
 )
-from lightly_studio.resolvers import tag_resolver
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    image_resolver,
+    tag_resolver,
+    video_frame_resolver,
+    video_resolver,
+)
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.resolvers.video_frame_resolver.video_frame_filter import VideoFrameFilter
+from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
 
 tag_router = APIRouter()
 
@@ -175,6 +189,8 @@ def add_sample_ids_to_tag_id(
     body: SampleIdsBody,
 ) -> bool:
     """Add sample_ids to a tag_id."""
+    # TODO(LIG-9942): backfill the collection-scope and tag-kind validation that
+    # add_samples_to_tag_by_filter enforces (separate PR — see plan, out of scope here).
     tag = tag_resolver.get_by_id(session=session, tag_id=tag_id)
     if not tag:
         raise HTTPException(
@@ -184,6 +200,108 @@ def add_sample_ids_to_tag_id(
 
     sample_ids = body.sample_ids if body.sample_ids else []
     tag_resolver.add_sample_ids_to_tag_id(session=session, tag_id=tag_id, sample_ids=sample_ids)
+    return True
+
+
+# A grid filter is self-describing: its ``filter_type`` literal selects both the source
+# table to tag from and the tag kind it is allowed to write. Mirrors the discriminated
+# union in ``services/sample_services/sample_adjacents_service.py``.
+GridFilter = Annotated[
+    Union[ImageFilter, VideoFilter, VideoFrameFilter, AnnotationsFilter],
+    PydanticField(discriminator="filter_type"),
+]
+
+
+class TagByFilterBody(BaseModel):
+    """Body for tagging every sample a grid filter matches.
+
+    ``filter`` is required, not optional: the source table is dispatched on
+    ``filter.filter_type``, so a ``null`` filter would be ambiguous. "Whole
+    collection" is expressed as a typed-but-empty filter (e.g. ``{"filter_type":
+    "image"}`` with no constraints), which the frontend already produces per grid.
+    """
+
+    filter: GridFilter
+
+
+def _build_sample_ids_query(
+    grid_filter: ImageFilter | VideoFilter | VideoFrameFilter | AnnotationsFilter,
+    collection_id: UUID,
+) -> SelectOfScalar[UUID]:
+    """Dispatch a grid filter to its resolver's ``build_sample_ids_query``.
+
+    The 4-branch dispatch mirrors the frontend's ``useSelectAll.fetchSampleIds``
+    switch; each branch scopes to ``collection_id`` and applies the filter.
+    """
+    if isinstance(grid_filter, ImageFilter):
+        return image_resolver.build_sample_ids_query(
+            collection_id=collection_id, filters=grid_filter
+        )
+    if isinstance(grid_filter, VideoFilter):
+        return video_resolver.build_sample_ids_query(
+            collection_id=collection_id, filters=grid_filter
+        )
+    if isinstance(grid_filter, VideoFrameFilter):
+        return video_frame_resolver.build_sample_ids_query(
+            collection_id=collection_id, filters=grid_filter
+        )
+    return annotation_resolver.build_sample_ids_query(
+        collection_id=collection_id, filters=grid_filter
+    )
+
+
+def _expected_tag_kind(
+    grid_filter: ImageFilter | VideoFilter | VideoFrameFilter | AnnotationsFilter,
+) -> TagKind:
+    """Return the tag kind a grid may write: annotations grid ⇒ annotation, else sample."""
+    return "annotation" if isinstance(grid_filter, AnnotationsFilter) else "sample"
+
+
+@tag_router.post(
+    "/collections/{collection_id}/tags/{tag_id}/add/samples_by_filter",
+    status_code=HTTP_STATUS_CREATED,
+)
+def add_samples_to_tag_by_filter(
+    session: SessionDep,
+    collection_id: Annotated[
+        UUID,
+        Path(title="collection Id", description="The ID of the collection"),
+    ],
+    tag_id: Annotated[UUID, Path(title="Tag Id")],
+    body: TagByFilterBody,
+) -> bool:
+    """Tag every sample a grid filter matches, entirely inside the DB.
+
+    No sample ids cross the wire: the matched ids are inserted via a single
+    server-side ``INSERT … SELECT``. Idempotent on re-run.
+    """
+    tag = tag_resolver.get_by_id(session=session, tag_id=tag_id)
+    if not tag:
+        raise HTTPException(
+            status_code=HTTP_STATUS_NOT_FOUND,
+            detail=f"Tag {tag_id} not found, can't add samples.",
+        )
+    # The link table carries only sample/tag FKs, so neither the collection scope nor
+    # the tag kind is enforced by the schema; both must be checked here.
+    if tag.collection_id != collection_id:
+        raise HTTPException(
+            status_code=HTTP_STATUS_NOT_FOUND,
+            detail=f"Tag {tag_id} not found in collection {collection_id}.",
+        )
+    expected_kind = _expected_tag_kind(body.filter)
+    if tag.kind != expected_kind:
+        raise HTTPException(
+            status_code=HTTP_STATUS_BAD_REQUEST,
+            detail=(
+                f"Tag {tag_id} has kind '{tag.kind}', but the "
+                f"'{body.filter.filter_type}' grid requires kind '{expected_kind}'."
+            ),
+        )
+
+    sample_ids_query = _build_sample_ids_query(grid_filter=body.filter, collection_id=collection_id)
+    tag_resolver.add_samples_to_tag_from_query(
+        session=session, tag_id=tag_id, sample_ids_query=sample_ids_query
+    )
     return True
 
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field
-from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.api.routes.api.status import (
@@ -29,18 +28,9 @@ from lightly_studio.models.tag import (
     TagTable,
     TagView,
 )
-from lightly_studio.resolvers import (
-    annotation_resolver,
-    image_resolver,
-    tag_resolver,
-    video_frame_resolver,
-    video_resolver,
-)
+from lightly_studio.resolvers import tag_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.grid_filter import GridFilter
-from lightly_studio.resolvers.image_filter import ImageFilter
-from lightly_studio.resolvers.video_frame_resolver.video_frame_filter import VideoFrameFilter
-from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
 
 tag_router = APIRouter()
 
@@ -214,28 +204,6 @@ class TagByFilterBody(BaseModel):
     filter: GridFilter
 
 
-def _build_sample_ids_query(
-    grid_filter: GridFilter,
-    collection_id: UUID,
-) -> SelectOfScalar[UUID]:
-    """Dispatch a grid filter to its resolver's ``build_sample_ids_query``."""
-    if isinstance(grid_filter, ImageFilter):
-        return image_resolver.build_sample_ids_query(
-            collection_id=collection_id, filters=grid_filter
-        )
-    if isinstance(grid_filter, VideoFilter):
-        return video_resolver.build_sample_ids_query(
-            collection_id=collection_id, filters=grid_filter
-        )
-    if isinstance(grid_filter, VideoFrameFilter):
-        return video_frame_resolver.build_sample_ids_query(
-            collection_id=collection_id, filters=grid_filter
-        )
-    return annotation_resolver.build_sample_ids_query(
-        collection_id=collection_id, filters=grid_filter
-    )
-
-
 def _expected_tag_kind(
     grid_filter: GridFilter,
 ) -> TagKind:
@@ -283,7 +251,7 @@ def add_samples_to_tag_by_filter(
             ),
         )
 
-    sample_ids_query = _build_sample_ids_query(grid_filter=body.filter, collection_id=collection_id)
+    sample_ids_query = body.filter.build_sample_ids_query(collection_id=collection_id)
     tag_resolver.add_samples_to_tag_from_query(
         session=session, tag_id=tag_id, sample_ids_query=sample_ids_query
     )

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -190,7 +190,7 @@ def add_sample_ids_to_tag_id(
 ) -> bool:
     """Add sample_ids to a tag_id."""
     # TODO(LIG-9942): backfill the collection-scope and tag-kind validation that
-    # add_samples_to_tag_by_filter enforces (separate PR — see plan, out of scope here).
+    # add_samples_to_tag_by_filter enforces.
     tag = tag_resolver.get_by_id(session=session, tag_id=tag_id)
     if not tag:
         raise HTTPException(
@@ -203,9 +203,8 @@ def add_sample_ids_to_tag_id(
     return True
 
 
-# A grid filter is self-describing: its ``filter_type`` literal selects both the source
-# table to tag from and the tag kind it is allowed to write. Mirrors the discriminated
-# union in ``services/sample_services/sample_adjacents_service.py``.
+# The ``filter_type`` discriminator selects both the source table to tag from and the
+# allowed tag kind. Same union as in services/sample_services/sample_adjacents_service.py.
 GridFilter = Annotated[
     Union[ImageFilter, VideoFilter, VideoFrameFilter, AnnotationsFilter],
     PydanticField(discriminator="filter_type"),
@@ -215,10 +214,9 @@ GridFilter = Annotated[
 class TagByFilterBody(BaseModel):
     """Body for tagging every sample a grid filter matches.
 
-    ``filter`` is required, not optional: the source table is dispatched on
-    ``filter.filter_type``, so a ``null`` filter would be ambiguous. "Whole
-    collection" is expressed as a typed-but-empty filter (e.g. ``{"filter_type":
-    "image"}`` with no constraints), which the frontend already produces per grid.
+    ``filter`` is required because the source table is dispatched on its
+    ``filter_type``. "Whole collection" is a typed-but-empty filter, e.g.
+    ``{"filter_type": "image"}``.
     """
 
     filter: GridFilter
@@ -228,11 +226,7 @@ def _build_sample_ids_query(
     grid_filter: ImageFilter | VideoFilter | VideoFrameFilter | AnnotationsFilter,
     collection_id: UUID,
 ) -> SelectOfScalar[UUID]:
-    """Dispatch a grid filter to its resolver's ``build_sample_ids_query``.
-
-    The 4-branch dispatch mirrors the frontend's ``useSelectAll.fetchSampleIds``
-    switch; each branch scopes to ``collection_id`` and applies the filter.
-    """
+    """Dispatch a grid filter to its resolver's ``build_sample_ids_query``."""
     if isinstance(grid_filter, ImageFilter):
         return image_resolver.build_sample_ids_query(
             collection_id=collection_id, filters=grid_filter
@@ -270,10 +264,9 @@ def add_samples_to_tag_by_filter(
     tag_id: Annotated[UUID, Path(title="Tag Id")],
     body: TagByFilterBody,
 ) -> bool:
-    """Tag every sample a grid filter matches, entirely inside the DB.
+    """Tag every sample a grid filter matches via a server-side ``INSERT … SELECT``.
 
-    No sample ids cross the wire: the matched ids are inserted via a single
-    server-side ``INSERT … SELECT``. Idempotent on re-run.
+    No sample ids cross the wire. Idempotent on re-run.
     """
     tag = tag_resolver.get_by_id(session=session, tag_id=tag_id)
     if not tag:
@@ -281,8 +274,8 @@ def add_samples_to_tag_by_filter(
             status_code=HTTP_STATUS_NOT_FOUND,
             detail=f"Tag {tag_id} not found, can't add samples.",
         )
-    # The link table carries only sample/tag FKs, so neither the collection scope nor
-    # the tag kind is enforced by the schema; both must be checked here.
+    # The link table carries only sample/tag FKs, so collection scope and tag kind
+    # are not schema-enforced and must be checked here.
     if tag.collection_id != collection_id:
         raise HTTPException(
             status_code=HTTP_STATUS_NOT_FOUND,

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -197,10 +197,8 @@ def add_sample_ids_to_tag_id(
 class TagByFilterBody(BaseModel):
     """Body for tagging every sample a grid filter matches.
 
-    ``filter`` has no default: its ``filter_type`` tells the server which grid
-    (images, videos, video frames, annotations) to read from, so the caller
-    must always supply it. To tag a whole collection, send a filter with only
-    the type and no predicates, e.g. ``{"filter_type": "image"}``.
+    The caller must supply a filter to determine the sample type. The filter
+    itself can have no conditions, e.g. ``{"filter_type": "image"}``.
     """
 
     filter: GridFilter

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -12,7 +12,6 @@ from sqlmodel import Field
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.api.routes.api.status import (
-    HTTP_STATUS_BAD_REQUEST,
     HTTP_STATUS_CONFLICT,
     HTTP_STATUS_CREATED,
     HTTP_STATUS_NOT_FOUND,
@@ -23,13 +22,11 @@ from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.tag import (
     TagCreate,
     TagCreateBody,
-    TagKind,
     TagRenameBody,
     TagTable,
     TagView,
 )
 from lightly_studio.resolvers import tag_resolver
-from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.grid_filter import GridFilter
 
 tag_router = APIRouter()
@@ -171,7 +168,7 @@ class SampleIdsBody(BaseModel):
 def add_sample_ids_to_tag_id(
     session: SessionDep,
     # collection_id is needed for the generator
-    collection_id: Annotated[  # noqa: ARG001
+    collection_id: Annotated[
         UUID,
         Path(title="collection Id", description="The ID of the collection"),
     ],
@@ -179,13 +176,17 @@ def add_sample_ids_to_tag_id(
     body: SampleIdsBody,
 ) -> bool:
     """Add sample_ids to a tag_id."""
-    # TODO(LIG-9942): backfill the collection-scope and tag-kind validation that
-    # add_samples_to_tag_by_filter enforces.
     tag = tag_resolver.get_by_id(session=session, tag_id=tag_id)
-    if not tag:
+    if tag is None:
         raise HTTPException(
             status_code=HTTP_STATUS_NOT_FOUND,
             detail=f"Tag {tag_id} not found, can't add sample_ids.",
+        )
+    # Validate the collection id.
+    if tag.collection_id != collection_id:
+        raise HTTPException(
+            status_code=HTTP_STATUS_NOT_FOUND,
+            detail=f"Tag {tag_id} not found in collection {collection_id}.",
         )
 
     sample_ids = body.sample_ids if body.sample_ids else []
@@ -220,29 +221,19 @@ def add_samples_to_tag_by_filter(
 ) -> bool:
     """Tag every sample a grid filter matches.
 
-    No sample ids cross the wire. Idempotent on re-run.
+    Idempotent on re-run.
     """
     tag = tag_resolver.get_by_id(session=session, tag_id=tag_id)
-    if not tag:
+    if tag is None:
         raise HTTPException(
             status_code=HTTP_STATUS_NOT_FOUND,
             detail=f"Tag {tag_id} not found, can't add samples.",
         )
-    # The link table carries only sample/tag FKs, so collection scope and tag kind
-    # are not schema-enforced and must be checked here.
+    # Validate the collection id.
     if tag.collection_id != collection_id:
         raise HTTPException(
             status_code=HTTP_STATUS_NOT_FOUND,
             detail=f"Tag {tag_id} not found in collection {collection_id}.",
-        )
-    expected_kind = _expected_tag_kind(body.filter)
-    if tag.kind != expected_kind:
-        raise HTTPException(
-            status_code=HTTP_STATUS_BAD_REQUEST,
-            detail=(
-                f"Tag {tag_id} has kind '{tag.kind}', but the "
-                f"'{body.filter.filter_type}' grid requires kind '{expected_kind}'."
-            ),
         )
 
     sample_ids_query = body.filter.build_sample_ids_query(collection_id=collection_id)
@@ -273,10 +264,3 @@ def remove_thing_ids_to_tag_id(
         session=session, tag_id=tag_id, sample_ids=sample_ids
     )
     return True
-
-
-def _expected_tag_kind(
-    grid_filter: GridFilter,
-) -> TagKind:
-    """Return the tag kind a grid may write: annotations grid ⇒ annotation, else sample."""
-    return "annotation" if isinstance(grid_filter, AnnotationsFilter) else "sample"

--- a/lightly_studio/tests/api/routes/api/test_collection_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_tag.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, col, select
+
+from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_BAD_REQUEST,
+    HTTP_STATUS_CREATED,
+    HTTP_STATUS_NOT_FOUND,
+)
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleTagLinkTable
+from lightly_studio.resolvers import collection_resolver
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+    create_tag,
+)
+from tests.resolvers.video.helpers import (
+    VideoStub,
+    create_video,
+    create_video_with_frames,
+)
+
+
+def _tagged_sample_ids(session: Session, tag_id: UUID) -> set[UUID]:
+    """Read the sample ids currently linked to ``tag_id`` straight from the link table."""
+    linked = session.exec(
+        select(SampleTagLinkTable.sample_id).where(col(SampleTagLinkTable.tag_id) == tag_id)
+    ).all()
+    return {sample_id for sample_id in linked if sample_id is not None}
+
+
+def _add_by_filter_url(collection_id: UUID, tag_id: UUID) -> str:
+    return f"/api/collections/{collection_id}/tags/{tag_id}/add/samples_by_filter"
+
+
+def test_add_samples_by_filter__image_empty_filter_tags_whole_collection(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    tag = create_tag(session=db_session, collection_id=collection_id, kind="sample")
+    images = [
+        create_image(session=db_session, collection_id=collection_id, file_path_abs=f"s{i}.png")
+        for i in range(3)
+    ]
+
+    response = test_client.post(
+        _add_by_filter_url(collection_id, tag.tag_id),
+        json={"filter": {"filter_type": "image"}},
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert _tagged_sample_ids(db_session, tag.tag_id) == {image.sample_id for image in images}
+
+
+def test_add_samples_by_filter__image_subset_filter_tags_only_subset(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    tag = create_tag(session=db_session, collection_id=collection_id, kind="sample")
+    wide = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="wide.png", width=1920
+    )
+    create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="narrow.png", width=10
+    )
+
+    response = test_client.post(
+        _add_by_filter_url(collection_id, tag.tag_id),
+        json={"filter": {"filter_type": "image", "width": {"min": 100}}},
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert _tagged_sample_ids(db_session, tag.tag_id) == {wide.sample_id}
+
+
+def test_add_samples_by_filter__idempotent_on_rerun(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    tag = create_tag(session=db_session, collection_id=collection_id, kind="sample")
+    image = create_image(session=db_session, collection_id=collection_id, file_path_abs="s.png")
+    body = {"filter": {"filter_type": "image"}}
+
+    first = test_client.post(_add_by_filter_url(collection_id, tag.tag_id), json=body)
+    second = test_client.post(_add_by_filter_url(collection_id, tag.tag_id), json=body)
+
+    assert first.status_code == HTTP_STATUS_CREATED
+    assert second.status_code == HTTP_STATUS_CREATED
+    # Re-running adds no duplicate link.
+    assert _tagged_sample_ids(db_session, tag.tag_id) == {image.sample_id}
+
+
+def test_add_samples_by_filter__video_grid(db_session: Session, test_client: TestClient) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    collection_id = collection.collection_id
+    tag = create_tag(session=db_session, collection_id=collection_id, kind="sample")
+    video = create_video(session=db_session, collection_id=collection_id, video=VideoStub())
+
+    response = test_client.post(
+        _add_by_filter_url(collection_id, tag.tag_id),
+        json={"filter": {"filter_type": "video"}},
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert _tagged_sample_ids(db_session, tag.tag_id) == {video.sample_id}
+
+
+def test_add_samples_by_filter__video_frame_grid(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_with_frames = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(duration_s=0.1, fps=30.0),
+    )
+    frame_collection_id = video_with_frames.video_frames_collection_id
+    tag = create_tag(session=db_session, collection_id=frame_collection_id, kind="sample")
+
+    response = test_client.post(
+        _add_by_filter_url(frame_collection_id, tag.tag_id),
+        json={"filter": {"filter_type": "video_frame"}},
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert _tagged_sample_ids(db_session, tag.tag_id) == set(video_with_frames.frame_sample_ids)
+
+
+def test_add_samples_by_filter__annotation_grid(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    label = create_annotation_label(session=db_session, root_collection_id=collection.collection_id)
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    tag = create_tag(session=db_session, collection_id=annotation_collection_id, kind="annotation")
+
+    response = test_client.post(
+        _add_by_filter_url(annotation_collection_id, tag.tag_id),
+        json={"filter": {"filter_type": "annotations"}},
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert _tagged_sample_ids(db_session, tag.tag_id) == {annotation.sample_id}
+
+
+def test_add_samples_by_filter__unknown_tag_returns_404(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+
+    response = test_client.post(
+        _add_by_filter_url(collection_id, uuid4()),
+        json={"filter": {"filter_type": "image"}},
+    )
+
+    assert response.status_code == HTTP_STATUS_NOT_FOUND
+
+
+def test_add_samples_by_filter__wrong_collection_returns_404(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    tag = create_tag(session=db_session, collection_id=collection_id, kind="sample")
+
+    # Tag exists, but not in the collection on the path.
+    response = test_client.post(
+        _add_by_filter_url(uuid4(), tag.tag_id),
+        json={"filter": {"filter_type": "image"}},
+    )
+
+    assert response.status_code == HTTP_STATUS_NOT_FOUND
+
+
+def test_add_samples_by_filter__wrong_kind_returns_400(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    # A sample-kind tag cannot be assigned through the annotations grid.
+    tag = create_tag(session=db_session, collection_id=collection_id, kind="sample")
+
+    response = test_client.post(
+        _add_by_filter_url(collection_id, tag.tag_id),
+        json={"filter": {"filter_type": "annotations"}},
+    )
+
+    assert response.status_code == HTTP_STATUS_BAD_REQUEST

--- a/lightly_studio/tests/api/routes/api/test_collection_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_tag.py
@@ -6,7 +6,6 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, col, select
 
 from lightly_studio.api.routes.api.status import (
-    HTTP_STATUS_BAD_REQUEST,
     HTTP_STATUS_CREATED,
     HTTP_STATUS_NOT_FOUND,
 )
@@ -145,18 +144,3 @@ def test_add_samples_by_filter__wrong_collection_returns_404(
     )
 
     assert response.status_code == HTTP_STATUS_NOT_FOUND
-
-
-def test_add_samples_by_filter__wrong_kind_returns_400(
-    db_session: Session, test_client: TestClient
-) -> None:
-    collection_id = create_collection(session=db_session).collection_id
-    # A sample-kind tag cannot be assigned through the annotations grid.
-    tag = create_tag(session=db_session, collection_id=collection_id, kind="sample")
-
-    response = test_client.post(
-        _add_by_filter_url(collection_id, tag.tag_id),
-        json={"filter": {"filter_type": "annotations"}},
-    )
-
-    assert response.status_code == HTTP_STATUS_BAD_REQUEST

--- a/lightly_studio/tests/api/routes/api/test_collection_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_tag.py
@@ -20,11 +20,6 @@ from tests.helpers_resolvers import (
     create_image,
     create_tag,
 )
-from tests.resolvers.video.helpers import (
-    VideoStub,
-    create_video,
-    create_video_with_frames,
-)
 
 
 def _tagged_sample_ids(session: Session, tag_id: UUID) -> set[UUID]:
@@ -94,42 +89,6 @@ def test_add_samples_by_filter__idempotent_on_rerun(
     assert second.status_code == HTTP_STATUS_CREATED
     # Re-running adds no duplicate link.
     assert _tagged_sample_ids(db_session, tag.tag_id) == {image.sample_id}
-
-
-def test_add_samples_by_filter__video_grid(db_session: Session, test_client: TestClient) -> None:
-    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
-    collection_id = collection.collection_id
-    tag = create_tag(session=db_session, collection_id=collection_id, kind="sample")
-    video = create_video(session=db_session, collection_id=collection_id, video=VideoStub())
-
-    response = test_client.post(
-        _add_by_filter_url(collection_id, tag.tag_id),
-        json={"filter": {"filter_type": "video"}},
-    )
-
-    assert response.status_code == HTTP_STATUS_CREATED
-    assert _tagged_sample_ids(db_session, tag.tag_id) == {video.sample_id}
-
-
-def test_add_samples_by_filter__video_frame_grid(
-    db_session: Session, test_client: TestClient
-) -> None:
-    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
-    video_with_frames = create_video_with_frames(
-        session=db_session,
-        collection_id=collection.collection_id,
-        video=VideoStub(duration_s=0.1, fps=30.0),
-    )
-    frame_collection_id = video_with_frames.video_frames_collection_id
-    tag = create_tag(session=db_session, collection_id=frame_collection_id, kind="sample")
-
-    response = test_client.post(
-        _add_by_filter_url(frame_collection_id, tag.tag_id),
-        json={"filter": {"filter_type": "video_frame"}},
-    )
-
-    assert response.status_code == HTTP_STATUS_CREATED
-    assert _tagged_sample_ids(db_session, tag.tag_id) == set(video_with_frames.frame_sample_ids)
 
 
 def test_add_samples_by_filter__annotation_grid(

--- a/lightly_studio/tests/api/routes/api/test_collection_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_tag.py
@@ -41,7 +41,9 @@ def test_add_samples_by_filter__image_empty_filter_tags_whole_collection(
     )
 
     assert response.status_code == HTTP_STATUS_CREATED
-    assert _tagged_sample_ids(db_session, tag.tag_id) == {image.sample_id for image in images}
+    assert _tagged_sample_ids(session=db_session, tag_id=tag.tag_id) == {
+        image.sample_id for image in images
+    }
 
 
 def test_add_samples_by_filter__image_subset_filter_tags_only_subset(
@@ -62,7 +64,7 @@ def test_add_samples_by_filter__image_subset_filter_tags_only_subset(
     )
 
     assert response.status_code == HTTP_STATUS_CREATED
-    assert _tagged_sample_ids(db_session, tag.tag_id) == {wide.sample_id}
+    assert _tagged_sample_ids(session=db_session, tag_id=tag.tag_id) == {wide.sample_id}
 
 
 def test_add_samples_by_filter__idempotent_on_rerun(
@@ -80,7 +82,7 @@ def test_add_samples_by_filter__idempotent_on_rerun(
     assert first.status_code == HTTP_STATUS_CREATED
     assert second.status_code == HTTP_STATUS_CREATED
     # Re-running adds no duplicate link.
-    assert _tagged_sample_ids(db_session, tag.tag_id) == {image.sample_id}
+    assert _tagged_sample_ids(session=db_session, tag_id=tag.tag_id) == {image.sample_id}
 
 
 def test_add_samples_by_filter__annotation_grid(
@@ -108,7 +110,7 @@ def test_add_samples_by_filter__annotation_grid(
     )
 
     assert response.status_code == HTTP_STATUS_CREATED
-    assert _tagged_sample_ids(db_session, tag.tag_id) == {annotation.sample_id}
+    assert _tagged_sample_ids(session=db_session, tag_id=tag.tag_id) == {annotation.sample_id}
 
 
 def test_add_samples_by_filter__unknown_tag_returns_404(

--- a/lightly_studio/tests/api/routes/api/test_collection_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_tag.py
@@ -13,24 +13,14 @@ from lightly_studio.models.collection import SampleType
 from lightly_studio.models.sample import SampleTagLinkTable
 from lightly_studio.resolvers import collection_resolver
 from tests.helpers_resolvers import (
+    ImageStub,
     create_annotation,
     create_annotation_label,
     create_collection,
     create_image,
+    create_images,
     create_tag,
 )
-
-
-def _tagged_sample_ids(session: Session, tag_id: UUID) -> set[UUID]:
-    """Read the sample ids currently linked to ``tag_id`` straight from the link table."""
-    linked = session.exec(
-        select(SampleTagLinkTable.sample_id).where(col(SampleTagLinkTable.tag_id) == tag_id)
-    ).all()
-    return {sample_id for sample_id in linked if sample_id is not None}
-
-
-def _add_by_filter_url(collection_id: UUID, tag_id: UUID) -> str:
-    return f"/api/collections/{collection_id}/tags/{tag_id}/add/samples_by_filter"
 
 
 def test_add_samples_by_filter__image_empty_filter_tags_whole_collection(
@@ -38,10 +28,11 @@ def test_add_samples_by_filter__image_empty_filter_tags_whole_collection(
 ) -> None:
     collection_id = create_collection(session=db_session).collection_id
     tag = create_tag(session=db_session, collection_id=collection_id, kind="sample")
-    images = [
-        create_image(session=db_session, collection_id=collection_id, file_path_abs=f"s{i}.png")
-        for i in range(3)
-    ]
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection_id,
+        images=[ImageStub(path="s0.png"), ImageStub(path="s1.png")],
+    )
 
     response = test_client.post(
         _add_by_filter_url(collection_id, tag.tag_id),
@@ -144,3 +135,15 @@ def test_add_samples_by_filter__wrong_collection_returns_404(
     )
 
     assert response.status_code == HTTP_STATUS_NOT_FOUND
+
+
+def _tagged_sample_ids(session: Session, tag_id: UUID) -> set[UUID]:
+    """Read the sample ids currently linked to ``tag_id`` straight from the link table."""
+    linked = session.exec(
+        select(SampleTagLinkTable.sample_id).where(col(SampleTagLinkTable.tag_id) == tag_id)
+    ).all()
+    return {sample_id for sample_id in linked if sample_id is not None}
+
+
+def _add_by_filter_url(collection_id: UUID, tag_id: UUID) -> str:
+    return f"/api/collections/{collection_id}/tags/{tag_id}/add/samples_by_filter"

--- a/lightly_studio/tests/api/routes/api/test_collection_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_tag.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from uuid import UUID, uuid4
+import uuid
+from uuid import UUID
 
 from fastapi.testclient import TestClient
 from sqlmodel import Session, col, select
@@ -35,7 +36,7 @@ def test_add_samples_by_filter__image_empty_filter_tags_whole_collection(
     )
 
     response = test_client.post(
-        _add_by_filter_url(collection_id, tag.tag_id),
+        f"/api/collections/{collection_id}/tags/{tag.tag_id}/add/samples_by_filter",
         json={"filter": {"filter_type": "image"}},
     )
 
@@ -56,7 +57,7 @@ def test_add_samples_by_filter__image_subset_filter_tags_only_subset(
     )
 
     response = test_client.post(
-        _add_by_filter_url(collection_id, tag.tag_id),
+        f"/api/collections/{collection_id}/tags/{tag.tag_id}/add/samples_by_filter",
         json={"filter": {"filter_type": "image", "width": {"min": 100}}},
     )
 
@@ -72,8 +73,9 @@ def test_add_samples_by_filter__idempotent_on_rerun(
     image = create_image(session=db_session, collection_id=collection_id, file_path_abs="s.png")
     body = {"filter": {"filter_type": "image"}}
 
-    first = test_client.post(_add_by_filter_url(collection_id, tag.tag_id), json=body)
-    second = test_client.post(_add_by_filter_url(collection_id, tag.tag_id), json=body)
+    url = f"/api/collections/{collection_id}/tags/{tag.tag_id}/add/samples_by_filter"
+    first = test_client.post(url, json=body)
+    second = test_client.post(url, json=body)
 
     assert first.status_code == HTTP_STATUS_CREATED
     assert second.status_code == HTTP_STATUS_CREATED
@@ -101,7 +103,7 @@ def test_add_samples_by_filter__annotation_grid(
     tag = create_tag(session=db_session, collection_id=annotation_collection_id, kind="annotation")
 
     response = test_client.post(
-        _add_by_filter_url(annotation_collection_id, tag.tag_id),
+        f"/api/collections/{annotation_collection_id}/tags/{tag.tag_id}/add/samples_by_filter",
         json={"filter": {"filter_type": "annotations"}},
     )
 
@@ -115,7 +117,7 @@ def test_add_samples_by_filter__unknown_tag_returns_404(
     collection_id = create_collection(session=db_session).collection_id
 
     response = test_client.post(
-        _add_by_filter_url(collection_id, uuid4()),
+        f"/api/collections/{collection_id}/tags/{uuid.uuid4()}/add/samples_by_filter",
         json={"filter": {"filter_type": "image"}},
     )
 
@@ -130,7 +132,7 @@ def test_add_samples_by_filter__wrong_collection_returns_404(
 
     # Tag exists, but not in the collection on the path.
     response = test_client.post(
-        _add_by_filter_url(uuid4(), tag.tag_id),
+        f"/api/collections/{uuid.uuid4()}/tags/{tag.tag_id}/add/samples_by_filter",
         json={"filter": {"filter_type": "image"}},
     )
 
@@ -143,7 +145,3 @@ def _tagged_sample_ids(session: Session, tag_id: UUID) -> set[UUID]:
         select(SampleTagLinkTable.sample_id).where(col(SampleTagLinkTable.tag_id) == tag_id)
     ).all()
     return {sample_id for sample_id in linked if sample_id is not None}
-
-
-def _add_by_filter_url(collection_id: UUID, tag_id: UUID) -> str:
-    return f"/api/collections/{collection_id}/tags/{tag_id}/add/samples_by_filter"


### PR DESCRIPTION
## What has changed and why?

Final backend change to support tagging by a filter.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint for tagging samples using filter criteria, enabling efficient bulk-tagging of filtered sample subsets within collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->