### PR TITLE
Apply class-enforced colors to classification UI

### DIFF
--- a/lightly_studio_view/src/lib/components/SampleClassificationPills/SampleClassificationPills.svelte
+++ b/lightly_studio_view/src/lib/components/SampleClassificationPills/SampleClassificationPills.svelte
@@ -2,7 +2,7 @@
     import type { ImageView } from '$lib/api/lightly_studio_local';
     import { useCustomLabelColors } from '$lib/hooks/useCustomLabelColors';
     import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
-    import { useSettings } from '$lib/hooks/useSettings';
+    import { useSettings } from '$lib/hooks';
     import { getColorByLabel } from '$lib/utils';
     import { getColorPair } from '$lib/utils/getColorPair';
     import {

--- a/lightly_studio_view/src/lib/components/SampleClassificationPills/SampleClassificationPills.svelte
+++ b/lightly_studio_view/src/lib/components/SampleClassificationPills/SampleClassificationPills.svelte
@@ -2,6 +2,7 @@
     import type { ImageView } from '$lib/api/lightly_studio_local';
     import { useCustomLabelColors } from '$lib/hooks/useCustomLabelColors';
     import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
+    import { useSettings } from '$lib/hooks/useSettings';
     import { getColorByLabel } from '$lib/utils';
     import { getColorPair } from '$lib/utils/getColorPair';
     import {
@@ -24,12 +25,14 @@
 
     const { selectedCollectionIds, collectionIdToName } = useAnnotationCollectionsFilter();
     const { customLabelColorsStore } = useCustomLabelColors();
+    const { enforceColoringByClassStore } = useSettings();
 
     const pills = $derived(
         getSampleClassificationPills({
             annotations: sample.annotations,
             selectedCollectionIds: $selectedCollectionIds,
-            collectionIdToName: $collectionIdToName
+            collectionIdToName: $collectionIdToName,
+            enforceColoringByClass: $enforceColoringByClassStore
         })
     );
 

--- a/lightly_studio_view/src/lib/components/SampleClassificationPills/getSampleClassificationPills.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleClassificationPills/getSampleClassificationPills.test.ts
@@ -59,7 +59,8 @@ describe('getSampleClassificationPills', () => {
             collectionIdToName: {
                 'collection-1': 'Animals',
                 'collection-2': 'Vehicles'
-            }
+            },
+            enforceColoringByClass: false
         });
 
         expect(pills).toEqual([
@@ -89,7 +90,8 @@ describe('getSampleClassificationPills', () => {
             collectionIdToName: {
                 'collection-1': 'Source A',
                 'collection-2': 'Source B'
-            }
+            },
+            enforceColoringByClass: false
         });
 
         expect(pills).toEqual([
@@ -119,7 +121,8 @@ describe('getSampleClassificationPills', () => {
             collectionIdToName: {
                 'collection-1': 'Source A',
                 'collection-2': 'Source B'
-            }
+            },
+            enforceColoringByClass: false
         });
 
         expect(pills).toEqual([
@@ -160,7 +163,8 @@ describe('getSampleClassificationPills', () => {
             collectionIdToName: {
                 'collection-a': 'Collection A',
                 'collection-b': 'Collection B'
-            }
+            },
+            enforceColoringByClass: false
         });
 
         expect(pills.map((pill) => pill.id)).toEqual([
@@ -181,7 +185,8 @@ describe('getSampleClassificationPills', () => {
             selectedCollectionIds: ['missing-collection', 'collection-2'],
             collectionIdToName: {
                 'collection-2': 'Known Source'
-            }
+            },
+            enforceColoringByClass: false
         });
 
         expect(pills).toEqual([
@@ -195,6 +200,44 @@ describe('getSampleClassificationPills', () => {
         ]);
     });
 
+    it('uses class colors when enforce coloring by class is enabled despite multiple selected sources', () => {
+        const pills = getSampleClassificationPills({
+            annotations: [
+                createAnnotation({
+                    annotationCollectionId: 'collection-1',
+                    annotationLabelName: 'car'
+                }),
+                createAnnotation({
+                    annotationCollectionId: 'collection-2',
+                    annotationLabelName: 'car'
+                }),
+                createAnnotation({
+                    annotationCollectionId: 'collection-1',
+                    annotationLabelName: 'truck'
+                })
+            ],
+            selectedCollectionIds: ['collection-1', 'collection-2'],
+            collectionIdToName: {
+                'collection-1': 'Ground Truth',
+                'collection-2': 'Predictions'
+            },
+            enforceColoringByClass: true
+        });
+
+        // With enforcement on, source colors are suppressed: duplicate labels are
+        // deduped and colorKey uses the class name, not the source name.
+        expect(pills).toEqual([
+            { id: 'car', label: 'car', displayLabel: 'car', colorKey: 'car', title: 'car' },
+            {
+                id: 'truck',
+                label: 'truck',
+                displayLabel: 'truck',
+                colorKey: 'truck',
+                title: 'truck'
+            }
+        ]);
+    });
+
     it('truncates long labels for display', () => {
         const pills = getSampleClassificationPills({
             annotations: [
@@ -204,7 +247,8 @@ describe('getSampleClassificationPills', () => {
                 })
             ],
             selectedCollectionIds: [],
-            collectionIdToName: {}
+            collectionIdToName: {},
+            enforceColoringByClass: false
         });
 
         expect(pills[0]).toMatchObject({

--- a/lightly_studio_view/src/lib/components/SampleClassificationPills/getSampleClassificationPills.ts
+++ b/lightly_studio_view/src/lib/components/SampleClassificationPills/getSampleClassificationPills.ts
@@ -1,5 +1,5 @@
 import { AnnotationType, type AnnotationView } from '$lib/api/lightly_studio_local';
-import { resolveEffectiveColorBySource } from '$lib/utils/resolveEffectiveColorBySource';
+import { resolveEffectiveColorBySource } from '$lib/utils';
 
 interface GetSampleClassificationPillsParams {
     annotations: AnnotationView[];

--- a/lightly_studio_view/src/lib/components/SampleClassificationPills/getSampleClassificationPills.ts
+++ b/lightly_studio_view/src/lib/components/SampleClassificationPills/getSampleClassificationPills.ts
@@ -1,9 +1,11 @@
 import { AnnotationType, type AnnotationView } from '$lib/api/lightly_studio_local';
+import { resolveEffectiveColorBySource } from '$lib/utils/resolveEffectiveColorBySource';
 
 interface GetSampleClassificationPillsParams {
     annotations: AnnotationView[];
     selectedCollectionIds: string[];
     collectionIdToName: Record<string, string>;
+    enforceColoringByClass: boolean;
 }
 
 interface CreateSampleClassificationPillParams {
@@ -76,9 +78,13 @@ function dedupeAndSortPills(pills: SampleClassificationPill[]): SampleClassifica
 export function getSampleClassificationPills({
     annotations,
     selectedCollectionIds,
-    collectionIdToName
+    collectionIdToName,
+    enforceColoringByClass
 }: GetSampleClassificationPillsParams): SampleClassificationPill[] {
-    const showSourceColors = selectedCollectionIds.length > 1;
+    const showSourceColors = resolveEffectiveColorBySource({
+        multipleSourcesVisible: selectedCollectionIds.length > 1,
+        enforceColoringByClass
+    });
 
     return dedupeAndSortPills(
         annotations

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSourceGroup/SampleDetailsAnnotationSourceGroup.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSourceGroup/SampleDetailsAnnotationSourceGroup.svelte
@@ -55,7 +55,11 @@
 <Collapsible bind:open>
     <div class="flex items-center gap-2" data-testid="annotation-source-group-header" title={name}>
         {#if showColorMarker}
-            <ColorMarker label={name} enableColorPicker />
+            <ColorMarker
+                label={name}
+                enableColorPicker
+                markerProps={{ 'data-testid': `color-marker-${name}` }}
+            />
         {/if}
         <CollapsibleTrigger class="flex min-w-0 flex-1 items-center justify-between py-1">
             <span class="truncate text-sm font-medium">{name}</span>

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -5,7 +5,7 @@
     import LabelNotFound from '$lib/components/LabelNotFound/LabelNotFound.svelte';
     import SelectList from '$lib/components/SelectList/SelectList.svelte';
     import { getSelectionItems } from '$lib/components/SelectList/getSelectionItems';
-    import { cn, formatConfidence } from '$lib/utils';
+    import { cn, formatConfidence, resolveEffectiveColorBySource } from '$lib/utils';
     import { addAnnotationCreateToUndoStack } from '$lib/services/addAnnotationCreateToUndoStack';
     import { addAnnotationDeleteToUndoStack } from '$lib/services/addAnnotationDeleteToUndoStack';
     import { addAnnotationLabelChangeToUndoStack } from '$lib/services/addAnnotationLabelChangeToUndoStack';
@@ -23,6 +23,8 @@
     import { useUpdateAnnotationsMutation } from '$lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation';
     import { useCollectionWithChildren } from '$lib/hooks/useCollection/useCollection';
     import { useAnnotationLabelContext } from '$lib/contexts/SampleDetailsAnnotation.svelte';
+    import { useSettings } from '$lib/hooks/useSettings';
+    import AnnotationColorLegend from '$lib/components/AnnotationColorLegend/AnnotationColorLegend.svelte';
     import { page } from '$app/state';
     import { Trash2 } from '@lucide/svelte';
     import { toast } from 'svelte-sonner';
@@ -37,6 +39,7 @@
         $props();
 
     const { isEditingMode, addReversibleAction } = useGlobalStorage();
+    const { enforceColoringByClassStore } = useSettings();
 
     const annotationLabels = useAnnotationLabels(() => ({ collectionId }));
     const { createAnnotation } = useCreateAnnotation({ collectionId });
@@ -78,6 +81,15 @@
     // the effect-written `annotationsIdsToHide`); drives the seed and the initial collapse.
     const seededHiddenIds = $derived(
         computeSeededHiddenIds(classificationAnnotations, $selectedCollectionIds, annotationSources)
+    );
+
+    // Color source group headers by source only when multiple sources are visible and class
+    // coloring is not enforced, mirroring the annotation segment and canvas behavior.
+    const colorBySource = $derived(
+        resolveEffectiveColorBySource({
+            multipleSourcesVisible: isGrouped,
+            enforceColoringByClass: $enforceColoringByClassStore
+        })
     );
 
     const handleDeleteAnnotation = async (annotationId: string) => {
@@ -211,7 +223,16 @@
         data-annotation-id={annotation.sample_id}
     >
         <span class="flex min-w-0 flex-1 flex-col gap-1">
-            <span class="min-w-0 text-sm font-medium">
+            <span class="flex min-w-0 items-center gap-2 text-sm font-medium">
+                {#if !colorBySource}
+                    <div class="h-4 shrink-0">
+                        <AnnotationColorLegend
+                            labelName={annotation.annotation_label.annotation_label_name}
+                            className="h-4 w-4"
+                            selected={false}
+                        />
+                    </div>
+                {/if}
                 {#if $isEditingMode}
                     <SelectList
                         {items}
@@ -280,7 +301,7 @@
                                 seededHiddenIds,
                                 annotationLabelContext.lastCreatedAnnotationId
                             )}
-                            showColorMarker={true}
+                            showColorMarker={colorBySource}
                         >
                             <div class="flex flex-col gap-2">
                                 {#each group.annotations as annotation (annotation.sample_id)}

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -23,7 +23,7 @@
     import { useUpdateAnnotationsMutation } from '$lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation';
     import { useCollectionWithChildren } from '$lib/hooks/useCollection/useCollection';
     import { useAnnotationLabelContext } from '$lib/contexts/SampleDetailsAnnotation.svelte';
-    import { useSettings } from '$lib/hooks/useSettings';
+    import { useSettings } from '$lib/hooks';
     import AnnotationColorLegend from '$lib/components/AnnotationColorLegend/AnnotationColorLegend.svelte';
     import { page } from '$app/state';
     import { Trash2 } from '@lucide/svelte';
@@ -87,7 +87,7 @@
     // coloring is not enforced, mirroring the annotation segment and canvas behavior.
     const colorBySource = $derived(
         resolveEffectiveColorBySource({
-            multipleSourcesVisible: isGrouped,
+            multipleSourcesVisible: $selectedCollectionIds.length > 1,
             enforceColoringByClass: $enforceColoringByClassStore
         })
     );
@@ -233,40 +233,42 @@
                         />
                     </div>
                 {/if}
-                {#if $isEditingMode}
-                    <SelectList
-                        {items}
-                        selectedItem={items.find(
-                            (i) => i.value === getLabelValue(annotation)?.value
-                        )}
-                        name="classification-label"
-                        placeholder="Select or create a class"
-                        className="w-full min-w-0"
-                        contentClassName="w-full min-w-0"
-                        onSelect={async (item) => {
-                            await updateClassificationLabel(annotation, item.value);
-                        }}
-                    >
-                        {#snippet notFound({ inputValue })}
-                            <LabelNotFound label={inputValue} />
-                        {/snippet}
-                    </SelectList>
-                {:else}
-                    <span class="block min-w-0 truncate">
-                        {annotation.annotation_label.annotation_label_name}
-                    </span>
-                    {#if annotation.confidence != null}
-                        {@const formattedConfidence = formatConfidence(annotation.confidence)}
-                        <span class="text-xs text-muted-foreground"
-                            >Confidence: {formattedConfidence}</span
+                <span class="flex min-w-0 flex-1 flex-col gap-1">
+                    {#if $isEditingMode}
+                        <SelectList
+                            {items}
+                            selectedItem={items.find(
+                                (i) => i.value === getLabelValue(annotation)?.value
+                            )}
+                            name="classification-label"
+                            placeholder="Select or create a class"
+                            className="w-full min-w-0"
+                            contentClassName="w-full min-w-0"
+                            onSelect={async (item) => {
+                                await updateClassificationLabel(annotation, item.value);
+                            }}
                         >
+                            {#snippet notFound({ inputValue })}
+                                <LabelNotFound label={inputValue} />
+                            {/snippet}
+                        </SelectList>
+                    {:else}
+                        <span class="block min-w-0 truncate">
+                            {annotation.annotation_label.annotation_label_name}
+                        </span>
+                        {#if annotation.confidence != null}
+                            {@const formattedConfidence = formatConfidence(annotation.confidence)}
+                            <span class="text-xs text-muted-foreground"
+                                >Confidence: {formattedConfidence}</span
+                            >
+                        {/if}
+                        {#if annotation.object_track_number != null}
+                            <span class="shrink-0 font-mono text-xs opacity-80"
+                                >#{annotation.object_track_number}</span
+                            >
+                        {/if}
                     {/if}
-                    {#if annotation.object_track_number != null}
-                        <span class="shrink-0 font-mono text-xs opacity-80"
-                            >#{annotation.object_track_number}</span
-                        >
-                    {/if}
-                {/if}
+                </span>
             </span>
         </span>
         <div class="flex shrink-0 items-center gap-3">

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -286,6 +286,10 @@ describe('SampleDetailsClassificationSegment', () => {
 
     it('hides source group color markers when enforce coloring by class is enabled', () => {
         mocks.collections = [groundTruthSource, predictionsSource];
+        mocks.selectedCollectionIds = [
+            groundTruthSource.collection_id,
+            predictionsSource.collection_id
+        ];
         mocks.enforceColoringByClassStore.set(true);
         const annotations = [
             createClassification('c1', groundTruthSource.collection_id, 'cat'),

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -8,7 +8,8 @@ const mocks = vi.hoisted(() => ({
     collections: [] as { collection_id: string; name: string }[],
     selectedCollectionIds: [] as string[],
     lastCreatedAnnotationId: null as string | null,
-    isEditingMode: undefined as unknown as { set: (value: boolean) => void }
+    isEditingMode: undefined as unknown as { set: (value: boolean) => void },
+    enforceColoringByClassStore: undefined as unknown as { set: (value: boolean) => void }
 }));
 
 vi.mock('$app/state', () => ({
@@ -40,6 +41,17 @@ vi.mock('$lib/hooks/useGlobalStorage', async () => {
             isEditingMode,
             addReversibleAction: vi.fn()
         })
+    };
+});
+
+vi.mock('$lib/hooks/useSettings', async () => {
+    const { writable } = await import('svelte/store');
+    const enforceColoringByClassStore = writable(false);
+    mocks.enforceColoringByClassStore = enforceColoringByClassStore;
+    return {
+        useSettings: vi.fn(() => ({
+            enforceColoringByClassStore
+        }))
     };
 });
 
@@ -84,6 +96,18 @@ vi.mock('svelte-sonner', () => ({
     toast: { success: vi.fn(), error: vi.fn() }
 }));
 
+vi.mock('$lib/hooks/useCustomLabelColors', async () => {
+    const { writable } = await import('svelte/store');
+    return {
+        useCustomLabelColors: () => ({
+            customLabelColorsStore: writable({}),
+            getCustomColor: () => undefined,
+            setCustomColor: vi.fn(),
+            hasCustomColor: () => false
+        })
+    };
+});
+
 const groundTruthSource = { collection_id: 'source-gt', name: 'Ground truth' };
 const predictionsSource = { collection_id: 'source-pred', name: 'Predictions' };
 
@@ -117,6 +141,7 @@ describe('SampleDetailsClassificationSegment', () => {
         mocks.selectedCollectionIds = [];
         mocks.lastCreatedAnnotationId = null;
         mocks.isEditingMode.set(false);
+        mocks.enforceColoringByClassStore.set(false);
     });
 
     it('renders a flat list without source groups for a single source', () => {
@@ -239,6 +264,38 @@ describe('SampleDetailsClassificationSegment', () => {
 
         expect(screen.getByText('bird')).toBeInTheDocument();
         expect(screen.queryByText(/Confidence:/)).not.toBeInTheDocument();
+    });
+
+    it('shows source group color markers when multiple sources are visible and enforce coloring is disabled', () => {
+        mocks.collections = [groundTruthSource, predictionsSource];
+        mocks.enforceColoringByClassStore.set(false);
+        const annotations = [
+            createClassification('c1', groundTruthSource.collection_id, 'cat'),
+            createClassification('c2', predictionsSource.collection_id, 'zebra')
+        ];
+
+        render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+        expect(screen.getByTestId(`color-marker-${groundTruthSource.name}`)).toBeInTheDocument();
+        expect(screen.getByTestId(`color-marker-${predictionsSource.name}`)).toBeInTheDocument();
+    });
+
+    it('hides source group color markers when enforce coloring by class is enabled', () => {
+        mocks.collections = [groundTruthSource, predictionsSource];
+        mocks.enforceColoringByClassStore.set(true);
+        const annotations = [
+            createClassification('c1', groundTruthSource.collection_id, 'cat'),
+            createClassification('c2', predictionsSource.collection_id, 'zebra')
+        ];
+
+        render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+        expect(
+            screen.queryByTestId(`color-marker-${groundTruthSource.name}`)
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByTestId(`color-marker-${predictionsSource.name}`)
+        ).not.toBeInTheDocument();
     });
 
     it('renders editable rows inside groups with a single add button below', async () => {

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -268,6 +268,10 @@ describe('SampleDetailsClassificationSegment', () => {
 
     it('shows source group color markers when multiple sources are visible and enforce coloring is disabled', () => {
         mocks.collections = [groundTruthSource, predictionsSource];
+        mocks.selectedCollectionIds = [
+            groundTruthSource.collection_id,
+            predictionsSource.collection_id
+        ];
         mocks.enforceColoringByClassStore.set(false);
         const annotations = [
             createClassification('c1', groundTruthSource.collection_id, 'cat'),

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -41,3 +41,4 @@ export { useColorPicker } from '$lib/hooks/useColorPicker/useColorPicker.svelte'
 export { useSubmitCombinationSelection } from '$lib/hooks/useSubmitCombinationSelection/useSubmitCombinationSelection';
 export { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
 export { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
+export { useSettings } from '$lib/hooks/useSettings';


### PR DESCRIPTION
## Summary

Closes [LIG-9949](https://linear.app/lightly/issue/LIG-9949/apply-class-enforced-colors-to-classification-ui). Applies the centralized `enforceColoringByClass` setting to classification UI, mirroring the existing behavior in the annotation canvas and annotation collections menu.

* **Classification pills** now use annotation class colors (not source colors) when Enforce Coloring by Class is enabled, via `resolveEffectiveColorBySource` in `getSampleClassificationPills`
* **Source group color markers** in the classification segment are hidden when enforcement is on (`showColorMarker={colorBySource}`)
* **Classification rows** show an `AnnotationColorLegend` when not coloring by source, aligning visually with annotation rows
* Added `data-testid` to `SampleDetailsAnnotationSourceGroup`'s `ColorMarker` for testability (consistent with `MenuItem.svelte`)

## Test plan

- [X] All 1702 frontend tests pass (`make test`)
- [X] Static checks pass (`make static-checks`)
- [X] With a single annotation source: classification rows show class color legend, no source groups
- [X] With multiple annotation sources and **Enforce Coloring by Class off**: source group headers show color markers, rows have no color legend
- [X] With multiple annotation sources and **Enforce Coloring by Class on**: source group headers have no color markers, rows show class color legends; classification pills use class colors and deduplicate across sources

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

## Summary by CodeRabbit

* **New Features**
  * Added an “enforce coloring by class” setting that adjusts classification pill color/title behavior when multiple sources are selected, including deduplication and class-based naming/coloring.
  * Updated sample details coloring behavior so per-source color markers and legends render conditionally based on the effective coloring mode.
* **Tests**
  * Expanded unit test coverage for the new enforcement rules, including pill computation and conditional rendering of source color markers.
  * Improved test targeting with more specific marker test IDs.