### PR TITLE
Add EvaluationMetricExpr query translation

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -16,6 +16,7 @@ from lightly_studio.core.dataset_query.classification_expression import (
     ClassificationField,
     ClassificationQuery,
 )
+from lightly_studio.core.dataset_query.evaluation_metric_expression import EvaluationMetricField
 from lightly_studio.core.dataset_query.field import Field
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
@@ -41,6 +42,7 @@ from lightly_studio.models.query_expr import (
     DatetimeExpr,
     EqualityComparisonOperator,
     EqualityFloatExpr,
+    EvaluationMetricExpr,
     FieldRef,
     IntegerExpr,
     MatchExpr,
@@ -234,8 +236,15 @@ def evaluation_metric_sort_to_order_by(
     return order_by
 
 
-def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 C901
+def to_match_expression(expr: MatchExpr) -> MatchExpression:
     """Translate a validated query-language expression to a dataset-query expression."""
+    return _to_match_expression(expr=expr, allow_sample_level_metrics=True)
+
+
+def _to_match_expression(  # noqa: PLR0911 PLR0912 C901
+    expr: MatchExpr, *, allow_sample_level_metrics: bool
+) -> MatchExpression:
+    """Translate a query expression with explicit sample-metric scope handling."""
     if isinstance(expr, StringExpr):
         return _apply_equality_operator(
             field=_lookup(mapping=_STRING_FIELDS, field=expr.field, type_="string"),
@@ -270,21 +279,59 @@ def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 C9
             operator=expr.operator,
             value=expr.value,
         )
+    if isinstance(expr, EvaluationMetricExpr):
+        if not allow_sample_level_metrics:
+            raise QueryExprError("evaluation_metric_expr is only valid at the sample-query level")
+        return _apply_ordinal_operator(
+            field=EvaluationMetricField(
+                run_name=expr.evaluation_run_name,
+                metric_name=expr.metric_name,
+            ),
+            operator=expr.operator,
+            value=expr.value,
+        )
     if isinstance(expr, TagsContainsExpr):
         accessor: _TagsAccessor = _lookup(mapping=_TAGS_FIELDS, field=expr.field, type_="tags")
         return accessor.contains(expr.tag_name)
     if isinstance(expr, ClassificationMatchExpr):
-        return ClassificationQuery.match(to_match_expression(expr=expr.subexpr))
+        return ClassificationQuery.match(
+            _to_match_expression(expr=expr.subexpr, allow_sample_level_metrics=False)
+        )
     if isinstance(expr, ObjectDetectionMatchExpr):
-        return ObjectDetectionQuery.match(to_match_expression(expr=expr.subexpr))
+        return ObjectDetectionQuery.match(
+            _to_match_expression(expr=expr.subexpr, allow_sample_level_metrics=False)
+        )
     if isinstance(expr, SegmentationMaskMatchExpr):
-        return SegmentationMaskQuery.match(to_match_expression(expr=expr.subexpr))
+        return SegmentationMaskQuery.match(
+            _to_match_expression(expr=expr.subexpr, allow_sample_level_metrics=False)
+        )
     if isinstance(expr, AndExpr):
-        return AND(*(to_match_expression(expr=child) for child in expr.children))
+        return AND(
+            *(
+                _to_match_expression(
+                    expr=child,
+                    allow_sample_level_metrics=allow_sample_level_metrics,
+                )
+                for child in expr.children
+            )
+        )
     if isinstance(expr, OrExpr):
-        return OR(*(to_match_expression(expr=child) for child in expr.children))
+        return OR(
+            *(
+                _to_match_expression(
+                    expr=child,
+                    allow_sample_level_metrics=allow_sample_level_metrics,
+                )
+                for child in expr.children
+            )
+        )
     if isinstance(expr, NotExpr):
-        return NOT(to_match_expression(expr=expr.child))
+        return NOT(
+            _to_match_expression(
+                expr=expr.child,
+                allow_sample_level_metrics=allow_sample_level_metrics,
+            )
+        )
     assert_never(expr)
 
 

--- a/lightly_studio/src/lightly_studio/models/query_expr.py
+++ b/lightly_studio/src/lightly_studio/models/query_expr.py
@@ -80,6 +80,16 @@ class EqualityFloatExpr(BaseModel):
     value: StrictInt | StrictFloat
 
 
+class EvaluationMetricExpr(BaseModel):
+    """Leaf node for comparisons against a persisted evaluation metric."""
+
+    type: Literal["evaluation_metric_expr"] = "evaluation_metric_expr"
+    evaluation_run_name: StrictStr
+    metric_name: StrictStr
+    operator: OrdinalComparisonOperator
+    value: StrictInt | StrictFloat
+
+
 class TagsContainsExpr(BaseModel):
     """Leaf node checking if a sample has a specific tag."""
 
@@ -137,6 +147,7 @@ MatchExpr: TypeAlias = Annotated[
         DatetimeExpr,
         OrdinalFloatExpr,
         EqualityFloatExpr,
+        EvaluationMetricExpr,
         TagsContainsExpr,
         ClassificationMatchExpr,
         ObjectDetectionMatchExpr,

--- a/lightly_studio/tests/core/dataset_query/test_query_translation__evaluation_metric.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation__evaluation_metric.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.core.dataset_query import query_translation
+from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
+from lightly_studio.errors import QueryExprError
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.evaluation_run import (
+    EvaluationRunCreate,
+    EvaluationTaskType,
+)
+from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
+from lightly_studio.models.query_expr import (
+    AndExpr,
+    ClassificationMatchExpr,
+    EvaluationMetricExpr,
+    ObjectDetectionMatchExpr,
+    OrdinalComparisonOperator,
+    SegmentationMaskMatchExpr,
+)
+from lightly_studio.resolvers import (
+    evaluation_run_resolver,
+    evaluation_sample_metric_resolver,
+)
+from tests.helpers_resolvers import create_collection, create_image
+
+
+def test_to_match_expression__evaluation_metric_sql() -> None:
+    expr = EvaluationMetricExpr(
+        evaluation_run_name="run1",
+        metric_name="miou",
+        operator=OrdinalComparisonOperator.LT,
+        value=0.3,
+    )
+
+    sql = str(
+        query_translation.to_match_expression(expr)
+        .get()
+        .compile(compile_kwargs={"literal_binds": True})
+    ).lower()
+    assert "exists (select 1" in sql
+    assert "join evaluation_run" in sql
+    assert "evaluation_run.name = 'run1'" in sql
+    assert "evaluation_sample_metric.metric_name = 'miou'" in sql
+    assert "evaluation_sample_metric.value < 0.3" in sql
+
+
+def test_to_match_expression__evaluation_metric_db(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    collection_id = dataset.collection_id
+    image_a = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="/path/to/a.jpg"
+    )
+    image_b = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="/path/to/b.jpg"
+    )
+    gt_collection = create_collection(
+        session=db_session,
+        parent_collection_id=collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        parent_collection_id=collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="semseg-eval",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            dataset_id=gt_collection.dataset_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            task_type=EvaluationTaskType.SEMANTIC_SEGMENTATION,
+        ),
+    )
+    evaluation_sample_metric_resolver.create_many(
+        session=db_session,
+        records=[
+            EvaluationSampleMetricCreate(
+                evaluation_run_id=run.id,
+                sample_id=image_a.sample_id,
+                metric_name="miou",
+                value=0.2,
+            ),
+            EvaluationSampleMetricCreate(
+                evaluation_run_id=run.id,
+                sample_id=image_b.sample_id,
+                metric_name="miou",
+                value=0.8,
+            ),
+        ],
+    )
+
+    expr = EvaluationMetricExpr(
+        evaluation_run_name=run.name,
+        metric_name="miou",
+        operator=OrdinalComparisonOperator.LT,
+        value=0.3,
+    )
+    match = query_translation.to_match_expression(expr)
+    results = DatasetQuery(dataset=dataset, session=db_session).match(match).to_list()
+
+    assert [result.sample_id for result in results] == [image_a.sample_id]
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        ClassificationMatchExpr(
+            subexpr=EvaluationMetricExpr(
+                evaluation_run_name="run1",
+                metric_name="score",
+                operator=OrdinalComparisonOperator.GT,
+                value=0.5,
+            )
+        ),
+        ObjectDetectionMatchExpr(
+            subexpr=EvaluationMetricExpr(
+                evaluation_run_name="run1",
+                metric_name="score",
+                operator=OrdinalComparisonOperator.GT,
+                value=0.5,
+            )
+        ),
+        SegmentationMaskMatchExpr(
+            subexpr=EvaluationMetricExpr(
+                evaluation_run_name="run1",
+                metric_name="score",
+                operator=OrdinalComparisonOperator.GT,
+                value=0.5,
+            )
+        ),
+    ],
+)
+def test_to_match_expression__evaluation_metric_inside_annotation_match_rejected(
+    expr: ClassificationMatchExpr | ObjectDetectionMatchExpr | SegmentationMaskMatchExpr,
+) -> None:
+    with pytest.raises(QueryExprError, match="sample-query level"):
+        query_translation.to_match_expression(expr)
+
+
+def test_to_match_expression__evaluation_metric_inside_nested_annotation_match_rejected() -> None:
+    expr = ObjectDetectionMatchExpr(
+        subexpr=AndExpr(
+            children=[
+                EvaluationMetricExpr(
+                    evaluation_run_name="run1",
+                    metric_name="score",
+                    operator=OrdinalComparisonOperator.GT,
+                    value=0.5,
+                )
+            ]
+        )
+    )
+
+    with pytest.raises(QueryExprError, match="sample-query level"):
+        query_translation.to_match_expression(expr)

--- a/lightly_studio/tests/models/test_query_expr.py
+++ b/lightly_studio/tests/models/test_query_expr.py
@@ -9,6 +9,7 @@ from lightly_studio.models.query_expr import (
     AndExpr,
     ClassificationMatchExpr,
     DatetimeExpr,
+    EvaluationMetricExpr,
     NotExpr,
     QueryExpr,
     StringExpr,
@@ -80,6 +81,22 @@ class TestQueryExpr:
         )
         assert isinstance(tree.match_expr, DatetimeExpr)
         assert tree.match_expr.value == datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    def test_model_validate__evaluation_metric_expr(self) -> None:
+        tree = QueryExpr.model_validate(
+            {
+                "match_expr": {
+                    "type": "evaluation_metric_expr",
+                    "evaluation_run_name": "cls-eval",
+                    "metric_name": "disagreement",
+                    "operator": ">=",
+                    "value": 0.8,
+                }
+            }
+        )
+        assert isinstance(tree.match_expr, EvaluationMetricExpr)
+        assert tree.match_expr.evaluation_run_name == "cls-eval"
+        assert tree.match_expr.metric_name == "disagreement"
 
     def test_model_validate__rejects_wrong_value_type(self) -> None:
         """String value is rejected where an integer is expected."""


### PR DESCRIPTION
## What has changed and why?
Needed to hook evaluation sampling Langium grammar to the DB.

## How has it been tested?
Added tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Datasets can now be filtered and queried using evaluation metrics from previous evaluation runs, supporting comparisons by metric name, run name, and numeric thresholds.
  * Evaluation metric filters are enforced at the sample-query level only; evaluation metrics within nested annotation-level expressions are explicitly rejected with validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->