### PR TITLE
Add SampleEvaluationMatchExpr model

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -271,17 +271,17 @@ def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 PL
             operator=expr.operator,
             value=expr.value,
         )
-    if isinstance(expr, ClassificationMatchExpr):
-        return ClassificationQuery.match(to_match_expression(expr=expr.subexpr))
-    if isinstance(expr, ObjectDetectionMatchExpr):
-        return ObjectDetectionQuery.match(to_match_expression(expr=expr.subexpr))
-    if isinstance(expr, SegmentationMaskMatchExpr):
-        return SegmentationMaskQuery.match(to_match_expression(expr=expr.subexpr))
-    if isinstance(expr, SampleEvaluationMatchExpr):
-        raise QueryExprError("evaluation_metric_match_expr is not yet supported")
     if isinstance(expr, TagsContainsExpr):
         accessor: _TagsAccessor = _lookup(mapping=_TAGS_FIELDS, field=expr.field, type_="tags")
         return accessor.contains(expr.tag_name)
+    if isinstance(expr, ClassificationMatchExpr):
+        return ClassificationQuery.match(_to_annotation_match_expression(expr=expr.subexpr))
+    if isinstance(expr, ObjectDetectionMatchExpr):
+        return ObjectDetectionQuery.match(_to_annotation_match_expression(expr=expr.subexpr))
+    if isinstance(expr, SegmentationMaskMatchExpr):
+        return SegmentationMaskQuery.match(_to_annotation_match_expression(expr=expr.subexpr))
+    if isinstance(expr, SampleEvaluationMatchExpr):
+        raise QueryExprError("SampleEvaluationMatchExpr is not yet supported")
     if isinstance(expr, AndExpr):
         return AND(*(to_match_expression(expr=child) for child in expr.children))
     if isinstance(expr, OrExpr):

--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -49,6 +49,7 @@ from lightly_studio.models.query_expr import (
     OrdinalComparisonOperator,
     OrdinalFloatExpr,
     OrExpr,
+    SampleEvaluationMatchExpr,
     SegmentationMaskMatchExpr,
     StringExpr,
     TagsContainsExpr,
@@ -234,7 +235,7 @@ def evaluation_metric_sort_to_order_by(
     return order_by
 
 
-def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 C901
+def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 PLR0912 C901
     """Translate a validated query-language expression to a dataset-query expression."""
     if isinstance(expr, StringExpr):
         return _apply_equality_operator(
@@ -270,22 +271,69 @@ def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 C9
             operator=expr.operator,
             value=expr.value,
         )
-    if isinstance(expr, TagsContainsExpr):
-        accessor: _TagsAccessor = _lookup(mapping=_TAGS_FIELDS, field=expr.field, type_="tags")
-        return accessor.contains(expr.tag_name)
     if isinstance(expr, ClassificationMatchExpr):
         return ClassificationQuery.match(to_match_expression(expr=expr.subexpr))
     if isinstance(expr, ObjectDetectionMatchExpr):
         return ObjectDetectionQuery.match(to_match_expression(expr=expr.subexpr))
     if isinstance(expr, SegmentationMaskMatchExpr):
         return SegmentationMaskQuery.match(to_match_expression(expr=expr.subexpr))
+    if isinstance(expr, SampleEvaluationMatchExpr):
+        raise QueryExprError("evaluation_metric_match_expr is not yet supported")
+    if isinstance(expr, TagsContainsExpr):
+        accessor: _TagsAccessor = _lookup(mapping=_TAGS_FIELDS, field=expr.field, type_="tags")
+        return accessor.contains(expr.tag_name)
     if isinstance(expr, AndExpr):
         return AND(*(to_match_expression(expr=child) for child in expr.children))
     if isinstance(expr, OrExpr):
         return OR(*(to_match_expression(expr=child) for child in expr.children))
     if isinstance(expr, NotExpr):
         return NOT(to_match_expression(expr=expr.child))
-    assert_never(expr)
+    raise RuntimeError("to_match_expression() called with the wrong type")
+
+
+def _to_annotation_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911
+    """Translate a query expression nested inside an annotation match wrapper."""
+    if isinstance(expr, StringExpr):
+        return _apply_equality_operator(
+            field=_lookup(mapping=_STRING_FIELDS, field=expr.field, type_="string"),
+            operator=expr.operator,
+            value=expr.value,
+        )
+    if isinstance(expr, IntegerExpr):
+        return _apply_ordinal_operator(
+            field=_lookup(mapping=_INTEGER_FIELDS, field=expr.field, type_="integer"),
+            operator=expr.operator,
+            value=expr.value,
+        )
+    if isinstance(expr, DatetimeExpr):
+        return _apply_ordinal_operator(
+            field=_lookup(mapping=_DATETIME_FIELDS, field=expr.field, type_="datetime"),
+            operator=expr.operator,
+            value=expr.value,
+        )
+    if isinstance(expr, OrdinalFloatExpr):
+        return _apply_ordinal_operator(
+            field=_lookup(
+                mapping=_ALL_ORDINAL_FLOAT_FIELDS,
+                field=expr.field,
+                type_="ordinal float",
+            ),
+            operator=expr.operator,
+            value=expr.value,
+        )
+    if isinstance(expr, EqualityFloatExpr):
+        return _apply_equality_operator(
+            field=_lookup(mapping=_EQUALITY_FLOAT_FIELDS, field=expr.field, type_="equality float"),
+            operator=expr.operator,
+            value=expr.value,
+        )
+    if isinstance(expr, AndExpr):
+        return AND(*(_to_annotation_match_expression(expr=child) for child in expr.children))
+    if isinstance(expr, OrExpr):
+        return OR(*(_to_annotation_match_expression(expr=child) for child in expr.children))
+    if isinstance(expr, NotExpr):
+        return NOT(_to_annotation_match_expression(expr=expr.child))
+    raise RuntimeError("_to_annotation_match_expression() called with the wrong type")
 
 
 def _apply_equality_operator(

--- a/lightly_studio/src/lightly_studio/models/query_expr.py
+++ b/lightly_studio/src/lightly_studio/models/query_expr.py
@@ -80,6 +80,14 @@ class EqualityFloatExpr(BaseModel):
     value: StrictInt | StrictFloat
 
 
+class SampleEvaluationMatchExpr(BaseModel):
+    """Wrapper node checking whether a sample matches evaluation criteria."""
+
+    type: Literal["evaluation_metric_match_expr"] = "evaluation_metric_match_expr"
+    evaluation_run_name: StrictStr
+    subexpr: MatchExpr
+
+
 class TagsContainsExpr(BaseModel):
     """Leaf node checking if a sample has a specific tag."""
 
@@ -137,6 +145,7 @@ MatchExpr: TypeAlias = Annotated[
         DatetimeExpr,
         OrdinalFloatExpr,
         EqualityFloatExpr,
+        SampleEvaluationMatchExpr,
         TagsContainsExpr,
         ClassificationMatchExpr,
         ObjectDetectionMatchExpr,
@@ -150,6 +159,7 @@ MatchExpr: TypeAlias = Annotated[
 
 
 # Rebuild models with recursive references between them.
+SampleEvaluationMatchExpr.model_rebuild()
 ClassificationMatchExpr.model_rebuild()
 ObjectDetectionMatchExpr.model_rebuild()
 SegmentationMaskMatchExpr.model_rebuild()

--- a/lightly_studio/tests/core/dataset_query/test_query_translation.py
+++ b/lightly_studio/tests/core/dataset_query/test_query_translation.py
@@ -22,6 +22,7 @@ from lightly_studio.models.query_expr import (
     OrdinalComparisonOperator,
     OrdinalFloatExpr,
     OrExpr,
+    SampleEvaluationMatchExpr,
     SegmentationMaskMatchExpr,
     StringExpr,
     TagsContainsExpr,
@@ -170,6 +171,20 @@ def test_to_match_expression__equality_float_unknown_field() -> None:
         value=1.0,
     )
     with pytest.raises(QueryExprError, match="Unknown equality float field"):
+        query_translation.to_match_expression(expr)
+
+
+def test_to_match_expression__sample_evaluation_match_rejected() -> None:
+    expr = SampleEvaluationMatchExpr(
+        evaluation_run_name="run1",
+        # TODO(lukas 6/2026): this is not a query that will be actually possible.
+        subexpr=IntegerExpr(
+            field=FieldRef(table="image", name="width"),
+            operator=OrdinalComparisonOperator.GTE,
+            value=128,
+        ),
+    )
+    with pytest.raises(QueryExprError, match="not yet supported"):
         query_translation.to_match_expression(expr)
 
 

--- a/lightly_studio/tests/models/test_query_expr.py
+++ b/lightly_studio/tests/models/test_query_expr.py
@@ -11,6 +11,7 @@ from lightly_studio.models.query_expr import (
     DatetimeExpr,
     NotExpr,
     QueryExpr,
+    SampleEvaluationMatchExpr,
     StringExpr,
 )
 
@@ -80,6 +81,25 @@ class TestQueryExpr:
         )
         assert isinstance(tree.match_expr, DatetimeExpr)
         assert tree.match_expr.value == datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    def test_model_validate__sample_evaluation_match_expr(self) -> None:
+        tree = QueryExpr.model_validate(
+            {
+                "match_expr": {
+                    "type": "evaluation_metric_match_expr",
+                    "evaluation_run_name": "cls-eval",
+                    # TODO(lukas 6/2026): this is not a query that will be actually possible.
+                    "subexpr": {
+                        "type": "integer_expr",
+                        "field": {"table": "image", "name": "width"},
+                        "operator": ">=",
+                        "value": 128,
+                    },
+                }
+            }
+        )
+        assert isinstance(tree.match_expr, SampleEvaluationMatchExpr)
+        assert tree.match_expr.evaluation_run_name == "cls-eval"
 
     def test_model_validate__rejects_wrong_value_type(self) -> None:
         """String value is rejected where an integer is expected."""


### PR DESCRIPTION
## What has changed and why?
Important piece towards having sample evaluation query expressions, i.e. this is the part of the (future) query corresponding to `sample_evaluation(...)`. The three dots will be in `SampleEvaluationMatchExpr.subexpr`, which will come in a later PR.
    
`_to_annotation_match_expression()` has been factored out of `to_match_expression()`.

## How has it been tested?
Added tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for parsing “evaluation metric match” expressions in query expression models, including evaluation run name and nested criteria.

* **Bug Fixes**
  * Query translation now clearly rejects “evaluation metric match” expressions with a “not yet supported” error.
  * Improved translation of boolean annotation match expressions (AND/OR/NOT) for consistent recursive handling.

* **Tests**
  * Added coverage to confirm the new model parses correctly and that translation fails for both direct and nested “evaluation metric match” cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->