### PR TITLE
feat: add top-N class selection for large confusion matrices

### DIFF
--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ClassSetDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ClassSetDialog.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+    import { Check as CheckIcon } from '@lucide/svelte';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+    import * as Command from '$lib/components/ui/command/index.js';
+    import * as Dialog from '$lib/components/ui/dialog/index.js';
+    import { Input } from '$lib/components/ui/input/index.js';
+    import { Slider } from '$lib/components/ui/slider/index.js';
+    import * as Tabs from '$lib/components/ui/tabs/index.js';
+    import { cn } from '$lib/utils';
+    import {
+        CLASS_SORT_LABELS,
+        type ClassSetConfig,
+        type ClassSortOption,
+        type ColorConfig
+    } from './topNMatrix';
+
+    interface Props {
+        open: boolean;
+        allClasses: string[];
+        config: ClassSetConfig;
+        color: ColorConfig;
+        onApply: (config: ClassSetConfig, color: ColorConfig) => void;
+    }
+
+    let { open = $bindable(), allClasses, config, color, onApply }: Props = $props();
+
+    // Draft state, synced from the applied config every time the dialog opens.
+    let draft: ClassSetConfig = $state({ ...config });
+    let colorDraft: ColorConfig = $state({ ...color });
+    $effect(() => {
+        if (open) {
+            draft = { ...config, manualClasses: [...config.manualClasses] };
+            colorDraft = { ...color };
+        }
+    });
+
+    const sortOptions = Object.keys(CLASS_SORT_LABELS) as ClassSortOption[];
+
+    const toggleManual = (className: string) => {
+        draft.manualClasses = draft.manualClasses.includes(className)
+            ? draft.manualClasses.filter((c) => c !== className)
+            : [...draft.manualClasses, className];
+    };
+
+    const apply = () => {
+        onApply(
+            { ...draft, n: Math.min(Math.max(draft.n, 1), allClasses.length) },
+            { ...colorDraft }
+        );
+        open = false;
+    };
+</script>
+
+<Dialog.Root bind:open>
+    <Dialog.Content class="max-w-[420px]">
+        <Dialog.Header>
+            <Dialog.Title>Configure classes</Dialog.Title>
+            <Dialog.Description>
+                Choose which classes the confusion matrix shows.
+            </Dialog.Description>
+        </Dialog.Header>
+        <Tabs.Root bind:value={draft.mode}>
+            <Tabs.List class="grid w-full grid-cols-2">
+                <Tabs.Trigger value="topN">Top N</Tabs.Trigger>
+                <Tabs.Trigger value="manual">Manual</Tabs.Trigger>
+            </Tabs.List>
+            <Tabs.Content value="topN" class="space-y-3 pt-2">
+                <label class="flex items-center justify-between gap-2 text-sm">
+                    Number of classes
+                    <Input
+                        type="number"
+                        min={1}
+                        max={allClasses.length}
+                        bind:value={draft.n}
+                        class="h-8 w-24"
+                        data-testid="class-set-top-n"
+                    />
+                </label>
+                <label class="flex items-center justify-between gap-2 text-sm">
+                    Sort by
+                    <select
+                        bind:value={draft.sortBy}
+                        class="h-8 rounded-md border bg-background px-2 text-sm"
+                        data-testid="class-set-sort-by"
+                    >
+                        {#each sortOptions as option (option)}
+                            <option value={option}>{CLASS_SORT_LABELS[option]}</option>
+                        {/each}
+                    </select>
+                </label>
+            </Tabs.Content>
+            <Tabs.Content value="manual" class="pt-2">
+                <div class="mb-1 flex items-center justify-between">
+                    <span class="text-xs text-muted-foreground">
+                        {draft.manualClasses.length} of {allClasses.length} selected
+                    </span>
+                    <div class="flex gap-1">
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            class="h-6 px-2 text-xs"
+                            onclick={() => (draft.manualClasses = [...allClasses])}
+                        >
+                            Select all
+                        </Button>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            class="h-6 px-2 text-xs"
+                            onclick={() => (draft.manualClasses = [])}
+                        >
+                            Clear
+                        </Button>
+                    </div>
+                </div>
+                <Command.Root class="rounded-md border">
+                    <Command.Input placeholder="Search classes..." data-testid="class-set-search" />
+                    <Command.List class="max-h-[220px] dark:[color-scheme:dark]">
+                        <Command.Empty>No class found.</Command.Empty>
+                        {#each allClasses as className (className)}
+                            <Command.Item
+                                value={className}
+                                onSelect={() => toggleManual(className)}
+                            >
+                                <CheckIcon
+                                    class={cn(
+                                        !draft.manualClasses.includes(className) &&
+                                            'text-transparent'
+                                    )}
+                                />
+                                <span class="min-w-0 flex-1 truncate">{className}</span>
+                            </Command.Item>
+                        {/each}
+                    </Command.List>
+                </Command.Root>
+            </Tabs.Content>
+        </Tabs.Root>
+        <div class="space-y-3 border-t pt-3">
+            <div class="text-sm font-medium">Coloring</div>
+            <div>
+                <div class="mb-2 flex items-center justify-between">
+                    <span class="text-xs text-muted-foreground">Color intensity</span>
+                    <span class="text-xs tabular-nums text-muted-foreground">
+                        {colorDraft.intensity.toFixed(1)}×
+                    </span>
+                </div>
+                <Slider
+                    type="single"
+                    bind:value={colorDraft.intensity}
+                    min={0.2}
+                    max={3}
+                    step={0.1}
+                    data-testid="color-intensity-slider"
+                />
+            </div>
+            <label class="flex items-center gap-2 text-sm">
+                <Checkbox
+                    bind:checked={colorDraft.logScale}
+                    data-testid="color-log-scale-checkbox"
+                />
+                <div class="flex flex-col">
+                    Logarithmic coloring
+                    <span class="text-xs text-muted-foreground">
+                        (keeps small counts visible next to large ones)
+                    </span>
+                </div>
+            </label>
+        </div>
+        <Dialog.Footer>
+            <Button variant="ghost" onclick={() => (open = false)}>Cancel</Button>
+            <Button
+                onclick={apply}
+                disabled={draft.mode === 'manual' && draft.manualClasses.length === 0}
+                data-testid="class-set-apply"
+            >
+                Apply
+            </Button>
+        </Dialog.Footer>
+    </Dialog.Content>
+</Dialog.Root>

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/CombinedConfusionMatrix.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/CombinedConfusionMatrix.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+    import { Maximize2 as Maximize2Icon, Settings as SettingsIcon } from '@lucide/svelte';
+    import { Button } from '$lib/components';
+    import * as Dialog from '$lib/components/ui/dialog/index.js';
+    import ConfusionMatrix from './ConfusionMatrix.svelte';
+    import type { ConfusionMatrix as ConfusionMatrixData } from './types';
+    import ClassSetDialog from './ClassSetDialog.svelte';
+    import {
+        buildSubMatrix,
+        CLASS_SORT_LABELS,
+        getRealClasses,
+        rankClasses,
+        type ClassSetConfig,
+        type ColorConfig
+    } from './topNMatrix';
+
+    interface Props {
+        matrix: ConfusionMatrixData;
+        /** Number of most-confused classes shown by default. */
+        topN?: number;
+        /** Below this class count the full matrix is shown unchanged. */
+        classCountThreshold?: number;
+        showLegend?: boolean;
+    }
+
+    const { matrix, topN = 5, classCountThreshold = 30, showLegend = false }: Props = $props();
+
+    let config: ClassSetConfig = $state({
+        mode: 'topN',
+        n: topN,
+        sortBy: 'most-confused',
+        manualClasses: []
+    });
+    let color: ColorConfig = $state({ intensity: 1, logScale: true });
+    let configDialogOpen = $state(false);
+    let expandOpen = $state(false);
+
+    const realClasses = $derived(getRealClasses(matrix));
+    const isLarge = $derived(realClasses.length > classCountThreshold);
+    const baseClasses = $derived(
+        config.mode === 'topN'
+            ? rankClasses(matrix, config.sortBy).slice(0, config.n)
+            : config.manualClasses
+    );
+    const visibleClasses = $derived(realClasses.filter((c) => baseClasses.includes(c)));
+    const subMatrix = $derived(buildSubMatrix(matrix, visibleClasses));
+
+    const applyConfig = (nextConfig: ClassSetConfig, nextColor: ColorConfig) => {
+        config = nextConfig;
+        color = nextColor;
+    };
+</script>
+
+{#if !isLarge}
+    <ConfusionMatrix {matrix} {showLegend} />
+{:else}
+    <!-- Row 1: controls -->
+    <div class="mb-1 flex flex-row items-center gap-2">
+        <!-- Row 2: explanation of the current view -->
+        <div class="mb-2 flex-1 text-xs text-muted-foreground">
+            {#if config.mode === 'topN'}
+                Top {config.n} of {realClasses.length} classes · sorted by {CLASS_SORT_LABELS[
+                    config.sortBy
+                ].toLowerCase()}
+            {:else}
+                Manual selection · {visibleClasses.length} of {realClasses.length} classes
+            {/if}
+            {#if visibleClasses.length < realClasses.length}
+                · rest aggregated as “(other)”
+            {/if}
+            {#if color.intensity !== 1 || !color.logScale}
+                · {color.logScale ? 'log' : 'linear'} coloring at {color.intensity.toFixed(1)}×
+            {/if}
+        </div>
+        <Button
+            variant="ghost"
+            icon={SettingsIcon}
+            buttonProps={{
+                size: 'sm',
+                class: 'h-8 gap-1',
+                onclick: () => (configDialogOpen = true),
+                'data-testid': 'confusion-matrix-configure'
+            }}
+        />
+        <Button
+            variant="ghost"
+            icon={Maximize2Icon}
+            ariaLabel="Expand confusion matrix"
+            buttonProps={{
+                size: 'sm',
+                class: 'h-8 w-8 p-0',
+                onclick: () => (expandOpen = true),
+                'data-testid': 'confusion-matrix-expand'
+            }}
+        />
+    </div>
+
+    <ConfusionMatrix
+        matrix={subMatrix}
+        {showLegend}
+        colorIntensity={color.intensity}
+        logScale={color.logScale}
+    />
+    <ClassSetDialog
+        bind:open={configDialogOpen}
+        allClasses={realClasses}
+        {config}
+        {color}
+        onApply={applyConfig}
+    />
+    <Dialog.Root bind:open={expandOpen}>
+        <Dialog.Content class="flex h-[92vh] max-w-[94vw] flex-col sm:max-w-[94vw]">
+            <Dialog.Header>
+                <Dialog.Title>Confusion matrix</Dialog.Title>
+                <Dialog.Description>
+                    Scroll or pinch inside the chart to zoom · hover a cell for details
+                </Dialog.Description>
+            </Dialog.Header>
+            <div class="min-h-0 flex-1 overflow-y-auto">
+                <ConfusionMatrix
+                    matrix={subMatrix}
+                    {showLegend}
+                    colorIntensity={color.intensity}
+                    logScale={color.logScale}
+                    zoomable
+                />
+            </div>
+        </Dialog.Content>
+    </Dialog.Root>
+{/if}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.stories.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.stories.svelte
@@ -10,7 +10,15 @@
 </script>
 
 <script lang="ts">
-    import { empty, large20Classes, medium8Classes, singleClass, small3Classes } from './fixtures';
+    import CombinedConfusionMatrix from './CombinedConfusionMatrix.svelte';
+    import {
+        coco80Classes,
+        empty,
+        large20Classes,
+        medium8Classes,
+        singleClass,
+        small3Classes
+    } from './fixtures';
 </script>
 
 <Story name="Small (3 classes)" args={{ matrix: small3Classes }} />
@@ -24,3 +32,13 @@
 <Story name="Single class" args={{ matrix: singleClass }} />
 
 <Story name="With legend" args={{ matrix: medium8Classes, showLegend: true }} />
+
+<!--
+  CombinedConfusionMatrix: shows the full matrix for small class counts and
+  switches to top-N + "(other)" aggregation for large ones.
+-->
+<Story name="Combined — large (80 classes, top-N)">
+    {#snippet template(args)}
+        <CombinedConfusionMatrix {...args} matrix={coco80Classes} showLegend={true} />
+    {/snippet}
+</Story>

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
@@ -2,7 +2,12 @@
     import { onDestroy } from 'svelte';
     import * as echarts from 'echarts/core';
     import { HeatmapChart } from 'echarts/charts';
-    import { GridComponent, TooltipComponent, VisualMapComponent } from 'echarts/components';
+    import {
+        DataZoomInsideComponent,
+        GridComponent,
+        TooltipComponent,
+        VisualMapComponent
+    } from 'echarts/components';
     import { CanvasRenderer } from 'echarts/renderers';
     import { buildEchartsOption } from './buildEchartsOption';
     import ConfusionMatrixLegend from './ConfusionMatrixLegend.svelte';
@@ -13,15 +18,28 @@
         TooltipComponent,
         VisualMapComponent,
         GridComponent,
+        DataZoomInsideComponent,
         CanvasRenderer
     ]);
 
     interface Props {
         matrix: ConfusionMatrix;
         showLegend?: boolean;
+        /** Enables inside (scroll/pinch) zoom on both axes. */
+        zoomable?: boolean;
+        /** Color intensity multiplier (> 0, default 1). */
+        colorIntensity?: number;
+        /** Map color from log10(count) instead of the raw count (default true). */
+        logScale?: boolean;
     }
 
-    const { matrix, showLegend = false }: Props = $props();
+    const {
+        matrix,
+        showLegend = false,
+        zoomable = false,
+        colorIntensity = 1,
+        logScale = true
+    }: Props = $props();
 
     let container: HTMLDivElement | undefined = $state();
     let chart: echarts.ECharts | null = $state(null);
@@ -48,7 +66,7 @@
 
     $effect(() => {
         if (!chart) return;
-        chart.setOption(buildEchartsOption(matrix), true);
+        chart.setOption(buildEchartsOption(matrix, { zoomable, colorIntensity, logScale }), true);
     });
 
     onDestroy(() => chart?.dispose());
@@ -66,6 +84,6 @@
         data-testid="confusion-matrix"
     ></div>
     {#if showLegend}
-        <ConfusionMatrixLegend {maxCount} />
+        <ConfusionMatrixLegend {maxCount} {logScale} />
     {/if}
 {/if}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.test.ts
@@ -7,7 +7,8 @@ vi.mock('echarts/core', () => ({
     init: vi.fn(() => ({
         setOption: vi.fn(),
         resize: vi.fn(),
-        dispose: vi.fn()
+        dispose: vi.fn(),
+        on: vi.fn()
     })),
     use: vi.fn()
 }));
@@ -15,7 +16,8 @@ vi.mock('echarts/charts', () => ({ HeatmapChart: {} }));
 vi.mock('echarts/components', () => ({
     TooltipComponent: {},
     VisualMapComponent: {},
-    GridComponent: {}
+    GridComponent: {},
+    DataZoomInsideComponent: {}
 }));
 vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
 

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixLegend.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixLegend.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
     interface Props {
         maxCount: number;
+        logScale?: boolean;
     }
 
-    const { maxCount }: Props = $props();
+    const { maxCount, logScale = true }: Props = $props();
 
     const TP_ALPHAS = [0.15, 0.3, 0.5, 0.7, 0.95];
     const FP_FN_ALPHAS = [0.15, 0.3, 0.5, 0.7, 0.95];
@@ -44,6 +45,7 @@
     </div>
 
     <span class="text-muted-foreground/70">
-        Color intensity scales with cell count. Hover for breakdown.
+        Color intensity scales {logScale ? 'logarithmically' : 'linearly'} with cell count. Hover for
+        breakdown.
     </span>
 </div>

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.test.ts
@@ -3,10 +3,15 @@ import { buildEchartsOption } from './buildEchartsOption';
 import { empty, singleClass, small3Classes } from './fixtures';
 import { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL, type ConfusionMatrix } from './types';
 
-type Cell = [string, string, number];
+type Cell = [string, string, number, number];
+
+function cell(col: string, row: string, count: number): Cell {
+    return [col, row, count, Math.log10(count)];
+}
 
 interface VisualMap {
     seriesIndex: number;
+    dimension: number;
     min: number;
     max: number;
     inRange: { color: [string, string] };
@@ -49,9 +54,9 @@ describe('buildEchartsOption', () => {
         // The sentinel/sentinel cell (FP-row, FN-col) is 0 and must be skipped.
         expect(new Set(tpSeries.data)).toEqual(
             new Set<Cell>([
-                ['bike', 'bike', 42],
-                ['car', 'car', 88],
-                ['person', 'person', 156]
+                cell('bike', 'bike', 42),
+                cell('car', 'car', 88),
+                cell('person', 'person', 156)
             ])
         );
     });
@@ -98,20 +103,42 @@ describe('buildEchartsOption', () => {
         const option = build(matrix);
         expect(option.series[0].data).toEqual([]);
         expect(option.series[1].data).toEqual([
-            [NO_GROUND_TRUTH_ROW_LABEL, NO_GROUND_TRUTH_ROW_LABEL, 9]
+            cell(NO_GROUND_TRUTH_ROW_LABEL, NO_GROUND_TRUTH_ROW_LABEL, 9)
         ]);
     });
 
-    it('sets both visualMaps to share the same max count, with min fixed at 1', () => {
+    it('maps color from the log dimension with a shared log-scaled range', () => {
         const option = build(small3Classes);
         const [tpMap, fpFnMap] = option.visualMap;
         // small3Classes' largest cell is 156 (person→person).
-        expect(tpMap.min).toBe(1);
-        expect(tpMap.max).toBe(156);
-        expect(fpFnMap.min).toBe(1);
-        expect(fpFnMap.max).toBe(156);
+        expect(tpMap.dimension).toBe(3);
+        expect(tpMap.min).toBe(0);
+        expect(tpMap.max).toBe(Math.log10(156));
+        expect(fpFnMap.dimension).toBe(3);
+        expect(fpFnMap.min).toBe(0);
+        expect(fpFnMap.max).toBe(Math.log10(156));
         expect(tpMap.seriesIndex).toBe(0);
         expect(fpFnMap.seriesIndex).toBe(1);
+    });
+
+    it('maps color from the raw count dimension when logScale is disabled', () => {
+        const option = buildEchartsOption(small3Classes, {
+            logScale: false
+        }) as unknown as BuiltOption;
+        const [tpMap, fpFnMap] = option.visualMap;
+        expect(tpMap.dimension).toBe(2);
+        expect(tpMap.min).toBe(1);
+        expect(tpMap.max).toBe(156);
+        expect(fpFnMap.dimension).toBe(2);
+        expect(fpFnMap.max).toBe(156);
+    });
+
+    it('divides the visualMap range by colorIntensity so cells saturate earlier', () => {
+        const option = buildEchartsOption(small3Classes, {
+            colorIntensity: 2
+        }) as unknown as BuiltOption;
+        expect(option.visualMap[0].max).toBe(Math.log10(156) / 2);
+        expect(option.visualMap[1].max).toBe(Math.log10(156) / 2);
     });
 
     it('keeps max at 1 when every cell is empty so visualMap stays valid', () => {
@@ -124,18 +151,18 @@ describe('buildEchartsOption', () => {
 
     it('handles the single-class fixture: one TP cell plus sentinel-involving FP/FN cells', () => {
         const option = build(singleClass);
-        expect(option.series[0].data).toEqual([['person', 'person', 142]]);
+        expect(option.series[0].data).toEqual([cell('person', 'person', 142)]);
         expect(new Set(option.series[1].data)).toEqual(
             new Set<Cell>([
-                [NO_PREDICTION_COL_LABEL, 'person', 18],
-                ['person', NO_GROUND_TRUTH_ROW_LABEL, 11]
+                cell(NO_PREDICTION_COL_LABEL, 'person', 18),
+                cell('person', NO_GROUND_TRUTH_ROW_LABEL, 11)
             ])
         );
     });
 
     it('renders a tooltip with GT, Pred, and Count from the cell value', () => {
         const option = build(small3Classes);
-        const html = option.tooltip.formatter({ value: ['car', 'bike', 3] });
+        const html = option.tooltip.formatter({ value: cell('car', 'bike', 3) });
         expect(html).toContain('GT: <b>bike</b>');
         expect(html).toContain('Pred: <b>car</b>');
         expect(html).toContain('Count: <b>3</b>');

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
@@ -5,15 +5,36 @@ const TP_COLOR_RAMP: [string, string] = ['rgba(34,197,94,0.15)', 'rgba(34,197,94
 const FP_FN_COLOR_RAMP: [string, string] = ['rgba(239,68,68,0.15)', 'rgba(239,68,68,0.95)'];
 const SENTINEL_LABELS = new Set<string>([NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL]);
 
+interface BuildEchartsOptionOptions {
+    /** Enables inside (scroll/pinch) zoom on both axes. */
+    zoomable?: boolean;
+    /**
+     * Color intensity multiplier (> 0, default 1). Values > 1 saturate
+     * cells earlier (more intense); values < 1 keep cells paler.
+     */
+    colorIntensity?: number;
+    /**
+     * Map color from log10(count) instead of the raw count (default true).
+     * Log scaling keeps small counts visible next to huge diagonal cells.
+     */
+    logScale?: boolean;
+}
+
 // TP and FP/FN are split into two series with separate visualMaps so each
 // can use its own color ramp (ECharts can't color cells in a single heatmap
 // series along two scales).
-export function buildEchartsOption(matrix: ConfusionMatrix): EChartsCoreOption {
+export function buildEchartsOption(
+    matrix: ConfusionMatrix,
+    options: BuildEchartsOptionOptions = {}
+): EChartsCoreOption {
     const xLabels = matrix.col_labels;
     const yLabels = [...matrix.row_labels].reverse();
 
-    const tpData: [string, string, number][] = [];
-    const fpFnData: [string, string, number][] = [];
+    // Cells carry [pred, gt, count, log10(count)]. Color maps to the log
+    // dimension so a few huge cells don't wash out all smaller counts;
+    // tooltips still read the raw count.
+    const tpData: [string, string, number, number][] = [];
+    const fpFnData: [string, string, number, number][] = [];
     let maxCount = 1;
 
     for (let i = 0; i < matrix.row_labels.length; i++) {
@@ -26,13 +47,29 @@ export function buildEchartsOption(matrix: ConfusionMatrix): EChartsCoreOption {
             const isTrueClassPair =
                 !SENTINEL_LABELS.has(rowLabel) && !SENTINEL_LABELS.has(colLabel);
             const isTp = isTrueClassPair && rowLabel === colLabel;
-            (isTp ? tpData : fpFnData).push([colLabel, rowLabel, count]);
+            (isTp ? tpData : fpFnData).push([colLabel, rowLabel, count, Math.log10(count)]);
         }
     }
+
+    // Falls back to 1 when all counts are <= 1 so the visualMap range stays valid.
+    const logMaxCount = maxCount > 1 ? Math.log10(maxCount) : 1;
+    // Dividing the range by the intensity makes cells hit full color sooner.
+    const colorIntensity = Math.max(options.colorIntensity ?? 1, 0.01);
+    const logScale = options.logScale ?? true;
+    // Dimension 3 is log10(count), dimension 2 the raw count.
+    const visualMapDimension = logScale ? 3 : 2;
+    const visualMapMin = logScale ? 0 : 1;
+    const visualMapMax = (logScale ? logMaxCount : maxCount) / colorIntensity;
 
     const nameGap = 20;
     return {
         backgroundColor: 'transparent',
+        ...(options.zoomable && {
+            dataZoom: [
+                { type: 'inside', xAxisIndex: 0 },
+                { type: 'inside', yAxisIndex: 0, orient: 'vertical' }
+            ]
+        }),
         tooltip: {
             trigger: 'item',
             formatter: (params: { value: [string, string, number] }) => {
@@ -68,15 +105,17 @@ export function buildEchartsOption(matrix: ConfusionMatrix): EChartsCoreOption {
         visualMap: [
             {
                 seriesIndex: 0,
-                min: 1,
-                max: maxCount,
+                dimension: visualMapDimension,
+                min: visualMapMin,
+                max: visualMapMax,
                 inRange: { color: TP_COLOR_RAMP },
                 show: false
             },
             {
                 seriesIndex: 1,
-                min: 1,
-                max: maxCount,
+                dimension: visualMapDimension,
+                min: visualMapMin,
+                max: visualMapMax,
                 inRange: { color: FP_FN_COLOR_RAMP },
                 show: false
             }

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/fixtures.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/fixtures.ts
@@ -85,6 +85,49 @@ export const large20Classes: ConfusionMatrix = (() => {
     return matrix(large20RealLabels, counts);
 })();
 
+// prettier-ignore
+const coco80RealLabels = [
+    'person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat',
+    'traffic light', 'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog',
+    'horse', 'sheep', 'cow', 'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella',
+    'handbag', 'tie', 'suitcase', 'frisbee', 'skis', 'snowboard', 'sports ball', 'kite',
+    'baseball bat', 'baseball glove', 'skateboard', 'surfboard', 'tennis racket', 'bottle',
+    'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl', 'banana', 'apple', 'sandwich',
+    'orange', 'broccoli', 'carrot', 'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
+    'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote',
+    'keyboard', 'cell phone', 'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'book',
+    'clock', 'vase', 'scissors', 'teddy bear', 'hair drier', 'toothbrush'
+];
+
+/**
+ * COCO-like 80-class fixture for the large-class-count edge case (LIG-9665).
+ * Confusion is concentrated between semantically adjacent labels (|i - j| <= 2)
+ * to mimic real OD confusion clusters (e.g. car/truck/bus, fork/knife/spoon).
+ */
+export const coco80Classes: ConfusionMatrix = (() => {
+    const n = coco80RealLabels.length;
+    const rng = mulberry32(7);
+    const counts: number[][] = [];
+    for (let i = 0; i <= n; i++) {
+        const row: number[] = [];
+        for (let j = 0; j <= n; j++) {
+            if (i === n && j === n) {
+                row.push(0);
+            } else if (i === j && i < n) {
+                row.push(10 + Math.floor(rng() * 300));
+            } else if (i === n || j === n) {
+                row.push(rng() < 0.6 ? Math.floor(rng() * 25) : 0);
+            } else if (Math.abs(i - j) <= 2) {
+                row.push(rng() < 0.5 ? Math.floor(rng() * 40) : 0);
+            } else {
+                row.push(rng() < 0.04 ? Math.floor(rng() * 8) : 0);
+            }
+        }
+        counts.push(row);
+    }
+    return matrix(coco80RealLabels, counts);
+})();
+
 export const empty: ConfusionMatrix = {
     row_labels: [],
     col_labels: [],

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/index.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/index.ts
@@ -1,2 +1,3 @@
 export { default as ConfusionMatrix } from './ConfusionMatrix.svelte';
+export { default as CombinedConfusionMatrix } from './CombinedConfusionMatrix.svelte';
 export { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL } from './types';

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL } from './types';
+import {
+    buildSubMatrix,
+    getRealClasses,
+    OTHER_LABEL,
+    rankClasses,
+    rankClassesByConfusion
+} from './topNMatrix';
+
+const fixture = {
+    row_labels: ['bike', 'car', 'person', NO_GROUND_TRUTH_ROW_LABEL],
+    col_labels: ['bike', 'car', 'person', NO_PREDICTION_COL_LABEL],
+    counts: [
+        [42, 1, 2, 5],
+        [0, 88, 4, 7],
+        [3, 6, 156, 21],
+        [2, 4, 8, 0]
+    ]
+};
+
+const total = fixture.counts.flat().reduce((a, b) => a + b, 0);
+
+describe('getRealClasses', () => {
+    it('excludes sentinel labels', () => {
+        expect(getRealClasses(fixture)).toEqual(['bike', 'car', 'person']);
+    });
+});
+
+describe('rankClassesByConfusion', () => {
+    it('ranks classes by off-diagonal involvement', () => {
+        // person: row(3+6+21) + col(2+4+8) = 44; car: row(0+4+7) + col(1+6+4) = 22;
+        // bike: row(1+2+5) + col(0+3+2) = 13
+        expect(rankClassesByConfusion(fixture)).toEqual(['person', 'car', 'bike']);
+    });
+});
+
+describe('rankClasses', () => {
+    it('most-confused matches rankClassesByConfusion and least-confused reverses it', () => {
+        expect(rankClasses(fixture, 'most-confused')).toEqual(['person', 'car', 'bike']);
+        expect(rankClasses(fixture, 'least-confused')).toEqual(['bike', 'car', 'person']);
+    });
+
+    it('most-samples ranks by ground-truth row totals', () => {
+        // GT rows: bike=50, car=99, person=186
+        expect(rankClasses(fixture, 'most-samples')).toEqual(['person', 'car', 'bike']);
+    });
+
+    it('alphabetical sorts labels without mutating the source order', () => {
+        expect(rankClasses(fixture, 'alphabetical')).toEqual(['bike', 'car', 'person']);
+        expect(getRealClasses(fixture)).toEqual(['bike', 'car', 'person']);
+    });
+});
+
+describe('buildSubMatrix', () => {
+    it('keeps visible classes, aggregates the rest into other, and preserves totals', () => {
+        const sub = buildSubMatrix(fixture, ['person']);
+        expect(sub.row_labels).toEqual(['person', OTHER_LABEL, NO_GROUND_TRUTH_ROW_LABEL]);
+        expect(sub.col_labels).toEqual(['person', OTHER_LABEL, NO_PREDICTION_COL_LABEL]);
+        expect(sub.counts.flat().reduce((a, b) => a + b, 0)).toBe(total);
+        // person diagonal untouched
+        expect(sub.counts[0][0]).toBe(156);
+        // other/other aggregates bike+car block: 42+1+0+88
+        expect(sub.counts[1][1]).toBe(131);
+    });
+
+    it('omits the other row/column when all classes are visible', () => {
+        const sub = buildSubMatrix(fixture, ['bike', 'car', 'person']);
+        expect(sub).toEqual(fixture);
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix.ts
@@ -1,0 +1,110 @@
+import { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL, type ConfusionMatrix } from './types';
+
+/**
+ * Helpers for LIG-9665: client-side top-N class selection with
+ * "(other)" aggregation. Pure functions, no ECharts dependency.
+ */
+
+export const OTHER_LABEL = '(other)';
+
+const SENTINELS = new Set<string>([NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL]);
+
+/** Real class labels, excluding the sentinel no-GT/no-prediction rows. */
+export function getRealClasses(matrix: ConfusionMatrix): string[] {
+    return matrix.row_labels.filter((label) => !SENTINELS.has(label));
+}
+
+/**
+ * Ranks real classes by total off-diagonal mass they are involved in
+ * (as ground truth or prediction, including no-GT/no-prediction cells).
+ */
+export function rankClassesByConfusion(matrix: ConfusionMatrix): string[] {
+    const scores = new Map<string, number>();
+    for (let i = 0; i < matrix.row_labels.length; i++) {
+        for (let j = 0; j < matrix.col_labels.length; j++) {
+            const row = matrix.row_labels[i];
+            const col = matrix.col_labels[j];
+            const count = matrix.counts[i][j];
+            if (row === col || count <= 0) continue;
+            if (!SENTINELS.has(row)) scores.set(row, (scores.get(row) ?? 0) + count);
+            if (!SENTINELS.has(col)) scores.set(col, (scores.get(col) ?? 0) + count);
+        }
+    }
+    return getRealClasses(matrix).sort((a, b) => (scores.get(b) ?? 0) - (scores.get(a) ?? 0));
+}
+
+export type ClassSortOption = 'most-confused' | 'least-confused' | 'most-samples' | 'alphabetical';
+
+export const CLASS_SORT_LABELS: Record<ClassSortOption, string> = {
+    'most-confused': 'Most confused',
+    'least-confused': 'Least confused',
+    'most-samples': 'Most ground truth samples',
+    alphabetical: 'Alphabetical'
+};
+
+/** How the visible class set is chosen (Voxel51-style configure dialog). */
+export interface ClassSetConfig {
+    mode: 'topN' | 'manual';
+    n: number;
+    sortBy: ClassSortOption;
+    manualClasses: string[];
+}
+
+/** Coloring options configured in the same dialog. */
+export interface ColorConfig {
+    intensity: number;
+    logScale: boolean;
+}
+
+/** Ranks real classes by the given sort criterion. */
+export function rankClasses(matrix: ConfusionMatrix, sortBy: ClassSortOption): string[] {
+    switch (sortBy) {
+        case 'most-confused':
+            return rankClassesByConfusion(matrix);
+        case 'least-confused':
+            return rankClassesByConfusion(matrix).reverse();
+        case 'most-samples': {
+            const gtCounts = new Map<string, number>();
+            for (let i = 0; i < matrix.row_labels.length; i++) {
+                const label = matrix.row_labels[i];
+                if (SENTINELS.has(label)) continue;
+                gtCounts.set(
+                    label,
+                    matrix.counts[i].reduce((a, b) => a + Math.max(b, 0), 0)
+                );
+            }
+            return getRealClasses(matrix).sort(
+                (a, b) => (gtCounts.get(b) ?? 0) - (gtCounts.get(a) ?? 0)
+            );
+        }
+        case 'alphabetical':
+            return [...getRealClasses(matrix)].sort((a, b) => a.localeCompare(b));
+    }
+}
+
+/**
+ * Builds a sub-matrix containing only `visibleClasses` (in original order).
+ * Hidden classes are aggregated into an "(other)" row/column so totals are
+ * preserved. Sentinel rows/columns are always kept.
+ */
+export function buildSubMatrix(matrix: ConfusionMatrix, visibleClasses: string[]): ConfusionMatrix {
+    const visible = new Set(visibleClasses);
+    const real = getRealClasses(matrix);
+    const kept = real.filter((label) => visible.has(label));
+    const other = kept.length < real.length ? [OTHER_LABEL] : [];
+
+    const rowLabels = [...kept, ...other, NO_GROUND_TRUTH_ROW_LABEL];
+    const colLabels = [...kept, ...other, NO_PREDICTION_COL_LABEL];
+    const rowIndex = new Map(rowLabels.map((label, i) => [label, i]));
+    const colIndex = new Map(colLabels.map((label, i) => [label, i]));
+
+    const counts = rowLabels.map(() => colLabels.map(() => 0));
+    for (let i = 0; i < matrix.row_labels.length; i++) {
+        const outRow = rowIndex.get(matrix.row_labels[i]) ?? rowIndex.get(OTHER_LABEL)!;
+        for (let j = 0; j < matrix.col_labels.length; j++) {
+            const outCol = colIndex.get(matrix.col_labels[j]) ?? colIndex.get(OTHER_LABEL)!;
+            counts[outRow][outCol] += matrix.counts[i][j];
+        }
+    }
+    return { row_labels: rowLabels, col_labels: colLabels, counts };
+}


### PR DESCRIPTION
## What has changed and why?

When a confusion matrix has more than 30 classes, renders a compact
sub-matrix instead of the full (unusable) grid:
 
- CombinedConfusionMatrix: auto-switches to sub-matrix view above
  classCountThreshold (default 30). Falls through to the plain
  ConfusionMatrix for small class counts.
- topNMatrix.ts: pure functions — rankClasses (most-confused /
  least-confused / most-samples / alphabetical), buildSubMatrix
  (keeps visible classes, aggregates hidden ones into '(other)').
- ClassSetDialog: settings dialog to pick Top-N or manual class
  selection, plus log-scale / color-intensity controls.
- Expand button opens the sub-matrix in a full-screen dialog with
  pinch/scroll zoom.
- coco80Classes fixture added for the 80-class edge case.
- CombinedConfusionMatrix exported from the module index.
 
Part of LIG-9665.

## How has it been tested?

by tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration dialog for selecting and filtering classes in confusion matrices with top-N and manual selection modes.
  * Zoom, color intensity, and logarithmic/linear scaling options for improved matrix visualization.
  * Expanded modal view for large matrices with aggregated "(other)" classes for hidden selections.

* **Tests**
  * Added comprehensive test coverage for matrix configuration and filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->