### PR TITLE
Add color intensity and log scale options to confusion matrix chart

### DIFF
--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.test.ts
@@ -3,10 +3,15 @@ import { buildEchartsOption } from './buildEchartsOption';
 import { empty, singleClass, small3Classes } from './fixtures';
 import { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL, type ConfusionMatrix } from './types';
 
-type Cell = [string, string, number];
+type Cell = [string, string, number, number];
+
+function cell(col: string, row: string, count: number): Cell {
+    return [col, row, count, Math.log10(count)];
+}
 
 interface VisualMap {
     seriesIndex: number;
+    dimension: number;
     min: number;
     max: number;
     inRange: { color: [string, string] };
@@ -49,9 +54,9 @@ describe('buildEchartsOption', () => {
         // The sentinel/sentinel cell (FP-row, FN-col) is 0 and must be skipped.
         expect(new Set(tpSeries.data)).toEqual(
             new Set<Cell>([
-                ['bike', 'bike', 42],
-                ['car', 'car', 88],
-                ['person', 'person', 156]
+                cell('bike', 'bike', 42),
+                cell('car', 'car', 88),
+                cell('person', 'person', 156)
             ])
         );
     });
@@ -98,20 +103,42 @@ describe('buildEchartsOption', () => {
         const option = build(matrix);
         expect(option.series[0].data).toEqual([]);
         expect(option.series[1].data).toEqual([
-            [NO_GROUND_TRUTH_ROW_LABEL, NO_GROUND_TRUTH_ROW_LABEL, 9]
+            cell(NO_GROUND_TRUTH_ROW_LABEL, NO_GROUND_TRUTH_ROW_LABEL, 9)
         ]);
     });
 
-    it('sets both visualMaps to share the same max count, with min fixed at 1', () => {
+    it('maps color from the log dimension with a shared log-scaled range', () => {
         const option = build(small3Classes);
         const [tpMap, fpFnMap] = option.visualMap;
         // small3Classes' largest cell is 156 (person→person).
-        expect(tpMap.min).toBe(1);
-        expect(tpMap.max).toBe(156);
-        expect(fpFnMap.min).toBe(1);
-        expect(fpFnMap.max).toBe(156);
+        expect(tpMap.dimension).toBe(3);
+        expect(tpMap.min).toBe(0);
+        expect(tpMap.max).toBe(Math.log10(156));
+        expect(fpFnMap.dimension).toBe(3);
+        expect(fpFnMap.min).toBe(0);
+        expect(fpFnMap.max).toBe(Math.log10(156));
         expect(tpMap.seriesIndex).toBe(0);
         expect(fpFnMap.seriesIndex).toBe(1);
+    });
+
+    it('maps color from the raw count dimension when logScale is disabled', () => {
+        const option = buildEchartsOption(small3Classes, {
+            logScale: false
+        }) as unknown as BuiltOption;
+        const [tpMap, fpFnMap] = option.visualMap;
+        expect(tpMap.dimension).toBe(2);
+        expect(tpMap.min).toBe(1);
+        expect(tpMap.max).toBe(156);
+        expect(fpFnMap.dimension).toBe(2);
+        expect(fpFnMap.max).toBe(156);
+    });
+
+    it('divides the visualMap range by colorIntensity so cells saturate earlier', () => {
+        const option = buildEchartsOption(small3Classes, {
+            colorIntensity: 2
+        }) as unknown as BuiltOption;
+        expect(option.visualMap[0].max).toBe(Math.log10(156) / 2);
+        expect(option.visualMap[1].max).toBe(Math.log10(156) / 2);
     });
 
     it('keeps max at 1 when every cell is empty so visualMap stays valid', () => {
@@ -124,18 +151,18 @@ describe('buildEchartsOption', () => {
 
     it('handles the single-class fixture: one TP cell plus sentinel-involving FP/FN cells', () => {
         const option = build(singleClass);
-        expect(option.series[0].data).toEqual([['person', 'person', 142]]);
+        expect(option.series[0].data).toEqual([cell('person', 'person', 142)]);
         expect(new Set(option.series[1].data)).toEqual(
             new Set<Cell>([
-                [NO_PREDICTION_COL_LABEL, 'person', 18],
-                ['person', NO_GROUND_TRUTH_ROW_LABEL, 11]
+                cell(NO_PREDICTION_COL_LABEL, 'person', 18),
+                cell('person', NO_GROUND_TRUTH_ROW_LABEL, 11)
             ])
         );
     });
 
     it('renders a tooltip with GT, Pred, and Count from the cell value', () => {
         const option = build(small3Classes);
-        const html = option.tooltip.formatter({ value: ['car', 'bike', 3] });
+        const html = option.tooltip.formatter({ value: cell('car', 'bike', 3) });
         expect(html).toContain('GT: <b>bike</b>');
         expect(html).toContain('Pred: <b>car</b>');
         expect(html).toContain('Count: <b>3</b>');

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
@@ -5,15 +5,36 @@ const TP_COLOR_RAMP: [string, string] = ['rgba(34,197,94,0.15)', 'rgba(34,197,94
 const FP_FN_COLOR_RAMP: [string, string] = ['rgba(239,68,68,0.15)', 'rgba(239,68,68,0.95)'];
 const SENTINEL_LABELS = new Set<string>([NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL]);
 
+interface BuildEchartsOptionOptions {
+    /** Enables inside (scroll/pinch) zoom on both axes. */
+    zoomable?: boolean;
+    /**
+     * Color intensity multiplier (> 0, default 1). Values > 1 saturate
+     * cells earlier (more intense); values < 1 keep cells paler.
+     */
+    colorIntensity?: number;
+    /**
+     * Map color from log10(count) instead of the raw count (default true).
+     * Log scaling keeps small counts visible next to huge diagonal cells.
+     */
+    logScale?: boolean;
+}
+
 // TP and FP/FN are split into two series with separate visualMaps so each
 // can use its own color ramp (ECharts can't color cells in a single heatmap
 // series along two scales).
-export function buildEchartsOption(matrix: ConfusionMatrix): EChartsCoreOption {
+export function buildEchartsOption(
+    matrix: ConfusionMatrix,
+    options: BuildEchartsOptionOptions = {}
+): EChartsCoreOption {
     const xLabels = matrix.col_labels;
     const yLabels = [...matrix.row_labels].reverse();
 
-    const tpData: [string, string, number][] = [];
-    const fpFnData: [string, string, number][] = [];
+    // Cells carry [pred, gt, count, log10(count)]. Color maps to the log
+    // dimension so a few huge cells don't wash out all smaller counts;
+    // tooltips still read the raw count.
+    const tpData: [string, string, number, number][] = [];
+    const fpFnData: [string, string, number, number][] = [];
     let maxCount = 1;
 
     for (let i = 0; i < matrix.row_labels.length; i++) {
@@ -26,13 +47,29 @@ export function buildEchartsOption(matrix: ConfusionMatrix): EChartsCoreOption {
             const isTrueClassPair =
                 !SENTINEL_LABELS.has(rowLabel) && !SENTINEL_LABELS.has(colLabel);
             const isTp = isTrueClassPair && rowLabel === colLabel;
-            (isTp ? tpData : fpFnData).push([colLabel, rowLabel, count]);
+            (isTp ? tpData : fpFnData).push([colLabel, rowLabel, count, Math.log10(count)]);
         }
     }
+
+    // Falls back to 1 when all counts are <= 1 so the visualMap range stays valid.
+    const logMaxCount = maxCount > 1 ? Math.log10(maxCount) : 1;
+    // Dividing the range by the intensity makes cells hit full color sooner.
+    const colorIntensity = Math.max(options.colorIntensity ?? 1, 0.01);
+    const logScale = options.logScale ?? true;
+    // Dimension 3 is log10(count), dimension 2 the raw count.
+    const visualMapDimension = logScale ? 3 : 2;
+    const visualMapMin = logScale ? 0 : 1;
+    const visualMapMax = (logScale ? logMaxCount : maxCount) / colorIntensity;
 
     const nameGap = 20;
     return {
         backgroundColor: 'transparent',
+        ...(options.zoomable && {
+            dataZoom: [
+                { type: 'inside', xAxisIndex: 0 },
+                { type: 'inside', yAxisIndex: 0, orient: 'vertical' }
+            ]
+        }),
         tooltip: {
             trigger: 'item',
             formatter: (params: { value: [string, string, number] }) => {
@@ -68,15 +105,17 @@ export function buildEchartsOption(matrix: ConfusionMatrix): EChartsCoreOption {
         visualMap: [
             {
                 seriesIndex: 0,
-                min: 1,
-                max: maxCount,
+                dimension: visualMapDimension,
+                min: visualMapMin,
+                max: visualMapMax,
                 inRange: { color: TP_COLOR_RAMP },
                 show: false
             },
             {
                 seriesIndex: 1,
-                min: 1,
-                max: maxCount,
+                dimension: visualMapDimension,
+                min: visualMapMin,
+                max: visualMapMax,
                 inRange: { color: FP_FN_COLOR_RAMP },
                 show: false
             }


### PR DESCRIPTION
## What has changed and why?

Adds BuildEchartsOptionOptions interface with:
- colorIntensity: Multiplier for color saturation (default 1)
- logScale: Use log10(count) for color mapping instead of raw count (default true)
- zoomable: Enable inside zoom on both axes

Log scaling keeps small counts visible next to huge diagonal cells. Color intensity lets cells saturate earlier when needed.

this is part of functionality from https://github.com/lightly-ai/lightly-studio/pull/1460
## How has it been tested?

by test 
## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added interactive zoom controls for the confusion matrix via a new `zoomable` option.
  * Introduced optional logarithmic color scaling for the heatmap (`logScale`) to improve readability across wide ranges.
  * Added `colorIntensity` to fine-tune heatmap saturation.

* **Improvements**
  * Heatmap coloring now adapts its visual range based on the selected scaling and intensity settings.

* **Tests**
  * Updated and expanded confusion-matrix visual configuration and expectation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->