### PR TITLE
Pass color and zoom options through ConfusionMatrix component

### DIFF
--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
@@ -2,7 +2,12 @@
     import { onDestroy } from 'svelte';
     import * as echarts from 'echarts/core';
     import { HeatmapChart } from 'echarts/charts';
-    import { GridComponent, TooltipComponent, VisualMapComponent } from 'echarts/components';
+    import {
+        DataZoomInsideComponent,
+        GridComponent,
+        TooltipComponent,
+        VisualMapComponent
+    } from 'echarts/components';
     import { CanvasRenderer } from 'echarts/renderers';
     import { buildEchartsOption } from './buildEchartsOption';
     import ConfusionMatrixLegend from './ConfusionMatrixLegend.svelte';
@@ -13,15 +18,28 @@
         TooltipComponent,
         VisualMapComponent,
         GridComponent,
+        DataZoomInsideComponent,
         CanvasRenderer
     ]);
 
     interface Props {
         matrix: ConfusionMatrix;
         showLegend?: boolean;
+        /** Enables inside (scroll/pinch) zoom on both axes. */
+        zoomable?: boolean;
+        /** Color intensity multiplier (> 0, default 1). */
+        colorIntensity?: number;
+        /** Map color from log10(count) instead of the raw count (default true). */
+        logScale?: boolean;
     }
 
-    const { matrix, showLegend = false }: Props = $props();
+    const {
+        matrix,
+        showLegend = false,
+        zoomable = false,
+        colorIntensity = 1,
+        logScale = true
+    }: Props = $props();
 
     let container: HTMLDivElement | undefined = $state();
     let chart: echarts.ECharts | null = $state(null);
@@ -48,7 +66,7 @@
 
     $effect(() => {
         if (!chart) return;
-        chart.setOption(buildEchartsOption(matrix), true);
+        chart.setOption(buildEchartsOption(matrix, { zoomable, colorIntensity, logScale }), true);
     });
 
     onDestroy(() => chart?.dispose());
@@ -66,6 +84,6 @@
         data-testid="confusion-matrix"
     ></div>
     {#if showLegend}
-        <ConfusionMatrixLegend {maxCount} />
+        <ConfusionMatrixLegend {maxCount} {logScale} />
     {/if}
 {/if}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.test.ts
@@ -7,7 +7,8 @@ vi.mock('echarts/core', () => ({
     init: vi.fn(() => ({
         setOption: vi.fn(),
         resize: vi.fn(),
-        dispose: vi.fn()
+        dispose: vi.fn(),
+        on: vi.fn()
     })),
     use: vi.fn()
 }));
@@ -15,7 +16,8 @@ vi.mock('echarts/charts', () => ({ HeatmapChart: {} }));
 vi.mock('echarts/components', () => ({
     TooltipComponent: {},
     VisualMapComponent: {},
-    GridComponent: {}
+    GridComponent: {},
+    DataZoomInsideComponent: {}
 }));
 vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
 

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixLegend.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixLegend.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
     interface Props {
         maxCount: number;
+        logScale?: boolean;
     }
 
-    const { maxCount }: Props = $props();
+    const { maxCount, logScale = true }: Props = $props();
 
     const TP_ALPHAS = [0.15, 0.3, 0.5, 0.7, 0.95];
     const FP_FN_ALPHAS = [0.15, 0.3, 0.5, 0.7, 0.95];
@@ -44,6 +45,7 @@
     </div>
 
     <span class="text-muted-foreground/70">
-        Color intensity scales with cell count. Hover for breakdown.
+        Color intensity scales {logScale ? 'logarithmically' : 'linearly'} with cell count. Hover for
+        breakdown.
     </span>
 </div>

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/fixtures.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/fixtures.ts
@@ -85,6 +85,49 @@ export const large20Classes: ConfusionMatrix = (() => {
     return matrix(large20RealLabels, counts);
 })();
 
+// prettier-ignore
+const coco80RealLabels = [
+    'person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat',
+    'traffic light', 'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog',
+    'horse', 'sheep', 'cow', 'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella',
+    'handbag', 'tie', 'suitcase', 'frisbee', 'skis', 'snowboard', 'sports ball', 'kite',
+    'baseball bat', 'baseball glove', 'skateboard', 'surfboard', 'tennis racket', 'bottle',
+    'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl', 'banana', 'apple', 'sandwich',
+    'orange', 'broccoli', 'carrot', 'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
+    'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote',
+    'keyboard', 'cell phone', 'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'book',
+    'clock', 'vase', 'scissors', 'teddy bear', 'hair drier', 'toothbrush'
+];
+
+/**
+ * COCO-like 80-class fixture for the large-class-count edge case (LIG-9665).
+ * Confusion is concentrated between semantically adjacent labels (|i - j| <= 2)
+ * to mimic real OD confusion clusters (e.g. car/truck/bus, fork/knife/spoon).
+ */
+export const coco80Classes: ConfusionMatrix = (() => {
+    const n = coco80RealLabels.length;
+    const rng = mulberry32(7);
+    const counts: number[][] = [];
+    for (let i = 0; i <= n; i++) {
+        const row: number[] = [];
+        for (let j = 0; j <= n; j++) {
+            if (i === n && j === n) {
+                row.push(0);
+            } else if (i === j && i < n) {
+                row.push(10 + Math.floor(rng() * 300));
+            } else if (i === n || j === n) {
+                row.push(rng() < 0.6 ? Math.floor(rng() * 25) : 0);
+            } else if (Math.abs(i - j) <= 2) {
+                row.push(rng() < 0.5 ? Math.floor(rng() * 40) : 0);
+            } else {
+                row.push(rng() < 0.04 ? Math.floor(rng() * 8) : 0);
+            }
+        }
+        counts.push(row);
+    }
+    return matrix(coco80RealLabels, counts);
+})();
+
 export const empty: ConfusionMatrix = {
     row_labels: [],
     col_labels: [],


### PR DESCRIPTION

## What has changed and why?

Adds props to ConfusionMatrix:
- zoomable: Enable inside (scroll/pinch) zoom on both axes
- colorIntensity: Multiplier for color saturation
- logScale: Use log10(count) for color mapping

Updates ConfusionMatrixLegend to display scaling method. Adds coco80Classes fixture for testing large class counts.

this is part of https://github.com/lightly-ai/lightly-studio/pull/1460

## How has it been tested?

by tests
## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added zoom controls to confusion matrices for detailed inspection
  * Added color intensity adjustment for customizable visualization
  * Added logarithmic and linear scaling modes for color distribution
  * Enhanced legend to display the active scaling mode

* **Tests**
  * Updated test infrastructure to support new visualization controls
  * Added fixture for multi-class confusion matrix scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->