### PR TITLE
Add topNMatrix utility for ranking and filtering confused classes

### DIFF
--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/buildSubMatrix/buildSubMatrix.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/buildSubMatrix/buildSubMatrix.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL } from '../../types';
+import { buildSubMatrix } from './buildSubMatrix';
+import { OTHER_LABEL } from '../constants/constants';
+import { small3Classes } from '../../fixtures';
+
+const total = small3Classes.counts.flat().reduce((a, b) => a + b, 0);
+
+describe('buildSubMatrix', () => {
+    it('keeps visible classes, aggregates the rest into other, and preserves totals', () => {
+        const sub = buildSubMatrix(small3Classes, ['person']);
+        expect(sub.row_labels).toEqual(['person', OTHER_LABEL, NO_GROUND_TRUTH_ROW_LABEL]);
+        expect(sub.col_labels).toEqual(['person', OTHER_LABEL, NO_PREDICTION_COL_LABEL]);
+        expect(sub.counts.flat().reduce((a, b) => a + b, 0)).toBe(total);
+        // person diagonal untouched
+        expect(sub.counts[0][0]).toBe(156);
+        // other/other aggregates bike+car block: 42+1+0+88
+        expect(sub.counts[1][1]).toBe(131);
+    });
+
+    it('returns the empty matrix unchanged so the component empty-state is preserved', () => {
+        const empty = { row_labels: [], col_labels: [], counts: [] };
+        expect(buildSubMatrix(empty, [])).toBe(empty);
+    });
+
+    it('omits the other row/column when all classes are visible', () => {
+        const sub = buildSubMatrix(small3Classes, ['bike', 'car', 'person']);
+        expect(sub).toEqual(small3Classes);
+    });
+
+    it('routes a hidden real class named "(other)" into the aggregate bucket without collision', () => {
+        // Dataset where one real annotation class is literally named '(other)'.
+        const withOtherClass = {
+            row_labels: ['bike', OTHER_LABEL, NO_GROUND_TRUTH_ROW_LABEL],
+            col_labels: ['bike', OTHER_LABEL, NO_PREDICTION_COL_LABEL],
+            counts: [
+                [10, 2, 1],
+                [3, 20, 4],
+                [1, 2, 0]
+            ]
+        };
+        const inputTotal = withOtherClass.counts.flat().reduce((a, b) => a + b, 0);
+
+        // Hide the real '(other)' class; only 'bike' is visible.
+        const sub = buildSubMatrix(withOtherClass, ['bike']);
+
+        expect(sub.row_labels).toEqual(['bike', OTHER_LABEL, NO_GROUND_TRUTH_ROW_LABEL]);
+        expect(sub.col_labels).toEqual(['bike', OTHER_LABEL, NO_PREDICTION_COL_LABEL]);
+        // Grand total must be preserved.
+        expect(sub.counts.flat().reduce((a, b) => a + b, 0)).toBe(inputTotal);
+        // 'bike' diagonal is untouched.
+        expect(sub.counts[0][0]).toBe(10);
+        // The hidden real '(other)' class routes entirely into the aggregate row/col.
+        expect(sub.counts[1]).toEqual([3, 20, 4]);
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/buildSubMatrix/buildSubMatrix.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/buildSubMatrix/buildSubMatrix.ts
@@ -1,0 +1,45 @@
+import {
+    NO_GROUND_TRUTH_ROW_LABEL,
+    NO_PREDICTION_COL_LABEL,
+    type ConfusionMatrix
+} from '../../types';
+import { OTHER_LABEL } from '../constants/constants';
+import { getRealClasses } from '../getRealClasses/getRealClasses';
+
+/**
+ * Builds a sub-matrix containing only `visibleClasses` (in original order).
+ * Hidden classes are aggregated into an "(other)" row/column so totals are
+ * preserved. Sentinel rows/columns are always kept.
+ */
+export function buildSubMatrix(matrix: ConfusionMatrix, visibleClasses: string[]): ConfusionMatrix {
+    if (matrix.row_labels.length === 0) return matrix;
+
+    const visible = new Set(visibleClasses);
+    const real = getRealClasses(matrix);
+    const kept = real.filter((label) => visible.has(label));
+    const hasOther = kept.length < real.length;
+
+    const rowLabels = [...kept, ...(hasOther ? [OTHER_LABEL] : []), NO_GROUND_TRUTH_ROW_LABEL];
+    const colLabels = [...kept, ...(hasOther ? [OTHER_LABEL] : []), NO_PREDICTION_COL_LABEL];
+
+    // Index only the kept classes and sentinels — never the aggregate label — so a
+    // real class named OTHER_LABEL cannot collide with the aggregate bucket. Any
+    // input label absent from the map is a hidden class and routes to otherIdx.
+    const rowIndex = new Map<string, number>(kept.map((label, i) => [label, i]));
+    rowIndex.set(NO_GROUND_TRUTH_ROW_LABEL, rowLabels.length - 1);
+    const colIndex = new Map<string, number>(kept.map((label, i) => [label, i]));
+    colIndex.set(NO_PREDICTION_COL_LABEL, colLabels.length - 1);
+
+    const otherRowIdx = hasOther ? kept.length : -1;
+    const otherColIdx = hasOther ? kept.length : -1;
+
+    const counts = rowLabels.map(() => colLabels.map(() => 0));
+    for (let i = 0; i < matrix.row_labels.length; i++) {
+        const outRow = rowIndex.get(matrix.row_labels[i]) ?? otherRowIdx;
+        for (let j = 0; j < matrix.col_labels.length; j++) {
+            const outCol = colIndex.get(matrix.col_labels[j]) ?? otherColIdx;
+            counts[outRow][outCol] += matrix.counts[i][j];
+        }
+    }
+    return { row_labels: rowLabels, col_labels: colLabels, counts };
+}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/computeConfusionScores/computeConfusionScores.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/computeConfusionScores/computeConfusionScores.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { computeConfusionScores } from './computeConfusionScores';
+import { small3Classes } from '../../fixtures';
+
+describe('computeConfusionScores', () => {
+    it('sums off-diagonal mass per real class (as ground truth and prediction)', () => {
+        // person: row(3+6+21) + col(2+4+8) = 44; car: row(4+7) + col(1+6+4) = 22;
+        // bike: row(1+2+5) + col(3+2) = 13
+        const scores = computeConfusionScores(small3Classes);
+        expect(scores.get('person')).toBe(44);
+        expect(scores.get('car')).toBe(22);
+        expect(scores.get('bike')).toBe(13);
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/computeConfusionScores/computeConfusionScores.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/computeConfusionScores/computeConfusionScores.ts
@@ -1,0 +1,18 @@
+import type { ConfusionMatrix } from '../../types';
+import { SENTINELS } from '../constants/constants';
+
+/** Computes total off-diagonal mass per real class (used for confusion-based ranking). */
+export function computeConfusionScores(matrix: ConfusionMatrix): Map<string, number> {
+    const scores = new Map<string, number>();
+    for (let i = 0; i < matrix.row_labels.length; i++) {
+        for (let j = 0; j < matrix.col_labels.length; j++) {
+            const row = matrix.row_labels[i];
+            const col = matrix.col_labels[j];
+            const count = matrix.counts[i][j];
+            if (row === col || count <= 0) continue;
+            if (!SENTINELS.has(row)) scores.set(row, (scores.get(row) ?? 0) + count);
+            if (!SENTINELS.has(col)) scores.set(col, (scores.get(col) ?? 0) + count);
+        }
+    }
+    return scores;
+}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/constants/constants.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/constants/constants.ts
@@ -1,0 +1,21 @@
+import { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL } from '../../types';
+import type { ClassSortOption } from '../types';
+
+/**
+ * Shared constants and types: client-side top-N class selection
+ * with "(other)" aggregation. The functions in this module are pure and have
+ * no ECharts dependency.
+ */
+
+/** Aggregate bucket label for classes hidden from a filtered matrix. */
+export const OTHER_LABEL = '(other)';
+
+/** Sentinel no-ground-truth / no-prediction labels that are not real classes. */
+export const SENTINELS = new Set<string>([NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL]);
+
+export const CLASS_SORT_LABELS: Record<ClassSortOption, string> = {
+    'most-confused': 'Most confused',
+    'least-confused': 'Least confused',
+    'most-samples': 'Most ground truth samples',
+    alphabetical: 'Alphabetical'
+};

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/filterClasses/filterClasses.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/filterClasses/filterClasses.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { filterClasses } from './filterClasses';
+
+describe('filterClasses', () => {
+    const classes = ['bike', 'car', 'person', 'traffic light'];
+
+    it('matches a single term as case-insensitive substring', () => {
+        expect(filterClasses(classes, 'CAR')).toEqual(['car']);
+        expect(filterClasses(classes, 'i')).toEqual(['bike', 'traffic light']);
+    });
+
+    it('OR-combines comma-separated terms', () => {
+        expect(filterClasses(classes, 'car, bike')).toEqual(['bike', 'car']);
+        expect(filterClasses(classes, 'person,traffic')).toEqual(['person', 'traffic light']);
+    });
+
+    it('ignores empty terms and returns all classes for a blank query', () => {
+        expect(filterClasses(classes, '')).toEqual(classes);
+        expect(filterClasses(classes, ' , ,')).toEqual(classes);
+        expect(filterClasses(classes, 'car, ,')).toEqual(['car']);
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/filterClasses/filterClasses.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/filterClasses/filterClasses.ts
@@ -1,0 +1,16 @@
+/**
+ * Filters class labels by a comma-separated query. Each term is matched
+ * case-insensitively as a substring; terms are OR-combined
+ * (e.g. "car, truck" matches both "car" and "truck").
+ */
+export function filterClasses(classes: string[], query: string): string[] {
+    const terms = query
+        .split(',')
+        .map((term) => term.trim().toLowerCase())
+        .filter((term) => term.length > 0);
+    if (terms.length === 0) return classes;
+    return classes.filter((label) => {
+        const lower = label.toLowerCase();
+        return terms.some((term) => lower.includes(term));
+    });
+}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/getRealClasses/getRealClasses.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/getRealClasses/getRealClasses.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { getRealClasses } from './getRealClasses';
+import { small3Classes } from '../../fixtures';
+
+describe('getRealClasses', () => {
+    it('excludes sentinel labels', () => {
+        expect(getRealClasses(small3Classes)).toEqual(['bike', 'car', 'person']);
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/getRealClasses/getRealClasses.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/getRealClasses/getRealClasses.ts
@@ -1,0 +1,7 @@
+import type { ConfusionMatrix } from '../../types';
+import { SENTINELS } from '../constants/constants';
+
+/** Real class labels, excluding the sentinel no-GT/no-prediction rows. */
+export function getRealClasses(matrix: ConfusionMatrix): string[] {
+    return matrix.row_labels.filter((label) => !SENTINELS.has(label));
+}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/index.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/index.ts
@@ -1,0 +1,8 @@
+export { OTHER_LABEL, CLASS_SORT_LABELS } from './constants/constants';
+export { type ClassSortOption } from './types';
+export { getRealClasses } from './getRealClasses/getRealClasses';
+export { rankClassesByConfusion } from './rankClassesByConfusion/rankClassesByConfusion';
+export { rankClassesByGroundTruthSamples } from './rankClassesByGroundTruthSamples/rankClassesByGroundTruthSamples';
+export { rankClasses } from './rankClasses/rankClasses';
+export { filterClasses } from './filterClasses/filterClasses';
+export { buildSubMatrix } from './buildSubMatrix/buildSubMatrix';

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClasses/rankClasses.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClasses/rankClasses.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getRealClasses } from '../getRealClasses/getRealClasses';
+import { rankClasses } from './rankClasses';
+import { small3Classes } from '../../fixtures';
+
+describe('rankClasses', () => {
+    it('most-confused matches the confusion ranking and least-confused reverses it', () => {
+        expect(rankClasses(small3Classes, 'most-confused')).toEqual(['person', 'car', 'bike']);
+        expect(rankClasses(small3Classes, 'least-confused')).toEqual(['bike', 'car', 'person']);
+    });
+
+    it('most-samples ranks by ground-truth row totals', () => {
+        expect(rankClasses(small3Classes, 'most-samples')).toEqual(['person', 'car', 'bike']);
+    });
+
+    it('alphabetical sorts labels without mutating the source order', () => {
+        expect(rankClasses(small3Classes, 'alphabetical')).toEqual(['bike', 'car', 'person']);
+        expect(getRealClasses(small3Classes)).toEqual(['bike', 'car', 'person']);
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClasses/rankClasses.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClasses/rankClasses.ts
@@ -1,0 +1,24 @@
+import type { ConfusionMatrix } from '../../types';
+import { computeConfusionScores } from '../computeConfusionScores/computeConfusionScores';
+import { getRealClasses } from '../getRealClasses/getRealClasses';
+import { type ClassSortOption } from '../types';
+import { rankClassesByConfusion } from '../rankClassesByConfusion/rankClassesByConfusion';
+import { rankClassesByGroundTruthSamples } from '../rankClassesByGroundTruthSamples/rankClassesByGroundTruthSamples';
+
+/** Ranks real classes by the given sort criterion. */
+export function rankClasses(matrix: ConfusionMatrix, sortBy: ClassSortOption): string[] {
+    switch (sortBy) {
+        case 'most-confused':
+            return rankClassesByConfusion(matrix);
+        case 'least-confused': {
+            const scores = computeConfusionScores(matrix);
+            return getRealClasses(matrix).sort(
+                (a, b) => (scores.get(a) ?? 0) - (scores.get(b) ?? 0)
+            );
+        }
+        case 'most-samples':
+            return rankClassesByGroundTruthSamples(matrix);
+        case 'alphabetical':
+            return [...getRealClasses(matrix)].sort((a, b) => a.localeCompare(b));
+    }
+}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClassesByConfusion/rankClassesByConfusion.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClassesByConfusion/rankClassesByConfusion.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { rankClassesByConfusion } from './rankClassesByConfusion';
+import { small3Classes } from '../../fixtures';
+
+describe('rankClassesByConfusion', () => {
+    it('ranks classes by off-diagonal involvement, descending', () => {
+        // person=44, car=22, bike=13
+        expect(rankClassesByConfusion(small3Classes)).toEqual(['person', 'car', 'bike']);
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClassesByConfusion/rankClassesByConfusion.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClassesByConfusion/rankClassesByConfusion.ts
@@ -1,0 +1,12 @@
+import type { ConfusionMatrix } from '../../types';
+import { computeConfusionScores } from '../computeConfusionScores/computeConfusionScores';
+import { getRealClasses } from '../getRealClasses/getRealClasses';
+
+/**
+ * Ranks real classes by total off-diagonal mass they are involved in
+ * (as ground truth or prediction, including no-GT/no-prediction cells).
+ */
+export function rankClassesByConfusion(matrix: ConfusionMatrix): string[] {
+    const scores = computeConfusionScores(matrix);
+    return getRealClasses(matrix).sort((a, b) => (scores.get(b) ?? 0) - (scores.get(a) ?? 0));
+}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClassesByGroundTruthSamples/rankClassesByGroundTruthSamples.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClassesByGroundTruthSamples/rankClassesByGroundTruthSamples.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { rankClassesByGroundTruthSamples } from './rankClassesByGroundTruthSamples';
+import { small3Classes } from '../../fixtures';
+
+describe('rankClassesByGroundTruthSamples', () => {
+    it('ranks classes by ground-truth row totals, descending', () => {
+        // GT rows: bike=50, car=99, person=186
+        expect(rankClassesByGroundTruthSamples(small3Classes)).toEqual(['person', 'car', 'bike']);
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClassesByGroundTruthSamples/rankClassesByGroundTruthSamples.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/rankClassesByGroundTruthSamples/rankClassesByGroundTruthSamples.ts
@@ -1,0 +1,17 @@
+import type { ConfusionMatrix } from '../../types';
+import { SENTINELS } from '../constants/constants';
+import { getRealClasses } from '../getRealClasses/getRealClasses';
+
+/** Ranks real classes by total ground-truth sample count, descending. */
+export function rankClassesByGroundTruthSamples(matrix: ConfusionMatrix): string[] {
+    const gtCounts = new Map<string, number>();
+    for (let i = 0; i < matrix.row_labels.length; i++) {
+        const label = matrix.row_labels[i];
+        if (SENTINELS.has(label)) continue;
+        gtCounts.set(
+            label,
+            matrix.counts[i].reduce((a, b) => a + Math.max(b, 0), 0)
+        );
+    }
+    return getRealClasses(matrix).sort((a, b) => (gtCounts.get(b) ?? 0) - (gtCounts.get(a) ?? 0));
+}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/types.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/types.ts
@@ -1,0 +1,1 @@
+export type ClassSortOption = 'most-confused' | 'least-confused' | 'most-samples' | 'alphabetical';


### PR DESCRIPTION
## What has changed and why?

Provides utilities for building submatrices focused on top-N confused classes:
- rankClasses: Rank classes by confusion (error rate and count)
- buildSubMatrix: Extract submatrix for top-N classes
- getRealClasses, CLASS_SORT_LABELS constants
- ColorConfig and ClassSetConfig types for filtering

Used by prototype components for visualizing class confusion subsets.

this is part of https://github.com/lightly-ai/lightly-studio/pull/1460

## How has it been tested?

by tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rank confusion-matrix classes by multiple criteria: most/least confused, most ground-truth samples, or alphabetical order.
  * Search and filter classes using comma-separated, case-insensitive query terms.
  * Build sub-matrices for selected classes, automatically aggregating all other classes into an “(other)” bucket.
* **Bug Fixes**
  * Prevent label collisions when a real class is literally named “(other)”, ensuring totals and visible-class values remain correct.
* **Tests**
  * Added unit tests for ranking, filtering, sub-matrix building, and confusion score computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->