### PR TITLE
Add ConfusionMatrixPanel component with interactive class filtering

### DIFF
--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.stories.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.stories.svelte
@@ -1,0 +1,24 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import ConfusionMatrixPanel from './ConfusionMatrixPanel.svelte';
+
+    const { Story } = defineMeta({
+        title: 'Components/ConfusionMatrixPanel',
+        component: ConfusionMatrixPanel,
+        tags: ['autodocs'],
+        args: { topN: 5, showLegend: true },
+        argTypes: {
+            topN: { control: { type: 'number', min: 1, max: 80, step: 1 } }
+        }
+    });
+</script>
+
+<script lang="ts">
+    import { coco80Classes } from '../fixtures';
+</script>
+
+<Story name="Default">
+    {#snippet template(args)}
+        <ConfusionMatrixPanel {...args} matrix={coco80Classes} />
+    {/snippet}
+</Story>

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+    import ConfusionMatrix from '../ConfusionMatrix.svelte';
+    import type { ConfusionMatrix as ConfusionMatrixData } from '../types';
+    import ClassSetDialog from '../ClassSetDialog/ClassSetDialog.svelte';
+    import type { ClassSetConfig, ColorConfig } from '../ClassSetDialog/types';
+    import { buildSubMatrix, getRealClasses } from '../topNMatrix';
+    import ExpandDialog from './ExpandDialog/ExpandDialog.svelte';
+    import PanelHeader from './PanelHeader/PanelHeader.svelte';
+    import { selectVisibleClasses } from './selectVisibleClasses';
+
+    interface Props {
+        matrix: ConfusionMatrixData;
+        /** Most-confused classes shown by default. */
+        topN?: number;
+        showLegend?: boolean;
+    }
+
+    const { matrix, topN = 5, showLegend = false }: Props = $props();
+
+    let config: ClassSetConfig = $state({
+        mode: 'topN',
+        n: topN,
+        sortBy: 'most-confused',
+        manualClasses: []
+    });
+    let color: ColorConfig = $state({ intensity: 1, logScale: true });
+    let configDialogOpen = $state(false);
+    let expandOpen = $state(false);
+
+    const realClasses = $derived(getRealClasses(matrix));
+    const visibleClasses = $derived(selectVisibleClasses(matrix, config));
+    const subMatrix = $derived(buildSubMatrix(matrix, visibleClasses));
+
+    const applyConfig = (nextConfig: ClassSetConfig, nextColor: ColorConfig) => {
+        config = nextConfig;
+        color = nextColor;
+    };
+</script>
+
+<PanelHeader
+    {config}
+    {color}
+    realClassCount={realClasses.length}
+    visibleClassCount={visibleClasses.length}
+    onConfigure={() => (configDialogOpen = true)}
+    onExpand={() => (expandOpen = true)}
+/>
+<ConfusionMatrix
+    matrix={subMatrix}
+    {showLegend}
+    colorIntensity={color.intensity}
+    logScale={color.logScale}
+/>
+<ClassSetDialog
+    bind:open={configDialogOpen}
+    allClasses={realClasses}
+    {config}
+    {color}
+    onApply={applyConfig}
+/>
+<ExpandDialog bind:open={expandOpen} matrix={subMatrix} {color} {showLegend} />

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.test.ts
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import ConfusionMatrixPanel from './ConfusionMatrixPanel.svelte';
+import { coco80Classes, small3Classes } from '../fixtures';
+
+vi.mock('echarts/core', () => ({
+    init: vi.fn(() => ({
+        setOption: vi.fn(),
+        resize: vi.fn(),
+        dispose: vi.fn(),
+        on: vi.fn()
+    })),
+    use: vi.fn()
+}));
+vi.mock('echarts/charts', () => ({ HeatmapChart: {} }));
+vi.mock('echarts/components', () => ({
+    TooltipComponent: {},
+    VisualMapComponent: {},
+    GridComponent: {},
+    DataZoomInsideComponent: {}
+}));
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+
+describe('ConfusionMatrixPanel', () => {
+    it('always shows the controls, even for a small matrix', () => {
+        render(ConfusionMatrixPanel, { props: { matrix: small3Classes } });
+
+        expect(screen.getByTestId('confusion-matrix')).toBeInTheDocument();
+        expect(screen.getByTestId('confusion-matrix-configure')).toBeInTheDocument();
+        expect(screen.getByTestId('confusion-matrix-expand')).toBeInTheDocument();
+    });
+
+    it('defaults to the top-N view regardless of matrix size', () => {
+        render(ConfusionMatrixPanel, { props: { matrix: coco80Classes } });
+
+        expect(screen.getByTestId('confusion-matrix-configure')).toBeInTheDocument();
+        expect(screen.getByText(/Top 5 of 80 classes/)).toBeInTheDocument();
+    });
+
+    it('respects a custom topN value', () => {
+        render(ConfusionMatrixPanel, { props: { matrix: coco80Classes, topN: 10 } });
+
+        expect(screen.getByText(/Top 10 of 80 classes/)).toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ExpandDialog/ExpandDialog.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+    import * as Dialog from '$lib/components/ui/dialog';
+    import ConfusionMatrix from '../../ConfusionMatrix.svelte';
+    import type { ConfusionMatrix as ConfusionMatrixData } from '../../types';
+    import type { ColorConfig } from '../../ClassSetDialog/types';
+
+    interface Props {
+        open: boolean;
+        matrix: ConfusionMatrixData;
+        color: ColorConfig;
+        showLegend?: boolean;
+    }
+
+    let { open = $bindable(), matrix, color, showLegend = false }: Props = $props();
+</script>
+
+<Dialog.Root bind:open>
+    <Dialog.Content class="flex h-[92vh] max-w-[94vw] flex-col sm:max-w-[94vw]">
+        <Dialog.Header>
+            <Dialog.Title>Confusion matrix</Dialog.Title>
+            <Dialog.Description>
+                Scroll or pinch inside the chart to zoom · hover a cell for details
+            </Dialog.Description>
+        </Dialog.Header>
+        <div class="min-h-0 flex-1 overflow-y-auto">
+            <ConfusionMatrix
+                {matrix}
+                {showLegend}
+                colorIntensity={color.intensity}
+                logScale={color.logScale}
+                zoomable
+            />
+        </div>
+    </Dialog.Content>
+</Dialog.Root>

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ExpandDialog/ExpandDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ExpandDialog/ExpandDialog.test.ts
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ExpandDialog from './ExpandDialog.svelte';
+import { small3Classes } from '../../fixtures';
+import type { ColorConfig } from '../../ClassSetDialog/types';
+
+vi.mock('echarts/core', () => ({
+    init: vi.fn(() => ({
+        setOption: vi.fn(),
+        resize: vi.fn(),
+        dispose: vi.fn(),
+        on: vi.fn()
+    })),
+    use: vi.fn()
+}));
+vi.mock('echarts/charts', () => ({ HeatmapChart: {} }));
+vi.mock('echarts/components', () => ({
+    TooltipComponent: {},
+    VisualMapComponent: {},
+    GridComponent: {},
+    DataZoomInsideComponent: {}
+}));
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+
+const color: ColorConfig = { intensity: 1, logScale: true };
+
+describe('ExpandDialog', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('renders the matrix and zoom hint when open', async () => {
+        render(ExpandDialog, { props: { open: true, matrix: small3Classes, color } });
+
+        await waitFor(() => expect(screen.getByText('Confusion matrix')).toBeInTheDocument());
+        expect(screen.getByText(/Scroll or pinch inside the chart to zoom/)).toBeInTheDocument();
+        expect(screen.getByTestId('confusion-matrix')).toBeInTheDocument();
+    });
+
+    it('renders nothing when closed', () => {
+        render(ExpandDialog, { props: { open: false, matrix: small3Classes, color } });
+
+        expect(screen.queryByText('Confusion matrix')).not.toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/PanelHeader/PanelHeader.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+    import { Maximize2 as Maximize2Icon, Settings as SettingsIcon } from '@lucide/svelte';
+    import { Button } from '$lib/components';
+    import { CLASS_SORT_LABELS } from '../../topNMatrix';
+    import type { ClassSetConfig, ColorConfig } from '../../ClassSetDialog/types';
+
+    interface Props {
+        config: ClassSetConfig;
+        color: ColorConfig;
+        realClassCount: number;
+        visibleClassCount: number;
+        onConfigure: () => void;
+        onExpand: () => void;
+    }
+
+    let { config, color, realClassCount, visibleClassCount, onConfigure, onExpand }: Props =
+        $props();
+</script>
+
+<div class="mb-1 flex flex-row items-center gap-2">
+    <div class="mb-2 flex-1 text-xs text-muted-foreground">
+        {#if config.mode === 'topN'}
+            Top {config.n} of {realClassCount} classes · sorted by {CLASS_SORT_LABELS[
+                config.sortBy
+            ].toLowerCase()}
+        {:else}
+            Manual selection · {visibleClassCount} of {realClassCount} classes
+        {/if}
+        {#if visibleClassCount < realClassCount}
+            · rest aggregated as “(other)”
+        {/if}
+        {#if color.intensity !== 1 || !color.logScale}
+            · {color.logScale ? 'log' : 'linear'} coloring at {color.intensity.toFixed(1)}×
+        {/if}
+    </div>
+    <Button
+        variant="ghost"
+        icon={SettingsIcon}
+        ariaLabel="Configure class filters and colors"
+        buttonProps={{
+            size: 'sm',
+            class: 'h-8 gap-1',
+            onclick: onConfigure,
+            'data-testid': 'confusion-matrix-configure'
+        }}
+    />
+    <Button
+        variant="ghost"
+        icon={Maximize2Icon}
+        ariaLabel="Expand confusion matrix"
+        buttonProps={{
+            size: 'sm',
+            class: 'h-8 w-8 p-0',
+            onclick: onExpand,
+            'data-testid': 'confusion-matrix-expand'
+        }}
+    />
+</div>

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/PanelHeader/PanelHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/PanelHeader/PanelHeader.test.ts
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import PanelHeader from './PanelHeader.svelte';
+import type { ClassSetConfig, ColorConfig } from '../../ClassSetDialog/types';
+
+const topNConfig: ClassSetConfig = {
+    mode: 'topN',
+    n: 5,
+    sortBy: 'most-confused',
+    manualClasses: []
+};
+const defaultColor: ColorConfig = { intensity: 1, logScale: true };
+
+const defaultProps = {
+    config: topNConfig,
+    color: defaultColor,
+    realClassCount: 80,
+    visibleClassCount: 5,
+    onConfigure: vi.fn(),
+    onExpand: vi.fn()
+};
+
+describe('PanelHeader', () => {
+    it('summarizes the top-N view and aggregation note', () => {
+        render(PanelHeader, { props: { ...defaultProps } });
+
+        expect(screen.getByText(/Top 5 of 80 classes/)).toBeInTheDocument();
+        expect(screen.getByText(/sorted by most confused/)).toBeInTheDocument();
+        expect(screen.getByText(/rest aggregated/)).toBeInTheDocument();
+    });
+
+    it('summarizes the manual view', () => {
+        render(PanelHeader, {
+            props: {
+                ...defaultProps,
+                config: { ...topNConfig, mode: 'manual', manualClasses: ['a', 'b'] },
+                visibleClassCount: 2
+            }
+        });
+
+        expect(screen.getByText(/Manual selection · 2 of 80 classes/)).toBeInTheDocument();
+    });
+
+    it('notes non-default coloring', () => {
+        render(PanelHeader, {
+            props: { ...defaultProps, color: { intensity: 1.5, logScale: false } }
+        });
+
+        expect(screen.getByText(/linear coloring at 1.5×/)).toBeInTheDocument();
+    });
+
+    it('exposes accessible labels and fires the control callbacks', async () => {
+        const onConfigure = vi.fn();
+        const onExpand = vi.fn();
+        render(PanelHeader, { props: { ...defaultProps, onConfigure, onExpand } });
+
+        const configure = screen.getByTestId('confusion-matrix-configure');
+        const expand = screen.getByTestId('confusion-matrix-expand');
+        expect(configure).toHaveAccessibleName('Configure class filters and colors');
+        expect(expand).toHaveAccessibleName('Expand confusion matrix');
+
+        await fireEvent.click(configure);
+        await fireEvent.click(expand);
+        expect(onConfigure).toHaveBeenCalledOnce();
+        expect(onExpand).toHaveBeenCalledOnce();
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/selectVisibleClasses.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/selectVisibleClasses.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { selectVisibleClasses } from './selectVisibleClasses';
+import { small3Classes } from '../fixtures';
+import type { ClassSetConfig } from '../ClassSetDialog/types';
+
+const baseConfig: ClassSetConfig = {
+    mode: 'topN',
+    n: 3,
+    sortBy: 'most-confused',
+    manualClasses: []
+};
+
+describe('selectVisibleClasses', () => {
+    it('keeps the top-N most-confused classes in matrix order', () => {
+        // most-confused ranking is person, car, bike; n=2 keeps person+car,
+        // returned in the matrix's original order (bike, car, person).
+        expect(selectVisibleClasses(small3Classes, { ...baseConfig, n: 2 })).toEqual([
+            'car',
+            'person'
+        ]);
+    });
+
+    it('keeps all real classes when n covers them', () => {
+        expect(selectVisibleClasses(small3Classes, { ...baseConfig, n: 10 })).toEqual([
+            'bike',
+            'car',
+            'person'
+        ]);
+    });
+
+    it('keeps only the manually selected classes in manual mode', () => {
+        const config: ClassSetConfig = {
+            ...baseConfig,
+            mode: 'manual',
+            manualClasses: ['person', 'bike']
+        };
+        expect(selectVisibleClasses(small3Classes, config)).toEqual(['bike', 'person']);
+    });
+
+    it('ignores manual selections that are not real classes', () => {
+        const config: ClassSetConfig = { ...baseConfig, mode: 'manual', manualClasses: ['ghost'] };
+        expect(selectVisibleClasses(small3Classes, config)).toEqual([]);
+    });
+});

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/selectVisibleClasses.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/selectVisibleClasses.ts
@@ -1,0 +1,16 @@
+import type { ConfusionMatrix } from '../types';
+import { getRealClasses, rankClasses } from '../topNMatrix';
+import type { ClassSetConfig } from '../ClassSetDialog/types';
+
+/**
+ * Resolves which real classes should be visible for the given config, in the
+ * matrix's original label order. Top-N mode keeps the highest-ranked `n`
+ * classes; manual mode keeps the explicitly selected labels.
+ */
+export function selectVisibleClasses(matrix: ConfusionMatrix, config: ClassSetConfig): string[] {
+    const baseClasses =
+        config.mode === 'topN'
+            ? rankClasses(matrix, config.sortBy).slice(0, config.n)
+            : config.manualClasses;
+    return getRealClasses(matrix).filter((c) => baseClasses.includes(c));
+}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/index.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/index.ts
@@ -1,2 +1,3 @@
 export { default as ConfusionMatrix } from './ConfusionMatrix.svelte';
+export { default as ConfusionMatrixPanel } from './ConfusionMatrixPanel/ConfusionMatrixPanel.svelte';
 export { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL } from './types';


### PR DESCRIPTION
## What has changed and why?

Combines top-N filtering with user-selectable class sets for exploring confusion patterns. Features:
- Default top-N confused classes view
- Dialog-based class set customization (toggle, quick filters)
- Settings for color intensity and zoom
- Maximize button for full-screen matrix view

Storybook stories demonstrate all filtering and configuration modes.

this is part of https://github.com/lightly-ai/lightly-studio/pull/1460
## How has it been tested?

By tests and storybook

Run storybook and check ConfusionMatrix Panel
## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ConfusionMatrixPanel` component with top-N class filtering and manual class selection.
  * Added expand dialog for full-size confusion matrix viewing with zoom and hover details.
  * Added configuration controls for class filtering, color intensity, and log-scale visualization.
  * Added legend display toggle and optional "(other)" aggregation indicator.

* **Tests**
  * Added unit test coverage for ConfusionMatrixPanel and related dialog components.

* **Documentation**
  * Added Storybook story for ConfusionMatrixPanel with interactive controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->