### PR TITLE
Add image crop embedding infrastructure

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 from uuid import UUID
 
@@ -10,6 +11,17 @@ import numpy as np
 from numpy.typing import NDArray
 
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
+
+
+@dataclass(frozen=True)
+class ImageCrop:
+    """Image crop to embed."""
+
+    filepath: str
+    x: int
+    y: int
+    width: int
+    height: int
 
 
 @runtime_checkable
@@ -64,6 +76,21 @@ class ImageEmbeddingGenerator(EmbeddingGenerator, Protocol):
         Returns:
             A numpy array representing the generated embeddings
             in the same order as the input file paths.
+        """
+        ...
+
+    def embed_image_crops(
+        self, image_crops: list[ImageCrop], show_progress: bool = True
+    ) -> NDArray[np.float32]:
+        """Generate embeddings for image crops.
+
+        Args:
+            image_crops: A list of image crop definitions to embed.
+            show_progress: Whether to show a progress bar during embedding.
+
+        Returns:
+            A numpy array representing the generated embeddings in the same order
+            as the input crops.
         """
         ...
 
@@ -125,6 +152,13 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         """Generate random embeddings for multiple image samples."""
         _ = show_progress  # Not used for random embeddings.
         return np.random.rand(len(filepaths), self._dimension).astype(np.float32)
+
+    def embed_image_crops(
+        self, image_crops: list[ImageCrop], show_progress: bool = True
+    ) -> NDArray[np.float32]:
+        """Generate random embeddings for multiple image crops."""
+        _ = show_progress  # Not used for random embeddings.
+        return np.random.rand(len(image_crops), self._dimension).astype(np.float32)
 
     def embed_videos(self, filepaths: list[str]) -> NDArray[np.float32]:
         """Generate random embeddings for multiple image samples."""

--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -1,0 +1,114 @@
+"""Shared helper for batched image-crop embedding."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import fsspec
+import numpy as np
+import torch
+from numpy.typing import NDArray
+from PIL import Image
+from tqdm import tqdm
+
+from lightly_studio.dataset.embedding_generator import ImageCrop
+
+
+def embed_image_crops_batched(  # noqa: PLR0913
+    image_crops: list[ImageCrop],
+    embedding_dimension: int,
+    max_batch_size: int,
+    device: torch.device,
+    preprocess: Callable[[Image.Image], torch.Tensor],
+    encode_batch: Callable[[torch.Tensor], NDArray[np.float32]],
+    show_progress: bool,
+) -> NDArray[np.float32]:
+    """Embed image crops, opening each source file once and preserving input order.
+
+    Args:
+        image_crops: Crop definitions to embed.
+        embedding_dimension: Output embedding width.
+        max_batch_size: Maximum crops encoded per model forward pass.
+        device: Torch device for model inference.
+        preprocess: Callable that converts a PIL crop to a model input tensor.
+        encode_batch: Callable that encodes a batch tensor and returns embeddings.
+        show_progress: Whether to show a tqdm progress bar.
+
+    Returns:
+        Float32 array of shape ``(len(image_crops), embedding_dimension)``.
+    """
+    total_crops = len(image_crops)
+    if not total_crops:
+        return np.empty((0, embedding_dimension), dtype=np.float32)
+
+    crops_by_filepath: dict[str, list[tuple[int, ImageCrop]]] = {}
+    for index, image_crop in enumerate(image_crops):
+        crops_by_filepath.setdefault(image_crop.filepath, []).append((index, image_crop))
+
+    embeddings = np.empty((total_crops, embedding_dimension), dtype=np.float32)
+    batch_tensors: list[torch.Tensor] = []
+    batch_indices: list[int] = []
+
+    with (
+        tqdm(
+            total=total_crops,
+            desc="Generating crop embeddings",
+            unit=" crops",
+            disable=not show_progress,
+        ) as progress_bar,
+        torch.no_grad(),
+    ):
+        for filepath, indexed_crops in crops_by_filepath.items():
+            with fsspec.open(filepath, "rb") as file:
+                image = Image.open(file).convert("RGB")
+                for index, image_crop in indexed_crops:
+                    cropped = image.crop(
+                        (
+                            image_crop.x,
+                            image_crop.y,
+                            image_crop.x + image_crop.width,
+                            image_crop.y + image_crop.height,
+                        )
+                    )
+                    batch_tensors.append(preprocess(cropped))
+                    batch_indices.append(index)
+                    if len(batch_tensors) >= max_batch_size:
+                        _flush_crop_batch(
+                            batch_tensors,
+                            batch_indices,
+                            embeddings,
+                            device,
+                            encode_batch,
+                            progress_bar,
+                        )
+
+        _flush_crop_batch(
+            batch_tensors,
+            batch_indices,
+            embeddings,
+            device,
+            encode_batch,
+            progress_bar,
+        )
+
+    return embeddings
+
+
+def _flush_crop_batch(  # noqa: PLR0913
+    batch_tensors: list[torch.Tensor],
+    batch_indices: list[int],
+    embeddings: NDArray[np.float32],
+    device: torch.device,
+    encode_batch: Callable[[torch.Tensor], NDArray[np.float32]],
+    progress_bar: Any,
+) -> None:
+    if not batch_tensors:
+        return
+    images_tensor = torch.stack(batch_tensors).to(device, non_blocking=True)
+    batch_embeddings = encode_batch(images_tensor)
+    for batch_position, crop_index in enumerate(batch_indices):
+        embeddings[crop_index] = batch_embeddings[batch_position]
+    progress_bar.update(len(batch_tensors))
+    batch_tensors.clear()
+    batch_indices.clear()

--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -75,21 +75,21 @@ def embed_image_crops_batched(  # noqa: PLR0913
                     batch_indices.append(index)
                     if len(batch_tensors) >= max_batch_size:
                         _flush_crop_batch(
-                            batch_tensors,
-                            batch_indices,
-                            embeddings,
-                            device,
-                            encode_batch,
-                            progress_bar,
+                            batch_tensors=batch_tensors,
+                            batch_indices=batch_indices,
+                            embeddings=embeddings,
+                            device=device,
+                            encode_batch=encode_batch,
+                            progress_bar=progress_bar,
                         )
 
         _flush_crop_batch(
-            batch_tensors,
-            batch_indices,
-            embeddings,
-            device,
-            encode_batch,
-            progress_bar,
+            batch_tensors=batch_tensors,
+            batch_indices=batch_indices,
+            embeddings=embeddings,
+            device=device,
+            encode_batch=encode_batch,
+            progress_bar=progress_bar,
         )
 
     return embeddings

--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import fsspec
@@ -15,24 +16,35 @@ from tqdm import tqdm
 from lightly_studio.dataset.embedding_generator import ImageCrop
 
 
-def embed_image_crops_batched(  # noqa: PLR0913
+@dataclass(frozen=True)
+class EmbeddingContext:
+    """Model-specific configuration for batched image-crop embedding.
+
+    Attributes:
+        embedding_dimension: Output embedding dimension.
+        max_batch_size: Maximum crops encoded per model forward pass.
+        device: Torch device for model inference.
+        preprocess: Callable that converts a PIL crop to a model input tensor.
+        encode_batch: Callable that encodes a batch tensor and returns embeddings.
+    """
+
+    embedding_dimension: int
+    max_batch_size: int
+    device: torch.device
+    preprocess: Callable[[Image.Image], torch.Tensor]
+    encode_batch: Callable[[torch.Tensor], NDArray[np.float32]]
+
+
+def embed_image_crops_batched(
     image_crops: list[ImageCrop],
-    embedding_dimension: int,
-    max_batch_size: int,
-    device: torch.device,
-    preprocess: Callable[[Image.Image], torch.Tensor],
-    encode_batch: Callable[[torch.Tensor], NDArray[np.float32]],
+    context: EmbeddingContext,
     show_progress: bool,
 ) -> NDArray[np.float32]:
     """Embed image crops, opening each source file once and preserving input order.
 
     Args:
         image_crops: Crop definitions to embed.
-        embedding_dimension: Output embedding width.
-        max_batch_size: Maximum crops encoded per model forward pass.
-        device: Torch device for model inference.
-        preprocess: Callable that converts a PIL crop to a model input tensor.
-        encode_batch: Callable that encodes a batch tensor and returns embeddings.
+        context: Model-specific embedding configuration.
         show_progress: Whether to show a tqdm progress bar.
 
     Returns:
@@ -40,14 +52,15 @@ def embed_image_crops_batched(  # noqa: PLR0913
     """
     total_crops = len(image_crops)
     if not total_crops:
-        return np.empty((0, embedding_dimension), dtype=np.float32)
+        return np.empty((0, context.embedding_dimension), dtype=np.float32)
 
     crops_by_filepath: dict[str, list[tuple[int, ImageCrop]]] = {}
     for index, image_crop in enumerate(image_crops):
         crops_by_filepath.setdefault(image_crop.filepath, []).append((index, image_crop))
 
-    embeddings = np.empty((total_crops, embedding_dimension), dtype=np.float32)
-    batch_tensors: list[torch.Tensor] = []
+    embeddings = np.empty((total_crops, context.embedding_dimension), dtype=np.float32)
+    # Reusable batch buffer, lazily sized from the first preprocessed crop.
+    batch_buffer: torch.Tensor | None = None
     batch_indices: list[int] = []
 
     with (
@@ -71,45 +84,48 @@ def embed_image_crops_batched(  # noqa: PLR0913
                             image_crop.y + image_crop.height,
                         )
                     )
-                    batch_tensors.append(preprocess(cropped))
+                    preprocessed = context.preprocess(cropped)
+                    if batch_buffer is None:
+                        batch_buffer = torch.empty(
+                            (context.max_batch_size, *preprocessed.shape),
+                            dtype=preprocessed.dtype,
+                        )
+                    batch_buffer[len(batch_indices)] = preprocessed
                     batch_indices.append(index)
-                    if len(batch_tensors) >= max_batch_size:
+                    if len(batch_indices) >= context.max_batch_size:
                         _flush_crop_batch(
-                            batch_tensors=batch_tensors,
+                            batch_buffer=batch_buffer,
                             batch_indices=batch_indices,
                             embeddings=embeddings,
-                            device=device,
-                            encode_batch=encode_batch,
+                            context=context,
                             progress_bar=progress_bar,
                         )
 
         _flush_crop_batch(
-            batch_tensors=batch_tensors,
+            batch_buffer=batch_buffer,
             batch_indices=batch_indices,
             embeddings=embeddings,
-            device=device,
-            encode_batch=encode_batch,
+            context=context,
             progress_bar=progress_bar,
         )
 
     return embeddings
 
 
-def _flush_crop_batch(  # noqa: PLR0913
-    batch_tensors: list[torch.Tensor],
+def _flush_crop_batch(
+    batch_buffer: torch.Tensor | None,
     batch_indices: list[int],
     embeddings: NDArray[np.float32],
-    device: torch.device,
-    encode_batch: Callable[[torch.Tensor], NDArray[np.float32]],
+    context: EmbeddingContext,
     progress_bar: Any,
 ) -> None:
     """Encode the current crop batch and write results into ``embeddings``."""
-    if not batch_tensors:
+    if batch_buffer is None or not batch_indices:
         return
-    images_tensor = torch.stack(batch_tensors).to(device, non_blocking=True)
-    batch_embeddings = encode_batch(images_tensor)
+    filled = len(batch_indices)
+    images_tensor = batch_buffer[:filled].to(context.device, non_blocking=True)
+    batch_embeddings = context.encode_batch(images_tensor)
     for batch_position, crop_index in enumerate(batch_indices):
         embeddings[crop_index] = batch_embeddings[batch_position]
-    progress_bar.update(len(batch_tensors))
-    batch_tensors.clear()
+    progress_bar.update(filled)
     batch_indices.clear()

--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -54,6 +54,9 @@ def embed_image_crops_batched(
     if not total_crops:
         return np.empty((0, context.embedding_dimension), dtype=np.float32)
 
+    if context.max_batch_size <= 0:
+        raise ValueError("max_batch_size must be positive.")
+
     crops_by_filepath: dict[str, list[tuple[int, ImageCrop]]] = {}
     for index, image_crop in enumerate(image_crops):
         crops_by_filepath.setdefault(image_crop.filepath, []).append((index, image_crop))

--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -103,6 +103,7 @@ def _flush_crop_batch(  # noqa: PLR0913
     encode_batch: Callable[[torch.Tensor], NDArray[np.float32]],
     progress_bar: Any,
 ) -> None:
+    """Encode the current crop batch and write results into ``embeddings``."""
     if not batch_tensors:
         return
     images_tensor = torch.stack(batch_tensors).to(device, non_blocking=True)

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -19,7 +19,8 @@ from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor import mobileclip
 
 from . import file_utils
-from .embedding_generator import ImageEmbeddingGenerator
+from .embedding_generator import ImageCrop, ImageEmbeddingGenerator
+from .image_crop_embedding import embed_image_crops_batched
 
 MODEL_NAME = "mobileclip_s0"
 MOBILECLIP_DOWNLOAD_URL = (
@@ -154,6 +155,33 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
                 progress_bar.update(batch_size)
 
         return embeddings
+
+    def embed_image_crops(
+        self, image_crops: list[ImageCrop], show_progress: bool = True
+    ) -> NDArray[np.float32]:
+        """Embed image crops with MobileCLIP.
+
+        Args:
+            image_crops: A list of image crop definitions to embed.
+            show_progress: Whether to show a progress bar during embedding.
+
+        Returns:
+            A numpy array representing the generated embeddings in the same order
+            as the input crops.
+        """
+        return embed_image_crops_batched(
+            image_crops,
+            embedding_dimension=EMBEDDING_DIMENSION,
+            max_batch_size=MAX_BATCH_SIZE,
+            device=self._device,
+            preprocess=self._preprocess,
+            encode_batch=lambda images_tensor: (
+                self._model.encode_image(images_tensor)  # type: ignore[operator]
+                .cpu()
+                .numpy()
+            ),
+            show_progress=show_progress,
+        )
 
 
 def _get_cached_mobileclip_checkpoint() -> Path:

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -170,7 +170,7 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             as the input crops.
         """
         return embed_image_crops_batched(
-            image_crops,
+            image_crops=image_crops,
             embedding_dimension=EMBEDDING_DIMENSION,
             max_batch_size=MAX_BATCH_SIZE,
             device=self._device,

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -20,7 +20,7 @@ from lightly_studio.vendor import mobileclip
 
 from . import file_utils
 from .embedding_generator import ImageCrop, ImageEmbeddingGenerator
-from .image_crop_embedding import embed_image_crops_batched
+from .image_crop_embedding import EmbeddingContext, embed_image_crops_batched
 
 MODEL_NAME = "mobileclip_s0"
 MOBILECLIP_DOWNLOAD_URL = (
@@ -171,14 +171,16 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
         """
         return embed_image_crops_batched(
             image_crops=image_crops,
-            embedding_dimension=EMBEDDING_DIMENSION,
-            max_batch_size=MAX_BATCH_SIZE,
-            device=self._device,
-            preprocess=self._preprocess,
-            encode_batch=lambda images_tensor: (
-                self._model.encode_image(images_tensor)  # type: ignore[operator]
-                .cpu()
-                .numpy()
+            context=EmbeddingContext(
+                embedding_dimension=EMBEDDING_DIMENSION,
+                max_batch_size=MAX_BATCH_SIZE,
+                device=self._device,
+                preprocess=self._preprocess,
+                encode_batch=lambda images_tensor: (
+                    self._model.encode_image(images_tensor)  # type: ignore[operator]
+                    .cpu()
+                    .numpy()
+                ),
             ),
             show_progress=show_progress,
         )

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -21,7 +21,7 @@ from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transfor
 
 from . import file_utils
 from .embedding_generator import ImageCrop, ImageEmbeddingGenerator, VideoEmbeddingGenerator
-from .image_crop_embedding import embed_image_crops_batched
+from .image_crop_embedding import EmbeddingContext, embed_image_crops_batched
 
 MODEL_NAME = "PE-Core-T16-384"
 DEFAULT_VIDEO_CHANNEL = 0
@@ -248,12 +248,14 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         """
         return embed_image_crops_batched(
             image_crops=image_crops,
-            embedding_dimension=self._model.output_dim,
-            max_batch_size=MAX_BATCH_SIZE,
-            device=self._device,
-            preprocess=self._preprocess,
-            encode_batch=lambda images_tensor: (
-                self._model.encode_image(images_tensor, normalize=True).cpu().numpy()
+            context=EmbeddingContext(
+                embedding_dimension=self._model.output_dim,
+                max_batch_size=MAX_BATCH_SIZE,
+                device=self._device,
+                preprocess=self._preprocess,
+                encode_batch=lambda images_tensor: (
+                    self._model.encode_image(images_tensor, normalize=True).cpu().numpy()
+                ),
             ),
             show_progress=show_progress,
         )

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -247,7 +247,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             as the input crops.
         """
         return embed_image_crops_batched(
-            image_crops,
+            image_crops=image_crops,
             embedding_dimension=self._model.output_dim,
             max_batch_size=MAX_BATCH_SIZE,
             device=self._device,

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -20,7 +20,8 @@ from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
 
 from . import file_utils
-from .embedding_generator import ImageEmbeddingGenerator, VideoEmbeddingGenerator
+from .embedding_generator import ImageCrop, ImageEmbeddingGenerator, VideoEmbeddingGenerator
+from .image_crop_embedding import embed_image_crops_batched
 
 MODEL_NAME = "PE-Core-T16-384"
 DEFAULT_VIDEO_CHANNEL = 0
@@ -231,6 +232,31 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
                 progress_bar.update(batch_size)
 
         return embeddings
+
+    def embed_image_crops(
+        self, image_crops: list[ImageCrop], show_progress: bool = True
+    ) -> NDArray[np.float32]:
+        """Embed image crops with Perception Encoder.
+
+        Args:
+            image_crops: A list of image crop definitions to embed.
+            show_progress: Whether to show a progress bar during embedding.
+
+        Returns:
+            A numpy array representing the generated embeddings in the same order
+            as the input crops.
+        """
+        return embed_image_crops_batched(
+            image_crops,
+            embedding_dimension=self._model.output_dim,
+            max_batch_size=MAX_BATCH_SIZE,
+            device=self._device,
+            preprocess=self._preprocess,
+            encode_batch=lambda images_tensor: (
+                self._model.encode_image(images_tensor, normalize=True).cpu().numpy()
+            ),
+            show_progress=show_progress,
+        )
 
     def embed_videos(self, filepaths: list[str]) -> NDArray[np.float32]:
         """Embed videos with Perception Encoder.

--- a/lightly_studio/tests/dataset/test_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_embedding_generator.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from lightly_studio.dataset.embedding_generator import (
+    ImageCrop,
+    RandomEmbeddingGenerator,
+)
+
+
+class TestRandomEmbeddingGeneratorCrops:
+    def test_embed_image_crops__returns_one_embedding_per_crop(self) -> None:
+        generator = RandomEmbeddingGenerator(dimension=4)
+        image_crops = [
+            ImageCrop(filepath="a.jpg", x=0, y=0, width=10, height=10),
+            ImageCrop(filepath="a.jpg", x=5, y=5, width=20, height=20),
+            ImageCrop(filepath="b.jpg", x=0, y=0, width=30, height=30),
+        ]
+
+        embeddings = generator.embed_image_crops(image_crops)
+
+        assert embeddings.shape == (3, 4)
+
+    def test_embed_image_crops__empty_input_returns_empty_array(self) -> None:
+        generator = RandomEmbeddingGenerator(dimension=4)
+
+        embeddings = generator.embed_image_crops([])
+
+        assert embeddings.shape == (0, 4)

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -12,6 +12,7 @@ from sqlmodel import Session, select
 
 from lightly_studio.dataset import embedding_manager
 from lightly_studio.dataset.embedding_generator import (
+    ImageCrop,
     ImageEmbeddingGenerator,
     RandomEmbeddingGenerator,
 )
@@ -89,6 +90,11 @@ def test_register_multiple_models(
 
         def embed_images(
             self, filepaths: list[str], show_progress: bool = True
+        ) -> NDArray[np.float32]:
+            raise NotImplementedError()
+
+        def embed_image_crops(
+            self, image_crops: list[ImageCrop], show_progress: bool = True
         ) -> NDArray[np.float32]:
             raise NotImplementedError()
 

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -11,12 +11,12 @@ from lightly_studio.dataset.image_crop_embedding import embed_image_crops_batche
 
 def test_embed_image_crops_batched__empty_input_returns_empty_array() -> None:
     embeddings = embed_image_crops_batched(
-        [],
+        image_crops=[],
         embedding_dimension=4,
         max_batch_size=2,
         device=torch.device("cpu"),
         preprocess=lambda image: torch.tensor([float(image.size[0])]),
-        encode_batch=lambda images_tensor: images_tensor.numpy(),
+        encode_batch=lambda images_tensor: images_tensor.cpu().numpy(),
         show_progress=False,
     )
 
@@ -52,7 +52,7 @@ def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
         ).astype(np.float32)
 
     embeddings = embed_image_crops_batched(
-        image_crops,
+        image_crops=image_crops,
         embedding_dimension=2,
         max_batch_size=3,
         device=torch.device("cpu"),

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -6,17 +6,22 @@ from numpy.typing import NDArray
 from PIL import Image
 
 from lightly_studio.dataset.embedding_generator import ImageCrop
-from lightly_studio.dataset.image_crop_embedding import embed_image_crops_batched
+from lightly_studio.dataset.image_crop_embedding import (
+    EmbeddingContext,
+    embed_image_crops_batched,
+)
 
 
 def test_embed_image_crops_batched__empty_input_returns_empty_array() -> None:
     embeddings = embed_image_crops_batched(
         image_crops=[],
-        embedding_dimension=4,
-        max_batch_size=2,
-        device=torch.device("cpu"),
-        preprocess=lambda image: torch.tensor([float(image.size[0])]),
-        encode_batch=lambda images_tensor: images_tensor.cpu().numpy(),
+        context=EmbeddingContext(
+            embedding_dimension=4,
+            max_batch_size=2,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=lambda images_tensor: images_tensor.cpu().numpy(),
+        ),
         show_progress=False,
     )
 
@@ -44,26 +49,25 @@ def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
 
     def encode_batch(images_tensor: torch.Tensor) -> NDArray[np.float32]:
         encode_calls.append(images_tensor.size(0))
-        return np.column_stack(
-            [
-                images_tensor[:, 0].numpy(),
-                images_tensor[:, 0].numpy() + 1.0,
-            ]
-        ).astype(np.float32)
+        # Each preprocessed crop is its width, so the batch is already the
+        # expected (batch_size, 1) embedding; encode is the identity here.
+        return images_tensor.numpy().astype(np.float32)
 
     embeddings = embed_image_crops_batched(
         image_crops=image_crops,
-        embedding_dimension=2,
-        max_batch_size=3,
-        device=torch.device("cpu"),
-        preprocess=lambda image: torch.tensor([float(image.size[0])]),
-        encode_batch=encode_batch,
+        context=EmbeddingContext(
+            embedding_dimension=1,
+            max_batch_size=3,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=encode_batch,
+        ),
         show_progress=False,
     )
 
     # Encode order is [a:5, a:7, b:6, b:8]; with max_batch_size=3 the first
     # batch spans both files and the last crop forms a partial final batch.
     assert encode_calls == [3, 1]
-    assert embeddings.shape == (4, 2)
-    # Each embedding's first column equals its crop width, in input order.
+    assert embeddings.shape == (4, 1)
+    # Each embedding equals its crop width, in input order.
     assert embeddings[:, 0].tolist() == [5.0, 6.0, 7.0, 8.0]

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -23,14 +23,22 @@ def test_embed_image_crops_batched__empty_input_returns_empty_array() -> None:
     assert embeddings.shape == (0, 4)
 
 
-def test_embed_image_crops_batched__preserves_input_order(tmp_path: Path) -> None:
-    image_path = tmp_path / "image.png"
-    Image.new("RGB", (20, 10), color=(255, 0, 0)).save(image_path)
+def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
+    tmp_path: Path,
+) -> None:
+    image_a_path = tmp_path / "image_a.png"
+    image_b_path = tmp_path / "image_b.png"
+    Image.new("RGB", (100, 100), color=(255, 0, 0)).save(image_a_path)
+    Image.new("RGB", (100, 100), color=(0, 255, 0)).save(image_b_path)
 
+    # Crops are interleaved across two files, each with a distinct width. The
+    # helper groups crops by filepath before encoding, so the encode order
+    # (a, a, b, b) differs from the input order.
     image_crops = [
-        ImageCrop(filepath=str(image_path), x=0, y=0, width=5, height=5),
-        ImageCrop(filepath=str(image_path), x=5, y=0, width=5, height=5),
-        ImageCrop(filepath=str(image_path), x=10, y=0, width=5, height=5),
+        ImageCrop(filepath=str(image_a_path), x=0, y=0, width=5, height=10),
+        ImageCrop(filepath=str(image_b_path), x=0, y=0, width=6, height=10),
+        ImageCrop(filepath=str(image_a_path), x=0, y=0, width=7, height=10),
+        ImageCrop(filepath=str(image_b_path), x=0, y=0, width=8, height=10),
     ]
     encode_calls: list[int] = []
 
@@ -46,15 +54,16 @@ def test_embed_image_crops_batched__preserves_input_order(tmp_path: Path) -> Non
     embeddings = embed_image_crops_batched(
         image_crops,
         embedding_dimension=2,
-        max_batch_size=2,
+        max_batch_size=3,
         device=torch.device("cpu"),
         preprocess=lambda image: torch.tensor([float(image.size[0])]),
         encode_batch=encode_batch,
         show_progress=False,
     )
 
-    assert encode_calls == [2, 1]
-    assert embeddings.shape == (3, 2)
-    assert embeddings[0, 0] == 5.0
-    assert embeddings[1, 0] == 5.0
-    assert embeddings[2, 0] == 5.0
+    # Encode order is [a:5, a:7, b:6, b:8]; with max_batch_size=3 the first
+    # batch spans both files and the last crop forms a partial final batch.
+    assert encode_calls == [3, 1]
+    assert embeddings.shape == (4, 2)
+    # Each embedding's first column equals its crop width, in input order.
+    assert embeddings[:, 0].tolist() == [5.0, 6.0, 7.0, 8.0]

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import numpy as np
+import torch
+from numpy.typing import NDArray
+from PIL import Image
+
+from lightly_studio.dataset.embedding_generator import ImageCrop
+from lightly_studio.dataset.image_crop_embedding import embed_image_crops_batched
+
+
+def test_embed_image_crops_batched__empty_input_returns_empty_array() -> None:
+    embeddings = embed_image_crops_batched(
+        [],
+        embedding_dimension=4,
+        max_batch_size=2,
+        device=torch.device("cpu"),
+        preprocess=lambda image: torch.tensor([float(image.size[0])]),
+        encode_batch=lambda images_tensor: images_tensor.numpy(),
+        show_progress=False,
+    )
+
+    assert embeddings.shape == (0, 4)
+
+
+def test_embed_image_crops_batched__preserves_input_order(tmp_path: Path) -> None:
+    image_path = tmp_path / "image.png"
+    Image.new("RGB", (20, 10), color=(255, 0, 0)).save(image_path)
+
+    image_crops = [
+        ImageCrop(filepath=str(image_path), x=0, y=0, width=5, height=5),
+        ImageCrop(filepath=str(image_path), x=5, y=0, width=5, height=5),
+        ImageCrop(filepath=str(image_path), x=10, y=0, width=5, height=5),
+    ]
+    encode_calls: list[int] = []
+
+    def encode_batch(images_tensor: torch.Tensor) -> NDArray[np.float32]:
+        encode_calls.append(images_tensor.size(0))
+        return np.column_stack(
+            [
+                images_tensor[:, 0].numpy(),
+                images_tensor[:, 0].numpy() + 1.0,
+            ]
+        ).astype(np.float32)
+
+    embeddings = embed_image_crops_batched(
+        image_crops,
+        embedding_dimension=2,
+        max_batch_size=2,
+        device=torch.device("cpu"),
+        preprocess=lambda image: torch.tensor([float(image.size[0])]),
+        encode_batch=encode_batch,
+        show_progress=False,
+    )
+
+    assert encode_calls == [2, 1]
+    assert embeddings.shape == (3, 2)
+    assert embeddings[0, 0] == 5.0
+    assert embeddings[1, 0] == 5.0
+    assert embeddings[2, 0] == 5.0

--- a/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import numpy as np
 import torch
+from PIL import Image
 
+from lightly_studio.dataset.embedding_generator import ImageCrop
 from lightly_studio.dataset.mobileclip_embedding_generator import (
     MobileCLIPEmbeddingGenerator,
 )
@@ -54,6 +56,27 @@ class TestMobileCLIPEmbeddingGenerator:
         assert np.isclose(cat_embedding_normed[1], 0.0563, atol=1e-4)
         assert np.isclose(cat_embedding_normed[2], -0.0272, atol=1e-4)
         assert np.isclose(cat_embedding_normed[3], 0.0319, atol=1e-4)
+
+    def test_embed_image_crops__empty_input(self) -> None:
+        mobileclip = MobileCLIPEmbeddingGenerator()
+        embeddings = mobileclip.embed_image_crops([])
+
+        assert embeddings.shape == (0, 512)
+
+    def test_embed_image_crops__full_image_crop_matches_embed_images(self) -> None:
+        mobileclip = MobileCLIPEmbeddingGenerator()
+        cat_image_path = FIXTURES_DIR / "cat.jpg"
+        with Image.open(cat_image_path) as image:
+            width, height = image.size
+
+        full_crop = ImageCrop(filepath=str(cat_image_path), x=0, y=0, width=width, height=height)
+        crop_embeddings = mobileclip.embed_image_crops([full_crop])
+        image_embeddings = mobileclip.embed_images([str(cat_image_path)])
+
+        assert crop_embeddings.shape == (1, 512)
+        # A crop covering the entire image is preprocessed and encoded identically
+        # to the full image, so the embeddings must match.
+        assert np.allclose(crop_embeddings[0], image_embeddings[0], atol=1e-4)
 
     def test_classification(self) -> None:
         """End-to-end test for embedding consistency.

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import numpy as np
 import torch
+from PIL import Image
 
+from lightly_studio.dataset.embedding_generator import ImageCrop
 from lightly_studio.dataset.perception_encoder_embedding_generator import (
     PerceptionEncoderEmbeddingGenerator,
 )
@@ -56,6 +58,27 @@ class TestPerceptionEncoderEmbeddingGenerator:
         assert np.isclose(cat_embedding_normed[1], 0.1103, atol=1e-4)
         assert np.isclose(cat_embedding_normed[2], 0.0307, atol=1e-4)
         assert np.isclose(cat_embedding_normed[3], -0.0493, atol=1e-4)
+
+    def test_embed_image_crops__empty_input(self) -> None:
+        perception_encoder = PerceptionEncoderEmbeddingGenerator()
+        embeddings = perception_encoder.embed_image_crops([])
+
+        assert embeddings.shape == (0, 512)
+
+    def test_embed_image_crops__full_image_crop_matches_embed_images(self) -> None:
+        perception_encoder = PerceptionEncoderEmbeddingGenerator()
+        cat_image_path = FIXTURES_DIR / "cat.jpg"
+        with Image.open(cat_image_path) as image:
+            width, height = image.size
+
+        full_crop = ImageCrop(filepath=str(cat_image_path), x=0, y=0, width=width, height=height)
+        crop_embeddings = perception_encoder.embed_image_crops([full_crop])
+        image_embeddings = perception_encoder.embed_images([str(cat_image_path)])
+
+        assert crop_embeddings.shape == (1, 512)
+        # A crop covering the entire image is preprocessed and encoded identically
+        # to the full image, so the embeddings must match.
+        assert np.allclose(crop_embeddings[0], image_embeddings[0], atol=1e-4)
 
     def test_embed_videos(self) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()


### PR DESCRIPTION
## What has changed and why?

Introduce ImageCrop and embed_image_crops() on the image embedding generators (MobileCLIP, Perception Encoder, Random) so object-level crops can be embedded with the same models as full images. Each source image is loaded once and crops are batched. Foundation for annotation-level embeddings.

## How has it been tested?

New tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a shared image-crop definition to describe regions to embed.
  * Introduced batched crop embedding with optional progress reporting, returning embeddings in the same order as the input crops.
  * Extended embedding generators to support embedding custom image crops (including MobileCLIP and Perception Encoder), with correct results even for empty inputs.

* **Tests**
  * Added coverage for empty-input handling, batching limits, and embedding order across multiple images.
  * Added checks that full-image crops match standard full-image embeddings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->