### PR TITLE
Hide source color markers in AnnotationSourcePill when class coloring is enforced

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationSourcePill/AnnotationSourcePill.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationSourcePill/AnnotationSourcePill.svelte
@@ -11,6 +11,7 @@
     import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
     import { useAnnotationLabelContext } from '$lib/contexts/SampleDetailsAnnotation.svelte';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+    import { useSettings } from '$lib/hooks/useSettings';
     import { cn } from '$lib/utils';
 
     // Not built on SelectList: it has no slot for a custom trigger or per-item colour swatch, and
@@ -30,6 +31,9 @@
     const { context: annotationLabelContext, setAnnotationSource } = useAnnotationLabelContext();
     const { updateLastAnnotationSource } = useGlobalStorage();
     const annotationCollections = useAnnotationCollections(() => ({ collectionId }));
+    const { enforceColoringByClassStore } = useSettings();
+
+    const showColorMarker = $derived(!$enforceColoringByClassStore);
 
     const sourceNames = $derived(annotationCollections.data?.map((c) => c.name) ?? []);
 
@@ -99,7 +103,12 @@
                     data-testid="annotation-source-pill-trigger"
                 >
                     <span class="shrink-0 text-muted-foreground">Adding to</span>
-                    <ColorMarker label={effectiveSource} />
+                    {#if showColorMarker}
+                        <ColorMarker
+                            label={effectiveSource}
+                            markerProps={{ 'data-testid': `color-marker-${effectiveSource}` }}
+                        />
+                    {/if}
                     <span class="min-w-0 truncate font-medium">{effectiveSource}</span>
                     <ChevronsUpDownIcon class="size-3.5 shrink-0 opacity-50" />
                 </button>
@@ -124,7 +133,12 @@
                                 <CheckIcon
                                     class={cn(effectiveSource !== name && 'text-transparent')}
                                 />
-                                <ColorMarker label={name} />
+                                {#if showColorMarker}
+                                    <ColorMarker
+                                        label={name}
+                                        markerProps={{ 'data-testid': `color-marker-${name}` }}
+                                    />
+                                {/if}
                                 <span class="min-w-0 flex-1 truncate">{name}</span>
                             </Command.Item>
                         {/each}

--- a/lightly_studio_view/src/lib/components/AnnotationSourcePill/AnnotationSourcePill.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationSourcePill/AnnotationSourcePill.svelte
@@ -11,7 +11,7 @@
     import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
     import { useAnnotationLabelContext } from '$lib/contexts/SampleDetailsAnnotation.svelte';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
-    import { useSettings } from '$lib/hooks/useSettings';
+    import { useSettings } from '$lib/hooks';
     import { cn } from '$lib/utils';
 
     // Not built on SelectList: it has no slot for a custom trigger or per-item colour swatch, and

--- a/lightly_studio_view/src/lib/components/AnnotationSourcePill/AnnotationSourcePill.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationSourcePill/AnnotationSourcePill.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import { type Writable } from 'svelte/store';
 import AnnotationSourcePill from './AnnotationSourcePill.svelte';
 
 // Control the source list, the current selection, and the persistence/setter spies.
@@ -9,7 +10,8 @@ const mocks = vi.hoisted(() => ({
     annotationSource: null as string | null,
     collections: [] as { collection_id: string; name: string }[],
     setAnnotationSource: vi.fn(),
-    updateLastAnnotationSource: vi.fn()
+    updateLastAnnotationSource: vi.fn(),
+    enforceColoringByClassStore: null as unknown as Writable<boolean>
 }));
 
 vi.mock('$lib/contexts/SampleDetailsAnnotation.svelte', () => ({
@@ -31,6 +33,16 @@ vi.mock('$lib/hooks/useAnnotationCollections/useAnnotationCollections', () => ({
     })
 }));
 
+vi.mock('$lib/hooks/useSettings', async () => {
+    const { writable } = await import('svelte/store');
+    mocks.enforceColoringByClassStore = writable<boolean>(false);
+    return {
+        useSettings: vi.fn(() => ({
+            enforceColoringByClassStore: mocks.enforceColoringByClassStore
+        }))
+    };
+});
+
 const source = (name: string) => ({ collection_id: name, name });
 
 describe('AnnotationSourcePill', () => {
@@ -38,6 +50,7 @@ describe('AnnotationSourcePill', () => {
         vi.clearAllMocks();
         mocks.annotationSource = null;
         mocks.collections = [];
+        mocks.enforceColoringByClassStore.set(false);
         Element.prototype.scrollIntoView = vi.fn();
     });
 
@@ -133,5 +146,33 @@ describe('AnnotationSourcePill', () => {
         expect(screen.getByRole('tooltip')).toHaveTextContent(
             'associated with the selected annotation source'
         );
+    });
+
+    it('shows color markers in trigger and options when enforce coloring by class is disabled', async () => {
+        const user = userEvent.setup();
+        mocks.annotationSource = 'ground_truth';
+        mocks.collections = [source('ground_truth'), source('predictions')];
+        mocks.enforceColoringByClassStore.set(false);
+        renderPill();
+
+        expect(screen.getByTestId('color-marker-ground_truth')).toBeInTheDocument();
+
+        await user.click(trigger());
+        expect(screen.getAllByTestId('color-marker-ground_truth')).toHaveLength(2);
+        expect(screen.getByTestId('color-marker-predictions')).toBeInTheDocument();
+    });
+
+    it('hides color markers in trigger and options when enforce coloring by class is enabled', async () => {
+        const user = userEvent.setup();
+        mocks.annotationSource = 'ground_truth';
+        mocks.collections = [source('ground_truth'), source('predictions')];
+        mocks.enforceColoringByClassStore.set(true);
+        renderPill();
+
+        expect(screen.queryByTestId('color-marker-ground_truth')).not.toBeInTheDocument();
+
+        await user.click(trigger());
+        expect(screen.queryByTestId('color-marker-ground_truth')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('color-marker-predictions')).not.toBeInTheDocument();
     });
 });

--- a/lightly_studio_view/src/lib/components/AnnotationSourcePill/AnnotationSourcePill.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationSourcePill/AnnotationSourcePill.test.ts
@@ -33,10 +33,12 @@ vi.mock('$lib/hooks/useAnnotationCollections/useAnnotationCollections', () => ({
     })
 }));
 
-vi.mock('$lib/hooks/useSettings', async () => {
+vi.mock('$lib/hooks', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('$lib/hooks')>();
     const { writable } = await import('svelte/store');
     mocks.enforceColoringByClassStore = writable<boolean>(false);
     return {
+        ...actual,
         useSettings: vi.fn(() => ({
             enforceColoringByClassStore: mocks.enforceColoringByClassStore
         }))
@@ -148,29 +150,24 @@ describe('AnnotationSourcePill', () => {
         );
     });
 
-    it('shows color markers in trigger and options when enforce coloring by class is disabled', async () => {
+    it('shows color markers when enforcement is off and hides them when enforcement is on', async () => {
         const user = userEvent.setup();
         mocks.annotationSource = 'ground_truth';
         mocks.collections = [source('ground_truth'), source('predictions')];
-        mocks.enforceColoringByClassStore.set(false);
-        renderPill();
 
-        expect(screen.getByTestId('color-marker-ground_truth')).toBeInTheDocument();
+        const { unmount } = renderPill();
 
+        // enforcement off — markers visible in trigger and options
         await user.click(trigger());
         expect(screen.getAllByTestId('color-marker-ground_truth')).toHaveLength(2);
         expect(screen.getByTestId('color-marker-predictions')).toBeInTheDocument();
-    });
 
-    it('hides color markers in trigger and options when enforce coloring by class is enabled', async () => {
-        const user = userEvent.setup();
-        mocks.annotationSource = 'ground_truth';
-        mocks.collections = [source('ground_truth'), source('predictions')];
+        unmount();
         mocks.enforceColoringByClassStore.set(true);
         renderPill();
 
+        // enforcement on — markers absent everywhere
         expect(screen.queryByTestId('color-marker-ground_truth')).not.toBeInTheDocument();
-
         await user.click(trigger());
         expect(screen.queryByTestId('color-marker-ground_truth')).not.toBeInTheDocument();
         expect(screen.queryByTestId('color-marker-predictions')).not.toBeInTheDocument();


### PR DESCRIPTION
Closes LIG-9967

## Summary

- Suppress the `ColorMarker` swatch in the `AnnotationSourcePill` trigger button and dropdown option items when `enforceColoringByClass` is enabled, matching the existing behavior in `AnnotationCollectionsMenu`, side-panel source group headers, and the labels menu
- Added `data-testid="color-marker-{name}"` via `markerProps` to both `ColorMarker` instances to enable test assertions

## Test plan

- [x] Two new rendered component tests cover the two-source scenario: markers present when enforcement is off, absent (trigger + all options) when enforcement is on
- [x] All 12 existing + new `AnnotationSourcePill` tests pass
- [x] `make static-checks` passes (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a settings-driven toggle to control whether color markers display in the annotation source selection UI.
* **Bug Fixes**
  * Updated the color marker rendering logic to conditionally show/hide markers based on the current enforcement setting.
* **Tests**
  * Enhanced coverage to verify color markers appear or disappear correctly when the enforcement setting is toggled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->