### PR TITLE
Cache embedding generators across collections in EmbeddingManager

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -323,7 +323,7 @@ class EmbeddingManager:
             return None
 
         if cache_key not in self._generators:
-            generator = _load_embedding_generator_from_env(sample_type=sample_type)
+            generator = _load_embedding_generator_from_env(sample_type=cache_key)
             if generator is None:
                 return None
             self._generators[cache_key] = generator

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -35,6 +35,13 @@ logger = logging.getLogger(__name__)
 # round-trips but higher peak memory. 1024 balances the two.
 EMBEDDING_INSERTION_BATCH_SIZE = 1024
 
+# Mapping of sample types to the generator type used for embedding generation.
+_GENERATOR_SAMPLE_TYPE: dict[SampleType, SampleType] = {
+    SampleType.IMAGE: SampleType.IMAGE,
+    SampleType.ANNOTATION: SampleType.IMAGE,
+    SampleType.VIDEO: SampleType.VIDEO,
+}
+
 
 class EmbeddingManagerProvider:
     """Provider for the EmbeddingManager singleton instance."""
@@ -71,9 +78,7 @@ class EmbeddingManager:
         """Initialize the embedding manager."""
         self._models: dict[UUID, EmbeddingGenerator] = {}
         self._collection_id_to_default_model_id: dict[UUID, UUID] = {}
-        # Loaded generators cache. A single physical model is held
-        # in memory once and shared across collections.
-        self._generators: dict[SampleType, EmbeddingGenerator] = {}
+        self._sample_type_to_model_id: dict[SampleType, UUID] = {}
 
     def register_embedding_model(
         self,
@@ -283,16 +288,26 @@ class EmbeddingManager:
             UUID of the default embedding model or None if the model cannot be loaded.
         """
         # Return the existing default model ID if available.
-
         if collection_id in self._collection_id_to_default_model_id:
             return self._collection_id_to_default_model_id[collection_id]
 
-        # Load the embedding generator based on sample_type from the env var.
         dataset = collection_resolver.get_by_id(session=session, collection_id=collection_id)
         if dataset is None:
             raise ValueError("Provided collection_id could not be found.")
 
-        embedding_generator = self._get_or_load_generator(sample_type=dataset.sample_type)
+        # Check if a model suitable for this sample type is already registered
+        generator_sample_type = _GENERATOR_SAMPLE_TYPE.get(dataset.sample_type)
+        if generator_sample_type is None:
+            return None
+        existing_model_id = self._sample_type_to_model_id.get(generator_sample_type)
+        embedding_generator: EmbeddingGenerator | None = None
+        if existing_model_id is not None:
+            embedding_generator = self._models[existing_model_id]
+        else:
+            # Load the embedding generator based on sample_type from the env var.
+            embedding_generator = _load_embedding_generator_from_env(
+                sample_type=generator_sample_type
+            )
         if embedding_generator is None:
             return None
 
@@ -303,32 +318,10 @@ class EmbeddingManager:
             embedding_generator=embedding_generator,
             set_as_default=True,
         )
+        # Store the model ID for the sample type to avoid reloading it in the future.
+        self._sample_type_to_model_id[generator_sample_type] = embedding_model.embedding_model_id
 
         return embedding_model.embedding_model_id
-
-    def _get_or_load_generator(self, sample_type: SampleType) -> EmbeddingGenerator | None:
-        """Return a generator for the sample type, loading its weights only once.
-
-        Generators are cached by model kind so a single physical model is held in
-        memory once and reused across collections.
-
-        Args:
-            sample_type: The sample type to load a generator for.
-
-        Returns:
-            The cached or newly loaded generator, or None if none can be loaded.
-        """
-        cache_key = _generator_cache_key(sample_type=sample_type)
-        if cache_key is None:
-            return None
-
-        if cache_key not in self._generators:
-            generator = _load_embedding_generator_from_env(sample_type=cache_key)
-            if generator is None:
-                return None
-            self._generators[cache_key] = generator
-
-        return self._generators[cache_key]
 
     def _get_default_or_validate(
         self, collection_id: UUID, embedding_model_id: UUID | None
@@ -382,19 +375,6 @@ def _store_embeddings(
             progress.update(len(sample_embeddings))
 
     session.commit()
-
-
-def _generator_cache_key(sample_type: SampleType) -> SampleType | None:
-    """Map a sample type to the key under which its generator is cached.
-
-    Image and annotation samples share the same image generator, so both map to
-    SampleType.IMAGE and reuse a single loaded instance.
-    """
-    if sample_type in (SampleType.IMAGE, SampleType.ANNOTATION):
-        return SampleType.IMAGE
-    if sample_type == SampleType.VIDEO:
-        return SampleType.VIDEO
-    return None
 
 
 def _load_embedding_generator_from_env(sample_type: SampleType) -> EmbeddingGenerator | None:

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -71,6 +71,9 @@ class EmbeddingManager:
         """Initialize the embedding manager."""
         self._models: dict[UUID, EmbeddingGenerator] = {}
         self._collection_id_to_default_model_id: dict[UUID, UUID] = {}
+        # Loaded generators cache. A single physical model is held
+        # in memory once and shared across collections.
+        self._generators: dict[SampleType, EmbeddingGenerator] = {}
 
     def register_embedding_model(
         self,
@@ -289,7 +292,7 @@ class EmbeddingManager:
         if dataset is None:
             raise ValueError("Provided collection_id could not be found.")
 
-        embedding_generator = _load_embedding_generator_from_env(sample_type=dataset.sample_type)
+        embedding_generator = self._get_or_load_generator(sample_type=dataset.sample_type)
         if embedding_generator is None:
             return None
 
@@ -302,6 +305,30 @@ class EmbeddingManager:
         )
 
         return embedding_model.embedding_model_id
+
+    def _get_or_load_generator(self, sample_type: SampleType) -> EmbeddingGenerator | None:
+        """Return a generator for the sample type, loading its weights only once.
+
+        Generators are cached by model kind so a single physical model is held in
+        memory once and reused across collections.
+
+        Args:
+            sample_type: The sample type to load a generator for.
+
+        Returns:
+            The cached or newly loaded generator, or None if none can be loaded.
+        """
+        cache_key = _generator_cache_key(sample_type=sample_type)
+        if cache_key is None:
+            return None
+
+        if cache_key not in self._generators:
+            generator = _load_embedding_generator_from_env(sample_type=sample_type)
+            if generator is None:
+                return None
+            self._generators[cache_key] = generator
+
+        return self._generators[cache_key]
 
     def _get_default_or_validate(
         self, collection_id: UUID, embedding_model_id: UUID | None
@@ -355,6 +382,19 @@ def _store_embeddings(
             progress.update(len(sample_embeddings))
 
     session.commit()
+
+
+def _generator_cache_key(sample_type: SampleType) -> SampleType | None:
+    """Map a sample type to the key under which its generator is cached.
+
+    Image and annotation samples share the same image generator, so both map to
+    SampleType.IMAGE and reuse a single loaded instance.
+    """
+    if sample_type in (SampleType.IMAGE, SampleType.ANNOTATION):
+        return SampleType.IMAGE
+    if sample_type == SampleType.VIDEO:
+        return SampleType.VIDEO
+    return None
 
 
 def _load_embedding_generator_from_env(sample_type: SampleType) -> EmbeddingGenerator | None:

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -359,6 +359,46 @@ def test_load_or_get_default_model(
     mock_load.assert_called_once_with(sample_type=SampleType.IMAGE)  # still only one call
 
 
+def test_load_or_get_default_model__shares_generator_across_collections(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """An annotation child collection reuses the parent's loaded generator.
+
+    The generator weights are loaded once, but each collection still gets its
+    own embedding-model record and id.
+    """
+    image_collection = create_collection(session=db_session, sample_type=SampleType.IMAGE)
+    annotation_collection = create_collection(
+        session=db_session,
+        parent_collection_id=image_collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    manager = EmbeddingManager()
+
+    mock_load = mocker.patch.object(
+        embedding_manager,
+        "_load_embedding_generator_from_env",
+        return_value=RandomEmbeddingGenerator(),
+    )
+
+    image_model_id = manager.load_or_get_default_model(
+        session=db_session, collection_id=image_collection.collection_id
+    )
+    annotation_model_id = manager.load_or_get_default_model(
+        session=db_session, collection_id=annotation_collection.collection_id
+    )
+    assert image_model_id is not None
+    assert annotation_model_id is not None
+
+    # The generator is loaded only once and shared between both collections.
+    mock_load.assert_called_once_with(sample_type=SampleType.IMAGE)
+    assert manager._models[image_model_id] is manager._models[annotation_model_id]
+
+    # Each collection still owns a distinct embedding-model record.
+    assert image_model_id != annotation_model_id
+
+
 def test_load_or_get_default_model__cant_load(
     db_session: Session,
     mocker: MockerFixture,

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -382,11 +382,11 @@ def test_load_or_get_default_model__shares_generator_across_collections(
         return_value=RandomEmbeddingGenerator(),
     )
 
-    image_model_id = manager.load_or_get_default_model(
-        session=db_session, collection_id=image_collection.collection_id
-    )
     annotation_model_id = manager.load_or_get_default_model(
         session=db_session, collection_id=annotation_collection.collection_id
+    )
+    image_model_id = manager.load_or_get_default_model(
+        session=db_session, collection_id=image_collection.collection_id
     )
     assert image_model_id is not None
     assert annotation_model_id is not None


### PR DESCRIPTION
## What has changed and why?

Cache loaded embedding generators by sample type so image and annotation collections share one in-memory model instance.
Each collection still gets its own embedding-model DB record and ID.

## How has it been tested?

new tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved embedding model loading by normalizing collection sample types so compatible collections (e.g., image and annotation) reuse the same underlying generator instead of loading weights repeatedly.
  * For unsupported sample types, default embedding model loading now cleanly returns no model rather than proceeding.

* **Tests**
  * Added a unit test ensuring the generator is loaded only once, shared across the resulting embedding model instances, and that persisted model record IDs are created distinctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->