### PR TITLE
Add confusion-cell sample filter

### DIFF
--- a/lightly_studio/src/lightly_studio/models/evaluation_confusion_matrix.py
+++ b/lightly_studio/src/lightly_studio/models/evaluation_confusion_matrix.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from pydantic import BaseModel, Field
 
 # Row label for predictions with no matching ground truth (false positives).
@@ -9,6 +11,26 @@ NO_GROUND_TRUTH_ROW_LABEL = "(no ground truth)"
 
 # Column label for ground truths with no matching prediction (false negatives).
 NO_PREDICTION_COL_LABEL = "(no prediction)"
+
+
+class ConfusionCell(BaseModel):
+    """A single class-by-class cell of a confusion matrix for one evaluation run.
+
+    Identifies samples that contain a ground-truth/prediction annotation pairing of
+    the given label combination. Labels are matched by name (unique per dataset), so
+    no annotation-id lookup is needed when resolving the cell to its samples.
+
+    Attributes:
+        evaluation_run_id: Evaluation run whose pairing metrics are queried.
+        gt_label: Ground-truth annotation label name (matrix row).
+        pred_label: Prediction annotation label name (matrix column).
+    """
+
+    evaluation_run_id: UUID = Field(
+        description="Evaluation run whose pairing metrics define the cell.",
+    )
+    gt_label: str = Field(description="Ground-truth annotation label name (matrix row).")
+    pred_label: str = Field(description="Prediction annotation label name (matrix column).")
 
 
 class ConfusionMatrix(BaseModel):

--- a/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
@@ -4,10 +4,15 @@ from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
+from sqlalchemy.orm import aliased
 from sqlmodel import col, select
 
 from lightly_studio.core.dataset_query import query_translation
 from lightly_studio.database import db_array
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation_label import AnnotationLabelTable
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
+from lightly_studio.models.evaluation_confusion_matrix import ConfusionCell
 from lightly_studio.models.metadata import SampleMetadataTable
 from lightly_studio.models.query_expr import QueryExpr
 from lightly_studio.models.sample import SampleTable
@@ -26,6 +31,7 @@ class SampleFilter(BaseModel):
     sample_ids: Optional[list[UUID]] = None
     has_captions: Optional[bool] = None
     annotations_filter: Optional[AnnotationsFilter] = None
+    confusion_cell: Optional[ConfusionCell] = None
 
     # Query expression filter
     #
@@ -41,6 +47,7 @@ class SampleFilter(BaseModel):
         query = self._apply_sample_ids_filter(query)
         query = self._apply_annotation_filters(query)
         query = self._apply_tag_filters(query)
+        query = self._apply_confusion_cell_filter(query)
         query = self._apply_metadata_filters(query)
         query = self._apply_captions_filter(query)
         return self._apply_query_expr_filter(query)
@@ -68,6 +75,49 @@ class SampleFilter(BaseModel):
             select(SampleTable.sample_id)
             .join(SampleTable.tags)
             .where(db_array.in_array(column=col(TagTable.tag_id), values=self.tag_ids))
+            .distinct()
+        )
+        return query.where(col(SampleTable.sample_id).in_(sample_ids_subquery))
+
+    def _apply_confusion_cell_filter(self, query: QueryType) -> QueryType:
+        if self.confusion_cell is None:
+            return query
+
+        # Resolve the cell to its samples with a subquery against the persisted
+        # pairing metrics, joining annotation labels by name (unique per dataset),
+        # mirroring the tag-filter subquery pattern. This slice handles the
+        # non-null/non-null case only, so both sides are inner-joined.
+        gt_annotation = aliased(AnnotationBaseTable)
+        pred_annotation = aliased(AnnotationBaseTable)
+        gt_label = aliased(AnnotationLabelTable)
+        pred_label = aliased(AnnotationLabelTable)
+
+        sample_ids_subquery = (
+            select(EvaluationAnnotationMetricTable.sample_id)
+            .join(
+                gt_annotation,
+                col(EvaluationAnnotationMetricTable.gt_annotation_id)
+                == col(gt_annotation.sample_id),
+            )
+            .join(
+                pred_annotation,
+                col(EvaluationAnnotationMetricTable.pred_annotation_id)
+                == col(pred_annotation.sample_id),
+            )
+            .join(
+                gt_label,
+                col(gt_annotation.annotation_label_id) == col(gt_label.annotation_label_id),
+            )
+            .join(
+                pred_label,
+                col(pred_annotation.annotation_label_id) == col(pred_label.annotation_label_id),
+            )
+            .where(
+                col(EvaluationAnnotationMetricTable.evaluation_run_id)
+                == self.confusion_cell.evaluation_run_id
+            )
+            .where(col(gt_label.annotation_label_name) == self.confusion_cell.gt_label)
+            .where(col(pred_label.annotation_label_name) == self.confusion_cell.pred_label)
             .distinct()
         )
         return query.where(col(SampleTable.sample_id).in_(sample_ids_subquery))

--- a/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from pydantic import BaseModel
 from sqlalchemy.orm import aliased
 from sqlmodel import col, select
+from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.core.dataset_query import query_translation
 from lightly_studio.database import db_array
@@ -82,7 +83,10 @@ class SampleFilter(BaseModel):
     def _apply_confusion_cell_filter(self, query: QueryType) -> QueryType:
         if self.confusion_cell is None:
             return query
+        sample_ids_subquery = self._build_confusion_cell_subquery(self.confusion_cell)
+        return query.where(col(SampleTable.sample_id).in_(sample_ids_subquery))
 
+    def _build_confusion_cell_subquery(self, confusion_cell: ConfusionCell) -> SelectOfScalar[UUID]:
         # Resolve the cell to its samples with a subquery against the persisted
         # pairing metrics, joining annotation labels by name (unique per dataset),
         # mirroring the tag-filter subquery pattern. This slice handles the
@@ -92,7 +96,7 @@ class SampleFilter(BaseModel):
         gt_label = aliased(AnnotationLabelTable)
         pred_label = aliased(AnnotationLabelTable)
 
-        sample_ids_subquery = (
+        return (
             select(EvaluationAnnotationMetricTable.sample_id)
             .join(
                 gt_annotation,
@@ -114,13 +118,12 @@ class SampleFilter(BaseModel):
             )
             .where(
                 col(EvaluationAnnotationMetricTable.evaluation_run_id)
-                == self.confusion_cell.evaluation_run_id
+                == confusion_cell.evaluation_run_id
             )
-            .where(col(gt_label.annotation_label_name) == self.confusion_cell.gt_label)
-            .where(col(pred_label.annotation_label_name) == self.confusion_cell.pred_label)
+            .where(col(gt_label.annotation_label_name) == confusion_cell.gt_label)
+            .where(col(pred_label.annotation_label_name) == confusion_cell.pred_label)
             .distinct()
         )
-        return query.where(col(SampleTable.sample_id).in_(sample_ids_subquery))
 
     def _apply_metadata_filters(self, query: QueryType) -> QueryType:
         if self.metadata_filters:

--- a/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
+++ b/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
@@ -506,42 +506,6 @@ class TestSampleFilter:
         assert result[0].sample_id == samples[1].sample_id
 
 
-def _seed_pair(
-    session: Session,
-    dataset_id: UUID,
-    run_id: UUID,
-    image: ImageTable,
-    labels: tuple[AnnotationLabelTable, AnnotationLabelTable],
-) -> None:
-    """Attach a gt/pred annotation pair to ``image`` and persist a metric row for it."""
-    gt_label, pred_label = labels
-    gt_annotation = create_annotation(
-        session=session,
-        collection_id=dataset_id,
-        sample_id=image.sample_id,
-        annotation_label_id=gt_label.annotation_label_id,
-    )
-    pred_annotation = create_annotation(
-        session=session,
-        collection_id=dataset_id,
-        sample_id=image.sample_id,
-        annotation_label_id=pred_label.annotation_label_id,
-    )
-    evaluation_annotation_metric_resolver.create_many(
-        session=session,
-        records=[
-            EvaluationAnnotationMetricCreate(
-                evaluation_run_id=run_id,
-                sample_id=image.sample_id,
-                gt_annotation_id=gt_annotation.sample_id,
-                pred_annotation_id=pred_annotation.sample_id,
-                metric_name="iou",
-                value=0.9,
-            )
-        ],
-    )
-
-
 class TestSampleFilterConfusionCell:
     def test_apply__confusion_cell__returns_only_matching_pairing(
         self, db_session: Session
@@ -569,9 +533,27 @@ class TestSampleFilterConfusionCell:
         person = create_annotation_label(
             session=db_session, root_collection_id=dataset_id, label_name="person"
         )
-        _seed_pair(db_session, dataset_id, run.id, samples[0], labels=(car, truck))
-        _seed_pair(db_session, dataset_id, run.id, samples[1], labels=(person, person))
-        _seed_pair(db_session, dataset_id, run.id, samples[2], labels=(car, person))
+        _seed_pair(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[0],
+            labels=(car, truck),
+        )
+        _seed_pair(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[1],
+            labels=(person, person),
+        )
+        _seed_pair(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[2],
+            labels=(car, person),
+        )
 
         sample_filter = SampleFilter(
             confusion_cell=ConfusionCell(
@@ -609,8 +591,20 @@ class TestSampleFilterConfusionCell:
             session=db_session, root_collection_id=dataset_id, label_name="truck"
         )
         # Same car -> truck pairing recorded in two different runs.
-        _seed_pair(db_session, dataset_id, run_a.id, samples[0], labels=(car, truck))
-        _seed_pair(db_session, dataset_id, run_b.id, samples[1], labels=(car, truck))
+        _seed_pair(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run_a.id,
+            image=samples[0],
+            labels=(car, truck),
+        )
+        _seed_pair(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run_b.id,
+            image=samples[1],
+            labels=(car, truck),
+        )
 
         sample_filter = SampleFilter(
             confusion_cell=ConfusionCell(
@@ -645,8 +639,20 @@ class TestSampleFilterConfusionCell:
             session=db_session, root_collection_id=dataset_id, label_name="truck"
         )
         # Both samples share the car -> truck pairing.
-        _seed_pair(db_session, dataset_id, run.id, samples[0], labels=(car, truck))
-        _seed_pair(db_session, dataset_id, run.id, samples[1], labels=(car, truck))
+        _seed_pair(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[0],
+            labels=(car, truck),
+        )
+        _seed_pair(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[1],
+            labels=(car, truck),
+        )
 
         # ANDing with a sample_ids predicate narrows the cell to a single sample.
         sample_filter = SampleFilter(
@@ -661,3 +667,39 @@ class TestSampleFilterConfusionCell:
 
         assert len(result) == 1
         assert result[0].sample_id == samples[1].sample_id
+
+
+def _seed_pair(
+    session: Session,
+    dataset_id: UUID,
+    run_id: UUID,
+    image: ImageTable,
+    labels: tuple[AnnotationLabelTable, AnnotationLabelTable],
+) -> None:
+    """Attach a gt/pred annotation pair to ``image`` and persist a metric row for it."""
+    gt_label, pred_label = labels
+    gt_annotation = create_annotation(
+        session=session,
+        collection_id=dataset_id,
+        sample_id=image.sample_id,
+        annotation_label_id=gt_label.annotation_label_id,
+    )
+    pred_annotation = create_annotation(
+        session=session,
+        collection_id=dataset_id,
+        sample_id=image.sample_id,
+        annotation_label_id=pred_label.annotation_label_id,
+    )
+    evaluation_annotation_metric_resolver.create_many(
+        session=session,
+        records=[
+            EvaluationAnnotationMetricCreate(
+                evaluation_run_id=run_id,
+                sample_id=image.sample_id,
+                gt_annotation_id=gt_annotation.sample_id,
+                pred_annotation_id=pred_annotation.sample_id,
+                metric_name="iou",
+                value=0.9,
+            )
+        ],
+    )

--- a/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
+++ b/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from sqlmodel import Session, col, select
 
+from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionCreate
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricCreate
+from lightly_studio.models.evaluation_confusion_matrix import ConfusionCell
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.query_expr import (
     EqualityComparisonOperator,
@@ -15,7 +20,11 @@ from lightly_studio.models.query_expr import (
     StringExpr,
 )
 from lightly_studio.models.sample import SampleTable
-from lightly_studio.resolvers import caption_resolver, tag_resolver
+from lightly_studio.resolvers import (
+    caption_resolver,
+    evaluation_annotation_metric_resolver,
+    tag_resolver,
+)
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.metadata_resolver.metadata_filter import Metadata
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
@@ -26,6 +35,9 @@ from tests.helpers_resolvers import (
     create_collection,
     create_images,
     create_tag,
+)
+from tests.resolvers.evaluation_sample_metric_resolver import (
+    helpers as evaluation_sample_metric_helpers,
 )
 
 
@@ -488,6 +500,163 @@ class TestSampleFilter:
 
         query = select(ImageTable).join(ImageTable.sample)
         filtered_query = sample_filter.apply(query=query)
+        result = db_session.exec(filtered_query).all()
+
+        assert len(result) == 1
+        assert result[0].sample_id == samples[1].sample_id
+
+
+def _seed_pair(
+    session: Session,
+    dataset_id: UUID,
+    run_id: UUID,
+    image: ImageTable,
+    labels: tuple[AnnotationLabelTable, AnnotationLabelTable],
+) -> None:
+    """Attach a gt/pred annotation pair to ``image`` and persist a metric row for it."""
+    gt_label, pred_label = labels
+    gt_annotation = create_annotation(
+        session=session,
+        collection_id=dataset_id,
+        sample_id=image.sample_id,
+        annotation_label_id=gt_label.annotation_label_id,
+    )
+    pred_annotation = create_annotation(
+        session=session,
+        collection_id=dataset_id,
+        sample_id=image.sample_id,
+        annotation_label_id=pred_label.annotation_label_id,
+    )
+    evaluation_annotation_metric_resolver.create_many(
+        session=session,
+        records=[
+            EvaluationAnnotationMetricCreate(
+                evaluation_run_id=run_id,
+                sample_id=image.sample_id,
+                gt_annotation_id=gt_annotation.sample_id,
+                pred_annotation_id=pred_annotation.sample_id,
+                metric_name="iou",
+                value=0.9,
+            )
+        ],
+    )
+
+
+class TestSampleFilterConfusionCell:
+    def test_apply__confusion_cell__returns_only_matching_pairing(
+        self, db_session: Session
+    ) -> None:
+        dataset = create_collection(session=db_session)
+        dataset_id = dataset.collection_id
+        run, _image = evaluation_sample_metric_helpers.create_run_and_image(
+            session=db_session, dataset_collection_id=dataset_id
+        )
+        samples = create_images(
+            db_session=db_session,
+            collection_id=dataset_id,
+            images=[
+                ImageStub(path="car_truck.png"),
+                ImageStub(path="person_person.png"),
+                ImageStub(path="car_person.png"),
+            ],
+        )
+        car = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="car"
+        )
+        truck = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="truck"
+        )
+        person = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="person"
+        )
+        _seed_pair(db_session, dataset_id, run.id, samples[0], labels=(car, truck))
+        _seed_pair(db_session, dataset_id, run.id, samples[1], labels=(person, person))
+        _seed_pair(db_session, dataset_id, run.id, samples[2], labels=(car, person))
+
+        sample_filter = SampleFilter(
+            confusion_cell=ConfusionCell(
+                evaluation_run_id=run.id, gt_label="car", pred_label="truck"
+            )
+        )
+
+        filtered_query = sample_filter.apply(query=select(SampleTable))
+        result = db_session.exec(filtered_query).all()
+
+        assert len(result) == 1
+        assert result[0].sample_id == samples[0].sample_id
+
+    def test_apply__confusion_cell__scopes_to_evaluation_run(self, db_session: Session) -> None:
+        dataset = create_collection(session=db_session)
+        dataset_id = dataset.collection_id
+        run_a, _image_a = evaluation_sample_metric_helpers.create_run_and_image(
+            session=db_session, dataset_collection_id=dataset_id, name="run_a"
+        )
+        run_b, _image_b = evaluation_sample_metric_helpers.create_run_and_image(
+            session=db_session, dataset_collection_id=dataset_id, name="run_b"
+        )
+        samples = create_images(
+            db_session=db_session,
+            collection_id=dataset_id,
+            images=[
+                ImageStub(path="run_a_sample.png"),
+                ImageStub(path="run_b_sample.png"),
+            ],
+        )
+        car = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="car"
+        )
+        truck = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="truck"
+        )
+        # Same car -> truck pairing recorded in two different runs.
+        _seed_pair(db_session, dataset_id, run_a.id, samples[0], labels=(car, truck))
+        _seed_pair(db_session, dataset_id, run_b.id, samples[1], labels=(car, truck))
+
+        sample_filter = SampleFilter(
+            confusion_cell=ConfusionCell(
+                evaluation_run_id=run_a.id, gt_label="car", pred_label="truck"
+            )
+        )
+
+        filtered_query = sample_filter.apply(query=select(SampleTable))
+        result = db_session.exec(filtered_query).all()
+
+        assert len(result) == 1
+        assert result[0].sample_id == samples[0].sample_id
+
+    def test_apply__confusion_cell__ands_with_other_predicate(self, db_session: Session) -> None:
+        dataset = create_collection(session=db_session)
+        dataset_id = dataset.collection_id
+        run, _image = evaluation_sample_metric_helpers.create_run_and_image(
+            session=db_session, dataset_collection_id=dataset_id
+        )
+        samples = create_images(
+            db_session=db_session,
+            collection_id=dataset_id,
+            images=[
+                ImageStub(path="car_truck_0.png"),
+                ImageStub(path="car_truck_1.png"),
+            ],
+        )
+        car = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="car"
+        )
+        truck = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="truck"
+        )
+        # Both samples share the car -> truck pairing.
+        _seed_pair(db_session, dataset_id, run.id, samples[0], labels=(car, truck))
+        _seed_pair(db_session, dataset_id, run.id, samples[1], labels=(car, truck))
+
+        # ANDing with a sample_ids predicate narrows the cell to a single sample.
+        sample_filter = SampleFilter(
+            confusion_cell=ConfusionCell(
+                evaluation_run_id=run.id, gt_label="car", pred_label="truck"
+            ),
+            sample_ids=[samples[1].sample_id],
+        )
+
+        filtered_query = sample_filter.apply(query=select(SampleTable))
         result = db_session.exec(filtered_query).all()
 
         assert len(result) == 1


### PR DESCRIPTION
## What

Adds a `ConfusionCell` model and a `SampleFilter.confusion_cell` predicate that resolves a single class-by-class confusion-matrix cell to the samples it covers.

The subquery joins `evaluation_annotation_metric` to annotation labels by name (unique per dataset) and scopes to the evaluation run, mirroring the existing tag-filter subquery pattern. It ANDs with the other `SampleFilter` predicates.

## Why

First of a 4-PR split for the "click a confusion-matrix cell to filter the image grid" feature. This backend slice is self-contained and must land first — adding `confusion_cell` to `SampleFilter` regenerates the frontend's `ConfusionCell` API type that the follow-up frontend PRs depend on.

## Scope

- `models/evaluation_confusion_matrix.py` — `ConfusionCell` model
- `resolvers/sample_resolver/sample_filter.py` — `_apply_confusion_cell_filter`
- `tests/resolvers/sample_resolver/test_sample_filter.py` — tests (matching pairing, run scoping, ANDing with other predicates)

## Testing

- `pytest tests/resolvers/sample_resolver/test_sample_filter.py` — 14 passed
- `ruff check` clean; `mypy` clean for these files (pre-existing `s3fs` stub errors in unrelated test files remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new confusion-matrix-based sample filter using a “confusion cell” (evaluation run + ground-truth label + predicted label) to find matching samples.
  * The confusion-cell filter is optional and can be combined with existing sample filter criteria.
* **Tests**
  * Added automated coverage to verify correct label pairing matching, proper evaluation-run scoping, and compatibility when combined with other filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->