### PR TITLE
Add select-all filter snapshot stores to useGlobalStorage

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.test.ts
@@ -2,9 +2,7 @@ import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useGlobalStorage } from './useGlobalStorage';
 
-type SelectAllSnapshot = Parameters<
-    ReturnType<typeof useGlobalStorage>['setSelectAllSnapshot']
->[1];
+type SelectAllSnapshot = Parameters<ReturnType<typeof useGlobalStorage>['setSelectAllSnapshot']>[1];
 
 describe('useGlobalStorage', () => {
     let storage: ReturnType<typeof useGlobalStorage>;

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.test.ts
@@ -202,6 +202,100 @@ describe('useGlobalStorage', () => {
         });
     });
 
+    describe('Select-all snapshot (sample grid)', () => {
+        const snapshot = { filter: { filter_type: 'image' }, size: 3 };
+
+        it('records the snapshot for a collection', () => {
+            storage.setSelectAllSnapshot(testCollectionId, snapshot);
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toEqual(snapshot);
+        });
+
+        it('is null when never set', () => {
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toBeNull();
+        });
+
+        it('is invalidated by a per-sample toggle', () => {
+            storage.setSelectAllSnapshot(testCollectionId, snapshot);
+            storage.toggleSampleSelection('sample1', testCollectionId);
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toBeNull();
+        });
+
+        it('is invalidated by clearing the selection', () => {
+            storage.setSelectAllSnapshot(testCollectionId, snapshot);
+            storage.clearSelectedSamples(testCollectionId);
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toBeNull();
+        });
+
+        it('is invalidated by a range selection', () => {
+            storage.setSelectAllSnapshot(testCollectionId, snapshot);
+            storage.setRangeSelectionForCollection(testCollectionId, null);
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toBeNull();
+        });
+
+        it('is NOT invalidated by setAllSelectedSampleIds', () => {
+            storage.setSelectAllSnapshot(testCollectionId, snapshot);
+            storage.setAllSelectedSampleIds(testCollectionId, new Set(['a', 'b']));
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toEqual(snapshot);
+        });
+
+        it('is invalidated by clearSelectAllSnapshot', () => {
+            storage.setSelectAllSnapshot(testCollectionId, snapshot);
+            storage.clearSelectAllSnapshot(testCollectionId);
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toBeNull();
+        });
+
+        it('is independent per collection', () => {
+            storage.setSelectAllSnapshot(testCollectionId, snapshot);
+            storage.toggleSampleSelection('sample1', testCollectionId2);
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toEqual(snapshot);
+            expect(get(storage.getSelectAllSnapshot(testCollectionId2))).toBeNull();
+        });
+    });
+
+    describe('Select-all snapshot (annotation grid)', () => {
+        const snapshot = { filter: { filter_type: 'annotations' }, size: 5 };
+
+        it('records the snapshot for a collection', () => {
+            storage.setSelectAllAnnotationSnapshot(testCollectionId, snapshot);
+            expect(get(storage.getSelectAllAnnotationSnapshot(testCollectionId))).toEqual(snapshot);
+        });
+
+        it('is invalidated by a per-annotation toggle', () => {
+            storage.setSelectAllAnnotationSnapshot(testCollectionId, snapshot);
+            storage.toggleSampleAnnotationCropSelection(testCollectionId, 'annotation1');
+            expect(get(storage.getSelectAllAnnotationSnapshot(testCollectionId))).toBeNull();
+        });
+
+        it('is invalidated by clearing annotation crops', () => {
+            storage.setSelectAllAnnotationSnapshot(testCollectionId, snapshot);
+            storage.clearSelectedSampleAnnotationCrops(testCollectionId);
+            expect(get(storage.getSelectAllAnnotationSnapshot(testCollectionId))).toBeNull();
+        });
+
+        it('is NOT invalidated by setAllSelectedAnnotationCropIds', () => {
+            storage.setSelectAllAnnotationSnapshot(testCollectionId, snapshot);
+            storage.setAllSelectedAnnotationCropIds(testCollectionId, new Set(['a', 'b']));
+            expect(get(storage.getSelectAllAnnotationSnapshot(testCollectionId))).toEqual(snapshot);
+        });
+
+        it('is independent from the sample snapshot store', () => {
+            const sampleSnapshot = { filter: { filter_type: 'image' }, size: 2 };
+            storage.setSelectAllSnapshot(testCollectionId, sampleSnapshot);
+            storage.setSelectAllAnnotationSnapshot(testCollectionId, snapshot);
+
+            // A sample-only mutation must not touch the annotation snapshot.
+            storage.toggleSampleSelection('sample1', testCollectionId);
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toBeNull();
+            expect(get(storage.getSelectAllAnnotationSnapshot(testCollectionId))).toEqual(snapshot);
+
+            // An annotation-only mutation must not touch the sample snapshot.
+            storage.setSelectAllSnapshot(testCollectionId, sampleSnapshot);
+            storage.toggleSampleAnnotationCropSelection(testCollectionId, 'annotation1');
+            expect(get(storage.getSelectAllAnnotationSnapshot(testCollectionId))).toBeNull();
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toEqual(sampleSnapshot);
+        });
+    });
+
     describe('Last annotation source', () => {
         it('stores the selected source per collection', () => {
             storage.updateLastAnnotationSource(testCollectionId, 'ground_truth');

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.test.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useGlobalStorage } from './useGlobalStorage';
+import { useGlobalStorage, type SelectAllSnapshot } from './useGlobalStorage';
 
 describe('useGlobalStorage', () => {
     let storage: ReturnType<typeof useGlobalStorage>;
@@ -203,7 +203,7 @@ describe('useGlobalStorage', () => {
     });
 
     describe('Select-all snapshot (sample grid)', () => {
-        const snapshot = { filter: { filter_type: 'image' }, size: 3 };
+        const snapshot: SelectAllSnapshot = { filter: { filter_type: 'image' }, size: 3 };
 
         it('records the snapshot for a collection', () => {
             storage.setSelectAllSnapshot(testCollectionId, snapshot);
@@ -226,10 +226,10 @@ describe('useGlobalStorage', () => {
             expect(get(storage.getSelectAllSnapshot(testCollectionId))).toBeNull();
         });
 
-        it('is invalidated by a range selection', () => {
+        it('is NOT invalidated by a range-filter change (not a selection mutation)', () => {
             storage.setSelectAllSnapshot(testCollectionId, snapshot);
             storage.setRangeSelectionForCollection(testCollectionId, null);
-            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toBeNull();
+            expect(get(storage.getSelectAllSnapshot(testCollectionId))).toEqual(snapshot);
         });
 
         it('is NOT invalidated by setAllSelectedSampleIds', () => {
@@ -253,7 +253,7 @@ describe('useGlobalStorage', () => {
     });
 
     describe('Select-all snapshot (annotation grid)', () => {
-        const snapshot = { filter: { filter_type: 'annotations' }, size: 5 };
+        const snapshot: SelectAllSnapshot = { filter: { filter_type: 'annotations' }, size: 5 };
 
         it('records the snapshot for a collection', () => {
             storage.setSelectAllAnnotationSnapshot(testCollectionId, snapshot);
@@ -279,7 +279,7 @@ describe('useGlobalStorage', () => {
         });
 
         it('is independent from the sample snapshot store', () => {
-            const sampleSnapshot = { filter: { filter_type: 'image' }, size: 2 };
+            const sampleSnapshot: SelectAllSnapshot = { filter: { filter_type: 'image' }, size: 2 };
             storage.setSelectAllSnapshot(testCollectionId, sampleSnapshot);
             storage.setSelectAllAnnotationSnapshot(testCollectionId, snapshot);
 

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.test.ts
@@ -1,6 +1,10 @@
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useGlobalStorage, type SelectAllSnapshot } from './useGlobalStorage';
+import { useGlobalStorage } from './useGlobalStorage';
+
+type SelectAllSnapshot = Parameters<
+    ReturnType<typeof useGlobalStorage>['setSelectAllSnapshot']
+>[1];
 
 describe('useGlobalStorage', () => {
     let storage: ReturnType<typeof useGlobalStorage>;

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
@@ -386,8 +386,6 @@ export const useGlobalStorage = () => {
             activePanel.update((p) => togglePanel(p, 'evaluationRuns', show)),
         getRangeSelection,
         setRangeSelectionForCollection: (collectionId: string, selection: Point[] | null) => {
-            // No snapshot invalidation: this sets the embedding-plot range filter, not the
-            // selection, so the snapshot invariant holds. Selection clears go via clearSelectedSamples.
             rangeSelectionBycollection.update((state) => ({
                 ...state,
                 [collectionId]: selection

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
@@ -8,7 +8,7 @@ import type { MetadataInfo } from '$lib/services/types';
 import type { MetadataBounds } from '$lib/services/types';
 import type { MetadataValues } from '$lib/services/types';
 import { useReversibleActions } from './useReversibleActions';
-import type { CollectionView, SampleType } from '$lib/api/lightly_studio_local';
+import type { CollectionView, SampleType, TagByFilterBody } from '$lib/api/lightly_studio_local';
 import type { Point } from 'embedding-atlas/svelte';
 
 const lastGridType = writable<GridType>('images');
@@ -21,8 +21,11 @@ const selectedSampleAnnotationCropIds = writable<Record<string, Set<string>>>({}
  * so it can be tagged by filter instead of by materialized IDs. Any per-sample edit
  * invalidates it (sets it `null`). `size` lets the tag logic backstop against a
  * selection whose size no longer matches the snapshot.
+ *
+ * `filter` is typed as the by-filter tag endpoint's payload (the discriminated union over the
+ * per-grid filters) so a snapshot can never hold a filter the endpoint cannot accept.
  */
-export type SelectAllSnapshot = { filter: unknown; size: number };
+export type SelectAllSnapshot = { filter: TagByFilterBody['filter']; size: number };
 
 const selectAllSnapshotByCollection = writable<Record<string, SelectAllSnapshot | null>>({});
 const selectAllAnnotationSnapshotByCollection = writable<Record<string, SelectAllSnapshot | null>>(
@@ -389,7 +392,9 @@ export const useGlobalStorage = () => {
             activePanel.update((p) => togglePanel(p, 'evaluationRuns', show)),
         getRangeSelection,
         setRangeSelectionForCollection: (collectionId: string, selection: Point[] | null) => {
-            invalidateSelectAllSnapshot(collectionId);
+            // Note: this updates the embedding-plot range filter, not the selected sample IDs, so
+            // it must NOT invalidate the select-all snapshot — the selection (and thus the snapshot
+            // invariant) is unchanged. Selection clears route through clearSelectedSamples instead.
             rangeSelectionBycollection.update((state) => ({
                 ...state,
                 [collectionId]: selection

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
@@ -16,14 +16,10 @@ const selectedSampleIdsByCollection = writable<Record<string, Set<string>>>({});
 const selectedSampleAnnotationCropIds = writable<Record<string, Set<string>>>({});
 
 /**
- * Snapshot of the filter that produced a select-all, captured at select-all time.
- * A non-`null` entry means "the current selection is still an unmodified select-all,"
- * so it can be tagged by filter instead of by materialized IDs. Any per-sample edit
- * invalidates it (sets it `null`). `size` lets the tag logic backstop against a
- * selection whose size no longer matches the snapshot.
- *
- * `filter` is typed as the by-filter tag endpoint's payload (the discriminated union over the
- * per-grid filters) so a snapshot can never hold a filter the endpoint cannot accept.
+ * Snapshot of the filter behind a select-all. A non-`null` entry means the selection is still an
+ * unmodified select-all, so it can be tagged by filter instead of materialized IDs; any manual
+ * edit invalidates it. `size` lets the tag logic detect a selection that no longer matches.
+ * `filter` is the by-filter tag endpoint's payload, so a snapshot can't hold a rejected filter.
  */
 export type SelectAllSnapshot = { filter: TagByFilterBody['filter']; size: number };
 
@@ -32,12 +28,10 @@ const selectAllAnnotationSnapshotByCollection = writable<Record<string, SelectAl
     {}
 );
 
-/** Drop the sample-grid select-all snapshot for a collection (any manual mutation invalidates it). */
 const invalidateSelectAllSnapshot = (collectionId: string) => {
     selectAllSnapshotByCollection.update((state) => ({ ...state, [collectionId]: null }));
 };
 
-/** Drop the annotation-grid select-all snapshot for a collection. */
 const invalidateSelectAllAnnotationSnapshot = (collectionId: string) => {
     selectAllAnnotationSnapshotByCollection.update((state) => ({ ...state, [collectionId]: null }));
 };
@@ -180,7 +174,7 @@ export const useGlobalStorage = () => {
             ($rangeSelections) => $rangeSelections[collectionId] ?? null
         );
 
-    // Select-all snapshot helpers (sample grid). `null`/absent = not an unmodified select-all.
+    // Select-all snapshot helpers (sample grid).
     const getSelectAllSnapshot = (collectionId: string) =>
         derived(selectAllSnapshotByCollection, ($snapshots) => $snapshots[collectionId] ?? null);
     const setSelectAllSnapshot = (collectionId: string, snapshot: SelectAllSnapshot) => {
@@ -392,9 +386,8 @@ export const useGlobalStorage = () => {
             activePanel.update((p) => togglePanel(p, 'evaluationRuns', show)),
         getRangeSelection,
         setRangeSelectionForCollection: (collectionId: string, selection: Point[] | null) => {
-            // Note: this updates the embedding-plot range filter, not the selected sample IDs, so
-            // it must NOT invalidate the select-all snapshot — the selection (and thus the snapshot
-            // invariant) is unchanged. Selection clears route through clearSelectedSamples instead.
+            // No snapshot invalidation: this sets the embedding-plot range filter, not the
+            // selection, so the snapshot invariant holds. Selection clears go via clearSelectedSamples.
             rangeSelectionBycollection.update((state) => ({
                 ...state,
                 [collectionId]: selection

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
@@ -14,6 +14,30 @@ import type { Point } from 'embedding-atlas/svelte';
 const lastGridType = writable<GridType>('images');
 const selectedSampleIdsByCollection = writable<Record<string, Set<string>>>({});
 const selectedSampleAnnotationCropIds = writable<Record<string, Set<string>>>({});
+
+/**
+ * Snapshot of the filter that produced a select-all, captured at select-all time.
+ * A non-`null` entry means "the current selection is still an unmodified select-all,"
+ * so it can be tagged by filter instead of by materialized IDs. Any per-sample edit
+ * invalidates it (sets it `null`). `size` lets the tag logic backstop against a
+ * selection whose size no longer matches the snapshot.
+ */
+export type SelectAllSnapshot = { filter: unknown; size: number };
+
+const selectAllSnapshotByCollection = writable<Record<string, SelectAllSnapshot | null>>({});
+const selectAllAnnotationSnapshotByCollection = writable<Record<string, SelectAllSnapshot | null>>(
+    {}
+);
+
+/** Drop the sample-grid select-all snapshot for a collection (any manual mutation invalidates it). */
+const invalidateSelectAllSnapshot = (collectionId: string) => {
+    selectAllSnapshotByCollection.update((state) => ({ ...state, [collectionId]: null }));
+};
+
+/** Drop the annotation-grid select-all snapshot for a collection. */
+const invalidateSelectAllAnnotationSnapshot = (collectionId: string) => {
+    selectAllAnnotationSnapshotByCollection.update((state) => ({ ...state, [collectionId]: null }));
+};
 const selectedAnnotationFilterIds = writable<Set<string>>(new Set());
 const filteredAnnotationCount = writable<number>(0);
 const filteredSampleCount = writable<number>(0);
@@ -153,6 +177,28 @@ export const useGlobalStorage = () => {
             ($rangeSelections) => $rangeSelections[collectionId] ?? null
         );
 
+    // Select-all snapshot helpers (sample grid). `null`/absent = not an unmodified select-all.
+    const getSelectAllSnapshot = (collectionId: string) =>
+        derived(selectAllSnapshotByCollection, ($snapshots) => $snapshots[collectionId] ?? null);
+    const setSelectAllSnapshot = (collectionId: string, snapshot: SelectAllSnapshot) => {
+        selectAllSnapshotByCollection.update((state) => ({ ...state, [collectionId]: snapshot }));
+    };
+    const clearSelectAllSnapshot = invalidateSelectAllSnapshot;
+
+    // Select-all snapshot helpers (annotation grid).
+    const getSelectAllAnnotationSnapshot = (collectionId: string) =>
+        derived(
+            selectAllAnnotationSnapshotByCollection,
+            ($snapshots) => $snapshots[collectionId] ?? null
+        );
+    const setSelectAllAnnotationSnapshot = (collectionId: string, snapshot: SelectAllSnapshot) => {
+        selectAllAnnotationSnapshotByCollection.update((state) => ({
+            ...state,
+            [collectionId]: snapshot
+        }));
+    };
+    const clearSelectAllAnnotationSnapshot = invalidateSelectAllAnnotationSnapshot;
+
     return {
         tags,
         textEmbedding,
@@ -161,6 +207,17 @@ export const useGlobalStorage = () => {
         selectedSampleIdsByCollection,
         getSelectedSampleIds,
         selectedSampleAnnotationCropIds,
+
+        // Select-all snapshots (sample + annotation grids)
+        selectAllSnapshotByCollection,
+        getSelectAllSnapshot,
+        setSelectAllSnapshot,
+        clearSelectAllSnapshot,
+        selectAllAnnotationSnapshotByCollection,
+        getSelectAllAnnotationSnapshot,
+        setSelectAllAnnotationSnapshot,
+        clearSelectAllAnnotationSnapshot,
+
         selectedAnnotationFilterIds,
         filteredAnnotationCount,
         filteredSampleCount,
@@ -206,6 +263,7 @@ export const useGlobalStorage = () => {
 
         // Individual sample selection methods
         toggleSampleSelection: (sampleId: string, collection_id: string) => {
+            invalidateSelectAllSnapshot(collection_id);
             selectedSampleIdsByCollection.update((selectedByCollection) => {
                 const selected = selectedByCollection[collection_id] ?? new Set<string>();
                 if (selected.has(sampleId)) {
@@ -220,6 +278,7 @@ export const useGlobalStorage = () => {
             });
         },
         clearSelectedSamples: (collection_id: string) => {
+            invalidateSelectAllSnapshot(collection_id);
             selectedSampleIdsByCollection.update((selectedByCollection) => {
                 return {
                     ...selectedByCollection,
@@ -239,6 +298,7 @@ export const useGlobalStorage = () => {
 
         // Individual sample annotation crop selection methods
         toggleSampleAnnotationCropSelection: (collectionId: string, annotationId: string) => {
+            invalidateSelectAllAnnotationSnapshot(collectionId);
             selectedSampleAnnotationCropIds.update((state) => {
                 const annotations = new Set(state[collectionId] ?? []);
 
@@ -255,6 +315,7 @@ export const useGlobalStorage = () => {
             });
         },
         clearSelectedSampleAnnotationCrops: (collectionId: string) => {
+            invalidateSelectAllAnnotationSnapshot(collectionId);
             selectedSampleAnnotationCropIds.update((state) => {
                 return {
                     ...state,
@@ -328,6 +389,7 @@ export const useGlobalStorage = () => {
             activePanel.update((p) => togglePanel(p, 'evaluationRuns', show)),
         getRangeSelection,
         setRangeSelectionForCollection: (collectionId: string, selection: Point[] | null) => {
+            invalidateSelectAllSnapshot(collectionId);
             rangeSelectionBycollection.update((state) => ({
                 ...state,
                 [collectionId]: selection

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
@@ -21,7 +21,7 @@ const selectedSampleAnnotationCropIds = writable<Record<string, Set<string>>>({}
  * edit invalidates it. `size` lets the tag logic detect a selection that no longer matches.
  * `filter` is the by-filter tag endpoint's payload, so a snapshot can't hold a rejected filter.
  */
-export type SelectAllSnapshot = { filter: TagByFilterBody['filter']; size: number };
+type SelectAllSnapshot = { filter: TagByFilterBody['filter']; size: number };
 
 const selectAllSnapshotByCollection = writable<Record<string, SelectAllSnapshot | null>>({});
 const selectAllAnnotationSnapshotByCollection = writable<Record<string, SelectAllSnapshot | null>>(
@@ -206,11 +206,9 @@ export const useGlobalStorage = () => {
         selectedSampleAnnotationCropIds,
 
         // Select-all snapshots (sample + annotation grids)
-        selectAllSnapshotByCollection,
         getSelectAllSnapshot,
         setSelectAllSnapshot,
         clearSelectAllSnapshot,
-        selectAllAnnotationSnapshotByCollection,
         getSelectAllAnnotationSnapshot,
         setSelectAllAnnotationSnapshot,
         clearSelectAllAnnotationSnapshot,


### PR DESCRIPTION
## What has changed and why?

First PR to allow tagging by filter in the frontend.

Introduces stores to capture the current filter state when select-all is toggled.

Any manual selection mutation invalidates the matching snapshot, so a non-null snapshot means "still an unmodified select-all." Behavior-neutral — nothing reads the snapshot yet.

## How has it been tested?

New tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cached “select all” snapshot memory separately for sample and annotation grids, preserved per collection to improve consistency when switching actions.

* **Bug Fixes**
  * “Select all” snapshots now invalidate correctly when individual samples/annotations are toggled or when selections are cleared.
  * Unrelated actions (such as range filtering and bulk “set all selected” updates) no longer reset these snapshots unexpectedly.
  * Sample and annotation “select all” states remain independent from each other.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->