### PR TITLE
Emit cell-click events from ConfusionMatrix chart

### DIFF
--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
@@ -11,7 +11,12 @@
     import { CanvasRenderer } from 'echarts/renderers';
     import { buildEchartsOption } from './buildEchartsOption';
     import ConfusionMatrixLegend from './ConfusionMatrixLegend.svelte';
-    import type { ConfusionMatrix } from './types';
+    import {
+        NO_GROUND_TRUTH_ROW_LABEL,
+        NO_PREDICTION_COL_LABEL,
+        type ConfusionCellSelection,
+        type ConfusionMatrix
+    } from './types';
 
     echarts.use([
         HeatmapChart,
@@ -31,6 +36,11 @@
         colorIntensity?: number;
         /** Map color from log10(count) instead of the raw count (default true). */
         logScale?: boolean;
+        /**
+         * Called when a real class-by-class cell is clicked. Synthetic FP/FN cells
+         * (no ground truth / no prediction) are ignored and never invoke this.
+         */
+        onCellClick?: (cell: ConfusionCellSelection) => void;
     }
 
     const {
@@ -38,8 +48,11 @@
         showLegend = false,
         zoomable = false,
         colorIntensity = 1,
-        logScale = true
+        logScale = true,
+        onCellClick
     }: Props = $props();
+
+    const SENTINEL_LABELS = new Set<string>([NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL]);
 
     let container: HTMLDivElement | undefined = $state();
     let chart: echarts.ECharts | null = $state(null);
@@ -55,6 +68,14 @@
         if (!container) return;
         const instance = echarts.init(container, null, { renderer: 'canvas' });
         chart = instance;
+        // Cells carry [pred, gt, count, log10(count)]; resolve back to labels and
+        // skip the synthetic FP/FN buckets, which are not class-by-class cells.
+        instance.on('click', (params: { value?: unknown }) => {
+            if (!Array.isArray(params.value)) return;
+            const [predLabel, gtLabel] = params.value as [string, string, number, number];
+            if (SENTINEL_LABELS.has(predLabel) || SENTINEL_LABELS.has(gtLabel)) return;
+            onCellClick?.({ gtLabel, predLabel });
+        });
         const resizeObserver = new ResizeObserver(() => instance.resize());
         resizeObserver.observe(container);
         return () => {

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
@@ -9,14 +9,10 @@
         VisualMapComponent
     } from 'echarts/components';
     import { CanvasRenderer } from 'echarts/renderers';
-    import { buildEchartsOption } from './buildEchartsOption';
+    import { buildEchartsOption, SENTINEL_LABELS } from './buildEchartsOption';
     import ConfusionMatrixLegend from './ConfusionMatrixLegend.svelte';
-    import {
-        NO_GROUND_TRUTH_ROW_LABEL,
-        NO_PREDICTION_COL_LABEL,
-        type ConfusionCellSelection,
-        type ConfusionMatrix
-    } from './types';
+    import { OTHER_LABEL } from './topNMatrix';
+    import { type ConfusionCellSelection, type ConfusionMatrix } from './types';
 
     echarts.use([
         HeatmapChart,
@@ -52,8 +48,6 @@
         onCellClick
     }: Props = $props();
 
-    const SENTINEL_LABELS = new Set<string>([NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL]);
-
     let container: HTMLDivElement | undefined = $state();
     let chart: echarts.ECharts | null = $state(null);
 
@@ -69,11 +63,13 @@
         const instance = echarts.init(container, null, { renderer: 'canvas' });
         chart = instance;
         // Cells carry [pred, gt, count, log10(count)]; resolve back to labels and
-        // skip the synthetic FP/FN buckets, which are not class-by-class cells.
+        // skip the synthetic FP/FN buckets and "(other)" aggregate cells, which
+        // are not real class-by-class cells.
         instance.on('click', (params: { value?: unknown }) => {
             if (!Array.isArray(params.value)) return;
             const [predLabel, gtLabel] = params.value as [string, string, number, number];
             if (SENTINEL_LABELS.has(predLabel) || SENTINEL_LABELS.has(gtLabel)) return;
+            if (predLabel === OTHER_LABEL || gtLabel === OTHER_LABEL) return;
             onCellClick?.({ gtLabel, predLabel });
         });
         const resizeObserver = new ResizeObserver(() => instance.resize());

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.svelte
@@ -9,9 +9,9 @@
         VisualMapComponent
     } from 'echarts/components';
     import { CanvasRenderer } from 'echarts/renderers';
-    import { buildEchartsOption, SENTINEL_LABELS } from './buildEchartsOption';
+    import { buildEchartsOption } from './buildEchartsOption';
     import ConfusionMatrixLegend from './ConfusionMatrixLegend.svelte';
-    import { OTHER_LABEL } from './topNMatrix';
+    import { OTHER_LABEL, SENTINELS } from './topNMatrix';
     import { type ConfusionCellSelection, type ConfusionMatrix } from './types';
 
     echarts.use([
@@ -68,7 +68,7 @@
         instance.on('click', (params: { value?: unknown }) => {
             if (!Array.isArray(params.value)) return;
             const [predLabel, gtLabel] = params.value as [string, string, number, number];
-            if (SENTINEL_LABELS.has(predLabel) || SENTINEL_LABELS.has(gtLabel)) return;
+            if (SENTINELS.has(predLabel) || SENTINELS.has(gtLabel)) return;
             if (predLabel === OTHER_LABEL || gtLabel === OTHER_LABEL) return;
             onCellClick?.({ gtLabel, predLabel });
         });

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.test.ts
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import ConfusionMatrix from './ConfusionMatrix.svelte';
 import { empty, small3Classes } from './fixtures';
+import { OTHER_LABEL } from './topNMatrix';
 import { NO_GROUND_TRUTH_ROW_LABEL } from './types';
 
 const echartsMock = vi.hoisted(() => {
@@ -70,6 +71,17 @@ describe('ConfusionMatrix', () => {
 
         const handler = echartsMock.getClickHandler();
         handler?.({ value: ['dog', NO_GROUND_TRUTH_ROW_LABEL, 1, 0] });
+
+        expect(onCellClick).not.toHaveBeenCalled();
+    });
+
+    it('ignores clicks on the "(other)" aggregate cells', () => {
+        const onCellClick = vi.fn();
+        render(ConfusionMatrix, { props: { matrix: small3Classes, onCellClick } });
+
+        const handler = echartsMock.getClickHandler();
+        handler?.({ value: [OTHER_LABEL, 'cat', 1, 0] });
+        handler?.({ value: ['dog', OTHER_LABEL, 1, 0] });
 
         expect(onCellClick).not.toHaveBeenCalled();
     });

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrix.test.ts
@@ -2,14 +2,26 @@ import { render, screen } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import ConfusionMatrix from './ConfusionMatrix.svelte';
 import { empty, small3Classes } from './fixtures';
+import { NO_GROUND_TRUTH_ROW_LABEL } from './types';
 
-vi.mock('echarts/core', () => ({
-    init: vi.fn(() => ({
+const echartsMock = vi.hoisted(() => {
+    let clickHandler: ((params: { value?: unknown }) => void) | undefined;
+    const instance = {
         setOption: vi.fn(),
         resize: vi.fn(),
         dispose: vi.fn(),
-        on: vi.fn()
-    })),
+        on: vi.fn((event: string, handler: (params: { value?: unknown }) => void) => {
+            if (event === 'click') clickHandler = handler;
+        })
+    };
+    return {
+        init: vi.fn(() => instance),
+        getClickHandler: () => clickHandler
+    };
+});
+
+vi.mock('echarts/core', () => ({
+    init: echartsMock.init,
     use: vi.fn()
 }));
 vi.mock('echarts/charts', () => ({ HeatmapChart: {} }));
@@ -38,5 +50,27 @@ describe('ConfusionMatrix', () => {
     it('renders the chart container for a non-empty matrix', () => {
         render(ConfusionMatrix, { props: { matrix: small3Classes } });
         expect(screen.getByTestId('confusion-matrix')).toBeInTheDocument();
+    });
+
+    it('resolves a class-by-class cell click to (gt_label, pred_label)', () => {
+        const onCellClick = vi.fn();
+        render(ConfusionMatrix, { props: { matrix: small3Classes, onCellClick } });
+
+        const handler = echartsMock.getClickHandler();
+        expect(handler).toBeDefined();
+        // Cell values are [pred, gt, count, log10(count)].
+        handler?.({ value: ['dog', 'cat', 3, Math.log10(3)] });
+
+        expect(onCellClick).toHaveBeenCalledWith({ gtLabel: 'cat', predLabel: 'dog' });
+    });
+
+    it('ignores clicks on the synthetic FP/FN cells', () => {
+        const onCellClick = vi.fn();
+        render(ConfusionMatrix, { props: { matrix: small3Classes, onCellClick } });
+
+        const handler = echartsMock.getClickHandler();
+        handler?.({ value: ['dog', NO_GROUND_TRUTH_ROW_LABEL, 1, 0] });
+
+        expect(onCellClick).not.toHaveBeenCalled();
     });
 });

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import ConfusionMatrix from '../ConfusionMatrix.svelte';
-    import type { ConfusionMatrix as ConfusionMatrixData } from '../types';
+    import type { ConfusionCellSelection, ConfusionMatrix as ConfusionMatrixData } from '../types';
     import ClassSetDialog from '../ClassSetDialog/ClassSetDialog.svelte';
     import type { ClassSetConfig, ColorConfig } from '../ClassSetDialog/types';
     import { buildSubMatrix, getRealClasses } from '../topNMatrix';
@@ -13,9 +13,11 @@
         /** Most-confused classes shown by default. */
         topN?: number;
         showLegend?: boolean;
+        /** Forwarded to the underlying chart; fires on a real class-by-class cell click. */
+        onCellClick?: (cell: ConfusionCellSelection) => void;
     }
 
-    const { matrix, topN = 5, showLegend = false }: Props = $props();
+    const { matrix, topN = 5, showLegend = false, onCellClick }: Props = $props();
 
     let config: ClassSetConfig = $state({
         mode: 'topN',
@@ -50,6 +52,7 @@
     {showLegend}
     colorIntensity={color.intensity}
     logScale={color.logScale}
+    {onCellClick}
 />
 <ClassSetDialog
     bind:open={configDialogOpen}
@@ -58,4 +61,4 @@
     {color}
     onApply={applyConfig}
 />
-<ExpandDialog bind:open={expandOpen} matrix={subMatrix} {color} {showLegend} />
+<ExpandDialog bind:open={expandOpen} matrix={subMatrix} {color} {showLegend} {onCellClick} />

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ExpandDialog/ExpandDialog.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
     import * as Dialog from '$lib/components/ui/dialog';
     import ConfusionMatrix from '../../ConfusionMatrix.svelte';
-    import type { ConfusionMatrix as ConfusionMatrixData } from '../../types';
+    import type {
+        ConfusionCellSelection,
+        ConfusionMatrix as ConfusionMatrixData
+    } from '../../types';
     import type { ColorConfig } from '../../ClassSetDialog/types';
 
     interface Props {
@@ -9,9 +12,10 @@
         matrix: ConfusionMatrixData;
         color: ColorConfig;
         showLegend?: boolean;
+        onCellClick?: (cell: ConfusionCellSelection) => void;
     }
 
-    let { open = $bindable(), matrix, color, showLegend = false }: Props = $props();
+    let { open = $bindable(), matrix, color, showLegend = false, onCellClick }: Props = $props();
 </script>
 
 <Dialog.Root bind:open>
@@ -29,6 +33,7 @@
                 colorIntensity={color.intensity}
                 logScale={color.logScale}
                 zoomable
+                {onCellClick}
             />
         </div>
     </Dialog.Content>

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.test.ts
@@ -94,7 +94,7 @@ describe('buildEchartsOption', () => {
     });
 
     it('does not treat sentinel/sentinel cells as TP even when row label equals col label', () => {
-        // Force a same-named sentinel row and col to exercise the SENTINEL_LABELS guard.
+        // Force a same-named sentinel row and col to exercise the SENTINELS guard.
         const matrix: ConfusionMatrix = {
             row_labels: [NO_GROUND_TRUTH_ROW_LABEL],
             col_labels: [NO_GROUND_TRUTH_ROW_LABEL],

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
@@ -3,7 +3,11 @@ import { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL, type ConfusionMatri
 
 const TP_COLOR_RAMP: [string, string] = ['rgba(34,197,94,0.15)', 'rgba(34,197,94,0.95)'];
 const FP_FN_COLOR_RAMP: [string, string] = ['rgba(239,68,68,0.15)', 'rgba(239,68,68,0.95)'];
-const SENTINEL_LABELS = new Set<string>([NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL]);
+/** Sentinel no-ground-truth / no-prediction labels that are not real class-by-class cells. */
+export const SENTINEL_LABELS = new Set<string>([
+    NO_GROUND_TRUTH_ROW_LABEL,
+    NO_PREDICTION_COL_LABEL
+]);
 
 interface BuildEchartsOptionOptions {
     /** Enables inside (scroll/pinch) zoom on both axes. */

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
@@ -1,13 +1,9 @@
 import type { EChartsCoreOption } from 'echarts/core';
-import { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL, type ConfusionMatrix } from './types';
+import { SENTINELS } from './topNMatrix';
+import { type ConfusionMatrix } from './types';
 
 const TP_COLOR_RAMP: [string, string] = ['rgba(34,197,94,0.15)', 'rgba(34,197,94,0.95)'];
 const FP_FN_COLOR_RAMP: [string, string] = ['rgba(239,68,68,0.15)', 'rgba(239,68,68,0.95)'];
-/** Sentinel no-ground-truth / no-prediction labels that are not real class-by-class cells. */
-export const SENTINEL_LABELS = new Set<string>([
-    NO_GROUND_TRUTH_ROW_LABEL,
-    NO_PREDICTION_COL_LABEL
-]);
 
 interface BuildEchartsOptionOptions {
     /** Enables inside (scroll/pinch) zoom on both axes. */
@@ -48,8 +44,7 @@ export function buildEchartsOption(
             maxCount = Math.max(maxCount, count);
             const rowLabel = matrix.row_labels[i];
             const colLabel = matrix.col_labels[j];
-            const isTrueClassPair =
-                !SENTINEL_LABELS.has(rowLabel) && !SENTINEL_LABELS.has(colLabel);
+            const isTrueClassPair = !SENTINELS.has(rowLabel) && !SENTINELS.has(colLabel);
             const isTp = isTrueClassPair && rowLabel === colLabel;
             (isTp ? tpData : fpFnData).push([colLabel, rowLabel, count, Math.log10(count)]);
         }

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/index.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/index.ts
@@ -1,3 +1,7 @@
 export { default as ConfusionMatrix } from './ConfusionMatrix.svelte';
 export { default as ConfusionMatrixPanel } from './ConfusionMatrixPanel/ConfusionMatrixPanel.svelte';
-export { NO_GROUND_TRUTH_ROW_LABEL, NO_PREDICTION_COL_LABEL } from './types';
+export {
+    NO_GROUND_TRUTH_ROW_LABEL,
+    NO_PREDICTION_COL_LABEL,
+    type ConfusionCellSelection
+} from './types';

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/index.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/topNMatrix/index.ts
@@ -1,4 +1,4 @@
-export { OTHER_LABEL, CLASS_SORT_LABELS } from './constants/constants';
+export { OTHER_LABEL, SENTINELS, CLASS_SORT_LABELS } from './constants/constants';
 export { type ClassSortOption } from './types';
 export { getRealClasses } from './getRealClasses/getRealClasses';
 export { rankClassesByConfusion } from './rankClassesByConfusion/rankClassesByConfusion';

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/types.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/types.ts
@@ -11,3 +11,11 @@ export interface ConfusionMatrix {
     col_labels: string[];
     counts: number[][];
 }
+
+/** A class-by-class cell resolved from a confusion-matrix click. */
+export interface ConfusionCellSelection {
+    /** Ground-truth label (matrix row). */
+    gtLabel: string;
+    /** Prediction label (matrix column). */
+    predLabel: string;
+}

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunItem/EvaluationRunConfusionMatrixSection/EvaluationRunConfusionMatrixSection.test.ts
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunItem/EvaluationRunConfusionMatrixSection/EvaluationRunConfusionMatrixSection.test.ts
@@ -22,7 +22,8 @@ vi.mock('echarts/core', () => ({
     init: vi.fn(() => ({
         setOption: vi.fn(),
         resize: vi.fn(),
-        dispose: vi.fn()
+        dispose: vi.fn(),
+        on: vi.fn()
     })),
     use: vi.fn()
 }));


### PR DESCRIPTION
## What

Adds an optional `onCellClick` callback to the `ConfusionMatrix` chart. It fires with the ground-truth/prediction labels of a clicked class-by-class cell. Synthetic FP/FN cells (`(no ground truth)` / `(no prediction)`) are ignored and never invoke it. `ConfusionMatrixPanel` and `ExpandDialog` forward the callback through to the underlying chart.

## Why

PR 2 of a 4-PR split for the "click a confusion-matrix cell to filter the image grid" feature. This is pure UI plumbing — nothing consumes the callback yet, so it's a safe no-op on its own. The consumer (filter wiring + chip) lands in later PRs.

## Scope

- `ConfusionMatrix/types.ts` — `ConfusionCellSelection` interface
- `ConfusionMatrix/ConfusionMatrix.svelte` — ECharts click handler + sentinel-label filtering
- `ConfusionMatrixPanel/ConfusionMatrixPanel.svelte` + `ExpandDialog/ExpandDialog.svelte` — forward the prop
- `ConfusionMatrix/ConfusionMatrix.test.ts` — click tests

## Testing

- `vitest ConfusionMatrix.test.ts` — 4 passed
- `svelte-check` — 0 errors; `prettier --check` + `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional click-to-select behavior for confusion matrix cells.
  * Clicks now provide the selected ground-truth and prediction labels.
  * Callback support is wired through the confusion matrix panel and its expanded dialog.
* **Bug Fixes**
  * Clicks on synthetic (no ground truth / no prediction) cells are ignored.
  * Clicks on “(other)” aggregate cells are ignored.
* **Tests**
  * Updated ECharts mocks to capture click handlers and added/expanded coverage for valid and ignored selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->