### PR TITLE
Drop match() method from annotation query classess

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
@@ -1,9 +1,9 @@
 from .boolean_expression import AND, NOT, OR
-from .classification_expression import ClassificationField, ClassificationQuery
+from .classification_query import ClassificationField, ClassificationQuery
 from .dataset_query import DatasetQuery
 from .evaluation_metric_expression import EvaluationMetricField
 from .image_sample_field import ImageSampleField
-from .object_detection_expression import ObjectDetectionField, ObjectDetectionQuery
+from .object_detection_query import ObjectDetectionField, ObjectDetectionQuery
 from .order_by import (
     OrderByEvaluationMetricField,
     OrderByExpression,
@@ -11,7 +11,7 @@ from .order_by import (
     OrderByMetadataField,
 )
 from .sample_evaluation_query import SampleEvaluationQuery
-from .segmentation_mask_expression import SegmentationMaskField, SegmentationMaskQuery
+from .segmentation_mask_query import SegmentationMaskField, SegmentationMaskQuery
 from .video_sample_field import VideoSampleField
 
 __all__ = [

--- a/lightly_studio/src/lightly_studio/core/dataset_query/classification_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/classification_query.py
@@ -32,7 +32,7 @@ class ClassificationField:
 class ClassificationQuery(MatchExpression):
     """Query if a sample has a classification matching a criterion."""
 
-    criteria: list[MatchExpression]
+    criterion: MatchExpression
 
     def __init__(self, *criteria: MatchExpression) -> None:
         """Combine multiple classification criteria into a single expression using AND.
@@ -43,13 +43,13 @@ class ClassificationQuery(MatchExpression):
         Args:
             criteria: The classification criteria to combine.
         """
-        self.criteria = list(criteria)
+        self.criterion = AND(*criteria)
 
     def get(self) -> ColumnElement[bool]:
         """Get the classification match expression."""
         return SampleTable.annotations.any(
             and_(
                 col(AnnotationBaseTable.annotation_type) == AnnotationType.CLASSIFICATION,
-                AND(*self.criteria).get(),
+                self.criterion.get(),
             )
         )

--- a/lightly_studio/src/lightly_studio/core/dataset_query/classification_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/classification_query.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from sqlalchemy import ColumnElement, and_
 from sqlmodel import col
 
@@ -31,33 +29,27 @@ class ClassificationField:
     confidence = NullableOrdinalField(col(AnnotationBaseTable.confidence))
 
 
-class ClassificationQuery:
-    """Provides access to classification query operations."""
+class ClassificationQuery(MatchExpression):
+    """Query if a sample has a classification matching a criterion."""
 
-    @staticmethod
-    def match(*criteria: MatchExpression) -> ClassificationMatchExpression:
-        """Combine multiple classification criteria into a single subquery using logical AND.
+    criteria: list[MatchExpression]
+
+    def __init__(self, *criteria: MatchExpression) -> None:
+        """Combine multiple classification criteria into a single expression using AND.
+
+        Example:
+            ``ClassificationQuery(ClassificationField.class_name == "cat")``
 
         Args:
-            criteria: The criteria to combine.
-
-        Returns:
-            A single match expression for satisfying all criteria.
+            criteria: The classification criteria to combine.
         """
-        return ClassificationMatchExpression(criterion=AND(*criteria))
-
-
-@dataclass
-class ClassificationMatchExpression(MatchExpression):
-    """Expression for checking if a sample has a classification matching a criterion."""
-
-    criterion: MatchExpression
+        self.criteria = list(criteria)
 
     def get(self) -> ColumnElement[bool]:
         """Get the classification match expression."""
         return SampleTable.annotations.any(
             and_(
                 col(AnnotationBaseTable.annotation_type) == AnnotationType.CLASSIFICATION,
-                self.criterion.get(),
+                AND(*self.criteria).get(),
             )
         )

--- a/lightly_studio/src/lightly_studio/core/dataset_query/object_detection_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/object_detection_query.py
@@ -52,7 +52,7 @@ class ObjectDetectionField:
 class ObjectDetectionQuery(MatchExpression):
     """Query if a sample has an object detection matching a criterion."""
 
-    criteria: list[MatchExpression]
+    criterion: MatchExpression
 
     def __init__(self, *criteria: MatchExpression) -> None:
         """Combine multiple object detection criteria into a single expression using AND.
@@ -63,13 +63,13 @@ class ObjectDetectionQuery(MatchExpression):
         Args:
             criteria: The object detection criteria to combine.
         """
-        self.criteria = list(criteria)
+        self.criterion = AND(*criteria)
 
     def get(self) -> ColumnElement[bool]:
         """Get the object detection match expression."""
         return SampleTable.annotations.any(
             and_(
                 col(AnnotationBaseTable.annotation_type) == AnnotationType.OBJECT_DETECTION,
-                AND(*self.criteria).get(),
+                self.criterion.get(),
             )
         )

--- a/lightly_studio/src/lightly_studio/core/dataset_query/object_detection_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/object_detection_query.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional
-
 from sqlalchemy import ColumnElement, and_
 from sqlmodel import col
-from typing_extensions import TypeVar
 
 from lightly_studio.core.dataset_query.annotation_expression import AnnotationSourceField
 from lightly_studio.core.dataset_query.boolean_expression import AND
@@ -24,8 +20,6 @@ from lightly_studio.models.annotation.annotation_base import (
 from lightly_studio.models.annotation.object_detection import ObjectDetectionAnnotationTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.sample import SampleTable
-
-T = TypeVar("T", default=Optional["ObjectDetectionAnnotationTable"])
 
 
 class ObjectDetectionField:
@@ -55,33 +49,27 @@ class ObjectDetectionField:
     confidence = NullableOrdinalField(col(AnnotationBaseTable.confidence))
 
 
-class ObjectDetectionQuery:
-    """Provides access to object detection query operations."""
+class ObjectDetectionQuery(MatchExpression):
+    """Query if a sample has an object detection matching a criterion."""
 
-    @staticmethod
-    def match(*criteria: MatchExpression) -> ObjectDetectionMatchExpression:
-        """Combine multiple object detection criteria into a single subquery using logical AND.
+    criteria: list[MatchExpression]
+
+    def __init__(self, *criteria: MatchExpression) -> None:
+        """Combine multiple object detection criteria into a single expression using AND.
+
+        Example:
+            ``ObjectDetectionQuery(ObjectDetectionField.width <= 100)``
 
         Args:
-            criteria: The criteria to combine.
-
-        Returns:
-            A single match expression for satisfying all criteria.
+            criteria: The object detection criteria to combine.
         """
-        return ObjectDetectionMatchExpression(criterion=AND(*criteria))
-
-
-@dataclass
-class ObjectDetectionMatchExpression(MatchExpression):
-    """Expression for checking if a sample has an object detection matching a criterion."""
-
-    criterion: MatchExpression
+        self.criteria = list(criteria)
 
     def get(self) -> ColumnElement[bool]:
         """Get the object detection match expression."""
         return SampleTable.annotations.any(
             and_(
                 col(AnnotationBaseTable.annotation_type) == AnnotationType.OBJECT_DETECTION,
-                self.criterion.get(),
+                AND(*self.criteria).get(),
             )
         )

--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -12,14 +12,14 @@ from typing import Protocol, TypeVar, Union
 from typing_extensions import assert_never
 
 from lightly_studio.core.dataset_query.boolean_expression import AND, NOT, OR
-from lightly_studio.core.dataset_query.classification_expression import (
+from lightly_studio.core.dataset_query.classification_query import (
     ClassificationField,
     ClassificationQuery,
 )
 from lightly_studio.core.dataset_query.field import Field
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
-from lightly_studio.core.dataset_query.object_detection_expression import (
+from lightly_studio.core.dataset_query.object_detection_query import (
     ObjectDetectionField,
     ObjectDetectionQuery,
 )
@@ -29,7 +29,7 @@ from lightly_studio.core.dataset_query.order_by import (
     OrderByField,
     OrderByMetadataField,
 )
-from lightly_studio.core.dataset_query.segmentation_mask_expression import (
+from lightly_studio.core.dataset_query.segmentation_mask_query import (
     SegmentationMaskField,
     SegmentationMaskQuery,
 )
@@ -274,11 +274,11 @@ def to_match_expression(expr: MatchExpr) -> MatchExpression:  # noqa: PLR0911 C9
         accessor: _TagsAccessor = _lookup(mapping=_TAGS_FIELDS, field=expr.field, type_="tags")
         return accessor.contains(expr.tag_name)
     if isinstance(expr, ClassificationMatchExpr):
-        return ClassificationQuery.match(to_match_expression(expr=expr.subexpr))
+        return ClassificationQuery(to_match_expression(expr=expr.subexpr))
     if isinstance(expr, ObjectDetectionMatchExpr):
-        return ObjectDetectionQuery.match(to_match_expression(expr=expr.subexpr))
+        return ObjectDetectionQuery(to_match_expression(expr=expr.subexpr))
     if isinstance(expr, SegmentationMaskMatchExpr):
-        return SegmentationMaskQuery.match(to_match_expression(expr=expr.subexpr))
+        return SegmentationMaskQuery(to_match_expression(expr=expr.subexpr))
     if isinstance(expr, AndExpr):
         return AND(*(to_match_expression(expr=child) for child in expr.children))
     if isinstance(expr, OrExpr):

--- a/lightly_studio/src/lightly_studio/core/dataset_query/segmentation_mask_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/segmentation_mask_query.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from sqlalchemy import ColumnElement, and_
 from sqlmodel import col
 
@@ -51,33 +49,27 @@ class SegmentationMaskField:
     confidence = NullableOrdinalField(col(AnnotationBaseTable.confidence))
 
 
-class SegmentationMaskQuery:
-    """Provides access to segmentation mask query operations."""
+class SegmentationMaskQuery(MatchExpression):
+    """Query if a sample has a segmentation mask matching a criterion."""
 
-    @staticmethod
-    def match(*criteria: MatchExpression) -> SegmentationMaskMatchExpression:
-        """Combine multiple segmentation mask criteria into a single subquery using logical AND.
+    criteria: list[MatchExpression]
+
+    def __init__(self, *criteria: MatchExpression) -> None:
+        """Combine multiple segmentation mask criteria into a single expression using AND.
+
+        Example:
+            ``SegmentationMaskQuery(SegmentationMaskField.width <= 100)``
 
         Args:
-            criteria: The criteria to combine.
-
-        Returns:
-            A single match expression for satisfying all criteria.
+            criteria: The segmentation mask criteria to combine.
         """
-        return SegmentationMaskMatchExpression(criterion=AND(*criteria))
-
-
-@dataclass
-class SegmentationMaskMatchExpression(MatchExpression):
-    """Expression for checking if a sample has a segmentation mask matching a criterion."""
-
-    criterion: MatchExpression
+        self.criteria = list(criteria)
 
     def get(self) -> ColumnElement[bool]:
         """Get the segmentation mask match expression."""
         return SampleTable.annotations.any(
             and_(
                 col(AnnotationBaseTable.annotation_type) == AnnotationType.SEGMENTATION_MASK,
-                self.criterion.get(),
+                AND(*self.criteria).get(),
             )
         )

--- a/lightly_studio/src/lightly_studio/core/dataset_query/segmentation_mask_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/segmentation_mask_query.py
@@ -52,7 +52,7 @@ class SegmentationMaskField:
 class SegmentationMaskQuery(MatchExpression):
     """Query if a sample has a segmentation mask matching a criterion."""
 
-    criteria: list[MatchExpression]
+    criterion: MatchExpression
 
     def __init__(self, *criteria: MatchExpression) -> None:
         """Combine multiple segmentation mask criteria into a single expression using AND.
@@ -63,13 +63,13 @@ class SegmentationMaskQuery(MatchExpression):
         Args:
             criteria: The segmentation mask criteria to combine.
         """
-        self.criteria = list(criteria)
+        self.criterion = AND(*criteria)
 
     def get(self) -> ColumnElement[bool]:
         """Get the segmentation mask match expression."""
         return SampleTable.annotations.any(
             and_(
                 col(AnnotationBaseTable.annotation_type) == AnnotationType.SEGMENTATION_MASK,
-                AND(*self.criteria).get(),
+                self.criterion.get(),
             )
         )

--- a/lightly_studio/tests/core/dataset_query/test_classification_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_classification_query.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from sqlmodel import Session, select
 
-from lightly_studio.core.dataset_query.segmentation_mask_expression import (
-    SegmentationMaskField,
-    SegmentationMaskQuery,
+from lightly_studio.core.dataset_query.classification_query import (
+    ClassificationField,
+    ClassificationQuery,
 )
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.image import ImageTable
@@ -17,20 +17,18 @@ from tests.helpers_resolvers import (
 )
 
 
-class TestSegmentationMaskExpressions:
-    def test_annotation_segmentation_mask_width__sql(self) -> None:
+class TestClassificationExpressions:
+    def test_annotation_classification_label__sql(self) -> None:
         query = select(ImageTable).where(
-            SegmentationMaskQuery.match(SegmentationMaskField.width <= 100).get()
+            ClassificationQuery(ClassificationField.class_name == "cat").get()
         )
         sql = str(query.compile(compile_kwargs={"literal_binds": True}))
         assert "EXISTS (SELECT 1" in sql
         assert "FROM annotation_base" in sql
-        assert "FROM segmentation_annotation" in sql
-        assert "segmentation_annotation.width <= 100" in sql
+        assert "annotation_type = 'CLASSIFICATION'" in sql
+        assert "annotation_label.annotation_label_name = 'cat'" in sql
 
-    def test_annotation_segmentation_mask__filters_matching_samples(
-        self, db_session: Session
-    ) -> None:
+    def test_annotation_classification__filters_matching_samples(self, db_session: Session) -> None:
         collection = create_collection(session=db_session)
         collection_id = collection.collection_id
         image1 = create_image(
@@ -42,47 +40,35 @@ class TestSegmentationMaskExpressions:
         label1 = create_annotation_label(
             session=db_session, root_collection_id=collection_id, label_name="label1"
         )
+        label2 = create_annotation_label(
+            session=db_session, root_collection_id=collection_id, label_name="label2"
+        )
 
         create_annotation(
             session=db_session,
             collection_id=collection_id,
             sample_id=image1.sample_id,
             annotation_label_id=label1.annotation_label_id,
-            annotation_type=AnnotationType.SEGMENTATION_MASK,
-            annotation_data={
-                "x": 0,
-                "y": 0,
-                "width": 150,
-                "height": 100,
-                "segmentation_mask": [1, 1, 4],
-            },
+            annotation_type=AnnotationType.CLASSIFICATION,
         )
         create_annotation(
             session=db_session,
             collection_id=collection_id,
             sample_id=image2.sample_id,
-            annotation_label_id=label1.annotation_label_id,
-            annotation_type=AnnotationType.SEGMENTATION_MASK,
-            annotation_data={"x": 0, "y": 0, "width": 50, "height": 100, "segmentation_mask": [6]},
+            annotation_label_id=label2.annotation_label_id,
+            annotation_type=AnnotationType.CLASSIFICATION,
         )
 
         query = (
             select(ImageTable)
             .join(ImageTable.sample)
             .where(SampleTable.collection_id == collection_id)
-            .where(
-                SegmentationMaskQuery.match(
-                    SegmentationMaskField.width > 100,
-                    SegmentationMaskField.height == 100,
-                ).get()
-            )
+            .where(ClassificationQuery(ClassificationField.class_name == "label1").get())
         )
         results = db_session.exec(query).all()
         assert [image.sample_id for image in results] == [image1.sample_id]
 
-    def test_annotation_segmentation_mask__with_other_annotations(
-        self, db_session: Session
-    ) -> None:
+    def test_annotation_classification__with_other_annotations(self, db_session: Session) -> None:
         collection = create_collection(session=db_session)
         collection_id = collection.collection_id
         image1 = create_image(
@@ -100,8 +86,7 @@ class TestSegmentationMaskExpressions:
             collection_id=collection_id,
             sample_id=image1.sample_id,
             annotation_label_id=label1.annotation_label_id,
-            annotation_type=AnnotationType.SEGMENTATION_MASK,
-            annotation_data={"x": 0, "y": 0, "width": 150, "height": 100, "segmentation_mask": [8]},
+            annotation_type=AnnotationType.CLASSIFICATION,
         )
         create_annotation(
             session=db_session,
@@ -109,15 +94,15 @@ class TestSegmentationMaskExpressions:
             sample_id=image2.sample_id,
             annotation_label_id=label1.annotation_label_id,
             annotation_type=AnnotationType.OBJECT_DETECTION,
-            annotation_data={"x": 0, "y": 0, "width": 150, "height": 100, "segmentation_mask": [6]},
+            annotation_data={"x": 0, "y": 0, "width": 150, "height": 100},
         )
 
         query = (
             select(ImageTable)
             .join(ImageTable.sample)
             .where(SampleTable.collection_id == collection_id)
-            .where(SegmentationMaskQuery.match(SegmentationMaskField.class_name == "label1").get())
+            .where(ClassificationQuery().get())
         )
         results = db_session.exec(query).all()
-        # There are two annotations with this annotation class but only one of the right type.
+        # There are two annotations but only one of the right type.
         assert [image.sample_id for image in results] == [image1.sample_id]

--- a/lightly_studio/tests/core/dataset_query/test_classification_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_classification_query.py
@@ -17,7 +17,7 @@ from tests.helpers_resolvers import (
 )
 
 
-class TestClassificationExpressions:
+class TestClassificationQuery:
     def test_annotation_classification_label__sql(self) -> None:
         query = select(ImageTable).where(
             ClassificationQuery(ClassificationField.class_name == "cat").get()

--- a/lightly_studio/tests/core/dataset_query/test_object_detection_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_object_detection_query.py
@@ -17,7 +17,7 @@ from tests.helpers_resolvers import (
 )
 
 
-class TestObjectDetectionExpressions:
+class TestObjectDetectionQuery:
     def test_annotation_object_detections_width__sql(self) -> None:
         query = select(ImageTable).where(
             ObjectDetectionQuery(ObjectDetectionField.width <= 100).get()

--- a/lightly_studio/tests/core/dataset_query/test_object_detection_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_object_detection_query.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlmodel import Session, select
 
-from lightly_studio.core.dataset_query.object_detection_expression import (
+from lightly_studio.core.dataset_query.object_detection_query import (
     ObjectDetectionField,
     ObjectDetectionQuery,
 )
@@ -20,7 +20,7 @@ from tests.helpers_resolvers import (
 class TestObjectDetectionExpressions:
     def test_annotation_object_detections_width__sql(self) -> None:
         query = select(ImageTable).where(
-            ObjectDetectionQuery.match(ObjectDetectionField.width <= 100).get()
+            ObjectDetectionQuery(ObjectDetectionField.width <= 100).get()
         )
         sql = str(query.compile(compile_kwargs={"literal_binds": True}))
         assert "EXISTS (SELECT 1" in sql
@@ -65,7 +65,7 @@ class TestObjectDetectionExpressions:
             .join(ImageTable.sample)
             .where(SampleTable.collection_id == collection_id)
             .where(
-                ObjectDetectionQuery.match(
+                ObjectDetectionQuery(
                     ObjectDetectionField.width > 100, ObjectDetectionField.height == 100
                 ).get()
             )
@@ -105,7 +105,7 @@ class TestObjectDetectionExpressions:
             .join(ImageTable.sample)
             .where(SampleTable.collection_id == collection_id)
             .where(
-                ObjectDetectionQuery.match(
+                ObjectDetectionQuery(
                     ObjectDetectionField.width > 100, ObjectDetectionField.width < 100
                 ).get()
             )
@@ -150,19 +150,19 @@ class TestObjectDetectionExpressions:
             select(ImageTable)
             .join(ImageTable.sample)
             .where(SampleTable.collection_id == collection_id)
-            .where(ObjectDetectionQuery.match(ObjectDetectionField.class_name == "label1").get())
+            .where(ObjectDetectionQuery(ObjectDetectionField.class_name == "label1").get())
         )
         results = db_session.exec(query).all()
         # There are two annotations with this annotation class but only one of the right type.
         assert [image.sample_id for image in results] == [image1.sample_id]
 
         # Repeat almost the same query but now without annotation class filtering. Just an empty
-        # ObjectDetectionQuery.match().
+        # ObjectDetectionQuery().
         query = (
             select(ImageTable)
             .join(ImageTable.sample)
             .where(SampleTable.collection_id == collection_id)
-            .where(ObjectDetectionQuery.match().get())
+            .where(ObjectDetectionQuery().get())
         )
         results = db_session.exec(query).all()
         # There are two annotations but only one of the right type.

--- a/lightly_studio/tests/core/dataset_query/test_segmentation_mask_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_segmentation_mask_query.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from sqlmodel import Session, select
 
-from lightly_studio.core.dataset_query.classification_expression import (
-    ClassificationField,
-    ClassificationQuery,
+from lightly_studio.core.dataset_query.segmentation_mask_query import (
+    SegmentationMaskField,
+    SegmentationMaskQuery,
 )
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.image import ImageTable
@@ -17,18 +17,20 @@ from tests.helpers_resolvers import (
 )
 
 
-class TestClassificationExpressions:
-    def test_annotation_classification_label__sql(self) -> None:
+class TestSegmentationMaskExpressions:
+    def test_annotation_segmentation_mask_width__sql(self) -> None:
         query = select(ImageTable).where(
-            ClassificationQuery.match(ClassificationField.class_name == "cat").get()
+            SegmentationMaskQuery(SegmentationMaskField.width <= 100).get()
         )
         sql = str(query.compile(compile_kwargs={"literal_binds": True}))
         assert "EXISTS (SELECT 1" in sql
         assert "FROM annotation_base" in sql
-        assert "annotation_type = 'CLASSIFICATION'" in sql
-        assert "annotation_label.annotation_label_name = 'cat'" in sql
+        assert "FROM segmentation_annotation" in sql
+        assert "segmentation_annotation.width <= 100" in sql
 
-    def test_annotation_classification__filters_matching_samples(self, db_session: Session) -> None:
+    def test_annotation_segmentation_mask__filters_matching_samples(
+        self, db_session: Session
+    ) -> None:
         collection = create_collection(session=db_session)
         collection_id = collection.collection_id
         image1 = create_image(
@@ -40,35 +42,47 @@ class TestClassificationExpressions:
         label1 = create_annotation_label(
             session=db_session, root_collection_id=collection_id, label_name="label1"
         )
-        label2 = create_annotation_label(
-            session=db_session, root_collection_id=collection_id, label_name="label2"
-        )
 
         create_annotation(
             session=db_session,
             collection_id=collection_id,
             sample_id=image1.sample_id,
             annotation_label_id=label1.annotation_label_id,
-            annotation_type=AnnotationType.CLASSIFICATION,
+            annotation_type=AnnotationType.SEGMENTATION_MASK,
+            annotation_data={
+                "x": 0,
+                "y": 0,
+                "width": 150,
+                "height": 100,
+                "segmentation_mask": [1, 1, 4],
+            },
         )
         create_annotation(
             session=db_session,
             collection_id=collection_id,
             sample_id=image2.sample_id,
-            annotation_label_id=label2.annotation_label_id,
-            annotation_type=AnnotationType.CLASSIFICATION,
+            annotation_label_id=label1.annotation_label_id,
+            annotation_type=AnnotationType.SEGMENTATION_MASK,
+            annotation_data={"x": 0, "y": 0, "width": 50, "height": 100, "segmentation_mask": [6]},
         )
 
         query = (
             select(ImageTable)
             .join(ImageTable.sample)
             .where(SampleTable.collection_id == collection_id)
-            .where(ClassificationQuery.match(ClassificationField.class_name == "label1").get())
+            .where(
+                SegmentationMaskQuery(
+                    SegmentationMaskField.width > 100,
+                    SegmentationMaskField.height == 100,
+                ).get()
+            )
         )
         results = db_session.exec(query).all()
         assert [image.sample_id for image in results] == [image1.sample_id]
 
-    def test_annotation_classification__with_other_annotations(self, db_session: Session) -> None:
+    def test_annotation_segmentation_mask__with_other_annotations(
+        self, db_session: Session
+    ) -> None:
         collection = create_collection(session=db_session)
         collection_id = collection.collection_id
         image1 = create_image(
@@ -86,7 +100,8 @@ class TestClassificationExpressions:
             collection_id=collection_id,
             sample_id=image1.sample_id,
             annotation_label_id=label1.annotation_label_id,
-            annotation_type=AnnotationType.CLASSIFICATION,
+            annotation_type=AnnotationType.SEGMENTATION_MASK,
+            annotation_data={"x": 0, "y": 0, "width": 150, "height": 100, "segmentation_mask": [8]},
         )
         create_annotation(
             session=db_session,
@@ -94,15 +109,15 @@ class TestClassificationExpressions:
             sample_id=image2.sample_id,
             annotation_label_id=label1.annotation_label_id,
             annotation_type=AnnotationType.OBJECT_DETECTION,
-            annotation_data={"x": 0, "y": 0, "width": 150, "height": 100},
+            annotation_data={"x": 0, "y": 0, "width": 150, "height": 100, "segmentation_mask": [6]},
         )
 
         query = (
             select(ImageTable)
             .join(ImageTable.sample)
             .where(SampleTable.collection_id == collection_id)
-            .where(ClassificationQuery.match().get())
+            .where(SegmentationMaskQuery(SegmentationMaskField.class_name == "label1").get())
         )
         results = db_session.exec(query).all()
-        # There are two annotations but only one of the right type.
+        # There are two annotations with this annotation class but only one of the right type.
         assert [image.sample_id for image in results] == [image1.sample_id]

--- a/lightly_studio/tests/core/dataset_query/test_segmentation_mask_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_segmentation_mask_query.py
@@ -17,7 +17,7 @@ from tests.helpers_resolvers import (
 )
 
 
-class TestSegmentationMaskExpressions:
+class TestSegmentationMaskQuery:
     def test_annotation_segmentation_mask_width__sql(self) -> None:
         query = select(ImageTable).where(
             SegmentationMaskQuery(SegmentationMaskField.width <= 100).get()


### PR DESCRIPTION
## What has changed and why?
Make *Query class inherit directly from MatchExpression, drop *MatchExpression class and use `__init__()` instead of `match()`.

Also renamed files once the class name has changed.

## How has it been tested?
Existing tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated dataset filtering queries for classification, object detection, and segmentation masks to use a consistent constructor-based API for building match conditions.
* **Bug Fixes**
  * Improved reliability when combining multiple annotation predicates by ensuring they’re combined with logical AND, preserving expected filtering results and generated SQL behavior.
* **Tests**
  * Updated query-related unit tests to reflect the new constructor-style query API and continue validating the same outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->