### PR TITLE
Fix right-side padding between image grid and scrollbar

### DIFF
--- a/lightly_studio_view/src/lib/components/Grid/Grid.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.svelte
@@ -5,6 +5,9 @@
     import { cn } from '$lib/utils';
 
     const GRID_GAP = 16;
+    // Compensates for the scrollbar width so the right edge aligns with the
+    // card's p-4 outer padding on the left side.
+    const SCROLLBAR_WIDTH_COMPENSATION = 4;
 
     let viewport: HTMLElement | null = null;
     let clientWidth = $state(0);
@@ -76,10 +79,7 @@
 
         const resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
-                // contentRect.width excludes the scrollbar, which causes items to stop
-                // GRID_GAP pixels short of the scrollbar — adding 4 compensates enough
-                // to align the right edge with the card's p-4 outer padding on the left.
-                clientWidth = Math.max(entry.contentRect.width + 4, 200);
+                clientWidth = Math.max(entry.contentRect.width + SCROLLBAR_WIDTH_COMPENSATION, 200);
             }
         });
 

--- a/lightly_studio_view/src/lib/components/Grid/Grid.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.svelte
@@ -4,6 +4,7 @@
     import type { HTMLAttributes } from 'svelte/elements';
     import { cn } from '$lib/utils';
 
+    const GRID_SCROLL_CLASS = 'grid-scroll';
     const GRID_GAP = 16;
     // Compensates for the scrollbar width so the right edge aligns with the
     // card's p-4 outer padding on the left side.
@@ -59,7 +60,7 @@
 
     const viewportClassName = $derived(cn('viewport h-full w-full', viewportProps?.class));
 
-    const gridClassName = $derived(cn('grid-scroll', gridProps?.class));
+    const gridClassName = $derived(cn(GRID_SCROLL_CLASS, gridProps?.class));
 
     const resolvedOverScan = $derived(overScan ?? overscan ?? gridProps?.overScan);
 
@@ -75,7 +76,7 @@
         // visible. Without this, items would be sized for the full viewport width and
         // the last column would partially slide under the scrollbar.
         const scrollView =
-            (viewport.querySelector('.grid-scroll') as HTMLElement | null) ?? viewport;
+            (viewport.querySelector(`.${GRID_SCROLL_CLASS}`) as HTMLElement | null) ?? viewport;
 
         const resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
@@ -170,6 +171,7 @@
         overflow-y: hidden;
     }
 
+    /* Selector must match GRID_SCROLL_CLASS in <script> */
     .viewport :global(.grid-scroll) {
         overflow-x: hidden !important;
     }

--- a/lightly_studio_view/src/lib/components/Grid/Grid.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.svelte
@@ -67,13 +67,23 @@
             return;
         }
 
+        // Observe the actual scroll container rather than the outer viewport div so
+        // that contentRect.width already excludes the scrollbar width when one is
+        // visible. Without this, items would be sized for the full viewport width and
+        // the last column would partially slide under the scrollbar.
+        const scrollView =
+            (viewport.querySelector('.grid-scroll') as HTMLElement | null) ?? viewport;
+
         const resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
-                clientWidth = Math.max(entry.contentRect.width, 200);
+                // contentRect.width excludes the scrollbar, which causes items to stop
+                // GRID_GAP pixels short of the scrollbar — adding 4 compensates enough
+                // to align the right edge with the card's p-4 outer padding on the left.
+                clientWidth = Math.max(entry.contentRect.width + 4, 200);
             }
         });
 
-        resizeObserver.observe(viewport);
+        resizeObserver.observe(scrollView);
 
         return () => resizeObserver.disconnect();
     });


### PR DESCRIPTION
## What has changed and why?

When a scrollbar is visible, the last column of images slides partially under it because `clientWidth` was measured from the outer viewport div. Observe the VirtualGrid scroll container instead of the outer viewport div, and a `+4` aligning the right edge with the card's `p-4` outer padding.

<img width="1920" height="996" alt="Screenshot 2026-06-24 at 11 57 02" src="https://github.com/user-attachments/assets/6d025229-dcf2-4dd9-9edf-bee06a7b2493" />

## How has it been tested?

Manual testing

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grid resizing so it measures the visible scroll area more accurately, helping items size and align correctly when scrollbars are present.
  * Updated resize behavior to better account for scrollbar width, reducing layout shifts and improving consistency across different viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->