### PR TITLE
evaluations(pr1): evaluate an explicit sample set in ImageDatasetEvaluate

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -596,7 +596,9 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         if query is None:
             query = self.query()
         return ImageDatasetEvaluate(
-            session=self.session, collection_id=self.collection_id, samples=query
+            session=self.session,
+            collection_id=self.collection_id,
+            sample_ids=(sample.sample_id for sample in query),
         )
 
 

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -598,7 +598,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         return ImageDatasetEvaluate(
             session=self.session,
             collection_id=self.collection_id,
-            sample_ids=(sample.sample_id for sample in query),
+            sample_ids=[sample.sample_id for sample in query],
         )
 
 

--- a/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
+++ b/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
@@ -9,7 +9,6 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 from sqlmodel import Session
 
-from lightly_studio.core.image.image_sample import ImageSample
 from lightly_studio.evaluation import (
     classification_metric,
     object_detection_metric,
@@ -52,11 +51,13 @@ class EvaluationResult(BaseModel):
     shared across tasks (object detection, classification, segmentation).
 
     Attributes:
+        evaluation_run_id: ID of the persisted evaluation run.
         sample_count: Number of samples included in the evaluation.
         gt_annotation_count: Number of ground truth annotations used.
         pred_annotation_count: Number of prediction annotations used.
     """
 
+    evaluation_run_id: UUID
     sample_count: int
     gt_annotation_count: int
     pred_annotation_count: int
@@ -65,6 +66,7 @@ class EvaluationResult(BaseModel):
     def from_evaluation_data(cls, data: EvaluationData) -> EvaluationResult:
         """Build a result from the prepared evaluation data."""
         return cls(
+            evaluation_run_id=data.evaluation_run_id,
             sample_count=len(data.selected_sample_ids),
             gt_annotation_count=sum(len(v) for v in data.gt_per_sample.values()),
             pred_annotation_count=sum(len(v) for v in data.pred_per_sample.values()),
@@ -92,19 +94,21 @@ class ImageDatasetEvaluate:
     and keeps evaluation-specific logic separate from ``ImageDataset``.
     """
 
-    def __init__(
-        self, session: Session, collection_id: UUID, samples: Iterable[ImageSample]
-    ) -> None:
+    def __init__(self, session: Session, collection_id: UUID, sample_ids: Iterable[UUID]) -> None:
         """Initialize the evaluator facade.
 
         Args:
             session: Database session used by resolver calls.
             collection_id: ID of the collection being evaluated.
-            samples: Samples selected for evaluation.
+            sample_ids: IDs of the samples selected for evaluation.
         """
         self.session = session
         self.collection_id = collection_id
-        self.samples = samples
+        # Materialize once: callers may pass a single-use generator, and the
+        # facade can be reused across task methods (object_detection(),
+        # classification(), ...). Without this, the second call would see an
+        # exhausted iterator and silently evaluate zero samples.
+        self.sample_ids: set[UUID] = set(sample_ids)
 
     def object_detection(
         self,
@@ -229,7 +233,7 @@ class ImageDatasetEvaluate:
             config_json=config_json,
         )
 
-        selected_sample_ids = {sample.sample_id for sample in self.samples}
+        selected_sample_ids = set(self.sample_ids)
         gt_covered_sample_ids = set(
             annotation_collection_coverage_resolver.list_by_collection_id(
                 session=self.session,
@@ -286,7 +290,16 @@ class ImageDatasetEvaluate:
 
         Returns:
             Tuple of (gt_collection_id, pred_collection_id, evaluation_run).
+
+        Raises:
+            ValueError: If the same annotation source is used for both ground
+                truth and predictions.
         """
+        if gt_annotation_source == pred_annotation_source:
+            raise ValueError(
+                "Ground truth and prediction annotation sources must be different, "
+                f"got {gt_annotation_source!r} for both."
+            )
         gt_collection_id = validators.resolve_and_validate_collection(
             session=self.session,
             collection_id=self.collection_id,

--- a/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
+++ b/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
@@ -9,7 +9,6 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 from sqlmodel import Session
 
-from lightly_studio.core.image.image_sample import ImageSample
 from lightly_studio.evaluation import (
     classification_metric,
     object_detection_metric,
@@ -52,11 +51,13 @@ class EvaluationResult(BaseModel):
     shared across tasks (object detection, classification, segmentation).
 
     Attributes:
+        evaluation_run_id: ID of the persisted evaluation run.
         sample_count: Number of samples included in the evaluation.
         gt_annotation_count: Number of ground truth annotations used.
         pred_annotation_count: Number of prediction annotations used.
     """
 
+    evaluation_run_id: UUID
     sample_count: int
     gt_annotation_count: int
     pred_annotation_count: int
@@ -65,6 +66,7 @@ class EvaluationResult(BaseModel):
     def from_evaluation_data(cls, data: EvaluationData) -> EvaluationResult:
         """Build a result from the prepared evaluation data."""
         return cls(
+            evaluation_run_id=data.evaluation_run_id,
             sample_count=len(data.selected_sample_ids),
             gt_annotation_count=sum(len(v) for v in data.gt_per_sample.values()),
             pred_annotation_count=sum(len(v) for v in data.pred_per_sample.values()),
@@ -92,19 +94,17 @@ class ImageDatasetEvaluate:
     and keeps evaluation-specific logic separate from ``ImageDataset``.
     """
 
-    def __init__(
-        self, session: Session, collection_id: UUID, samples: Iterable[ImageSample]
-    ) -> None:
+    def __init__(self, session: Session, collection_id: UUID, sample_ids: Iterable[UUID]) -> None:
         """Initialize the evaluator facade.
 
         Args:
             session: Database session used by resolver calls.
             collection_id: ID of the collection being evaluated.
-            samples: Samples selected for evaluation.
+            sample_ids: IDs of the samples selected for evaluation.
         """
         self.session = session
         self.collection_id = collection_id
-        self.samples = samples
+        self.sample_ids = sample_ids
 
     def object_detection(
         self,
@@ -229,7 +229,7 @@ class ImageDatasetEvaluate:
             config_json=config_json,
         )
 
-        selected_sample_ids = {sample.sample_id for sample in self.samples}
+        selected_sample_ids = set(self.sample_ids)
         gt_covered_sample_ids = set(
             annotation_collection_coverage_resolver.list_by_collection_id(
                 session=self.session,
@@ -286,7 +286,16 @@ class ImageDatasetEvaluate:
 
         Returns:
             Tuple of (gt_collection_id, pred_collection_id, evaluation_run).
+
+        Raises:
+            ValueError: If the same annotation source is used for both ground
+                truth and predictions.
         """
+        if gt_annotation_source == pred_annotation_source:
+            raise ValueError(
+                "Ground truth and prediction annotation sources must be different, "
+                f"got {gt_annotation_source!r} for both."
+            )
         gt_collection_id = validators.resolve_and_validate_collection(
             session=self.session,
             collection_id=self.collection_id,


### PR DESCRIPTION
## What has changed and why?

Take an explicit set of sample IDs (instead of ImageSample objects) so callers, including the HTTP trigger, can drive evaluation from sample IDs.


## How has it been tested?

By the test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Evaluation results now include an **evaluation run ID** for easier tracking and reference.

* **Bug Fixes**
  * Image dataset evaluation now bases result selection directly on the **selected sample IDs**, improving consistency.
  * An explicit error is raised if the same source is used for both **ground truth** and **predictions**, preventing accidental misconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->