### PR TITLE
[Prefactor] Generalize LoadingLoggingContext into a per-run file-outcome report

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/add_images.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_images.py
@@ -22,13 +22,12 @@ from tqdm import tqdm
 
 from lightly_studio.core.image import add_annotations
 from lightly_studio.core.image.image_sample import ImageSample
-from lightly_studio.core.loading_log import LoadingLoggingContext, log_loading_results
+from lightly_studio.core.loading_log import FileOutcome, FileOutcomeReport
 from lightly_studio.models.caption import CaptionCreate
 from lightly_studio.models.image import ImageCreate
 from lightly_studio.resolvers import (
     caption_resolver,
     image_resolver,
-    sample_resolver,
     tag_resolver,
 )
 from lightly_studio.type_definitions import PathLike
@@ -60,12 +59,7 @@ def load_into_dataset_from_paths(
     samples_to_create: list[ImageCreate] = []
     created_sample_ids: list[UUID] = []
 
-    logging_context = LoadingLoggingContext(
-        n_samples_to_be_inserted=sum(1 for _ in image_paths),
-        n_samples_before_loading=sample_resolver.count_by_collection_id(
-            session=session, collection_id=root_collection_id
-        ),
-    )
+    report = FileOutcomeReport()
 
     for image_path in tqdm(
         image_paths,
@@ -96,7 +90,7 @@ def load_into_dataset_from_paths(
                 session=session, collection_id=root_collection_id, samples=samples_to_create
             )
             created_sample_ids.extend(created_path_to_id.values())
-            logging_context.update_example_paths(paths_not_inserted)
+            _record_batch_outcomes(report, created_path_to_id, paths_not_inserted)
             samples_to_create = []
 
     # Handle remaining samples
@@ -105,14 +99,10 @@ def load_into_dataset_from_paths(
             session=session, collection_id=root_collection_id, samples=samples_to_create
         )
         created_sample_ids.extend(created_path_to_id.values())
-        logging_context.update_example_paths(paths_not_inserted)
+        _record_batch_outcomes(report, created_path_to_id, paths_not_inserted)
 
-    log_loading_results(
-        session=session,
-        collection_id=root_collection_id,
-        logging_context=logging_context,
-        print_summary=show_progress,
-    )
+    if show_progress:
+        report.log_summary()
     return created_sample_ids
 
 
@@ -136,12 +126,7 @@ def load_into_dataset_from_labelformat(
         A list of UUIDs of the created samples.
     """
     images_root_abs = add_annotations.normalize_images_root(images_root=images_path)
-    logging_context = LoadingLoggingContext(
-        n_samples_to_be_inserted=0,
-        n_samples_before_loading=sample_resolver.count_by_collection_id(
-            session=session, collection_id=root_collection_id
-        ),
-    )
+    report = FileOutcomeReport()
 
     samples_to_create: list[ImageCreate] = []
     created_sample_ids: list[UUID] = []
@@ -149,7 +134,6 @@ def load_into_dataset_from_labelformat(
     # Phase 1: Sample creation
     for image_data in tqdm(input_labels.get_labels(), desc="Processing images", unit=" images"):
         image: Image = image_data.image  # type: ignore[attr-defined]
-        logging_context.n_samples_to_be_inserted += 1
 
         sample = ImageCreate(
             file_name=str(image.filename),
@@ -164,7 +148,7 @@ def load_into_dataset_from_labelformat(
                 session=session, collection_id=root_collection_id, samples=samples_to_create
             )
             created_sample_ids.extend(created_path_to_id.values())
-            logging_context.update_example_paths(paths_not_inserted)
+            _record_batch_outcomes(report, created_path_to_id, paths_not_inserted)
             samples_to_create.clear()
 
     if samples_to_create:
@@ -172,7 +156,7 @@ def load_into_dataset_from_labelformat(
             session=session, collection_id=root_collection_id, samples=samples_to_create
         )
         created_sample_ids.extend(created_path_to_id.values())
-        logging_context.update_example_paths(paths_not_inserted)
+        _record_batch_outcomes(report, created_path_to_id, paths_not_inserted)
 
     # Phase 2: Annotation creation (only if samples were created)
     if created_sample_ids:
@@ -185,12 +169,7 @@ def load_into_dataset_from_labelformat(
             restrict_to_sample_ids=set(created_sample_ids),
         )
 
-    log_loading_results(
-        session=session,
-        collection_id=root_collection_id,
-        logging_context=logging_context,
-        print_summary=True,
-    )
+    report.log_summary()
     return created_sample_ids
 
 
@@ -230,12 +209,7 @@ def load_into_dataset_from_coco_captions(
             continue
         captions_by_image_id[image_id].append(caption_text)
 
-    logging_context = LoadingLoggingContext(
-        n_samples_to_be_inserted=len(images),
-        n_samples_before_loading=sample_resolver.count_by_collection_id(
-            session=session, collection_id=root_collection_id
-        ),
-    )
+    report = FileOutcomeReport()
 
     samples_to_create: list[ImageCreate] = []
     created_sample_ids: list[UUID] = []
@@ -264,7 +238,7 @@ def load_into_dataset_from_coco_captions(
                 session=session, collection_id=root_collection_id, samples=samples_to_create
             )
             created_sample_ids.extend(created_path_to_id.values())
-            logging_context.update_example_paths(paths_not_inserted)
+            _record_batch_outcomes(report, created_path_to_id, paths_not_inserted)
             _process_batch_captions(
                 session=session,
                 collection_id=root_collection_id,
@@ -279,7 +253,7 @@ def load_into_dataset_from_coco_captions(
             session=session, collection_id=root_collection_id, samples=samples_to_create
         )
         created_sample_ids.extend(created_path_to_id.values())
-        logging_context.update_example_paths(paths_not_inserted)
+        _record_batch_outcomes(report, created_path_to_id, paths_not_inserted)
         _process_batch_captions(
             session=session,
             collection_id=root_collection_id,
@@ -287,12 +261,7 @@ def load_into_dataset_from_coco_captions(
             path_to_captions=path_to_captions,
         )
 
-    log_loading_results(
-        session=session,
-        collection_id=root_collection_id,
-        logging_context=logging_context,
-        print_summary=True,
-    )
+    report.log_summary()
     return created_sample_ids
 
 
@@ -374,6 +343,16 @@ def _create_batch_samples(
     # Create a mapping from file path to sample ID for new samples
     file_path_new_to_sample_id = dict(zip(file_paths_new, created_sample_ids))
     return (file_path_new_to_sample_id, file_paths_exist)
+
+
+def _record_batch_outcomes(
+    report: FileOutcomeReport,
+    created_path_to_id: Mapping[str, UUID],
+    paths_not_inserted: Iterable[str],
+) -> None:
+    """Record the outcome of a `_create_batch_samples` call into the report."""
+    report.record_many(created_path_to_id.keys(), FileOutcome.ADDED)
+    report.record_many(paths_not_inserted, FileOutcome.ALREADY_PRESENT)
 
 
 def _process_batch_captions(

--- a/lightly_studio/src/lightly_studio/core/loading_log.py
+++ b/lightly_studio/src/lightly_studio/core/loading_log.py
@@ -1,16 +1,13 @@
-"""Functions to add samples and their annotations to a dataset in the database."""
+"""Per-run report recording the outcome of every input file during loading."""
 
 from __future__ import annotations
 
+import enum
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from uuid import UUID
 
-from sqlmodel import Session
-
-from lightly_studio.resolvers import (
-    sample_resolver,
-)
+from lightly_studio.type_definitions import PathLike
 
 logger = logging.getLogger(__name__)
 
@@ -18,46 +15,79 @@ logger = logging.getLogger(__name__)
 MAX_EXAMPLE_PATHS_TO_SHOW = 5
 
 
-@dataclass
-class LoadingLoggingContext:
-    """Context for the logging while loading data."""
+class FileOutcome(enum.Enum):
+    """The single outcome recorded for each input file of a loading run."""
 
-    n_samples_before_loading: int
-    n_samples_to_be_inserted: int = 0
-    example_paths_not_inserted: list[str] = field(default_factory=list)
-
-    def update_example_paths(self, example_paths_not_inserted: list[str]) -> None:
-        """Update the list of example paths that were not inserted."""
-        if len(self.example_paths_not_inserted) >= MAX_EXAMPLE_PATHS_TO_SHOW:
-            return
-        upper_limit = MAX_EXAMPLE_PATHS_TO_SHOW - len(self.example_paths_not_inserted)
-        self.example_paths_not_inserted.extend(example_paths_not_inserted[:upper_limit])
+    ADDED = "added"
+    ALREADY_PRESENT = "already-present"
+    MISSING = "missing"
+    BROKEN = "broken"
 
 
-def log_loading_results(
-    session: Session,
-    collection_id: UUID,
-    logging_context: LoadingLoggingContext,
-    print_summary: bool,
-) -> None:
-    """Log the results of loading samples into a dataset.
+class AllInputFilesFailedError(RuntimeError):
+    """Raised when every attempted input file failed and none were added.
 
-    If `print_summary` is True, calculates how many samples were successfully inserted and prints
-    a summary message.
-
-    If any paths failed to be inserted, prints examples of those paths as a warning.
+    This is the wrong-path / real-bug case. It is distinct from a run where no file
+    was attempted because everything was already present, which is not an error.
     """
-    if print_summary:
-        n_samples_end = sample_resolver.count_by_collection_id(
-            session=session, collection_id=collection_id
-        )
-        n_samples_inserted = n_samples_end - logging_context.n_samples_before_loading
-        logger.info(
-            f"Added {n_samples_inserted} out of {logging_context.n_samples_to_be_inserted} "
-            "new samples to the dataset."
-        )
-    if logging_context.example_paths_not_inserted:
-        logger.warning(
-            "Examples paths that were not added to the dataset: "
-            f"{', '.join(logging_context.example_paths_not_inserted)}"
-        )
+
+
+@dataclass
+class FileOutcomeReport:
+    """Per-run report recording exactly one outcome per input file.
+
+    Every loading pipeline writes to one report instead of returning per-file values.
+    The report is the single place outcomes are recorded, the all-failed error is
+    decided, and the end-of-run summary is logged.
+    """
+
+    counts: dict[FileOutcome, int] = field(default_factory=lambda: dict.fromkeys(FileOutcome, 0))
+    example_paths: dict[FileOutcome, list[str]] = field(
+        default_factory=lambda: {outcome: [] for outcome in FileOutcome}
+    )
+
+    def record(self, path: PathLike, outcome: FileOutcome) -> None:
+        """Record a single file with one of the four outcomes."""
+        self.counts[outcome] += 1
+        examples = self.example_paths[outcome]
+        if len(examples) < MAX_EXAMPLE_PATHS_TO_SHOW:
+            examples.append(str(path))
+
+    def record_many(self, paths: Iterable[PathLike], outcome: FileOutcome) -> None:
+        """Record multiple files that share the same outcome."""
+        for path in paths:
+            self.record(path, outcome)
+
+    @property
+    def n_attempted(self) -> int:
+        """Number of files that were attempted (added + missing + broken).
+
+        Already-present files are skipped before being attempted, so they do not count.
+        """
+        return sum(self.counts.values()) - self.counts[FileOutcome.ALREADY_PRESENT]
+
+    @property
+    def n_added(self) -> int:
+        """Number of files that were successfully added."""
+        return self.counts[FileOutcome.ADDED]
+
+    def raise_if_all_failed(self) -> None:
+        """Raise if every attempted file failed (0 succeeded of N attempted).
+
+        Does not raise when nothing was attempted (e.g. everything was already present).
+        """
+        if self.n_attempted > 0 and self.n_added == 0:
+            raise AllInputFilesFailedError(
+                f"None of the {self.n_attempted} attempted files could be added to the dataset. "
+                "Check that the input paths are correct and the files are readable."
+            )
+
+    def log_summary(self) -> None:
+        """Log a single end-of-run summary: counts per outcome plus example paths."""
+        summary = ", ".join(f"{self.counts[outcome]} {outcome.value}" for outcome in FileOutcome)
+        logger.info(f"File loading summary: {summary}.")
+
+        for outcome in (FileOutcome.MISSING, FileOutcome.BROKEN, FileOutcome.ALREADY_PRESENT):
+            examples = self.example_paths[outcome]
+            if examples:
+                logger.warning(f"Example {outcome.value} paths: {', '.join(examples)}")

--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -32,7 +32,8 @@ from labelformat.model.object_detection_track import (
 from sqlmodel import Session
 from tqdm import tqdm
 
-from lightly_studio.core import labelformat_helpers, loading_log
+from lightly_studio.core import labelformat_helpers
+from lightly_studio.core.loading_log import FileOutcome, FileOutcomeReport
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
 )
@@ -43,7 +44,6 @@ from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
     object_track_resolver,
-    sample_resolver,
     video_frame_resolver,
     video_resolver,
 )
@@ -114,13 +114,8 @@ def load_into_collection_from_paths(  # noqa: PLR0913
     file_paths_new, file_paths_exist = video_resolver.filter_new_paths(
         session=session, collection_id=collection_id, file_paths_abs=video_paths_list
     )
-    video_logging_context = loading_log.LoadingLoggingContext(
-        n_samples_to_be_inserted=len(video_paths_list),
-        n_samples_before_loading=sample_resolver.count_by_collection_id(
-            session=session, collection_id=collection_id
-        ),
-    )
-    video_logging_context.update_example_paths(file_paths_exist)
+    report = FileOutcomeReport()
+    report.record_many(file_paths_exist, FileOutcome.ALREADY_PRESENT)
     # Get the video frames collection ID
     video_frames_collection_id = collection_resolver.get_or_create_child_collection(
         session=session, collection_id=collection_id, sample_type=SampleType.VIDEO_FRAME
@@ -170,6 +165,7 @@ def load_into_collection_from_paths(  # noqa: PLR0913
                     video_container.close()
                     raise (RuntimeError(f"There was an error adding {video_path} to the dataset."))
                 created_video_sample_ids.append(video_sample_ids[0])
+                report.record(video_path, FileOutcome.ADDED)
 
                 # Create video frame samples by parsing all frames
                 extraction_context = FrameExtractionContext(
@@ -195,12 +191,8 @@ def load_into_collection_from_paths(  # noqa: PLR0913
             logger.error(f"Error processing video {video_path}: {e}")
             continue
 
-    loading_log.log_loading_results(
-        session=session,
-        collection_id=collection_id,
-        logging_context=video_logging_context,
-        print_summary=show_progress,
-    )
+    if show_progress:
+        report.log_summary()
 
     return created_video_sample_ids, created_video_frame_sample_ids
 

--- a/lightly_studio/tests/core/image/test_image_dataset__labelformat.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__labelformat.py
@@ -125,8 +125,8 @@ class TestDataset:
         assert len(list(dataset)) == 2
 
         log_text = caplog.text
-        assert "Added 0 out of 1 new samples to the dataset." in log_text
-        assert "Examples paths that were not added to the dataset:" in log_text
+        assert "0 added, 1 already-present" in log_text
+        assert "Example already-present paths:" in log_text
         assert "/fake/path/images/image.jpg" in log_text
 
     def test_from_labelformat__annotations_synced_images(

--- a/lightly_studio/tests/core/image/test_image_dataset__path.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__path.py
@@ -175,8 +175,8 @@ class TestDataset:
         assert len(list(dataset)) == 6
 
         log_text = caplog.text
-        assert "Added 2 out of 6 new samples to the dataset." in log_text
-        assert "Examples paths that were not added to the dataset:" in log_text
+        assert "2 added, 4 already-present" in log_text
+        assert "Example already-present paths:" in log_text
         assert f"{images_path}" in log_text
 
     def test_dataset_add_images_from_path__dont_embed(

--- a/lightly_studio/tests/core/test_loading_log.py
+++ b/lightly_studio/tests/core/test_loading_log.py
@@ -1,0 +1,115 @@
+"""Unit tests for the per-run file-outcome report."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lightly_studio.core import loading_log
+from lightly_studio.core.loading_log import (
+    AllInputFilesFailedError,
+    FileOutcome,
+    FileOutcomeReport,
+)
+
+
+class TestRecordOutcomes:
+    def test_record_each_outcome_counts_and_keeps_examples(self) -> None:
+        report = FileOutcomeReport()
+
+        report.record("added.jpg", FileOutcome.ADDED)
+        report.record("present.jpg", FileOutcome.ALREADY_PRESENT)
+        report.record("missing.jpg", FileOutcome.MISSING)
+        report.record("broken.jpg", FileOutcome.BROKEN)
+
+        assert report.counts[FileOutcome.ADDED] == 1
+        assert report.counts[FileOutcome.ALREADY_PRESENT] == 1
+        assert report.counts[FileOutcome.MISSING] == 1
+        assert report.counts[FileOutcome.BROKEN] == 1
+        assert report.example_paths[FileOutcome.ADDED] == ["added.jpg"]
+        assert report.example_paths[FileOutcome.MISSING] == ["missing.jpg"]
+
+    def test_record_many_records_every_path(self) -> None:
+        report = FileOutcomeReport()
+
+        report.record_many(["a.jpg", "b.jpg", "c.jpg"], FileOutcome.ALREADY_PRESENT)
+
+        assert report.counts[FileOutcome.ALREADY_PRESENT] == 3
+        assert report.example_paths[FileOutcome.ALREADY_PRESENT] == ["a.jpg", "b.jpg", "c.jpg"]
+
+    def test_example_paths_are_capped(self) -> None:
+        report = FileOutcomeReport()
+
+        report.record_many(
+            [f"file_{i}.jpg" for i in range(loading_log.MAX_EXAMPLE_PATHS_TO_SHOW + 3)],
+            FileOutcome.BROKEN,
+        )
+
+        # Every file is counted, but only a few examples are kept.
+        assert report.counts[FileOutcome.BROKEN] == loading_log.MAX_EXAMPLE_PATHS_TO_SHOW + 3
+        assert (
+            len(report.example_paths[FileOutcome.BROKEN]) == loading_log.MAX_EXAMPLE_PATHS_TO_SHOW
+        )
+
+
+class TestRaiseIfAllFailed:
+    def test_raises_when_zero_succeeded_of_n_attempted(self) -> None:
+        report = FileOutcomeReport()
+        report.record_many(["a.jpg", "b.jpg"], FileOutcome.MISSING)
+        report.record("c.jpg", FileOutcome.BROKEN)
+
+        with pytest.raises(AllInputFilesFailedError):
+            report.raise_if_all_failed()
+
+    def test_does_not_raise_when_at_least_one_added(self) -> None:
+        report = FileOutcomeReport()
+        report.record("ok.jpg", FileOutcome.ADDED)
+        report.record("bad.jpg", FileOutcome.BROKEN)
+
+        report.raise_if_all_failed()  # Must not raise.
+
+    def test_does_not_raise_when_zero_attempted_all_already_present(self) -> None:
+        report = FileOutcomeReport()
+        report.record_many(["a.jpg", "b.jpg"], FileOutcome.ALREADY_PRESENT)
+
+        report.raise_if_all_failed()  # Must not raise: already-present is not an attempt.
+
+    def test_does_not_raise_when_nothing_recorded(self) -> None:
+        report = FileOutcomeReport()
+
+        report.raise_if_all_failed()  # Must not raise.
+
+
+class TestLogSummary:
+    def test_summary_logs_counts_per_outcome(self, caplog: pytest.LogCaptureFixture) -> None:
+        report = FileOutcomeReport()
+        report.record("a.jpg", FileOutcome.ADDED)
+        report.record_many(["b.jpg", "c.jpg"], FileOutcome.ALREADY_PRESENT)
+        report.record("d.jpg", FileOutcome.MISSING)
+        report.record("e.jpg", FileOutcome.BROKEN)
+
+        caplog.set_level(logging.INFO, logger="lightly_studio.core.loading_log")
+        report.log_summary()
+
+        log_text = caplog.text
+        assert "1 added" in log_text
+        assert "2 already-present" in log_text
+        assert "1 missing" in log_text
+        assert "1 broken" in log_text
+
+    def test_summary_logs_example_paths_for_problem_outcomes(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        report = FileOutcomeReport()
+        report.record("missing.jpg", FileOutcome.MISSING)
+        report.record("broken.jpg", FileOutcome.BROKEN)
+        report.record("present.jpg", FileOutcome.ALREADY_PRESENT)
+
+        caplog.set_level(logging.INFO, logger="lightly_studio.core.loading_log")
+        report.log_summary()
+
+        log_text = caplog.text
+        assert "missing.jpg" in log_text
+        assert "broken.jpg" in log_text
+        assert "present.jpg" in log_text


### PR DESCRIPTION
## What

Generalizes the ingest-only `LoadingLoggingContext` (binary inserted/not-inserted + a few example paths) into a single per-run **`FileOutcomeReport`** that records exactly one outcome per input file:

- **added** · **already-present** · **missing** · **broken**

The report owns the three behaviours from [LIG-10029](https://linear.app/lightly/issue/LIG-10029):

1. **Skip-and-record, not return values** — `record()` / `record_many()` are the single place outcomes are recorded.
2. **One end-of-run summary** — `log_summary()` logs counts per outcome plus a few example paths per category.
3. **All-failed raise rule** — `raise_if_all_failed()` raises `AllInputFilesFailedError` on "0 succeeded of N *attempted*", while "0 attempted because everything was already present" does **not** raise.

`strict` mode and percentage thresholds are out of scope (follow-ups).

## Scope

This is the central helper every other slice of [LIG-9953](https://linear.app/lightly/issue/LIG-9953) builds on. Per the issue, the report is built and **unit-tested in isolation here**; wiring the all-failed rule and recording missing/broken into the pipelines is deferred to the dedicated slices (LIG-10030 / 10032 / …).

Image and video ingest call sites are migrated onto the new API and stay green (they record `added`/`already-present`); their broken/missing *behaviour* is unchanged in this slice.

## Tests

- New `tests/core/test_loading_log.py` covers the four outcomes, example-path capping, the summary, and the raise rule (incl. the negative "all already-present → no raise" case).
- Updated two existing ingest tests to the new summary format.
- `make static-checks` clean (ruff + mypy); full `make test` → 1497 passed, 32 skipped (2 pre-existing collection errors from optional `s3fs` missing locally, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading status messages when adding images and videos, with clearer counts for added, already-present, missing, and broken items.
  * Duplicate items are now reported in a more consistent format, including example paths.

* **New Features**
  * Added a more detailed end-of-run outcome summary for file loading.
  * Loading now tracks per-file results more accurately across batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->