### PR TITLE
[Prefactor] Add central FileOutcomeReport helper (additive)

### DIFF
--- a/lightly_studio/src/lightly_studio/core/file_outcome_report.py
+++ b/lightly_studio/src/lightly_studio/core/file_outcome_report.py
@@ -1,0 +1,142 @@
+"""Central per-run file-outcome report and error-handling wrapper for pipeline steps.
+
+This is the single place where every pipeline step routes its per-item file operations,
+so the error-handling decision ("on what to error, and how to handle it") lives in one
+place instead of in N scattered try/except blocks.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+
+from lightly_studio.errors import AllInputFilesFailedError
+
+logger = logging.getLogger(__name__)
+
+# Number of example paths kept and shown per outcome in the end-of-run summary.
+MAX_EXAMPLE_PATHS_PER_OUTCOME = 5
+
+
+class FileOutcome(Enum):
+    """The outcome of attempting to add a single input file to a dataset."""
+
+    ADDED = "added"
+    """The file was newly added."""
+
+    ALREADY_PRESENT = "already_present"
+    """The file was already present and therefore not added again."""
+
+    MISSING = "missing"
+    """The path does not resolve to an existing file."""
+
+    BROKEN = "broken"
+    """The file is present but unreadable or undecodable."""
+
+
+# Outcomes that represent an attempt to process the file (as opposed to a skip because the
+# file was already present). The all-failed raise rule is computed over these.
+_ATTEMPTED_OUTCOMES = (FileOutcome.ADDED, FileOutcome.MISSING, FileOutcome.BROKEN)
+
+
+@dataclass
+class FileOutcomeReport:
+    """Per-run report recording one outcome per file and owning error-handling policy.
+
+    Pipeline steps route each per-item file operation through `process_file`, which catches
+    the failure, classifies it into an outcome, applies the skip policy, and records it. At
+    the end of the run, `raise_if_all_failed` enforces the all-failed rule and `log_summary`
+    logs counts and example paths per outcome.
+
+    Attributes:
+        counts: Number of files recorded per outcome.
+        example_paths: Up to `MAX_EXAMPLE_PATHS_PER_OUTCOME` example paths per outcome.
+    """
+
+    counts: dict[FileOutcome, int] = field(default_factory=lambda: dict.fromkeys(FileOutcome, 0))
+    example_paths: dict[FileOutcome, list[str]] = field(
+        default_factory=lambda: {outcome: [] for outcome in FileOutcome}
+    )
+
+    def process_file(self, path: str, operation: Callable[[], FileOutcome]) -> FileOutcome | None:
+        """Run a per-item file operation, classify any failure, and record the outcome.
+
+        The operation performs the actual work for a single file and returns the success
+        outcome (`ADDED` or `ALREADY_PRESENT`). A `FileNotFoundError` is classified as
+        `MISSING`; any other exception is classified as `BROKEN`. Failures are tolerated:
+        the bad item is recorded and skipped, no exception propagates and no placeholder
+        is created.
+
+        Args:
+            path: The path of the file being processed, used for the recorded examples.
+            operation: A callable performing the work for a single file. Returns the
+                success outcome of the file.
+
+        Returns:
+            The recorded outcome, or `None` if the operation failed and was skipped.
+        """
+        try:
+            outcome = operation()
+        except FileNotFoundError:
+            self.record(path=path, outcome=FileOutcome.MISSING)
+            return None
+        except Exception:
+            # Any non-missing failure means the file is present but could not be read or
+            # decoded. We tolerate it instead of crashing the whole run.
+            logger.debug(f"Failed to process file: {path}", exc_info=True)
+            self.record(path=path, outcome=FileOutcome.BROKEN)
+            return None
+        self.record(path=path, outcome=outcome)
+        return outcome
+
+    def record(self, path: str, outcome: FileOutcome) -> None:
+        """Record a single file's outcome.
+
+        Args:
+            path: The path of the file.
+            outcome: The outcome to record for the file.
+        """
+        self.counts[outcome] += 1
+        examples = self.example_paths[outcome]
+        if len(examples) < MAX_EXAMPLE_PATHS_PER_OUTCOME:
+            examples.append(path)
+
+    @property
+    def n_attempted(self) -> int:
+        """Number of files that were actually attempted (added, missing, or broken)."""
+        return sum(self.counts[outcome] for outcome in _ATTEMPTED_OUTCOMES)
+
+    @property
+    def n_succeeded(self) -> int:
+        """Number of files that were successfully added."""
+        return self.counts[FileOutcome.ADDED]
+
+    def raise_if_all_failed(self) -> None:
+        """Raise if every attempted file failed, signalling a wrong path or real bug.
+
+        This is distinct from "nothing was attempted because all files were already
+        present", which does not raise.
+
+        Raises:
+            AllInputFilesFailedError: If at least one file was attempted and none
+                succeeded.
+        """
+        if self.n_attempted > 0 and self.n_succeeded == 0:
+            raise AllInputFilesFailedError(
+                f"All {self.n_attempted} attempted input files failed to be added "
+                f"({self.counts[FileOutcome.MISSING]} missing, "
+                f"{self.counts[FileOutcome.BROKEN]} broken)."
+            )
+
+    def log_summary(self) -> None:
+        """Log a single end-of-run summary with counts and example paths per outcome."""
+        counts_summary = ", ".join(
+            f"{outcome.value}: {self.counts[outcome]}" for outcome in FileOutcome
+        )
+        logger.info(f"File outcome summary - {counts_summary}.")
+        for outcome in FileOutcome:
+            examples = self.example_paths[outcome]
+            if examples:
+                logger.info(f"Example {outcome.value} paths: {', '.join(examples)}")

--- a/lightly_studio/src/lightly_studio/core/file_outcome_report.py
+++ b/lightly_studio/src/lightly_studio/core/file_outcome_report.py
@@ -7,9 +7,9 @@ place instead of in N scattered try/except blocks.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass, field
 from enum import Enum
 
 from lightly_studio.errors import AllInputFilesFailedError
@@ -41,7 +41,7 @@ class FileOutcome(Enum):
 _ATTEMPTED_OUTCOMES = (FileOutcome.ADDED, FileOutcome.MISSING, FileOutcome.BROKEN)
 
 
-@dataclass
+@dataclasses.dataclass
 class FileOutcomeReport:
     """Per-run report recording one outcome per file and owning error-handling policy.
 
@@ -55,8 +55,10 @@ class FileOutcomeReport:
         example_paths: Up to `MAX_EXAMPLE_PATHS_PER_OUTCOME` example paths per outcome.
     """
 
-    counts: dict[FileOutcome, int] = field(default_factory=lambda: dict.fromkeys(FileOutcome, 0))
-    example_paths: dict[FileOutcome, list[str]] = field(
+    counts: dict[FileOutcome, int] = dataclasses.field(
+        default_factory=lambda: dict.fromkeys(FileOutcome, 0)
+    )
+    example_paths: dict[FileOutcome, list[str]] = dataclasses.field(
         default_factory=lambda: {outcome: [] for outcome in FileOutcome}
     )
 

--- a/lightly_studio/src/lightly_studio/errors.py
+++ b/lightly_studio/src/lightly_studio/errors.py
@@ -7,3 +7,11 @@ class TagNotFoundError(Exception):
 
 class QueryExprError(Exception):
     """Exception raised when a query expression cannot be translated."""
+
+
+class AllInputFilesFailedError(Exception):
+    """Exception raised when every attempted input file failed to be added.
+
+    This signals a likely wrong path or real bug rather than a few bad files, and is
+    distinct from the case where no file was attempted because all were already present.
+    """

--- a/lightly_studio/tests/core/test_file_outcome_report.py
+++ b/lightly_studio/tests/core/test_file_outcome_report.py
@@ -16,7 +16,7 @@ class TestFileOutcomeReport:
     def test_process_file__added(self) -> None:
         report = FileOutcomeReport()
 
-        outcome = report.process_file("a.jpg", lambda: FileOutcome.ADDED)
+        outcome = report.process_file(path="a.jpg", operation=lambda: FileOutcome.ADDED)
 
         assert outcome == FileOutcome.ADDED
         assert report.counts[FileOutcome.ADDED] == 1
@@ -25,7 +25,7 @@ class TestFileOutcomeReport:
     def test_process_file__already_present(self) -> None:
         report = FileOutcomeReport()
 
-        outcome = report.process_file("a.jpg", lambda: FileOutcome.ALREADY_PRESENT)
+        outcome = report.process_file(path="a.jpg", operation=lambda: FileOutcome.ALREADY_PRESENT)
 
         assert outcome == FileOutcome.ALREADY_PRESENT
         assert report.counts[FileOutcome.ALREADY_PRESENT] == 1
@@ -36,7 +36,7 @@ class TestFileOutcomeReport:
         def operation() -> FileOutcome:
             raise FileNotFoundError("a.jpg")
 
-        outcome = report.process_file("a.jpg", operation)
+        outcome = report.process_file(path="a.jpg", operation=operation)
 
         assert outcome is None
         assert report.counts[FileOutcome.MISSING] == 1
@@ -48,7 +48,7 @@ class TestFileOutcomeReport:
         def operation() -> FileOutcome:
             raise ValueError("cannot decode image")
 
-        outcome = report.process_file("a.jpg", operation)
+        outcome = report.process_file(path="a.jpg", operation=operation)
 
         assert outcome is None
         assert report.counts[FileOutcome.BROKEN] == 1
@@ -58,7 +58,7 @@ class TestFileOutcomeReport:
         # A bad item is recorded and skipped; no other outcome row is created.
         report = FileOutcomeReport()
 
-        report.process_file("bad.jpg", lambda: (_ for _ in ()).throw(OSError()))
+        report.process_file(path="bad.jpg", operation=lambda: (_ for _ in ()).throw(OSError()))
 
         assert report.counts[FileOutcome.ADDED] == 0
         assert report.counts[FileOutcome.ALREADY_PRESENT] == 0

--- a/lightly_studio/tests/core/test_file_outcome_report.py
+++ b/lightly_studio/tests/core/test_file_outcome_report.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lightly_studio.core.file_outcome_report import (
+    MAX_EXAMPLE_PATHS_PER_OUTCOME,
+    FileOutcome,
+    FileOutcomeReport,
+)
+from lightly_studio.errors import AllInputFilesFailedError
+
+
+class TestFileOutcomeReport:
+    def test_process_file__added(self) -> None:
+        report = FileOutcomeReport()
+
+        outcome = report.process_file("a.jpg", lambda: FileOutcome.ADDED)
+
+        assert outcome == FileOutcome.ADDED
+        assert report.counts[FileOutcome.ADDED] == 1
+        assert report.example_paths[FileOutcome.ADDED] == ["a.jpg"]
+
+    def test_process_file__already_present(self) -> None:
+        report = FileOutcomeReport()
+
+        outcome = report.process_file("a.jpg", lambda: FileOutcome.ALREADY_PRESENT)
+
+        assert outcome == FileOutcome.ALREADY_PRESENT
+        assert report.counts[FileOutcome.ALREADY_PRESENT] == 1
+
+    def test_process_file__missing(self) -> None:
+        report = FileOutcomeReport()
+
+        def operation() -> FileOutcome:
+            raise FileNotFoundError("a.jpg")
+
+        outcome = report.process_file("a.jpg", operation)
+
+        assert outcome is None
+        assert report.counts[FileOutcome.MISSING] == 1
+        assert report.example_paths[FileOutcome.MISSING] == ["a.jpg"]
+
+    def test_process_file__broken(self) -> None:
+        report = FileOutcomeReport()
+
+        def operation() -> FileOutcome:
+            raise ValueError("cannot decode image")
+
+        outcome = report.process_file("a.jpg", operation)
+
+        assert outcome is None
+        assert report.counts[FileOutcome.BROKEN] == 1
+        assert report.example_paths[FileOutcome.BROKEN] == ["a.jpg"]
+
+    def test_process_file__tolerates_failure_without_placeholder(self) -> None:
+        # A bad item is recorded and skipped; no other outcome row is created.
+        report = FileOutcomeReport()
+
+        report.process_file("bad.jpg", lambda: (_ for _ in ()).throw(OSError()))
+
+        assert report.counts[FileOutcome.ADDED] == 0
+        assert report.counts[FileOutcome.ALREADY_PRESENT] == 0
+        assert report.counts[FileOutcome.MISSING] == 0
+        assert report.counts[FileOutcome.BROKEN] == 1
+
+    def test_record__caps_example_paths(self) -> None:
+        report = FileOutcomeReport()
+        n_paths = MAX_EXAMPLE_PATHS_PER_OUTCOME + 3
+
+        for i in range(n_paths):
+            report.record(path=f"{i}.jpg", outcome=FileOutcome.MISSING)
+
+        assert report.counts[FileOutcome.MISSING] == n_paths
+        assert len(report.example_paths[FileOutcome.MISSING]) == MAX_EXAMPLE_PATHS_PER_OUTCOME
+
+    def test_n_attempted__excludes_already_present(self) -> None:
+        report = FileOutcomeReport()
+        report.record(path="a.jpg", outcome=FileOutcome.ADDED)
+        report.record(path="b.jpg", outcome=FileOutcome.MISSING)
+        report.record(path="c.jpg", outcome=FileOutcome.BROKEN)
+        report.record(path="d.jpg", outcome=FileOutcome.ALREADY_PRESENT)
+
+        assert report.n_attempted == 3
+        assert report.n_succeeded == 1
+
+    def test_raise_if_all_failed__raises_when_all_attempts_fail(self) -> None:
+        report = FileOutcomeReport()
+        report.record(path="a.jpg", outcome=FileOutcome.MISSING)
+        report.record(path="b.jpg", outcome=FileOutcome.BROKEN)
+
+        with pytest.raises(AllInputFilesFailedError):
+            report.raise_if_all_failed()
+
+    def test_raise_if_all_failed__no_raise_when_some_added(self) -> None:
+        report = FileOutcomeReport()
+        report.record(path="a.jpg", outcome=FileOutcome.ADDED)
+        report.record(path="b.jpg", outcome=FileOutcome.MISSING)
+
+        report.raise_if_all_failed()  # Does not raise.
+
+    def test_raise_if_all_failed__no_raise_when_all_already_present(self) -> None:
+        # 0 attempted because everything was already present must not raise.
+        report = FileOutcomeReport()
+        report.record(path="a.jpg", outcome=FileOutcome.ALREADY_PRESENT)
+        report.record(path="b.jpg", outcome=FileOutcome.ALREADY_PRESENT)
+
+        report.raise_if_all_failed()  # Does not raise.
+
+    def test_raise_if_all_failed__no_raise_when_nothing_recorded(self) -> None:
+        report = FileOutcomeReport()
+
+        report.raise_if_all_failed()  # Does not raise.
+
+    def test_log_summary(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO, logger="lightly_studio.core.file_outcome_report")
+        report = FileOutcomeReport()
+        report.record(path="a.jpg", outcome=FileOutcome.ADDED)
+        report.record(path="b.jpg", outcome=FileOutcome.MISSING)
+
+        report.log_summary()
+
+        log_text = caplog.text
+        assert "added: 1" in log_text
+        assert "missing: 1" in log_text
+        assert "Example added paths: a.jpg" in log_text
+        assert "Example missing paths: b.jpg" in log_text


### PR DESCRIPTION
## Summary

Implements [LIG-10029](https://linear.app/lightly/issue/LIG-10029/prefactor-implement-the-central-error-handling-helper-additive). Introduces a new, self-contained per-run file-outcome report that owns both the per-file outcome recording and the error-handling decision for pipeline steps — one place for this logic instead of N scattered try/except blocks.

This slice is **additive only**: no existing call site changes and the current `LoadingLoggingContext` keeps working. Migration of call sites (LIG-10037) and per-pipeline outcome behavior (LIG-10030…10035) are separate downstream slices.

## What's in it

`core/file_outcome_report.py`:
- **`FileOutcome`** enum: `ADDED`, `ALREADY_PRESENT`, `MISSING`, `BROKEN`.
- **`FileOutcomeReport`** with per-outcome counts and capped example paths:
  - **`process_file(path, operation)`** — central wrapper. Runs a per-item file operation, classifies failures (`FileNotFoundError` → missing, otherwise → broken), tolerates them (records + skips, no propagation, no placeholder), and records the operation's success outcome.
  - **`raise_if_all_failed()`** — raises `AllInputFilesFailedError` when ≥1 file was *attempted* and none succeeded. `already-present` is excluded from "attempted", so "0 attempted, all already present" does **not** raise.
  - **`log_summary()`** — one end-of-run summary: counts per outcome plus example paths.

`errors.py`: adds `AllInputFilesFailedError`.

## Acceptance criteria

- [x] Report records each file with one of the four outcomes.
- [x] Central wrapper catches, classifies missing vs broken, applies skip policy, records.
- [x] End-of-run summary prints counts plus example paths.
- [x] Raise on "0 succeeded of N attempted" + negative case "0 attempted, all already present → no raise".
- [x] Additive: no existing call site changed; build stays green with old `LoadingLoggingContext`.
- [x] Unit tests cover the four outcomes, missing-vs-broken classification, and the raise rule.

## Testing

- `make static-checks` — ruff + mypy clean.
- `make test` — 1500 passed, including 12 new unit tests. (The 2 collection errors for `test_enterprise.py` / `test_fsspec_lister.py` are pre-existing — `s3fs` is not installed locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added run-level file outcome tracking with per-file statuses, counts, and sample paths.
  * Added automatic handling for missing or broken input files, with a clear error when all attempted inputs fail.
* **Bug Fixes**
  * Improved file-processing robustness by preventing individual file errors from stopping the full run.
  * Added end-of-run summaries to make input processing results easier to review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->