### PR TITLE
Add docs for sample evaluation query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ filtered sample count.
 - Deduplication strategy is available in the Sampling Dialog in the GUI
 - Improve confusion matrix usability for large numbers of classes
 - Python dataset queries now support classifications, object detections, and segmentation mask annotations.
+- Python dataset queries now model evaluation queries on the sample level.
 
 ### Changed
 

--- a/lightly_studio/docs/docs/api/dataset_query.md
+++ b/lightly_studio/docs/docs/api/dataset_query.md
@@ -12,6 +12,13 @@
         members: [ImageSampleField]
         show_if_no_docstring: true
 
+## VideoSampleField
+
+::: lightly_studio.core.dataset_query.video_sample_field
+    options:
+        members: [VideoSampleField]
+        show_if_no_docstring: true
+
 ## ClassificationField
 
 ::: lightly_studio.core.dataset_query.classification_query
@@ -51,9 +58,21 @@
     options:
         members: [SegmentationMaskQuery]
 
-## VideoSampleField
+## SampleEvaluationQuery
 
-::: lightly_studio.core.dataset_query.video_sample_field
+::: lightly_studio.core.dataset_query.sample_evaluation_query
     options:
-        members: [VideoSampleField]
+        members: [SampleEvaluationQuery]
+
+## EvaluationMetricField
+
+::: lightly_studio.core.dataset_query.evaluation_metric_expression
+    options:
+        members: [EvaluationMetricField]
         show_if_no_docstring: true
+
+## OrderByEvaluationMetricField
+
+::: lightly_studio.core.dataset_query.order_by
+    options:
+        members: [OrderByEvaluationMetricField]

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -278,6 +278,7 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
     query.match(expr)
     ```
 
+    #### Boolean operators
     The filtering on individual fields can flexibly be combined to create more complex match expression. For this, the boolean operators `AND`, `OR`, and `NOT` are available. Boolean operators can arbitrarily be nested.
 
 

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -77,7 +77,10 @@ sample-level filtering; for video datasets, use
 [`ObjectDetectionField`](../api/dataset_query.md#objectdetectionfield) to demonstrate annotation
 filtering. For the other annotation types, see
 [`ClassificationField`](../api/dataset_query.md#classificationfield) and
-[`SegmentationMaskField`](../api/dataset_query.md#segmentationmaskfield).
+[`SegmentationMaskField`](../api/dataset_query.md#segmentationmaskfield). For filtering by
+evaluation run metrics, see
+[`SampleEvaluationQuery`](../api/dataset_query.md#sampleevaluationquery) and
+[`EvaluationMetricField`](../api/dataset_query.md#evaluationmetricfield) in the reference below.
 ```py
 from lightly_studio.core.dataset_query import (
     AND,
@@ -103,7 +106,7 @@ query = dataset.match(
     )
 )
 # match (with annotations): Samples with at least one confident "person" detection
-# larger than 100 px tall, # in an image with 500 px or more width.
+# larger than 100 px tall, in an image with 500 px or more width.
 query = dataset.match(
     AND(
         ImageSampleField.width >= 500,
@@ -159,7 +162,12 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
     ```py
     query.match(<expression>)
     ```
-    To create an expression for filtering on certain sample fields, the `ImageSampleField.<field_name> <operator> <value>` syntax can be used. Available field names can be seen in [`ImageSampleField`](../api/dataset_query.md#lightly_studio.core.dataset_query.image_sample_field.ImageSampleField).
+
+    #### Sample queries
+
+    Sample-level queries use the `ImageSampleField.<field_name> <operator> <value>` syntax.
+    Available field names can be seen in
+    [`ImageSampleField`](../api/dataset_query.md#lightly_studio.core.dataset_query.image_sample_field.ImageSampleField).
 
     ```py
     from lightly_studio.core.dataset_query import ImageSampleField
@@ -179,6 +187,8 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
     # Assign any of the previous expressions to a query:
     query.match(expr)
     ```
+
+    #### Annotation queries
 
     Annotation queries use `ClassificationQuery(...)`, `ObjectDetectionQuery(...)`, and
     `SegmentationMaskQuery(...)`. Each helper matches a sample when it has at least one
@@ -223,6 +233,48 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
         SegmentationMaskField.height >= 80,
     )
 
+    # Assign any of the previous expressions to a query:
+    query.match(expr)
+    ```
+
+    #### Sample evaluation queries
+
+    Sample evaluation queries use `SampleEvaluationQuery(...)` together with
+    `EvaluationMetricField(...)` to filter samples by metrics from a specific evaluation run.
+    They match only samples that are part of the named run and satisfy all passed metric
+    criteria.
+
+    ```py
+    from lightly_studio.core.dataset_query import (
+        AND,
+        EvaluationMetricField,
+        ImageSampleField,
+        SampleEvaluationQuery,
+    )
+
+    # Metric operators: <, <=, >, >=, ==, !=
+    expr = SampleEvaluationQuery(
+        "run1",
+        EvaluationMetricField("score") > 0.5,
+    )
+
+    # Multiple metrics inside SampleEvaluationQuery are combined with AND
+    expr = SampleEvaluationQuery(
+        "run1",
+        EvaluationMetricField("precision") > 0.5,
+        EvaluationMetricField("recall") > 0.5,
+    )
+
+    # Evaluation queries can be combined with sample-level filters
+    expr = AND(
+        ImageSampleField.tags.contains("reviewed"),
+        SampleEvaluationQuery(
+            "run1",
+            EvaluationMetricField("score") >= 0.8,
+        ),
+    )
+
+    # Assign any of the previous expressions to a query:
     query.match(expr)
     ```
 
@@ -287,11 +339,18 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
     query.order_by(<expression>)
     ```
 
-    The order expression can be defined by `OrderByField(ImageSampleField.<field_name>).<order_direction>()`.
+    The order expression can be defined by
+    `OrderByField(ImageSampleField.<field_name>).<order_direction>()` for sample fields or
+    `OrderByEvaluationMetricField("<run_name>", "<metric_name>").<order_direction>()` for
+    evaluation metrics.
 
 
     ```py
-    from lightly_studio.core.dataset_query import OrderByField, ImageSampleField
+    from lightly_studio.core.dataset_query import (
+        ImageSampleField,
+        OrderByEvaluationMetricField,
+        OrderByField,
+    )
 
     # Sort the query by the width of the image in ascending order
     expr = OrderByField(ImageSampleField.width)
@@ -299,6 +358,9 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
 
     # Sort the query by the file name in descending order
     expr = OrderByField(ImageSampleField.file_name).desc()
+
+    # Sort the query by an evaluation metric in descending order
+    expr = OrderByEvaluationMetricField("run1", "score").desc()
 
     # Assign any of the previous expressions to a query:
     query.order_by(expr)


### PR DESCRIPTION
## What has changed and why?
Also added order_by examples, as it wasn't mentioned before.

## How has it been tested?
Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Python dataset queries to model evaluation queries on the sample level.
* **Documentation**
  * Expanded and reorganized dataset query API docs with added reference entries for sample evaluation queries and evaluation metric fields.
  * Enhanced search-and-filter guidance to include sample-evaluation-based filtering and ordering, with examples and clearer section structure for annotation vs. sample queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->