### PR TITLE
Tag by filter for unmodified select-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ filtered sample count.
 - Improve confusion matrix usability for large numbers of classes
 - Python dataset queries now support classifications, object detections, and segmentation mask annotations.
 - Python dataset queries now model evaluation queries on the sample level.
+- Improved performance when tagging all samples in the GUI for large datasets.
 
 ### Changed
 

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -53,9 +53,8 @@
     let openActionsTagId = $state<string | null>(null);
     let suppressCloseAutoFocusTagId = $state<string | null>(null);
 
-    // Tag by filter when the selection is still an unmodified select-all (no IDs cross the wire —
-    // avoids a 413 at ~10M samples), else fall back to the materialized-ID path. The snapshot is
-    // keyed by `collection_id`, assuming one active grid (one `filter_type`) per collection.
+    // Tag by filter when the selection is still an unmodified select-all (do not send
+    // a potentially large ID list), else fall back to the ID-list path.
     function assignSelectionToTag(tag_id: string) {
         const snapshot = get(
             tagKind === 'annotation'

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -8,6 +8,7 @@
     import {
         createTag,
         addSampleIdsToTagId,
+        addSamplesToTagByFilter,
         deleteTag,
         renameTag
     } from '$lib/api/lightly_studio_local';
@@ -15,6 +16,7 @@
     import TagRenameInput from './TagRenameInput.svelte';
     import TagActionMenu from './TagActionMenu.svelte';
     import { toast } from 'svelte-sonner';
+    import { get } from 'svelte/store';
 
     let { collection_id, gridType }: Parameters<typeof useTags>[0] & { gridType: GridType } =
         $props();
@@ -25,7 +27,12 @@
         useTags({ collection_id, kind: [tagKind] })
     );
 
-    const { getSelectedSampleIds, selectedSampleAnnotationCropIds } = useGlobalStorage();
+    const {
+        getSelectedSampleIds,
+        selectedSampleAnnotationCropIds,
+        getSelectAllSnapshot,
+        getSelectAllAnnotationSnapshot
+    } = useGlobalStorage();
 
     const selectedSampleIds = $derived(getSelectedSampleIds(collection_id));
     const hasSelection = $derived(
@@ -46,6 +53,28 @@
     let openActionsTagId = $state<string | null>(null);
     let suppressCloseAutoFocusTagId = $state<string | null>(null);
 
+    // Tag by filter when the selection is still an unmodified select-all (no IDs cross the wire —
+    // avoids a 413 at ~10M samples), else fall back to the materialized-ID path. The snapshot is
+    // keyed by `collection_id`, assuming one active grid (one `filter_type`) per collection.
+    function assignSelectionToTag(tag_id: string) {
+        const snapshot = get(
+            tagKind === 'annotation'
+                ? getSelectAllAnnotationSnapshot(collection_id)
+                : getSelectAllSnapshot(collection_id)
+        );
+        const isUnmodifiedSelectAll = snapshot != null && snapshot.size === selectedIds.size;
+        if (isUnmodifiedSelectAll) {
+            return addSamplesToTagByFilter({
+                path: { collection_id, tag_id },
+                body: { filter: snapshot.filter }
+            });
+        }
+        return addSampleIdsToTagId({
+            path: { collection_id, tag_id },
+            body: { sample_ids: [...selectedIds] }
+        });
+    }
+
     async function handleAssign(name: string) {
         assignBusy = true;
         try {
@@ -53,10 +82,7 @@
                 (t: TagView) => t.name.toLowerCase() === name.toLowerCase()
             );
             if (existingTag) {
-                const response = await addSampleIdsToTagId({
-                    path: { collection_id, tag_id: existingTag.tag_id },
-                    body: { sample_ids: [...selectedIds] }
-                });
+                const response = await assignSelectionToTag(existingTag.tag_id);
                 if (response.error) {
                     toast.error('Failed to assign tag. Please try again.');
                     return;
@@ -70,10 +96,7 @@
                     toast.error('Failed to create tag. Please try again.');
                     return;
                 }
-                const assignResponse = await addSampleIdsToTagId({
-                    path: { collection_id, tag_id: createResponse.data.tag_id },
-                    body: { sample_ids: [...selectedIds] }
-                });
+                const assignResponse = await assignSelectionToTag(createResponse.data.tag_id);
                 if (assignResponse.error) {
                     toast.error('Failed to assign tag. Please try again.');
                     return;

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
@@ -13,7 +13,6 @@ import type { TagByFilterBody } from '$lib/api/lightly_studio_local';
 import type { TagView } from '$lib/services/types';
 import { toast } from 'svelte-sonner';
 
-// Mirror the production snapshot type so a malformed filter fixture fails type-checking.
 type SelectAllSnapshot = { filter: TagByFilterBody['filter']; size: number };
 
 const mocks = vi.hoisted(() => ({
@@ -132,7 +131,6 @@ describe('TagsMenu', () => {
         });
     });
 
-    // Drive the assign-input combobox to pick an existing tag by name.
     async function pickExistingTag(query: string, optionLabel: string) {
         const input = screen.getByPlaceholderText('Assign tag to selection');
         await fireEvent.focus(input);
@@ -240,7 +238,6 @@ describe('TagsMenu', () => {
         mocks.selectedSampleIdsByCollection = {
             'collection-1': new Set(['sample-1', 'sample-2'])
         };
-        // Stale snapshot from a larger select-all; the size backstop forces the ID path.
         mocks.selectAllSnapshotByCollection = {
             'collection-1': { filter: { filter_type: 'image' }, size: 5 }
         };

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
@@ -1,5 +1,6 @@
 import {
     addSampleIdsToTagId,
+    addSamplesToTagByFilter,
     createTag,
     deleteTag,
     renameTag
@@ -11,11 +12,15 @@ import TagsMenu from './TagsMenu.svelte';
 import type { TagView } from '$lib/services/types';
 import { toast } from 'svelte-sonner';
 
+type SelectAllSnapshot = { filter: unknown; size: number };
+
 const mocks = vi.hoisted(() => ({
     tags: [] as TagView[],
     tagsSelected: new Set<string>(),
     selectedSampleIdsByCollection: {} as Record<string, Set<string>>,
     selectedSampleAnnotationCropIds: {} as Record<string, Set<string>>,
+    selectAllSnapshotByCollection: {} as Record<string, SelectAllSnapshot | null>,
+    selectAllAnnotationSnapshotByCollection: {} as Record<string, SelectAllSnapshot | null>,
     loadTags: vi.fn(),
     tagSelectionToggle: vi.fn(),
     clearTagSelected: vi.fn()
@@ -27,6 +32,7 @@ vi.mock('$lib/api/lightly_studio_local', async () => {
         ...actual,
         createTag: vi.fn(),
         addSampleIdsToTagId: vi.fn(),
+        addSamplesToTagByFilter: vi.fn(),
         deleteTag: vi.fn(),
         renameTag: vi.fn()
     };
@@ -46,7 +52,11 @@ vi.mock('$lib/hooks/useGlobalStorage', () => ({
     useGlobalStorage: () => ({
         getSelectedSampleIds: (collectionId: string) =>
             readable(mocks.selectedSampleIdsByCollection[collectionId] ?? new Set<string>()),
-        selectedSampleAnnotationCropIds: readable(mocks.selectedSampleAnnotationCropIds)
+        selectedSampleAnnotationCropIds: readable(mocks.selectedSampleAnnotationCropIds),
+        getSelectAllSnapshot: (collectionId: string) =>
+            readable(mocks.selectAllSnapshotByCollection[collectionId] ?? null),
+        getSelectAllAnnotationSnapshot: (collectionId: string) =>
+            readable(mocks.selectAllAnnotationSnapshotByCollection[collectionId] ?? null)
     })
 }));
 
@@ -75,7 +85,15 @@ describe('TagsMenu', () => {
         mocks.tagsSelected = new Set<string>();
         mocks.selectedSampleIdsByCollection = {};
         mocks.selectedSampleAnnotationCropIds = {};
+        mocks.selectAllSnapshotByCollection = {};
+        mocks.selectAllAnnotationSnapshotByCollection = {};
         vi.mocked(addSampleIdsToTagId).mockResolvedValue({
+            data: true,
+            error: undefined,
+            request: mockRequest,
+            response: mockResponse
+        });
+        vi.mocked(addSamplesToTagByFilter).mockResolvedValue({
             data: true,
             error: undefined,
             request: mockRequest,
@@ -143,6 +161,113 @@ describe('TagsMenu', () => {
 
         expect(createTag).not.toHaveBeenCalled();
         expect(mocks.loadTags).toHaveBeenCalled();
+    });
+
+    it('tags by filter when the selection is an unmodified select-all', async () => {
+        mocks.selectedSampleIdsByCollection = {
+            'collection-1': new Set(['sample-1', 'sample-2'])
+        };
+        mocks.selectAllSnapshotByCollection = {
+            'collection-1': { filter: { filter_type: 'image' }, size: 2 }
+        };
+
+        render(TagsMenu, {
+            props: {
+                collection_id: 'collection-1',
+                gridType: 'images'
+            }
+        });
+
+        const input = screen.getByPlaceholderText('Assign tag to selection');
+        await fireEvent.focus(input);
+        await fireEvent.input(input, { target: { value: 'veh' } });
+        await fireEvent.click(screen.getByRole('button', { name: 'Vehicle' }));
+
+        await waitFor(() => {
+            expect(addSamplesToTagByFilter).toHaveBeenCalledWith({
+                path: {
+                    collection_id: 'collection-1',
+                    tag_id: 'tag-1'
+                },
+                body: {
+                    filter: { filter_type: 'image' }
+                }
+            });
+        });
+
+        expect(addSampleIdsToTagId).not.toHaveBeenCalled();
+        expect(mocks.loadTags).toHaveBeenCalled();
+    });
+
+    it('tags by the annotation filter when the annotation select-all is unmodified', async () => {
+        mocks.selectedSampleAnnotationCropIds = {
+            'collection-1': new Set(['annotation-1', 'annotation-2'])
+        };
+        mocks.selectAllAnnotationSnapshotByCollection = {
+            'collection-1': { filter: { filter_type: 'annotations' }, size: 2 }
+        };
+
+        render(TagsMenu, {
+            props: {
+                collection_id: 'collection-1',
+                gridType: 'annotations'
+            }
+        });
+
+        const input = screen.getByPlaceholderText('Assign tag to selection');
+        await fireEvent.focus(input);
+        await fireEvent.input(input, { target: { value: 'veh' } });
+        await fireEvent.click(screen.getByRole('button', { name: 'Vehicle' }));
+
+        await waitFor(() => {
+            expect(addSamplesToTagByFilter).toHaveBeenCalledWith({
+                path: {
+                    collection_id: 'collection-1',
+                    tag_id: 'tag-1'
+                },
+                body: {
+                    filter: { filter_type: 'annotations' }
+                }
+            });
+        });
+
+        expect(addSampleIdsToTagId).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the ID path when the snapshot size no longer matches', async () => {
+        mocks.selectedSampleIdsByCollection = {
+            'collection-1': new Set(['sample-1', 'sample-2'])
+        };
+        // Stale snapshot from a larger select-all; the size backstop forces the ID path.
+        mocks.selectAllSnapshotByCollection = {
+            'collection-1': { filter: { filter_type: 'image' }, size: 5 }
+        };
+
+        render(TagsMenu, {
+            props: {
+                collection_id: 'collection-1',
+                gridType: 'images'
+            }
+        });
+
+        const input = screen.getByPlaceholderText('Assign tag to selection');
+        await fireEvent.focus(input);
+        await fireEvent.input(input, { target: { value: 'veh' } });
+        await fireEvent.click(screen.getByRole('button', { name: 'Vehicle' }));
+
+        await waitFor(() => {
+            expect(addSampleIdsToTagId).toHaveBeenCalledWith({
+                path: {
+                    collection_id: 'collection-1',
+                    tag_id: 'tag-1'
+                },
+                body: {
+                    sample_ids: ['sample-1', 'sample-2']
+                }
+            });
+        });
+
+        expect(addSamplesToTagByFilter).not.toHaveBeenCalled();
     });
 
     it('creates an annotation tag and assigns it to the selected annotations', async () => {

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.test.ts
@@ -9,10 +9,12 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import TagsMenu from './TagsMenu.svelte';
+import type { TagByFilterBody } from '$lib/api/lightly_studio_local';
 import type { TagView } from '$lib/services/types';
 import { toast } from 'svelte-sonner';
 
-type SelectAllSnapshot = { filter: unknown; size: number };
+// Mirror the production snapshot type so a malformed filter fixture fails type-checking.
+type SelectAllSnapshot = { filter: TagByFilterBody['filter']; size: number };
 
 const mocks = vi.hoisted(() => ({
     tags: [] as TagView[],
@@ -130,6 +132,14 @@ describe('TagsMenu', () => {
         });
     });
 
+    // Drive the assign-input combobox to pick an existing tag by name.
+    async function pickExistingTag(query: string, optionLabel: string) {
+        const input = screen.getByPlaceholderText('Assign tag to selection');
+        await fireEvent.focus(input);
+        await fireEvent.input(input, { target: { value: query } });
+        await fireEvent.click(screen.getByRole('button', { name: optionLabel }));
+    }
+
     it('assigns an existing tag to the selected samples', async () => {
         mocks.selectedSampleIdsByCollection = {
             'collection-1': new Set(['sample-1', 'sample-2'])
@@ -142,10 +152,7 @@ describe('TagsMenu', () => {
             }
         });
 
-        const input = screen.getByPlaceholderText('Assign tag to selection');
-        await fireEvent.focus(input);
-        await fireEvent.input(input, { target: { value: 'veh' } });
-        await fireEvent.click(screen.getByRole('button', { name: 'Vehicle' }));
+        await pickExistingTag('veh', 'Vehicle');
 
         await waitFor(() => {
             expect(addSampleIdsToTagId).toHaveBeenCalledWith({
@@ -178,10 +185,7 @@ describe('TagsMenu', () => {
             }
         });
 
-        const input = screen.getByPlaceholderText('Assign tag to selection');
-        await fireEvent.focus(input);
-        await fireEvent.input(input, { target: { value: 'veh' } });
-        await fireEvent.click(screen.getByRole('button', { name: 'Vehicle' }));
+        await pickExistingTag('veh', 'Vehicle');
 
         await waitFor(() => {
             expect(addSamplesToTagByFilter).toHaveBeenCalledWith({
@@ -200,6 +204,7 @@ describe('TagsMenu', () => {
     });
 
     it('tags by the annotation filter when the annotation select-all is unmodified', async () => {
+        mocks.tags = [{ ...sampleTag, kind: 'annotation' }];
         mocks.selectedSampleAnnotationCropIds = {
             'collection-1': new Set(['annotation-1', 'annotation-2'])
         };
@@ -214,10 +219,7 @@ describe('TagsMenu', () => {
             }
         });
 
-        const input = screen.getByPlaceholderText('Assign tag to selection');
-        await fireEvent.focus(input);
-        await fireEvent.input(input, { target: { value: 'veh' } });
-        await fireEvent.click(screen.getByRole('button', { name: 'Vehicle' }));
+        await pickExistingTag('veh', 'Vehicle');
 
         await waitFor(() => {
             expect(addSamplesToTagByFilter).toHaveBeenCalledWith({
@@ -250,10 +252,7 @@ describe('TagsMenu', () => {
             }
         });
 
-        const input = screen.getByPlaceholderText('Assign tag to selection');
-        await fireEvent.focus(input);
-        await fireEvent.input(input, { target: { value: 'veh' } });
-        await fireEvent.click(screen.getByRole('button', { name: 'Vehicle' }));
+        await pickExistingTag('veh', 'Vehicle');
 
         await waitFor(() => {
             expect(addSampleIdsToTagId).toHaveBeenCalledWith({
@@ -337,10 +336,7 @@ describe('TagsMenu', () => {
             }
         });
 
-        const input = screen.getByPlaceholderText('Assign tag to selection');
-        await fireEvent.focus(input);
-        await fireEvent.input(input, { target: { value: 'veh' } });
-        await fireEvent.click(screen.getByRole('button', { name: 'Vehicle' }));
+        await pickExistingTag('veh', 'Vehicle');
 
         await waitFor(() => {
             expect(toast.error).toHaveBeenCalledWith('Failed to assign tag. Please try again.');


### PR DESCRIPTION
## What has changed and why?

Stacked on #1479.

Enable tagging by filter. Speeds up tagging samples after pressing the "Select all" button. The speedup is important for large datasets (~1M).

## How has it been tested?

- Unit tests
- Manual test with 3M images artificial dataset on DuckDB.
    - Select-all + tag: a couple of seconds
    - Select-all + manually deselect one + tag: a minute or two

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved performance when tagging all samples in the GUI for large datasets.
  * Tag assignment now optimizes full selections by using filter-based tagging when the current selection matches an unchanged “select all” view (including annotation select-all), with a fallback to ID-based assignment.

* **Bug Fixes**
  * Ensured tag assignment continues to work correctly when the selection changes after selecting all items.
  * Preserved existing toast/error handling behavior when tag assignment fails.

* **Tests**
  * Expanded `TagsMenu` tests to cover filter-based tagging, annotation filter tagging, and the ID fallback path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->