### PR TITLE
Thread confusion_cell through image filter plumbing

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
@@ -68,4 +68,39 @@ describe('useImageFilters', () => {
             expect(get(imageFilter)?.sample_filter?.query_expr).toBeUndefined();
         });
     });
+
+    describe('updateConfusionCell', () => {
+        const cell = {
+            evaluation_run_id: 'run-1',
+            gt_label: 'car',
+            pred_label: 'truck'
+        };
+
+        it('adds confusion_cell alongside an existing sample_ids selection', () => {
+            const { imageFilter, updateFilterParams, updateSampleIds, updateConfusionCell } =
+                useImageFilters();
+            updateFilterParams(normalFilterParams);
+
+            updateSampleIds(['sample-1', 'sample-2']);
+            updateConfusionCell(cell);
+
+            const sampleFilter = get(imageFilter)?.sample_filter;
+            expect(sampleFilter?.sample_ids).toEqual(['sample-1', 'sample-2']);
+            expect(sampleFilter?.confusion_cell).toEqual(cell);
+        });
+
+        it('clears confusion_cell when called with null, leaving sample_ids intact', () => {
+            const { imageFilter, updateFilterParams, updateSampleIds, updateConfusionCell } =
+                useImageFilters();
+            updateFilterParams(normalFilterParams);
+
+            updateSampleIds(['sample-1']);
+            updateConfusionCell(cell);
+            updateConfusionCell(null);
+
+            const sampleFilter = get(imageFilter)?.sample_filter;
+            expect(sampleFilter?.confusion_cell).toBeUndefined();
+            expect(sampleFilter?.sample_ids).toEqual(['sample-1']);
+        });
+    });
 });

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -5,6 +5,7 @@ import type { DimensionBounds } from '$lib/services/loadDimensionBounds';
 import { SortDirection } from '$lib/api/lightly_studio_local';
 import type {
     AnnotationsFilter,
+    ConfusionCell,
     ImageFilter,
     QueryExpr,
     SampleFilter
@@ -87,6 +88,11 @@ const imageFilter = derived(
             sampleFilter.tag_ids = tagIds;
         }
 
+        const confusionCell = $filterParams.filters?.confusion_cell;
+        if (confusionCell) {
+            sampleFilter.confusion_cell = confusionCell;
+        }
+
         if ($filterParams.metadata_values) {
             const metadataFilters = createMetadataFilters($filterParams.metadata_values);
             if (metadataFilters.length > 0) {
@@ -145,6 +151,27 @@ export const useImageFilters = () => {
         filterParams.set(newParams);
     };
 
+    // updates only the confusion-matrix cell in the existing filter params
+    const updateConfusionCell = (confusionCell: ConfusionCell | null) => {
+        const params: ImagesInfiniteParams = {
+            ...get(filterParams)
+        };
+
+        if (params.mode !== 'normal') {
+            return;
+        }
+
+        const newParams: ImagesInfiniteParams = {
+            ...params,
+            filters: {
+                ...params.filters,
+                confusion_cell: confusionCell ?? undefined
+            }
+        };
+
+        filterParams.set(newParams);
+    };
+
     const updateSortBy = (sort: SortExpr[] | null) => {
         imageSortBy.set(sort);
     };
@@ -157,6 +184,7 @@ export const useImageFilters = () => {
         updateFilterParams,
         updateQueryExpr,
         updateSampleIds,
+        updateConfusionCell,
         updateSortBy
     };
 };

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
@@ -40,7 +40,8 @@ const withNormalFilters = (
             ...(base.filters?.sample_filter ?? {}),
             annotations_filter: getAnnotationsFilter(filters),
             tag_ids: filters.tag_ids?.length ? filters.tag_ids : undefined,
-            sample_ids: filters.sample_ids?.length ? filters.sample_ids : undefined
+            sample_ids: filters.sample_ids?.length ? filters.sample_ids : undefined,
+            confusion_cell: filters.confusion_cell ?? undefined
         },
         // TODO(Malte, 10/2025): Share the width/height mapping with useImageFilters to avoid drift.
         width: filters.dimensions

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -15,7 +15,7 @@ export interface ClassifierSamples {
 }
 
 export type NormalModeFilters = Pick<AnnotationsFilter, 'annotation_label_ids' | 'collection_ids'> &
-    Pick<SampleFilter, 'tag_ids' | 'sample_ids'> & {
+    Pick<SampleFilter, 'tag_ids' | 'sample_ids' | 'confusion_cell'> & {
         dimensions?: DimensionBounds;
     };
 


### PR DESCRIPTION
## What

Adds the store/request plumbing for the `confusion_cell` image filter:

- `useImageFilters.ts` — new `updateConfusionCell(cell | null)` action; injects `confusion_cell` into the derived `SampleFilter`.
- `useImagesInfinite/types.ts` — `confusion_cell` added to `NormalModeFilters`.
- `useImagesInfinite/buildRequestBody.ts` — threads `confusion_cell` into the request body.

## Why

PR 3 of the LIG-10003 split ("click a confusion-matrix cell to filter the image grid"). The backend predicate (#1471) and the chart's `onCellClick` callback (#1475) are already merged. This is the store/request layer that connects them. No UI sets the filter yet — the matrix wiring, `Images.svelte` external-filter handling, and the filter chip land in the next PR.

## Scope

4 files: `useImageFilters.ts` (+test), `useImagesInfinite/types.ts`, `buildRequestBody.ts`.

## Testing

- `vitest` hooks suites — 50 passed
- `svelte-check` 0 errors; prettier + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image filters now support selecting a confusion cell alongside existing sample filters.
  * Added a new control to update or clear the confusion cell selection without affecting other chosen sample IDs.

* **Bug Fixes**
  * Filter requests now consistently include the confusion cell when present, so image results stay in sync with the selected filter state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->