### PR TITLE
Introduce *MetricStub dataclasses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,6 @@ and make as many of them as necessary. Use succinct language in the comments.
 - Make sure the PR follows guidelines in the `ai_guidelines` folder.
 
 Exceptions from the guidelines:
-- We allow direct function imports from `tests.helpers_resolvers` and `tests.resolvers.video.helpers` in Python
+- We allow direct function imports from `tests.helpers_resolvers`, `tests.resolvers.video.helpers`, and `tests.resolvers.evaluation_sample_metric_resolver.helpers` in Python
 
 

--- a/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
+++ b/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
@@ -14,6 +14,12 @@ from tests.helpers_resolvers import create_annotation, create_annotation_label, 
 from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
 )
+from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
+    AnnotationMetricStub,
+    SampleMetricStub,
+    create_annotation_metrics,
+    create_sample_metrics,
+)
 
 
 def test_delete_annotation__success(
@@ -102,11 +108,25 @@ def test_delete_annotation__deletes_evaluation_annotation_metrics(
         annotation_label_id=label.annotation_label_id,
     )
 
-    evaluation_sample_metric_helpers.create_evaluation_metrics(
+    create_annotation_metrics(
         db_session,
         run.id,
-        pred_annotation,
-        gt_annotation,
+        [
+            AnnotationMetricStub(
+                sample_id=pred_annotation.parent_sample_id,
+                metric_name="iou",
+                value=0.75,
+                pred_annotation_id=pred_annotation.sample_id,
+                gt_annotation_id=gt_annotation.sample_id,
+            )
+        ],
+    )
+    create_sample_metrics(
+        session=db_session,
+        run_id=run.id,
+        sample_metrics=[
+            SampleMetricStub(sample_id=pred_annotation.parent_sample_id, metrics={"score": 0.5})
+        ],
     )
 
     annotation_resolver.delete_annotation(db_session, gt_annotation.sample_id)
@@ -165,17 +185,47 @@ def test_delete_annotation__preserves_other_run_sample_metrics(
         annotation_label_id=label.annotation_label_id,
     )
 
-    evaluation_sample_metric_helpers.create_evaluation_metrics(
+    create_annotation_metrics(
         db_session,
         run.id,
-        pred_annotation,
-        gt_annotation,
+        [
+            AnnotationMetricStub(
+                sample_id=pred_annotation.parent_sample_id,
+                metric_name="iou",
+                value=0.75,
+                pred_annotation_id=pred_annotation.sample_id,
+                gt_annotation_id=gt_annotation.sample_id,
+            )
+        ],
     )
-    evaluation_sample_metric_helpers.create_evaluation_metrics(
+    create_sample_metrics(
+        session=db_session,
+        run_id=run.id,
+        sample_metrics=[
+            SampleMetricStub(sample_id=pred_annotation.parent_sample_id, metrics={"score": 0.5})
+        ],
+    )
+    create_annotation_metrics(
         db_session,
         other_run.id,
-        other_pred_annotation,
-        other_gt_annotation,
+        [
+            AnnotationMetricStub(
+                sample_id=other_pred_annotation.parent_sample_id,
+                metric_name="iou",
+                value=0.75,
+                pred_annotation_id=other_pred_annotation.sample_id,
+                gt_annotation_id=other_gt_annotation.sample_id,
+            )
+        ],
+    )
+    create_sample_metrics(
+        session=db_session,
+        run_id=other_run.id,
+        sample_metrics=[
+            SampleMetricStub(
+                sample_id=other_pred_annotation.parent_sample_id, metrics={"score": 0.5}
+            )
+        ],
     )
 
     annotation_resolver.delete_annotation(db_session, gt_annotation.sample_id)

--- a/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
+++ b/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
@@ -109,9 +109,9 @@ def test_delete_annotation__deletes_evaluation_annotation_metrics(
     )
 
     create_annotation_metrics(
-        db_session,
-        run.id,
-        [
+        session=db_session,
+        run_id=run.id,
+        annotation_metrics=[
             AnnotationMetricStub(
                 sample_id=pred_annotation.parent_sample_id,
                 metric_name="iou",
@@ -186,9 +186,9 @@ def test_delete_annotation__preserves_other_run_sample_metrics(
     )
 
     create_annotation_metrics(
-        db_session,
-        run.id,
-        [
+        session=db_session,
+        run_id=run.id,
+        annotation_metrics=[
             AnnotationMetricStub(
                 sample_id=pred_annotation.parent_sample_id,
                 metric_name="iou",
@@ -206,9 +206,9 @@ def test_delete_annotation__preserves_other_run_sample_metrics(
         ],
     )
     create_annotation_metrics(
-        db_session,
-        other_run.id,
-        [
+        session=db_session,
+        run_id=other_run.id,
+        annotation_metrics=[
             AnnotationMetricStub(
                 sample_id=other_pred_annotation.parent_sample_id,
                 metric_name="iou",

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from uuid import UUID
 
 from sqlmodel import Session
 
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricCreate
 from lightly_studio.models.evaluation_run import (
@@ -20,6 +20,25 @@ from lightly_studio.resolvers import (
     evaluation_sample_metric_resolver,
 )
 from tests.helpers_resolvers import create_collection, create_image
+
+
+@dataclass
+class AnnotationMetricStub:
+    """Helper class to represent an annotation-level evaluation metric."""
+
+    sample_id: UUID
+    metric_name: str
+    value: float
+    pred_annotation_id: UUID | None = None
+    gt_annotation_id: UUID | None = None
+
+
+@dataclass
+class SampleMetricStub:
+    """Helper class to represent a sample-level evaluation metric."""
+
+    sample_id: UUID
+    metrics: dict[str, float]
 
 
 def create_run_and_image(
@@ -53,53 +72,44 @@ def create_run_and_image(
     return run, image
 
 
-def create_evaluation_metrics(
+def create_sample_metrics(
     session: Session,
     run_id: UUID,
-    pred_annotation: AnnotationBaseTable,
-    gt_annotation: AnnotationBaseTable,
+    sample_metrics: list[SampleMetricStub] | None = None,
 ) -> None:
+    sample_metrics = sample_metrics or []
+    evaluation_sample_metric_resolver.create_many(
+        session=session,
+        records=[
+            EvaluationSampleMetricCreate(
+                evaluation_run_id=run_id,
+                sample_id=stub.sample_id,
+                metric_name=metric,
+                value=value,
+            )
+            for stub in sample_metrics
+            for metric, value in stub.metrics.items()
+        ],
+    )
+
+
+def create_annotation_metrics(
+    session: Session,
+    run_id: UUID,
+    annotation_metrics: list[AnnotationMetricStub] | None = None,
+) -> None:
+    annotation_metrics = annotation_metrics or []
     evaluation_annotation_metric_resolver.create_many(
         session=session,
         records=[
             EvaluationAnnotationMetricCreate(
                 evaluation_run_id=run_id,
-                sample_id=pred_annotation.parent_sample_id,
-                pred_annotation_id=pred_annotation.sample_id,
-                gt_annotation_id=gt_annotation.sample_id,
-                metric_name="iou",
-                value=0.75,
+                sample_id=metric.sample_id,
+                pred_annotation_id=metric.pred_annotation_id,
+                gt_annotation_id=metric.gt_annotation_id,
+                metric_name=metric.metric_name,
+                value=metric.value,
             )
-        ],
-    )
-    evaluation_sample_metric_resolver.create_many(
-        session=session,
-        records=[
-            EvaluationSampleMetricCreate(
-                evaluation_run_id=run_id,
-                sample_id=pred_annotation.parent_sample_id,
-                metric_name="score",
-                value=0.5,
-            )
-        ],
-    )
-
-
-def insert_metrics(
-    session: Session,
-    evaluation_run_id: UUID,
-    sample_id: UUID,
-    metrics: dict[str, float],
-) -> None:
-    evaluation_sample_metric_resolver.create_many(
-        session=session,
-        records=[
-            EvaluationSampleMetricCreate(
-                evaluation_run_id=evaluation_run_id,
-                sample_id=sample_id,
-                metric_name=name,
-                value=value,
-            )
-            for name, value in metrics.items()
+            for metric in annotation_metrics
         ],
     )

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get.py
@@ -15,11 +15,15 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
 
 def test_get_all_by_evaluation_run_id(db_session: Session) -> None:
     run, image = evaluation_sample_metric_helpers.create_run_and_image(session=db_session)
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run.id,
-        sample_id=image.sample_id,
-        metrics={"precision": 0.9, "recall": 0.8},
+        run_id=run.id,
+        sample_metrics=[
+            evaluation_sample_metric_helpers.SampleMetricStub(
+                sample_id=image.sample_id,
+                metrics={"precision": 0.9, "recall": 0.8},
+            )
+        ],
     )
 
     results = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(
@@ -51,17 +55,25 @@ def test_get_all_by_evaluation_run_id__excludes_other_runs(db_session: Session) 
     run2, image2 = evaluation_sample_metric_helpers.create_run_and_image(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run2"
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run1.id,
-        sample_id=image1.sample_id,
-        metrics={"ap": 0.9},
+        run_id=run1.id,
+        sample_metrics=[
+            evaluation_sample_metric_helpers.SampleMetricStub(
+                sample_id=image1.sample_id,
+                metrics={"ap": 0.9},
+            )
+        ],
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run2.id,
-        sample_id=image2.sample_id,
-        metrics={"ap": 0.5},
+        run_id=run2.id,
+        sample_metrics=[
+            evaluation_sample_metric_helpers.SampleMetricStub(
+                sample_id=image2.sample_id,
+                metrics={"ap": 0.5},
+            )
+        ],
     )
 
     results = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get_metric_list.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get_metric_list.py
@@ -23,17 +23,25 @@ def test_get_metric_list_by_evaluation_run_id(db_session: Session) -> None:
         collection_id=dataset.collection_id,
         file_path_abs="/path/to/sample2.png",
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run.id,
-        sample_id=image1.sample_id,
-        metrics={"precision": 0.9, "recall": 0.7},
+        run_id=run.id,
+        sample_metrics=[
+            evaluation_sample_metric_helpers.SampleMetricStub(
+                sample_id=image1.sample_id,
+                metrics={"precision": 0.9, "recall": 0.7},
+            )
+        ],
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run.id,
-        sample_id=image2.sample_id,
-        metrics={"precision": 0.6, "recall": 0.8},
+        run_id=run.id,
+        sample_metrics=[
+            evaluation_sample_metric_helpers.SampleMetricStub(
+                sample_id=image2.sample_id,
+                metrics={"precision": 0.6, "recall": 0.8},
+            )
+        ],
     )
 
     results = evaluation_sample_metric_resolver.get_metric_list_by_evaluation_run_id(
@@ -52,11 +60,15 @@ def test_get_metric_list_by_evaluation_run_id(db_session: Session) -> None:
 
 def test_get_metric_list_by_evaluation_run_id__single_sample(db_session: Session) -> None:
     run, image = evaluation_sample_metric_helpers.create_run_and_image(session=db_session)
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run.id,
-        sample_id=image.sample_id,
-        metrics={"ap": 0.75},
+        run_id=run.id,
+        sample_metrics=[
+            evaluation_sample_metric_helpers.SampleMetricStub(
+                sample_id=image.sample_id,
+                metrics={"ap": 0.75},
+            )
+        ],
     )
 
     results = evaluation_sample_metric_resolver.get_metric_list_by_evaluation_run_id(
@@ -89,17 +101,25 @@ def test_get_metric_list_by_evaluation_run_id__excludes_other_runs(db_session: S
     run2, image2 = evaluation_sample_metric_helpers.create_run_and_image(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run2"
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run1.id,
-        sample_id=image1.sample_id,
-        metrics={"ap": 0.9},
+        run_id=run1.id,
+        sample_metrics=[
+            evaluation_sample_metric_helpers.SampleMetricStub(
+                sample_id=image1.sample_id,
+                metrics={"ap": 0.9},
+            )
+        ],
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run2.id,
-        sample_id=image2.sample_id,
-        metrics={"ap": 0.1},
+        run_id=run2.id,
+        sample_metrics=[
+            evaluation_sample_metric_helpers.SampleMetricStub(
+                sample_id=image2.sample_id,
+                metrics={"ap": 0.1},
+            )
+        ],
     )
 
     results = evaluation_sample_metric_resolver.get_metric_list_by_evaluation_run_id(

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_get_sample_metrics_info_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_get_sample_metrics_info_by_dataset_id.py
@@ -19,6 +19,7 @@ from tests.helpers_resolvers import create_collection, create_image
 from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
 )
+from tests.resolvers.evaluation_sample_metric_resolver.helpers import SampleMetricStub
 
 
 def _create_named_run_and_image(
@@ -60,17 +61,25 @@ def test_get_sample_metrics_info_by_dataset_id(db_session: Session) -> None:
         collection_id=dataset.collection_id,
         file_path_abs="/path/to/sample2.png",
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run.id,
-        sample_id=image1.sample_id,
-        metrics={"precision": 0.9, "recall": 0.7},
+        run_id=run.id,
+        sample_metrics=[
+            SampleMetricStub(
+                sample_id=image1.sample_id,
+                metrics={"precision": 0.9, "recall": 0.7},
+            )
+        ],
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run.id,
-        sample_id=image2.sample_id,
-        metrics={"precision": 0.6, "recall": 0.8},
+        run_id=run.id,
+        sample_metrics=[
+            SampleMetricStub(
+                sample_id=image2.sample_id,
+                metrics={"precision": 0.6, "recall": 0.8},
+            )
+        ],
     )
 
     results = evaluation_sample_metric_resolver.get_sample_metrics_info_by_dataset_id(
@@ -96,17 +105,17 @@ def test_get_sample_metrics_info_by_dataset_id__multiple_runs(db_session: Sessio
     run2, image2 = _create_named_run_and_image(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run_2"
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run1.id,
-        sample_id=image1.sample_id,
-        metrics={"ap": 0.9},
+        run_id=run1.id,
+        sample_metrics=[SampleMetricStub(sample_id=image1.sample_id, metrics={"ap": 0.9})],
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run2.id,
-        sample_id=image2.sample_id,
-        metrics={"ap": 0.5, "ar": 0.4},
+        run_id=run2.id,
+        sample_metrics=[
+            SampleMetricStub(sample_id=image2.sample_id, metrics={"ap": 0.5, "ar": 0.4})
+        ],
     )
 
     results = evaluation_sample_metric_resolver.get_sample_metrics_info_by_dataset_id(
@@ -142,17 +151,15 @@ def test_get_sample_metrics_info_by_dataset_id__excludes_other_datasets(
     other_run, other_image = evaluation_sample_metric_helpers.create_run_and_image(
         session=db_session, dataset_collection_id=other_dataset.collection_id
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=run.id,
-        sample_id=image.sample_id,
-        metrics={"ap": 0.9},
+        run_id=run.id,
+        sample_metrics=[SampleMetricStub(sample_id=image.sample_id, metrics={"ap": 0.9})],
     )
-    evaluation_sample_metric_helpers.insert_metrics(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        evaluation_run_id=other_run.id,
-        sample_id=other_image.sample_id,
-        metrics={"ap": 0.1},
+        run_id=other_run.id,
+        sample_metrics=[SampleMetricStub(sample_id=other_image.sample_id, metrics={"ap": 0.1})],
     )
 
     results = evaluation_sample_metric_resolver.get_sample_metrics_info_by_dataset_id(

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_adjacent_images.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_adjacent_images.py
@@ -13,8 +13,9 @@ from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests import helpers_resolvers
 from tests.helpers_resolvers import AnnotationDetails
 from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
+    SampleMetricStub,
     create_run_and_image,
-    insert_metrics,
+    create_sample_metrics,
 )
 
 
@@ -408,9 +409,15 @@ def test_get_adjacent_images__sort_by_evaluation_metric(db_session: Session) -> 
     )
 
     # score order: b(1) < c(2) < a(3), so sorted sequence is b, c, a
-    insert_metrics(db_session, run.id, image_a.sample_id, {"score": 3.0})
-    insert_metrics(db_session, run.id, image_b.sample_id, {"score": 1.0})
-    insert_metrics(db_session, run.id, image_c.sample_id, {"score": 2.0})
+    create_sample_metrics(
+        session=db_session,
+        run_id=run.id,
+        sample_metrics=[
+            SampleMetricStub(sample_id=image_a.sample_id, metrics={"score": 3.0}),
+            SampleMetricStub(sample_id=image_b.sample_id, metrics={"score": 1.0}),
+            SampleMetricStub(sample_id=image_c.sample_id, metrics={"score": 2.0}),
+        ],
+    )
 
     result = image_resolver.get_adjacent_images(
         session=db_session,

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
@@ -38,8 +38,9 @@ from tests.helpers_resolvers import (
     create_tag,
 )
 from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
+    SampleMetricStub,
     create_run_and_image,
-    insert_metrics,
+    create_sample_metrics,
 )
 
 
@@ -845,9 +846,15 @@ def test_get_all_by_collection_id__sort_by_evaluation_metric_asc(db_session: Ses
     )
 
     # score order: b(1) < c(2) < a(3), so ascending sorted sequence is b, c, a
-    insert_metrics(db_session, run.id, image_a.sample_id, {"score": 3.0})
-    insert_metrics(db_session, run.id, image_b.sample_id, {"score": 1.0})
-    insert_metrics(db_session, run.id, image_c.sample_id, {"score": 2.0})
+    create_sample_metrics(
+        session=db_session,
+        run_id=run.id,
+        sample_metrics=[
+            SampleMetricStub(sample_id=image_a.sample_id, metrics={"score": 3.0}),
+            SampleMetricStub(sample_id=image_b.sample_id, metrics={"score": 1.0}),
+            SampleMetricStub(sample_id=image_c.sample_id, metrics={"score": 2.0}),
+        ],
+    )
 
     result = image_resolver.get_all_by_collection_id(
         session=db_session,
@@ -868,17 +875,22 @@ def test_get_all_by_collection_id__sort_by_evaluation_metric_desc(db_session: Se
     collection_id = collection.collection_id
 
     run, image_a = create_run_and_image(session=db_session, dataset_collection_id=collection_id)
-    image_b = create_image(
-        session=db_session, collection_id=collection_id, file_path_abs="/images/b.png"
-    )
-    image_c = create_image(
-        session=db_session, collection_id=collection_id, file_path_abs="/images/c.png"
+    [image_b, image_c] = create_images(
+        db_session=db_session,
+        collection_id=collection_id,
+        images=[ImageStub(path="/images/b.png"), ImageStub(path="/images/c.png")],
     )
 
     # score order: b(1) < c(2) < a(3), so descending sorted sequence is a, c, b
-    insert_metrics(db_session, run.id, image_a.sample_id, {"score": 3.0})
-    insert_metrics(db_session, run.id, image_b.sample_id, {"score": 1.0})
-    insert_metrics(db_session, run.id, image_c.sample_id, {"score": 2.0})
+    create_sample_metrics(
+        session=db_session,
+        run_id=run.id,
+        sample_metrics=[
+            SampleMetricStub(sample_id=image_a.sample_id, metrics={"score": 3.0}),
+            SampleMetricStub(sample_id=image_b.sample_id, metrics={"score": 1.0}),
+            SampleMetricStub(sample_id=image_c.sample_id, metrics={"score": 2.0}),
+        ],
+    )
 
     result = image_resolver.get_all_by_collection_id(
         session=db_session,
@@ -909,9 +921,15 @@ def test_get_all_by_collection_id__sort_by_two_evaluation_metrics(db_session: Se
     )
 
     # score ties a and b at 1.0; rank breaks the tie so b precedes a.
-    insert_metrics(db_session, run.id, image_a.sample_id, {"score": 1.0, "rank": 2.0})
-    insert_metrics(db_session, run.id, image_b.sample_id, {"score": 1.0, "rank": 1.0})
-    insert_metrics(db_session, run.id, image_c.sample_id, {"score": 2.0, "rank": 3.0})
+    create_sample_metrics(
+        session=db_session,
+        run_id=run.id,
+        sample_metrics=[
+            SampleMetricStub(sample_id=image_a.sample_id, metrics={"score": 1.0, "rank": 2.0}),
+            SampleMetricStub(sample_id=image_b.sample_id, metrics={"score": 1.0, "rank": 1.0}),
+            SampleMetricStub(sample_id=image_c.sample_id, metrics={"score": 2.0, "rank": 3.0}),
+        ],
+    )
 
     result = image_resolver.get_all_by_collection_id(
         session=db_session,


### PR DESCRIPTION
## What has changed and why?
Inspired by the `helpers_resolvers` module which has multiple functions taking e.g. `ImageStub`, we've created `SampleMetricStub` and `AnnotationMetricStub` for more ergonomic test case creation.

The logic behind this is explaine well in "Tests Too DRY? Make Them DAMP!" blog post:
https://testing.googleblog.com/2019/12/testing-on-toilet-tests-too-dry-make.html

## How has it been tested?
Existing tests 

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored evaluation-metric test data setup to use stub-based bulk helpers (`SampleMetricStub`, `AnnotationMetricStub`) and new creators (`create_sample_metrics`, `create_annotation_metrics`) instead of direct inserts or broader metric helpers.
  * Updated resolver tests for sample metric retrieval, metric info-by-dataset, and adjacent/all-by-dataset ordering to align with the new seeding approach.
  * Strengthened annotation deletion coverage to verify that only the targeted evaluation run’s evaluation metric rows are cleared, while other runs’ metrics remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->