### PR TITLE
Renumber reserved category block to reserve index 0 for Hidden

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -14,6 +14,9 @@ T_contra = TypeVar("T_contra", contravariant=True)
 
 # The plotting library renders at most this many legend slots, indexed [0, MAX_LEGEND_SLOTS).
 MAX_LEGEND_SLOTS = 256
+# First slot available for colored categories. Slots below it are reserved for the
+# frontend's non-colored categories (0 hidden, 1 filtered-out, 2 unassigned).
+FIRST_COLORED_CATEGORY = 3
 # Number of category names listed inside an "Other" bucket label before truncating with an ellipsis.
 MAX_OTHER_NAMES = 5
 
@@ -54,7 +57,7 @@ class DiscreteColorScale(Generic[T]):
     def from_values(
         cls,
         values: Iterable[T],
-        start_cat: int = 3,
+        start_cat: int = FIRST_COLORED_CATEGORY,
         format_fn: Callable[[T], str] = str,
     ) -> DiscreteColorScale[T]:
         """Build a DiscreteColorScale by assigning a category to each value.
@@ -116,7 +119,7 @@ class DiscreteColorScale(Generic[T]):
     def from_integers(
         cls,
         values: Iterable[int],
-        start_cat: int = 3,
+        start_cat: int = FIRST_COLORED_CATEGORY,
         max_categories: int = 50,
     ) -> DiscreteColorScale[int]:
         """Build a color scale for integer values.

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/coloring_helpers.py
@@ -54,7 +54,7 @@ class DiscreteColorScale(Generic[T]):
     def from_values(
         cls,
         values: Iterable[T],
-        start_cat: int = 2,
+        start_cat: int = 3,
         format_fn: Callable[[T], str] = str,
     ) -> DiscreteColorScale[T]:
         """Build a DiscreteColorScale by assigning a category to each value.
@@ -65,8 +65,8 @@ class DiscreteColorScale(Generic[T]):
 
         The plotting library can render at most ``MAX_LEGEND_SLOTS`` legend
         slots. Categories occupy the slots ``[start_cat, MAX_LEGEND_SLOTS)``;
-        the slots below ``start_cat`` are reserved (e.g. filtered-out and
-        unassigned samples). When the values fit in those slots, each value gets
+        the slots below ``start_cat`` are reserved (e.g. hidden, filtered-out
+        and unassigned samples). When the values fit in those slots, each value gets
         its own category. Otherwise the values that fit are listed individually
         and every remaining value is grouped into a trailing "Other" category in
         the final slot.
@@ -74,8 +74,9 @@ class DiscreteColorScale(Generic[T]):
         Args:
             values: Values to assign color categories to, in the desired order.
                 Values must be unique.
-            start_cat: First category ID to assign. Defaults to 2, reserving
-                0 for filtered-out samples and 1 for unassigned samples.
+            start_cat: First category ID to assign. Defaults to 3, reserving
+                0 for hidden samples, 1 for filtered-out samples and 2 for
+                unassigned samples.
             format_fn: Function to produce a legend label from a value.
                 Defaults to ``str``.
 
@@ -115,7 +116,7 @@ class DiscreteColorScale(Generic[T]):
     def from_integers(
         cls,
         values: Iterable[int],
-        start_cat: int = 2,
+        start_cat: int = 3,
         max_categories: int = 50,
     ) -> DiscreteColorScale[int]:
         """Build a color scale for integer values.
@@ -129,8 +130,9 @@ class DiscreteColorScale(Generic[T]):
 
         Args:
             values: Integer values to build the scale from. Need not be unique.
-            start_cat: First category ID to assign. Defaults to 2, reserving
-                0 for filtered-out samples and 1 for unassigned samples.
+            start_cat: First category ID to assign. Defaults to 3, reserving
+                0 for hidden samples, 1 for filtered-out samples and 2 for
+                unassigned samples.
             max_categories: Maximum number of distinct color categories before
                 bucketing is applied. Defaults to 50.
 

--- a/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
+++ b/lightly_studio/tests/api/routes/api/embedding_coloring/test_coloring_helpers.py
@@ -19,10 +19,10 @@ class TestDiscreteColorScale:
 
     def test_from_values__strings(self) -> None:
         scale = DiscreteColorScale.from_values(values=["Berlin", "London", "Paris"])
-        assert scale.value_to_category("Berlin") == 2
-        assert scale.value_to_category("London") == 3
-        assert scale.value_to_category("Paris") == 4
-        assert scale.legend == {2: "Berlin", 3: "London", 4: "Paris"}
+        assert scale.value_to_category("Berlin") == 3
+        assert scale.value_to_category("London") == 4
+        assert scale.value_to_category("Paris") == 5
+        assert scale.legend == {3: "Berlin", 4: "London", 5: "Paris"}
 
     def test_from_values__booleans(self) -> None:
         scale = DiscreteColorScale.from_values(
@@ -30,9 +30,9 @@ class TestDiscreteColorScale:
             format_fn=lambda v: str(v).lower(),
         )
         # Sorted by format_fn: "false" < "true"
-        assert scale.value_to_category(False) == 2
-        assert scale.value_to_category(True) == 3
-        assert scale.legend == {2: "false", 3: "true"}
+        assert scale.value_to_category(False) == 3
+        assert scale.value_to_category(True) == 4
+        assert scale.legend == {3: "false", 4: "true"}
 
     def test_from_values__custom_start_cat(self) -> None:
         scale = DiscreteColorScale.from_values(values=["x", "y"], start_cat=10)
@@ -47,46 +47,46 @@ class TestDiscreteColorScale:
 
     def test_from_values__single_value(self) -> None:
         scale = DiscreteColorScale.from_values(values=["only"])
-        assert scale.value_to_category("only") == 2
-        assert scale.legend == {2: "only"}
+        assert scale.value_to_category("only") == 3
+        assert scale.legend == {3: "only"}
 
     def test_from_values__exactly_fits_all_listed(self) -> None:
-        # 254 values fit in slots [2, 256): every value keeps its own category.
-        values = [f"v{i:03d}" for i in range(254)]
+        # 253 values fit in slots [3, 256): every value keeps its own category.
+        values = [f"v{i:03d}" for i in range(253)]
         scale = DiscreteColorScale.from_values(values=values)
-        assert len(scale.legend) == 254
-        assert scale.value_to_category("v000") == 2
-        assert scale.value_to_category("v253") == 255
-        assert scale.legend[255] == "v253"
+        assert len(scale.legend) == 253
+        assert scale.value_to_category("v000") == 3
+        assert scale.value_to_category("v252") == 255
+        assert scale.legend[255] == "v252"
         assert all(not label.startswith("Other") for label in scale.legend.values())
 
     def test_from_values__overflow_groups_into_other(self) -> None:
-        # 256 values exceed the 254 slots: 253 are listed, the rest go to "Other".
+        # 256 values exceed the 253 slots: 252 are listed, the rest go to "Other".
         values = [f"v{i:03d}" for i in range(256)]
         scale = DiscreteColorScale.from_values(values=values)
-        # 253 individual categories (slots 2..254) + the "Other" slot 255.
-        assert len(scale.legend) == 254
-        assert scale.value_to_category("v000") == 2
-        assert scale.value_to_category("v252") == 254
-        # Everything from the 254th value onward collapses into the final slot.
+        # 252 individual categories (slots 3..254) + the "Other" slot 255.
+        assert len(scale.legend) == 253
+        assert scale.value_to_category("v000") == 3
+        assert scale.value_to_category("v251") == 254
+        # Everything from the 253rd value onward collapses into the final slot.
+        assert scale.value_to_category("v252") == 255
         assert scale.value_to_category("v253") == 255
-        assert scale.value_to_category("v254") == 255
         assert scale.value_to_category("v255") == 255
         # The "Other" label lists the first few grouped names then truncates.
-        assert scale.legend[255] == "Other (v253, v254, v255)"
+        assert scale.legend[255] == "Other (v252, v253, v254, v255)"
 
     def test_from_values__overflow_other_label_truncated(self) -> None:
         values = [f"v{i:03d}" for i in range(260)]
         scale = DiscreteColorScale.from_values(values=values)
         # More grouped values than MAX_OTHER_NAMES -> ellipsis appended.
-        assert scale.legend[255] == "Other (v253, v254, v255, v256, v257, …)"
+        assert scale.legend[255] == "Other (v252, v253, v254, v255, v256, …)"
 
     def test_from_integers__few_values(self) -> None:
         scale = DiscreteColorScale.from_integers(values=[3, 1, 2])
-        assert scale.value_to_category(1) == 2
-        assert scale.value_to_category(2) == 3
-        assert scale.value_to_category(3) == 4
-        assert scale.legend == {2: "1", 3: "2", 4: "3"}
+        assert scale.value_to_category(1) == 3
+        assert scale.value_to_category(2) == 4
+        assert scale.value_to_category(3) == 5
+        assert scale.legend == {3: "1", 4: "2", 5: "3"}
 
     def test_from_integers__empty(self) -> None:
         scale = DiscreteColorScale.from_integers(values=[])
@@ -95,10 +95,10 @@ class TestDiscreteColorScale:
 
     def test_from_integers__duplicates_deduplicated(self) -> None:
         scale = DiscreteColorScale.from_integers(values=[5, 5, 3, 3, 1])
-        assert scale.value_to_category(1) == 2
-        assert scale.value_to_category(3) == 3
-        assert scale.value_to_category(5) == 4
-        assert scale.legend == {2: "1", 3: "3", 4: "5"}
+        assert scale.value_to_category(1) == 3
+        assert scale.value_to_category(3) == 4
+        assert scale.value_to_category(5) == 5
+        assert scale.legend == {3: "1", 4: "3", 5: "5"}
 
     def test_from_integers__custom_start_cat(self) -> None:
         scale = DiscreteColorScale.from_integers(values=[10, 20], start_cat=5)
@@ -108,27 +108,27 @@ class TestDiscreteColorScale:
 
     def test_from_integers__exactly_max_categories_no_bucketing(self) -> None:
         scale = DiscreteColorScale.from_integers(values=[1, 2, 3], max_categories=3)
-        assert scale.value_to_category(1) == 2
-        assert scale.value_to_category(2) == 3
-        assert scale.value_to_category(3) == 4
-        assert scale.legend == {2: "1", 3: "2", 4: "3"}
+        assert scale.value_to_category(1) == 3
+        assert scale.value_to_category(2) == 4
+        assert scale.value_to_category(3) == 5
+        assert scale.legend == {3: "1", 4: "2", 5: "3"}
 
     def test_from_integers__bucketing(self) -> None:
         # value_range=300, raw_width=150, magnitude=100, bucket_width=200
         # -> 2 buckets: [0, 199] and [200, 399]
         scale = DiscreteColorScale.from_integers(values=[0, 100, 200, 300], max_categories=2)
-        assert scale.value_to_category(0) == 2
-        assert scale.value_to_category(100) == 2
-        assert scale.value_to_category(200) == 3
-        assert scale.value_to_category(300) == 3
-        assert scale.legend == {2: "0-199", 3: "200-399"}
+        assert scale.value_to_category(0) == 3
+        assert scale.value_to_category(100) == 3
+        assert scale.value_to_category(200) == 4
+        assert scale.value_to_category(300) == 4
+        assert scale.legend == {3: "0-199", 4: "200-399"}
 
     def test_from_integers__bucketing_width_one(self) -> None:
         scale = DiscreteColorScale.from_integers(values=[0, 1, 2], max_categories=2)
-        assert scale.value_to_category(0) == 2
-        assert scale.value_to_category(1) == 3
-        assert scale.value_to_category(2) == 4
-        assert scale.legend == {2: "0", 3: "1", 4: "2"}
+        assert scale.value_to_category(0) == 3
+        assert scale.value_to_category(1) == 4
+        assert scale.value_to_category(2) == 5
+        assert scale.legend == {3: "0", 4: "1", 5: "2"}
 
 
 def test_assign_color_categories() -> None:
@@ -143,8 +143,8 @@ def test_assign_color_categories() -> None:
     )
 
     # No reserved entries: the legend only describes the color scale.
-    assert legend == {2: "cat", 3: "dog"}
-    assert categories == [[2], [3]]
+    assert legend == {3: "cat", 4: "dog"}
+    assert categories == [[3], [4]]
 
 
 def test_assign_color_categories__multiple_values_sorted_by_category() -> None:
@@ -159,8 +159,8 @@ def test_assign_color_categories__multiple_values_sorted_by_category() -> None:
         scale=scale,
     )
 
-    assert legend == {2: "cat", 3: "dog", 4: "fish"}
-    assert categories == [[3, 4]]
+    assert legend == {3: "cat", 4: "dog", 5: "fish"}
+    assert categories == [[4, 5]]
 
 
 def test_assign_color_categories__missing_value_is_empty() -> None:
@@ -174,10 +174,10 @@ def test_assign_color_categories__missing_value_is_empty() -> None:
         scale=scale,
     )
 
-    assert legend == {2: "cat"}
+    assert legend == {3: "cat"}
     # Samples without a value map to an empty list; the filter/unassigned
     # reserved categories are assigned downstream.
-    assert categories == [[2], []]
+    assert categories == [[3], []]
 
 
 def test_assign_color_categories__mixed() -> None:
@@ -196,8 +196,8 @@ def test_assign_color_categories__mixed() -> None:
         scale=scale,
     )
 
-    assert legend == {2: "London", 3: "Paris"}
-    assert categories == [[3], [], [2, 3]]
+    assert legend == {3: "London", 4: "Paris"}
+    assert categories == [[4], [], [3, 4]]
 
 
 def test_assign_color_categories__empty() -> None:
@@ -209,7 +209,7 @@ def test_assign_color_categories__empty() -> None:
         scale=scale,
     )
 
-    assert legend == {2: "x"}
+    assert legend == {3: "x"}
     assert categories == []
 
 
@@ -224,7 +224,7 @@ def test_assign_color_categories__unmapped_value_is_empty() -> None:
         scale=scale,
     )
 
-    assert legend == {2: "known"}
+    assert legend == {3: "known"}
     assert categories == [[]]
 
 

--- a/lightly_studio/tests/api/routes/api/test_embeddings2d__color_by.py
+++ b/lightly_studio/tests/api/routes/api/test_embeddings2d__color_by.py
@@ -65,14 +65,14 @@ def test_get_embeddings2d__with_metadata_field_color_by(
 
     # Values are ranked by frequency: "Paris" (2 samples) before "London" (1).
     sample_id_to_colors = dict(zip(sample_ids_payload, color_categories))
-    assert sample_id_to_colors[str(samples[0].sample_id)] == [2]  # Paris
-    assert sample_id_to_colors[str(samples[1].sample_id)] == [3]  # London
-    assert sample_id_to_colors[str(samples[2].sample_id)] == [2]  # Paris
+    assert sample_id_to_colors[str(samples[0].sample_id)] == [3]  # Paris
+    assert sample_id_to_colors[str(samples[1].sample_id)] == [4]  # London
+    assert sample_id_to_colors[str(samples[2].sample_id)] == [3]  # Paris
     assert sample_id_to_colors[str(samples[3].sample_id)] == []  # Unassigned
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend["2"] == "Paris"
-    assert legend["3"] == "London"
+    assert legend["3"] == "Paris"
+    assert legend["4"] == "London"
 
 
 def test_get_embeddings2d__with_mixed_type_metadata_color_by(
@@ -149,15 +149,15 @@ def test_get_embeddings2d__with_boolean_metadata_color_by(
     color_categories = table.column("color_categories").to_pylist()
 
     # Values are frequency-ordered: False is in 2 samples, True in 1, so False
-    # takes cat 2 and True cat 3.
+    # takes cat 3 and True cat 4.
     sample_id_to_colors = dict(zip(sample_ids_payload, color_categories))
-    assert sample_id_to_colors[str(samples[0].sample_id)] == [2]  # False -> cat 2
-    assert sample_id_to_colors[str(samples[1].sample_id)] == [3]  # True -> cat 3
-    assert sample_id_to_colors[str(samples[2].sample_id)] == [2]  # False -> cat 2
+    assert sample_id_to_colors[str(samples[0].sample_id)] == [3]  # False -> cat 3
+    assert sample_id_to_colors[str(samples[1].sample_id)] == [4]  # True -> cat 4
+    assert sample_id_to_colors[str(samples[2].sample_id)] == [3]  # False -> cat 3
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend["2"] == "false"
-    assert legend["3"] == "true"
+    assert legend["3"] == "false"
+    assert legend["4"] == "true"
 
 
 def test_get_embeddings2d__with_integer_metadata_color_by(
@@ -197,16 +197,16 @@ def test_get_embeddings2d__with_integer_metadata_color_by(
     sample_ids_payload = table.column("sample_id").to_pylist()
     color_categories = table.column("color_categories").to_pylist()
 
-    # Values are sorted numerically: 10 -> cat 2, 20 -> cat 3, 30 -> cat 4.
+    # Values are sorted numerically: 10 -> cat 3, 20 -> cat 4, 30 -> cat 5.
     sample_id_to_colors = dict(zip(sample_ids_payload, color_categories))
-    assert sample_id_to_colors[str(samples[0].sample_id)] == [2]  # score=10
-    assert sample_id_to_colors[str(samples[1].sample_id)] == [4]  # score=30
-    assert sample_id_to_colors[str(samples[2].sample_id)] == [3]  # score=20
+    assert sample_id_to_colors[str(samples[0].sample_id)] == [3]  # score=10
+    assert sample_id_to_colors[str(samples[1].sample_id)] == [5]  # score=30
+    assert sample_id_to_colors[str(samples[2].sample_id)] == [4]  # score=20
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend["2"] == "10"
-    assert legend["3"] == "20"
-    assert legend["4"] == "30"
+    assert legend["3"] == "10"
+    assert legend["4"] == "20"
+    assert legend["5"] == "30"
 
 
 def test_get_embeddings2d__with_integer_metadata_color_by__buckets_when_more_than_50_unique_values(
@@ -247,16 +247,16 @@ def test_get_embeddings2d__with_integer_metadata_color_by__buckets_when_more_tha
     color_categories = table.column("color_categories").to_pylist()
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend["2"] == "0-1"
-    assert legend["51"] == "98-99"
+    assert legend["3"] == "0-1"
+    assert legend["52"] == "98-99"
     assert len(legend) == 50
 
     # score=0 and score=1 share bucket "0-1" -> same category.
     sample_id_to_colors = dict(zip(sample_ids_payload, color_categories))
-    assert sample_id_to_colors[str(samples[0].sample_id)] == [2]  # score=0 -> bucket "0-1"
-    assert sample_id_to_colors[str(samples[1].sample_id)] == [2]  # score=1 -> bucket "0-1"
-    assert sample_id_to_colors[str(samples[2].sample_id)] == [3]  # score=2 -> bucket "2-3"
-    assert sample_id_to_colors[str(samples[99].sample_id)] == [51]  # score=99 -> bucket "98-99"
+    assert sample_id_to_colors[str(samples[0].sample_id)] == [3]  # score=0 -> bucket "0-1"
+    assert sample_id_to_colors[str(samples[1].sample_id)] == [3]  # score=1 -> bucket "0-1"
+    assert sample_id_to_colors[str(samples[2].sample_id)] == [4]  # score=2 -> bucket "2-3"
+    assert sample_id_to_colors[str(samples[99].sample_id)] == [52]  # score=99 -> bucket "98-99"
 
 
 def test_get_embeddings2d__with_metadata_field_color_by_and_sample_ids_filter(
@@ -318,13 +318,13 @@ def test_get_embeddings2d__with_metadata_field_color_by_and_sample_ids_filter(
     # so "London" and "Berlin" (filtered out) are dropped and their samples report
     # no category. The survivors keep individual slots, ordered by label on the tie.
     sample_id_to_colors = dict(zip(sample_ids_payload, color_categories))
-    assert sample_id_to_colors[str(samples[0].sample_id)] == [2]  # Paris
+    assert sample_id_to_colors[str(samples[0].sample_id)] == [3]  # Paris
     assert sample_id_to_colors[str(samples[1].sample_id)] == []  # London, hidden
-    assert sample_id_to_colors[str(samples[2].sample_id)] == [3]  # Rome
+    assert sample_id_to_colors[str(samples[2].sample_id)] == [4]  # Rome
     assert sample_id_to_colors[str(samples[3].sample_id)] == []  # Berlin, hidden
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend == {"2": "Paris", "3": "Rome"}
+    assert legend == {"3": "Paris", "4": "Rome"}
 
 
 def test_get_embeddings2d__filter_promotes_metadata_value_out_of_other(
@@ -347,7 +347,7 @@ def test_get_embeddings2d__filter_promotes_metadata_value_out_of_other(
     ).samples
     assert len(samples) == n_samples
 
-    # More distinct values than fit in the 254 individual slots, one per sample.
+    # More distinct values than fit in the 253 individual slots, one per sample.
     for i, sample in enumerate(samples):
         sample.sample["label"] = f"v{i:03d}"
 
@@ -378,7 +378,7 @@ def test_get_embeddings2d__filter_promotes_metadata_value_out_of_other(
     assert response.status_code == 200
     table = ipc.open_stream(pa.BufferReader(response.content)).read_all()
     legend_filtered = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend_filtered == {"2": "v299"}
+    assert legend_filtered == {"3": "v299"}
 
 
 @pytest.mark.parametrize(
@@ -483,16 +483,16 @@ def test_get_embeddings2d__with_tag_color_by(
     assert table.schema.field("color_categories").type == pa.list_(pa.uint8())
     color_categories = table.column("color_categories").to_pylist()
     sample_id_to_colors = dict(zip(sample_ids_payload, color_categories))
-    assert sample_id_to_colors[str(samples[0].sample_id)] == [2]  # alpha
-    assert sample_id_to_colors[str(samples[1].sample_id)] == [3]  # beta
-    assert sample_id_to_colors[str(samples[2].sample_id)] == [2, 3]  # both, sorted
+    assert sample_id_to_colors[str(samples[0].sample_id)] == [3]  # alpha
+    assert sample_id_to_colors[str(samples[1].sample_id)] == [4]  # beta
+    assert sample_id_to_colors[str(samples[2].sample_id)] == [3, 4]  # both, sorted
     assert sample_id_to_colors[str(samples[3].sample_id)] == []  # untagged
     assert sample_id_to_colors[str(samples[4].sample_id)] == []  # untagged
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
     assert legend == {
-        "2": "alpha",
-        "3": "beta",
+        "3": "alpha",
+        "4": "beta",
     }
 
 
@@ -574,17 +574,17 @@ def test_get_embeddings2d__with_tag_color_by_and_filter(
     assert sample_id_to_filter[str(samples[2].sample_id)] == 0
     assert sample_id_to_filter[str(samples[3].sample_id)] == 0
 
-    # All samples have the color tag → category 2. The hidden tag has no matching
+    # All samples have the color tag → category 3. The hidden tag has no matching
     # sample, so it is dropped from the legend and contributes no category.
     sample_id_to_colors = dict(zip(sample_ids_payload, color_categories))
-    assert sample_id_to_colors[str(samples[0].sample_id)] == [2]
-    assert sample_id_to_colors[str(samples[1].sample_id)] == [2]
-    assert sample_id_to_colors[str(samples[2].sample_id)] == [2]
-    assert sample_id_to_colors[str(samples[3].sample_id)] == [2]
+    assert sample_id_to_colors[str(samples[0].sample_id)] == [3]
+    assert sample_id_to_colors[str(samples[1].sample_id)] == [3]
+    assert sample_id_to_colors[str(samples[2].sample_id)] == [3]
+    assert sample_id_to_colors[str(samples[3].sample_id)] == [3]
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
     assert legend == {
-        "2": "color_tag",
+        "3": "color_tag",
     }
 
 
@@ -662,16 +662,16 @@ def test_get_embeddings2d__with_annotation_color_by(
 
     color_categories = table.column("color_categories").to_pylist()
     sample_id_to_colors = dict(zip(sample_ids_payload, color_categories))
-    assert sample_id_to_colors[str(samples[0].sample_id)] == [2]  # cat
-    assert sample_id_to_colors[str(samples[1].sample_id)] == [3]  # dog
-    assert sample_id_to_colors[str(samples[2].sample_id)] == [2, 3]  # both, sorted
+    assert sample_id_to_colors[str(samples[0].sample_id)] == [3]  # cat
+    assert sample_id_to_colors[str(samples[1].sample_id)] == [4]  # dog
+    assert sample_id_to_colors[str(samples[2].sample_id)] == [3, 4]  # both, sorted
     assert sample_id_to_colors[str(samples[3].sample_id)] == []  # unannotated
     assert sample_id_to_colors[str(samples[4].sample_id)] == []  # unannotated
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
     assert legend == {
-        "2": "cat",
-        "3": "dog",
+        "3": "cat",
+        "4": "dog",
     }
 
 
@@ -751,13 +751,13 @@ def test_get_embeddings2d__with_annotation_color_by_and_filter(
     assert sample_id_to_filter[str(samples[2].sample_id)] == 0
     assert sample_id_to_filter[str(samples[3].sample_id)] == 0
 
-    # All samples have "cat" → category 2. The hidden label has no matching
+    # All samples have "cat" → category 3. The hidden label has no matching
     # sample, so it is dropped from the legend and contributes no category.
     sample_id_to_colors = dict(zip(sample_ids_payload, color_categories))
-    assert sample_id_to_colors[str(samples[0].sample_id)] == [2]
-    assert sample_id_to_colors[str(samples[1].sample_id)] == [2]
-    assert sample_id_to_colors[str(samples[2].sample_id)] == [2]
-    assert sample_id_to_colors[str(samples[3].sample_id)] == [2]
+    assert sample_id_to_colors[str(samples[0].sample_id)] == [3]
+    assert sample_id_to_colors[str(samples[1].sample_id)] == [3]
+    assert sample_id_to_colors[str(samples[2].sample_id)] == [3]
+    assert sample_id_to_colors[str(samples[3].sample_id)] == [3]
 
     legend = json.loads(table.schema.metadata[b"color_legend"])
-    assert legend == {"2": "cat"}
+    assert legend == {"3": "cat"}

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
@@ -254,7 +254,7 @@ describe('PlotPanel.svelte', () => {
             x: new Float32Array([1, 2, 3]),
             y: new Float32Array([1, 2, 3]),
             fulfils_filter: new Uint8Array([1, 1, 0]),
-            color_categories: [[2], [2], []],
+            color_categories: [[3], [3], []],
             sample_id: ['sample-1', 'sample-2', 'sample-3']
         });
 
@@ -308,7 +308,7 @@ describe('PlotPanel.svelte', () => {
 
         // Ignore the reset that fires on mount; assert the one triggered by the legend change.
         mockResetCategoryVisibility.mockClear();
-        colorLegendStore.set(new Map([[2, 'dog']]));
+        colorLegendStore.set(new Map([[3, 'dog']]));
         await tick();
 
         expect(mockResetCategoryVisibility).toHaveBeenCalled();

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
     import { cn } from '$lib/utils';
-    import { EXCLUDED_BY_FILTERS_LABEL, INCLUDED_BY_FILTERS_LABEL } from './plotCategories';
+    import {
+        EXCLUDED_BY_FILTERS_CATEGORY,
+        EXCLUDED_BY_FILTERS_LABEL,
+        INCLUDED_BY_FILTERS_CATEGORY,
+        INCLUDED_BY_FILTERS_LABEL
+    } from './plotCategories';
 
     interface LegendEntry {
         cat: number;
@@ -54,11 +59,17 @@
             <span class="my-0.5 w-full shrink-0 border-t border-white/10"></span>
         {/if}
         <span class="flex shrink-0 items-center gap-1.5">
-            <span class="legend-dot" style={`background-color: ${categoryColors[1]}`}></span>
+            <span
+                class="legend-dot"
+                style={`background-color: ${categoryColors[EXCLUDED_BY_FILTERS_CATEGORY]}`}
+            ></span>
             {excludedLabel}
         </span>
         <span class="flex shrink-0 items-center gap-1.5">
-            <span class="legend-dot" style={`background-color: ${categoryColors[2]}`}></span>
+            <span
+                class="legend-dot"
+                style={`background-color: ${categoryColors[INCLUDED_BY_FILTERS_CATEGORY]}`}
+            ></span>
             {includedLabel}
         </span>
     </div>

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
@@ -54,11 +54,11 @@
             <span class="my-0.5 w-full shrink-0 border-t border-white/10"></span>
         {/if}
         <span class="flex shrink-0 items-center gap-1.5">
-            <span class="legend-dot" style={`background-color: ${categoryColors[0]}`}></span>
+            <span class="legend-dot" style={`background-color: ${categoryColors[1]}`}></span>
             {excludedLabel}
         </span>
         <span class="flex shrink-0 items-center gap-1.5">
-            <span class="legend-dot" style={`background-color: ${categoryColors[1]}`}></span>
+            <span class="legend-dot" style={`background-color: ${categoryColors[2]}`}></span>
             {includedLabel}
         </span>
     </div>

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.test.ts
@@ -1,16 +1,16 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import PlotPanelLegend from './PlotPanelLegend.svelte';
-import { FILTERED_COLOR, NOT_FILTERED_COLOR } from './plotColorUtils';
+import { FILTERED_COLOR, HIDDEN_COLOR, NOT_FILTERED_COLOR } from './plotColorUtils';
 import { getColorByLabel } from '$lib/utils';
 
 describe('PlotPanelLegend', () => {
     it('renders the fixed entries and the custom legend list', () => {
         render(PlotPanelLegend, {
-            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'rgb(255, 0, 136)'],
+            categoryColors: [HIDDEN_COLOR, NOT_FILTERED_COLOR, FILTERED_COLOR, 'rgb(255, 0, 136)'],
             includedLabel: 'No category',
             legendEntries: [
-                { cat: 2, label: 'metadata.split: train', color: 'rgb(255, 0, 136)', hidden: false }
+                { cat: 3, label: 'metadata.split: train', color: 'rgb(255, 0, 136)', hidden: false }
             ]
         });
 
@@ -22,7 +22,7 @@ describe('PlotPanelLegend', () => {
 
     it('defaults to the "Included by filters" label when none is passed', () => {
         render(PlotPanelLegend, {
-            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR]
+            categoryColors: [HIDDEN_COLOR, NOT_FILTERED_COLOR, FILTERED_COLOR]
         });
 
         expect(screen.getByTestId('plot-legend')).toHaveTextContent('Excluded by filters');
@@ -33,28 +33,28 @@ describe('PlotPanelLegend', () => {
         const onToggleCategory = vi.fn();
 
         render(PlotPanelLegend, {
-            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'rgb(255, 0, 136)'],
-            legendEntries: [{ cat: 2, label: 'Train', color: 'rgb(255, 0, 136)', hidden: false }],
+            categoryColors: [HIDDEN_COLOR, NOT_FILTERED_COLOR, FILTERED_COLOR, 'rgb(255, 0, 136)'],
+            legendEntries: [{ cat: 3, label: 'Train', color: 'rgb(255, 0, 136)', hidden: false }],
             onToggleCategory
         });
 
-        await fireEvent.click(screen.getByTestId('plot-legend-entry-2'));
+        await fireEvent.click(screen.getByTestId('plot-legend-entry-3'));
 
-        expect(onToggleCategory).toHaveBeenCalledWith(2);
+        expect(onToggleCategory).toHaveBeenCalledWith(3);
     });
 
     it('calls the double-click handler for custom legend entries', async () => {
         const onDoubleClickCategory = vi.fn();
 
         render(PlotPanelLegend, {
-            categoryColors: [NOT_FILTERED_COLOR, FILTERED_COLOR, 'rgb(255, 0, 136)'],
-            legendEntries: [{ cat: 2, label: 'Train', color: 'rgb(255, 0, 136)', hidden: false }],
+            categoryColors: [HIDDEN_COLOR, NOT_FILTERED_COLOR, FILTERED_COLOR, 'rgb(255, 0, 136)'],
+            legendEntries: [{ cat: 3, label: 'Train', color: 'rgb(255, 0, 136)', hidden: false }],
             onDoubleClickCategory
         });
 
-        await fireEvent.dblClick(screen.getByTestId('plot-legend-entry-2'));
+        await fireEvent.dblClick(screen.getByTestId('plot-legend-entry-3'));
 
-        expect(onDoubleClickCategory).toHaveBeenCalledWith(2);
+        expect(onDoubleClickCategory).toHaveBeenCalledWith(3);
     });
 
     it('renders tag legend entries with getColorByLabel colors', () => {
@@ -63,14 +63,15 @@ describe('PlotPanelLegend', () => {
 
         render(PlotPanelLegend, {
             categoryColors: [
+                HIDDEN_COLOR,
                 NOT_FILTERED_COLOR,
                 FILTERED_COLOR,
                 reviewBatch1Color,
                 reviewBatch2Color
             ],
             legendEntries: [
-                { cat: 2, label: 'review-batch-1', color: reviewBatch1Color, hidden: false },
-                { cat: 3, label: 'review-batch-2', color: reviewBatch2Color, hidden: false }
+                { cat: 3, label: 'review-batch-1', color: reviewBatch1Color, hidden: false },
+                { cat: 4, label: 'review-batch-2', color: reviewBatch2Color, hidden: false }
             ]
         });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
@@ -16,7 +16,7 @@ describe('getCategoryBySelection', () => {
         x: new Float32Array([1.0, 2.0, 3.0, 4.0]),
         y: new Float32Array([5.0, 6.0, 7.0, 8.0]),
         fulfils_filter: new Uint8Array([1, 1, 0, 1]),
-        color_categories: [[2, 3], [2], [], [3]],
+        color_categories: [[3, 4], [3], [], [4]],
         sample_id: ['sample1', 'sample2', 'sample3', 'sample4']
     });
 
@@ -66,9 +66,9 @@ describe('getCategoryBySelection', () => {
         vi.mocked(isPointInPolygon).mockReturnValue(false);
 
         const reducer = getCategoryBySelection(mockSelection, mockData);
-        const result = reducer(1, 0);
+        const result = reducer(3, 0);
 
-        expect(result).toBe(0);
+        expect(result).toBe(1);
         expect(isPointInPolygon).toHaveBeenCalledWith(1.0, 5.0, mockSelection);
     });
 
@@ -93,10 +93,10 @@ describe('getCategoryBySelection', () => {
             .mockReturnValueOnce(false); // index 3
 
         const reducer = getCategoryBySelection(mockSelection, mockData);
-        const categories = [1, 1, 1, 1];
+        const categories = [3, 3, 3, 3];
         const result = categories.map(reducer);
 
-        expect(result).toEqual([1, 1, 0, 0]);
+        expect(result).toEqual([3, 3, 1, 1]);
         expect(isPointInPolygon).toHaveBeenCalledTimes(4);
     });
 
@@ -136,9 +136,9 @@ describe('getCategoryBySelection', () => {
         vi.mocked(isPointInPolygon).mockReturnValue(false);
 
         const reducer = getCategoryBySelection([], mockData);
-        const result = reducer(1, 0);
+        const result = reducer(3, 0);
 
-        expect(result).toBe(0);
+        expect(result).toBe(1);
         expect(isPointInPolygon).toHaveBeenCalledWith(1.0, 5.0, []);
     });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotCategories.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotCategories.ts
@@ -1,8 +1,10 @@
-export const EXCLUDED_BY_FILTERS_CATEGORY = 0;
-export const INCLUDED_BY_FILTERS_CATEGORY = 1;
+export const HIDDEN_CATEGORY = 0;
+export const EXCLUDED_BY_FILTERS_CATEGORY = 1;
+export const INCLUDED_BY_FILTERS_CATEGORY = 2;
 
-// Labels for the reserved categories. The backend reserves indices 0 and 1 by index only;
-// the frontend owns their human-readable labels.
+// Labels for the reserved categories. The backend reserves indices 0, 1 and 2 by index only;
+// the frontend owns their human-readable labels. Index 0 (Hidden) is transparent and has no
+// legend row, so it carries no label.
 export const EXCLUDED_BY_FILTERS_LABEL = 'Excluded by filters';
 export const INCLUDED_BY_FILTERS_LABEL = 'Included by filters';
 export const NO_CATEGORY_LABEL = 'No category';

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.test.ts
@@ -5,35 +5,41 @@ import {
     getCategoryColors,
     getCategoryCount,
     getLegendEntries,
+    HIDDEN_COLOR,
     NOT_FILTERED_COLOR,
     UNASSIGNED_COLOR
 } from './plotColorUtils';
 
 describe('plotColorUtils', () => {
     it('returns the reserved count when the legend is empty', () => {
-        expect(getCategoryCount(undefined)).toBe(2);
+        expect(getCategoryCount(undefined)).toBe(3);
     });
 
     it('returns the highest legend category plus one', () => {
         const colorLegend = new Map([
-            [2, 'Train'],
-            [4, 'Validation']
+            [3, 'Train'],
+            [5, 'Validation']
         ]);
 
-        expect(getCategoryCount(colorLegend)).toBe(5);
+        expect(getCategoryCount(colorLegend)).toBe(6);
     });
 
     it('keeps the reserved categories fixed', () => {
-        expect(getCategoryColors(undefined)).toEqual([NOT_FILTERED_COLOR, FILTERED_COLOR]);
+        expect(getCategoryColors(undefined)).toEqual([
+            HIDDEN_COLOR,
+            NOT_FILTERED_COLOR,
+            FILTERED_COLOR
+        ]);
     });
 
     it('uses label-based colors for categories above the reserved slots', () => {
         const colorLegend = new Map([
-            [2, 'Train'],
-            [3, 'Validation']
+            [3, 'Train'],
+            [4, 'Validation']
         ]);
 
         expect(getCategoryColors(colorLegend, true, true)).toEqual([
+            HIDDEN_COLOR,
             NOT_FILTERED_COLOR,
             UNASSIGNED_COLOR,
             getColorByLabel('Train').color,
@@ -44,18 +50,18 @@ describe('plotColorUtils', () => {
     it('builds legend entries from categories above the reserved slots', () => {
         expect(
             getLegendEntries(
-                // A reserved category (1) is included here to verify it is excluded from the entries.
+                // A reserved category (2) is included here to verify it is excluded from the entries.
                 new Map([
-                    [1, 'should be excluded'],
-                    [3, 'Validation'],
-                    [2, 'Train']
+                    [2, 'should be excluded'],
+                    [4, 'Validation'],
+                    [3, 'Train']
                 ]),
-                new Set([3])
+                new Set([4])
             )
         ).toEqual([
-            { cat: 2, label: 'Train', color: getColorByLabel('Train').color, hidden: false },
+            { cat: 3, label: 'Train', color: getColorByLabel('Train').color, hidden: false },
             {
-                cat: 3,
+                cat: 4,
                 label: 'Validation',
                 color: getColorByLabel('Validation').color,
                 hidden: true
@@ -67,36 +73,41 @@ describe('plotColorUtils', () => {
         expect(
             getLegendEntries(
                 new Map([
-                    [2, 'Train'],
-                    [3, 'Validation']
+                    [3, 'Train'],
+                    [4, 'Validation']
                 ]),
                 new Set(),
                 false
             )
         ).toEqual([
-            { cat: 2, label: 'Train', color: 'rgb(255, 0, 136)', hidden: false },
-            { cat: 3, label: 'Validation', color: 'rgb(0, 193, 150)', hidden: false }
+            { cat: 3, label: 'Train', color: 'rgb(255, 0, 136)', hidden: false },
+            { cat: 4, label: 'Validation', color: 'rgb(0, 193, 150)', hidden: false }
         ]);
     });
 
-    it('uses unassigned color for category 1 when colorBy is active', () => {
+    it('uses unassigned color for category 2 when colorBy is active', () => {
         const colorLegend = new Map([
-            [2, 'Train'],
-            [3, 'Validation']
+            [3, 'Train'],
+            [4, 'Validation']
         ]);
 
-        expect(getCategoryColors(colorLegend, false, true)[1]).toBe(UNASSIGNED_COLOR);
-        expect(getCategoryColors(colorLegend)[1]).toBe(FILTERED_COLOR);
+        expect(getCategoryColors(colorLegend, false, true)[2]).toBe(UNASSIGNED_COLOR);
+        expect(getCategoryColors(colorLegend)[2]).toBe(FILTERED_COLOR);
     });
 
     it('uses label colors for labeled categories when requested', () => {
-        const legend = new Map([[2, 'labelName']]);
+        const legend = new Map([[3, 'labelName']]);
 
         const labelColor = getColorByLabel('labelName').color;
         const defaultColors = getCategoryColors(legend, false);
         const labelColors = getCategoryColors(legend, true, true);
 
-        expect(labelColors).toEqual([NOT_FILTERED_COLOR, UNASSIGNED_COLOR, labelColor]);
-        expect(defaultColors[2]).not.toBe(labelColor);
+        expect(labelColors).toEqual([
+            HIDDEN_COLOR,
+            NOT_FILTERED_COLOR,
+            UNASSIGNED_COLOR,
+            labelColor
+        ]);
+        expect(defaultColors[3]).not.toBe(labelColor);
     });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -10,7 +10,6 @@ const OKLCH_CHROMA = 0.3;
 
 const RESERVED_CATEGORY_COUNT = 3;
 
-// Index 0 is the Hidden bucket: transparent so its points are not rendered.
 export const HIDDEN_COLOR = 'rgba(0, 0, 0, 0)';
 export const NOT_FILTERED_COLOR = '#222222';
 export const FILTERED_COLOR = '#FF7220';

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -1,4 +1,9 @@
 import { getColorByLabel, oklchHueWheelColor } from '$lib/utils';
+import {
+    EXCLUDED_BY_FILTERS_CATEGORY,
+    HIDDEN_CATEGORY,
+    INCLUDED_BY_FILTERS_CATEGORY
+} from './plotCategories';
 
 const OKLCH_LIGHTNESS = 0.65;
 const OKLCH_CHROMA = 0.3;
@@ -47,15 +52,15 @@ function getBaseCategoryColor(
     label: string,
     isColorByActive: boolean = false
 ): string {
-    if (category === 0) {
+    if (category === HIDDEN_CATEGORY) {
         return HIDDEN_COLOR;
     }
 
-    if (category === 1) {
+    if (category === EXCLUDED_BY_FILTERS_CATEGORY) {
         return NOT_FILTERED_COLOR;
     }
 
-    if (category === 2) {
+    if (category === INCLUDED_BY_FILTERS_CATEGORY) {
         return isColorByActive ? UNASSIGNED_COLOR : FILTERED_COLOR;
     }
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -3,8 +3,10 @@ import { getColorByLabel, oklchHueWheelColor } from '$lib/utils';
 const OKLCH_LIGHTNESS = 0.65;
 const OKLCH_CHROMA = 0.3;
 
-const RESERVED_CATEGORY_COUNT = 2;
+const RESERVED_CATEGORY_COUNT = 3;
 
+// Index 0 is the Hidden bucket: transparent so its points are not rendered.
+export const HIDDEN_COLOR = 'rgba(0, 0, 0, 0)';
 export const NOT_FILTERED_COLOR = '#222222';
 export const FILTERED_COLOR = '#FF7220';
 export const UNASSIGNED_COLOR = '#666666';
@@ -46,10 +48,14 @@ function getBaseCategoryColor(
     isColorByActive: boolean = false
 ): string {
     if (category === 0) {
-        return NOT_FILTERED_COLOR;
+        return HIDDEN_COLOR;
     }
 
     if (category === 1) {
+        return NOT_FILTERED_COLOR;
+    }
+
+    if (category === 2) {
         return isColorByActive ? UNASSIGNED_COLOR : FILTERED_COLOR;
     }
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
@@ -2,31 +2,31 @@ import { describe, it, expect } from 'vitest';
 import { resolveVisibleCategory } from './resolveVisibleCategory';
 
 describe('resolveVisibleCategory', () => {
-    it('returns EXCLUDED_BY_FILTERS_CATEGORY (0) when the point does not fulfil the filter', () => {
-        expect(resolveVisibleCategory([2, 3], 0, new Set())).toBe(0);
+    it('returns EXCLUDED_BY_FILTERS_CATEGORY (1) when the point does not fulfil the filter', () => {
+        expect(resolveVisibleCategory([3, 4], 0, new Set())).toBe(1);
     });
 
     it('returns the first category when none are hidden', () => {
-        expect(resolveVisibleCategory([2, 3], 1, new Set())).toBe(2);
+        expect(resolveVisibleCategory([3, 4], 1, new Set())).toBe(3);
     });
 
-    it('returns INCLUDED_BY_FILTERS_CATEGORY (1) when the point has no categories', () => {
-        expect(resolveVisibleCategory([], 1, new Set())).toBe(1);
+    it('returns INCLUDED_BY_FILTERS_CATEGORY (2) when the point has no categories', () => {
+        expect(resolveVisibleCategory([], 1, new Set())).toBe(2);
     });
 
     it('falls back to the next visible category when the first is hidden', () => {
-        expect(resolveVisibleCategory([2, 3], 1, new Set([2]))).toBe(3);
+        expect(resolveVisibleCategory([3, 4], 1, new Set([3]))).toBe(4);
     });
 
-    it('falls back to INCLUDED_BY_FILTERS_CATEGORY (1) when the only category is hidden', () => {
-        expect(resolveVisibleCategory([2], 1, new Set([2]))).toBe(1);
+    it('falls back to INCLUDED_BY_FILTERS_CATEGORY (2) when the only category is hidden', () => {
+        expect(resolveVisibleCategory([3], 1, new Set([3]))).toBe(2);
     });
 
-    it('falls back to INCLUDED_BY_FILTERS_CATEGORY (1) when all categories are hidden', () => {
-        expect(resolveVisibleCategory([2, 3], 1, new Set([2, 3]))).toBe(1);
+    it('falls back to INCLUDED_BY_FILTERS_CATEGORY (2) when all categories are hidden', () => {
+        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 4]))).toBe(2);
     });
 
     it('ignores the filter when resolving a hidden fallback', () => {
-        expect(resolveVisibleCategory([2, 3, 4], 1, new Set([2, 3]))).toBe(4);
+        expect(resolveVisibleCategory([3, 4, 5], 1, new Set([3, 4]))).toBe(5);
     });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -10,9 +10,10 @@ vi.mock('embedding-atlas/svelte', () => ({
 
 vi.mock('../getCategoryBySelection/getCategoryBySelection', () => ({
     getCategoryBySelection: vi.fn((selection) => (prevValue: number, index: number) => {
-        // Mock implementation: first two points are inside the polygon (keep prevValue), rest are outside (0)
+        // Mock implementation: first two points are inside the polygon (keep prevValue), rest
+        // are outside (demoted to EXCLUDED_BY_FILTERS_CATEGORY = 1).
         if (!selection) return prevValue;
-        return index < 2 ? prevValue : 0;
+        return index < 2 ? prevValue : 1;
     })
 }));
 
@@ -20,14 +21,14 @@ vi.mock('../getCategoryBySelection/getCategoryBySelection', () => ({
 const { usePlotData } = await import('./usePlotData');
 
 describe('usePlotData', () => {
-    // color_categories + fulfils_filter resolve to categories [1, 2, 0, 3]: sample1 has no
-    // categories (-> unassigned 1), sample2 takes the first of its two categories (2),
-    // sample3 is filtered out (-> 0).
+    // color_categories + fulfils_filter resolve to categories [2, 3, 1, 4]: sample1 has no
+    // categories (-> unassigned INCLUDED 2), sample2 takes the first of its two categories (3),
+    // sample3 is filtered out (-> EXCLUDED 1), sample4 takes its only category (4).
     const createMockArrowData = (): ArrowData => ({
         x: new Float32Array([1.0, 2.0, 3.0, 4.0]),
         y: new Float32Array([5.0, 6.0, 7.0, 8.0]),
         fulfils_filter: new Uint8Array([1, 1, 0, 1]),
-        color_categories: [[], [2, 5], [], [3]],
+        color_categories: [[], [3, 5], [], [4]],
         sample_id: ['sample1', 'sample2', 'sample3', 'sample4']
     });
 
@@ -54,25 +55,25 @@ describe('usePlotData', () => {
         expect(data).toEqual({
             x: mockData.x,
             y: mockData.y,
-            category: new Uint8Array([1, 2, 0, 3])
+            category: new Uint8Array([2, 3, 1, 4])
         });
         expect(get(result.selectedSampleIds)).toEqual([]);
     });
 
     it('falls back to the next visible category when one is hidden', () => {
         const mockData = createMockArrowData();
-        // sample2 belongs to categories [2, 3]; sample4 only to [4].
-        mockData.color_categories = [[], [2, 3], [], [4]];
+        // sample2 belongs to categories [3, 4]; sample4 only to [5].
+        mockData.color_categories = [[], [3, 4], [], [5]];
 
         const result = usePlotData({
             arrowData: mockData,
             rangeSelection: null,
-            hiddenCategories: new Set([2, 4])
+            hiddenCategories: new Set([3, 5])
         });
 
         const data = get(result.data) as { category: Uint8Array };
-        // sample2 falls back from hidden 2 to visible 3; sample4's only category is hidden -> unassigned 1.
-        expect(Array.from(data.category)).toEqual([1, 3, 0, 1]);
+        // sample2 falls back from hidden 3 to visible 4; sample4's only category is hidden -> unassigned 2.
+        expect(Array.from(data.category)).toEqual([2, 4, 1, 2]);
     });
 
     it('should update categories based on range selection', () => {
@@ -92,12 +93,12 @@ describe('usePlotData', () => {
         const data = get(result.data);
         expect(data?.category).toBeInstanceOf(Uint8Array);
 
-        // First two points are in polygon (keep previous categories), last two are outside (demoted to 0)
+        // First two points are in polygon (keep previous categories), last two are outside (demoted to 1)
         const categoryArray = Array.from(data?.category as Uint8Array);
-        expect(categoryArray[0]).toBe(1); // in polygon, keeps INCLUDED_BY_FILTERS_CATEGORY
-        expect(categoryArray[1]).toBe(2); // in polygon, preserves color category
-        expect(categoryArray[2]).toBe(0); // outside polygon, demoted to EXCLUDED_BY_FILTERS_CATEGORY
-        expect(categoryArray[3]).toBe(0); // outside polygon, demoted to EXCLUDED_BY_FILTERS_CATEGORY
+        expect(categoryArray[0]).toBe(2); // in polygon, keeps INCLUDED_BY_FILTERS_CATEGORY
+        expect(categoryArray[1]).toBe(3); // in polygon, preserves color category
+        expect(categoryArray[2]).toBe(1); // outside polygon, demoted to EXCLUDED_BY_FILTERS_CATEGORY
+        expect(categoryArray[3]).toBe(1); // outside polygon, demoted to EXCLUDED_BY_FILTERS_CATEGORY
     });
 
     it('should collect selected sample ids when range selection is applied', () => {
@@ -115,7 +116,7 @@ describe('usePlotData', () => {
         });
 
         const selectedIds = get(result.selectedSampleIds);
-        // Based on our mock, first two non-zero categories should be selected
+        // Based on our mock, first two non-excluded categories should be selected
         expect(selectedIds).toEqual(['sample1', 'sample2']);
     });
 
@@ -133,7 +134,7 @@ describe('usePlotData', () => {
         expect(get(result.selectedSampleIds)).toEqual(['sample1', 'sample2']);
     });
 
-    it('should set all categories to 1 when hasActiveFilter is false', () => {
+    it('should set all categories to INCLUDED (2) when hasActiveFilter is false', () => {
         const mockData = createMockArrowData();
 
         const result = usePlotData({
@@ -144,7 +145,7 @@ describe('usePlotData', () => {
 
         const data = get(result.data);
         const categoryArray = Array.from(data?.category as Uint8Array);
-        expect(categoryArray).toEqual([1, 1, 1, 1]);
+        expect(categoryArray).toEqual([2, 2, 2, 2]);
         expect(get(result.selectedSampleIds)).toEqual([]);
     });
 
@@ -165,11 +166,11 @@ describe('usePlotData', () => {
 
         const data = get(result.data) as { category: Uint8Array };
         const categoryArray = Array.from(data.category);
-        expect(categoryArray).toEqual([1, 1, 0, 0]);
+        expect(categoryArray).toEqual([2, 2, 1, 1]);
         expect(get(result.selectedSampleIds)).toEqual(['sample1', 'sample2']);
     });
 
-    it('should keep categories 2 and above selectable during range selection', () => {
+    it('keeps included and colored categories selectable during range selection', () => {
         const mockData = createMockArrowData();
         const mockSelection: Point[] = [
             { x: 0, y: 0 },
@@ -186,7 +187,7 @@ describe('usePlotData', () => {
         expect(get(result.selectedSampleIds)).toEqual(['sample1', 'sample2']);
     });
 
-    it('should preserve highlighted non-zero color categories and demote other samples', () => {
+    it('should preserve highlighted color categories and demote other samples', () => {
         const mockData = createMockArrowData();
 
         const result = usePlotData({
@@ -196,7 +197,9 @@ describe('usePlotData', () => {
         });
 
         const data = get(result.data) as { category: Uint8Array };
-        expect(Array.from(data.category)).toEqual([0, 2, 0, 0]);
+        // sample2 is highlighted -> keeps 3; sample3 is already EXCLUDED (1) -> stays 1;
+        // sample1 and sample4 are not highlighted -> demoted to EXCLUDED 1.
+        expect(Array.from(data.category)).toEqual([1, 3, 1, 1]);
     });
 
     it('should return error store', () => {


### PR DESCRIPTION
## What has changed and why?

Reserve categories 0, 1 and 2 for the embedding plot.

Before, we reserved 0 (excluded by filters) and 1 (included by filters). Now we have 0 (hidden), 1 (excluded by filters) and 2 (included by filters).

Tests are most affected.

## How has it been tested?

CI

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected plot coloring and legend rendering using the updated reserved category slots for hidden, excluded-by-filters, and included-by-filters states.
  * Fixed category numbering consistency across embedding color-by results and plot interactions (selection, filtering, and overflow), including “no category” handling.
  * Updated discrete color category assignment so legends and category indices align with the new reserved slot offset.
* **Tests**
  * Updated unit and integration test expectations to match the revised category/legend indexing and color behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->