### PR TITLE
Hide plot points when their reserved legend category is hidden

### DIFF
--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
@@ -29,4 +29,24 @@ describe('resolveVisibleCategory', () => {
     it('ignores the filter when resolving a hidden fallback', () => {
         expect(resolveVisibleCategory([3, 4, 5], 1, new Set([3, 4]))).toBe(5);
     });
+
+    it('routes to HIDDEN_CATEGORY (0) when filtered out and EXCLUDED is hidden', () => {
+        expect(resolveVisibleCategory([3, 4], 0, new Set([1]))).toBe(0);
+    });
+
+    it('routes to HIDDEN_CATEGORY (0) when the point has no categories and INCLUDED is hidden', () => {
+        expect(resolveVisibleCategory([], 1, new Set([2]))).toBe(0);
+    });
+
+    it('routes to HIDDEN_CATEGORY (0) when all colored categories and INCLUDED are hidden', () => {
+        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 4, 2]))).toBe(0);
+    });
+
+    it('falls back to a visible colored category even when INCLUDED is hidden', () => {
+        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 2]))).toBe(4);
+    });
+
+    it('still returns EXCLUDED (1) when filtered out and EXCLUDED is visible', () => {
+        expect(resolveVisibleCategory([3], 0, new Set([2]))).toBe(1);
+    });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
@@ -45,8 +45,4 @@ describe('resolveVisibleCategory', () => {
     it('falls back to a visible colored category even when INCLUDED is hidden', () => {
         expect(resolveVisibleCategory([3, 4], 1, new Set([3, 2]))).toBe(4);
     });
-
-    it('still returns EXCLUDED (1) when filtered out and EXCLUDED is visible', () => {
-        expect(resolveVisibleCategory([3], 0, new Set([2]))).toBe(1);
-    });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
@@ -6,15 +6,11 @@ import {
 
 /**
  * Resolves the category a point is displayed as, given every category it belongs to in
- * priority order. Hidden categories are skipped so a multi-category point falls back to
- * its next visible category. When the reserved non-categorical row a point would resolve
- * to is itself hidden, the point is routed to HIDDEN_CATEGORY (transparent, not rendered,
- * not selectable):
- * - point does not fulfil the filter -> EXCLUDED_BY_FILTERS_CATEGORY,
- *   or HIDDEN_CATEGORY if that row is hidden
- * - otherwise the first category that is not hidden
- * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY (no category),
- *   or HIDDEN_CATEGORY if that row is hidden
+ * priority order. A multi-category point falls back to its next visible category, and a
+ * point whose resolved category is hidden routes to HIDDEN_CATEGORY (not rendered):
+ * - filtered out -> EXCLUDED_BY_FILTERS_CATEGORY
+ * - otherwise the first non-hidden category
+ * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY
  *
  * @param colorCategories - All categories the point belongs to, in priority order
  * @param fulfilsFilter - Whether the point passes the active filter (0 = filtered out)

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
@@ -1,12 +1,20 @@
-import { EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY } from '../plotCategories';
+import {
+    EXCLUDED_BY_FILTERS_CATEGORY,
+    HIDDEN_CATEGORY,
+    INCLUDED_BY_FILTERS_CATEGORY
+} from '../plotCategories';
 
 /**
  * Resolves the category a point is displayed as, given every category it belongs to in
  * priority order. Hidden categories are skipped so a multi-category point falls back to
- * its next visible category:
- * - point does not fulfil the filter -> EXCLUDED_BY_FILTERS_CATEGORY
+ * its next visible category. When the reserved non-categorical row a point would resolve
+ * to is itself hidden, the point is routed to HIDDEN_CATEGORY (transparent, not rendered,
+ * not selectable):
+ * - point does not fulfil the filter -> EXCLUDED_BY_FILTERS_CATEGORY,
+ *   or HIDDEN_CATEGORY if that row is hidden
  * - otherwise the first category that is not hidden
- * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY (no category)
+ * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY (no category),
+ *   or HIDDEN_CATEGORY if that row is hidden
  *
  * @param colorCategories - All categories the point belongs to, in priority order
  * @param fulfilsFilter - Whether the point passes the active filter (0 = filtered out)
@@ -18,7 +26,9 @@ export const resolveVisibleCategory = (
     hiddenCategories: ReadonlySet<number>
 ): number => {
     if (fulfilsFilter === 0) {
-        return EXCLUDED_BY_FILTERS_CATEGORY;
+        return hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)
+            ? HIDDEN_CATEGORY
+            : EXCLUDED_BY_FILTERS_CATEGORY;
     }
 
     for (const category of colorCategories) {
@@ -27,5 +37,7 @@ export const resolveVisibleCategory = (
         }
     }
 
-    return INCLUDED_BY_FILTERS_CATEGORY;
+    return hiddenCategories.has(INCLUDED_BY_FILTERS_CATEGORY)
+        ? HIDDEN_CATEGORY
+        : INCLUDED_BY_FILTERS_CATEGORY;
 };


### PR DESCRIPTION
## What has changed and why?

The previous PR added index 0 as the hidden category. This PR implements logic to assign the new hidden category 0 to a point, based on which categories are toggled off.

No user-facing change - the "legend entries below the line" cannot be toggled off yet.

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category visibility handling in the plot panel so hidden legend items now stay hidden in fallback cases.
  * When filtered results would normally map to excluded or included categories, the app now returns a hidden state if those categories are not visible.
  * Preserves fallback behavior to a visible colored category when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->