### PR TITLE
Add annotation class visibility toggles in videos and video frames grid view

### DIFF
--- a/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationItem.svelte
+++ b/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationItem.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-    import { useHideAnnotations } from '$lib/hooks/useHideAnnotations';
-    import { useAnnotationClassVisibility } from '$lib/hooks';
-    import { useSettings } from '$lib/hooks/useSettings';
     import { type ComponentProps } from 'svelte';
     import SampleAnnotation from '../SampleAnnotation/SampleAnnotation.svelte';
     import type { SampleImageObjectFit } from '../SampleImage/types';
@@ -11,8 +8,8 @@
         SampleView,
         VideoFrameView
     } from '$lib/api/lightly_studio_local';
-    import { shouldShowBoundingBoxForAnnotation } from '$lib/utils/shouldShowBoundingBoxForAnnotation';
     import { SampleAnnotations } from '..';
+    import VideoFrameAnnotationSvg from './VideoFrameAnnotationSvg/VideoFrameAnnotationSvg.svelte';
 
     export interface PrerenderedAnnotation {
         frameId: string;
@@ -43,28 +40,7 @@
         prerenderedAnnotations?: PrerenderedAnnotation[];
     } = $props();
 
-    const { isHidden } = useHideAnnotations();
-    const { hiddenClassNamesStore } = useAnnotationClassVisibility();
-    const { showBoundingBoxesForSegmentationStore } = useSettings();
     const annotations: AnnotationView[] = $derived((sample.sample as SampleView).annotations ?? []);
-    const annotationsWithVisuals = $derived(
-        annotations
-            .filter((annotation) => annotation.annotation_type !== 'classification')
-            .filter(
-                (annotation) =>
-                    !$hiddenClassNamesStore.includes(
-                        annotation.annotation_label.annotation_label_name
-                    )
-            )
-    );
-
-    // Create a map of annotationId to prerendered data for quick lookup
-    const prerenderedMap = $derived.by(() => {
-        if (!prerenderedAnnotations) return new Map();
-        return new Map(
-            prerenderedAnnotations.map((prerendered) => [prerendered.annotationId, prerendered])
-        );
-    });
 </script>
 
 {#if !showLabel}
@@ -79,31 +55,14 @@
         objectFit={sampleImageObjectFit}
     />
 {:else}
-    <svg
-        style="position: absolute; top: 0; left: 0; pointer-events: none"
-        viewBox={`0 0 ${sampleWidth} ${sampleHeight}`}
-        preserveAspectRatio={sampleImageObjectFit === 'contain'
-            ? 'xMidYMid meet'
-            : 'xMidYMid slice'}
+    <VideoFrameAnnotationSvg
+        {annotations}
+        {prerenderedAnnotations}
         {width}
         {height}
-    >
-        <g class="sample-annotation" class:invisible={$isHidden}>
-            <!-- Render all annotations with prerendered data when available -->
-            {#each annotationsWithVisuals as annotation (annotation.sample_id)}
-                {@const prerendered = prerenderedMap.get(annotation.sample_id)}
-                <SampleAnnotation
-                    {annotation}
-                    {showLabel}
-                    showBoundingBox={shouldShowBoundingBoxForAnnotation(
-                        annotation,
-                        $showBoundingBoxesForSegmentationStore
-                    )}
-                    imageWidth={sampleWidth}
-                    prerenderedDataUrl={prerendered?.dataUrl}
-                    prerenderedHeight={prerendered?.height}
-                />
-            {/each}
-        </g>
-    </svg>
+        {sampleWidth}
+        {sampleHeight}
+        {sampleImageObjectFit}
+        {showLabel}
+    />
 {/if}

--- a/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationItem.svelte
+++ b/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationItem.svelte
@@ -13,7 +13,7 @@
 
     export interface PrerenderedAnnotation {
         frameId: string;
-        annotationId: string;
+        sample_id: string;
         dataUrl: string;
         width: number;
         height: number;

--- a/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationItem.svelte
+++ b/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { useHideAnnotations } from '$lib/hooks/useHideAnnotations';
+    import { useAnnotationClassVisibility } from '$lib/hooks';
     import { useSettings } from '$lib/hooks/useSettings';
     import { type ComponentProps } from 'svelte';
     import SampleAnnotation from '../SampleAnnotation/SampleAnnotation.svelte';
@@ -43,10 +44,18 @@
     } = $props();
 
     const { isHidden } = useHideAnnotations();
+    const { hiddenClassNamesStore } = useAnnotationClassVisibility();
     const { showBoundingBoxesForSegmentationStore } = useSettings();
     const annotations: AnnotationView[] = $derived((sample.sample as SampleView).annotations ?? []);
     const annotationsWithVisuals = $derived(
-        annotations.filter((annotation) => annotation.annotation_type !== 'classification')
+        annotations
+            .filter((annotation) => annotation.annotation_type !== 'classification')
+            .filter(
+                (annotation) =>
+                    !$hiddenClassNamesStore.includes(
+                        annotation.annotation_label.annotation_label_name
+                    )
+            )
     );
 
     // Create a map of annotationId to prerendered data for quick lookup

--- a/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationSvg/VideoFrameAnnotationSvg.svelte
+++ b/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationSvg/VideoFrameAnnotationSvg.svelte
@@ -56,7 +56,7 @@
     const prerenderedMap = $derived.by(() => {
         if (!prerenderedAnnotations) return new Map();
         return new Map(
-            prerenderedAnnotations.map((prerendered) => [prerendered.annotationId, prerendered])
+            prerenderedAnnotations.map((prerendered) => [prerendered.sample_id, prerendered])
         );
     });
 </script>

--- a/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationSvg/VideoFrameAnnotationSvg.svelte
+++ b/lightly_studio_view/src/lib/components/VideoFrameAnnotationItem/VideoFrameAnnotationSvg/VideoFrameAnnotationSvg.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+    import { useHideAnnotations } from '$lib/hooks/useHideAnnotations';
+    import { useAnnotationClassVisibility, useSettings } from '$lib/hooks';
+    import { type ComponentProps } from 'svelte';
+    import { SampleAnnotation } from '$lib/components';
+    import type { SampleImageObjectFit } from '../../SampleImage/types';
+    import type { AnnotationView } from '$lib/api/lightly_studio_local';
+    import { shouldShowBoundingBoxForAnnotation } from '$lib/utils/shouldShowBoundingBoxForAnnotation';
+    import type { PrerenderedAnnotation } from '../VideoFrameAnnotationItem.svelte';
+
+    interface Props {
+        /** Annotations for the current frame. */
+        annotations: AnnotationView[];
+        /** Pre-rendered mask image data keyed by annotation ID, used to avoid re-rendering heavy segmentation masks. */
+        prerenderedAnnotations?: PrerenderedAnnotation[];
+        /** Rendered width of the SVG overlay in pixels. */
+        width: number;
+        /** Rendered height of the SVG overlay in pixels. */
+        height: number;
+        /** Original width of the source sample in pixels, used for the SVG viewBox. */
+        sampleWidth: number;
+        /** Original height of the source sample in pixels, used for the SVG viewBox. */
+        sampleHeight: number;
+        /** How the underlying image is fitted, controls SVG preserveAspectRatio. */
+        sampleImageObjectFit?: SampleImageObjectFit;
+        /** Controls whether annotation labels are rendered alongside bounding boxes. */
+        showLabel?: ComponentProps<typeof SampleAnnotation>['showLabel'];
+    }
+
+    const {
+        annotations,
+        prerenderedAnnotations,
+        width,
+        height,
+        sampleWidth,
+        sampleHeight,
+        sampleImageObjectFit = 'contain',
+        showLabel
+    }: Props = $props();
+
+    const { isHidden } = useHideAnnotations();
+    const { hiddenClassNamesStore } = useAnnotationClassVisibility();
+    const { showBoundingBoxesForSegmentationStore } = useSettings();
+
+    const annotationsWithVisuals = $derived(
+        annotations
+            .filter((annotation) => annotation.annotation_type !== 'classification')
+            .filter(
+                (annotation) =>
+                    !$hiddenClassNamesStore.includes(
+                        annotation.annotation_label.annotation_label_name
+                    )
+            )
+    );
+
+    const prerenderedMap = $derived.by(() => {
+        if (!prerenderedAnnotations) return new Map();
+        return new Map(
+            prerenderedAnnotations.map((prerendered) => [prerendered.annotationId, prerendered])
+        );
+    });
+</script>
+
+<svg
+    style="position: absolute; top: 0; left: 0; pointer-events: none"
+    viewBox={`0 0 ${sampleWidth} ${sampleHeight}`}
+    preserveAspectRatio={sampleImageObjectFit === 'contain' ? 'xMidYMid meet' : 'xMidYMid slice'}
+    {width}
+    {height}
+>
+    <g class="sample-annotation" class:invisible={$isHidden}>
+        <!-- Render all annotations with prerendered data when available -->
+        {#each annotationsWithVisuals as annotation (annotation.sample_id)}
+            {@const prerendered = prerenderedMap.get(annotation.sample_id)}
+            <SampleAnnotation
+                {annotation}
+                {showLabel}
+                showBoundingBox={shouldShowBoundingBoxForAnnotation(
+                    annotation,
+                    $showBoundingBoxesForSegmentationStore
+                )}
+                imageWidth={sampleWidth}
+                prerenderedDataUrl={prerendered?.dataUrl}
+                prerenderedHeight={prerendered?.height}
+            />
+        {/each}
+    </g>
+</svg>

--- a/lightly_studio_view/src/lib/hooks/useVideoFrameAnnotations/useVideoFrameAnnotations.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFrameAnnotations/useVideoFrameAnnotations.test.ts
@@ -131,7 +131,7 @@ describe('useVideoFrameAnnotations', () => {
         expect(frame1Data).toEqual([
             {
                 frameId: 'frame-1',
-                annotationId: 'annotation-1',
+                sample_id: 'annotation-1',
                 dataUrl: 'data:image/png;base64,mockDataUrl',
                 width: 1920,
                 height: 100

--- a/lightly_studio_view/src/lib/hooks/useVideoFrameAnnotations/useVideoFrameAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFrameAnnotations/useVideoFrameAnnotations.ts
@@ -4,7 +4,7 @@ import calculateBinaryMaskFromRLE from '$lib/components/SampleAnnotation/SampleA
 
 interface FrameAnnotationDataURL {
     frameId: string;
-    annotationId: string;
+    sample_id: string;
     dataUrl: string;
     width: number;
     height: number;
@@ -67,7 +67,7 @@ export function useVideoFrameAnnotations({
 
                     frameAnnotations.push({
                         frameId: frame.sample_id,
-                        annotationId: segmentationAnnotation.sample_id,
+                        sample_id: segmentationAnnotation.sample_id,
                         dataUrl,
                         width: imageWidth,
                         height

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -114,6 +114,9 @@
     const isVideoFrames = $derived(isVideoFramesRoute(page.route.id));
     const isVideoDetails = $derived(isVideoDetailsRoute(page.route.id));
     const canSelectAll = $derived(isImages || isVideos || isVideoFrames || isAnnotations);
+    const showAnnotationVisibilityToggle = $derived(
+        isAnnotations || isImages || isVideos || isVideoFrames
+    );
 
     let gridType = $state<GridType>('images');
     let lastCollectionId: string | null = null;
@@ -361,10 +364,7 @@
                             <LabelsMenu
                                 {annotationFilterRows}
                                 onToggleAnnotationFilter={toggleAnnotationFilterSelection}
-                                showVisibilityToggle={isAnnotations ||
-                                    isImages ||
-                                    isVideos ||
-                                    isVideoFrames}
+                                showVisibilityToggle={showAnnotationVisibilityToggle}
                             />
 
                             {#if isImages || isVideos || isVideoFrames}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -361,7 +361,10 @@
                             <LabelsMenu
                                 {annotationFilterRows}
                                 onToggleAnnotationFilter={toggleAnnotationFilterSelection}
-                                showVisibilityToggle={isAnnotations || isImages}
+                                showVisibilityToggle={isAnnotations ||
+                                    isImages ||
+                                    isVideos ||
+                                    isVideoFrames}
                             />
 
                             {#if isImages || isVideos || isVideoFrames}


### PR DESCRIPTION
## What has changed and why?

Extends the annotation class visibility toggle feature (added in #1480) to the videos and video frames grid views.

https://github.com/user-attachments/assets/7416d019-4c75-45cd-a3ce-032aab53852c


## How has it been tested?

Manual testing.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visibility controls are now available on video and video-frame pages, matching the experience on annotation and image views.
* **Bug Fixes**
  * Hidden labels are consistently excluded from video-frame annotations.
  * Classification-related entries are no longer shown in the video-frame overlay.
* **Refactor**
  * Video-frame label rendering is now handled by a dedicated SVG overlay component.
* **Tests**
  * Updated expectations for the returned annotation object shape in `useVideoFrameAnnotations`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->