### PR TITLE
Show scope count and filter state in operator dialog

### DIFF
--- a/lightly_studio_view/src/lib/components/Captions/Captions.svelte
+++ b/lightly_studio_view/src/lib/components/Captions/Captions.svelte
@@ -37,7 +37,13 @@
 
     let viewport: HTMLElement | null = $state(null);
 
-    const { sampleSize } = useGlobalStorage();
+    const { sampleSize, setfilteredSampleCount } = useGlobalStorage();
+
+    $effect(() => {
+        if (query.isSuccess && query.data?.pages.length > 0) {
+            setfilteredSampleCount(query.data.pages[0].total_count);
+        }
+    });
     let viewportHeight = $state(0);
     let size = $state(0);
     let captionSize = $state(0);

--- a/lightly_studio_view/src/lib/components/Footer/Footer.svelte
+++ b/lightly_studio_view/src/lib/components/Footer/Footer.svelte
@@ -2,7 +2,12 @@
     import { BookOpen, Mail } from '@lucide/svelte';
     import { page } from '$app/state';
     import { version, git_sha, is_tagged_commit } from '$lib/version.json';
-    import { isAnnotationsRoute, isVideoFramesRoute, isVideosRoute } from '$lib/routes';
+    import {
+        isAnnotationsRoute,
+        isCaptionsRoute,
+        isVideoFramesRoute,
+        isVideosRoute
+    } from '$lib/routes';
 
     type FooterProps = {
         totalSamples?: number;
@@ -25,6 +30,8 @@
             return 'video frames';
         } else if (isVideosRoute(page.route.id)) {
             return 'videos';
+        } else if (isCaptionsRoute(page.route.id)) {
+            return 'captions';
         } else {
             return 'images';
         }

--- a/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
@@ -62,10 +62,7 @@
 
     const { tagsSelected } = useTags({ collection_id: collectionId, kind: ['annotation'] });
 
-    const { isOnDetailPage, scopeLabel, contextFilter } = useOperatorContext(
-        pageContext,
-        tagsSelected
-    );
+    const { scopeLabel, contextFilter } = useOperatorContext(pageContext, tagsSelected);
 
     function resetExecutionState() {
         executionError = undefined;
@@ -184,20 +181,10 @@
             <Dialog.Title>
                 {operator?.name || operatorMetadata?.name || 'Operator'}
             </Dialog.Title>
-            <Dialog.Description>
-                Configure the parameters for this operator and click Execute to run it.
+            <Dialog.Description class="text-foreground">
+                Configure the parameters for this operator and click Execute to run it on
+                <strong class="font-semibold text-primary">{$scopeLabel}</strong>.
             </Dialog.Description>
-            <div class="mt-1 flex items-center gap-2 text-sm">
-                <span class="text-muted-foreground">Scope:</span>
-                <span
-                    class="inline-flex items-center rounded-full px-2 py-1 text-xs font-medium
-                    {$isOnDetailPage
-                        ? 'bg-primary text-primary-foreground'
-                        : 'bg-secondary text-secondary-foreground'}"
-                >
-                    {$scopeLabel}
-                </span>
-            </div>
         </Dialog.Header>
 
         {#if isLoadingParameters}

--- a/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.test.ts
@@ -48,29 +48,52 @@ describe('resolveIsDetailPage', () => {
 });
 
 describe('resolveScopeLabel', () => {
-    it('returns "Full collection" for null sampleType', () => {
-        expect(resolveScopeLabel(null, false)).toBe('Full collection');
-        expect(resolveScopeLabel(null, true)).toBe('Full collection');
+    it('returns entire-collection fragment for null sampleType regardless of count or filter', () => {
+        expect(resolveScopeLabel(null, false, 100, false)).toBe('the entire collection');
+        expect(resolveScopeLabel(null, true, 1, true)).toBe('the entire collection');
     });
 
-    it('returns detail label when isOnDetailPage is true', () => {
-        expect(resolveScopeLabel(SampleTypeValues.IMAGE, true)).toBe('Current image');
-        expect(resolveScopeLabel(SampleTypeValues.VIDEO, true)).toBe('Current video');
-        expect(resolveScopeLabel(SampleTypeValues.VIDEO_FRAME, true)).toBe('Current video frame');
-        expect(resolveScopeLabel(SampleTypeValues.ANNOTATION, true)).toBe('Current annotation');
+    it('returns currently-viewed fragment when isOnDetailPage is true', () => {
+        expect(resolveScopeLabel(SampleTypeValues.IMAGE, true, 1, false)).toBe(
+            'the currently viewed image'
+        );
+        expect(resolveScopeLabel(SampleTypeValues.VIDEO, true, 1, false)).toBe(
+            'the currently viewed video'
+        );
+        expect(resolveScopeLabel(SampleTypeValues.VIDEO_FRAME, true, 1, false)).toBe(
+            'the currently viewed video frame'
+        );
+        expect(resolveScopeLabel(SampleTypeValues.ANNOTATION, true, 1, false)).toBe(
+            'the currently viewed annotation'
+        );
     });
 
-    it('returns collection label when isOnDetailPage is false', () => {
-        expect(resolveScopeLabel(SampleTypeValues.IMAGE, false)).toBe('All images in the view');
-        expect(resolveScopeLabel(SampleTypeValues.VIDEO, false)).toBe('All videos in the view');
-        expect(resolveScopeLabel(SampleTypeValues.VIDEO_FRAME, false)).toBe(
-            'All video frames in the view'
+    it('returns "all {count} {type}s" when no filter is active', () => {
+        expect(resolveScopeLabel(SampleTypeValues.IMAGE, false, 1204, false)).toBe(
+            'all 1204 images'
         );
-        expect(resolveScopeLabel(SampleTypeValues.ANNOTATION, false)).toBe(
-            'All annotations in the view'
+        expect(resolveScopeLabel(SampleTypeValues.VIDEO, false, 42, false)).toBe('all 42 videos');
+        expect(resolveScopeLabel(SampleTypeValues.VIDEO_FRAME, false, 50, false)).toBe(
+            'all 50 video frames'
         );
-        expect(resolveScopeLabel(SampleTypeValues.GROUP, false)).toBe('All groups in the view');
-        expect(resolveScopeLabel(SampleTypeValues.CAPTION, false)).toBe('All captions in the view');
+        expect(resolveScopeLabel(SampleTypeValues.ANNOTATION, false, 30, false)).toBe(
+            'all 30 annotations'
+        );
+        expect(resolveScopeLabel(SampleTypeValues.GROUP, false, 10, false)).toBe('all 10 groups');
+        expect(resolveScopeLabel(SampleTypeValues.CAPTION, false, 5, false)).toBe('all 5 captions');
+    });
+
+    it('returns "{count} filtered {type}s" when a filter is active', () => {
+        expect(resolveScopeLabel(SampleTypeValues.IMAGE, false, 248, true)).toBe(
+            '248 filtered images'
+        );
+        expect(resolveScopeLabel(SampleTypeValues.VIDEO, false, 3, true)).toBe('3 filtered videos');
+        expect(resolveScopeLabel(SampleTypeValues.VIDEO_FRAME, false, 20, true)).toBe(
+            '20 filtered video frames'
+        );
+        expect(resolveScopeLabel(SampleTypeValues.ANNOTATION, false, 12, true)).toBe(
+            '12 filtered annotations'
+        );
     });
 });
 

--- a/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.test.ts
@@ -95,6 +95,15 @@ describe('resolveScopeLabel', () => {
             '12 filtered annotations'
         );
     });
+
+    it('uses singular form when scopeCount is 1', () => {
+        expect(resolveScopeLabel(SampleTypeValues.IMAGE, false, 1, false)).toBe('all 1 image');
+        expect(resolveScopeLabel(SampleTypeValues.VIDEO, false, 1, false)).toBe('all 1 video');
+        expect(resolveScopeLabel(SampleTypeValues.IMAGE, false, 1, true)).toBe('1 filtered image');
+        expect(resolveScopeLabel(SampleTypeValues.VIDEO_FRAME, false, 1, true)).toBe(
+            '1 filtered video frame'
+        );
+    });
 });
 
 describe('resolveContextFilter', () => {

--- a/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.ts
@@ -60,10 +60,11 @@ export function resolveScopeLabel(
         return `the currently viewed ${sampleType.replaceAll('_', ' ')}`;
     }
     const typeName = sampleType.replaceAll('_', ' ');
+    const plural = scopeCount === 1 ? typeName : `${typeName}s`;
     if (hasActiveFilter) {
-        return `${scopeCount} filtered ${typeName}s`;
+        return `${scopeCount} filtered ${plural}`;
     }
-    return `all ${scopeCount} ${typeName}s`;
+    return `all ${scopeCount} ${plural}`;
 }
 
 export function resolveContextFilter(

--- a/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.ts
@@ -49,11 +49,21 @@ export function resolveIsDetailPage(routeId: string | null): boolean {
     );
 }
 
-export function resolveScopeLabel(sampleType: SampleType | null, isOnDetailPage: boolean): string {
-    if (sampleType === null) return 'Full collection';
-    return isOnDetailPage
-        ? `Current ${sampleType.replaceAll('_', ' ')}`
-        : `All ${sampleType.replaceAll('_', ' ')}s in the view`;
+export function resolveScopeLabel(
+    sampleType: SampleType | null,
+    isOnDetailPage: boolean,
+    scopeCount: number,
+    hasActiveFilter: boolean
+): string {
+    if (sampleType === null) return 'the entire collection';
+    if (isOnDetailPage) {
+        return `the currently viewed ${sampleType.replaceAll('_', ' ')}`;
+    }
+    const typeName = sampleType.replaceAll('_', ' ');
+    if (hasActiveFilter) {
+        return `${scopeCount} filtered ${typeName}s`;
+    }
+    return `all ${scopeCount} ${typeName}s`;
 }
 
 export function resolveContextFilter(
@@ -94,14 +104,12 @@ export function useOperatorContext(
 
     const isOnDetailPage = derived(routeId, resolveIsDetailPage);
     const currentScope = derived(pageContext, ($p) => $p.sampleType as OperatorScope | null);
-    const scopeLabel = derived(pageContext, ($p) =>
-        resolveScopeLabel($p.sampleType, resolveIsDetailPage($p.routeId))
-    );
 
     const { imageFilter } = useImageFilters();
     const { videoFilter } = useVideoFilters();
     const { frameFilter } = useFramesFilter();
-    const { selectedAnnotationFilterIds } = useGlobalStorage();
+    const { selectedAnnotationFilterIds, filteredSampleCount, filteredAnnotationCount } =
+        useGlobalStorage();
 
     const contextFilter = derived(
         [
@@ -128,6 +136,40 @@ export function useOperatorContext(
                 $annotationFilterIds,
                 $tagsSelected
             )
+    );
+
+    // True only when the user has applied explicit filters — excludes intrinsic route constraints
+    // (e.g. the captions route always sends has_captions:true, which is not a user-applied filter).
+    const hasActiveFilter = derived(
+        [routeId, imageFilter, videoFilter, frameFilter, selectedAnnotationFilterIds, tagsSelected],
+        ([
+            $routeId,
+            $imageFilter,
+            $videoFilter,
+            $frameFilter,
+            $annotationFilterIds,
+            $tagsSelected
+        ]) => {
+            if (isAnnotationsRoute($routeId)) {
+                return $annotationFilterIds.size > 0 || $tagsSelected.size > 0;
+            }
+            if (isImagesRoute($routeId)) return $imageFilter !== null;
+            if (isVideosRoute($routeId)) return $videoFilter !== null;
+            if (isVideoFramesRoute($routeId)) return $frameFilter !== null;
+            return false;
+        }
+    );
+
+    const scopeCount = derived(
+        [routeId, filteredSampleCount, filteredAnnotationCount],
+        ([$routeId, $sampleCount, $annotationCount]) =>
+            isAnnotationsRoute($routeId) ? $annotationCount : $sampleCount
+    );
+
+    const scopeLabel = derived(
+        [pageContext, isOnDetailPage, scopeCount, hasActiveFilter],
+        ([$p, $isDetail, $count, $hasFilter]) =>
+            resolveScopeLabel($p.sampleType, $isDetail, $count, $hasFilter)
     );
 
     return {


### PR DESCRIPTION
## What has changed and why?

Replaces the scope badge in the operator dialog with inline text in the description that includes the actual item count and whether a filter is active.

<img width="1920" height="997" alt="Screenshot 2026-06-26 at 09 07 36" src="https://github.com/user-attachments/assets/6c8dec33-96e2-4711-9101-d914b43458d7" />
<img width="1920" height="998" alt="Screenshot 2026-06-26 at 09 07 50" src="https://github.com/user-attachments/assets/29fb1b28-8dbd-469e-8518-a7a18e4ae059" />


## How has it been tested?

Unit tests + Manual tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator dialog wording and description rendering to accurately reflect the current scope and whether filters are active.
  * Updated scope label logic to use the correct counts, showing “the entire collection” vs “the currently viewed,” and switching between “all X …” and “X filtered …” messaging.
  * Updated the captions view’s “Showing …” stats text to reflect the captions route.
* **Tests**
  * Updated and expanded scope-label unit tests for the revised labeling contract, additional sample types, and correct singular/plural output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->