### PR TITLE
Resolve confusion-matrix FP/FN buckets in the sample filter

### DIFF
--- a/lightly_studio/src/lightly_studio/models/evaluation_confusion_matrix.py
+++ b/lightly_studio/src/lightly_studio/models/evaluation_confusion_matrix.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # Row label for predictions with no matching ground truth (false positives).
 NO_GROUND_TRUTH_ROW_LABEL = "(no ground truth)"
@@ -14,23 +14,50 @@ NO_PREDICTION_COL_LABEL = "(no prediction)"
 
 
 class ConfusionCell(BaseModel):
-    """A single class-by-class cell of a confusion matrix for one evaluation run.
+    """A single cell of a confusion matrix for one evaluation run.
 
-    Identifies samples that contain a ground-truth/prediction annotation pairing of
-    the given label combination. Labels are matched by name (unique per dataset), so
-    no annotation-id lookup is needed when resolving the cell to its samples.
+    Identifies samples behind a ground-truth/prediction pairing bucket. Labels are
+    matched by name (unique per dataset), so no annotation-id lookup is needed when
+    resolving the cell to its samples. A ``None`` label selects a synthetic margin
+    bucket instead of a real class:
+
+    - ``gt_label = None`` is the false-positive bucket (prediction with no matching
+      ground truth).
+    - ``pred_label = None`` is the false-negative bucket (ground truth with no
+      matching prediction).
+
+    Both labels ``None`` is meaningless (no pairing to select) and is rejected.
 
     Attributes:
         evaluation_run_id: Evaluation run whose pairing metrics are queried.
-        gt_label: Ground-truth annotation label name (matrix row).
-        pred_label: Prediction annotation label name (matrix column).
+        gt_label: Ground-truth annotation label name (matrix row), or ``None`` for
+            the false-positive bucket.
+        pred_label: Prediction annotation label name (matrix column), or ``None`` for
+            the false-negative bucket.
     """
 
     evaluation_run_id: UUID = Field(
         description="Evaluation run whose pairing metrics define the cell.",
     )
-    gt_label: str = Field(description="Ground-truth annotation label name (matrix row).")
-    pred_label: str = Field(description="Prediction annotation label name (matrix column).")
+    gt_label: str | None = Field(
+        default=None,
+        description="Ground-truth annotation label name (matrix row), "
+        "or null for the false-positive bucket.",
+    )
+    pred_label: str | None = Field(
+        default=None,
+        description="Prediction annotation label name (matrix column), "
+        "or null for the false-negative bucket.",
+    )
+
+    @model_validator(mode="after")
+    def _reject_both_labels_null(self) -> ConfusionCell:  # noqa: N804
+        if self.gt_label is None and self.pred_label is None:
+            raise ValueError(
+                "A confusion cell needs at least one of gt_label or pred_label; "
+                "both null selects no pairing."
+            )
+        return self
 
 
 class ConfusionMatrix(BaseModel):

--- a/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
@@ -131,8 +131,7 @@ class SampleFilter(BaseModel):
                 )
                 .join(
                     pred_label,
-                    col(pred_annotation.annotation_label_id)
-                    == col(pred_label.annotation_label_id),
+                    col(pred_annotation.annotation_label_id) == col(pred_label.annotation_label_id),
                 )
                 .where(col(pred_label.annotation_label_name) == confusion_cell.pred_label)
             )

--- a/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
@@ -89,41 +89,59 @@ class SampleFilter(BaseModel):
     def _build_confusion_cell_subquery(self, confusion_cell: ConfusionCell) -> SelectOfScalar[UUID]:
         # Resolve the cell to its samples with a subquery against the persisted
         # pairing metrics, joining annotation labels by name (unique per dataset),
-        # mirroring the tag-filter subquery pattern. This slice handles the
-        # non-null/non-null case only, so both sides are inner-joined.
+        # mirroring the tag-filter subquery pattern. Each side is handled
+        # independently: a real label inner-joins its annotation/label and matches by
+        # name; a null label (synthetic margin bucket) instead requires that side's
+        # annotation id to be NULL (false positive when gt is null, false negative
+        # when pred is null). The model rejects the both-null combination upstream.
         gt_annotation = aliased(AnnotationBaseTable)
         pred_annotation = aliased(AnnotationBaseTable)
         gt_label = aliased(AnnotationLabelTable)
         pred_label = aliased(AnnotationLabelTable)
 
-        return (
-            select(EvaluationAnnotationMetricTable.sample_id)
-            .join(
-                gt_annotation,
-                col(EvaluationAnnotationMetricTable.gt_annotation_id)
-                == col(gt_annotation.sample_id),
-            )
-            .join(
-                pred_annotation,
-                col(EvaluationAnnotationMetricTable.pred_annotation_id)
-                == col(pred_annotation.sample_id),
-            )
-            .join(
-                gt_label,
-                col(gt_annotation.annotation_label_id) == col(gt_label.annotation_label_id),
-            )
-            .join(
-                pred_label,
-                col(pred_annotation.annotation_label_id) == col(pred_label.annotation_label_id),
-            )
-            .where(
-                col(EvaluationAnnotationMetricTable.evaluation_run_id)
-                == confusion_cell.evaluation_run_id
-            )
-            .where(col(gt_label.annotation_label_name) == confusion_cell.gt_label)
-            .where(col(pred_label.annotation_label_name) == confusion_cell.pred_label)
-            .distinct()
+        subquery = select(EvaluationAnnotationMetricTable.sample_id).where(
+            col(EvaluationAnnotationMetricTable.evaluation_run_id)
+            == confusion_cell.evaluation_run_id
         )
+
+        if confusion_cell.gt_label is not None:
+            subquery = (
+                subquery.join(
+                    gt_annotation,
+                    col(EvaluationAnnotationMetricTable.gt_annotation_id)
+                    == col(gt_annotation.sample_id),
+                )
+                .join(
+                    gt_label,
+                    col(gt_annotation.annotation_label_id) == col(gt_label.annotation_label_id),
+                )
+                .where(col(gt_label.annotation_label_name) == confusion_cell.gt_label)
+            )
+        else:
+            subquery = subquery.where(
+                col(EvaluationAnnotationMetricTable.gt_annotation_id).is_(None)
+            )
+
+        if confusion_cell.pred_label is not None:
+            subquery = (
+                subquery.join(
+                    pred_annotation,
+                    col(EvaluationAnnotationMetricTable.pred_annotation_id)
+                    == col(pred_annotation.sample_id),
+                )
+                .join(
+                    pred_label,
+                    col(pred_annotation.annotation_label_id)
+                    == col(pred_label.annotation_label_id),
+                )
+                .where(col(pred_label.annotation_label_name) == confusion_cell.pred_label)
+            )
+        else:
+            subquery = subquery.where(
+                col(EvaluationAnnotationMetricTable.pred_annotation_id).is_(None)
+            )
+
+        return subquery.distinct()
 
     def _apply_metadata_filters(self, query: QueryType) -> QueryType:
         if self.metadata_filters:

--- a/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
+++ b/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
+import pytest
+from pydantic import ValidationError
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.annotation_label import AnnotationLabelTable
@@ -668,6 +670,124 @@ class TestSampleFilterConfusionCell:
         assert len(result) == 1
         assert result[0].sample_id == samples[1].sample_id
 
+    def test_apply__confusion_cell__false_positive_bucket(self, db_session: Session) -> None:
+        # gt_label=None selects predictions with no matching ground truth.
+        dataset = create_collection(session=db_session)
+        dataset_id = dataset.collection_id
+        run, _image = evaluation_sample_metric_helpers.create_run_and_image(
+            session=db_session, dataset_collection_id=dataset_id
+        )
+        samples = create_images(
+            db_session=db_session,
+            collection_id=dataset_id,
+            images=[
+                ImageStub(path="fp_truck.png"),
+                ImageStub(path="fp_car.png"),
+                ImageStub(path="tp_truck.png"),
+            ],
+        )
+        truck = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="truck"
+        )
+        car = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="car"
+        )
+        # A spurious truck (FP), a spurious car (FP), and a correctly paired truck (TP).
+        _seed_false_positive(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[0],
+            label=truck,
+        )
+        _seed_false_positive(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[1],
+            label=car,
+        )
+        _seed_pair(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[2],
+            labels=(truck, truck),
+        )
+
+        sample_filter = SampleFilter(
+            confusion_cell=ConfusionCell(
+                evaluation_run_id=run.id, gt_label=None, pred_label="truck"
+            )
+        )
+
+        filtered_query = sample_filter.apply(query=select(SampleTable))
+        result = db_session.exec(filtered_query).all()
+
+        assert len(result) == 1
+        assert result[0].sample_id == samples[0].sample_id
+
+    def test_apply__confusion_cell__false_negative_bucket(self, db_session: Session) -> None:
+        # pred_label=None selects ground truths with no matching prediction.
+        dataset = create_collection(session=db_session)
+        dataset_id = dataset.collection_id
+        run, _image = evaluation_sample_metric_helpers.create_run_and_image(
+            session=db_session, dataset_collection_id=dataset_id
+        )
+        samples = create_images(
+            db_session=db_session,
+            collection_id=dataset_id,
+            images=[
+                ImageStub(path="fn_car.png"),
+                ImageStub(path="fn_truck.png"),
+                ImageStub(path="tp_car.png"),
+            ],
+        )
+        car = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="car"
+        )
+        truck = create_annotation_label(
+            session=db_session, root_collection_id=dataset_id, label_name="truck"
+        )
+        # A missed car (FN), a missed truck (FN), and a correctly paired car (TP).
+        _seed_false_negative(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[0],
+            label=car,
+        )
+        _seed_false_negative(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[1],
+            label=truck,
+        )
+        _seed_pair(
+            session=db_session,
+            dataset_id=dataset_id,
+            run_id=run.id,
+            image=samples[2],
+            labels=(car, car),
+        )
+
+        sample_filter = SampleFilter(
+            confusion_cell=ConfusionCell(
+                evaluation_run_id=run.id, gt_label="car", pred_label=None
+            )
+        )
+
+        filtered_query = sample_filter.apply(query=select(SampleTable))
+        result = db_session.exec(filtered_query).all()
+
+        assert len(result) == 1
+        assert result[0].sample_id == samples[0].sample_id
+
+    def test_confusion_cell__rejects_both_labels_null(self) -> None:
+        with pytest.raises(ValidationError):
+            ConfusionCell(evaluation_run_id=uuid4(), gt_label=None, pred_label=None)
+
 
 def _seed_pair(
     session: Session,
@@ -700,6 +820,60 @@ def _seed_pair(
                 pred_annotation_id=pred_annotation.sample_id,
                 metric_name="iou",
                 value=0.9,
+            )
+        ],
+    )
+
+
+def _seed_false_positive(
+    session: Session,
+    dataset_id: UUID,
+    run_id: UUID,
+    image: ImageTable,
+    label: AnnotationLabelTable,
+) -> None:
+    """Persist a false-positive metric row (prediction with no matching ground truth)."""
+    pred_annotation = create_annotation(
+        session=session,
+        collection_id=dataset_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    evaluation_annotation_metric_resolver.create_many(
+        session=session,
+        records=[
+            EvaluationAnnotationMetricCreate(
+                evaluation_run_id=run_id,
+                sample_id=image.sample_id,
+                gt_annotation_id=None,
+                pred_annotation_id=pred_annotation.sample_id,
+            )
+        ],
+    )
+
+
+def _seed_false_negative(
+    session: Session,
+    dataset_id: UUID,
+    run_id: UUID,
+    image: ImageTable,
+    label: AnnotationLabelTable,
+) -> None:
+    """Persist a false-negative metric row (ground truth with no matching prediction)."""
+    gt_annotation = create_annotation(
+        session=session,
+        collection_id=dataset_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    evaluation_annotation_metric_resolver.create_many(
+        session=session,
+        records=[
+            EvaluationAnnotationMetricCreate(
+                evaluation_run_id=run_id,
+                sample_id=image.sample_id,
+                gt_annotation_id=gt_annotation.sample_id,
+                pred_annotation_id=None,
             )
         ],
     )

--- a/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
+++ b/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
@@ -674,7 +674,7 @@ class TestSampleFilterConfusionCell:
         # gt_label=None selects predictions with no matching ground truth.
         dataset = create_collection(session=db_session)
         dataset_id = dataset.collection_id
-        run, _image = evaluation_sample_metric_helpers.create_run_and_image(
+        run = evaluation_sample_metric_helpers.create_run(
             session=db_session, dataset_collection_id=dataset_id
         )
         samples = create_images(
@@ -731,7 +731,7 @@ class TestSampleFilterConfusionCell:
         # pred_label=None selects ground truths with no matching prediction.
         dataset = create_collection(session=db_session)
         dataset_id = dataset.collection_id
-        run, _image = evaluation_sample_metric_helpers.create_run_and_image(
+        run = evaluation_sample_metric_helpers.create_run(
             session=db_session, dataset_collection_id=dataset_id
         )
         samples = create_images(

--- a/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
+++ b/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
@@ -773,9 +773,7 @@ class TestSampleFilterConfusionCell:
         )
 
         sample_filter = SampleFilter(
-            confusion_cell=ConfusionCell(
-                evaluation_run_id=run.id, gt_label="car", pred_label=None
-            )
+            confusion_cell=ConfusionCell(evaluation_run_id=run.id, gt_label="car", pred_label=None)
         )
 
         filtered_query = sample_filter.apply(query=select(SampleTable))


### PR DESCRIPTION
## What

Part 1 of 2 (backend). Extends the `confusion_cell` sample filter to the confusion matrix's synthetic margin buckets, so a caller can select **false positives** (a prediction with no matching ground truth) and **false negatives** (a ground truth the model missed), not just confusions between two real classes.

## Changes

- `ConfusionCell.gt_label` / `pred_label` are now optional. A `null` label selects a margin bucket:
  - `gt_label = null` → false-positive bucket (no gt pairing)
  - `pred_label = null` → false-negative bucket (no pred pairing)
  - a model validator rejects the meaningless `gt_label = null && pred_label = null` corner.
- `_build_confusion_cell_subquery` now handles each side independently: a real label inner-joins its annotation/label and matches by name; a `null` label instead requires that side's annotation id to be `NULL`.

## Tests

`test_sample_filter.py` gains coverage for the FP bucket (`gt_label = null`), the FN bucket (`pred_label = null`), and the rejected null/null combination. The filter is task-agnostic, so it works for both classification and object-detection runs.

## Notes for reviewer

- The OpenAPI schema / generated TS client are gitignored build artifacts; the frontend PR (part 2) regenerates them and consumes the now-nullable labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional confusion-matrix “margin” buckets when either ground-truth or prediction is missing.
  * Updated sample filtering so results match these false-positive/false-negative bucket definitions.
* **Bug Fixes**
  * Strengthened validation to reject confusion-matrix cells where both ground-truth and prediction are missing.
* **Tests**
  * Added coverage for false-positive and false-negative scenarios to ensure the correct sample is returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->