### PR TITLE
Pass annotation source at export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- When multiple annotation sources exist, the export dialog now shows a dropdown to select which source to export annotations from.
 - Annotation classes can now be shown or hidden individually in the grid views using an eye icon toggle in the Annotation Classes sidebar.
 - Python SDK: `target_fps` parameter on `VideoDataset.add_videos_from_path` to subsample frames to a
   lower frame rate. Retained frames keep their original frame numbers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ filtered sample count.
 - Improve confusion matrix usability for large numbers of classes
 - Python dataset queries now support classifications, object detections, and segmentation mask annotations.
 - Python dataset queries now model evaluation queries on the sample level.
-- When multiple annotation sources exist, the export dialog now shows a dropdown to select which source to export annotations from.
+- Annotation source selection for exports: when multiple annotation collections exist, the export dialog shows a dropdown to choose which collection to export from. The annotation source can also be specified via the Python API using the `annotation_collection_id` parameter.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- When multiple annotation sources exist, the export dialog now shows a dropdown to select which source to export annotations from.
 - Annotation classes can now be shown or hidden individually in the grid views using an eye icon toggle in the Annotation Classes sidebar.
 - Python SDK: `target_fps` parameter on `VideoDataset.add_videos_from_path` to subsample frames to a
   lower frame rate. Retained frames keep their original frame numbers.
@@ -20,6 +19,7 @@ filtered sample count.
 - Improve confusion matrix usability for large numbers of classes
 - Python dataset queries now support classifications, object detections, and segmentation mask annotations.
 - Python dataset queries now model evaluation queries on the sample level.
+- When multiple annotation sources exist, the export dialog now shows a dropdown to select which source to export annotations from.
 
 ### Changed
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path as PathlibPath
 from tempfile import TemporaryDirectory
 from typing import Annotated
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.responses import PlainTextResponse, StreamingResponse
@@ -37,6 +38,7 @@ def export_collection_annotations(
     ],
     session: SessionDep,
     export_format: ExportFormat = ExportFormat.OBJECT_DETECTION_COCO,
+    annotation_collection_id: UUID | None = None,
 ) -> StreamingResponse:
     """Export collection annotations in the selected export format."""
     # Query to export - all samples in the collection.
@@ -54,6 +56,7 @@ def export_collection_annotations(
                 dataset_id=collection.dataset_id,
                 samples=dataset_query,
                 output_json=output_path,
+                annotation_collection_id=annotation_collection_id,
             )
         except Exception:
             temp_dir.cleanup()
@@ -68,6 +71,7 @@ def export_collection_annotations(
                 dataset_id=collection.dataset_id,
                 samples=dataset_query,
                 output_json=output_path,
+                annotation_collection_id=annotation_collection_id,
             )
         except Exception:
             temp_dir.cleanup()
@@ -82,6 +86,7 @@ def export_collection_annotations(
                 dataset_id=collection.dataset_id,
                 samples=dataset_query,
                 output_folder=output_path,
+                annotation_collection_id=annotation_collection_id,
             )
         except Exception:
             temp_dir.cleanup()

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -37,8 +37,8 @@ def export_collection_annotations(
         Depends(collection_api.get_and_validate_collection_id),
     ],
     session: SessionDep,
+    annotation_collection_id: UUID | None,
     export_format: ExportFormat = ExportFormat.OBJECT_DETECTION_COCO,
-    annotation_collection_id: UUID | None = None,
 ) -> StreamingResponse:
     """Export collection annotations in the selected export format."""
     # Query to export - all samples in the collection.

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -102,7 +102,11 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         """
         if query is None:
             query = self.query()
-        return ImageDatasetExport(session=self.session, dataset_id=self.dataset_id, samples=query)
+        return ImageDatasetExport(
+            session=self.session,
+            dataset_id=self.dataset_id,
+            samples=query,
+        )
 
     def get_sample(self, sample_id: UUID) -> ImageSample:
         """Get a single sample from the dataset by its ID.

--- a/lightly_studio/src/lightly_studio/export/image_dataset_export.py
+++ b/lightly_studio/src/lightly_studio/export/image_dataset_export.py
@@ -33,17 +33,26 @@ class ImageDatasetExport:
     It allows exporting data in various formats.
     """
 
-    def __init__(self, session: Session, dataset_id: UUID, samples: Iterable[ImageSample]):
+    def __init__(
+        self,
+        session: Session,
+        dataset_id: UUID,
+        samples: Iterable[ImageSample],
+        annotation_collection_id: UUID | None = None,
+    ):
         """Initializes the ImageDatasetExport object.
 
         Args:
             session: The database session.
             dataset_id: The dataset ID for label retrieval.
             samples: Samples to export.
+            annotation_collection_id: If provided, only annotations from this collection
+                are exported. If None, all annotations are exported.
         """
         self.session = session
         self._dataset_id = dataset_id
         self.samples = samples
+        self._annotation_collection_id = annotation_collection_id
 
     def to_coco_object_detections(self, output_json: PathLike | None = None) -> None:
         """Exports object detection annotations to a COCO format JSON file.
@@ -62,6 +71,7 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             output_json=Path(output_json),
+            annotation_collection_id=self._annotation_collection_id,
         )
 
     def to_coco_captions(self, output_json: PathLike | None = None) -> None:
@@ -89,6 +99,7 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             output_json=Path(output_json),
+            annotation_collection_id=self._annotation_collection_id,
         )
 
     def to_pascalvoc_segmentation_mask(self, output_folder: PathLike) -> None:
@@ -106,6 +117,7 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             output_folder=Path(output_folder),
+            annotation_collection_id=self._annotation_collection_id,
         )
 
 
@@ -114,6 +126,7 @@ def to_coco_object_detections(
     dataset_id: UUID,
     samples: Iterable[ImageSample],
     output_json: Path,
+    annotation_collection_id: UUID | None = None,
 ) -> None:
     """Exports object detection annotations to a COCO format JSON file.
 
@@ -125,11 +138,14 @@ def to_coco_object_detections(
         dataset_id: The dataset ID for label retrieval.
         samples: The samples to export.
         output_json: The path to save the output JSON file.
+        annotation_collection_id: If provided, only annotations from this collection
+            are exported. If None, all annotations are exported.
     """
     export_input = LightlyStudioObjectDetectionInput(
         session=session,
         dataset_id=dataset_id,
         samples=samples,
+        annotation_collection_id=annotation_collection_id,
     )
     COCOObjectDetectionOutput(output_file=output_json).save(label_input=export_input)
 
@@ -139,6 +155,7 @@ def to_coco_segmentation_masks(
     dataset_id: UUID,
     samples: Iterable[ImageSample],
     output_json: Path,
+    annotation_collection_id: UUID | None = None,
 ) -> None:
     """Exports segmentation mask annotations to a COCO format JSON file.
 
@@ -150,11 +167,14 @@ def to_coco_segmentation_masks(
         dataset_id: The dataset ID for label retrieval.
         samples: The samples to export.
         output_json: The path to save the output JSON file.
+        annotation_collection_id: If provided, only annotations from this collection
+            are exported. If None, all annotations are exported.
     """
     export_input = LightlyStudioInstanceSegmentationInput(
         session=session,
         dataset_id=dataset_id,
         samples=samples,
+        annotation_collection_id=annotation_collection_id,
     )
     COCOInstanceSegmentationOutput(output_file=output_json).save(label_input=export_input)
 
@@ -164,6 +184,7 @@ def to_pascalvoc_segmentation_mask(
     dataset_id: UUID,
     samples: Iterable[ImageSample],
     output_folder: Path,
+    annotation_collection_id: UUID | None = None,
 ) -> None:
     """Exports segmentation mask annotations to a Pascal VOC segmentation folder.
 
@@ -175,11 +196,14 @@ def to_pascalvoc_segmentation_mask(
         dataset_id: The dataset ID for label retrieval.
         samples: The samples to export.
         output_folder: The folder where Pascal VOC segmentation files are written.
+        annotation_collection_id: If provided, only annotations from this collection
+            are exported. If None, all annotations are exported.
     """
     export_input = LightlyStudioPascalVOCInstanceSegmentationInput(
         session=session,
         dataset_id=dataset_id,
         samples=samples,
+        annotation_collection_id=annotation_collection_id,
     )
 
     # Keep `background_class_id` unchanged: the label input defines category IDs and

--- a/lightly_studio/src/lightly_studio/export/image_dataset_export.py
+++ b/lightly_studio/src/lightly_studio/export/image_dataset_export.py
@@ -38,7 +38,6 @@ class ImageDatasetExport:
         session: Session,
         dataset_id: UUID,
         samples: Iterable[ImageSample],
-        annotation_collection_id: UUID | None = None,
     ):
         """Initializes the ImageDatasetExport object.
 
@@ -46,20 +45,23 @@ class ImageDatasetExport:
             session: The database session.
             dataset_id: The dataset ID for label retrieval.
             samples: Samples to export.
-            annotation_collection_id: If provided, only annotations from this collection
-                are exported. If None, all annotations are exported.
         """
         self.session = session
         self._dataset_id = dataset_id
         self.samples = samples
-        self._annotation_collection_id = annotation_collection_id
 
-    def to_coco_object_detections(self, output_json: PathLike | None = None) -> None:
+    def to_coco_object_detections(
+        self,
+        output_json: PathLike | None = None,
+        annotation_collection_id: UUID | None = None,
+    ) -> None:
         """Exports object detection annotations to a COCO format JSON file.
 
         Args:
             output_json: The path to the output COCO JSON file. If not provided,
                 defaults to "coco_export.json" in the current working directory.
+            annotation_collection_id: If provided, only annotations from this collection
+                are exported. If None, all annotations are exported.
 
         Raises:
             ValueError: If the annotation source with the given name does not exist.
@@ -71,7 +73,7 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             output_json=Path(output_json),
-            annotation_collection_id=self._annotation_collection_id,
+            annotation_collection_id=annotation_collection_id,
         )
 
     def to_coco_captions(self, output_json: PathLike | None = None) -> None:
@@ -85,12 +87,18 @@ class ImageDatasetExport:
             output_json = DEFAULT_EXPORT_FILENAME
         to_coco_captions(samples=self.samples, output_json=Path(output_json))
 
-    def to_coco_segmentation_masks(self, output_json: PathLike | None = None) -> None:
+    def to_coco_segmentation_masks(
+        self,
+        output_json: PathLike | None = None,
+        annotation_collection_id: UUID | None = None,
+    ) -> None:
         """Exports segmentation masks to a COCO format JSON file.
 
         Args:
             output_json: The path to the output COCO JSON file. If not provided,
                 defaults to "coco_export.json" in the current working directory.
+            annotation_collection_id: If provided, only annotations from this collection
+                are exported. If None, all annotations are exported.
         """
         if output_json is None:
             output_json = DEFAULT_EXPORT_FILENAME
@@ -99,10 +107,14 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             output_json=Path(output_json),
-            annotation_collection_id=self._annotation_collection_id,
+            annotation_collection_id=annotation_collection_id,
         )
 
-    def to_pascalvoc_segmentation_mask(self, output_folder: PathLike) -> None:
+    def to_pascalvoc_segmentation_mask(
+        self,
+        output_folder: PathLike,
+        annotation_collection_id: UUID | None = None,
+    ) -> None:
         """Exports segmentation mask annotations to Pascal VOC format.
 
         Creates a folder with per-pixel class masks (PNG) and a class map (JSON).
@@ -111,13 +123,15 @@ class ImageDatasetExport:
             output_folder: The folder where Pascal VOC segmentation files are
                 written. The folder contains a `SegmentationClass` subfolder
                 with PNG masks and a `class_id_to_name.json` file.
+            annotation_collection_id: If provided, only annotations from this collection
+                are exported. If None, all annotations are exported.
         """
         to_pascalvoc_segmentation_mask(
             session=self.session,
             dataset_id=self._dataset_id,
             samples=self.samples,
             output_folder=Path(output_folder),
-            annotation_collection_id=self._annotation_collection_id,
+            annotation_collection_id=annotation_collection_id,
         )
 
 
@@ -126,7 +140,7 @@ def to_coco_object_detections(
     dataset_id: UUID,
     samples: Iterable[ImageSample],
     output_json: Path,
-    annotation_collection_id: UUID | None = None,
+    annotation_collection_id: UUID | None,
 ) -> None:
     """Exports object detection annotations to a COCO format JSON file.
 
@@ -155,7 +169,7 @@ def to_coco_segmentation_masks(
     dataset_id: UUID,
     samples: Iterable[ImageSample],
     output_json: Path,
-    annotation_collection_id: UUID | None = None,
+    annotation_collection_id: UUID | None,
 ) -> None:
     """Exports segmentation mask annotations to a COCO format JSON file.
 
@@ -184,7 +198,7 @@ def to_pascalvoc_segmentation_mask(
     dataset_id: UUID,
     samples: Iterable[ImageSample],
     output_folder: Path,
-    annotation_collection_id: UUID | None = None,
+    annotation_collection_id: UUID | None,
 ) -> None:
     """Exports segmentation mask annotations to a Pascal VOC segmentation folder.
 

--- a/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
+++ b/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
@@ -37,7 +37,7 @@ class LightlyStudioInputBase:
         session: Session,
         dataset_id: UUID,
         samples: Iterable[ImageSample],
-        annotation_collection_id: UUID | None = None,
+        annotation_collection_id: UUID | None,
     ) -> None:
         """Initializes the adapter.
 
@@ -96,7 +96,7 @@ class LightlyStudioInstanceSegmentationInput(LightlyStudioInputBase, InstanceSeg
         sample: ImageSample,
         image_id: int,
         label_id_to_category: dict[UUID, Category],
-        annotation_collection_id: UUID | None = None,
+        annotation_collection_id: UUID | None,
     ) -> ImageInstanceSegmentation:
         # TODO(lukas, 02/2026): We can optimise in the future to filter annotations in a DB query.
         objects = []
@@ -147,7 +147,7 @@ class LightlyStudioPascalVOCInstanceSegmentationInput(
         sample: ImageSample,
         image_id: int,
         label_id_to_category: dict[UUID, Category],
-        annotation_collection_id: UUID | None = None,
+        annotation_collection_id: UUID | None,
     ) -> ImageInstanceSegmentation:
         objects = []
         for annotation in sample.sample_table.annotations:
@@ -230,7 +230,7 @@ def _sample_to_image_obj_det(
     sample: ImageSample,
     image_id: int,
     label_id_to_category: dict[UUID, Category],
-    annotation_collection_id: UUID | None = None,
+    annotation_collection_id: UUID | None,
 ) -> ImageObjectDetection:
     # TODO(Michal, 09/2025): We can optimise in the future to filter annotations in a DB query.
     objects = [

--- a/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
+++ b/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
@@ -32,7 +32,13 @@ class LightlyStudioInputBase:
 
     CATEGORY_ID_START = 0
 
-    def __init__(self, session: Session, dataset_id: UUID, samples: Iterable[ImageSample]) -> None:
+    def __init__(
+        self,
+        session: Session,
+        dataset_id: UUID,
+        samples: Iterable[ImageSample],
+        annotation_collection_id: UUID | None = None,
+    ) -> None:
         """Initializes the adapter.
 
         Args:
@@ -40,8 +46,11 @@ class LightlyStudioInputBase:
                 constructor to fetch the labels for the given annotation source.
             dataset_id: The dataset ID for label retrieval.
             samples: Dataset samples.
+            annotation_collection_id: If provided, only annotations belonging to this
+                annotation collection are exported. If None, all annotations are exported.
         """
         self._samples = list(samples)
+        self._annotation_collection_id = annotation_collection_id
         self._label_id_to_category = _build_label_id_to_category(
             session=session,
             dataset_id=dataset_id,
@@ -70,11 +79,14 @@ class LightlyStudioObjectDetectionInput(LightlyStudioInputBase, ObjectDetectionI
 
     def get_labels(self) -> Iterable[ImageObjectDetection]:
         """Returns the labels for export."""
+        print("Exporting object detection labels...")
+        print(self._annotation_collection_id)
         for idx, sample in enumerate(self._samples):
             yield _sample_to_image_obj_det(
                 sample=sample,
                 image_id=idx,
                 label_id_to_category=self._label_id_to_category,
+                annotation_collection_id=self._annotation_collection_id,
             )
 
 
@@ -86,22 +98,29 @@ class LightlyStudioInstanceSegmentationInput(LightlyStudioInputBase, InstanceSeg
         sample: ImageSample,
         image_id: int,
         label_id_to_category: dict[UUID, Category],
+        annotation_collection_id: UUID | None = None,
     ) -> ImageInstanceSegmentation:
         # TODO(lukas, 02/2026): We can optimise in the future to filter annotations in a DB query.
         objects = []
         for annotation in sample.sample_table.annotations:
-            if annotation.annotation_type == AnnotationType.SEGMENTATION_MASK:
-                obj = _annotation_to_single_inst_seg(
-                    annotation=annotation,
-                    label_id_to_category=label_id_to_category,
-                    image_width=sample.width,
-                    image_height=sample.height,
-                )
-                # TODO(lukas 3/2026): workaround needed because
-                # annotation.segmentation_details.segmentation_mask can be None.
-                # See lightly_studio/src/lightly_studio/models/annotation/segmentation.py.
-                if obj is not None:
-                    objects.append(obj)
+            if annotation.annotation_type != AnnotationType.SEGMENTATION_MASK:
+                continue
+            if (
+                annotation_collection_id is not None
+                and annotation.annotation_collection_id != annotation_collection_id
+            ):
+                continue
+            obj = _annotation_to_single_inst_seg(
+                annotation=annotation,
+                label_id_to_category=label_id_to_category,
+                image_width=sample.width,
+                image_height=sample.height,
+            )
+            # TODO(lukas 3/2026): workaround needed because
+            # annotation.segmentation_details.segmentation_mask can be None.
+            # See lightly_studio/src/lightly_studio/models/annotation/segmentation.py.
+            if obj is not None:
+                objects.append(obj)
 
         return ImageInstanceSegmentation(
             image=_sample_to_image(sample=sample, image_id=image_id),
@@ -115,6 +134,7 @@ class LightlyStudioInstanceSegmentationInput(LightlyStudioInputBase, InstanceSeg
                 sample=sample,
                 image_id=idx,
                 label_id_to_category=self._label_id_to_category,
+                annotation_collection_id=self._annotation_collection_id,
             )
 
 
@@ -132,18 +152,25 @@ class LightlyStudioPascalVOCInstanceSegmentationInput(
         sample: ImageSample,
         image_id: int,
         label_id_to_category: dict[UUID, Category],
+        annotation_collection_id: UUID | None = None,
     ) -> ImageInstanceSegmentation:
         objects = []
         for annotation in sample.sample_table.annotations:
-            if annotation.annotation_type == AnnotationType.SEGMENTATION_MASK:
-                obj = _annotation_to_single_inst_seg(
-                    annotation=annotation,
-                    label_id_to_category=label_id_to_category,
-                    image_width=sample.width,
-                    image_height=sample.height,
-                )
-                if obj is not None:
-                    objects.append(obj)
+            if annotation.annotation_type != AnnotationType.SEGMENTATION_MASK:
+                continue
+            if (
+                annotation_collection_id is not None
+                and annotation.annotation_collection_id != annotation_collection_id
+            ):
+                continue
+            obj = _annotation_to_single_inst_seg(
+                annotation=annotation,
+                label_id_to_category=label_id_to_category,
+                image_width=sample.width,
+                image_height=sample.height,
+            )
+            if obj is not None:
+                objects.append(obj)
 
         return ImageInstanceSegmentation(
             image=_sample_to_image(
@@ -172,6 +199,7 @@ class LightlyStudioPascalVOCInstanceSegmentationInput(
                 sample=sample,
                 image_id=idx,
                 label_id_to_category=self._label_id_to_category,
+                annotation_collection_id=self._annotation_collection_id,
             )
 
 
@@ -210,6 +238,7 @@ def _sample_to_image_obj_det(
     sample: ImageSample,
     image_id: int,
     label_id_to_category: dict[UUID, Category],
+    annotation_collection_id: UUID | None = None,
 ) -> ImageObjectDetection:
     # TODO(Michal, 09/2025): We can optimise in the future to filter annotations in a DB query.
     objects = [
@@ -219,6 +248,10 @@ def _sample_to_image_obj_det(
         )
         for annotation in sample.sample_table.annotations
         if annotation.annotation_type == AnnotationType.OBJECT_DETECTION
+        and (
+            annotation_collection_id is None
+            or annotation.annotation_collection_id == annotation_collection_id
+        )
     ]
     return ImageObjectDetection(
         image=_sample_to_image(sample=sample, image_id=image_id),

--- a/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
+++ b/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
@@ -79,8 +79,6 @@ class LightlyStudioObjectDetectionInput(LightlyStudioInputBase, ObjectDetectionI
 
     def get_labels(self) -> Iterable[ImageObjectDetection]:
         """Returns the labels for export."""
-        print("Exporting object detection labels...")
-        print(self._annotation_collection_id)
         for idx, sample in enumerate(self._samples):
             yield _sample_to_image_obj_det(
                 sample=sample,

--- a/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
+++ b/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
@@ -101,24 +101,21 @@ class LightlyStudioInstanceSegmentationInput(LightlyStudioInputBase, InstanceSeg
         # TODO(lukas, 02/2026): We can optimise in the future to filter annotations in a DB query.
         objects = []
         for annotation in sample.sample_table.annotations:
-            if annotation.annotation_type != AnnotationType.SEGMENTATION_MASK:
-                continue
-            if (
-                annotation_collection_id is not None
-                and annotation.annotation_collection_id != annotation_collection_id
+            if annotation.annotation_type == AnnotationType.SEGMENTATION_MASK and (
+                annotation_collection_id is None
+                or annotation.annotation_collection_id == annotation_collection_id
             ):
-                continue
-            obj = _annotation_to_single_inst_seg(
-                annotation=annotation,
-                label_id_to_category=label_id_to_category,
-                image_width=sample.width,
-                image_height=sample.height,
-            )
-            # TODO(lukas 3/2026): workaround needed because
-            # annotation.segmentation_details.segmentation_mask can be None.
-            # See lightly_studio/src/lightly_studio/models/annotation/segmentation.py.
-            if obj is not None:
-                objects.append(obj)
+                obj = _annotation_to_single_inst_seg(
+                    annotation=annotation,
+                    label_id_to_category=label_id_to_category,
+                    image_width=sample.width,
+                    image_height=sample.height,
+                )
+                # TODO(lukas 3/2026): workaround needed because
+                # annotation.segmentation_details.segmentation_mask can be None.
+                # See lightly_studio/src/lightly_studio/models/annotation/segmentation.py.
+                if obj is not None:
+                    objects.append(obj)
 
         return ImageInstanceSegmentation(
             image=_sample_to_image(sample=sample, image_id=image_id),
@@ -154,21 +151,18 @@ class LightlyStudioPascalVOCInstanceSegmentationInput(
     ) -> ImageInstanceSegmentation:
         objects = []
         for annotation in sample.sample_table.annotations:
-            if annotation.annotation_type != AnnotationType.SEGMENTATION_MASK:
-                continue
-            if (
-                annotation_collection_id is not None
-                and annotation.annotation_collection_id != annotation_collection_id
+            if annotation.annotation_type == AnnotationType.SEGMENTATION_MASK and (
+                annotation_collection_id is None
+                or annotation.annotation_collection_id == annotation_collection_id
             ):
-                continue
-            obj = _annotation_to_single_inst_seg(
-                annotation=annotation,
-                label_id_to_category=label_id_to_category,
-                image_width=sample.width,
-                image_height=sample.height,
-            )
-            if obj is not None:
-                objects.append(obj)
+                obj = _annotation_to_single_inst_seg(
+                    annotation=annotation,
+                    label_id_to_category=label_id_to_category,
+                    image_width=sample.width,
+                    image_height=sample.height,
+                )
+                if obj is not None:
+                    objects.append(obj)
 
         return ImageInstanceSegmentation(
             image=_sample_to_image(

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -17,7 +17,12 @@ from lightly_studio.models.annotation.annotation_base import (
 )
 from lightly_studio.models.annotation.object_track import ObjectTrackCreate
 from lightly_studio.models.collection import SampleType
-from lightly_studio.resolvers import annotation_resolver, object_track_resolver, tag_resolver
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    collection_resolver,
+    object_track_resolver,
+    tag_resolver,
+)
 from tests.helpers_resolvers import (
     ImageStub,
     create_annotation_label,
@@ -61,9 +66,17 @@ def test_export_collection_annotations(
             )
         ],
     )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
 
     # Call the API.
-    response = test_client.get(f"/api/collections/{collection.collection_id}/export/annotations")
+    response = test_client.get(
+        f"/api/collections/{collection.collection_id}/export/annotations",
+        params={"annotation_collection_id": str(annotation_collection_id)},
+    )
 
     # Check the response.
     assert response.status_code == HTTP_STATUS_OK
@@ -110,10 +123,18 @@ def test_export_collection_segmentation_masks(
             )
         ],
     )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
 
     response = test_client.get(
         f"/api/collections/{collection.collection_id}/export/annotations",
-        params={"export_format": "segmentation_mask_coco"},
+        params={
+            "export_format": "segmentation_mask_coco",
+            "annotation_collection_id": str(annotation_collection_id),
+        },
     )
 
     assert response.status_code == HTTP_STATUS_OK
@@ -169,10 +190,18 @@ def test_export_collection_pascalvoc_from_segmentation_masks(
             )
         ],
     )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
 
     response = test_client.get(
         f"/api/collections/{collection.collection_id}/export/annotations",
-        params={"export_format": "pascal_voc"},
+        params={
+            "export_format": "pascal_voc",
+            "annotation_collection_id": str(annotation_collection_id),
+        },
     )
 
     assert response.status_code == HTTP_STATUS_OK

--- a/lightly_studio/tests/export/test_image_dataset_export.py
+++ b/lightly_studio/tests/export/test_image_dataset_export.py
@@ -16,14 +16,13 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
     AnnotationType,
 )
-from lightly_studio.models.collection import CollectionTable, SampleType
-from lightly_studio.resolvers import annotation_resolver, collection_resolver
+from lightly_studio.models.collection import CollectionTable
+from lightly_studio.resolvers import annotation_resolver
 from tests.helpers_resolvers import (
     ImageStub,
     create_annotation_label,
     create_caption,
     create_collection,
-    create_image,
     create_images,
 )
 
@@ -674,81 +673,4 @@ def test_to_coco_captions(
         "annotations": [
             {"id": 0, "image_id": 0, "caption": "caption one"},
         ],
-    }
-
-
-def test_to_coco_object_detections__annotation_collection_id(
-    db_session: Session,
-    tmp_path: Path,
-) -> None:
-    """Only annotations from the specified annotation collection are exported."""
-    collection = create_collection(session=db_session)
-    image = create_image(
-        session=db_session,
-        collection_id=collection.collection_id,
-        file_path_abs="img1",
-        width=100,
-        height=100,
-    )
-    dog_label = create_annotation_label(
-        session=db_session, root_collection_id=collection.collection_id, label_name="dog"
-    )
-    cat_label = create_annotation_label(
-        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
-    )
-    annotation_resolver.create_many(
-        session=db_session,
-        parent_collection_id=collection.collection_id,
-        collection_name="source_1",
-        annotations=[
-            AnnotationCreate(
-                parent_sample_id=image.sample_id,
-                annotation_label_id=dog_label.annotation_label_id,
-                annotation_type=AnnotationType.OBJECT_DETECTION,
-                x=10,
-                y=10,
-                width=10,
-                height=10,
-            )
-        ],
-    )
-    annotation_resolver.create_many(
-        session=db_session,
-        parent_collection_id=collection.collection_id,
-        collection_name="source_2",
-        annotations=[
-            AnnotationCreate(
-                parent_sample_id=image.sample_id,
-                annotation_label_id=cat_label.annotation_label_id,
-                annotation_type=AnnotationType.OBJECT_DETECTION,
-                x=20,
-                y=20,
-                width=20,
-                height=20,
-            )
-        ],
-    )
-    source_1_id = collection_resolver.get_or_create_child_collection(
-        session=db_session,
-        collection_id=collection.collection_id,
-        sample_type=SampleType.ANNOTATION,
-        name="source_1",
-    )
-
-    output_json = tmp_path / "export.json"
-    image_dataset_export.to_coco_object_detections(
-        session=db_session,
-        dataset_id=collection.dataset_id,
-        samples=DatasetQuery(dataset=collection, session=db_session),
-        output_json=output_json,
-        annotation_collection_id=source_1_id,
-    )
-
-    with open(output_json) as f:
-        coco_data = json.load(f)
-    # cat=id_0, dog=id_1 (alphabetical); only source_1's dog annotation is exported
-    assert coco_data == {
-        "images": [{"id": 0, "file_name": "img1", "width": 100, "height": 100}],
-        "categories": [{"id": 0, "name": "cat"}, {"id": 1, "name": "dog"}],
-        "annotations": [{"image_id": 0, "category_id": 1, "bbox": [10.0, 10.0, 10.0, 10.0]}],
     }

--- a/lightly_studio/tests/export/test_image_dataset_export.py
+++ b/lightly_studio/tests/export/test_image_dataset_export.py
@@ -16,13 +16,14 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
     AnnotationType,
 )
-from lightly_studio.models.collection import CollectionTable
-from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.models.collection import CollectionTable, SampleType
+from lightly_studio.resolvers import annotation_resolver, collection_resolver
 from tests.helpers_resolvers import (
     ImageStub,
     create_annotation_label,
     create_caption,
     create_collection,
+    create_image,
     create_images,
 )
 
@@ -123,6 +124,7 @@ class TestImageDatasetExport:
             dataset_id=dataset.dataset_id,
             samples=mocker.ANY,
             output_json=Path("coco_export.json"),
+            annotation_collection_id=None,
         )
 
     def test_to_coco_captions(
@@ -672,4 +674,81 @@ def test_to_coco_captions(
         "annotations": [
             {"id": 0, "image_id": 0, "caption": "caption one"},
         ],
+    }
+
+
+def test_to_coco_object_detections__annotation_collection_id(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    """Only annotations from the specified annotation collection are exported."""
+    collection = create_collection(session=db_session)
+    image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="img1",
+        width=100,
+        height=100,
+    )
+    dog_label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="dog"
+    )
+    cat_label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    annotation_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        collection_name="source_1",
+        annotations=[
+            AnnotationCreate(
+                parent_sample_id=image.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+                x=10,
+                y=10,
+                width=10,
+                height=10,
+            )
+        ],
+    )
+    annotation_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        collection_name="source_2",
+        annotations=[
+            AnnotationCreate(
+                parent_sample_id=image.sample_id,
+                annotation_label_id=cat_label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+                x=20,
+                y=20,
+                width=20,
+                height=20,
+            )
+        ],
+    )
+    source_1_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+        name="source_1",
+    )
+
+    output_json = tmp_path / "export.json"
+    image_dataset_export.to_coco_object_detections(
+        session=db_session,
+        dataset_id=collection.dataset_id,
+        samples=DatasetQuery(dataset=collection, session=db_session),
+        output_json=output_json,
+        annotation_collection_id=source_1_id,
+    )
+
+    with open(output_json) as f:
+        coco_data = json.load(f)
+    # cat=id_0, dog=id_1 (alphabetical); only source_1's dog annotation is exported
+    assert coco_data == {
+        "images": [{"id": 0, "file_name": "img1", "width": 100, "height": 100}],
+        "categories": [{"id": 0, "name": "cat"}, {"id": 1, "name": "dog"}],
+        "annotations": [{"image_id": 0, "category_id": 1, "bbox": [10.0, 10.0, 10.0, 10.0]}],
     }

--- a/lightly_studio/tests/export/test_image_dataset_export.py
+++ b/lightly_studio/tests/export/test_image_dataset_export.py
@@ -347,6 +347,7 @@ class TestImageDatasetExport:
             dataset_id=dataset.dataset_id,
             samples=dataset.query(),
             output_folder=output_folder,
+            annotation_collection_id=None,
         )
 
         class_map_path = output_folder / "class_id_to_name.json"
@@ -403,6 +404,7 @@ class TestImageDatasetExport:
             dataset_id=dataset.dataset_id,
             samples=dataset.query(),
             output_folder=output_folder,
+            annotation_collection_id=None,
         )
 
         class_map_path = output_folder / "class_id_to_name.json"
@@ -451,6 +453,7 @@ class TestImageDatasetExport:
             dataset_id=dataset.dataset_id,
             samples=dataset.query(),
             output_folder=output_folder,
+            annotation_collection_id=None,
         )
 
         class_map_path = output_folder / "class_id_to_name.json"
@@ -498,6 +501,7 @@ class TestImageDatasetExport:
             dataset_id=dataset.dataset_id,
             samples=dataset.query(),
             output_folder=output_folder,
+            annotation_collection_id=None,
         )
 
         class_map_path = output_folder / "class_id_to_name.json"
@@ -549,6 +553,7 @@ class TestImageDatasetExport:
             dataset_id=dataset.dataset_id,
             samples=dataset.query(),
             output_folder=output_folder,
+            annotation_collection_id=None,
         )
 
         class_map_path = output_folder / "class_id_to_name.json"
@@ -582,6 +587,7 @@ def test_to_coco_object_detections(
         dataset_id=dataset.dataset_id,
         samples=DatasetQuery(dataset=dataset, session=db_session),
         output_json=output_json,
+        annotation_collection_id=None,
     )
 
     # Load the generated JSON and verify its content
@@ -624,6 +630,7 @@ def test_to_coco_object_detections__no_annotations(
         dataset_id=dataset.dataset_id,
         samples=DatasetQuery(dataset=dataset, session=db_session),
         output_json=output_json,
+        annotation_collection_id=None,
     )
 
     # Load the generated JSON and verify its content

--- a/lightly_studio/tests/export/test_lightly_studio_label_input.py
+++ b/lightly_studio/tests/export/test_lightly_studio_label_input.py
@@ -40,6 +40,7 @@ class TestLightlyStudioLabelInput:
             session=db_session,
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=None,
         )
         assert list(label_input.get_categories()) == [
             Category(id=0, name="cat"),
@@ -58,6 +59,7 @@ class TestLightlyStudioLabelInput:
             session=db_session,
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=None,
         )
         assert list(label_input.get_categories()) == [
             Category(id=1, name="cat"),
@@ -79,6 +81,7 @@ class TestLightlyStudioLabelInput:
             session=db_session,
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=None,
         )
         assert list(label_input.get_categories()) == []
 
@@ -91,6 +94,7 @@ class TestLightlyStudioLabelInput:
             session=db_session,
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=None,
         )
         assert list(label_input.get_images()) == [
             Image(id=0, filename="img1", width=100, height=100),
@@ -104,6 +108,7 @@ class TestLightlyStudioLabelInput:
             session=db_session,
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=None,
         )
         assert list(label_input.get_images()) == []
 
@@ -116,6 +121,7 @@ class TestLightlyStudioLabelInput:
             session=db_session,
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=None,
         )
         labels = list(label_input.get_labels())
 
@@ -164,6 +170,7 @@ class TestLightlyStudioLabelInput:
             session=db_session,
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=None,
         )
         labels = list(label_input.get_labels())
 
@@ -312,6 +319,7 @@ class TestLightlyStudioLabelInput:
             session=db_session,
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=None,
         )
         labels = list(label_input.get_labels())
 

--- a/lightly_studio/tests/export/test_lightly_studio_label_input.py
+++ b/lightly_studio/tests/export/test_lightly_studio_label_input.py
@@ -17,12 +17,13 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
     AnnotationType,
 )
-from lightly_studio.models.collection import CollectionTable
-from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.models.collection import CollectionTable, SampleType
+from lightly_studio.resolvers import annotation_resolver, collection_resolver
 from tests.helpers_resolvers import (
     ImageStub,
     create_annotation_label,
     create_collection,
+    create_image,
     create_images,
 )
 
@@ -176,6 +177,106 @@ class TestLightlyStudioLabelInput:
             image=Image(id=1, filename="img2", width=200, height=200),
             objects=[],
         )
+
+    def test_get_labels__annotation_collection_id(self, db_session: Session) -> None:
+        """Only annotations from the specified collection are exported."""
+        collection = create_collection(session=db_session)
+        image = create_image(
+            session=db_session,
+            collection_id=collection.collection_id,
+            file_path_abs="img1",
+            width=100,
+            height=100,
+        )
+        dog_label = create_annotation_label(
+            session=db_session, root_collection_id=collection.collection_id, label_name="dog"
+        )
+        cat_label = create_annotation_label(
+            session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+        )
+        annotation_resolver.create_many(
+            session=db_session,
+            parent_collection_id=collection.collection_id,
+            collection_name="source_1",
+            annotations=[
+                AnnotationCreate(
+                    parent_sample_id=image.sample_id,
+                    annotation_label_id=dog_label.annotation_label_id,
+                    annotation_type=AnnotationType.OBJECT_DETECTION,
+                    x=10,
+                    y=10,
+                    width=10,
+                    height=10,
+                )
+            ],
+        )
+        annotation_resolver.create_many(
+            session=db_session,
+            parent_collection_id=collection.collection_id,
+            collection_name="source_2",
+            annotations=[
+                AnnotationCreate(
+                    parent_sample_id=image.sample_id,
+                    annotation_label_id=cat_label.annotation_label_id,
+                    annotation_type=AnnotationType.OBJECT_DETECTION,
+                    x=20,
+                    y=20,
+                    width=20,
+                    height=20,
+                )
+            ],
+        )
+        source_1_id = collection_resolver.get_or_create_child_collection(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_type=SampleType.ANNOTATION,
+            name="source_1",
+        )
+        source_2_id = collection_resolver.get_or_create_child_collection(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_type=SampleType.ANNOTATION,
+            name="source_2",
+        )
+
+        # cat=id_0, dog=id_1 (categories are sorted alphabetically)
+        label_input_source_1 = LightlyStudioObjectDetectionInput(
+            session=db_session,
+            dataset_id=collection.dataset_id,
+            samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=source_1_id,
+        )
+        assert list(label_input_source_1.get_labels()) == [
+            ImageObjectDetection(
+                image=Image(id=0, filename="img1", width=100, height=100),
+                objects=[
+                    SingleObjectDetection(
+                        category=Category(id=1, name="dog"),
+                        box=BoundingBox(xmin=10, ymin=10, xmax=20, ymax=20),
+                        confidence=None,
+                    )
+                ],
+            )
+        ]
+
+        label_input_source_2 = LightlyStudioObjectDetectionInput(
+            session=db_session,
+            dataset_id=collection.dataset_id,
+            samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=source_2_id,
+        )
+        assert list(label_input_source_2.get_labels()) == [
+            ImageObjectDetection(
+                image=Image(id=0, filename="img1", width=100, height=100),
+                objects=[
+                    SingleObjectDetection(
+                        category=Category(id=0, name="cat"),
+                        box=BoundingBox(xmin=20, ymin=20, xmax=40, ymax=40),
+                        confidence=None,
+                    )
+                ],
+            )
+        ]
 
     def test_get_labels__segmentation_mask(self, db_session: Session) -> None:
         """We currently export only object detection annotations, not segmentation mask."""

--- a/lightly_studio/tests/export/test_lightly_studio_label_input.py
+++ b/lightly_studio/tests/export/test_lightly_studio_label_input.py
@@ -21,6 +21,7 @@ from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.resolvers import annotation_resolver, collection_resolver
 from tests.helpers_resolvers import (
     ImageStub,
+    create_annotation,
     create_annotation_label,
     create_collection,
     create_image,
@@ -201,37 +202,21 @@ class TestLightlyStudioLabelInput:
         cat_label = create_annotation_label(
             session=db_session, root_collection_id=collection.collection_id, label_name="cat"
         )
-        annotation_resolver.create_many(
+        create_annotation(
             session=db_session,
-            parent_collection_id=collection.collection_id,
-            collection_name="source_1",
-            annotations=[
-                AnnotationCreate(
-                    parent_sample_id=image.sample_id,
-                    annotation_label_id=dog_label.annotation_label_id,
-                    annotation_type=AnnotationType.OBJECT_DETECTION,
-                    x=10,
-                    y=10,
-                    width=10,
-                    height=10,
-                )
-            ],
+            collection_id=collection.collection_id,
+            sample_id=image.sample_id,
+            annotation_label_id=dog_label.annotation_label_id,
+            annotation_collection_name="source_1",
+            annotation_data={"x": 10, "y": 10, "width": 10, "height": 10},
         )
-        annotation_resolver.create_many(
+        create_annotation(
             session=db_session,
-            parent_collection_id=collection.collection_id,
-            collection_name="source_2",
-            annotations=[
-                AnnotationCreate(
-                    parent_sample_id=image.sample_id,
-                    annotation_label_id=cat_label.annotation_label_id,
-                    annotation_type=AnnotationType.OBJECT_DETECTION,
-                    x=20,
-                    y=20,
-                    width=20,
-                    height=20,
-                )
-            ],
+            collection_id=collection.collection_id,
+            sample_id=image.sample_id,
+            annotation_label_id=cat_label.annotation_label_id,
+            annotation_collection_name="source_2",
+            annotation_data={"x": 20, "y": 20, "width": 20, "height": 20},
         )
         source_1_id = collection_resolver.get_or_create_child_collection(
             session=db_session,
@@ -283,6 +268,65 @@ class TestLightlyStudioLabelInput:
                     )
                 ],
             )
+        ]
+
+    def test_get_labels__annotation_collection_id_none_with_multiple_sources(
+        self, db_session: Session
+    ) -> None:
+        """Annotations from all collections are exported when annotation_collection_id is None."""
+        collection = create_collection(session=db_session)
+        image = create_image(
+            session=db_session,
+            collection_id=collection.collection_id,
+            file_path_abs="img1",
+            width=100,
+            height=100,
+        )
+        dog_label = create_annotation_label(
+            session=db_session, root_collection_id=collection.collection_id, label_name="dog"
+        )
+        cat_label = create_annotation_label(
+            session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+        )
+        create_annotation(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_id=image.sample_id,
+            annotation_label_id=dog_label.annotation_label_id,
+            annotation_collection_name="source_1",
+            annotation_data={"x": 10, "y": 10, "width": 10, "height": 10},
+        )
+        create_annotation(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_id=image.sample_id,
+            annotation_label_id=cat_label.annotation_label_id,
+            annotation_collection_name="source_2",
+            annotation_data={"x": 20, "y": 20, "width": 20, "height": 20},
+        )
+
+        # cat=id_0, dog=id_1 (categories are sorted alphabetically)
+        label_input = LightlyStudioObjectDetectionInput(
+            session=db_session,
+            dataset_id=collection.dataset_id,
+            samples=DatasetQuery(dataset=collection, session=db_session),
+            annotation_collection_id=None,
+        )
+        labels = list(label_input.get_labels())
+        assert len(labels) == 1
+        assert labels[0].image == Image(id=0, filename="img1", width=100, height=100)
+        # cat=id_0, dog=id_1 (categories are sorted alphabetically)
+        assert sorted(labels[0].objects, key=lambda o: o.category.name) == [
+            SingleObjectDetection(
+                category=Category(id=0, name="cat"),
+                box=BoundingBox(xmin=20, ymin=20, xmax=40, ymax=40),
+                confidence=None,
+            ),
+            SingleObjectDetection(
+                category=Category(id=1, name="dog"),
+                box=BoundingBox(xmin=10, ymin=10, xmax=20, ymax=20),
+                confidence=None,
+            ),
         ]
 
     def test_get_labels__segmentation_mask(self, db_session: Session) -> None:

--- a/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte
@@ -11,13 +11,15 @@
         sourceOptions: SourceOption[];
         /** Currently selected source id. */
         selectedSource?: string;
+        /** Placeholder text shown in the trigger when nothing is selected. */
+        placeholder?: string;
         /** Optional notification when the selection changes (the value also flows out via `bind:selectedSource`). */
         onSelect?: (sourceId: string) => void;
         /** `id` forwarded to the trigger element so a `<label for>` can reference it. */
         id?: string;
     }
 
-    let { sourceOptions, selectedSource = $bindable(), onSelect, id }: Props = $props();
+    let { sourceOptions, selectedSource = $bindable(), placeholder = 'Select a source...', onSelect, id }: Props = $props();
 
     const items = $derived(
         sourceOptions.map((option) => ({
@@ -31,7 +33,7 @@
 <Select
     {items}
     value={selectedSource}
-    placeholder="Select a source..."
+    {placeholder}
     class="w-full"
     testId="annotation-source-trigger"
     selectProps={id ? { id } : undefined}

--- a/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte
@@ -19,7 +19,13 @@
         id?: string;
     }
 
-    let { sourceOptions, selectedSource = $bindable(), placeholder = 'Select a source...', onSelect, id }: Props = $props();
+    let {
+        sourceOptions,
+        selectedSource = $bindable(),
+        placeholder = 'Select a source...',
+        onSelect,
+        id
+    }: Props = $props();
 
     const items = $derived(
         sourceOptions.map((option) => ({

--- a/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationSourceSelect/AnnotationSourceSelect.test.ts
@@ -23,6 +23,14 @@ describe('AnnotationSourceSelect', () => {
         );
     });
 
+    it('shows a custom placeholder when provided', () => {
+        render(AnnotationSourceSelect, {
+            props: { ...defaultProps, placeholder: 'Pick a source' }
+        });
+
+        expect(screen.getByTestId('annotation-source-trigger')).toHaveTextContent('Pick a source');
+    });
+
     it('shows the currently selected source', () => {
         render(AnnotationSourceSelect, {
             props: { ...defaultProps, selectedSource: 'predictions-id' }

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -11,6 +11,8 @@
     } from '$lib/components/Select';
     import * as Tabs from '$lib/components/ui/tabs/index.js';
     import { useTags } from '$lib/hooks/useTags/useTags';
+    import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
+    import AnnotationSourceSelect from '$lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte';
     import { exportCollection } from '$lib/services/exportCollection';
     import type { ExportFilter } from '$lib/services/types';
     import { useExportSamplesCount } from './useExportSamplesCount/useExportSamplesCount';
@@ -52,6 +54,20 @@
     };
     const exportTypeTriggerContent = $derived(exportTypeLabels[exportType]);
     let collectionId = page.params.collection_id;
+
+    //
+    // Annotation source selection
+    //
+    const annotationCollectionsQuery = useAnnotationCollections(() => ({ collectionId }));
+    const annotationSources = $derived(
+        (annotationCollectionsQuery.data ?? []).map((c) => ({ id: c.collection_id, name: c.name }))
+    );
+    let selectedAnnotationCollectionId = $state<string | undefined>(undefined);
+    const annotationCollectionParam = $derived(
+        selectedAnnotationCollectionId
+            ? `&annotation_collection_id=${selectedAnnotationCollectionId}`
+            : ''
+    );
 
     //
     // Sample export
@@ -121,12 +137,16 @@
     //
     // Annotation export
     //
-    const exportAnnotationsURL = `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/annotations?ts=${Date.now()}&export_format=object_detection_coco`;
+    const exportAnnotationsURL = $derived(
+        `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/annotations?ts=${Date.now()}&export_format=object_detection_coco${annotationCollectionParam}`
+    );
 
     //
     // Segmentation mask export
     //
-    const exportSegmentationMaskURL = `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/annotations?ts=${Date.now()}&export_format=segmentation_mask_coco`;
+    const exportSegmentationMaskURL = $derived(
+        `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/annotations?ts=${Date.now()}&export_format=segmentation_mask_coco${annotationCollectionParam}`
+    );
 
     //
     // YouTube-VIS video Segmentation mask export
@@ -134,7 +154,9 @@
     const exportYoutubeVisSegmentationMaskURL = `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/youtube-vis?ts=${Date.now()}&export_format=youtube_vis_segmentation`;
     // Semantic segmentation export
     //
-    const exportPascalVocURL = `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/annotations?ts=${Date.now()}&export_format=pascal_voc`;
+    const exportPascalVocURL = $derived(
+        `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/annotations?ts=${Date.now()}&export_format=pascal_voc${annotationCollectionParam}`
+    );
 
     //
     // Caption export
@@ -314,6 +336,17 @@
                             The object detection annotations will be exported in COCO format.
                         </p>
 
+                        {#if annotationSources.length > 1}
+                            <div class="mt-3">
+                                <FormField label="Annotation Source">
+                                    <AnnotationSourceSelect
+                                        sourceOptions={annotationSources}
+                                        bind:selectedSource={selectedAnnotationCollectionId}
+                                    />
+                                </FormField>
+                            </div>
+                        {/if}
+
                         <Button
                             class="relative my-4 w-full"
                             href={exportAnnotationsURL}
@@ -328,6 +361,17 @@
                         <p class="text-sm text-muted-foreground">
                             The segmentation masks will be exported in COCO format.
                         </p>
+
+                        {#if annotationSources.length > 1}
+                            <div class="mt-3">
+                                <FormField label="Annotation Source">
+                                    <AnnotationSourceSelect
+                                        sourceOptions={annotationSources}
+                                        bind:selectedSource={selectedAnnotationCollectionId}
+                                    />
+                                </FormField>
+                            </div>
+                        {/if}
 
                         <Button
                             class="relative my-4 w-full"
@@ -359,6 +403,17 @@
                         <p class="text-sm text-muted-foreground">
                             The semantic segmentations will be exported in PASCAL VOC format.
                         </p>
+
+                        {#if annotationSources.length > 1}
+                            <div class="mt-3">
+                                <FormField label="Annotation Source">
+                                    <AnnotationSourceSelect
+                                        sourceOptions={annotationSources}
+                                        bind:selectedSource={selectedAnnotationCollectionId}
+                                    />
+                                </FormField>
+                            </div>
+                        {/if}
 
                         <Button
                             class="relative my-4 w-full"

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -64,11 +64,6 @@
     );
     let selectedAnnotationCollectionId = $state<string | undefined>(undefined);
 
-    $effect(() => {
-        if (annotationSources.length > 1 && selectedAnnotationCollectionId === undefined) {
-            selectedAnnotationCollectionId = annotationSources[0].id;
-        }
-    });
     const annotationCollectionParam = $derived(
         selectedAnnotationCollectionId
             ? `&annotation_collection_id=${selectedAnnotationCollectionId}`
@@ -343,13 +338,16 @@
                         </p>
 
                         {#if annotationSources.length > 1}
-                            <div class="mt-3">
+                            <div class="mt-6">
                                 <FormField label="Annotation Source">
                                     <AnnotationSourceSelect
                                         sourceOptions={annotationSources}
                                         bind:selectedSource={selectedAnnotationCollectionId}
                                     />
                                 </FormField>
+                                <p class="text-sm text-muted-foreground">
+                                    Select the annotation collection to export from.
+                                </p>
                             </div>
                         {/if}
 
@@ -369,13 +367,16 @@
                         </p>
 
                         {#if annotationSources.length > 1}
-                            <div class="mt-3">
+                            <div class="mt-6">
                                 <FormField label="Annotation Source">
                                     <AnnotationSourceSelect
                                         sourceOptions={annotationSources}
                                         bind:selectedSource={selectedAnnotationCollectionId}
                                     />
                                 </FormField>
+                                <p class="mt-2 text-sm text-muted-foreground">
+                                    Select the annotation collection to export from.
+                                </p>
                             </div>
                         {/if}
 
@@ -411,13 +412,16 @@
                         </p>
 
                         {#if annotationSources.length > 1}
-                            <div class="mt-3">
+                            <div class="mt-6">
                                 <FormField label="Annotation Source">
                                     <AnnotationSourceSelect
                                         sourceOptions={annotationSources}
                                         bind:selectedSource={selectedAnnotationCollectionId}
                                     />
                                 </FormField>
+                                <p class="text-sm text-muted-foreground">
+                                    Select the annotation collection to export from.
+                                </p>
                             </div>
                         {/if}
 

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -64,9 +64,12 @@
     );
     let selectedAnnotationCollectionId = $state<string | undefined>(undefined);
 
+    const effectiveAnnotationCollectionId = $derived(
+        selectedAnnotationCollectionId ?? annotationSources[0]?.id
+    );
     const annotationCollectionParam = $derived(
-        selectedAnnotationCollectionId
-            ? `&annotation_collection_id=${selectedAnnotationCollectionId}`
+        effectiveAnnotationCollectionId
+            ? `&annotation_collection_id=${effectiveAnnotationCollectionId}`
             : ''
     );
 

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -63,6 +63,12 @@
         (annotationCollectionsQuery.data ?? []).map((c) => ({ id: c.collection_id, name: c.name }))
     );
     let selectedAnnotationCollectionId = $state<string | undefined>(undefined);
+
+    $effect(() => {
+        if (annotationSources.length > 1 && selectedAnnotationCollectionId === undefined) {
+            selectedAnnotationCollectionId = annotationSources[0].id;
+        }
+    });
     const annotationCollectionParam = $derived(
         selectedAnnotationCollectionId
             ? `&annotation_collection_id=${selectedAnnotationCollectionId}`

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -342,12 +342,10 @@
                                 <FormField label="Annotation Source">
                                     <AnnotationSourceSelect
                                         sourceOptions={annotationSources}
+                                        placeholder="Only annotations from the selected source will be exported"
                                         bind:selectedSource={selectedAnnotationCollectionId}
                                     />
                                 </FormField>
-                                <p class="text-sm text-muted-foreground">
-                                    Select the annotation collection to export from.
-                                </p>
                             </div>
                         {/if}
 
@@ -371,6 +369,7 @@
                                 <FormField label="Annotation Source">
                                     <AnnotationSourceSelect
                                         sourceOptions={annotationSources}
+                                        placeholder="Select an annotation collection to export from (required)"
                                         bind:selectedSource={selectedAnnotationCollectionId}
                                     />
                                 </FormField>
@@ -416,6 +415,7 @@
                                 <FormField label="Annotation Source">
                                     <AnnotationSourceSelect
                                         sourceOptions={annotationSources}
+                                        placeholder="Select an annotation collection to export from (required)"
                                         bind:selectedSource={selectedAnnotationCollectionId}
                                     />
                                 </FormField>

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -376,9 +376,6 @@
                                         bind:selectedSource={selectedAnnotationCollectionId}
                                     />
                                 </FormField>
-                                <p class="mt-2 text-sm text-muted-foreground">
-                                    Select the annotation collection to export from.
-                                </p>
                             </div>
                         {/if}
 
@@ -422,9 +419,6 @@
                                         bind:selectedSource={selectedAnnotationCollectionId}
                                     />
                                 </FormField>
-                                <p class="text-sm text-muted-foreground">
-                                    Select the annotation collection to export from.
-                                </p>
                             </div>
                         {/if}
 


### PR DESCRIPTION
## What has changed and why?

Add annotation source selection (if multiple are available) to the export dialog for Image Object detection and segmentation masks.

## How has it been tested?

Manual tests and updated unit tests.
<img width="548" height="387" alt="image" src="https://github.com/user-attachments/assets/9938ddeb-66d2-4332-97ee-4244e2106204" />
<img width="516" height="369" alt="image" src="https://github.com/user-attachments/assets/b351323a-f61e-4f39-a0c2-96e5697423a1" />
<img width="505" height="358" alt="image" src="https://github.com/user-attachments/assets/852417e7-0117-4998-ab0e-018239d019cb" />

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export dialogs now include an annotation-source dropdown (when multiple sources exist) for object detections, COCO segmentation masks, and Pascal VOC semantic segmentations.
  * The export API and Python export helpers now support selecting an annotation source via an optional `annotation_collection_id` parameter.
* **Bug Fixes**
  * Exported labels/annotations are now filtered consistently to the selected annotation source across supported annotation-based formats (object detection, COCO segmentation, Pascal VOC).
  * Updated exports to include the selected `annotation_collection_id` in generated export URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->