### PR TITLE
Plot selection excludes the hidden bucket

### DIFF
--- a/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
@@ -89,7 +89,6 @@ describe('getCategoryBySelection', () => {
 
         const reducer = getCategoryBySelection(mockSelection, mockData);
 
-        // A hidden point inside the lasso keeps category 0; usePlotData never collects it.
         expect(reducer(0, 0)).toBe(0);
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
@@ -83,24 +83,6 @@ describe('getCategoryBySelection', () => {
         expect(isPointInPolygon).toHaveBeenCalledWith(3.0, 7.0, mockSelection);
     });
 
-    it('keeps an in-polygon HIDDEN_CATEGORY (0) point as HIDDEN so it stays unselectable', () => {
-        const mockData = createMockArrowData();
-        vi.mocked(isPointInPolygon).mockReturnValue(true);
-
-        const reducer = getCategoryBySelection(mockSelection, mockData);
-
-        expect(reducer(0, 0)).toBe(0);
-    });
-
-    it('demotes an out-of-polygon HIDDEN_CATEGORY (0) point to EXCLUDED (1)', () => {
-        const mockData = createMockArrowData();
-        vi.mocked(isPointInPolygon).mockReturnValue(false);
-
-        const reducer = getCategoryBySelection(mockSelection, mockData);
-
-        expect(reducer(0, 0)).toBe(1);
-    });
-
     it('should work correctly with array reduce for multiple points', () => {
         const mockData = createMockArrowData();
         // Mock: first two points are in selection, last two are not

--- a/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.test.ts
@@ -83,6 +83,25 @@ describe('getCategoryBySelection', () => {
         expect(isPointInPolygon).toHaveBeenCalledWith(3.0, 7.0, mockSelection);
     });
 
+    it('keeps an in-polygon HIDDEN_CATEGORY (0) point as HIDDEN so it stays unselectable', () => {
+        const mockData = createMockArrowData();
+        vi.mocked(isPointInPolygon).mockReturnValue(true);
+
+        const reducer = getCategoryBySelection(mockSelection, mockData);
+
+        // A hidden point inside the lasso keeps category 0; usePlotData never collects it.
+        expect(reducer(0, 0)).toBe(0);
+    });
+
+    it('demotes an out-of-polygon HIDDEN_CATEGORY (0) point to EXCLUDED (1)', () => {
+        const mockData = createMockArrowData();
+        vi.mocked(isPointInPolygon).mockReturnValue(false);
+
+        const reducer = getCategoryBySelection(mockSelection, mockData);
+
+        expect(reducer(0, 0)).toBe(1);
+    });
+
     it('should work correctly with array reduce for multiple points', () => {
         const mockData = createMockArrowData();
         // Mock: first two points are in selection, last two are not

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
@@ -29,4 +29,24 @@ describe('resolveVisibleCategory', () => {
     it('ignores the filter when resolving a hidden fallback', () => {
         expect(resolveVisibleCategory([3, 4, 5], 1, new Set([3, 4]))).toBe(5);
     });
+
+    it('routes to HIDDEN_CATEGORY (0) when filtered out and EXCLUDED is hidden', () => {
+        expect(resolveVisibleCategory([3, 4], 0, new Set([1]))).toBe(0);
+    });
+
+    it('routes to HIDDEN_CATEGORY (0) when the point has no categories and INCLUDED is hidden', () => {
+        expect(resolveVisibleCategory([], 1, new Set([2]))).toBe(0);
+    });
+
+    it('routes to HIDDEN_CATEGORY (0) when all colored categories and INCLUDED are hidden', () => {
+        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 4, 2]))).toBe(0);
+    });
+
+    it('falls back to a visible colored category even when INCLUDED is hidden', () => {
+        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 2]))).toBe(4);
+    });
+
+    it('still returns EXCLUDED (1) when filtered out and EXCLUDED is visible', () => {
+        expect(resolveVisibleCategory([3], 0, new Set([2]))).toBe(1);
+    });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
@@ -45,8 +45,4 @@ describe('resolveVisibleCategory', () => {
     it('falls back to a visible colored category even when INCLUDED is hidden', () => {
         expect(resolveVisibleCategory([3, 4], 1, new Set([3, 2]))).toBe(4);
     });
-
-    it('still returns EXCLUDED (1) when filtered out and EXCLUDED is visible', () => {
-        expect(resolveVisibleCategory([3], 0, new Set([2]))).toBe(1);
-    });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
@@ -6,15 +6,11 @@ import {
 
 /**
  * Resolves the category a point is displayed as, given every category it belongs to in
- * priority order. Hidden categories are skipped so a multi-category point falls back to
- * its next visible category. When the reserved non-categorical row a point would resolve
- * to is itself hidden, the point is routed to HIDDEN_CATEGORY (transparent, not rendered,
- * not selectable):
- * - point does not fulfil the filter -> EXCLUDED_BY_FILTERS_CATEGORY,
- *   or HIDDEN_CATEGORY if that row is hidden
- * - otherwise the first category that is not hidden
- * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY (no category),
- *   or HIDDEN_CATEGORY if that row is hidden
+ * priority order. A multi-category point falls back to its next visible category, and a
+ * point whose resolved category is hidden routes to HIDDEN_CATEGORY (not rendered):
+ * - filtered out -> EXCLUDED_BY_FILTERS_CATEGORY
+ * - otherwise the first non-hidden category
+ * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY
  *
  * @param colorCategories - All categories the point belongs to, in priority order
  * @param fulfilsFilter - Whether the point passes the active filter (0 = filtered out)

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
@@ -1,12 +1,20 @@
-import { EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY } from '../plotCategories';
+import {
+    EXCLUDED_BY_FILTERS_CATEGORY,
+    HIDDEN_CATEGORY,
+    INCLUDED_BY_FILTERS_CATEGORY
+} from '../plotCategories';
 
 /**
  * Resolves the category a point is displayed as, given every category it belongs to in
  * priority order. Hidden categories are skipped so a multi-category point falls back to
- * its next visible category:
- * - point does not fulfil the filter -> EXCLUDED_BY_FILTERS_CATEGORY
+ * its next visible category. When the reserved non-categorical row a point would resolve
+ * to is itself hidden, the point is routed to HIDDEN_CATEGORY (transparent, not rendered,
+ * not selectable):
+ * - point does not fulfil the filter -> EXCLUDED_BY_FILTERS_CATEGORY,
+ *   or HIDDEN_CATEGORY if that row is hidden
  * - otherwise the first category that is not hidden
- * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY (no category)
+ * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY (no category),
+ *   or HIDDEN_CATEGORY if that row is hidden
  *
  * @param colorCategories - All categories the point belongs to, in priority order
  * @param fulfilsFilter - Whether the point passes the active filter (0 = filtered out)
@@ -18,7 +26,9 @@ export const resolveVisibleCategory = (
     hiddenCategories: ReadonlySet<number>
 ): number => {
     if (fulfilsFilter === 0) {
-        return EXCLUDED_BY_FILTERS_CATEGORY;
+        return hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)
+            ? HIDDEN_CATEGORY
+            : EXCLUDED_BY_FILTERS_CATEGORY;
     }
 
     for (const category of colorCategories) {
@@ -27,5 +37,7 @@ export const resolveVisibleCategory = (
         }
     }
 
-    return INCLUDED_BY_FILTERS_CATEGORY;
+    return hiddenCategories.has(INCLUDED_BY_FILTERS_CATEGORY)
+        ? HIDDEN_CATEGORY
+        : INCLUDED_BY_FILTERS_CATEGORY;
 };

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -205,10 +205,8 @@ describe('usePlotData', () => {
         });
 
         const data = get(result.data) as { category: Uint8Array };
-        // sample1 is HIDDEN (0) and in-polygon -> stays 0; sample2 keeps its color 3;
-        // sample3/sample4 are outside the polygon -> demoted to EXCLUDED 1.
+        // sample1 hidden+in-lasso stays 0; sample2 keeps color 3; out-of-lasso 3/4 -> EXCLUDED 1.
         expect(Array.from(data.category)).toEqual([0, 3, 1, 1]);
-        // The hidden in-lasso sample1 is excluded; only the visible sample2 is selected.
         expect(get(result.selectedSampleIds)).toEqual(['sample2']);
     });
 
@@ -224,9 +222,8 @@ describe('usePlotData', () => {
         });
 
         const data = get(result.data) as { category: Uint8Array };
-        // sample1 is HIDDEN (0): even though highlighted it stays 0, never selected;
-        // sample2 is highlighted -> keeps color 3; sample3 is HIDDEN -> stays 0;
-        // sample4 is not highlighted -> demoted to EXCLUDED 1.
+        // Highlighted-but-hidden sample1 stays 0; sample2 highlighted keeps 3; sample3 hidden
+        // stays 0; un-highlighted sample4 -> EXCLUDED 1.
         expect(Array.from(data.category)).toEqual([0, 3, 0, 1]);
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -187,6 +187,49 @@ describe('usePlotData', () => {
         expect(get(result.selectedSampleIds)).toEqual(['sample1', 'sample2']);
     });
 
+    it('does not select an in-lasso point routed to HIDDEN_CATEGORY', () => {
+        const mockData = createMockArrowData();
+        // sample1 and sample3 are filtered out; hiding EXCLUDED routes them to HIDDEN (0).
+        mockData.fulfils_filter = new Uint8Array([0, 1, 0, 1]);
+        const mockSelection: Point[] = [
+            { x: 0, y: 0 },
+            { x: 2, y: 0 },
+            { x: 2, y: 6 },
+            { x: 0, y: 6 }
+        ];
+
+        const result = usePlotData({
+            arrowData: mockData,
+            rangeSelection: mockSelection,
+            hiddenCategories: new Set([1])
+        });
+
+        const data = get(result.data) as { category: Uint8Array };
+        // sample1 is HIDDEN (0) and in-polygon -> stays 0; sample2 keeps its color 3;
+        // sample3/sample4 are outside the polygon -> demoted to EXCLUDED 1.
+        expect(Array.from(data.category)).toEqual([0, 3, 1, 1]);
+        // The hidden in-lasso sample1 is excluded; only the visible sample2 is selected.
+        expect(get(result.selectedSampleIds)).toEqual(['sample2']);
+    });
+
+    it('keeps highlighted-path HIDDEN points hidden rather than demoting them', () => {
+        const mockData = createMockArrowData();
+        mockData.fulfils_filter = new Uint8Array([0, 1, 0, 1]);
+
+        const result = usePlotData({
+            arrowData: mockData,
+            rangeSelection: null,
+            highlightedSampleIds: ['sample1', 'sample2'],
+            hiddenCategories: new Set([1])
+        });
+
+        const data = get(result.data) as { category: Uint8Array };
+        // sample1 is HIDDEN (0): even though highlighted it stays 0, never selected;
+        // sample2 is highlighted -> keeps color 3; sample3 is HIDDEN -> stays 0;
+        // sample4 is not highlighted -> demoted to EXCLUDED 1.
+        expect(Array.from(data.category)).toEqual([0, 3, 0, 1]);
+    });
+
     it('should preserve highlighted color categories and demote other samples', () => {
         const mockData = createMockArrowData();
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
@@ -4,9 +4,18 @@ import type { ComponentProps } from 'svelte';
 import type { ArrowData } from '../useArrowData/useArrowData';
 import { getCategoryBySelection } from '../getCategoryBySelection/getCategoryBySelection';
 import { resolveVisibleCategory } from '../resolveVisibleCategory/resolveVisibleCategory';
-import { EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY } from '../plotCategories';
+import {
+    EXCLUDED_BY_FILTERS_CATEGORY,
+    HIDDEN_CATEGORY,
+    INCLUDED_BY_FILTERS_CATEGORY
+} from '../plotCategories';
 
 type PlotColumn = 'x' | 'y' | 'category';
+
+// A point is never part of a selection when it is filtered out or hidden: both are routed
+// to non-selectable reserved categories and must not contribute sample ids.
+const isUnselectableCategory = (category: number): boolean =>
+    category === EXCLUDED_BY_FILTERS_CATEGORY || category === HIDDEN_CATEGORY;
 
 type UsePlotDataReturn = {
     data: ComponentProps<typeof EmbeddingView>['data'];
@@ -75,9 +84,9 @@ export function usePlotData({
         // Points inside the polygon keep their prevValue; points outside are demoted to EXCLUDED_BY_FILTERS_CATEGORY.
         category = category.map(getCategoryBySelection(rangeSelection, data));
 
-        // Collect selected sample ids: in-polygon included points are not EXCLUDED_BY_FILTERS_CATEGORY.
+        // Collect selected sample ids: in-polygon points that are neither filtered out nor hidden.
         const _ids = category.reduce<string[]>((acc, pointCategory, index) => {
-            if (pointCategory !== EXCLUDED_BY_FILTERS_CATEGORY) {
+            if (!isUnselectableCategory(pointCategory)) {
                 acc.push(sampleIds[index]);
             }
             return acc;
@@ -86,7 +95,7 @@ export function usePlotData({
     } else if (highlightedSampleIds.length > 0) {
         const highlightedSampleIdSet = new Set(highlightedSampleIds);
         category = category.map((pointCategory, index) => {
-            if (pointCategory === EXCLUDED_BY_FILTERS_CATEGORY) {
+            if (isUnselectableCategory(pointCategory)) {
                 return pointCategory;
             }
             return highlightedSampleIdSet.has(sampleIds[index])

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
@@ -12,8 +12,7 @@ import {
 
 type PlotColumn = 'x' | 'y' | 'category';
 
-// A point is never part of a selection when it is filtered out or hidden: both are routed
-// to non-selectable reserved categories and must not contribute sample ids.
+// Filtered-out and hidden points land in reserved categories and must never be selected.
 const isUnselectableCategory = (category: number): boolean =>
     category === EXCLUDED_BY_FILTERS_CATEGORY || category === HIDDEN_CATEGORY;
 
@@ -84,7 +83,7 @@ export function usePlotData({
         // Points inside the polygon keep their prevValue; points outside are demoted to EXCLUDED_BY_FILTERS_CATEGORY.
         category = category.map(getCategoryBySelection(rangeSelection, data));
 
-        // Collect selected sample ids: in-polygon points that are neither filtered out nor hidden.
+        // Collect the sample ids of the selectable in-polygon points.
         const _ids = category.reduce<string[]>((acc, pointCategory, index) => {
             if (!isUnselectableCategory(pointCategory)) {
                 acc.push(sampleIds[index]);


### PR DESCRIPTION
## What has changed and why?

Points routed to the reserved HIDDEN category are now excluded from plot selection, the same as filtered-out points.

No user-facing change yet — the reserved legend entries cannot be toggled off.

## How has it been tested?

Unit tests.

Will be also manually tested with the frontend change.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
