### PR TITLE
Change create_run_and_image to create_run

### DIFF
--- a/lightly_studio/tests/resolvers/annotations/test_annotations_update_annotation_label.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotations_update_annotation_label.py
@@ -20,6 +20,8 @@ from tests.conftest import AnnotationsTestData, assert_contains_properties
 from tests.helpers_resolvers import (
     create_annotation,
     create_annotation_label,
+    create_collection,
+    create_image,
     get_annotation_by_type,
 )
 from tests.resolvers.evaluation_sample_metric_resolver import (
@@ -209,8 +211,13 @@ def test_update_annotation_label__deletes_evaluation_metrics(
     db_session: Session,
 ) -> None:
     """Test label updates remove invalidated evaluation annotation and sample metrics."""
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(session=db_session)
-    collection_id = image.sample.collection_id
+    dataset = create_collection(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(
+        session=db_session,
+        dataset_collection_id=dataset.collection_id,
+    )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
+    collection_id = dataset.collection_id
     old_label = create_annotation_label(
         session=db_session,
         root_collection_id=collection_id,

--- a/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
+++ b/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
@@ -10,7 +10,13 @@ from lightly_studio.resolvers import (
     evaluation_sample_metric_resolver,
 )
 from tests.conftest import AnnotationsTestData
-from tests.helpers_resolvers import create_annotation, create_annotation_label, create_tag
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+    create_tag,
+)
 from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
 )
@@ -92,8 +98,13 @@ def test_delete_annotation__deletes_evaluation_annotation_metrics(
     db_session: Session,
 ) -> None:
     """Test deleting an annotation removes invalidated evaluation rows."""
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(session=db_session)
-    collection_id = image.sample.collection_id
+    dataset = create_collection(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(
+        session=db_session,
+        dataset_collection_id=dataset.collection_id,
+    )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
+    collection_id = dataset.collection_id
     label = create_annotation_label(session=db_session, root_collection_id=collection_id)
     pred_annotation = create_annotation(
         session=db_session,
@@ -147,18 +158,22 @@ def test_delete_annotation__preserves_other_run_sample_metrics(
     db_session: Session,
 ) -> None:
     """Test deleting an annotation only invalidates sample metrics for affected runs."""
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
-        session=db_session, name="run1"
-    )
-    other_run, _ = evaluation_sample_metric_helpers.create_run_and_image(
+    dataset = create_collection(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=image.sample.collection_id,
+        dataset_collection_id=dataset.collection_id,
+        name="run1",
+    )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
+    other_run = evaluation_sample_metric_helpers.create_run(
+        session=db_session,
+        dataset_collection_id=dataset.collection_id,
         name="run2",
     )
 
     label = create_annotation_label(
         session=db_session,
-        root_collection_id=image.sample.collection_id,
+        root_collection_id=dataset.collection_id,
     )
     pred_annotation = create_annotation(
         session=db_session,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -449,9 +449,10 @@ def test_deep_copy__can_delete_original_after_copy(db_session: Session) -> None:
 def test_deep_copy__with_evaluation_sample_metrics(db_session: Session) -> None:
     # Arrange
     dataset = create_collection(session=db_session, collection_name="original")
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         db_session, dataset_collection_id=dataset.collection_id
     )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     evaluation_sample_metric_resolver.create_many(
         session=db_session,
         records=[
@@ -767,9 +768,10 @@ def test_deep_copy__with_evaluation_runs(db_session: Session) -> None:
 def test_deep_copy__with_evaluation_annotation_metrics(db_session: Session) -> None:
     # Arrange
     dataset = create_collection(session=db_session, collection_name="original")
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         db_session, dataset_collection_id=dataset.collection_id
     )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     label = create_annotation_label(session=db_session, root_collection_id=dataset.collection_id)
     gt_annotation = create_annotation(
         session=db_session,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -450,7 +450,7 @@ def test_deep_copy__with_evaluation_sample_metrics(db_session: Session) -> None:
     # Arrange
     dataset = create_collection(session=db_session, collection_name="original")
     run = evaluation_sample_metric_helpers.create_run(
-        db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, dataset_collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     evaluation_sample_metric_resolver.create_many(
@@ -769,7 +769,7 @@ def test_deep_copy__with_evaluation_annotation_metrics(db_session: Session) -> N
     # Arrange
     dataset = create_collection(session=db_session, collection_name="original")
     run = evaluation_sample_metric_helpers.create_run(
-        db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, dataset_collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     label = create_annotation_label(session=db_session, root_collection_id=dataset.collection_id)

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -215,7 +215,7 @@ def _build_full_dataset(session: Session, name: str) -> UUID:
 
     # evaluation run + sample metric + annotation metric (gt/pred annotations)
     run = evaluation_sample_metric_helpers.create_run(
-        session, dataset_collection_id=root.collection_id
+        session=session, dataset_collection_id=root.collection_id
     )
     eval_image = create_image(session=session, collection_id=root.collection_id)
     evaluation_sample_metric_resolver.create_many(

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -214,9 +214,10 @@ def _build_full_dataset(session: Session, name: str) -> UUID:
     )
 
     # evaluation run + sample metric + annotation metric (gt/pred annotations)
-    run, eval_image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session, dataset_collection_id=root.collection_id
     )
+    eval_image = create_image(session=session, collection_id=root.collection_id)
     evaluation_sample_metric_resolver.create_many(
         session=session,
         records=[

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -253,9 +253,10 @@ def test_delete_dataset__does_not_affect_other_datasets(db_session: Session) -> 
 def test_delete_dataset__with_evaluation_sample_metrics(db_session: Session) -> None:
     # Arrange
     dataset = create_collection(session=db_session, collection_name="to_delete")
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         db_session, dataset_collection_id=dataset.collection_id
     )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     run_id = run.id  # Capture before delete
     evaluation_sample_metric_resolver.create_many(
         session=db_session,
@@ -336,9 +337,10 @@ def test_delete_dataset__with_evaluation_runs(db_session: Session) -> None:
 def test_delete_dataset__with_evaluation_annotation_metrics(db_session: Session) -> None:
     # Arrange
     dataset = create_collection(session=db_session, collection_name="to_delete")
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         db_session, dataset_collection_id=dataset.collection_id
     )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     run_id = run.id  # Capture before delete
     label = create_annotation_label(session=db_session, root_collection_id=dataset.collection_id)
     gt_annotation = create_annotation(

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -254,7 +254,7 @@ def test_delete_dataset__with_evaluation_sample_metrics(db_session: Session) -> 
     # Arrange
     dataset = create_collection(session=db_session, collection_name="to_delete")
     run = evaluation_sample_metric_helpers.create_run(
-        db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, dataset_collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     run_id = run.id  # Capture before delete
@@ -338,7 +338,7 @@ def test_delete_dataset__with_evaluation_annotation_metrics(db_session: Session)
     # Arrange
     dataset = create_collection(session=db_session, collection_name="to_delete")
     run = evaluation_sample_metric_helpers.create_run(
-        db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, dataset_collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     run_id = run.id  # Capture before delete

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_create.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_create.py
@@ -10,6 +10,7 @@ from tests.helpers_resolvers import (
     create_annotation,
     create_annotation_label,
     create_collection,
+    create_image,
 )
 from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
@@ -18,10 +19,11 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
 
 def test_create_many(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
         dataset_collection_id=dataset.collection_id,
     )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     label = create_annotation_label(
         session=db_session,
         root_collection_id=dataset.collection_id,
@@ -74,7 +76,7 @@ def test_create_many(db_session: Session) -> None:
 
 
 def test_create_many__empty_list_is_noop(db_session: Session) -> None:
-    run, _ = evaluation_sample_metric_helpers.create_run_and_image(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(session=db_session)
 
     evaluation_annotation_metric_resolver.create_many(session=db_session, records=[])
 

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_get.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_get.py
@@ -13,6 +13,7 @@ from tests.helpers_resolvers import (
     create_annotation,
     create_annotation_label,
     create_collection,
+    create_image,
 )
 from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
@@ -21,10 +22,11 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
 
 def test_get_all_by_evaluation_run_id(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
         dataset_collection_id=dataset.collection_id,
     )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     label = create_annotation_label(
         session=db_session,
         root_collection_id=dataset.collection_id,
@@ -89,11 +91,21 @@ def test_get_all_by_evaluation_run_id__returns_empty_for_unknown_run(
 
 def test_get_all_by_evaluation_run_id__excludes_other_runs(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
-    run1, image1 = evaluation_sample_metric_helpers.create_run_and_image(
+    run1 = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run1"
     )
-    run2, image2 = evaluation_sample_metric_helpers.create_run_and_image(
+    image1 = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/run1.png",
+    )
+    run2 = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run2"
+    )
+    image2 = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/run2.png",
     )
     label = create_annotation_label(
         session=db_session,

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
@@ -16,6 +16,7 @@ from tests.helpers_resolvers import (
     create_annotation,
     create_annotation_label,
     create_collection,
+    create_image,
 )
 from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
@@ -26,7 +27,7 @@ def test_get_confusion_matrix__empty_run(
     db_session: Session,
 ) -> None:
     dataset = create_collection(session=db_session)
-    run, _image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
         dataset_collection_id=dataset.collection_id,
     )
@@ -43,10 +44,11 @@ def test_get_confusion_matrix__aggregates_tp_fp_fn(
     db_session: Session,
 ) -> None:
     dataset = create_collection(session=db_session)
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
         dataset_collection_id=dataset.collection_id,
     )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     label_a = create_annotation_label(
         session=db_session,
         root_collection_id=dataset.collection_id,
@@ -138,10 +140,11 @@ def test_get_confusion_matrix__class_only_in_gt(
     synthetic FP row is also present even though it has no entries.
     """
     dataset = create_collection(session=db_session)
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
         dataset_collection_id=dataset.collection_id,
     )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     label_a = create_annotation_label(
         session=db_session,
         root_collection_id=dataset.collection_id,
@@ -214,10 +217,11 @@ def test_get_confusion_matrix__class_only_in_pred(
     synthetic FN column is also present even though it has no entries.
     """
     dataset = create_collection(session=db_session)
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
         dataset_collection_id=dataset.collection_id,
     )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     label_a = create_annotation_label(
         session=db_session,
         root_collection_id=dataset.collection_id,
@@ -289,10 +293,11 @@ def test_get_confusion_matrix__no_fp_or_fn_keeps_synthetic_axes(
     that callers can rely on a stable axis layout.
     """
     dataset = create_collection(session=db_session)
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
         dataset_collection_id=dataset.collection_id,
     )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     label_a = create_annotation_label(
         session=db_session,
         root_collection_id=dataset.collection_id,

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
@@ -13,13 +13,13 @@ from lightly_studio.models.evaluation_run import (
     EvaluationTaskType,
 )
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
-from lightly_studio.models.image import ImageTable
 from lightly_studio.resolvers import (
+    collection_resolver,
     evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
     evaluation_sample_metric_resolver,
 )
-from tests.helpers_resolvers import create_collection, create_image
+from tests.helpers_resolvers import create_collection
 
 
 @dataclass
@@ -41,13 +41,20 @@ class SampleMetricStub:
     metrics: dict[str, float]
 
 
-def create_run_and_image(
+def create_run(
     session: Session,
     dataset_collection_id: UUID | None = None,
     name: str = "test_run",
-) -> tuple[EvaluationRunTable, ImageTable]:
+) -> EvaluationRunTable:
+    """Create an evaluation run with gt/pred annotation collections, but no images."""
     if dataset_collection_id is None:
         dataset_collection_id = create_collection(session=session).collection_id
+    dataset_collection = collection_resolver.get_by_id(
+        session=session,
+        collection_id=dataset_collection_id,
+    )
+    if dataset_collection is None:
+        raise ValueError(f"Collection {dataset_collection_id} doesn't exist")
     gt_collection = create_collection(
         session=session,
         sample_type=SampleType.ANNOTATION,
@@ -58,18 +65,16 @@ def create_run_and_image(
         sample_type=SampleType.ANNOTATION,
         parent_collection_id=dataset_collection_id,
     )
-    run = evaluation_run_resolver.create(
+    return evaluation_run_resolver.create(
         session=session,
         evaluation_run_input=EvaluationRunCreate(
             name=name,
             gt_annotation_collection_id=gt_collection.collection_id,
-            dataset_id=gt_collection.dataset_id,
+            dataset_id=dataset_collection.dataset_id,
             pred_annotation_collection_id=pred_collection.collection_id,
             task_type=EvaluationTaskType.OBJECT_DETECTION,
         ),
     )
-    image = create_image(session=session, collection_id=dataset_collection_id)
-    return run, image
 
 
 def create_sample_metrics(

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
@@ -46,7 +46,7 @@ def create_run(
     dataset_collection_id: UUID | None = None,
     name: str = "test_run",
 ) -> EvaluationRunTable:
-    """Create an evaluation run with gt/pred annotation collections, but no images."""
+    """Create an evaluation run with gt/pred annotation collections."""
     if dataset_collection_id is None:
         dataset_collection_id = create_collection(session=session).collection_id
     dataset_collection = collection_resolver.get_by_id(

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_create.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_create.py
@@ -12,7 +12,7 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
 
 def test_create_many(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
-    run, _ = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id
     )
     image1 = create_image(session=db_session, collection_id=dataset.collection_id)
@@ -50,7 +50,7 @@ def test_create_many(db_session: Session) -> None:
 
 
 def test_create_many__empty_list_is_noop(db_session: Session) -> None:
-    run, _ = evaluation_sample_metric_helpers.create_run_and_image(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(session=db_session)
 
     evaluation_sample_metric_resolver.create_many(session=db_session, records=[])
 

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get.py
@@ -7,14 +7,18 @@ from sqlmodel import Session
 
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricTable
 from lightly_studio.resolvers import evaluation_sample_metric_resolver
-from tests.helpers_resolvers import create_collection
+from tests.helpers_resolvers import create_collection, create_image
 from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
 )
 
 
 def test_get_all_by_evaluation_run_id(db_session: Session) -> None:
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(session=db_session)
+    dataset = create_collection(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(
+        session=db_session, dataset_collection_id=dataset.collection_id
+    )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
         run_id=run.id,
@@ -49,11 +53,21 @@ def test_get_all_by_evaluation_run_id__returns_empty_for_unknown_run(db_session:
 
 def test_get_all_by_evaluation_run_id__excludes_other_runs(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
-    run1, image1 = evaluation_sample_metric_helpers.create_run_and_image(
+    run1 = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run1"
     )
-    run2, image2 = evaluation_sample_metric_helpers.create_run_and_image(
+    image1 = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/sample1.png",
+    )
+    run2 = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run2"
+    )
+    image2 = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/sample2.png",
     )
     evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get_metric_list.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get_metric_list.py
@@ -15,9 +15,10 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
 
 def test_get_metric_list_by_evaluation_run_id(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
-    run, image1 = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id
     )
+    image1 = create_image(session=db_session, collection_id=dataset.collection_id)
     image2 = create_image(
         session=db_session,
         collection_id=dataset.collection_id,
@@ -59,7 +60,11 @@ def test_get_metric_list_by_evaluation_run_id(db_session: Session) -> None:
 
 
 def test_get_metric_list_by_evaluation_run_id__single_sample(db_session: Session) -> None:
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(session=db_session)
+    dataset = create_collection(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(
+        session=db_session, dataset_collection_id=dataset.collection_id
+    )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
     evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
         run_id=run.id,
@@ -95,11 +100,21 @@ def test_get_metric_list_by_evaluation_run_id__returns_empty_for_unknown_run(
 
 def test_get_metric_list_by_evaluation_run_id__excludes_other_runs(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
-    run1, image1 = evaluation_sample_metric_helpers.create_run_and_image(
+    run1 = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run1"
     )
-    run2, image2 = evaluation_sample_metric_helpers.create_run_and_image(
+    image1 = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/sample1.png",
+    )
+    run2 = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run2"
+    )
+    image2 = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/sample2.png",
     )
     evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_get_sample_metrics_info_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_get_sample_metrics_info_by_dataset_id.py
@@ -1,20 +1,12 @@
 from __future__ import annotations
 
 import uuid
-from uuid import UUID
 
 import pytest
 from sqlmodel import Session
 
-from lightly_studio.models.collection import SampleType
-from lightly_studio.models.evaluation_run import (
-    EvaluationRunCreate,
-    EvaluationRunTable,
-    EvaluationTaskType,
-)
 from lightly_studio.models.evaluation_sample_metric import EvaluationRunMetricsInfoView
-from lightly_studio.models.image import ImageTable
-from lightly_studio.resolvers import evaluation_run_resolver, evaluation_sample_metric_resolver
+from lightly_studio.resolvers import evaluation_sample_metric_resolver
 from tests.helpers_resolvers import create_collection, create_image
 from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
@@ -22,40 +14,12 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
 from tests.resolvers.evaluation_sample_metric_resolver.helpers import SampleMetricStub
 
 
-def _create_named_run_and_image(
-    session: Session,
-    dataset_collection_id: UUID,
-    name: str,
-) -> tuple[EvaluationRunTable, ImageTable]:
-    gt_collection = create_collection(
-        session=session,
-        sample_type=SampleType.ANNOTATION,
-        parent_collection_id=dataset_collection_id,
-    )
-    pred_collection = create_collection(
-        session=session,
-        sample_type=SampleType.ANNOTATION,
-        parent_collection_id=dataset_collection_id,
-    )
-    run = evaluation_run_resolver.create(
-        session=session,
-        evaluation_run_input=EvaluationRunCreate(
-            name=name,
-            gt_annotation_collection_id=gt_collection.collection_id,
-            dataset_id=gt_collection.dataset_id,
-            pred_annotation_collection_id=pred_collection.collection_id,
-            task_type=EvaluationTaskType.OBJECT_DETECTION,
-        ),
-    )
-    image = create_image(session=session, collection_id=dataset_collection_id)
-    return run, image
-
-
 def test_get_sample_metrics_info_by_dataset_id(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
-    run, image1 = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id
     )
+    image1 = create_image(session=db_session, collection_id=dataset.collection_id)
     image2 = create_image(
         session=db_session,
         collection_id=dataset.collection_id,
@@ -99,11 +63,21 @@ def test_get_sample_metrics_info_by_dataset_id(db_session: Session) -> None:
 
 def test_get_sample_metrics_info_by_dataset_id__multiple_runs(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
-    run1, image1 = _create_named_run_and_image(
+    run1 = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run_1"
     )
-    run2, image2 = _create_named_run_and_image(
+    image1 = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/sample1.png",
+    )
+    run2 = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id, name="run_2"
+    )
+    image2 = create_image(
+        session=db_session,
+        collection_id=dataset.collection_id,
+        file_path_abs="/path/to/sample2.png",
     )
     evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
@@ -145,12 +119,14 @@ def test_get_sample_metrics_info_by_dataset_id__excludes_other_datasets(
 ) -> None:
     dataset = create_collection(session=db_session)
     other_dataset = create_collection(session=db_session)
-    run, image = evaluation_sample_metric_helpers.create_run_and_image(
+    run = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id
     )
-    other_run, other_image = evaluation_sample_metric_helpers.create_run_and_image(
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
+    other_run = evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=other_dataset.collection_id
     )
+    other_image = create_image(session=db_session, collection_id=other_dataset.collection_id)
     evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
         run_id=run.id,
@@ -187,7 +163,7 @@ def test_get_sample_metrics_info_by_dataset_id__empty_for_run_without_metrics(
 ) -> None:
     dataset = create_collection(session=db_session)
     # Create a run but add no metrics.
-    evaluation_sample_metric_helpers.create_run_and_image(
+    evaluation_sample_metric_helpers.create_run(
         session=db_session, dataset_collection_id=dataset.collection_id
     )
 

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_adjacent_images.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_adjacent_images.py
@@ -14,7 +14,7 @@ from tests import helpers_resolvers
 from tests.helpers_resolvers import AnnotationDetails
 from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
     SampleMetricStub,
-    create_run_and_image,
+    create_run,
     create_sample_metrics,
 )
 
@@ -400,7 +400,8 @@ def test_get_adjacent_images__sort_by_evaluation_metric(db_session: Session) -> 
     collection = helpers_resolvers.create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    run, image_a = create_run_and_image(session=db_session, dataset_collection_id=collection_id)
+    run = create_run(session=db_session, dataset_collection_id=collection_id)
+    image_a = helpers_resolvers.create_image(session=db_session, collection_id=collection_id)
     image_b = helpers_resolvers.create_image(
         session=db_session, collection_id=collection_id, file_path_abs="/images/b.png"
     )

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
@@ -39,7 +39,7 @@ from tests.helpers_resolvers import (
 )
 from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
     SampleMetricStub,
-    create_run_and_image,
+    create_run,
     create_sample_metrics,
 )
 
@@ -837,7 +837,8 @@ def test_get_all_by_collection_id__sort_by_evaluation_metric_asc(db_session: Ses
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    run, image_a = create_run_and_image(session=db_session, dataset_collection_id=collection_id)
+    run = create_run(session=db_session, dataset_collection_id=collection_id)
+    image_a = create_image(session=db_session, collection_id=collection_id)
     image_b = create_image(
         session=db_session, collection_id=collection_id, file_path_abs="/images/b.png"
     )
@@ -874,7 +875,8 @@ def test_get_all_by_collection_id__sort_by_evaluation_metric_desc(db_session: Se
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    run, image_a = create_run_and_image(session=db_session, dataset_collection_id=collection_id)
+    run = create_run(session=db_session, dataset_collection_id=collection_id)
+    image_a = create_image(session=db_session, collection_id=collection_id)
     [image_b, image_c] = create_images(
         db_session=db_session,
         collection_id=collection_id,
@@ -912,7 +914,8 @@ def test_get_all_by_collection_id__sort_by_two_evaluation_metrics(db_session: Se
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    run, image_a = create_run_and_image(session=db_session, dataset_collection_id=collection_id)
+    run = create_run(session=db_session, dataset_collection_id=collection_id)
+    image_a = create_image(session=db_session, collection_id=collection_id)
     image_b = create_image(
         session=db_session, collection_id=collection_id, file_path_abs="/images/b.png"
     )

--- a/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
+++ b/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
@@ -512,7 +512,7 @@ class TestSampleFilterConfusionCell:
     ) -> None:
         dataset = create_collection(session=db_session)
         dataset_id = dataset.collection_id
-        run, _image = evaluation_sample_metric_helpers.create_run_and_image(
+        run = evaluation_sample_metric_helpers.create_run(
             session=db_session, dataset_collection_id=dataset_id
         )
         samples = create_images(
@@ -570,10 +570,10 @@ class TestSampleFilterConfusionCell:
     def test_apply__confusion_cell__scopes_to_evaluation_run(self, db_session: Session) -> None:
         dataset = create_collection(session=db_session)
         dataset_id = dataset.collection_id
-        run_a, _image_a = evaluation_sample_metric_helpers.create_run_and_image(
+        run_a = evaluation_sample_metric_helpers.create_run(
             session=db_session, dataset_collection_id=dataset_id, name="run_a"
         )
-        run_b, _image_b = evaluation_sample_metric_helpers.create_run_and_image(
+        run_b = evaluation_sample_metric_helpers.create_run(
             session=db_session, dataset_collection_id=dataset_id, name="run_b"
         )
         samples = create_images(
@@ -621,7 +621,7 @@ class TestSampleFilterConfusionCell:
     def test_apply__confusion_cell__ands_with_other_predicate(self, db_session: Session) -> None:
         dataset = create_collection(session=db_session)
         dataset_id = dataset.collection_id
-        run, _image = evaluation_sample_metric_helpers.create_run_and_image(
+        run = evaluation_sample_metric_helpers.create_run(
             session=db_session, dataset_collection_id=dataset_id
         )
         samples = create_images(


### PR DESCRIPTION
## What has changed and why?
We don't have a function for creating just one evaluation run, and tests often discard the created image. The ergonomics is not that great.

## How has it been tested?
Existing tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated annotation, dataset, and evaluation metric resolver tests to use separate setup steps for evaluation runs and images.
  * Refactored evaluation test fixtures to replace combined “run+image” setup with run-only creation plus explicit image creation where needed.
  * Removed shared helper(s) that returned both run and image; updated multi-run/multi-dataset scenarios to construct objects explicitly.
  * Preserved existing assertions for cleanup, deep-copy behavior, filtering, and confusion-matrix/adjacent-image ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->