### PR TITLE
Make non-categorical legend rows clickable to hide points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ filtered sample count.
 - Python dataset queries now support classifications, object detections, and segmentation mask annotations.
 - Python dataset queries now model evaluation queries on the sample level.
 - Improved performance when tagging all samples in the GUI for large datasets.
+- All embedding plot legend entries (especially e.g. `Excluded by filters`, `No category`, etc.) can be hidden by clicking on them.
 
 ### Changed
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -137,13 +137,25 @@
 
     const hasActiveFilter = $derived(filter !== null || activeSampleIds.length > 0);
 
+    // Activating a lasso unhides the Excluded category, otherwise out-of-selection points (which
+    // get demoted to Excluded) would vanish and blank out the canvas mid-draw. The legend keeps
+    // showing the user's real toggle state.
+    const effectiveHiddenCategories = $derived.by(() => {
+        if ($rangeSelection === null || !$hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)) {
+            return $hiddenCategories;
+        }
+        const next = new Set($hiddenCategories);
+        next.delete(EXCLUDED_BY_FILTERS_CATEGORY);
+        return next;
+    });
+
     let { data: plotData, selectedSampleIds } = $derived(
         usePlotData({
             arrowData: $arrowData,
             rangeSelection: $rangeSelection,
             highlightedSampleIds: activeSampleIds,
             hasActiveFilter: hasActiveFilter,
-            hiddenCategories: $hiddenCategories
+            hiddenCategories: effectiveHiddenCategories
         })
     );
     const categoryCount = $derived.by(() => getCategoryCount($colorLegend));

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -122,9 +122,10 @@
     // (most frequent in-filter values win individual slots), so a new legend remaps those indices.
     // Reset hidden categories whenever the legend changes — covering both filter and color-by
     // changes — so a stale toggle can never hide a different category than the user picked.
+    // The reserved rows are stable by index and never remap, so they survive the reset.
     $effect(() => {
         void $colorLegend;
-        resetCategoryVisibility();
+        resetCategoryVisibility([EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY]);
     });
 
     const hasActiveFilter = $derived(filter !== null || activeSampleIds.length > 0);

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -17,7 +17,12 @@
     import { useCategoryVisibility } from './useCategoryVisibility/useCategoryVisibility';
     import { isEqual } from 'lodash-es';
     import { getCategoryColors, getCategoryCount, getLegendEntries } from './plotColorUtils';
-    import { INCLUDED_BY_FILTERS_LABEL, NO_CATEGORY_LABEL } from './plotCategories';
+    import {
+        EXCLUDED_BY_FILTERS_CATEGORY,
+        INCLUDED_BY_FILTERS_CATEGORY,
+        INCLUDED_BY_FILTERS_LABEL,
+        NO_CATEGORY_LABEL
+    } from './plotCategories';
     import { page } from '$app/state';
     import { isVideosRoute } from '$lib/routes';
     import { usePlotColorByType } from './PlotColorByPopover/usePlotColorByType/usePlotColorByType';
@@ -337,6 +342,8 @@
                         {categoryColors}
                         {includedLabel}
                         {legendEntries}
+                        excludedHidden={$hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)}
+                        includedHidden={$hiddenCategories.has(INCLUDED_BY_FILTERS_CATEGORY)}
                         onToggleCategory={toggleCategoryVisibility}
                         onDoubleClickCategory={(category) => {
                             focusCategoryVisibility(

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -118,14 +118,21 @@
         resetCategoryVisibility
     } = useCategoryVisibility();
 
-    // Hide-toggles are keyed by color-slot index, but the backend re-ranks slots per request
-    // (most frequent in-filter values win individual slots), so a new legend remaps those indices.
-    // Reset hidden categories whenever the legend changes — covering both filter and color-by
-    // changes — so a stale toggle can never hide a different category than the user picked.
-    // The reserved rows are stable by index and never remap, so they survive the reset.
+    // The backend re-ranks color slots per request, so a stale toggle would hide the wrong slot;
+    // reset hidden categories on every legend change. EXCLUDED keeps its meaning, so it always
+    // survives. INCLUDED is relabeled with the color-by mode, so it survives only a filter-only
+    // change — else a hidden "No category" would empty the plot once all points collapse into it.
+    let previousColorByKey: string | undefined = undefined;
     $effect(() => {
         void $colorLegend;
-        resetCategoryVisibility([EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY]);
+        const colorByKey = JSON.stringify($colorBy);
+        const colorByChanged = colorByKey !== previousColorByKey;
+        previousColorByKey = colorByKey;
+        resetCategoryVisibility(
+            colorByChanged
+                ? [EXCLUDED_BY_FILTERS_CATEGORY]
+                : [EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY]
+        );
     });
 
     const hasActiveFilter = $derived(filter !== null || activeSampleIds.length > 0);

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
@@ -318,4 +318,22 @@ describe('PlotPanel.svelte', () => {
             INCLUDED_BY_FILTERS_CATEGORY
         ]);
     });
+
+    it('drops the "Included by filters / No category" row when the color-by mode changes', async () => {
+        const user = userEvent.setup();
+        render(PlotPanel);
+        await tick();
+
+        // Ignore the resets from mount; assert the one triggered by the color-by change.
+        mockResetCategoryVisibility.mockClear();
+        await user.click(screen.getByTestId('plot-color-by-button'));
+        await user.click(await screen.findByRole('option', { name: 'metadata.split' }));
+        await tick();
+
+        // INCLUDED is relabeled when the color-by mode flips, so its hidden state must not carry
+        // over (it would otherwise hide every point in the relabeled slot). Only EXCLUDED survives.
+        expect(mockResetCategoryVisibility).toHaveBeenLastCalledWith([
+            EXCLUDED_BY_FILTERS_CATEGORY
+        ]);
+    });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
@@ -6,6 +6,7 @@ import { useEmbeddings } from '$lib/hooks/useEmbeddings/useEmbeddings';
 import { writable, type Writable } from 'svelte/store';
 import { tick } from 'svelte';
 import { usePlotColorByType } from './PlotColorByPopover/usePlotColorByType/usePlotColorByType';
+import { EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY } from './plotCategories';
 
 let rangeSelectionStore: Writable<Array<{ x: number; y: number }> | null>;
 let selectedSampleIdsStore: Writable<string[]>;
@@ -302,7 +303,7 @@ describe('PlotPanel.svelte', () => {
         });
     });
 
-    it('resets hidden categories when the legend changes', async () => {
+    it('resets remapped categories when the legend changes but preserves the reserved rows', async () => {
         render(PlotPanel);
         await tick();
 
@@ -311,6 +312,10 @@ describe('PlotPanel.svelte', () => {
         colorLegendStore.set(new Map([[3, 'dog']]));
         await tick();
 
-        expect(mockResetCategoryVisibility).toHaveBeenCalled();
+        // Reserved rows are stable by index, so they must survive a legend refresh.
+        expect(mockResetCategoryVisibility).toHaveBeenCalledWith([
+            EXCLUDED_BY_FILTERS_CATEGORY,
+            INCLUDED_BY_FILTERS_CATEGORY
+        ]);
     });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.svelte
@@ -18,6 +18,8 @@
         categoryColors: string[];
         excludedLabel?: string;
         includedLabel?: string;
+        excludedHidden?: boolean;
+        includedHidden?: boolean;
         legendEntries?: LegendEntry[];
         onToggleCategory?: (cat: number) => void;
         onDoubleClickCategory?: (cat: number) => void;
@@ -27,10 +29,28 @@
         categoryColors,
         excludedLabel = EXCLUDED_BY_FILTERS_LABEL,
         includedLabel = INCLUDED_BY_FILTERS_LABEL,
+        excludedHidden = false,
+        includedHidden = false,
         legendEntries = [],
         onToggleCategory,
         onDoubleClickCategory
     }: Props = $props();
+
+    // Reserved rows toggle on click but never isolate on double-click (a no-op for a binary row).
+    const reservedRows = $derived([
+        {
+            cat: EXCLUDED_BY_FILTERS_CATEGORY,
+            label: excludedLabel,
+            color: categoryColors[EXCLUDED_BY_FILTERS_CATEGORY],
+            hidden: excludedHidden
+        },
+        {
+            cat: INCLUDED_BY_FILTERS_CATEGORY,
+            label: includedLabel,
+            color: categoryColors[INCLUDED_BY_FILTERS_CATEGORY],
+            hidden: includedHidden
+        }
+    ]);
 </script>
 
 <div
@@ -58,20 +78,22 @@
         {#if legendEntries.length > 0}
             <span class="my-0.5 w-full shrink-0 border-t border-white/10"></span>
         {/if}
-        <span class="flex shrink-0 items-center gap-1.5">
-            <span
-                class="legend-dot"
-                style={`background-color: ${categoryColors[EXCLUDED_BY_FILTERS_CATEGORY]}`}
-            ></span>
-            {excludedLabel}
-        </span>
-        <span class="flex shrink-0 items-center gap-1.5">
-            <span
-                class="legend-dot"
-                style={`background-color: ${categoryColors[INCLUDED_BY_FILTERS_CATEGORY]}`}
-            ></span>
-            {includedLabel}
-        </span>
+        {#each reservedRows as row (row.cat)}
+            <button
+                type="button"
+                class={cn(
+                    'flex w-full shrink-0 cursor-pointer items-center gap-1.5 rounded text-left transition-opacity hover:opacity-80',
+                    row.hidden && 'opacity-40'
+                )}
+                data-testid={`plot-legend-entry-${row.cat}`}
+                aria-pressed={row.hidden}
+                title={row.hidden ? 'Show category' : 'Hide category'}
+                onclick={() => onToggleCategory?.(row.cat)}
+            >
+                <span class="legend-dot shrink-0" style={`background-color: ${row.color}`}></span>
+                <span class="min-w-0 truncate" title={row.label}>{row.label}</span>
+            </button>
+        {/each}
     </div>
 </div>
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanelLegend.test.ts
@@ -57,6 +57,52 @@ describe('PlotPanelLegend', () => {
         expect(onDoubleClickCategory).toHaveBeenCalledWith(3);
     });
 
+    it('toggles the reserved rows on single click', async () => {
+        const onToggleCategory = vi.fn();
+
+        render(PlotPanelLegend, {
+            categoryColors: [HIDDEN_COLOR, NOT_FILTERED_COLOR, FILTERED_COLOR],
+            onToggleCategory
+        });
+
+        // EXCLUDED_BY_FILTERS_CATEGORY === 1, INCLUDED_BY_FILTERS_CATEGORY === 2.
+        await fireEvent.click(screen.getByTestId('plot-legend-entry-1'));
+        expect(onToggleCategory).toHaveBeenCalledWith(1);
+
+        await fireEvent.click(screen.getByTestId('plot-legend-entry-2'));
+        expect(onToggleCategory).toHaveBeenCalledWith(2);
+    });
+
+    it('does not isolate the reserved rows on double click', async () => {
+        const onDoubleClickCategory = vi.fn();
+
+        render(PlotPanelLegend, {
+            categoryColors: [HIDDEN_COLOR, NOT_FILTERED_COLOR, FILTERED_COLOR],
+            onDoubleClickCategory
+        });
+
+        await fireEvent.dblClick(screen.getByTestId('plot-legend-entry-1'));
+        await fireEvent.dblClick(screen.getByTestId('plot-legend-entry-2'));
+
+        expect(onDoubleClickCategory).not.toHaveBeenCalled();
+    });
+
+    it('dims the reserved rows when hidden', () => {
+        render(PlotPanelLegend, {
+            categoryColors: [HIDDEN_COLOR, NOT_FILTERED_COLOR, FILTERED_COLOR],
+            excludedHidden: true,
+            includedHidden: false
+        });
+
+        const excludedRow = screen.getByTestId('plot-legend-entry-1');
+        const includedRow = screen.getByTestId('plot-legend-entry-2');
+
+        expect(excludedRow).toHaveAttribute('aria-pressed', 'true');
+        expect(excludedRow.className).toContain('opacity-40');
+        expect(includedRow).toHaveAttribute('aria-pressed', 'false');
+        expect(includedRow.className).not.toContain('opacity-40');
+    });
+
     it('renders tag legend entries with getColorByLabel colors', () => {
         const reviewBatch1Color = getColorByLabel('review-batch-1').color;
         const reviewBatch2Color = getColorByLabel('review-batch-2').color;

--- a/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.ts
@@ -10,25 +10,18 @@ type Selection = Point[] | null;
  *
  * @param selection - Polygon selection defining the area to check against
  * @param data - Arrow data containing x and y coordinates as Float32Arrays
- * @param outsideCategory - Category assigned to points outside the selection (defaults to
- *        `EXCLUDED_BY_FILTERS_CATEGORY`)
  * @returns A reducer function that takes (prevValue: number, index: number) and returns:
  *          - `prevValue` if the point intersects the selection polygon
- *          - `outsideCategory` if the point does not intersect the selection polygon
+ *          - `EXCLUDED_BY_FILTERS_CATEGORY` if the point does not intersect the selection polygon
  *          - `prevValue` if no selection is given
  */
 export const getCategoryBySelection =
-    (
-        selection: Selection,
-        data: ArrowData,
-        outsideCategory: number = EXCLUDED_BY_FILTERS_CATEGORY
-    ) =>
-    (prevValue: number, index: number) => {
+    (selection: Selection, data: ArrowData) => (prevValue: number, index: number) => {
         if (!selection) {
             return prevValue;
         }
         const x = (data.x as Float32Array)[index];
         const y = (data.y as Float32Array)[index];
         const isIntersected = isPointInPolygon(x, y, selection);
-        return isIntersected ? prevValue : outsideCategory;
+        return isIntersected ? prevValue : EXCLUDED_BY_FILTERS_CATEGORY;
     };

--- a/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/getCategoryBySelection/getCategoryBySelection.ts
@@ -10,18 +10,25 @@ type Selection = Point[] | null;
  *
  * @param selection - Polygon selection defining the area to check against
  * @param data - Arrow data containing x and y coordinates as Float32Arrays
+ * @param outsideCategory - Category assigned to points outside the selection (defaults to
+ *        `EXCLUDED_BY_FILTERS_CATEGORY`)
  * @returns A reducer function that takes (prevValue: number, index: number) and returns:
  *          - `prevValue` if the point intersects the selection polygon
- *          - `EXCLUDED_BY_FILTERS_CATEGORY` if the point does not intersect the selection polygon
+ *          - `outsideCategory` if the point does not intersect the selection polygon
  *          - `prevValue` if no selection is given
  */
 export const getCategoryBySelection =
-    (selection: Selection, data: ArrowData) => (prevValue: number, index: number) => {
+    (
+        selection: Selection,
+        data: ArrowData,
+        outsideCategory: number = EXCLUDED_BY_FILTERS_CATEGORY
+    ) =>
+    (prevValue: number, index: number) => {
         if (!selection) {
             return prevValue;
         }
         const x = (data.x as Float32Array)[index];
         const y = (data.y as Float32Array)[index];
         const isIntersected = isPointInPolygon(x, y, selection);
-        return isIntersected ? prevValue : EXCLUDED_BY_FILTERS_CATEGORY;
+        return isIntersected ? prevValue : outsideCategory;
     };

--- a/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/plotColorUtils.ts
@@ -10,7 +10,7 @@ const OKLCH_CHROMA = 0.3;
 
 const RESERVED_CATEGORY_COUNT = 3;
 
-export const HIDDEN_COLOR = 'rgba(0, 0, 0, 0)';
+export const HIDDEN_COLOR = '#000000';
 export const NOT_FILTERED_COLOR = '#222222';
 export const FILTERED_COLOR = '#FF7220';
 export const UNASSIGNED_COLOR = '#666666';

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
@@ -30,19 +30,9 @@ describe('resolveVisibleCategory', () => {
         expect(resolveVisibleCategory([3, 4, 5], 1, new Set([3, 4]))).toBe(5);
     });
 
-    it('routes to HIDDEN_CATEGORY (0) when filtered out and EXCLUDED is hidden', () => {
-        expect(resolveVisibleCategory([3, 4], 0, new Set([1]))).toBe(0);
-    });
-
-    it('routes to HIDDEN_CATEGORY (0) when the point has no categories and INCLUDED is hidden', () => {
-        expect(resolveVisibleCategory([], 1, new Set([2]))).toBe(0);
-    });
-
-    it('routes to HIDDEN_CATEGORY (0) when all colored categories and INCLUDED are hidden', () => {
-        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 4, 2]))).toBe(0);
-    });
-
-    it('falls back to a visible colored category even when INCLUDED is hidden', () => {
-        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 2]))).toBe(4);
+    it('ignores hidden reserved buckets — usePlotData applies hiding to the final category', () => {
+        expect(resolveVisibleCategory([3, 4], 0, new Set([1]))).toBe(1); // filtered out, EXCLUDED hidden
+        expect(resolveVisibleCategory([], 1, new Set([2]))).toBe(2); // no categories, INCLUDED hidden
+        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 4, 2]))).toBe(2); // all colored hidden
     });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
@@ -1,16 +1,13 @@
-import {
-    EXCLUDED_BY_FILTERS_CATEGORY,
-    HIDDEN_CATEGORY,
-    INCLUDED_BY_FILTERS_CATEGORY
-} from '../plotCategories';
+import { EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY } from '../plotCategories';
 
 /**
- * Resolves the category a point is displayed as, given every category it belongs to in
- * priority order. A multi-category point falls back to its next visible category, and a
- * point whose resolved category is hidden routes to HIDDEN_CATEGORY (not rendered):
+ * Resolves the pre-hiding bucket a point is displayed as:
  * - filtered out -> EXCLUDED_BY_FILTERS_CATEGORY
  * - otherwise the first non-hidden category
- * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY
+ * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY ("No category")
+ *
+ * `hiddenCategories` only skips hidden color slots here; routing a hidden bucket to
+ * HIDDEN_CATEGORY happens in `usePlotData` after demotion, on the final category.
  *
  * @param colorCategories - All categories the point belongs to, in priority order
  * @param fulfilsFilter - Whether the point passes the active filter (0 = filtered out)
@@ -22,9 +19,7 @@ export const resolveVisibleCategory = (
     hiddenCategories: ReadonlySet<number>
 ): number => {
     if (fulfilsFilter === 0) {
-        return hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)
-            ? HIDDEN_CATEGORY
-            : EXCLUDED_BY_FILTERS_CATEGORY;
+        return EXCLUDED_BY_FILTERS_CATEGORY;
     }
 
     for (const category of colorCategories) {
@@ -33,7 +28,5 @@ export const resolveVisibleCategory = (
         }
     }
 
-    return hiddenCategories.has(INCLUDED_BY_FILTERS_CATEGORY)
-        ? HIDDEN_CATEGORY
-        : INCLUDED_BY_FILTERS_CATEGORY;
+    return INCLUDED_BY_FILTERS_CATEGORY;
 };

--- a/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.test.ts
@@ -50,4 +50,17 @@ describe('useCategoryVisibility', () => {
 
         expect(get(hiddenCategories)).toEqual(new Set());
     });
+
+    it('preserves requested reserved rows on reset while clearing remapped color slots', () => {
+        const { hiddenCategories, resetCategoryVisibility, toggleCategoryVisibility } =
+            useCategoryVisibility();
+
+        toggleCategoryVisibility(1); // reserved row, stable by index
+        toggleCategoryVisibility(4); // color slot, remapped on refresh
+
+        resetCategoryVisibility([1, 2]);
+
+        // Reserved row 1 survives; color slot 4 clears; row 2 was never hidden so it is not added.
+        expect(get(hiddenCategories)).toEqual(new Set([1]));
+    });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.test.ts
@@ -24,6 +24,23 @@ describe('useCategoryVisibility', () => {
         expect(get(hiddenCategories)).toEqual(new Set());
     });
 
+    it('preserves a hidden reserved row through both isolate branches', () => {
+        const { hiddenCategories, toggleCategoryVisibility, focusCategoryVisibility } =
+            useCategoryVisibility();
+        // Colored isolate universe; reserved row 1 lives outside it.
+        const categories = [3, 4, 5];
+
+        toggleCategoryVisibility(1);
+
+        // Isolate-to-siblings branch: reserved row 1 survives alongside the hidden siblings.
+        focusCategoryVisibility(categories, 4);
+        expect(get(hiddenCategories)).toEqual(new Set([1, 3, 5]));
+
+        // Show-all branch: colored hidden state clears but reserved row 1 survives.
+        focusCategoryVisibility(categories, 4);
+        expect(get(hiddenCategories)).toEqual(new Set([1]));
+    });
+
     it('resets hidden categories', () => {
         const { hiddenCategories, resetCategoryVisibility, toggleCategoryVisibility } =
             useCategoryVisibility();

--- a/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.ts
@@ -33,8 +33,7 @@ export const useCategoryVisibility = (): UseCategoryVisibilityReturn => {
         categories: number[],
         category: number
     ) => {
-        // `categories` is the colored-only isolate universe; anything hidden outside it is a
-        // reserved row whose state must survive isolation.
+        // Categories hidden outside the `categories` isolate set are reserved rows; keep them hidden.
         const preservedHiddenCategories = [...currentHiddenCategories].filter(
             (hiddenCategory) => !categories.includes(hiddenCategory)
         );
@@ -66,8 +65,7 @@ export const useCategoryVisibility = (): UseCategoryVisibilityReturn => {
     };
 
     const resetCategoryVisibility = (preservedCategories: number[] = []) => {
-        // The legend remaps color slots on refresh, so their hidden state must clear; reserved rows
-        // are stable by index and stay hidden if the caller asks to preserve them.
+        // Clears remapped color slots; keeps the reserved rows the caller asks to preserve.
         hiddenCategories.update(
             (currentHiddenCategories) =>
                 new Set<number>(

--- a/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.ts
@@ -4,7 +4,7 @@ interface UseCategoryVisibilityReturn {
     hiddenCategories: Readable<Set<number>>;
     toggleCategoryVisibility: (category: number) => void;
     focusCategoryVisibility: (categories: number[], category: number) => void;
-    resetCategoryVisibility: () => void;
+    resetCategoryVisibility: (preservedCategories?: number[]) => void;
 }
 
 /**
@@ -65,8 +65,15 @@ export const useCategoryVisibility = (): UseCategoryVisibilityReturn => {
         );
     };
 
-    const resetCategoryVisibility = () => {
-        hiddenCategories.set(new Set<number>());
+    const resetCategoryVisibility = (preservedCategories: number[] = []) => {
+        // The legend remaps color slots on refresh, so their hidden state must clear; reserved rows
+        // are stable by index and stay hidden if the caller asks to preserve them.
+        hiddenCategories.update(
+            (currentHiddenCategories) =>
+                new Set<number>(
+                    preservedCategories.filter((category) => currentHiddenCategories.has(category))
+                )
+        );
     };
 
     return {

--- a/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.ts
@@ -33,15 +33,24 @@ export const useCategoryVisibility = (): UseCategoryVisibilityReturn => {
         categories: number[],
         category: number
     ) => {
+        // `categories` is the colored-only isolate universe; anything hidden outside it is a
+        // reserved row whose state must survive isolation.
+        const preservedHiddenCategories = [...currentHiddenCategories].filter(
+            (hiddenCategory) => !categories.includes(hiddenCategory)
+        );
+
         const visibleCategories = categories.filter(
             (visibleCategory) => !currentHiddenCategories.has(visibleCategory)
         );
 
         if (visibleCategories.length === 1 && visibleCategories[0] === category) {
-            return new Set<number>();
+            return new Set<number>(preservedHiddenCategories);
         }
 
-        return new Set(categories.filter((visibleCategory) => visibleCategory !== category));
+        return new Set([
+            ...preservedHiddenCategories,
+            ...categories.filter((visibleCategory) => visibleCategory !== category)
+        ]);
     };
 
     const toggleCategoryVisibility = (category: number) => {

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -9,12 +9,15 @@ vi.mock('embedding-atlas/svelte', () => ({
 }));
 
 vi.mock('../getCategoryBySelection/getCategoryBySelection', () => ({
-    getCategoryBySelection: vi.fn((selection) => (prevValue: number, index: number) => {
-        // Mock implementation: first two points are inside the polygon (keep prevValue), rest
-        // are outside (demoted to EXCLUDED_BY_FILTERS_CATEGORY = 1).
-        if (!selection) return prevValue;
-        return index < 2 ? prevValue : 1;
-    })
+    getCategoryBySelection: vi.fn(
+        (selection, _data, outsideCategory = 1) =>
+            (prevValue: number, index: number) => {
+                // Mock implementation: first two points are inside the polygon (keep prevValue),
+                // rest are outside (demoted to outsideCategory, default EXCLUDED_BY_FILTERS = 1).
+                if (!selection) return prevValue;
+                return index < 2 ? prevValue : outsideCategory;
+            }
+    )
 }));
 
 // Import after mocks are set up
@@ -205,8 +208,9 @@ describe('usePlotData', () => {
         });
 
         const data = get(result.data) as { category: Uint8Array };
-        // sample1 hidden+in-lasso stays 0; sample2 keeps color 3; out-of-lasso 3/4 -> EXCLUDED 1.
-        expect(Array.from(data.category)).toEqual([0, 3, 1, 1]);
+        // sample1 hidden+in-lasso stays 0; sample2 keeps color 3. Out-of-lasso points demote to
+        // the hidden Excluded row, so they route to HIDDEN (0) rather than reappearing grey.
+        expect(Array.from(data.category)).toEqual([0, 3, 0, 0]);
         expect(get(result.selectedSampleIds)).toEqual(['sample2']);
     });
 
@@ -223,8 +227,8 @@ describe('usePlotData', () => {
 
         const data = get(result.data) as { category: Uint8Array };
         // Highlighted-but-hidden sample1 stays 0; sample2 highlighted keeps 3; sample3 hidden
-        // stays 0; un-highlighted sample4 -> EXCLUDED 1.
-        expect(Array.from(data.category)).toEqual([0, 3, 0, 1]);
+        // stays 0; un-highlighted sample4 demotes to the hidden Excluded row -> HIDDEN 0.
+        expect(Array.from(data.category)).toEqual([0, 3, 0, 0]);
     });
 
     it('should preserve highlighted color categories and demote other samples', () => {
@@ -240,6 +244,22 @@ describe('usePlotData', () => {
         // sample2 is highlighted -> keeps 3; sample3 is already EXCLUDED (1) -> stays 1;
         // sample1 and sample4 are not highlighted -> demoted to EXCLUDED 1.
         expect(Array.from(data.category)).toEqual([1, 3, 1, 1]);
+    });
+
+    it('hides all points when "Included by filters" is hidden and there is no active filter', () => {
+        const mockData = createMockArrowData();
+
+        const result = usePlotData({
+            arrowData: mockData,
+            rangeSelection: null,
+            hasActiveFilter: false,
+            hiddenCategories: new Set([2])
+        });
+
+        const data = get(result.data) as { category: Uint8Array };
+        // Without a filter every point is "Included by filters" (2); hiding that row routes
+        // them all to HIDDEN (0) instead of staying visible.
+        expect(Array.from(data.category)).toEqual([0, 0, 0, 0]);
     });
 
     it('should return error store', () => {

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -208,8 +208,7 @@ describe('usePlotData', () => {
         });
 
         const data = get(result.data) as { category: Uint8Array };
-        // sample1 hidden+in-lasso stays 0; sample2 keeps color 3. Out-of-lasso points demote to
-        // the hidden Excluded row, so they route to HIDDEN (0) rather than reappearing grey.
+        // Only sample2 is selectable; the rest are Excluded, then hidden (row 1) -> HIDDEN (0).
         expect(Array.from(data.category)).toEqual([0, 3, 0, 0]);
         expect(get(result.selectedSampleIds)).toEqual(['sample2']);
     });
@@ -226,8 +225,7 @@ describe('usePlotData', () => {
         });
 
         const data = get(result.data) as { category: Uint8Array };
-        // Highlighted-but-hidden sample1 stays 0; sample2 highlighted keeps 3; sample3 hidden
-        // stays 0; un-highlighted sample4 demotes to the hidden Excluded row -> HIDDEN 0.
+        // Only highlighted+passing sample2 keeps its color; the rest are Excluded, then hidden -> 0.
         expect(Array.from(data.category)).toEqual([0, 3, 0, 0]);
     });
 
@@ -243,6 +241,25 @@ describe('usePlotData', () => {
         const data = get(result.data) as { category: Uint8Array };
         // sample2 is highlighted -> keeps 3; sample3 is already EXCLUDED (1) -> stays 1;
         // sample1 and sample4 are not highlighted -> demoted to EXCLUDED 1.
+        expect(Array.from(data.category)).toEqual([1, 3, 1, 1]);
+    });
+
+    it('hides "No category" points by their displayed bucket, not their pre-demotion identity', () => {
+        const mockData = createMockArrowData();
+        // All pass the filter, so demotion is purely highlight-driven; sample1/sample3 have no
+        // annotation (would be "No category" 2 if Included).
+        mockData.fulfils_filter = new Uint8Array([1, 1, 1, 1]);
+
+        const result = usePlotData({
+            arrowData: mockData,
+            rangeSelection: null,
+            highlightedSampleIds: ['sample2'],
+            hiddenCategories: new Set([2]) // hide "No category"
+        });
+
+        const data = get(result.data) as { category: Uint8Array };
+        // Un-highlighted points demote to Excluded and render as Excluded; hiding "No category" (2)
+        // must not touch them. (The pre-fix pipeline produced [0, 3, 0, 0].)
         expect(Array.from(data.category)).toEqual([1, 3, 1, 1]);
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -210,6 +210,28 @@ describe('usePlotData', () => {
         expect(get(result.selectedSampleIds)).toEqual(['sample2']);
     });
 
+    it('does not select an in-lasso point hidden via the "No category" legend row', () => {
+        const mockData = createMockArrowData();
+        const mockSelection: Point[] = [
+            { x: 0, y: 0 },
+            { x: 2, y: 0 },
+            { x: 2, y: 6 },
+            { x: 0, y: 6 }
+        ];
+
+        const result = usePlotData({
+            arrowData: mockData,
+            rangeSelection: mockSelection,
+            hiddenCategories: new Set([2]) // hide "Included by filters / No category"
+        });
+
+        const data = get(result.data) as { category: Uint8Array };
+        // sample1 is in-lasso but "No category" (2) -> routed to HIDDEN (0); sample2 keeps color 3.
+        expect(Array.from(data.category)).toEqual([0, 3, 1, 1]);
+        // The hidden sample1 must not be committed to the filter, only the visible sample2.
+        expect(get(result.selectedSampleIds)).toEqual(['sample2']);
+    });
+
     it('keeps highlighted-path HIDDEN points hidden rather than demoting them', () => {
         const mockData = createMockArrowData();
         mockData.fulfils_filter = new Uint8Array([0, 1, 0, 1]);

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -9,15 +9,12 @@ vi.mock('embedding-atlas/svelte', () => ({
 }));
 
 vi.mock('../getCategoryBySelection/getCategoryBySelection', () => ({
-    getCategoryBySelection: vi.fn(
-        (selection, _data, outsideCategory = 1) =>
-            (prevValue: number, index: number) => {
-                // Mock implementation: first two points are inside the polygon (keep prevValue),
-                // rest are outside (demoted to outsideCategory, default EXCLUDED_BY_FILTERS = 1).
-                if (!selection) return prevValue;
-                return index < 2 ? prevValue : outsideCategory;
-            }
-    )
+    getCategoryBySelection: vi.fn((selection) => (prevValue: number, index: number) => {
+        // Mock implementation: first two points are inside the polygon (keep prevValue), rest
+        // are outside (demoted to EXCLUDED_BY_FILTERS_CATEGORY = 1).
+        if (!selection) return prevValue;
+        return index < 2 ? prevValue : 1;
+    })
 }));
 
 // Import after mocks are set up

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
@@ -62,15 +62,6 @@ export function usePlotData({
     const colorCategories = data.color_categories as number[][];
     const fulfilsFilter = data.fulfils_filter as ArrayLike<number>;
 
-    // Deselected points demote to the Excluded row and the no-filter fill is the Included row;
-    // route either to HIDDEN when its legend row is hidden so the points vanish, not turn grey.
-    const demotedCategory = hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)
-        ? HIDDEN_CATEGORY
-        : EXCLUDED_BY_FILTERS_CATEGORY;
-    const includedCategory = hiddenCategories.has(INCLUDED_BY_FILTERS_CATEGORY)
-        ? HIDDEN_CATEGORY
-        : INCLUDED_BY_FILTERS_CATEGORY;
-
     // Each point is displayed as its first visible category, so it falls back to the next
     // one when a category is toggled off. Without an active filter every point starts as
     // INCLUDED_BY_FILTERS_CATEGORY so range selection still works.
@@ -84,15 +75,16 @@ export function usePlotData({
             );
         }
     } else {
-        category.fill(includedCategory);
+        category.fill(INCLUDED_BY_FILTERS_CATEGORY);
     }
     const sampleIds = data.sample_id as string[];
 
     if (rangeSelection) {
-        // Points inside the polygon keep their prevValue; points outside are demoted.
-        category = category.map(getCategoryBySelection(rangeSelection, data, demotedCategory));
+        // Points inside the polygon keep their prevValue; points outside are demoted to Excluded.
+        category = category.map(getCategoryBySelection(rangeSelection, data));
 
-        // Collect the sample ids of the selectable in-polygon points.
+        // Collect selectable in-polygon ids before the hide pass, so legend toggles never change
+        // which ids get committed to the filter.
         const _ids = category.reduce<string[]>((acc, pointCategory, index) => {
             if (!isUnselectableCategory(pointCategory)) {
                 acc.push(sampleIds[index]);
@@ -106,8 +98,18 @@ export function usePlotData({
             if (isUnselectableCategory(pointCategory)) {
                 return pointCategory;
             }
-            return highlightedSampleIdSet.has(sampleIds[index]) ? pointCategory : demotedCategory;
+            return highlightedSampleIdSet.has(sampleIds[index])
+                ? pointCategory
+                : EXCLUDED_BY_FILTERS_CATEGORY;
         });
+    }
+
+    // Hide on each point's final category, after demotion — so a hidden toggle removes exactly the
+    // points rendered in that bucket (a demoted point is hidden by Excluded, not its pre-demotion bucket).
+    if (hiddenCategories.size > 0) {
+        category = category.map((pointCategory) =>
+            hiddenCategories.has(pointCategory) ? HIDDEN_CATEGORY : pointCategory
+        );
     }
 
     plotData.set({

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
@@ -83,10 +83,10 @@ export function usePlotData({
         // Points inside the polygon keep their prevValue; points outside are demoted to Excluded.
         category = category.map(getCategoryBySelection(rangeSelection, data));
 
-        // Collect selectable in-polygon ids before the hide pass, so legend toggles never change
-        // which ids get committed to the filter.
+        // Collect in-polygon ids, skipping points that are filtered out or hidden by a legend
+        // toggle — a point the user cannot see must never be committed to the filter.
         const _ids = category.reduce<string[]>((acc, pointCategory, index) => {
-            if (!isUnselectableCategory(pointCategory)) {
+            if (!isUnselectableCategory(pointCategory) && !hiddenCategories.has(pointCategory)) {
                 acc.push(sampleIds[index]);
             }
             return acc;

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
@@ -104,8 +104,8 @@ export function usePlotData({
         });
     }
 
-    // Hide on each point's final category, after demotion — so a hidden toggle removes exactly the
-    // points rendered in that bucket (a demoted point is hidden by Excluded, not its pre-demotion bucket).
+    // Hide on each point's final category, after demotion: a demoted point is hidden as Excluded,
+    // not its pre-demotion bucket.
     if (hiddenCategories.size > 0) {
         category = category.map((pointCategory) =>
             hiddenCategories.has(pointCategory) ? HIDDEN_CATEGORY : pointCategory

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
@@ -62,6 +62,15 @@ export function usePlotData({
     const colorCategories = data.color_categories as number[][];
     const fulfilsFilter = data.fulfils_filter as ArrayLike<number>;
 
+    // Deselected points demote to the Excluded row and the no-filter fill is the Included row;
+    // route either to HIDDEN when its legend row is hidden so the points vanish, not turn grey.
+    const demotedCategory = hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)
+        ? HIDDEN_CATEGORY
+        : EXCLUDED_BY_FILTERS_CATEGORY;
+    const includedCategory = hiddenCategories.has(INCLUDED_BY_FILTERS_CATEGORY)
+        ? HIDDEN_CATEGORY
+        : INCLUDED_BY_FILTERS_CATEGORY;
+
     // Each point is displayed as its first visible category, so it falls back to the next
     // one when a category is toggled off. Without an active filter every point starts as
     // INCLUDED_BY_FILTERS_CATEGORY so range selection still works.
@@ -75,13 +84,13 @@ export function usePlotData({
             );
         }
     } else {
-        category.fill(INCLUDED_BY_FILTERS_CATEGORY);
+        category.fill(includedCategory);
     }
     const sampleIds = data.sample_id as string[];
 
     if (rangeSelection) {
-        // Points inside the polygon keep their prevValue; points outside are demoted to EXCLUDED_BY_FILTERS_CATEGORY.
-        category = category.map(getCategoryBySelection(rangeSelection, data));
+        // Points inside the polygon keep their prevValue; points outside are demoted.
+        category = category.map(getCategoryBySelection(rangeSelection, data, demotedCategory));
 
         // Collect the sample ids of the selectable in-polygon points.
         const _ids = category.reduce<string[]>((acc, pointCategory, index) => {
@@ -97,9 +106,7 @@ export function usePlotData({
             if (isUnselectableCategory(pointCategory)) {
                 return pointCategory;
             }
-            return highlightedSampleIdSet.has(sampleIds[index])
-                ? pointCategory
-                : EXCLUDED_BY_FILTERS_CATEGORY;
+            return highlightedSampleIdSet.has(sampleIds[index]) ? pointCategory : demotedCategory;
         });
     }
 


### PR DESCRIPTION
## What has changed and why?

Make non-categorical legend rows clickable to hide points.

Two caveats:
- Hiding means setting the point color to black.
    - There is a slight visual artifact, the old point leaves a shadow. It goes away on zoom as the overlap reduces.
    - Learned that opacity is not supported by embedding-plot. Note that plotting is point-order-independent.
- There was a bug, hiding `No category` points would hide some `Excluded by filters` points. Resolved by changing point color resolution order:
    - First assign `Excluded by filters` category
    - After that handle category hiding (with `No category` logic)

## How has it been tested?

* Manually
* Modified unit tests

<img width="275" height="185" alt="Screenshot 2026-06-29 at 15 05 47" src="https://github.com/user-attachments/assets/9df0adae-9346-48ad-a2e1-02c4dcefb03c" />
<img width="275" height="185" alt="Screenshot 2026-06-29 at 15 05 57" src="https://github.com/user-attachments/assets/45ac7d62-355c-42d6-b9bf-57da57128e7c" />
<img width="275" height="185" alt="Screenshot 2026-06-29 at 15 06 25" src="https://github.com/user-attachments/assets/a0828687-745b-494d-8157-7204e3639eca" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plot legend entries for reserved categories can now be toggled on and off, with clearer hidden-state styling.
  * Plot selections now respect hidden legend categories more consistently during range selection and highlighting.

* **Bug Fixes**
  * Prevented plots from briefly blanking when selecting while a hidden category is active.
  * Improved hidden-category handling so legend changes preserve the right reserved entries.

* **Documentation**
  * Updated the release notes to mention hidden plot legend entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->