### PR TITLE
Filter sources by evaluation type and introduce editable run name 

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/get_annotation_types_by_collection_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/get_annotation_types_by_collection_ids.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from uuid import UUID
 
+from sqlalchemy.orm import aliased
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
@@ -29,10 +30,11 @@ def get_annotation_types_by_collection_ids(
     if not collection_ids:
         return {}
 
+    sample = aliased(SampleTable)
     statement = (
-        select(col(SampleTable.collection_id), col(AnnotationBaseTable.annotation_type))
-        .join(SampleTable, AnnotationBaseTable.sample)
-        .where(col(SampleTable.collection_id).in_(collection_ids))
+        select(col(sample.collection_id), col(AnnotationBaseTable.annotation_type))
+        .join(sample, AnnotationBaseTable.sample)
+        .where(col(sample.collection_id).in_(collection_ids))
         .distinct()
     )
 

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunsPanel.svelte
@@ -79,7 +79,7 @@
                     class="h-8 w-8"
                     data-testid="evaluation-runs-add-button"
                 >
-                    <Plus class="size-4" /> Run evaluation
+                    <Plus class="size-4" />
                 </Button>
             {/if}
             <Button

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/TriggerEvaluationDialog.helpers.test.ts
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/TriggerEvaluationDialog.helpers.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
     buildEvaluationRunBody,
     canSubmitEvaluation,
-    defaultEvaluationRunName
+    defaultEvaluationRunName,
+    sourceMatchesTask
 } from './TriggerEvaluationDialog.helpers';
 
 describe('buildEvaluationRunBody', () => {
@@ -16,7 +17,7 @@ describe('buildEvaluationRunBody', () => {
         now
     };
 
-    it('includes object-detection config and a default local-time name', () => {
+    it('includes object-detection config and a local-time name for object_detection runs', () => {
         const body = buildEvaluationRunBody({ ...base, taskType: 'object_detection' });
 
         expect(body).toEqual({
@@ -57,6 +58,22 @@ describe('buildEvaluationRunBody', () => {
         });
         expect(body.name).toBe('my run');
     });
+
+    it('falls back to the default name when the provided name is blank', () => {
+        const body = buildEvaluationRunBody({
+            ...base,
+            taskType: 'object_detection',
+            name: '   '
+        });
+        expect(body.name).toBe('object_detection 2026-06-24 10:15:33');
+    });
+});
+
+describe('defaultEvaluationRunName', () => {
+    it('formats the task type and local time, zero-padded', () => {
+        const name = defaultEvaluationRunName('object_detection', new Date(2026, 0, 5, 9, 3, 7));
+        expect(name).toBe('object_detection 2026-01-05 09:03:07');
+    });
 });
 
 describe('canSubmitEvaluation', () => {
@@ -79,9 +96,18 @@ describe('canSubmitEvaluation', () => {
     });
 });
 
-describe('defaultEvaluationRunName', () => {
-    it('formats the task type and local time, zero-padded', () => {
-        const name = defaultEvaluationRunName('object_detection', new Date(2026, 0, 5, 9, 3, 7));
-        expect(name).toBe('object_detection 2026-01-05 09:03:07');
+describe('sourceMatchesTask', () => {
+    it('matches a source whose annotations are all the task type', () => {
+        expect(sourceMatchesTask(['object_detection'], 'object_detection')).toBe(true);
+        expect(sourceMatchesTask(['classification'], 'classification')).toBe(true);
+        expect(sourceMatchesTask(['segmentation_mask'], 'semantic_segmentation')).toBe(true);
+    });
+
+    it('rejects empty, mismatched, or mixed-type sources', () => {
+        expect(sourceMatchesTask([], 'object_detection')).toBe(false);
+        expect(sourceMatchesTask(['classification'], 'object_detection')).toBe(false);
+        expect(sourceMatchesTask(['object_detection', 'classification'], 'object_detection')).toBe(
+            false
+        );
     });
 });

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/TriggerEvaluationDialog.helpers.ts
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/TriggerEvaluationDialog.helpers.ts
@@ -71,3 +71,24 @@ export const canSubmitEvaluation = (params: {
     !!params.predSource &&
     params.gtSource !== params.predSource &&
     !params.isSubmitting;
+
+/** Annotation type each evaluation task requires its sources to contain. */
+const TASK_TO_ANNOTATION_TYPE: Record<EvaluationTaskType, string> = {
+    object_detection: 'object_detection',
+    classification: 'classification',
+    semantic_segmentation: 'segmentation_mask'
+};
+
+/**
+ * Whether an annotation source can be used for the given evaluation task.
+ *
+ * Mirrors the backend validator: every annotation in the source must be of the
+ * task's expected type (and the source must contain at least one annotation).
+ */
+export const sourceMatchesTask = (
+    annotationTypes: string[],
+    taskType: EvaluationTaskType
+): boolean => {
+    const expected = TASK_TO_ANNOTATION_TYPE[taskType];
+    return annotationTypes.length > 0 && annotationTypes.every((type) => type === expected);
+};

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/TriggerEvaluationDialog.svelte
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/TriggerEvaluationDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import * as Dialog from '$lib/components/ui/dialog';
     import { Button } from '$lib/components/ui/button';
+    import { Input } from '$lib/components/ui/input';
     import { Label } from '$lib/components/ui/label';
     import Select from '$lib/components/Select/Select.svelte';
     import { Spinner } from '$lib/components';
@@ -11,6 +12,7 @@
         buildEvaluationRunBody,
         canSubmitEvaluation,
         defaultEvaluationRunName,
+        sourceMatchesTask,
         type EvaluationTaskType
     } from './TriggerEvaluationDialog.helpers';
 
@@ -40,12 +42,23 @@
     let predSource = $state<string | undefined>(undefined);
     let iouThreshold = $state(0.5);
     let classwise = $state(true);
+    // Empty means "use the auto-generated default" (shown as the placeholder).
+    let name = $state('');
+
+    const defaultName = $derived(defaultEvaluationRunName(taskType));
 
     const annotationCollectionsQuery = useAnnotationCollections(() => ({ collectionId }));
     const sources = $derived(annotationCollectionsQuery.data ?? []);
 
+    // Only sources whose annotations match the selected task type are valid
+    // (mirrors the backend validator), so the user can't pick an incompatible one.
+    const matchingSources = $derived(
+        sources.filter((source) => sourceMatchesTask(source.annotation_types ?? [], taskType))
+    );
+    const hasNoMatchingSources = $derived(matchingSources.length === 0);
+
     const sourceItems = (excluded: string | undefined) =>
-        sources.map((source) => ({
+        matchingSources.map((source) => ({
             value: source.name,
             label: source.name,
             disabled: source.name === excluded
@@ -74,12 +87,13 @@
                 collectionId,
                 iouThreshold,
                 classwise,
-                name: defaultEvaluationRunName(taskType)
+                name
             })
         );
         if (ok) {
             gtSource = undefined;
             predSource = undefined;
+            name = '';
             onOpenChange(false);
         }
     };
@@ -109,26 +123,46 @@
                     </div>
 
                     <div class="grid gap-2">
-                        <Label class="text-foreground">Ground truth source</Label>
-                        <Select
-                            items={sourceItems(predSource)}
-                            value={gtSource}
-                            placeholder="Select a source"
-                            onValueChange={(value) => (gtSource = value)}
-                            testId="gt-source-select"
+                        <Label for="evaluation-run-name" class="text-foreground">Name</Label>
+                        <Input
+                            id="evaluation-run-name"
+                            bind:value={name}
+                            placeholder={defaultName}
+                            data-testid="evaluation-name-input"
                         />
                     </div>
 
-                    <div class="grid gap-2">
-                        <Label class="text-foreground">Prediction source</Label>
-                        <Select
-                            items={sourceItems(gtSource)}
-                            value={predSource}
-                            placeholder="Select a source"
-                            onValueChange={(value) => (predSource = value)}
-                            testId="pred-source-select"
-                        />
-                    </div>
+                    {#if hasNoMatchingSources}
+                        <p
+                            class="text-sm text-muted-foreground"
+                            data-testid="no-matching-sources-warning"
+                        >
+                            No annotation sources with matching annotations were found for this
+                            evaluation type.
+                        </p>
+                    {:else}
+                        <div class="grid gap-2">
+                            <Label class="text-foreground">Ground truth source</Label>
+                            <Select
+                                items={sourceItems(predSource)}
+                                value={gtSource}
+                                placeholder="Select a source"
+                                onValueChange={(value) => (gtSource = value)}
+                                testId="gt-source-select"
+                            />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label class="text-foreground">Prediction source</Label>
+                            <Select
+                                items={sourceItems(gtSource)}
+                                value={predSource}
+                                placeholder="Select a source"
+                                onValueChange={(value) => (predSource = value)}
+                                testId="pred-source-select"
+                            />
+                        </div>
+                    {/if}
 
                     {#if sameSource}
                         <p class="text-sm text-destructive-text" data-testid="same-source-warning">

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/TriggerEvaluationDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/TriggerEvaluationDialog.test.ts
@@ -2,7 +2,11 @@ import { render, screen } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import TriggerEvaluationDialog from './TriggerEvaluationDialog.svelte';
 
-let annotationCollectionsData: { collection_id: string; name: string }[] = [];
+let annotationCollectionsData: {
+    collection_id: string;
+    name: string;
+    annotation_types: string[];
+}[] = [];
 
 vi.mock('$lib/hooks/useAnnotationCollections/useAnnotationCollections', () => ({
     useAnnotationCollections: () => ({ data: annotationCollectionsData })
@@ -32,8 +36,8 @@ const defaultProps = {
 describe('TriggerEvaluationDialog', () => {
     beforeEach(() => {
         annotationCollectionsData = [
-            { collection_id: 'a', name: 'gt' },
-            { collection_id: 'b', name: 'pred' }
+            { collection_id: 'a', name: 'gt', annotation_types: ['object_detection'] },
+            { collection_id: 'b', name: 'pred', annotation_types: ['object_detection'] }
         ];
         triggerMock.mockReset();
         isPending = false;
@@ -49,6 +53,11 @@ describe('TriggerEvaluationDialog', () => {
         expect(screen.getByTestId('gt-source-select')).toBeInTheDocument();
         expect(screen.getByTestId('pred-source-select')).toBeInTheDocument();
         expect(screen.getByTestId('evaluation-duration-note')).toBeInTheDocument();
+
+        // Editable name, empty by default with the auto-name shown as placeholder.
+        const nameInput = screen.getByTestId('evaluation-name-input') as HTMLInputElement;
+        expect(nameInput).toHaveValue('');
+        expect(nameInput.placeholder).toMatch(/^object_detection \d{4}-\d{2}-\d{2}/);
     });
 
     it('shows object-detection config fields by default', () => {
@@ -61,6 +70,18 @@ describe('TriggerEvaluationDialog', () => {
     it('disables the submit button until distinct sources are selected', () => {
         render(TriggerEvaluationDialog, { props: defaultProps });
 
+        expect(screen.getByTestId('trigger-evaluation-submit')).toBeDisabled();
+    });
+
+    it('shows an empty state and hides source selects when no source matches the eval type', () => {
+        annotationCollectionsData = [
+            { collection_id: 'a', name: 'gt', annotation_types: ['classification'] }
+        ];
+        render(TriggerEvaluationDialog, { props: defaultProps });
+
+        // Default eval type is object_detection; the only source is classification.
+        expect(screen.getByTestId('no-matching-sources-warning')).toBeInTheDocument();
+        expect(screen.queryByTestId('gt-source-select')).not.toBeInTheDocument();
         expect(screen.getByTestId('trigger-evaluation-submit')).toBeDisabled();
     });
 });

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/useTriggerEvaluation.svelte.ts
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/useTriggerEvaluation.svelte.ts
@@ -1,6 +1,7 @@
 import {
     createEvaluationRunMutation,
-    getEvaluationRunsQueryKey
+    getEvaluationRunsQueryKey,
+    getEvaluationSampleMetricsInfoQueryKey
 } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
 import type { CreateEvaluationRunData } from '$lib/api/lightly_studio_local/types.gen';
 import { createMutation, useQueryClient } from '@tanstack/svelte-query';
@@ -30,10 +31,14 @@ export const useTriggerEvaluation = (getParams: () => UseTriggerEvaluationParams
                 {
                     onSuccess: () => {
                         toast.success('Evaluation started');
+                        const path = { dataset_id: datasetId };
+                        // Refresh the runs list and the per-run metric bounds that
+                        // feed the sort options, so both update without a reload.
                         client.invalidateQueries({
-                            queryKey: getEvaluationRunsQueryKey({
-                                path: { dataset_id: datasetId }
-                            })
+                            queryKey: getEvaluationRunsQueryKey({ path })
+                        });
+                        client.invalidateQueries({
+                            queryKey: getEvaluationSampleMetricsInfoQueryKey({ path })
                         });
                         resolve(true);
                     },


### PR DESCRIPTION
## What has changed and why?

Part of LIG-9843 (trigger model evaluation from the GUI). Refines the
"Start evaluation" dialog with three changes:

- **Filter annotation sources by evaluation type.** New `sourceMatchesTask` helper
  maps each task to its required annotation type (`object_detection`,
  `classification`, `semantic_segmentation` → `segmentation_mask`) and accepts a
  source only when it's non-empty and *all* of its annotations are that type —
  mirroring the backend validator. The ground-truth and prediction dropdowns now
  only list compatible sources, so users can't pick one that would fail server-side.
  When no source matches the selected type, the selects are hidden and an empty-state
  message is shown ("No annotation sources with matching annotations were found for
  this evaluation type").

- **Editable run name.** Added a Name input, empty by default with the
  auto-generated name shown as the placeholder; a blank/whitespace value falls back
  to that default. Previously the run name was always auto-generated.

- **Refresh sort params after triggering a run.** `useTriggerEvaluation` now also
  invalidates the evaluation sample-metrics-info query (which feeds the per-run
  metric bounds / sort options), alongside the runs list, so both update without a
  page reload.

## How has it been tested?

- Unit tests for `sourceMatchesTask` (matching, empty, mismatched, and mixed-type
  sources).
- `TriggerEvaluationDialog` component tests: name input is empty with the auto-name
  as placeholder, and the no-matching-sources empty state hides the selects and
  disables submit.
- Updated the dialog/annotation-collections mocks to include `annotation_types`.

https://github.com/user-attachments/assets/d236e8d3-d530-4f45-ac57-244cca65c10d



## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now enter a custom name when starting an evaluation run, with a helpful default name suggested automatically.
  * Evaluation sources are now filtered to show only compatible options for the selected task, with a warning shown when none are available.

* **Bug Fixes**
  * Submission now resets the evaluation name and selected sources after a successful run.
  * Evaluation run and related metrics data refresh together more reliably after creating a run.
  * The new evaluation action button now uses a cleaner icon-only appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->