### PR TITLE
Add AnnotationEvaluationMetricField class

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
@@ -1,3 +1,4 @@
+from .annotation_evaluation_metric_expression import AnnotationEvaluationMetricField
 from .boolean_expression import AND, NOT, OR
 from .classification_query import ClassificationField, ClassificationQuery
 from .dataset_query import DatasetQuery
@@ -18,6 +19,7 @@ __all__ = [
     "AND",
     "NOT",
     "OR",
+    "AnnotationEvaluationMetricField",
     "ClassificationField",
     "ClassificationQuery",
     "DatasetQuery",

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_metric_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_metric_expression.py
@@ -1,0 +1,82 @@
+"""Classes for filtering samples by persisted annotation evaluation metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import ColumnElement, and_
+from sqlmodel import col
+
+from lightly_studio.core.dataset_query.field_expression import OrdinalOperator
+from lightly_studio.core.dataset_query.match_expression import MatchExpression
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
+
+
+class AnnotationEvaluationMetricField:  # noqa: PLW1641
+    """Queryable annotation metric field for matching samples within an evaluation run."""
+
+    def __init__(self, metric_name: str) -> None:
+        """Initialize a queryable annotation metric reference."""
+        self.metric_name = metric_name
+
+    def _expression(self, other: float | int, operator: OrdinalOperator) -> MatchExpression:
+        return AnnotationEvaluationMetricMatchExpression(
+            metric_name=self.metric_name,
+            operator=operator,
+            value=other,
+        )
+
+    def __gt__(self, other: float | int) -> MatchExpression:
+        """Create a greater-than filter."""
+        return self._expression(other=other, operator=">")
+
+    def __lt__(self, other: float | int) -> MatchExpression:
+        """Create a less-than filter."""
+        return self._expression(other=other, operator="<")
+
+    def __ge__(self, other: float | int) -> MatchExpression:
+        """Create a greater-than-or-equal filter."""
+        return self._expression(other=other, operator=">=")
+
+    def __le__(self, other: float | int) -> MatchExpression:
+        """Create a less-than-or-equal filter."""
+        return self._expression(other=other, operator="<=")
+
+    def __eq__(self, other: float | int) -> MatchExpression:  # type: ignore[override]
+        """Create an equality filter."""
+        return self._expression(other=other, operator="==")
+
+    def __ne__(self, other: float | int) -> MatchExpression:  # type: ignore[override]
+        """Create an inequality filter."""
+        return self._expression(other=other, operator="!=")
+
+
+@dataclass
+class AnnotationEvaluationMetricMatchExpression(MatchExpression):
+    """A match expression that filters samples by their annotation evaluation metrics.
+
+    This expression constructs a SQL query predicate targeting the evaluation annotation
+    metrics table. It filters for a specific metric by its name and asserts that the metric's
+    numeric value satisfies the specified comparison operator against a given threshold.
+    """
+
+    # TODO(lukas): Validate that this expression is not nested inside AND/OR/NOT combinators.
+    metric_name: str
+    operator: OrdinalOperator
+    value: float | int
+
+    def get(self) -> ColumnElement[bool]:
+        """Build a predicate against the current annotation metric row."""
+        metric_value = col(EvaluationAnnotationMetricTable.value)
+        operations: dict[OrdinalOperator, ColumnElement[bool]] = {
+            "<": metric_value < self.value,
+            "<=": metric_value <= self.value,
+            ">": metric_value > self.value,
+            ">=": metric_value >= self.value,
+            "==": metric_value == self.value,
+            "!=": metric_value != self.value,
+        }
+        return and_(
+            col(EvaluationAnnotationMetricTable.metric_name) == self.metric_name,
+            operations[self.operator],
+        )

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_metric_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_metric_expression.py
@@ -60,7 +60,7 @@ class AnnotationEvaluationMetricMatchExpression(MatchExpression):
     numeric value satisfies the specified comparison operator against a given threshold.
     """
 
-    # TODO(lukas): Validate that this expression is not nested inside AND/OR/NOT combinators.
+    # TODO(lukas 6/2026): Validate that this expression is not nested inside AND/OR/NOT combinators.
     metric_name: str
     operator: OrdinalOperator
     value: float | int

--- a/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_metric_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_metric_expression.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+from sqlmodel import select
+
+from lightly_studio.core.dataset_query.annotation_evaluation_metric_expression import (
+    AnnotationEvaluationMetricField,
+)
+from lightly_studio.core.dataset_query.match_expression import MatchExpression
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
+from lightly_studio.models.evaluation_run import EvaluationRunTable
+from lightly_studio.models.sample import SampleTable
+
+
+def test_annotation_evaluation_metric_field__sql_filters_metric_value() -> None:
+    query = select(EvaluationRunTable, SampleTable).where(
+        (AnnotationEvaluationMetricField(metric_name="score") >= 0.5).get()
+    )
+    sql = " ".join(str(query.compile(compile_kwargs={"literal_binds": True})).lower().split())
+
+    assert "evaluation_annotation_metric" in sql.split("where")[0]
+    assert "evaluation_annotation_metric.metric_name = 'score'" in sql
+    assert "evaluation_annotation_metric.value >= 0.5" in sql
+    assert "exists (select 1" not in sql
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected_sql"),
+    [
+        (
+            AnnotationEvaluationMetricField(metric_name="score") > 0.5,
+            "evaluation_annotation_metric.value > 0.5",
+        ),
+        (
+            AnnotationEvaluationMetricField(metric_name="score") >= 0.5,
+            "evaluation_annotation_metric.value >= 0.5",
+        ),
+        (
+            AnnotationEvaluationMetricField(metric_name="score") < 0.5,
+            "evaluation_annotation_metric.value < 0.5",
+        ),
+        (
+            AnnotationEvaluationMetricField(metric_name="score") <= 0.5,
+            "evaluation_annotation_metric.value <= 0.5",
+        ),
+        (
+            AnnotationEvaluationMetricField(metric_name="score") == 0.5,
+            "evaluation_annotation_metric.value = 0.5",
+        ),
+        (
+            AnnotationEvaluationMetricField(metric_name="score") != 0.5,
+            "evaluation_annotation_metric.value != 0.5",
+        ),
+    ],
+)
+def test_annotation_evaluation_metric_field__operators(
+    expression: MatchExpression, expected_sql: str
+) -> None:
+    query = select(EvaluationAnnotationMetricTable).where(expression.get())
+    sql = str(query.compile(compile_kwargs={"literal_binds": True})).lower()
+
+    assert expected_sql in sql

--- a/lightly_studio/tests/core/dataset_query/test_evaluation_metric_expression.py
+++ b/lightly_studio/tests/core/dataset_query/test_evaluation_metric_expression.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from sqlmodel import col, select
+from sqlmodel import select
 
 from lightly_studio.core.dataset_query.evaluation_metric_expression import EvaluationMetricField
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
@@ -10,20 +10,14 @@ from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetri
 
 
 def test_evaluation_metric_field__sql_filters_metric_value() -> None:
-    query = (
-        select(EvaluationSampleMetricTable)
-        .join(
-            EvaluationRunTable,
-            col(EvaluationSampleMetricTable.evaluation_run_id) == col(EvaluationRunTable.id),
-        )
-        .where(col(EvaluationRunTable.name) == "run1")
-        .where((EvaluationMetricField(metric_name="score") >= 0.5).get())
+    query = select(EvaluationRunTable).where(
+        (EvaluationMetricField(metric_name="score") >= 0.5).get()
     )
     sql = str(query.compile(compile_kwargs={"literal_binds": True})).lower()
 
+    assert "exists (select 1" in sql
     assert "from evaluation_sample_metric" in sql
-    assert "join evaluation_run" in sql
-    assert "evaluation_run.name = 'run1'" in sql
+    assert "evaluation_sample_metric.evaluation_run_id = evaluation_run.id" in sql
     assert "evaluation_sample_metric.metric_name = 'score'" in sql
     assert "evaluation_sample_metric.value >= 0.5" in sql
 


### PR DESCRIPTION
## What has changed and why?
Future use:
`TruePositiveQuery("run1", AnnotationEvaluationMetricField("iou") >= 0.5)`.

Or `FalsePositiveQuery("run1", AnnotationEvaluationMetricField("iou") >= 0.5)`.

API might change slightly.

## How has it been tested?
Added tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dataset query support for filtering by persisted annotation evaluation metrics using comparison operators (>, >=, <, <=, ==, !=).
  * Made the new metric query field available as a public, wildcard-importable API symbol.

* **Tests**
  * Added SQL-generation coverage to verify correct metric-name and metric-value predicates for the new comparisons.
  * Updated existing metric-filtering SQL assertions to match the new query structure (including the expected `EXISTS` behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->