### PR TITLE
Hide plot points by their final displayed category

### DIFF
--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.test.ts
@@ -30,19 +30,9 @@ describe('resolveVisibleCategory', () => {
         expect(resolveVisibleCategory([3, 4, 5], 1, new Set([3, 4]))).toBe(5);
     });
 
-    it('routes to HIDDEN_CATEGORY (0) when filtered out and EXCLUDED is hidden', () => {
-        expect(resolveVisibleCategory([3, 4], 0, new Set([1]))).toBe(0);
-    });
-
-    it('routes to HIDDEN_CATEGORY (0) when the point has no categories and INCLUDED is hidden', () => {
-        expect(resolveVisibleCategory([], 1, new Set([2]))).toBe(0);
-    });
-
-    it('routes to HIDDEN_CATEGORY (0) when all colored categories and INCLUDED are hidden', () => {
-        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 4, 2]))).toBe(0);
-    });
-
-    it('falls back to a visible colored category even when INCLUDED is hidden', () => {
-        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 2]))).toBe(4);
+    it('ignores hidden reserved buckets — usePlotData applies hiding to the final category', () => {
+        expect(resolveVisibleCategory([3, 4], 0, new Set([1]))).toBe(1); // filtered out, EXCLUDED hidden
+        expect(resolveVisibleCategory([], 1, new Set([2]))).toBe(2); // no categories, INCLUDED hidden
+        expect(resolveVisibleCategory([3, 4], 1, new Set([3, 4, 2]))).toBe(2); // all colored hidden
     });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/resolveVisibleCategory/resolveVisibleCategory.ts
@@ -1,16 +1,13 @@
-import {
-    EXCLUDED_BY_FILTERS_CATEGORY,
-    HIDDEN_CATEGORY,
-    INCLUDED_BY_FILTERS_CATEGORY
-} from '../plotCategories';
+import { EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY } from '../plotCategories';
 
 /**
- * Resolves the category a point is displayed as, given every category it belongs to in
- * priority order. A multi-category point falls back to its next visible category, and a
- * point whose resolved category is hidden routes to HIDDEN_CATEGORY (not rendered):
+ * Resolves the pre-hiding bucket a point is displayed as:
  * - filtered out -> EXCLUDED_BY_FILTERS_CATEGORY
  * - otherwise the first non-hidden category
- * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY
+ * - otherwise (no categories, or all hidden) -> INCLUDED_BY_FILTERS_CATEGORY ("No category")
+ *
+ * `hiddenCategories` only skips hidden color slots here; routing a hidden bucket to
+ * HIDDEN_CATEGORY happens in `usePlotData` after demotion, on the final category.
  *
  * @param colorCategories - All categories the point belongs to, in priority order
  * @param fulfilsFilter - Whether the point passes the active filter (0 = filtered out)
@@ -22,9 +19,7 @@ export const resolveVisibleCategory = (
     hiddenCategories: ReadonlySet<number>
 ): number => {
     if (fulfilsFilter === 0) {
-        return hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)
-            ? HIDDEN_CATEGORY
-            : EXCLUDED_BY_FILTERS_CATEGORY;
+        return EXCLUDED_BY_FILTERS_CATEGORY;
     }
 
     for (const category of colorCategories) {
@@ -33,7 +28,5 @@ export const resolveVisibleCategory = (
         }
     }
 
-    return hiddenCategories.has(INCLUDED_BY_FILTERS_CATEGORY)
-        ? HIDDEN_CATEGORY
-        : INCLUDED_BY_FILTERS_CATEGORY;
+    return INCLUDED_BY_FILTERS_CATEGORY;
 };

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -208,8 +208,7 @@ describe('usePlotData', () => {
         });
 
         const data = get(result.data) as { category: Uint8Array };
-        // sample1 hidden+in-lasso stays 0; sample2 keeps color 3. Out-of-lasso points demote to
-        // the hidden Excluded row, so they route to HIDDEN (0) rather than reappearing grey.
+        // Only sample2 is selectable; the rest are Excluded, then hidden (row 1) -> HIDDEN (0).
         expect(Array.from(data.category)).toEqual([0, 3, 0, 0]);
         expect(get(result.selectedSampleIds)).toEqual(['sample2']);
     });
@@ -226,8 +225,7 @@ describe('usePlotData', () => {
         });
 
         const data = get(result.data) as { category: Uint8Array };
-        // Highlighted-but-hidden sample1 stays 0; sample2 highlighted keeps 3; sample3 hidden
-        // stays 0; un-highlighted sample4 demotes to the hidden Excluded row -> HIDDEN 0.
+        // Only highlighted+passing sample2 keeps its color; the rest are Excluded, then hidden -> 0.
         expect(Array.from(data.category)).toEqual([0, 3, 0, 0]);
     });
 
@@ -243,6 +241,25 @@ describe('usePlotData', () => {
         const data = get(result.data) as { category: Uint8Array };
         // sample2 is highlighted -> keeps 3; sample3 is already EXCLUDED (1) -> stays 1;
         // sample1 and sample4 are not highlighted -> demoted to EXCLUDED 1.
+        expect(Array.from(data.category)).toEqual([1, 3, 1, 1]);
+    });
+
+    it('hides "No category" points by their displayed bucket, not their pre-demotion identity', () => {
+        const mockData = createMockArrowData();
+        // All pass the filter, so demotion is purely highlight-driven; sample1/sample3 have no
+        // annotation (would be "No category" 2 if Included).
+        mockData.fulfils_filter = new Uint8Array([1, 1, 1, 1]);
+
+        const result = usePlotData({
+            arrowData: mockData,
+            rangeSelection: null,
+            highlightedSampleIds: ['sample2'],
+            hiddenCategories: new Set([2]) // hide "No category"
+        });
+
+        const data = get(result.data) as { category: Uint8Array };
+        // Un-highlighted points demote to Excluded and render as Excluded; hiding "No category" (2)
+        // must not touch them. (The pre-fix pipeline produced [0, 3, 0, 0].)
         expect(Array.from(data.category)).toEqual([1, 3, 1, 1]);
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
@@ -62,15 +62,6 @@ export function usePlotData({
     const colorCategories = data.color_categories as number[][];
     const fulfilsFilter = data.fulfils_filter as ArrayLike<number>;
 
-    // Deselected points demote to the Excluded row and the no-filter fill is the Included row;
-    // route either to HIDDEN when its legend row is hidden so the points vanish, not turn grey.
-    const demotedCategory = hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)
-        ? HIDDEN_CATEGORY
-        : EXCLUDED_BY_FILTERS_CATEGORY;
-    const includedCategory = hiddenCategories.has(INCLUDED_BY_FILTERS_CATEGORY)
-        ? HIDDEN_CATEGORY
-        : INCLUDED_BY_FILTERS_CATEGORY;
-
     // Each point is displayed as its first visible category, so it falls back to the next
     // one when a category is toggled off. Without an active filter every point starts as
     // INCLUDED_BY_FILTERS_CATEGORY so range selection still works.
@@ -84,15 +75,16 @@ export function usePlotData({
             );
         }
     } else {
-        category.fill(includedCategory);
+        category.fill(INCLUDED_BY_FILTERS_CATEGORY);
     }
     const sampleIds = data.sample_id as string[];
 
     if (rangeSelection) {
-        // Points inside the polygon keep their prevValue; points outside are demoted.
-        category = category.map(getCategoryBySelection(rangeSelection, data, demotedCategory));
+        // Points inside the polygon keep their prevValue; points outside are demoted to Excluded.
+        category = category.map(getCategoryBySelection(rangeSelection, data));
 
-        // Collect the sample ids of the selectable in-polygon points.
+        // Collect selectable in-polygon ids before the hide pass, so legend toggles never change
+        // which ids get committed to the filter.
         const _ids = category.reduce<string[]>((acc, pointCategory, index) => {
             if (!isUnselectableCategory(pointCategory)) {
                 acc.push(sampleIds[index]);
@@ -106,8 +98,18 @@ export function usePlotData({
             if (isUnselectableCategory(pointCategory)) {
                 return pointCategory;
             }
-            return highlightedSampleIdSet.has(sampleIds[index]) ? pointCategory : demotedCategory;
+            return highlightedSampleIdSet.has(sampleIds[index])
+                ? pointCategory
+                : EXCLUDED_BY_FILTERS_CATEGORY;
         });
+    }
+
+    // Hide on each point's final category, after demotion — so a hidden toggle removes exactly the
+    // points rendered in that bucket (a demoted point is hidden by Excluded, not its pre-demotion bucket).
+    if (hiddenCategories.size > 0) {
+        category = category.map((pointCategory) =>
+            hiddenCategories.has(pointCategory) ? HIDDEN_CATEGORY : pointCategory
+        );
     }
 
     plotData.set({


### PR DESCRIPTION
## What has changed and why?

Hiding the "No category" legend row in the embedding plot also hid points displayed as "Excluded by filters": category resolution ran before selection demotion, so a no-annotation point hidden via "No category" was routed out before being demoted into the Excluded bucket it actually rendered in.

The two passes are now reversed — decide inclusion first, color the survivors, then apply hiding to each point's final category — so a legend toggle hides exactly the points rendered in that bucket.

## How has it been tested?

- Unit tests for `usePlotData` and `resolveVisibleCategory`, including a regression test.
- `make static-checks` and `make test` pass.
- Manual: with color-by-annotation and an active filter, hiding "No category" leaves Excluded points visible.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
