### PR TITLE
Annotation metrics test cleanup

### DIFF
--- a/lightly_studio/tests/api/routes/api/test_image.py
+++ b/lightly_studio/tests/api/routes/api/test_image.py
@@ -25,8 +25,10 @@ from lightly_studio.resolvers.image_resolver.get_all_by_collection_id import (
 )
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import (
+    AnnotationDetails,
     create_annotation,
     create_annotation_label,
+    create_annotations,
     create_collection,
     create_image,
 )
@@ -384,23 +386,23 @@ def test_count_image_annotations_by_collection__with_image_filter(
         label_name="cat",
     )
 
-    create_annotation(
+    create_annotations(
         session=db_session,
-        sample_id=image_1.sample_id,
-        annotation_label_id=cat_label.annotation_label_id,
         collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=image_2.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
-        collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=image_3.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
-        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image_1.sample_id,
+                annotation_label_id=cat_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_2.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_3.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+        ],
     )
 
     response = test_client.post(

--- a/lightly_studio/tests/api/routes/api/test_video.py
+++ b/lightly_studio/tests/api/routes/api/test_video.py
@@ -6,7 +6,12 @@ from sqlmodel import Session
 from lightly_studio.api.routes.api.status import HTTP_STATUS_OK
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import video_resolver
-from tests.helpers_resolvers import create_annotation, create_annotation_label, create_collection
+from tests.helpers_resolvers import (
+    AnnotationDetails,
+    create_annotation_label,
+    create_annotations,
+    create_collection,
+)
 from tests.resolvers.video.helpers import VideoStub, create_video_with_frames, create_videos
 
 
@@ -198,26 +203,23 @@ def test_get_fields_bounds(test_client: TestClient, db_session: Session) -> None
         label_name="airplane",
     )
 
-    # Create annotations
-    create_annotation(
+    create_annotations(
         session=db_session,
-        sample_id=video_frame_id_1,
-        annotation_label_id=car_label.annotation_label_id,
         collection_id=collection_id,
-    )
-
-    create_annotation(
-        session=db_session,
-        sample_id=video_frame_id_2,
-        annotation_label_id=car_label.annotation_label_id,
-        collection_id=collection_id,
-    )
-
-    create_annotation(
-        session=db_session,
-        sample_id=video_frame_id_3,
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=video_frame_id_1,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id_2,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id_3,
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+        ],
     )
 
     response = test_client.post(
@@ -279,24 +281,23 @@ def test_count_video_frame_annotations_by_video_collection(
         label_name="house",
     )
 
-    # Create annotations
-    create_annotation(
+    create_annotations(
         session=db_session,
-        sample_id=video_frame_id,
-        annotation_label_id=car_label.annotation_label_id,
         collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frame_id_1,
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frame_id_1,
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=video_frame_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id_1,
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id_1,
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+        ],
     )
 
     response = test_client.post(

--- a/lightly_studio/tests/resolvers/annotations/test_annotations_update_annotation_label.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotations_update_annotation_label.py
@@ -214,7 +214,7 @@ def test_update_annotation_label__deletes_evaluation_metrics(
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     collection_id = dataset.collection_id

--- a/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
+++ b/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
@@ -101,7 +101,7 @@ def test_delete_annotation__deletes_evaluation_annotation_metrics(
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     collection_id = dataset.collection_id
@@ -161,13 +161,13 @@ def test_delete_annotation__preserves_other_run_sample_metrics(
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
         name="run1",
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     other_run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
         name="run2",
     )
 

--- a/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
@@ -35,25 +35,25 @@ def test_get_adjacent_annotations__orders_by_path(db_session: Session) -> None:
         file_path_abs="/images/c.png",
     )
 
-    annotation_a = helpers_resolvers.create_annotation(
+    annotation_a, annotation_b, annotation_c = helpers_resolvers.create_annotations(
         session=db_session,
         collection_id=collection_id,
-        sample_id=image_a.sample_id,
-        annotation_label_id=label.annotation_label_id,
+        annotations=[
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            ),
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            ),
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_c.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            ),
+        ],
     )
     annotation_collection_id = annotation_a.sample.collection_id
-    annotation_b = helpers_resolvers.create_annotation(
-        session=db_session,
-        collection_id=collection_id,
-        sample_id=image_b.sample_id,
-        annotation_label_id=label.annotation_label_id,
-    )
-    annotation_c = helpers_resolvers.create_annotation(
-        session=db_session,
-        collection_id=collection_id,
-        sample_id=image_c.sample_id,
-        annotation_label_id=label.annotation_label_id,
-    )
 
     result = annotation_resolver.get_adjacent_annotations(
         session=db_session,
@@ -137,25 +137,25 @@ def test_get_adjacent_annotations__respects_annotation_filter(db_session: Sessio
         file_path_abs="/images/c.png",
     )
 
-    annotation_a = helpers_resolvers.create_annotation(
+    annotation_a, annotation_b, _ = helpers_resolvers.create_annotations(
         session=db_session,
         collection_id=collection_id,
-        sample_id=image_a.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
+        annotations=[
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_c.sample_id,
+                annotation_label_id=cat_label.annotation_label_id,
+            ),
+        ],
     )
     annotation_collection_id = annotation_a.sample.collection_id
-    annotation_b = helpers_resolvers.create_annotation(
-        session=db_session,
-        collection_id=collection_id,
-        sample_id=image_b.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
-    )
-    helpers_resolvers.create_annotation(
-        session=db_session,
-        collection_id=collection_id,
-        sample_id=image_c.sample_id,
-        annotation_label_id=cat_label.annotation_label_id,
-    )
 
     result = annotation_resolver.get_adjacent_annotations(
         session=db_session,
@@ -202,25 +202,25 @@ def test_get_adjacent_annotations__respects_annotation_tags(db_session: Session)
         file_path_abs="/images/c.png",
     )
 
-    annotation_a = helpers_resolvers.create_annotation(
+    annotation_a, annotation_b, annotation_c = helpers_resolvers.create_annotations(
         session=db_session,
         collection_id=collection_id,
-        sample_id=image_a.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
+        annotations=[
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_c.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+        ],
     )
     annotation_collection_id = annotation_a.sample.collection_id
-    annotation_b = helpers_resolvers.create_annotation(
-        session=db_session,
-        collection_id=collection_id,
-        sample_id=image_b.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
-    )
-    annotation_c = helpers_resolvers.create_annotation(
-        session=db_session,
-        collection_id=collection_id,
-        sample_id=image_c.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
-    )
 
     tag_one = helpers_resolvers.create_tag(
         session=db_session,
@@ -293,25 +293,25 @@ def test_get_adjacent_annotations__respects_sample_tags(db_session: Session) -> 
         file_path_abs="/images/c.png",
     )
 
-    annotation_a = helpers_resolvers.create_annotation(
+    annotation_a, annotation_b, annotation_c = helpers_resolvers.create_annotations(
         session=db_session,
         collection_id=collection_id,
-        sample_id=image_a.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
+        annotations=[
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_c.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+        ],
     )
     annotation_collection_id = annotation_a.sample.collection_id
-    annotation_b = helpers_resolvers.create_annotation(
-        session=db_session,
-        collection_id=collection_id,
-        sample_id=image_b.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
-    )
-    annotation_c = helpers_resolvers.create_annotation(
-        session=db_session,
-        collection_id=collection_id,
-        sample_id=image_c.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
-    )
 
     sample_tag_one = helpers_resolvers.create_tag(
         session=db_session,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -361,34 +361,35 @@ def test_deep_copy__can_delete_original_after_copy(db_session: Session) -> None:
         session=db_session, root_collection_id=original.collection_id, label_name="test"
     )
 
-    create_annotation(
+    create_annotations(
         session=db_session,
         collection_id=original.collection_id,
-        sample_id=img.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.CLASSIFICATION,
-    )
-    create_annotation(
-        session=db_session,
-        collection_id=original.collection_id,
-        sample_id=img.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.OBJECT_DETECTION,
-        annotation_data={"x": 10, "y": 20, "width": 30, "height": 40},
-    )
-    create_annotation(
-        session=db_session,
-        collection_id=original.collection_id,
-        sample_id=img.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.SEGMENTATION_MASK,
-        annotation_data={
-            "x": 2,
-            "y": 4,
-            "width": 6,
-            "height": 8,
-            "segmentation_mask": [1, 0, 0, 1],
-        },
+        annotations=[
+            AnnotationDetails(
+                sample_id=img.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+            ),
+            AnnotationDetails(
+                sample_id=img.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+                x=10,
+                y=20,
+                width=30,
+                height=40,
+            ),
+            AnnotationDetails(
+                sample_id=img.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.SEGMENTATION_MASK,
+                x=2,
+                y=4,
+                width=6,
+                height=8,
+                segmentation_mask=[1, 0, 0, 1],
+            ),
+        ],
     )
 
     embedding_model = create_embedding_model(
@@ -450,7 +451,7 @@ def test_deep_copy__with_evaluation_sample_metrics(db_session: Session) -> None:
     # Arrange
     dataset = create_collection(session=db_session, collection_name="original")
     run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     evaluation_sample_metric_resolver.create_many(
@@ -535,40 +536,36 @@ def test_deep_copy__with_annotations(db_session: Session) -> None:
         tracks=[ObjectTrackCreate(object_track_number=7, dataset_id=original.dataset_id)],
     )
 
-    classification = create_annotation(
+    classification, obj_detection, instance_seg = create_annotations(
         session=db_session,
         collection_id=original.collection_id,
-        sample_id=img.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.CLASSIFICATION,
-    )
-    obj_detection = create_annotation(
-        session=db_session,
-        collection_id=original.collection_id,
-        sample_id=img.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.OBJECT_DETECTION,
-        annotation_data={
-            "x": 10,
-            "y": 20,
-            "width": 30,
-            "height": 40,
-            "object_track_id": original_track_id,
-        },
-    )
-    instance_seg = create_annotation(
-        session=db_session,
-        collection_id=original.collection_id,
-        sample_id=img.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.SEGMENTATION_MASK,
-        annotation_data={
-            "x": 2,
-            "y": 4,
-            "width": 6,
-            "height": 8,
-            "segmentation_mask": [1, 0, 0, 1],
-        },
+        annotations=[
+            AnnotationDetails(
+                sample_id=img.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+            ),
+            AnnotationDetails(
+                sample_id=img.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+                x=10,
+                y=20,
+                width=30,
+                height=40,
+                object_track_id=original_track_id,
+            ),
+            AnnotationDetails(
+                sample_id=img.sample_id,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.SEGMENTATION_MASK,
+                x=2,
+                y=4,
+                width=6,
+                height=8,
+                segmentation_mask=[1, 0, 0, 1],
+            ),
+        ],
     )
 
     original_sample_ids = {
@@ -769,7 +766,7 @@ def test_deep_copy__with_evaluation_annotation_metrics(db_session: Session) -> N
     # Arrange
     dataset = create_collection(session=db_session, collection_name="original")
     run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     label = create_annotation_label(session=db_session, root_collection_id=dataset.collection_id)

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -215,7 +215,7 @@ def _build_full_dataset(session: Session, name: str) -> UUID:
 
     # evaluation run + sample metric + annotation metric (gt/pred annotations)
     run = evaluation_sample_metric_helpers.create_run(
-        session=session, dataset_collection_id=root.collection_id
+        session=session, collection_id=root.collection_id
     )
     eval_image = create_image(session=session, collection_id=root.collection_id)
     evaluation_sample_metric_resolver.create_many(

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -254,7 +254,7 @@ def test_delete_dataset__with_evaluation_sample_metrics(db_session: Session) -> 
     # Arrange
     dataset = create_collection(session=db_session, collection_name="to_delete")
     run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     run_id = run.id  # Capture before delete
@@ -338,7 +338,7 @@ def test_delete_dataset__with_evaluation_annotation_metrics(db_session: Session)
     # Arrange
     dataset = create_collection(session=db_session, collection_name="to_delete")
     run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     run_id = run.id  # Capture before delete

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_create.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_create.py
@@ -7,8 +7,9 @@ from lightly_studio.models.evaluation_annotation_metric import (
 )
 from lightly_studio.resolvers import evaluation_annotation_metric_resolver
 from tests.helpers_resolvers import (
-    create_annotation,
+    AnnotationDetails,
     create_annotation_label,
+    create_annotations,
     create_collection,
     create_image,
 )
@@ -21,30 +22,30 @@ def test_create_many(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     label = create_annotation_label(
         session=db_session,
         root_collection_id=dataset.collection_id,
     )
-    pred_annotation = create_annotation(
+    pred_annotation, gt_annotation, unmatched_pred_annotation = create_annotations(
         session=db_session,
         collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
-    )
-    gt_annotation = create_annotation(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
-    )
-    unmatched_pred_annotation = create_annotation(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=label.annotation_label_id,
+            ),
+        ],
     )
 
     evaluation_annotation_metric_resolver.create_many(

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_get.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_get.py
@@ -24,7 +24,7 @@ def test_get_all_by_evaluation_run_id(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     label = create_annotation_label(
@@ -92,7 +92,7 @@ def test_get_all_by_evaluation_run_id__returns_empty_for_unknown_run(
 def test_get_all_by_evaluation_run_id__excludes_other_runs(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run1 = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id, name="run1"
+        session=db_session, collection_id=dataset.collection_id, name="run1"
     )
     image1 = create_image(
         session=db_session,
@@ -100,7 +100,7 @@ def test_get_all_by_evaluation_run_id__excludes_other_runs(db_session: Session) 
         file_path_abs="/path/to/run1.png",
     )
     run2 = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id, name="run2"
+        session=db_session, collection_id=dataset.collection_id, name="run2"
     )
     image2 = create_image(
         session=db_session,

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
@@ -13,8 +13,9 @@ from lightly_studio.models.evaluation_confusion_matrix import (
 )
 from lightly_studio.resolvers import evaluation_annotation_metric_resolver
 from tests.helpers_resolvers import (
-    create_annotation,
+    AnnotationDetails,
     create_annotation_label,
+    create_annotations,
     create_collection,
     create_image,
 )
@@ -29,7 +30,7 @@ def test_get_confusion_matrix__empty_run(
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
     )
     matrix = evaluation_annotation_metric_resolver.get_confusion_matrix(
         session=db_session,
@@ -46,9 +47,10 @@ def test_get_confusion_matrix__aggregates_tp_fp_fn(
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
+    sample_id = image.sample_id
     label_a = create_annotation_label(
         session=db_session,
         root_collection_id=dataset.collection_id,
@@ -59,29 +61,15 @@ def test_get_confusion_matrix__aggregates_tp_fp_fn(
         root_collection_id=dataset.collection_id,
         label_name="class_b",
     )
-    gt_a = create_annotation(
+    [gt_a, gt_b, pred_a, pred_b] = create_annotations(
         session=db_session,
         collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_a.annotation_label_id,
-    )
-    gt_b = create_annotation(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_b.annotation_label_id,
-    )
-    pred_a = create_annotation(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_a.annotation_label_id,
-    )
-    pred_b = create_annotation(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_b.annotation_label_id,
+        annotations=[
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_b.annotation_label_id),
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_b.annotation_label_id),
+        ],
     )
 
     evaluation_annotation_metric_resolver.create_many(
@@ -142,7 +130,7 @@ def test_get_confusion_matrix__class_only_in_gt(
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     label_a = create_annotation_label(
@@ -155,23 +143,15 @@ def test_get_confusion_matrix__class_only_in_gt(
         root_collection_id=dataset.collection_id,
         label_name="class_b",
     )
-    gt_a = create_annotation(
+    sample_id = image.sample_id
+    [gt_a, gt_b, pred_a] = create_annotations(
         session=db_session,
         collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_a.annotation_label_id,
-    )
-    gt_b = create_annotation(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_b.annotation_label_id,
-    )
-    pred_a = create_annotation(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_a.annotation_label_id,
+        annotations=[
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_b.annotation_label_id),
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
+        ],
     )
 
     evaluation_annotation_metric_resolver.create_many(
@@ -219,7 +199,7 @@ def test_get_confusion_matrix__class_only_in_pred(
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     label_a = create_annotation_label(
@@ -232,23 +212,15 @@ def test_get_confusion_matrix__class_only_in_pred(
         root_collection_id=dataset.collection_id,
         label_name="class_b",
     )
-    gt_a = create_annotation(
+    sample_id = image.sample_id
+    [gt_a, pred_a, pred_b] = create_annotations(
         session=db_session,
         collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_a.annotation_label_id,
-    )
-    pred_a = create_annotation(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_a.annotation_label_id,
-    )
-    pred_b = create_annotation(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_b.annotation_label_id,
+        annotations=[
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_b.annotation_label_id),
+        ],
     )
 
     evaluation_annotation_metric_resolver.create_many(
@@ -295,7 +267,7 @@ def test_get_confusion_matrix__no_fp_or_fn_keeps_synthetic_axes(
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
-        dataset_collection_id=dataset.collection_id,
+        collection_id=dataset.collection_id,
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     label_a = create_annotation_label(
@@ -303,17 +275,14 @@ def test_get_confusion_matrix__no_fp_or_fn_keeps_synthetic_axes(
         root_collection_id=dataset.collection_id,
         label_name="class_a",
     )
-    gt_a = create_annotation(
+    sample_id = image.sample_id
+    [gt_a, pred_a] = create_annotations(
         session=db_session,
         collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_a.annotation_label_id,
-    )
-    pred_a = create_annotation(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label_a.annotation_label_id,
+        annotations=[
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
+            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
+        ],
     )
 
     evaluation_annotation_metric_resolver.create_many(

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
@@ -31,8 +31,6 @@ class AnnotationMetricStub:
     value: float
     pred_annotation_id: UUID | None = None
     gt_annotation_id: UUID | None = None
-    create_pred_annotation: bool = False
-    create_gt_annotation: bool = False
 
 
 @dataclass
@@ -54,7 +52,8 @@ def create_run(
             session=session,
             collection_id=collection_id,
         )
-        assert collection is not None, f"Collection {collection_id} doesn't exist"
+        if collection is None:
+            raise RuntimeError(f"Collection {collection_id} doesn't exist")
     else:
         collection = create_collection(session=session)
         collection_id = collection.collection_id

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
@@ -31,6 +31,8 @@ class AnnotationMetricStub:
     value: float
     pred_annotation_id: UUID | None = None
     gt_annotation_id: UUID | None = None
+    create_pred_annotation: bool = False
+    create_gt_annotation: bool = False
 
 
 @dataclass
@@ -43,34 +45,36 @@ class SampleMetricStub:
 
 def create_run(
     session: Session,
-    dataset_collection_id: UUID | None = None,
+    collection_id: UUID | None = None,
     name: str = "test_run",
 ) -> EvaluationRunTable:
-    """Create an evaluation run with gt/pred annotation collections."""
-    if dataset_collection_id is None:
-        dataset_collection_id = create_collection(session=session).collection_id
-    dataset_collection = collection_resolver.get_by_id(
-        session=session,
-        collection_id=dataset_collection_id,
-    )
-    if dataset_collection is None:
-        raise ValueError(f"Collection {dataset_collection_id} doesn't exist")
+    """Create an evaluation run with ground truth/prediction annotation collections."""
+    if collection_id is not None:
+        collection = collection_resolver.get_by_id(
+            session=session,
+            collection_id=collection_id,
+        )
+        assert collection is not None, f"Collection {collection_id} doesn't exist"
+    else:
+        collection = create_collection(session=session)
+        collection_id = collection.collection_id
+
     gt_collection = create_collection(
         session=session,
         sample_type=SampleType.ANNOTATION,
-        parent_collection_id=dataset_collection_id,
+        parent_collection_id=collection_id,
     )
     pred_collection = create_collection(
         session=session,
         sample_type=SampleType.ANNOTATION,
-        parent_collection_id=dataset_collection_id,
+        parent_collection_id=collection_id,
     )
     return evaluation_run_resolver.create(
         session=session,
         evaluation_run_input=EvaluationRunCreate(
             name=name,
+            dataset_id=collection.dataset_id,
             gt_annotation_collection_id=gt_collection.collection_id,
-            dataset_id=dataset_collection.dataset_id,
             pred_annotation_collection_id=pred_collection.collection_id,
             task_type=EvaluationTaskType.OBJECT_DETECTION,
         ),
@@ -104,6 +108,10 @@ def create_annotation_metrics(
     annotation_metrics: list[AnnotationMetricStub] | None = None,
 ) -> None:
     annotation_metrics = annotation_metrics or []
+    run = evaluation_run_resolver.get_by_id(session=session, evaluation_id=run_id)
+    if run is None:
+        raise ValueError(f"Evaluation run {run_id} doesn't exist")
+
     evaluation_annotation_metric_resolver.create_many(
         session=session,
         records=[

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_create.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_create.py
@@ -13,7 +13,7 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
 def test_create_many(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
     image1 = create_image(session=db_session, collection_id=dataset.collection_id)
     image2 = create_image(

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get.py
@@ -16,7 +16,7 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
 def test_get_all_by_evaluation_run_id(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     evaluation_sample_metric_helpers.create_sample_metrics(
@@ -54,7 +54,7 @@ def test_get_all_by_evaluation_run_id__returns_empty_for_unknown_run(db_session:
 def test_get_all_by_evaluation_run_id__excludes_other_runs(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run1 = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id, name="run1"
+        session=db_session, collection_id=dataset.collection_id, name="run1"
     )
     image1 = create_image(
         session=db_session,
@@ -62,7 +62,7 @@ def test_get_all_by_evaluation_run_id__excludes_other_runs(db_session: Session) 
         file_path_abs="/path/to/sample1.png",
     )
     run2 = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id, name="run2"
+        session=db_session, collection_id=dataset.collection_id, name="run2"
     )
     image2 = create_image(
         session=db_session,

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get_metric_list.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_evaluation_sample_metric_get_metric_list.py
@@ -16,7 +16,7 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
 def test_get_metric_list_by_evaluation_run_id(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
     image1 = create_image(session=db_session, collection_id=dataset.collection_id)
     image2 = create_image(
@@ -62,7 +62,7 @@ def test_get_metric_list_by_evaluation_run_id(db_session: Session) -> None:
 def test_get_metric_list_by_evaluation_run_id__single_sample(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     evaluation_sample_metric_helpers.create_sample_metrics(
@@ -101,7 +101,7 @@ def test_get_metric_list_by_evaluation_run_id__returns_empty_for_unknown_run(
 def test_get_metric_list_by_evaluation_run_id__excludes_other_runs(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run1 = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id, name="run1"
+        session=db_session, collection_id=dataset.collection_id, name="run1"
     )
     image1 = create_image(
         session=db_session,
@@ -109,7 +109,7 @@ def test_get_metric_list_by_evaluation_run_id__excludes_other_runs(db_session: S
         file_path_abs="/path/to/sample1.png",
     )
     run2 = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id, name="run2"
+        session=db_session, collection_id=dataset.collection_id, name="run2"
     )
     image2 = create_image(
         session=db_session,

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_get_sample_metrics_info_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/test_get_sample_metrics_info_by_dataset_id.py
@@ -17,7 +17,7 @@ from tests.resolvers.evaluation_sample_metric_resolver.helpers import SampleMetr
 def test_get_sample_metrics_info_by_dataset_id(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
     image1 = create_image(session=db_session, collection_id=dataset.collection_id)
     image2 = create_image(
@@ -64,7 +64,7 @@ def test_get_sample_metrics_info_by_dataset_id(db_session: Session) -> None:
 def test_get_sample_metrics_info_by_dataset_id__multiple_runs(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     run1 = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id, name="run_1"
+        session=db_session, collection_id=dataset.collection_id, name="run_1"
     )
     image1 = create_image(
         session=db_session,
@@ -72,7 +72,7 @@ def test_get_sample_metrics_info_by_dataset_id__multiple_runs(db_session: Sessio
         file_path_abs="/path/to/sample1.png",
     )
     run2 = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id, name="run_2"
+        session=db_session, collection_id=dataset.collection_id, name="run_2"
     )
     image2 = create_image(
         session=db_session,
@@ -120,11 +120,11 @@ def test_get_sample_metrics_info_by_dataset_id__excludes_other_datasets(
     dataset = create_collection(session=db_session)
     other_dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
     other_run = evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=other_dataset.collection_id
+        session=db_session, collection_id=other_dataset.collection_id
     )
     other_image = create_image(session=db_session, collection_id=other_dataset.collection_id)
     evaluation_sample_metric_helpers.create_sample_metrics(
@@ -164,7 +164,7 @@ def test_get_sample_metrics_info_by_dataset_id__empty_for_run_without_metrics(
     dataset = create_collection(session=db_session)
     # Create a run but add no metrics.
     evaluation_sample_metric_helpers.create_run(
-        session=db_session, dataset_collection_id=dataset.collection_id
+        session=db_session, collection_id=dataset.collection_id
     )
 
     results = evaluation_sample_metric_resolver.get_sample_metrics_info_by_dataset_id(

--- a/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
@@ -12,8 +12,9 @@ from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsF
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import (
-    create_annotation,
+    AnnotationDetails,
     create_annotation_label,
+    create_annotations,
     create_collection,
     create_image,
 )
@@ -53,23 +54,23 @@ def test_data(db_session: Session) -> _TestData:
         label_name="cat",
     )
 
-    create_annotation(
+    create_annotations(
         session=db_session,
-        sample_id=image1.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
         collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=image2.sample_id,
-        annotation_label_id=dog_label.annotation_label_id,
-        collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=image1.sample_id,
-        annotation_label_id=cat_label.annotation_label_id,
-        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image1.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image2.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image1.sample_id,
+                annotation_label_id=cat_label.annotation_label_id,
+            ),
+        ],
     )
 
     return _TestData(collection=collection, dog_label=dog_label, cat_label=cat_label)

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_adjacent_images.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_adjacent_images.py
@@ -400,7 +400,7 @@ def test_get_adjacent_images__sort_by_evaluation_metric(db_session: Session) -> 
     collection = helpers_resolvers.create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    run = create_run(session=db_session, dataset_collection_id=collection_id)
+    run = create_run(session=db_session, collection_id=collection_id)
     image_a = helpers_resolvers.create_image(session=db_session, collection_id=collection_id)
     image_b = helpers_resolvers.create_image(
         session=db_session, collection_id=collection_id, file_path_abs="/images/b.png"

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
@@ -837,7 +837,7 @@ def test_get_all_by_collection_id__sort_by_evaluation_metric_asc(db_session: Ses
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    run = create_run(session=db_session, dataset_collection_id=collection_id)
+    run = create_run(session=db_session, collection_id=collection_id)
     image_a = create_image(session=db_session, collection_id=collection_id)
     image_b = create_image(
         session=db_session, collection_id=collection_id, file_path_abs="/images/b.png"
@@ -875,7 +875,7 @@ def test_get_all_by_collection_id__sort_by_evaluation_metric_desc(db_session: Se
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    run = create_run(session=db_session, dataset_collection_id=collection_id)
+    run = create_run(session=db_session, collection_id=collection_id)
     image_a = create_image(session=db_session, collection_id=collection_id)
     [image_b, image_c] = create_images(
         db_session=db_session,
@@ -914,7 +914,7 @@ def test_get_all_by_collection_id__sort_by_two_evaluation_metrics(db_session: Se
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    run = create_run(session=db_session, dataset_collection_id=collection_id)
+    run = create_run(session=db_session, collection_id=collection_id)
     image_a = create_image(session=db_session, collection_id=collection_id)
     image_b = create_image(
         session=db_session, collection_id=collection_id, file_path_abs="/images/b.png"

--- a/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
+++ b/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
@@ -31,9 +31,11 @@ from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsF
 from lightly_studio.resolvers.metadata_resolver.metadata_filter import Metadata
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import (
+    AnnotationDetails,
     ImageStub,
     create_annotation,
     create_annotation_label,
+    create_annotations,
     create_collection,
     create_images,
     create_tag,
@@ -170,29 +172,27 @@ class TestSampleFilter:
         )
 
         # Add 2 cat and dog annotations to the first sample
-        create_annotation(
+        create_annotations(
             session=db_session,
             collection_id=collection_id,
-            sample_id=samples[0].sample_id,
-            annotation_label_id=cat_label.annotation_label_id,
-        )
-        create_annotation(
-            session=db_session,
-            collection_id=collection_id,
-            sample_id=samples[0].sample_id,
-            annotation_label_id=cat_label.annotation_label_id,
-        )
-        create_annotation(
-            session=db_session,
-            collection_id=collection_id,
-            sample_id=samples[0].sample_id,
-            annotation_label_id=dog_label.annotation_label_id,
-        )
-        create_annotation(
-            session=db_session,
-            collection_id=collection_id,
-            sample_id=samples[0].sample_id,
-            annotation_label_id=dog_label.annotation_label_id,
+            annotations=[
+                AnnotationDetails(
+                    sample_id=samples[0].sample_id,
+                    annotation_label_id=cat_label.annotation_label_id,
+                ),
+                AnnotationDetails(
+                    sample_id=samples[0].sample_id,
+                    annotation_label_id=cat_label.annotation_label_id,
+                ),
+                AnnotationDetails(
+                    sample_id=samples[0].sample_id,
+                    annotation_label_id=dog_label.annotation_label_id,
+                ),
+                AnnotationDetails(
+                    sample_id=samples[0].sample_id,
+                    annotation_label_id=dog_label.annotation_label_id,
+                ),
+            ],
         )
 
         # Create the filter
@@ -515,7 +515,7 @@ class TestSampleFilterConfusionCell:
         dataset = create_collection(session=db_session)
         dataset_id = dataset.collection_id
         run = evaluation_sample_metric_helpers.create_run(
-            session=db_session, dataset_collection_id=dataset_id
+            session=db_session, collection_id=dataset_id
         )
         samples = create_images(
             db_session=db_session,
@@ -573,10 +573,10 @@ class TestSampleFilterConfusionCell:
         dataset = create_collection(session=db_session)
         dataset_id = dataset.collection_id
         run_a = evaluation_sample_metric_helpers.create_run(
-            session=db_session, dataset_collection_id=dataset_id, name="run_a"
+            session=db_session, collection_id=dataset_id, name="run_a"
         )
         run_b = evaluation_sample_metric_helpers.create_run(
-            session=db_session, dataset_collection_id=dataset_id, name="run_b"
+            session=db_session, collection_id=dataset_id, name="run_b"
         )
         samples = create_images(
             db_session=db_session,
@@ -624,7 +624,7 @@ class TestSampleFilterConfusionCell:
         dataset = create_collection(session=db_session)
         dataset_id = dataset.collection_id
         run = evaluation_sample_metric_helpers.create_run(
-            session=db_session, dataset_collection_id=dataset_id
+            session=db_session, collection_id=dataset_id
         )
         samples = create_images(
             db_session=db_session,
@@ -675,7 +675,7 @@ class TestSampleFilterConfusionCell:
         dataset = create_collection(session=db_session)
         dataset_id = dataset.collection_id
         run = evaluation_sample_metric_helpers.create_run(
-            session=db_session, dataset_collection_id=dataset_id
+            session=db_session, collection_id=dataset_id
         )
         samples = create_images(
             db_session=db_session,
@@ -732,7 +732,7 @@ class TestSampleFilterConfusionCell:
         dataset = create_collection(session=db_session)
         dataset_id = dataset.collection_id
         run = evaluation_sample_metric_helpers.create_run(
-            session=db_session, dataset_collection_id=dataset_id
+            session=db_session, collection_id=dataset_id
         )
         samples = create_images(
             db_session=db_session,

--- a/lightly_studio/tests/resolvers/video/video_frame_resolver/test_count_video_frames_annotations.py
+++ b/lightly_studio/tests/resolvers/video/video_frame_resolver/test_count_video_frames_annotations.py
@@ -5,7 +5,12 @@ from lightly_studio.resolvers import video_frame_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from lightly_studio.resolvers.video_frame_resolver.video_frame_filter import VideoFrameFilter
-from tests.helpers_resolvers import create_annotation, create_annotation_label, create_collection
+from tests.helpers_resolvers import (
+    AnnotationDetails,
+    create_annotation_label,
+    create_annotations,
+    create_collection,
+)
 from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
 
 
@@ -29,24 +34,23 @@ def test_get_video_frames_count_annotation_views_without_filter(db_session: Sess
         session=db_session, root_collection_id=collection.collection_id, label_name="house"
     )
 
-    # Create annotations
-    create_annotation(
+    create_annotations(
         session=db_session,
-        sample_id=video_frames_data.frame_sample_ids[0],
-        annotation_label_id=car_label.annotation_label_id,
         collection_id=video_frames_data.video_frames_collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frames_data.frame_sample_ids[1],
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=video_frames_data.video_frames_collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frames_data.frame_sample_ids[1],
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=video_frames_data.video_frames_collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=video_frames_data.frame_sample_ids[0],
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frames_data.frame_sample_ids[1],
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frames_data.frame_sample_ids[1],
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+        ],
     )
 
     annotations = video_frame_resolver.get_video_frames_count_annotation_views(
@@ -87,24 +91,23 @@ def test_get_video_frames_count_annotation_views_without_annotations_filter(
         session=db_session, root_collection_id=collection.collection_id, label_name="house"
     )
 
-    # Create annotations
-    create_annotation(
+    create_annotations(
         session=db_session,
-        sample_id=video_frames_data.frame_sample_ids[0],
-        annotation_label_id=car_label.annotation_label_id,
         collection_id=video_frames_data.video_frames_collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frames_data.frame_sample_ids[1],
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=video_frames_data.video_frames_collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frames_data.frame_sample_ids[1],
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=video_frames_data.video_frames_collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=video_frames_data.frame_sample_ids[0],
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frames_data.frame_sample_ids[1],
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frames_data.frame_sample_ids[1],
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+        ],
     )
 
     annotations = video_frame_resolver.get_video_frames_count_annotation_views(

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_count_video_frame_annotations_by_video_dataset.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_count_video_frame_annotations_by_video_dataset.py
@@ -5,7 +5,12 @@ from lightly_studio.resolvers import video_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
-from tests.helpers_resolvers import create_annotation, create_annotation_label, create_collection
+from tests.helpers_resolvers import (
+    AnnotationDetails,
+    create_annotation_label,
+    create_annotations,
+    create_collection,
+)
 from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
 
 
@@ -57,30 +62,27 @@ def test_count_video_frame_annotations_by_video_collection_without_filter(
         label_name="house",
     )
 
-    # Create annotations
-    create_annotation(
+    create_annotations(
         session=db_session,
-        sample_id=video_frame_id,
-        annotation_label_id=car_label.annotation_label_id,
         collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frame_id_1,
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frame_id_1,
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frame_id_2,
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=video_frame_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id_1,
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id_1,
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id_2,
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+        ],
     )
 
     annotations = video_resolver.count_video_frame_annotations_by_video_collection(
@@ -147,30 +149,27 @@ def test_count_video_frame_annotations_by_video_collection_with_annotation_filte
         label_name="house",
     )
 
-    # Create annotations
-    create_annotation(
+    create_annotations(
         session=db_session,
-        sample_id=video_frame_id,
-        annotation_label_id=car_label.annotation_label_id,
         collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frame_id_1,
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frame_id_1,
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=collection_id,
-    )
-    create_annotation(
-        session=db_session,
-        sample_id=video_frame_id_2,
-        annotation_label_id=airplane_label.annotation_label_id,
-        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=video_frame_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id_1,
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id_1,
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id_2,
+                annotation_label_id=airplane_label.annotation_label_id,
+            ),
+        ],
     )
 
     annotations = video_resolver.count_video_frame_annotations_by_video_collection(


### PR DESCRIPTION
## What has changed and why?
* Renamed the parameter of create_run to `collection_id`, the old name was misleading and too long.
* Use `create_annotations()` at more places - to guide AI models to write shorter tests.

## How has it been tested?
Existing tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability around annotation counting, adjacent item navigation, deep-copy flows, and evaluation metric handling.
  * Fixed dataset and collection scoping in evaluation-related workflows, including cases with multiple runs.

* **Tests**
  * Updated test coverage to better reflect batch annotation creation and the latest evaluation run setup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->