### PR TITLE
Use the Engineering team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,13 @@
 # We use CODEOWNERS to specify protected folders.
-# These locations need a human review (anyone from the GitHub team "@lightly-ai/lightly")
+# These locations need a human review (anyone from the GitHub team "@lightly-ai/engineering")
 # and cannot be merged with just a Fast Track approval.
 
 # Catch-all: Temporarily, every PR needs a human review.
 # TODO(Michal, 07/2026): Remove when Fast Track is implemented.
-* @lightly-ai/lightly
+* @lightly-ai/engineering
 
 # Protected locations.
-/.github/            @lightly-ai/lightly
-/.githooks/          @lightly-ai/lightly
-/ai_guidelines/      @lightly-ai/lightly
-/fast_track/         @lightly-ai/lightly
+/.github/            @lightly-ai/engineering
+/.githooks/          @lightly-ai/engineering
+/ai_guidelines/      @lightly-ai/engineering
+/fast_track/         @lightly-ai/engineering


### PR DESCRIPTION
## What has changed and why?

Change to a subteam in CODEOWNERS to exclude non-engineers with access to GitHub. This should also limit the notifications.

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments across several repository paths.
  * Broader review responsibility now routes to the engineering team for general changes and protected areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->