### PR TITLE
Add limit support to fsspec file listing

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/fsspec_lister.py
+++ b/lightly_studio/src/lightly_studio/dataset/fsspec_lister.py
@@ -68,7 +68,11 @@ def iter_files_from_path(
 
     Yields:
         File paths as they are discovered, with progress tracking
+
+    Raises:
+        ValueError: If ``limit`` is not None and not greater than 0.
     """
+    validate_limit(limit)
     seen: set[str] = set()
     extensions = allowed_extensions or IMAGE_EXTENSIONS
     with tqdm(desc="Discovering files", unit=" files", dynamic_ncols=True) as pbar:

--- a/lightly_studio/src/lightly_studio/dataset/fsspec_lister.py
+++ b/lightly_studio/src/lightly_studio/dataset/fsspec_lister.py
@@ -5,6 +5,7 @@ Handles local and remote paths, directories, and glob patterns.
 
 from __future__ import annotations
 
+import itertools
 import logging
 from collections.abc import Iterator
 from typing import Any
@@ -36,7 +37,22 @@ IMAGE_EXTENSIONS = {
 }
 
 
-def iter_files_from_path(path: str, allowed_extensions: set[str] | None = None) -> Iterator[str]:
+def validate_limit(limit: int | None) -> None:
+    """Validate a ``limit`` argument passed to a dataset loader.
+
+    Args:
+        limit: Maximum number of samples to load, or None for no limit.
+
+    Raises:
+        ValueError: If ``limit`` is not None and not greater than 0.
+    """
+    if limit is not None and limit <= 0:
+        raise ValueError(f"limit must be greater than 0, got {limit}.")
+
+
+def iter_files_from_path(
+    path: str, allowed_extensions: set[str] | None = None, limit: int | None = None
+) -> Iterator[str]:
     """List all files from a single path, handling directories, globs, and individual files.
 
     Args:
@@ -47,6 +63,8 @@ def iter_files_from_path(path: str, allowed_extensions: set[str] | None = None) 
             - Remote path (s3://, gcs://, etc.)
         allowed_extensions: Optional set of allowed file extensions (e.g., {".jpg", ".png"}).
             If None, uses default IMAGE_EXTENSIONS.
+        limit: If set, stop after yielding this many files (the first ``limit`` in
+            discovery order). If None, yields all discovered files.
 
     Yields:
         File paths as they are discovered, with progress tracking
@@ -58,7 +76,10 @@ def iter_files_from_path(path: str, allowed_extensions: set[str] | None = None) 
         if not cleaned_path:
             return
         fs = _get_filesystem(cleaned_path)
-        yield from _process_single_path_streaming(fs, cleaned_path, seen, pbar, extensions)
+        files = _process_single_path_streaming(fs, cleaned_path, seen, pbar, extensions)
+        if limit is not None:
+            files = itertools.islice(files, limit)
+        yield from files
 
 
 def _process_single_path_streaming(

--- a/lightly_studio/tests/dataset/test_fsspec_lister.py
+++ b/lightly_studio/tests/dataset/test_fsspec_lister.py
@@ -224,6 +224,19 @@ class TestFsspecLister:
         result = list(fsspec_lister.iter_files_from_path("s3://test/images/empty_dir"))
         assert len(result) == 0
 
+    def test_get_file_list_from_s3__limit(self, s3_bucket: str, mock_fsspec_s3fs: None) -> None:  # noqa: ARG002
+        # The directory holds 5 files; limit caps how many are yielded.
+        result = list(fsspec_lister.iter_files_from_path("s3://test/images/", limit=2))
+        assert len(result) == 2
+
+    def test_get_file_list_from_s3__limit_larger_than_total(
+        self,
+        s3_bucket: str,  # noqa: ARG002
+        mock_fsspec_s3fs: None,  # noqa: ARG002
+    ) -> None:
+        result = list(fsspec_lister.iter_files_from_path("s3://test/images/", limit=100))
+        assert len(result) == 5
+
     def test_get_file_list_from_s3__single_file_read(
         self,
         s3_bucket: str,  # noqa: ARG002
@@ -235,3 +248,15 @@ class TestFsspecLister:
         with fsspec.open(result[0], "rb") as file:
             content = file.read()
             assert content == b"fake_bmp_content"
+
+
+class TestValidateLimit:
+    @pytest.mark.parametrize("limit", [None, 1, 100])
+    def test_valid(self, limit: int | None) -> None:
+        # Should not raise.
+        fsspec_lister.validate_limit(limit)
+
+    @pytest.mark.parametrize("limit", [0, -1, -100])
+    def test_invalid(self, limit: int) -> None:
+        with pytest.raises(ValueError, match=r"limit must be greater than 0"):
+            fsspec_lister.validate_limit(limit)

--- a/lightly_studio/tests/dataset/test_fsspec_lister.py
+++ b/lightly_studio/tests/dataset/test_fsspec_lister.py
@@ -237,6 +237,14 @@ class TestFsspecLister:
         result = list(fsspec_lister.iter_files_from_path("s3://test/images/", limit=100))
         assert len(result) == 5
 
+    def test_get_file_list_from_s3__limit_invalid(
+        self,
+        s3_bucket: str,  # noqa: ARG002
+        mock_fsspec_s3fs: None,  # noqa: ARG002
+    ) -> None:
+        with pytest.raises(ValueError, match=r"limit must be greater than 0"):
+            list(fsspec_lister.iter_files_from_path("s3://test/images/", limit=0))
+
     def test_get_file_list_from_s3__single_file_read(
         self,
         s3_bucket: str,  # noqa: ARG002
@@ -250,13 +258,13 @@ class TestFsspecLister:
             assert content == b"fake_bmp_content"
 
 
-class TestValidateLimit:
-    @pytest.mark.parametrize("limit", [None, 1, 100])
-    def test_valid(self, limit: int | None) -> None:
-        # Should not raise.
-        fsspec_lister.validate_limit(limit)
+@pytest.mark.parametrize("limit", [None, 1, 100])
+def test_validate_limit(limit: int | None) -> None:
+    # Should not raise.
+    fsspec_lister.validate_limit(limit)
 
-    @pytest.mark.parametrize("limit", [0, -1, -100])
-    def test_invalid(self, limit: int) -> None:
-        with pytest.raises(ValueError, match=r"limit must be greater than 0"):
-            fsspec_lister.validate_limit(limit)
+
+@pytest.mark.parametrize("limit", [0, -1, -100])
+def test_validate_limit__invalid(limit: int) -> None:
+    with pytest.raises(ValueError, match=r"limit must be greater than 0"):
+        fsspec_lister.validate_limit(limit)


### PR DESCRIPTION
## What has changed and why?

 - Adds limit support to the core file-listing logic
 - This is the core building block for a follow-up PR that exposes limit on the ImageDataset/VideoDataset import methods

## How has it been tested?

- Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `limit` parameter to file listing, stopping after discovering up to N files (in discovery order) and returning only those results.
  * Added validation so `limit` must be positive when provided, otherwise an error is raised.

* **Tests**
  * Added coverage for `limit` behavior (capped results, full results with large limits) and for limit validation, including error messages for invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->