### PR TITLE
Fast Track: Add guardrail runner

### DIFF
--- a/fast_track/src/guardrails/context/types.ts
+++ b/fast_track/src/guardrails/context/types.ts
@@ -14,10 +14,17 @@ export interface GuardrailContext {
     changedFiles(): Promise<ChangedFile[]>;
 }
 
+/**
+ * What a guardrail's `run` returns: a {@link GuardrailResult} minus its `name`.
+ * The runner supplies the name from the definition, so a guardrail cannot
+ * mislabel its own entry in the verdict — it isn't given the chance to.
+ */
+export type GuardrailOutcome = Omit<GuardrailResult, 'name'>;
+
 export interface Guardrail {
     name: string;
     required: boolean;
     /** True if it needs the PR API (CI only); false runs anywhere. */
     needsPrContext: boolean;
-    run(context: GuardrailContext): Promise<GuardrailResult>;
+    run(context: GuardrailContext): Promise<GuardrailOutcome>;
 }

--- a/fast_track/src/guardrails/context/types.ts
+++ b/fast_track/src/guardrails/context/types.ts
@@ -14,11 +14,7 @@ export interface GuardrailContext {
     changedFiles(): Promise<ChangedFile[]>;
 }
 
-/**
- * What a guardrail's `run` returns: a {@link GuardrailResult} minus its `name`.
- * The runner supplies the name from the definition, so a guardrail cannot
- * mislabel its own entry in the verdict — it isn't given the chance to.
- */
+/** A guardrail's `run` output; the runner adds the `name` from the definition. */
 export type GuardrailOutcome = Omit<GuardrailResult, 'name'>;
 
 export interface Guardrail {

--- a/fast_track/src/guardrails/dummy.test.ts
+++ b/fast_track/src/guardrails/dummy.test.ts
@@ -8,6 +8,6 @@ describe('dummyGuardrail', () => {
             baseRef: 'origin/main',
             changedFiles: async () => []
         });
-        expect(result).toEqual({ name: 'dummy', status: 'pass', summary: 'Always passes.' });
+        expect(result).toEqual({ status: 'pass', summary: 'Always passes.' });
     });
 });

--- a/fast_track/src/guardrails/dummy.ts
+++ b/fast_track/src/guardrails/dummy.ts
@@ -5,5 +5,5 @@ export const dummyGuardrail: Guardrail = {
     name: 'dummy',
     required: true,
     needsPrContext: false,
-    run: async () => ({ name: 'dummy', status: 'pass', summary: 'Always passes.' })
+    run: async () => ({ status: 'pass', summary: 'Always passes.' })
 };

--- a/fast_track/src/guardrails/registry.test.ts
+++ b/fast_track/src/guardrails/registry.test.ts
@@ -7,7 +7,7 @@ const guardrail = (name: string, needsPrContext: boolean): Guardrail => ({
     name,
     required: true,
     needsPrContext,
-    run: async () => ({ name, status: 'pass', summary: '' })
+    run: async () => ({ status: 'pass', summary: '' })
 });
 
 const local = guardrail('local-check', false);

--- a/fast_track/src/guardrails/run-guardrails.test.ts
+++ b/fast_track/src/guardrails/run-guardrails.test.ts
@@ -66,18 +66,4 @@ describe('runGuardrails', () => {
         ]);
         expect(result.status).toBe('pass');
     });
-
-    it('fails closed on a status that is neither pass nor fail', async () => {
-        // Only reachable by a type-violating guardrail (status is typed
-        // `'pass' | 'fail'`), so the cast simulates a buggy first-party return.
-        const malformed: Guardrail = {
-            name: 'malformed',
-            required: true,
-            needsPrContext: false,
-            run: async () => ({ status: 'weird' as GuardrailStatus, summary: '' })
-        };
-        const result = await runGuardrails(context, [malformed]);
-        expect(result.status).toBe('fail');
-        expect(result.guardrails[0]?.status).toBe('fail');
-    });
 });

--- a/fast_track/src/guardrails/run-guardrails.test.ts
+++ b/fast_track/src/guardrails/run-guardrails.test.ts
@@ -66,4 +66,33 @@ describe('runGuardrails', () => {
         ]);
         expect(result.status).toBe('pass');
     });
+
+    it('labels the breakdown with the definition name, not the self-reported one', async () => {
+        const misnamed: Guardrail = {
+            name: 'real-name',
+            required: true,
+            needsPrContext: false,
+            run: async () => ({ name: 'wrong-name', status: 'pass', summary: '' })
+        };
+        const result = await runGuardrails(context, [misnamed]);
+        expect(result.guardrails[0]?.name).toBe('real-name');
+    });
+
+    it('fails closed on a status that is neither pass nor fail', async () => {
+        // Only reachable by a type-violating guardrail (status is typed
+        // `'pass' | 'fail'`), so the cast simulates a buggy first-party return.
+        const malformed: Guardrail = {
+            name: 'malformed',
+            required: true,
+            needsPrContext: false,
+            run: async () => ({
+                name: 'malformed',
+                status: 'weird' as GuardrailStatus,
+                summary: ''
+            })
+        };
+        const result = await runGuardrails(context, [malformed]);
+        expect(result.status).toBe('fail');
+        expect(result.guardrails[0]?.status).toBe('fail');
+    });
 });

--- a/fast_track/src/guardrails/run-guardrails.test.ts
+++ b/fast_track/src/guardrails/run-guardrails.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GuardrailStatus } from '../shared/verdict';
+import type { Guardrail, GuardrailContext } from './context/types';
+import { runGuardrails } from './run-guardrails';
+
+const context: GuardrailContext = {
+    baseRef: 'origin/main',
+    changedFiles: async () => []
+};
+
+/** A guardrail that reports a fixed status. */
+const stub = (name: string, status: GuardrailStatus, required = true): Guardrail => ({
+    name,
+    required,
+    needsPrContext: false,
+    run: async () => ({ name, status, summary: '' })
+});
+
+/** A guardrail that throws instead of returning a result. */
+const throwing = (name: string, required = true): Guardrail => ({
+    name,
+    required,
+    needsPrContext: false,
+    run: async () => {
+        throw new Error('boom');
+    }
+});
+
+describe('runGuardrails', () => {
+    it('passes when every required guardrail passes', async () => {
+        const result = await runGuardrails(context, [stub('a', 'pass'), stub('b', 'pass')]);
+        expect(result.status).toBe('pass');
+    });
+
+    it('fails when any required guardrail fails', async () => {
+        const result = await runGuardrails(context, [stub('a', 'pass'), stub('b', 'fail')]);
+        expect(result.status).toBe('fail');
+    });
+
+    it('ignores a failing optional guardrail in the aggregate', async () => {
+        const result = await runGuardrails(context, [
+            stub('required', 'pass'),
+            stub('optional', 'fail', false)
+        ]);
+        expect(result.status).toBe('pass');
+    });
+
+    it('reports every guardrail in run order', async () => {
+        const result = await runGuardrails(context, [stub('a', 'pass'), stub('b', 'fail')]);
+        expect(result.guardrails.map((g) => g.name)).toEqual(['a', 'b']);
+    });
+
+    it('records a throwing guardrail as a fail instead of crashing', async () => {
+        const result = await runGuardrails(context, [throwing('exploder')]);
+        expect(result.status).toBe('fail');
+        expect(result.guardrails).toEqual([
+            { name: 'exploder', status: 'fail', summary: 'Guardrail threw: boom' }
+        ]);
+    });
+
+    it('lets a throwing optional guardrail pass the run', async () => {
+        const result = await runGuardrails(context, [
+            stub('required', 'pass'),
+            throwing('optional', false)
+        ]);
+        expect(result.status).toBe('pass');
+    });
+});

--- a/fast_track/src/guardrails/run-guardrails.test.ts
+++ b/fast_track/src/guardrails/run-guardrails.test.ts
@@ -14,7 +14,7 @@ const stub = (name: string, status: GuardrailStatus, required = true): Guardrail
     name,
     required,
     needsPrContext: false,
-    run: async () => ({ name, status, summary: '' })
+    run: async () => ({ status, summary: '' })
 });
 
 /** A guardrail that throws instead of returning a result. */
@@ -46,7 +46,7 @@ describe('runGuardrails', () => {
         expect(result.status).toBe('pass');
     });
 
-    it('reports every guardrail in run order', async () => {
+    it('reports every guardrail in run order, named from the definition', async () => {
         const result = await runGuardrails(context, [stub('a', 'pass'), stub('b', 'fail')]);
         expect(result.guardrails.map((g) => g.name)).toEqual(['a', 'b']);
     });
@@ -67,17 +67,6 @@ describe('runGuardrails', () => {
         expect(result.status).toBe('pass');
     });
 
-    it('labels the breakdown with the definition name, not the self-reported one', async () => {
-        const misnamed: Guardrail = {
-            name: 'real-name',
-            required: true,
-            needsPrContext: false,
-            run: async () => ({ name: 'wrong-name', status: 'pass', summary: '' })
-        };
-        const result = await runGuardrails(context, [misnamed]);
-        expect(result.guardrails[0]?.name).toBe('real-name');
-    });
-
     it('fails closed on a status that is neither pass nor fail', async () => {
         // Only reachable by a type-violating guardrail (status is typed
         // `'pass' | 'fail'`), so the cast simulates a buggy first-party return.
@@ -85,11 +74,7 @@ describe('runGuardrails', () => {
             name: 'malformed',
             required: true,
             needsPrContext: false,
-            run: async () => ({
-                name: 'malformed',
-                status: 'weird' as GuardrailStatus,
-                summary: ''
-            })
+            run: async () => ({ status: 'weird' as GuardrailStatus, summary: '' })
         };
         const result = await runGuardrails(context, [malformed]);
         expect(result.status).toBe('fail');

--- a/fast_track/src/guardrails/run-guardrails.ts
+++ b/fast_track/src/guardrails/run-guardrails.ts
@@ -12,9 +12,9 @@ export interface RunResult {
  * Run the guardrails sequentially and aggregate: `pass` iff every *required*
  * one passed. Pure over {@link GuardrailContext}, so CI and local runs share it.
  *
- * Guardrails run PR-author-controlled code, so results are normalized in
- * {@link runOne} (fail-closed on a throw or a non-`pass` status, name taken from
- * the definition), and required-ness is read from the guardrail definition.
+ * Guardrails run PR-author-controlled code, so a throwing guardrail is recorded
+ * as a `fail` rather than crashing the run (see {@link runOne}), and required-ness
+ * is read from the guardrail definition.
  */
 export async function runGuardrails(
     context: GuardrailContext,
@@ -35,18 +35,13 @@ export async function runGuardrails(
 }
 
 /**
- * Run one guardrail into a well-formed result. The name is the definition's —
- * a {@link GuardrailOutcome} carries none — and the status fails closed: a
- * throw, or anything other than `pass`, becomes `fail`.
+ * Run one guardrail into a full result: the name from the definition (a
+ * {@link GuardrailOutcome} carries none) plus its outcome, or a `fail` if it throws.
  */
 async function runOne(guardrail: Guardrail, context: GuardrailContext): Promise<GuardrailResult> {
     try {
         const outcome = await guardrail.run(context);
-        return {
-            name: guardrail.name,
-            status: outcome.status === 'pass' ? 'pass' : 'fail',
-            summary: outcome.summary
-        };
+        return { name: guardrail.name, ...outcome };
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return {

--- a/fast_track/src/guardrails/run-guardrails.ts
+++ b/fast_track/src/guardrails/run-guardrails.ts
@@ -1,0 +1,49 @@
+import type { GuardrailStatus, GuardrailResult } from '../shared/verdict';
+import type { Guardrail, GuardrailContext } from './context/types';
+
+export interface RunResult {
+    /** `pass` iff every *required* guardrail passed. */
+    status: GuardrailStatus;
+    /** One entry per guardrail, in run order. */
+    guardrails: GuardrailResult[];
+}
+
+/**
+ * Run the guardrails sequentially and aggregate: `pass` iff every *required*
+ * one passed. Pure over {@link GuardrailContext}, so CI and local runs share it.
+ *
+ * Guardrails run PR-author-controlled code, so: a throwing guardrail is recorded
+ * as a `fail` rather than crashing the run, and required-ness is read from the
+ * guardrail definition, never the result's self-reported `name`.
+ */
+export async function runGuardrails(
+    context: GuardrailContext,
+    guardrails: Guardrail[]
+): Promise<RunResult> {
+    const results: GuardrailResult[] = [];
+    let status: GuardrailStatus = 'pass';
+
+    for (const guardrail of guardrails) {
+        const result = await runOne(guardrail, context);
+        results.push(result);
+        if (guardrail.required && result.status === 'fail') {
+            status = 'fail';
+        }
+    }
+
+    return { status, guardrails: results };
+}
+
+/** Convert a thrown error into a `fail` result. */
+async function runOne(guardrail: Guardrail, context: GuardrailContext): Promise<GuardrailResult> {
+    try {
+        return await guardrail.run(context);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+            name: guardrail.name,
+            status: 'fail',
+            summary: `Guardrail threw: ${message}`
+        };
+    }
+}

--- a/fast_track/src/guardrails/run-guardrails.ts
+++ b/fast_track/src/guardrails/run-guardrails.ts
@@ -35,17 +35,17 @@ export async function runGuardrails(
 }
 
 /**
- * Run one guardrail into a well-formed result. The name always comes from the
- * definition so the breakdown can't be mislabeled, and the status fails closed:
- * a throw, or anything other than `pass`, becomes `fail`.
+ * Run one guardrail into a well-formed result. The name is the definition's —
+ * a {@link GuardrailOutcome} carries none — and the status fails closed: a
+ * throw, or anything other than `pass`, becomes `fail`.
  */
 async function runOne(guardrail: Guardrail, context: GuardrailContext): Promise<GuardrailResult> {
     try {
-        const result = await guardrail.run(context);
+        const outcome = await guardrail.run(context);
         return {
             name: guardrail.name,
-            status: result.status === 'pass' ? 'pass' : 'fail',
-            summary: result.summary
+            status: outcome.status === 'pass' ? 'pass' : 'fail',
+            summary: outcome.summary
         };
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/fast_track/src/guardrails/run-guardrails.ts
+++ b/fast_track/src/guardrails/run-guardrails.ts
@@ -12,9 +12,9 @@ export interface RunResult {
  * Run the guardrails sequentially and aggregate: `pass` iff every *required*
  * one passed. Pure over {@link GuardrailContext}, so CI and local runs share it.
  *
- * Guardrails run PR-author-controlled code, so: a throwing guardrail is recorded
- * as a `fail` rather than crashing the run, and required-ness is read from the
- * guardrail definition, never the result's self-reported `name`.
+ * Guardrails run PR-author-controlled code, so results are normalized in
+ * {@link runOne} (fail-closed on a throw or a non-`pass` status, name taken from
+ * the definition), and required-ness is read from the guardrail definition.
  */
 export async function runGuardrails(
     context: GuardrailContext,
@@ -34,10 +34,19 @@ export async function runGuardrails(
     return { status, guardrails: results };
 }
 
-/** Convert a thrown error into a `fail` result. */
+/**
+ * Run one guardrail into a well-formed result. The name always comes from the
+ * definition so the breakdown can't be mislabeled, and the status fails closed:
+ * a throw, or anything other than `pass`, becomes `fail`.
+ */
 async function runOne(guardrail: Guardrail, context: GuardrailContext): Promise<GuardrailResult> {
     try {
-        return await guardrail.run(context);
+        const result = await guardrail.run(context);
+        return {
+            name: guardrail.name,
+            status: result.status === 'pass' ? 'pass' : 'fail',
+            summary: result.summary
+        };
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return {


### PR DESCRIPTION
## What has changed and why?

A function to run selected guardrails sequentially and return `pass` iff every *required* one passed.

## How has it been tested?

New unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sequential guardrail runner that executes checks in order and returns an overall pass/fail outcome.
  * Runner results now capture each guardrail’s outcome for clearer review (with execution order preserved).

* **Bug Fixes**
  * Guardrails that throw errors are now handled gracefully and reported as failures instead of interrupting the run.
  * Failures from optional guardrails no longer affect the final aggregate result when required guardrails pass.

* **Tests / Maintenance**
  * Updated dummy and registry test expectations to match the new result shape returned by guardrails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->