### PR TITLE
Add docs for AnnotationMetricQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Python dataset queries now support model evaluation queries on the annotation level.
 
 - Python SDK: `limit` parameter on `ImageDataset.add_samples_from*` methods to index only the first N samples of a dataset.
+- Python dataset queries now support model evaluation queries on the annotation level.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ filtered sample count.
 - Deduplication strategy is available in the Sampling Dialog in the GUI
 - Improve confusion matrix usability for large numbers of classes
 - Python dataset queries now support classifications, object detections, and segmentation mask annotations.
-- Python dataset queries now support model evaluation queries on the sample level.
+- Python dataset queries now model evaluation queries on the sample level.
 - Improved performance when tagging all samples in the GUI for large datasets.
 - Annotation source selection for exports: when multiple annotation collections exist, the export dialog shows a dropdown to choose which collection to export from. The annotation source can also be specified via the Python API using the `annotation_collection_id` parameter.
 - All embedding plot legend entries (especially e.g. `Excluded by filters`, `No category`, etc.) can be hidden by clicking on them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Python dataset queries now support model evaluation queries on the annotation level.
 
 - Python SDK: `limit` parameter on `ImageDataset.add_samples_from*` methods to index only the first N samples of a dataset.
 
@@ -34,7 +35,7 @@ filtered sample count.
 - Deduplication strategy is available in the Sampling Dialog in the GUI
 - Improve confusion matrix usability for large numbers of classes
 - Python dataset queries now support classifications, object detections, and segmentation mask annotations.
-- Python dataset queries now model evaluation queries on the sample level.
+- Python dataset queries now support model evaluation queries on the sample level.
 - Improved performance when tagging all samples in the GUI for large datasets.
 - Annotation source selection for exports: when multiple annotation collections exist, the export dialog shows a dropdown to choose which collection to export from. The annotation source can also be specified via the Python API using the `annotation_collection_id` parameter.
 - All embedding plot legend entries (especially e.g. `Excluded by filters`, `No category`, etc.) can be hidden by clicking on them.

--- a/lightly_studio/docs/docs/api/dataset_query.md
+++ b/lightly_studio/docs/docs/api/dataset_query.md
@@ -64,6 +64,19 @@
     options:
         members: [SampleEvaluationQuery]
 
+## AnnotationMetricQuery
+
+::: lightly_studio.core.dataset_query.annotation_evaluation_query
+    options:
+        members: [AnnotationMetricQuery]
+
+## AnnotationEvaluationMetricField
+
+::: lightly_studio.core.dataset_query.annotation_evaluation_metric_expression
+    options:
+        members: [AnnotationEvaluationMetricField]
+        show_if_no_docstring: true
+
 ## EvaluationMetricField
 
 ::: lightly_studio.core.dataset_query.evaluation_metric_expression

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -278,6 +278,29 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
     query.match(expr)
     ```
 
+    #### Annotation evaluation queries
+
+    Annotation evaluation queries use `AnnotationMetricQuery.confusion(...)` together with
+    `AnnotationEvaluationMetricField(...)` to filter samples by annotation-level evaluation
+    results from a specific run, such as confusion-matrix cells.
+
+    ```py
+    from lightly_studio.core.dataset_query import (
+        AnnotationEvaluationMetricField,
+        AnnotationMetricQuery,
+    )
+
+    expr = AnnotationMetricQuery.confusion(
+        run_name="run1",
+        ground_truth="cat",
+        prediction="dog",
+        AnnotationEvaluationMetricField("iou") > 0.3,
+    )
+
+    # Assign the expression to a query:
+    query.match(expr)
+    ```
+
     #### Boolean operators
     The filtering on individual fields can flexibly be combined to create more complex match expression. For this, the boolean operators `AND`, `OR`, and `NOT` are available. Boolean operators can arbitrarily be nested.
 

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -280,9 +280,7 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
 
     #### Annotation evaluation queries
 
-    Annotation evaluation queries use `AnnotationMetricQuery.confusion(...)` together with
-    `AnnotationEvaluationMetricField(...)` to filter samples by annotation-level evaluation
-    Filtering samples by annotation evaluation results from a specific evaluation run  ( link it <model_eval_link>), can be realized via `AnnotationMetricQuery.confusion(...)` together with `AnnotationEvaluationMetricField(...)`.  In the below example we filter for samples where 'cat' got confused as a 'dog' by the model, and the iou is higher than '0.3'.
+    Annotation evaluation queries use `AnnotationMetricQuery.confusion(...)` together with `AnnotationEvaluationMetricField(...)` to filter samples by annotation-level evaluation Filtering samples by annotation evaluation results from a specific evaluation run  ( link it <model_eval_link>), can be realized via `AnnotationMetricQuery.confusion(...)` together with `AnnotationEvaluationMetricField(...)`.  In the below example we filter for samples where 'cat' got confused as a 'dog' by the model, and the iou is higher than '0.3'.
 
     ```py
     from lightly_studio.core.dataset_query import (

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -280,7 +280,7 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
 
     #### Annotation evaluation queries
 
-    Filtering samples by annotation evaluation results from a specific [evaluation run](evaluation.md), can be realized via `AnnotationMetricQuery.confusion(...)` together with `AnnotationEvaluationMetricField(...)`. In the below example we filter for samples where 'cat' got confused as a 'dog' by the model, and the iou is higher than '0.3'.
+    Filtering samples by annotation evaluation results from a specific [evaluation run](evaluation.md), can be realized via `AnnotationMetricQuery.confusion(...)` together with `AnnotationEvaluationMetricField(...)`. In the below example we filter for samples where `cat` got confused as a `dog` by the model, and the IOU is higher than 0.3.
 
     ```py
     from lightly_studio.core.dataset_query import (

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -282,7 +282,7 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
 
     Annotation evaluation queries use `AnnotationMetricQuery.confusion(...)` together with
     `AnnotationEvaluationMetricField(...)` to filter samples by annotation-level evaluation
-    results from a specific run, such as confusion-matrix cells.
+    Filtering samples by annotation evaluation results from a specific evaluation run  ( link it <model_eval_link>), can be realized via `AnnotationMetricQuery.confusion(...)` together with `AnnotationEvaluationMetricField(...)`.  In the below example we filter for samples where 'cat' got confused as a 'dog' by the model, and the iou is higher than '0.3'.
 
     ```py
     from lightly_studio.core.dataset_query import (

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -291,9 +291,9 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
     )
 
     expr = AnnotationMetricQuery.confusion(
-        run_name="run1",
-        ground_truth="cat",
-        prediction="dog",
+        "run1",
+        "cat",
+        "dog",
         AnnotationEvaluationMetricField("iou") > 0.3,
     )
 

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -280,7 +280,7 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
 
     #### Annotation evaluation queries
 
-    Annotation evaluation queries use `AnnotationMetricQuery.confusion(...)` together with `AnnotationEvaluationMetricField(...)` to filter samples by annotation-level evaluation Filtering samples by annotation evaluation results from a specific evaluation run  ( link it <model_eval_link>), can be realized via `AnnotationMetricQuery.confusion(...)` together with `AnnotationEvaluationMetricField(...)`.  In the below example we filter for samples where 'cat' got confused as a 'dog' by the model, and the iou is higher than '0.3'.
+    Filtering samples by annotation evaluation results from a specific [evaluation run](evaluation.md), can be realized via `AnnotationMetricQuery.confusion(...)` together with `AnnotationEvaluationMetricField(...)`. In the below example we filter for samples where 'cat' got confused as a 'dog' by the model, and the iou is higher than '0.3'.
 
     ```py
     from lightly_studio.core.dataset_query import (

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_metric_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_metric_expression.py
@@ -13,7 +13,21 @@ from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotat
 
 
 class AnnotationEvaluationMetricField:  # noqa: PLW1641
-    """Queryable annotation metric field for matching samples within an evaluation run."""
+    """Queryable annotation metric field for annotation-level evaluation results.
+
+    Use this field inside :meth:`AnnotationMetricQuery.confusion` to filter samples by
+    persisted annotation metrics such as IoU.
+
+    Example:
+        ```python
+        AnnotationMetricQuery.confusion(
+            run_name="run1",
+            ground_truth="cat",
+            prediction="dog",
+            AnnotationEvaluationMetricField("iou") > 0.3,
+        )
+        ```
+    """
 
     def __init__(self, metric_name: str) -> None:
         """Initialize a queryable annotation metric reference."""

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_metric_expression.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_metric_expression.py
@@ -21,9 +21,9 @@ class AnnotationEvaluationMetricField:  # noqa: PLW1641
     Example:
         ```python
         AnnotationMetricQuery.confusion(
-            run_name="run1",
-            ground_truth="cat",
-            prediction="dog",
+            "run1",
+            "cat",
+            "dog",
             AnnotationEvaluationMetricField("iou") > 0.3,
         )
         ```

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
@@ -27,7 +27,22 @@ AnnotationMetricMatchKind = Literal["confusion"]
 
 @dataclass
 class AnnotationMetricQuery(MatchExpression):
-    """Query if a sample has annotation evaluation metrics matching a criterion."""
+    """Query samples by annotation-level evaluation results.
+
+    This query matches samples that belong to an evaluation run and contain annotation
+    pairs in a selected confusion-matrix cell, optionally constrained by persisted
+    annotation metrics.
+
+    Example:
+        ```python
+        AnnotationMetricQuery.confusion(
+            run_name="run1",
+            ground_truth="cat",
+            prediction="dog",
+            AnnotationEvaluationMetricField("iou") > 0.3,
+        )
+        ```
+    """
 
     match_kind: AnnotationMetricMatchKind
     run_name: str
@@ -46,16 +61,21 @@ class AnnotationMetricQuery(MatchExpression):
         """Match samples by confusion-matrix cell within an evaluation run.
 
         Example:
-            ```
+            ```python
             AnnotationMetricQuery.confusion(
-                "run1", "cat", "dog", AnnotationEvaluationMetricField("iou") < 0.3
-            )```
+                "run1",
+                "cat",
+                "dog",
+                AnnotationEvaluationMetricField("iou") < 0.3,
+            )
+            ```
 
         Args:
             run_name: The evaluation run name to match metrics against.
             ground_truth: Ground-truth annotation class name.
             prediction: Predicted annotation class name.
-            criteria: The annotation evaluation metric criteria to combine.
+            criteria: Zero or more metric comparisons that must all match the same
+                annotation pair.
         """
         return cls(
             match_kind="confusion",

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
@@ -36,9 +36,9 @@ class AnnotationMetricQuery(MatchExpression):
     Example:
         ```python
         AnnotationMetricQuery.confusion(
-            run_name="run1",
-            ground_truth="cat",
-            prediction="dog",
+            "run1",
+            "cat",
+            "dog",
             AnnotationEvaluationMetricField("iou") > 0.3,
         )
         ```

--- a/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_query.py
@@ -290,7 +290,7 @@ def test_annotation_metric_query__matches_off_diagonal_confusion_cell(
     )
 
     results = DatasetQuery(dataset=collection, session=db_session).match(
-        AnnotationMetricQuery.confusion("run1", "cat", "dog")
+        AnnotationMetricQuery.confusion(run_name="run1", ground_truth="cat", prediction="dog")
     )
 
     assert [result.sample_id for result in results] == [image.sample_id]

--- a/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_query.py
@@ -290,7 +290,7 @@ def test_annotation_metric_query__matches_off_diagonal_confusion_cell(
     )
 
     results = DatasetQuery(dataset=collection, session=db_session).match(
-        AnnotationMetricQuery.confusion(run_name="run1", ground_truth="cat", prediction="dog")
+        AnnotationMetricQuery.confusion("run1", "cat", "dog")
     )
 
     assert [result.sample_id for result in results] == [image.sample_id]


### PR DESCRIPTION
## What has changed and why?
And for AnnotationEvaluationMetricField.

## How has it been tested?
Rendered manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for annotation-level evaluation queries in dataset search, including confusion-based matching.
  * Expanded documentation with examples for building queries against annotation evaluation metrics.

* **Documentation**
  * Clarified how to use new query fields and comparison expressions in API and search/filter guides.
  * Improved example snippets to show practical filtering by evaluation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->