### PR TITLE
Restore 1.0.2 section in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Python SDK: `limit` parameter on `ImageDataset.add_samples_from*` methods to index only the first N samples of a dataset.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## \[1.0.2\] - 2026-07-02
+
+### Added
+
 - Annotation classes can now be shown or hidden individually in the grid views using an eye icon toggle in the Annotation Classes sidebar.
 - Python SDK: `target_fps` parameter on `VideoDataset.add_videos_from_path` to subsample frames to a
   lower frame rate. Retained frames keep their original frame numbers.
@@ -23,17 +39,7 @@ filtered sample count.
 - Annotation source selection for exports: when multiple annotation collections exist, the export dialog shows a dropdown to choose which collection to export from. The annotation source can also be specified via the Python API using the `annotation_collection_id` parameter.
 - All embedding plot legend entries (especially e.g. `Excluded by filters`, `No category`, etc.) can be hidden by clicking on them.
 - YOLO object detection export: object detection annotations can now be exported in YOLO format from the GUI export dialog, via the Python API (`dataset.export().to_yolo_object_detections(...)`), and via the export API (`export_format=object_detection_yolo`).
-- Python SDK: `limit` parameter on `ImageDataset.add_samples_from*` methods to index only the first N samples of a dataset.
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
+- Object-level (annotation) embeddings: annotations can now be embedded and searched by text or image similarity and visualized in the embedding plot.
 
 ## \[1.0.1\] - 2026-06-17
 


### PR DESCRIPTION
## Summary

The `## [1.0.2] - 2026-07-02` section created by the release bump (#1543) was accidentally removed by a bad merge in #1545. This collapsed all 1.0.2 entries back under `Unreleased` and dropped the object-level embeddings entry entirely.

This PR restores the changelog to match the `v1.0.2` tag exactly, with the only difference being the `limit` parameter entry from #1545, which merged after the release and therefore correctly stays under `Unreleased`.

You can verify with `git diff v1.0.2 -- CHANGELOG.md` on this branch — it shows only that one added line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog’s upcoming release section with standard categories for upcoming changes.
  * Added the latest note about the Python SDK `limit` parameter.
  * Documented support for object-level embeddings, including text/image similarity search and visualization in the embedding plot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->