### PR TITLE
[Prefactor] Extract shared embed_image_files_batched helper

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Any
 
 import fsspec
@@ -14,25 +12,7 @@ from PIL import Image
 from tqdm import tqdm
 
 from lightly_studio.dataset.embedding_generator import ImageCrop
-
-
-@dataclass(frozen=True)
-class EmbeddingContext:
-    """Model-specific configuration for batched image-crop embedding.
-
-    Attributes:
-        embedding_dimension: Output embedding dimension.
-        max_batch_size: Maximum crops encoded per model forward pass.
-        device: Torch device for model inference.
-        preprocess: Callable that converts a PIL crop to a model input tensor.
-        encode_batch: Callable that encodes a batch tensor and returns embeddings.
-    """
-
-    embedding_dimension: int
-    max_batch_size: int
-    device: torch.device
-    preprocess: Callable[[Image.Image], torch.Tensor]
-    encode_batch: Callable[[torch.Tensor], NDArray[np.float32]]
+from lightly_studio.dataset.image_embedding import EmbeddingContext
 
 
 def embed_image_crops_batched(

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -1,0 +1,114 @@
+"""Shared helpers for batched image embedding.
+
+Holds the model-agnostic :class:`EmbeddingContext` used across the image and
+image-crop embedding paths, plus the batched full-image embedding helper. The
+crop-specific path lives in ``image_crop_embedding.py`` and reuses the same
+``EmbeddingContext``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import fsspec
+import numpy as np
+import torch
+from numpy.typing import NDArray
+from PIL import Image
+from torch.utils.data import DataLoader, Dataset
+from tqdm import tqdm
+
+
+@dataclass(frozen=True)
+class EmbeddingContext:
+    """Model-specific configuration for batched image and image-crop embedding.
+
+    Attributes:
+        embedding_dimension: Output embedding dimension.
+        max_batch_size: Maximum images/crops encoded per model forward pass.
+        device: Torch device for model inference.
+        preprocess: Callable that converts a PIL image to a model input tensor.
+        encode_batch: Callable that encodes a batch tensor and returns embeddings.
+    """
+
+    embedding_dimension: int
+    max_batch_size: int
+    device: torch.device
+    preprocess: Callable[[Image.Image], torch.Tensor]
+    encode_batch: Callable[[torch.Tensor], NDArray[np.float32]]
+
+
+class _ImageFileDataset(Dataset[torch.Tensor]):
+    """Dataset wrapping image file paths and a preprocess function.
+
+    Used for efficient batched image loading and preprocessing.
+    """
+
+    def __init__(
+        self,
+        filepaths: list[str],
+        preprocess: Callable[[Image.Image], torch.Tensor],
+    ) -> None:
+        self.filepaths = filepaths
+        self.preprocess = preprocess
+
+    def __len__(self) -> int:
+        return len(self.filepaths)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        with fsspec.open(self.filepaths[idx], "rb") as file:
+            image = Image.open(file).convert("RGB")
+            return self.preprocess(image)
+
+
+def embed_image_files_batched(
+    filepaths: list[str],
+    context: EmbeddingContext,
+    show_progress: bool,
+) -> NDArray[np.float32]:
+    """Embed image files in batches, preserving input order.
+
+    Args:
+        filepaths: Paths of the images to embed.
+        context: Model-specific embedding configuration.
+        show_progress: Whether to show a tqdm progress bar.
+
+    Returns:
+        Float32 array of shape ``(len(filepaths), embedding_dimension)``.
+    """
+    total_images = len(filepaths)
+    if not total_images:
+        return np.empty((0, context.embedding_dimension), dtype=np.float32)
+
+    dataset = _ImageFileDataset(filepaths, context.preprocess)
+
+    # To avoid issues with db locking and multiprocessing we set the number of
+    # workers to 0 (no multiprocessing). The DataLoader is still very useful for
+    # batching and async prefetching of images.
+    loader = DataLoader(
+        dataset,
+        batch_size=context.max_batch_size,
+        num_workers=0,  # must be 0 to avoid multiprocessing issues
+    )
+
+    embeddings = np.empty((total_images, context.embedding_dimension), dtype=np.float32)
+    position = 0
+    with (
+        tqdm(
+            total=total_images,
+            desc="Generating embeddings",
+            unit=" images",
+            disable=not show_progress,
+        ) as progress_bar,
+        torch.no_grad(),
+    ):
+        for images_tensor in loader:
+            imgs = images_tensor.to(context.device, non_blocking=True)
+            batch_embeddings = context.encode_batch(imgs)
+            batch_size = imgs.size(0)
+            embeddings[position : position + batch_size] = batch_embeddings
+            position += batch_size
+            progress_bar.update(batch_size)
+
+    return embeddings

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -81,6 +81,9 @@ def embed_image_files_batched(
     if not total_images:
         return np.empty((0, context.embedding_dimension), dtype=np.float32)
 
+    if context.max_batch_size <= 0:
+        raise ValueError("max_batch_size must be positive.")
+
     dataset = _ImageFileDataset(filepaths, context.preprocess)
 
     # To avoid issues with db locking and multiprocessing we set the number of

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -3,16 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable
 from uuid import UUID
 
-import fsspec
 import numpy as np
 import torch
 from numpy.typing import NDArray
-from PIL import Image
-from torch.utils.data import DataLoader, Dataset
-from tqdm import tqdm
 
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
@@ -20,7 +15,8 @@ from lightly_studio.vendor import mobileclip
 
 from . import file_utils
 from .embedding_generator import ImageCrop, ImageEmbeddingGenerator
-from .image_crop_embedding import EmbeddingContext, embed_image_crops_batched
+from .image_crop_embedding import embed_image_crops_batched
+from .image_embedding import EmbeddingContext, embed_image_files_batched
 
 MODEL_NAME = "mobileclip_s0"
 MOBILECLIP_DOWNLOAD_URL = (
@@ -28,27 +24,6 @@ MOBILECLIP_DOWNLOAD_URL = (
 )
 MAX_BATCH_SIZE: int = 16
 EMBEDDING_DIMENSION: int = 512
-
-
-# Dataset for efficient batched image loading and preprocessing
-class _ImageFileDataset(Dataset[torch.Tensor]):
-    """Dataset wrapping image file paths and a preprocess function."""
-
-    def __init__(
-        self,
-        filepaths: list[str],
-        preprocess: Callable[[Image.Image], torch.Tensor],
-    ) -> None:
-        self.filepaths = filepaths
-        self.preprocess = preprocess
-
-    def __len__(self) -> int:
-        return len(self.filepaths)
-
-    def __getitem__(self, idx: int) -> torch.Tensor:
-        with fsspec.open(self.filepaths[idx], "rb") as file:
-            image = Image.open(file).convert("RGB")
-            return self.preprocess(image)
 
 
 class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
@@ -120,41 +95,11 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             A numpy array representing the generated embeddings
             in the same order as the input file paths.
         """
-        total_images = len(filepaths)
-        if not total_images:
-            return np.empty((0, EMBEDDING_DIMENSION), dtype=np.float32)
-
-        dataset = _ImageFileDataset(filepaths, self._preprocess)
-
-        # To avoid issues with db locking and multiprocessing we set the
-        # number of workers to 0 (no multiprocessing). The DataLoader is still
-        # very useful for batching and async prefetching of images.
-        loader = DataLoader(
-            dataset,
-            batch_size=MAX_BATCH_SIZE,
-            num_workers=0,  # must be 0 to avoid multiprocessing issues
+        return embed_image_files_batched(
+            filepaths=filepaths,
+            context=self._embedding_context(),
+            show_progress=show_progress,
         )
-
-        embeddings = np.empty((total_images, EMBEDDING_DIMENSION), dtype=np.float32)
-        position = 0
-        with (
-            tqdm(
-                total=total_images,
-                desc="Generating embeddings",
-                unit=" images",
-                disable=not show_progress,
-            ) as progress_bar,
-            torch.no_grad(),
-        ):
-            for images_tensor in loader:
-                imgs = images_tensor.to(self._device, non_blocking=True)
-                batch_embeddings = self._model.encode_image(imgs).cpu().numpy()  # type: ignore[operator]
-                batch_size = imgs.size(0)
-                embeddings[position : position + batch_size] = batch_embeddings
-                position += batch_size
-                progress_bar.update(batch_size)
-
-        return embeddings
 
     def embed_image_crops(
         self, image_crops: list[ImageCrop], show_progress: bool = True
@@ -171,18 +116,22 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
         """
         return embed_image_crops_batched(
             image_crops=image_crops,
-            context=EmbeddingContext(
-                embedding_dimension=EMBEDDING_DIMENSION,
-                max_batch_size=MAX_BATCH_SIZE,
-                device=self._device,
-                preprocess=self._preprocess,
-                encode_batch=lambda images_tensor: (
-                    self._model.encode_image(images_tensor)  # type: ignore[operator]
-                    .cpu()
-                    .numpy()
-                ),
-            ),
+            context=self._embedding_context(),
             show_progress=show_progress,
+        )
+
+    def _embedding_context(self) -> EmbeddingContext:
+        """Build the model-specific configuration for batched image embedding."""
+        return EmbeddingContext(
+            embedding_dimension=EMBEDDING_DIMENSION,
+            max_batch_size=MAX_BATCH_SIZE,
+            device=self._device,
+            preprocess=self._preprocess,
+            encode_batch=lambda images_tensor: (
+                self._model.encode_image(images_tensor)  # type: ignore[operator]
+                .cpu()
+                .numpy()
+            ),
         )
 
 

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -13,10 +13,9 @@ from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor import mobileclip
 
-from . import file_utils
+from . import file_utils, image_crop_embedding, image_embedding
 from .embedding_generator import ImageCrop, ImageEmbeddingGenerator
-from .image_crop_embedding import embed_image_crops_batched
-from .image_embedding import EmbeddingContext, embed_image_files_batched
+from .image_embedding import EmbeddingContext
 
 MODEL_NAME = "mobileclip_s0"
 MOBILECLIP_DOWNLOAD_URL = (
@@ -95,7 +94,7 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             A numpy array representing the generated embeddings
             in the same order as the input file paths.
         """
-        return embed_image_files_batched(
+        return image_embedding.embed_image_files_batched(
             filepaths=filepaths,
             context=self._embedding_context(),
             show_progress=show_progress,
@@ -114,7 +113,7 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             A numpy array representing the generated embeddings in the same order
             as the input crops.
         """
-        return embed_image_crops_batched(
+        return image_crop_embedding.embed_image_crops_batched(
             image_crops=image_crops,
             context=self._embedding_context(),
             show_progress=show_progress,

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -21,36 +21,13 @@ from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transfor
 
 from . import file_utils
 from .embedding_generator import ImageCrop, ImageEmbeddingGenerator, VideoEmbeddingGenerator
-from .image_crop_embedding import EmbeddingContext, embed_image_crops_batched
+from .image_crop_embedding import embed_image_crops_batched
+from .image_embedding import EmbeddingContext, embed_image_files_batched
 
 MODEL_NAME = "PE-Core-T16-384"
 DEFAULT_VIDEO_CHANNEL = 0
 MAX_BATCH_SIZE: int = 16
 VIDEO_FRAMES_PER_SAMPLE: int = 8
-
-
-# TODO(Jonas, 12/225): Move to a helper.
-class _ImageFileDataset(Dataset[torch.Tensor]):
-    """Dataset wrapping image file paths and a preprocess function.
-
-    Used for efficient batched image loading and preprocessing
-    """
-
-    def __init__(
-        self,
-        filepaths: list[str],
-        preprocess: Callable[[Image.Image], torch.Tensor],
-    ) -> None:
-        self.filepaths = filepaths
-        self.preprocess = preprocess
-
-    def __len__(self) -> int:
-        return len(self.filepaths)
-
-    def __getitem__(self, idx: int) -> torch.Tensor:
-        with fsspec.open(self.filepaths[idx], "rb") as file:
-            image = Image.open(file).convert("RGB")
-            return self.preprocess(image)
 
 
 class _VideoFileDataset(Dataset[torch.Tensor]):
@@ -197,41 +174,11 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             A numpy array representing the generated embeddings
             in the same order as the input file paths.
         """
-        total_images = len(filepaths)
-        if not total_images:
-            return np.empty((0, self._model.output_dim), dtype=np.float32)
-
-        dataset = _ImageFileDataset(filepaths, self._preprocess)
-
-        # To avoid issues with db locking and multiprocessing we set the
-        # number of workers to 0 (no multiprocessing). The DataLoader is still
-        # very useful for batching and async prefetching of images.
-        loader = DataLoader(
-            dataset,
-            batch_size=MAX_BATCH_SIZE,
-            num_workers=0,  # must be 0 to avoid multiprocessing issues
+        return embed_image_files_batched(
+            filepaths=filepaths,
+            context=self._embedding_context(),
+            show_progress=show_progress,
         )
-
-        embeddings = np.empty((total_images, self._model.output_dim), dtype=np.float32)
-        position = 0
-        with (
-            tqdm(
-                total=total_images,
-                desc="Generating embeddings",
-                unit=" images",
-                disable=not show_progress,
-            ) as progress_bar,
-            torch.no_grad(),
-        ):
-            for images_tensor in loader:
-                imgs = images_tensor.to(self._device, non_blocking=True)
-                batch_embeddings = self._model.encode_image(imgs, normalize=True).cpu().numpy()
-                batch_size = imgs.size(0)
-                embeddings[position : position + batch_size] = batch_embeddings
-                position += batch_size
-                progress_bar.update(batch_size)
-
-        return embeddings
 
     def embed_image_crops(
         self, image_crops: list[ImageCrop], show_progress: bool = True
@@ -248,16 +195,20 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         """
         return embed_image_crops_batched(
             image_crops=image_crops,
-            context=EmbeddingContext(
-                embedding_dimension=self._model.output_dim,
-                max_batch_size=MAX_BATCH_SIZE,
-                device=self._device,
-                preprocess=self._preprocess,
-                encode_batch=lambda images_tensor: (
-                    self._model.encode_image(images_tensor, normalize=True).cpu().numpy()
-                ),
-            ),
+            context=self._embedding_context(),
             show_progress=show_progress,
+        )
+
+    def _embedding_context(self) -> EmbeddingContext:
+        """Build the model-specific configuration for batched image embedding."""
+        return EmbeddingContext(
+            embedding_dimension=self._model.output_dim,
+            max_batch_size=MAX_BATCH_SIZE,
+            device=self._device,
+            preprocess=self._preprocess,
+            encode_batch=lambda images_tensor: (
+                self._model.encode_image(images_tensor, normalize=True).cpu().numpy()
+            ),
         )
 
     def embed_videos(self, filepaths: list[str]) -> NDArray[np.float32]:

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -19,10 +19,9 @@ from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
 
-from . import file_utils
+from . import file_utils, image_crop_embedding, image_embedding
 from .embedding_generator import ImageCrop, ImageEmbeddingGenerator, VideoEmbeddingGenerator
-from .image_crop_embedding import embed_image_crops_batched
-from .image_embedding import EmbeddingContext, embed_image_files_batched
+from .image_embedding import EmbeddingContext
 
 MODEL_NAME = "PE-Core-T16-384"
 DEFAULT_VIDEO_CHANNEL = 0
@@ -174,7 +173,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             A numpy array representing the generated embeddings
             in the same order as the input file paths.
         """
-        return embed_image_files_batched(
+        return image_embedding.embed_image_files_batched(
             filepaths=filepaths,
             context=self._embedding_context(),
             show_progress=show_progress,
@@ -193,7 +192,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             A numpy array representing the generated embeddings in the same order
             as the input crops.
         """
-        return embed_image_crops_batched(
+        return image_crop_embedding.embed_image_crops_batched(
             image_crops=image_crops,
             context=self._embedding_context(),
             show_progress=show_progress,

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -5,13 +5,13 @@ import torch
 from numpy.typing import NDArray
 from PIL import Image
 
+from lightly_studio.dataset import image_crop_embedding
 from lightly_studio.dataset.embedding_generator import ImageCrop
-from lightly_studio.dataset.image_crop_embedding import embed_image_crops_batched
 from lightly_studio.dataset.image_embedding import EmbeddingContext
 
 
 def test_embed_image_crops_batched__empty_input_returns_empty_array() -> None:
-    embeddings = embed_image_crops_batched(
+    embeddings = image_crop_embedding.embed_image_crops_batched(
         image_crops=[],
         context=EmbeddingContext(
             embedding_dimension=4,
@@ -51,7 +51,7 @@ def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
         # expected (batch_size, 1) embedding; encode is the identity here.
         return images_tensor.numpy().astype(np.float32)
 
-    embeddings = embed_image_crops_batched(
+    embeddings = image_crop_embedding.embed_image_crops_batched(
         image_crops=image_crops,
         context=EmbeddingContext(
             embedding_dimension=1,

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -6,10 +6,8 @@ from numpy.typing import NDArray
 from PIL import Image
 
 from lightly_studio.dataset.embedding_generator import ImageCrop
-from lightly_studio.dataset.image_crop_embedding import (
-    EmbeddingContext,
-    embed_image_crops_batched,
-)
+from lightly_studio.dataset.image_crop_embedding import embed_image_crops_batched
+from lightly_studio.dataset.image_embedding import EmbeddingContext
 
 
 def test_embed_image_crops_batched__empty_input_returns_empty_array() -> None:

--- a/lightly_studio/tests/dataset/test_image_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_embedding.py
@@ -4,14 +4,12 @@ import numpy as np
 import torch
 from PIL import Image
 
-from lightly_studio.dataset.image_embedding import (
-    EmbeddingContext,
-    embed_image_files_batched,
-)
+from lightly_studio.dataset import image_embedding
+from lightly_studio.dataset.image_embedding import EmbeddingContext
 
 
 def test_embed_image_files_batched__empty_input_returns_empty_array() -> None:
-    embeddings = embed_image_files_batched(
+    embeddings = image_embedding.embed_image_files_batched(
         filepaths=[],
         context=EmbeddingContext(
             embedding_dimension=4,
@@ -36,7 +34,7 @@ def test_embed_image_files_batched__preserves_input_order(tmp_path: Path) -> Non
         Image.new("RGB", (width, 10), color=(255, 0, 0)).save(path)
         filepaths.append(str(path))
 
-    embeddings = embed_image_files_batched(
+    embeddings = image_embedding.embed_image_files_batched(
         filepaths=filepaths,
         context=EmbeddingContext(
             embedding_dimension=1,

--- a/lightly_studio/tests/dataset/test_image_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_embedding.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+
+from lightly_studio.dataset.image_embedding import (
+    EmbeddingContext,
+    embed_image_files_batched,
+)
+
+
+def test_embed_image_files_batched__empty_input_returns_empty_array() -> None:
+    embeddings = embed_image_files_batched(
+        filepaths=[],
+        context=EmbeddingContext(
+            embedding_dimension=4,
+            max_batch_size=2,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=lambda images_tensor: images_tensor.cpu().numpy(),
+        ),
+        show_progress=False,
+    )
+
+    assert embeddings.shape == (0, 4)
+
+
+def test_embed_image_files_batched__preserves_input_order(tmp_path: Path) -> None:
+    # Each image has a distinct width, and preprocess encodes an image as its
+    # width, so the embeddings must come back in input order across batches.
+    widths = [5, 6, 7]
+    filepaths = []
+    for index, width in enumerate(widths):
+        path = tmp_path / f"image_{index}.png"
+        Image.new("RGB", (width, 10), color=(255, 0, 0)).save(path)
+        filepaths.append(str(path))
+
+    embeddings = embed_image_files_batched(
+        filepaths=filepaths,
+        context=EmbeddingContext(
+            embedding_dimension=1,
+            max_batch_size=2,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
+        ),
+        show_progress=False,
+    )
+
+    assert embeddings.shape == (3, 1)
+    assert embeddings[:, 0].tolist() == [float(width) for width in widths]


### PR DESCRIPTION
## What

The full-image `DataLoader` embedding loop was duplicated verbatim in the MobileCLIP and Perception Encoder generators, each with its own copy of `_ImageFileDataset`. This extracts both into a new `dataset/image_embedding.py`:

- New `image_embedding.py` holds the model-agnostic `EmbeddingContext` (moved out of `image_crop_embedding.py`), `_ImageFileDataset`, and `embed_image_files_batched`.
- `image_crop_embedding.py` now contains only the crop path and imports `EmbeddingContext` from `image_embedding.py`.
- Each generator delegates to `embed_image_files_batched` via a small `_embedding_context()` helper, mirroring the existing `embed_image_crops_batched` usage.

## Why

Pure, behavior-preserving refactor. Splitting this out shrinks the follow-up change (per-item broken-file tolerance) to just layering the tolerance on top of the shared helpers, keeping that PR focused and reviewable.

## Notes

- The `NDArray` return contract and behavior are unchanged; existing generator tests pass without modification.
- File-helper tests moved to a new `tests/dataset/test_image_embedding.py`; the crop test keeps only crop cases.

## Testing

- `make static-checks` (ruff + mypy) pass on the changed files.
- `tests/dataset/` embedding tests pass (`test_image_embedding.py`, `test_image_crop_embedding.py`, `test_mobileclip_embedding_generator.py`, `test_perception_encoder_embedding_generator.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added shared batched image embedding utilities (including a reusable embedding configuration) for consistent full-image and crop embedding behavior.

* **Bug Fixes**
  * Ensured batched embedding results preserve the original input order.
  * Improved empty-input handling to return an empty embeddings array cleanly.

* **Refactor**
  * Updated MobileCLIP and Perception Encoder embedding generators to delegate image embedding to the shared batched helpers.

* **Tests**
  * Added/updated unit tests for empty inputs, output shape, and input-order preservation in batched image embedding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->