### PR TITLE
Add VideoDataset.frames() and queryable VideoFrameSampleField

### DIFF
--- a/lightly_studio/src/lightly_studio/__init__.py
+++ b/lightly_studio/src/lightly_studio/__init__.py
@@ -10,6 +10,8 @@ from lightly_studio import utils  # noqa: F401
 
 from lightly_studio.core.image.image_dataset import ImageDataset
 from lightly_studio.core.video.video_dataset import VideoDataset
+from lightly_studio.core.video.video_frame_dataset import VideoFrameDataset
+from lightly_studio.core.video.video_frame_sample import VideoFrameSample
 from lightly_studio.core.group.group_dataset import GroupDataset
 from lightly_studio.core.image.create_image import CreateImage
 from lightly_studio.core.video.create_video import CreateVideo
@@ -34,6 +36,8 @@ __all__ = [
     "ImageDataset",
     "SampleType",
     "VideoDataset",
+    "VideoFrameDataset",
+    "VideoFrameSample",
     "connect",
     "lt_train_script",
     "start_gui",

--- a/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/__init__.py
@@ -14,6 +14,7 @@ from .order_by import (
 )
 from .sample_evaluation_query import SampleEvaluationQuery
 from .segmentation_mask_query import SegmentationMaskField, SegmentationMaskQuery
+from .video_frame_sample_field import VideoFrameSampleField
 from .video_sample_field import VideoSampleField
 
 __all__ = [
@@ -36,5 +37,6 @@ __all__ = [
     "SampleEvaluationQuery",
     "SegmentationMaskField",
     "SegmentationMaskQuery",
+    "VideoFrameSampleField",
     "VideoSampleField",
 ]

--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -313,10 +313,11 @@ class DatasetQuery(Generic[T]):
             default_order_by = OrderByField(ImageSampleField.created_at)
             query = default_order_by.apply(query)
         elif self.dataset.sample_type == SampleType.VIDEO_FRAME:
-            # Default to a deterministic order across videos: group by parent video,
-            # then by frame number. Both are columns on the frame table, so no join.
-            query = query.order_by(
-                col(VideoFrameTable.parent_sample_id),
+            # Match get_all_by_collection_id: order by parent-video path, then frame
+            # number. parent_sample_id is a random UUID (unstable across re-imports),
+            # so join the parent video and sort by its path for a stable order.
+            query = query.join(VideoFrameTable.video).order_by(
+                col(VideoTable.file_path_abs),
                 col(VideoFrameTable.frame_number),
             )
 

--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import Generic, cast
 
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 from sqlmodel.sql.expression import SelectOfScalar
 from typing_extensions import Self, TypeVar
 
@@ -312,6 +312,13 @@ class DatasetQuery(Generic[T]):
             # Order by ImageSampleField.created_at by default.
             default_order_by = OrderByField(ImageSampleField.created_at)
             query = default_order_by.apply(query)
+        elif self.dataset.sample_type == SampleType.VIDEO_FRAME:
+            # Default to a deterministic order across videos: group by parent video,
+            # then by frame number. Both are columns on the frame table, so no join.
+            query = query.order_by(
+                col(VideoFrameTable.parent_sample_id),
+                col(VideoFrameTable.frame_number),
+            )
 
         # Apply slicing if present
         if self._slice is not None:

--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -313,9 +313,6 @@ class DatasetQuery(Generic[T]):
             default_order_by = OrderByField(ImageSampleField.created_at)
             query = default_order_by.apply(query)
         elif self.dataset.sample_type == SampleType.VIDEO_FRAME:
-            # Match get_all_by_collection_id: order by parent-video path, then frame
-            # number. parent_sample_id is a random UUID (unstable across re-imports),
-            # so join the parent video and sort by its path for a stable order.
             query = query.join(VideoFrameTable.video).order_by(
                 col(VideoTable.file_path_abs),
                 col(VideoFrameTable.frame_number),

--- a/lightly_studio/src/lightly_studio/core/dataset_query/video_frame_sample_field.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/video_frame_sample_field.py
@@ -1,0 +1,32 @@
+"""Fields for querying video frame sample properties in the dataset query system."""
+
+from __future__ import annotations
+
+from sqlmodel import col
+
+from lightly_studio.core.dataset_query.field import NumericalField
+from lightly_studio.core.dataset_query.tags_expression import TagsAccessor
+from lightly_studio.models.video import VideoFrameTable
+
+
+class VideoFrameSampleField:
+    """Providing access to predefined video frame fields for queries.
+
+    It is used for the `query.match(...)` and `query.order_by(...)` methods of the
+    `DatasetQuery` class.
+
+    ```python
+    from lightly_studio.core.dataset_query import VideoFrameSampleField, OrderByField
+
+    frames = video_dataset.frames()
+    query = frames.match(VideoFrameSampleField.frame_number > 10)
+    query = query.order_by(OrderByField(VideoFrameSampleField.frame_timestamp_s))
+    ```
+    """
+
+    frame_number = NumericalField(col(VideoFrameTable.frame_number))
+    frame_timestamp_s = NumericalField(col(VideoFrameTable.frame_timestamp_s))
+    frame_timestamp_pts = NumericalField(col(VideoFrameTable.frame_timestamp_pts))
+    rotation_deg = NumericalField(col(VideoFrameTable.rotation_deg))
+
+    tags = TagsAccessor()

--- a/lightly_studio/src/lightly_studio/core/video/video_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/video/video_dataset.py
@@ -17,13 +17,14 @@ from lightly_studio.core.dataset import BaseSampleDataset
 from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
 from lightly_studio.core.video import add_videos
 from lightly_studio.core.video.add_videos import VIDEO_EXTENSIONS
+from lightly_studio.core.video.video_frame_dataset import VideoFrameDataset
 from lightly_studio.core.video.video_sample import VideoSample
 from lightly_studio.dataset import fsspec_lister
 from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
 from lightly_studio.export.video_dataset_export import VideoDatasetExport
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import SampleType
-from lightly_studio.resolvers import video_resolver
+from lightly_studio.resolvers import collection_resolver, video_resolver
 from lightly_studio.type_definitions import PathLike
 
 logger = logging.getLogger(__name__)
@@ -79,6 +80,23 @@ class VideoDataset(BaseSampleDataset[VideoSample]):
         if query is None:
             query = self.query()
         return VideoDatasetExport(session=self.session, samples=query)
+
+    def frames(self) -> VideoFrameDataset:
+        """Return a dataset over the individual frames of this dataset's videos.
+
+        Returns:
+            A VideoFrameDataset exposing the video frames as queryable samples.
+        """
+        frame_collection_id = collection_resolver.get_or_create_child_collection(
+            session=self.session,
+            collection_id=self.collection_id,
+            sample_type=SampleType.VIDEO_FRAME,
+        )
+        frame_collection = collection_resolver.get_by_id(
+            session=self.session, collection_id=frame_collection_id
+        )
+        assert frame_collection is not None
+        return VideoFrameDataset(collection=frame_collection)
 
     def get_sample(self, sample_id: UUID) -> VideoSample:
         """Get a single sample from the dataset by its ID.

--- a/lightly_studio/src/lightly_studio/core/video/video_frame_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/video/video_frame_dataset.py
@@ -11,14 +11,30 @@ from lightly_studio.resolvers import video_frame_resolver
 
 
 class VideoFrameDataset(Dataset[VideoFrameSample]):
-    """Dataset over the individual frames of a video dataset.
+    """Video frame dataset.
 
-    Exposes each video frame as a `VideoFrameSample`. Like any dataset, it can be
-    iterated over or sliced:
+    It is not created or loaded directly. It is obtained from a `VideoDataset` via
+    `video_dataset.frames()` and exposes the individual video frames as queryable
+    `VideoFrameSample` objects.
+
+    The dataset frames can be accessed directly by iterating over it or slicing it:
     ```python
+    from lightly_studio import VideoDataset
+
+    frames = VideoDataset.load("my_dataset").frames()
     first_ten_frames = frames[:10]
     for frame in frames:
         print(frame.frame_number, frame.frame_timestamp_s)
+    ```
+
+    For filtering or ordering frames first, use the query interface:
+    ```python
+    from lightly_studio.core.dataset_query import VideoFrameSampleField
+
+    frames = VideoDataset.load("my_dataset").frames()
+    query = frames.match(VideoFrameSampleField.frame_number > 10)
+    for frame in query:
+        ...
     ```
     """
 

--- a/lightly_studio/src/lightly_studio/examples/example_video_frames.py
+++ b/lightly_studio/src/lightly_studio/examples/example_video_frames.py
@@ -1,0 +1,62 @@
+"""Example of how to query, tag, sample, and export individual video frames.
+
+It opens a video dataset, queries its frames by frame-level fields, tags the matches,
+runs a sampling strategy on the query, and exports the sampled frames as
+`(frame_number, frame_timestamp_s)` rows to a CSV file.
+"""
+
+from __future__ import annotations
+
+import csv
+import tempfile
+from pathlib import Path
+
+from environs import Env
+
+import lightly_studio as ls
+from lightly_studio.core.dataset_query import VideoFrameSampleField
+from lightly_studio.database import db_manager
+
+env = Env()
+env.read_env()
+db_manager.connect(cleanup_existing=True)
+dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH", "/path/to/your/dataset")
+
+dataset = ls.VideoDataset.create()
+dataset.add_videos_from_path(path=dataset_path, embed=False, target_fps=1)
+
+frames = dataset.frames()
+print(f"\nTotal frames in dataset: {len(list(frames))}")
+
+# Filtering by a frame-level field (frame_number) works
+min_frame_number = 3
+selected = frames.match(VideoFrameSampleField.frame_number > min_frame_number)
+print(
+    f"\nFiltering by fields: There are {len(selected.to_list())} frames after frame "
+    f"{min_frame_number}."
+)
+
+# Writing metadata for all frames in a query works
+for frame in frames.match(VideoFrameSampleField.frame_number > 1):
+    frame.metadata["score"] = float(frame.frame_number)
+print("\nAdded metadata to frames with frame_number > 1.")
+
+
+# Sampling works
+frames.match(VideoFrameSampleField.frame_number > 1).sampling().metadata_weighting(
+    n_samples_to_select=5,
+    sampling_result_tag_name="sampled",
+    metadata_key="score",
+)
+print("\nSampled the 5 frames with the highest metadata.score value.")
+
+# Export the sampled frames as (frame_number, frame_timestamp_s) rows to a CSV file.
+out_csv = Path(tempfile.gettempdir()) / "sampled_video_frames.csv"
+with out_csv.open("w", newline="") as fh:
+    writer = csv.writer(fh)
+    writer.writerow(["frame_number", "frame_timestamp_s"])
+    for frame in frames.match(VideoFrameSampleField.tags.contains("sampled")):
+        writer.writerow([frame.frame_number, frame.frame_timestamp_s])
+
+print(f"\nExported sampled frames to {out_csv}")
+print(f"First 3 lines: {list(out_csv.read_text().splitlines())[:3]}")

--- a/lightly_studio/tests/core/dataset_query/test_video_frame_dataset_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_video_frame_dataset_query.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from lightly_studio.core.dataset_query import OrderByField
+from lightly_studio.core.dataset_query.video_frame_sample_field import VideoFrameSampleField
+from lightly_studio.core.video.video_dataset import VideoDataset
+from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
+
+
+@pytest.fixture
+def dataset(patch_collection: None) -> VideoDataset:  # noqa: ARG001
+    """Video A (frames 0-2) and video B (frames 0-1) => 5 frames."""
+    dataset = VideoDataset.create(name="ds")
+    for path, fps in (("/data/a.mp4", 3.0), ("/data/b.mp4", 2.0)):
+        create_video_with_frames(
+            session=dataset.session,
+            collection_id=dataset.collection_id,
+            video=VideoStub(path=path, duration_s=1.0, fps=fps),
+        )
+    return dataset
+
+
+class TestVideoFrameDatasetQuery:
+    def test_match_frame_number(self, dataset: VideoDataset) -> None:
+        result = dataset.frames().match(VideoFrameSampleField.frame_number > 0).to_list()
+
+        # video A: frames 1, 2 ; video B: frame 1 => 3 frames
+        assert len(result) == 3
+        assert all(frame.frame_number > 0 for frame in result)
+
+    @pytest.mark.parametrize(
+        ("order_by_field", "reverse"),
+        [
+            (OrderByField(VideoFrameSampleField.frame_number), False),
+            (OrderByField(VideoFrameSampleField.frame_number).desc(), True),
+        ],
+    )
+    def test_ordering(
+        self, dataset: VideoDataset, order_by_field: OrderByField, reverse: bool
+    ) -> None:
+        frame_numbers = [frame.frame_number for frame in dataset.frames().order_by(order_by_field)]
+        assert frame_numbers == sorted(frame_numbers, reverse=reverse)

--- a/lightly_studio/tests/core/video/test_video_frame_dataset.py
+++ b/lightly_studio/tests/core/video/test_video_frame_dataset.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from lightly_studio.core.video.video_dataset import VideoDataset
 from lightly_studio.core.video.video_frame_dataset import VideoFrameDataset
 from lightly_studio.core.video.video_frame_sample import VideoFrameSample
-from lightly_studio.resolvers import collection_resolver
-from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
+from tests.resolvers.video.helpers import (
+    VideoStub,
+    create_video_file,
+    create_video_with_frames,
+)
 
 
 class TestVideoFrameDataset:
-    def test_iterates_video_frame_samples(
+    def test_frames_iterates_video_frame_samples(
         self,
         patch_collection: None,  # noqa: ARG002
     ) -> None:
@@ -18,12 +23,10 @@ class TestVideoFrameDataset:
             collection_id=dataset.collection_id,
             video=VideoStub(path="/data/a.mp4", duration_s=1.0, fps=3.0),
         )
-        frame_collection = collection_resolver.get_by_id(
-            session=dataset.session, collection_id=result.video_frames_collection_id
-        )
-        assert frame_collection is not None
-        frames = VideoFrameDataset(collection=frame_collection)
 
+        frames = dataset.frames()
+
+        assert isinstance(frames, VideoFrameDataset)
         frame_list = list(frames)
         assert len(frame_list) == len(result.frame_sample_ids) == 3
         assert all(isinstance(frame, VideoFrameSample) for frame in frame_list)
@@ -38,14 +41,36 @@ class TestVideoFrameDataset:
             collection_id=dataset.collection_id,
             video=VideoStub(path="/data/a.mp4", duration_s=1.0, fps=3.0),
         )
-        frame_collection = collection_resolver.get_by_id(
-            session=dataset.session, collection_id=result.video_frames_collection_id
-        )
-        assert frame_collection is not None
-        frames = VideoFrameDataset(collection=frame_collection)
 
         sample_id = result.frame_sample_ids[0]
-        frame = frames.get_sample(sample_id)
+        frame = dataset.frames().get_sample(sample_id)
 
         assert isinstance(frame, VideoFrameSample)
         assert frame.sample_id == sample_id
+
+    def test_frames_empty_without_videos(
+        self,
+        patch_collection: None,  # noqa: ARG002
+    ) -> None:
+        dataset = VideoDataset.create(name="empty_dataset")
+        assert list(dataset.frames()) == []
+
+    def test_frames_end_to_end_from_real_videos(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        create_video_file(
+            output_path=tmp_path / "vid.mp4",
+            width=320,
+            height=240,
+            num_frames=5,
+            fps=5,
+        )
+
+        dataset = VideoDataset.create(name="real_dataset")
+        dataset.add_videos_from_path(path=tmp_path, embed=False)
+
+        frame_numbers = [frame.frame_number for frame in dataset.frames()]
+        assert len(frame_numbers) > 0
+        assert frame_numbers == sorted(frame_numbers)

--- a/lightly_studio/tests/core/video/test_video_frame_sample.py
+++ b/lightly_studio/tests/core/video/test_video_frame_sample.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import pytest
 
 from lightly_studio.core.video.video_dataset import VideoDataset
-from lightly_studio.core.video.video_frame_dataset import VideoFrameDataset
-from lightly_studio.resolvers import collection_resolver
 from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
 
 
@@ -19,12 +17,8 @@ class TestVideoFrameSample:
             collection_id=dataset.collection_id,
             video=VideoStub(path="/data/a.mp4", width=640, height=480, duration_s=1.0, fps=3.0),
         )
-        frame_collection = collection_resolver.get_by_id(
-            session=dataset.session, collection_id=result.video_frames_collection_id
-        )
-        assert frame_collection is not None
-        frames = VideoFrameDataset(collection=frame_collection)
-        frame = frames.get_sample(result.frame_sample_ids[1])
+
+        frame = dataset.frames().get_sample(result.frame_sample_ids[1])
 
         assert frame.frame_number == 1
         assert frame.frame_timestamp_s == pytest.approx(1 / 3.0)


### PR DESCRIPTION
## What has changed and why?

Follow-up to #1502 (which added the `VideoFrameDataset` + `VideoFrameSample` type). Makes video frames obtainable and queryable from the Python API:

- `VideoDataset.frames()` returns a `VideoFrameDataset` over the videos' frames (creates/reuses the frame child collection)
- `VideoFrameSampleField` for filtering/ordering frame queries (`frame_number`, `frame_timestamp_s`, `frame_timestamp_pts`, `rotation_deg`, `tags`)
- default deterministic frame ordering (by parent video, then frame number)
- top-level `lightly_studio.VideoFrameDataset` / `VideoFrameSample` exports

Querying and sampling work exactly like on `ImageDataset` / `VideoDataset` — the query system is fully reused. The frame tests now use `frames()` again, since the entry point exists.

## Example script

See `lightly_studio/src/lightly_studio/examples/example_video_frames.py`.

```
Total frames in dataset: 5

Filtering by fields: There are 4 frames after frame 3.

Added metadata to frames with frame_number > 1.

Sampled the 5 frames with the highest metadata.score value.

Exported sampled frames to /var/.../sampled_video_frames.csv
First 3 lines: ['frame_number,frame_timestamp_s', '30,1.0', '60,2.0']
```

## Known limitation

Ordering a frame query by metadata (`OrderByMetadataField`) or an evaluation metric is not supported yet: their `apply_joins` hard-code the join to `ImageTable.sample_id`, so they only build correct SQL for image queries. Pre-existing (also affects `VideoDataset` metadata ordering); tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `frames()` API on `VideoDataset` to access and iterate frame samples.
  - Introduced `VideoFrameSampleField` to enable frame-level querying (numeric fields and tags).
  - Exposed new frame dataset/query symbols as part of the public API.
  - Added an end-to-end example for filtering, tagging, sampling, and CSV export.

- **Bug Fixes**
  - Ensured deterministic default ordering for video-frame queries when no explicit sort is provided.

- **Documentation**
  - Expanded docs with clearer frame dataset and frame-field usage examples.

- **Tests**
  - Added/updated tests for frame filtering, ordering, and the new `frames()` workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->