### PR TITLE
Fast Track: Add Checks workflow + API guardrail context (C2)

### DIFF
--- a/.github/workflows/fast_track_checks.yml
+++ b/.github/workflows/fast_track_checks.yml
@@ -1,0 +1,62 @@
+name: Fast Track Checks
+
+# Judges only. Runs the guardrails on every non-draft PR event with a READ-ONLY
+# token and publishes a machine-readable verdict as an artifact for the Fast
+# Track Bot to act on. Holds no privileged credential — the token that can
+# approve lives only in the Bot's base-repo context (design §2, §3).
+#
+# Deliberately NOT a required status check: requiring it would block every
+# non-fast-track PR (design §4).
+
+on:
+  pull_request:
+    # `labeled`/`unlabeled` are included so adding/removing the opt-out label
+    # (Stage C5) re-evaluates the PR.
+    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+
+# Only the latest push per PR needs judging; cancel superseded runs.
+concurrency:
+  group: fast-track-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# Read-only everywhere. No write scope is granted to any job in this workflow.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  checks:
+    name: Run guardrails
+    # Skip drafts: the Bot no-ops without a verdict, so there is nothing to do.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: fast_track
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      # Pin Node from .nvmrc, matching the local Makefile's nvm setup.
+      - name: Set Up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: fast_track/.nvmrc
+          cache: npm
+          cache-dependency-path: fast_track/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run guardrails and publish verdict
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npm run checks
+
+      - name: Upload verdict
+        uses: actions/upload-artifact@v4
+        with:
+          name: fast-track-verdict
+          path: fast_track/verdict.json
+          if-no-files-found: error
+          retention-days: 7

--- a/fast_track/.gitignore
+++ b/fast_track/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 *.tsbuildinfo
+
+# Verdict artifact written by `npm run checks` (Fast Track Checks).
+verdict.json

--- a/fast_track/README.md
+++ b/fast_track/README.md
@@ -2,16 +2,27 @@
 
 TypeScript package for the Fast Track Bot: **guardrails** that judge a PR and
 produce a machine-readable verdict, and a **bot** that acts on that verdict. Two
-thin GitHub workflows will launch it (added in later PRs).
+thin GitHub workflows launch it.
 
 Runs via [`tsx`](https://tsx.is/) — no build step, no compiled artifact.
 
-> **Status:** early scaffolding. The verdict contract, the guardrail framework
-> (context types, an always-pass dummy guardrail, the registry + selector), the
-> runner, and the local git-backed context provider are in place with unit
-> tests — `make run-guardrails` runs the guardrails against your branch's
-> committed changes. The API context provider, the bot, and the two workflows land in subsequent,
-> independently reviewable PRs.
+> **Status:** the judging half is live. The verdict contract, the guardrail
+> framework (context types, an always-pass dummy guardrail, the registry +
+> selector), the runner, and both context providers (local `git` and CI `API`)
+> are in place with unit tests. `make run-guardrails` judges your branch's
+> committed changes locally; the **Fast Track Checks** workflow
+> ([`.github/workflows/fast_track_checks.yml`](../.github/workflows/fast_track_checks.yml))
+> runs the guardrails on every non-draft PR with a read-only token and uploads
+> the verdict as an artifact. The bot and its workflow — the acting half — land
+> in subsequent PRs.
+
+## The two components
+
+- **Fast Track Checks** (this workflow, read-only): runs the guardrails in PR
+  context via `npm run checks` and writes `verdict.json`. Holds no credential
+  that can approve. Not a required status check.
+- **Fast Track Bot** (later PR, base-repo context): reads the verdict artifact
+  and approves / dismisses / comments with a GitHub App token.
 
 ## Local commands
 

--- a/fast_track/package-lock.json
+++ b/fast_track/package-lock.json
@@ -7,6 +7,10 @@
         "": {
             "name": "fast_track",
             "version": "0.0.1",
+            "dependencies": {
+                "@actions/core": "^1.11.1",
+                "@actions/github": "^6.0.1"
+            },
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
                 "@types/node": "^24.0.0",
@@ -22,6 +26,56 @@
             "engines": {
                 "node": ">=24"
             }
+        },
+        "node_modules/@actions/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+            "license": "MIT",
+            "dependencies": {
+                "@actions/exec": "^1.1.1",
+                "@actions/http-client": "^2.0.1"
+            }
+        },
+        "node_modules/@actions/exec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+            "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+            "license": "MIT",
+            "dependencies": {
+                "@actions/io": "^1.0.1"
+            }
+        },
+        "node_modules/@actions/github": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+            "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+            "license": "MIT",
+            "dependencies": {
+                "@actions/http-client": "^2.2.0",
+                "@octokit/core": "^5.0.1",
+                "@octokit/plugin-paginate-rest": "^9.2.2",
+                "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "undici": "^5.28.5"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+            "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+            "license": "MIT",
+            "dependencies": {
+                "tunnel": "^0.0.6",
+                "undici": "^5.25.4"
+            }
+        },
+        "node_modules/@actions/io": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+            "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.28.1",
@@ -622,6 +676,15 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.2",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -694,6 +757,164 @@
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@octokit/auth-token": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+            "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.1.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "9.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+            "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+            "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/request": "^8.4.1",
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "24.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+            "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+            "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/endpoint": "^9.0.6",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+            "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^13.1.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "13.10.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^24.2.0"
+            }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.62.2",
@@ -1564,6 +1785,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.15",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -1715,6 +1942,12 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+            "license": "ISC"
         },
         "node_modules/es-module-lexer": {
             "version": "1.7.0",
@@ -2334,6 +2567,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2773,6 +3015,15 @@
                 "fsevents": "~2.3.3"
             }
         },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2824,12 +3075,30 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
+        },
         "node_modules/undici-types": {
             "version": "7.18.2",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
             "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+            "license": "ISC"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -3054,6 +3323,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",

--- a/fast_track/package.json
+++ b/fast_track/package.json
@@ -13,7 +13,8 @@
         "static-checks": "npm run lint && npm run check",
         "test": "vitest run",
         "guardrails": "tsx src/guardrails/run-guardrails.ts",
-        "list-guardrails": "tsx src/guardrails/run-guardrails.ts --list"
+        "list-guardrails": "tsx src/guardrails/run-guardrails.ts --list",
+        "checks": "tsx src/checks/run-checks.ts"
     },
     "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -26,5 +27,9 @@
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.22.0",
         "vitest": "^3.0.4"
+    },
+    "dependencies": {
+        "@actions/core": "^1.11.1",
+        "@actions/github": "^6.0.1"
     }
 }

--- a/fast_track/src/checks/run-checks.ts
+++ b/fast_track/src/checks/run-checks.ts
@@ -1,0 +1,63 @@
+import { writeFileSync } from 'node:fs';
+
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+import { ApiGuardrailContext } from '../guardrails/context/api-context';
+import { guardrails, selectGuardrails } from '../guardrails/registry';
+import { runGuardrails } from '../guardrails/run-guardrails';
+import { buildVerdict } from './verdict';
+
+/** Where the verdict is serialized; the workflow uploads this as an artifact. */
+const VERDICT_PATH = 'verdict.json';
+
+/** The `pull_request` fields Checks needs from the event payload. */
+interface PullRequestEvent {
+    number: number;
+    head: { sha: string };
+    base: { ref: string };
+    draft?: boolean;
+}
+
+/**
+ * Fast Track Checks entry point (CI only). Runs in PR context with a read-only
+ * token, judges the PR against the guardrails, and writes the verdict to disk.
+ * The job succeeds whatever the verdict is — a `fail` is a normal, published
+ * outcome, not a job failure. `setFailed` is reserved for genuine errors (a
+ * missing token or a crash), which leave no verdict for the Bot to act on.
+ */
+async function main(): Promise<void> {
+    const token = process.env.GITHUB_TOKEN;
+    if (!token) {
+        core.setFailed('GITHUB_TOKEN is not set.');
+        return;
+    }
+
+    const pr = github.context.payload.pull_request as PullRequestEvent | undefined;
+    if (pr === undefined) {
+        core.info('No pull_request in the event payload; nothing to judge.');
+        return;
+    }
+
+    const { owner, repo } = github.context.repo;
+    const octokit = github.getOctokit(token);
+    // Base ref from the event, so a stacked PR (non-main base) diffs correctly.
+    const context = new ApiGuardrailContext(
+        octokit,
+        { owner, repo, pull_number: pr.number },
+        pr.base.ref
+    );
+
+    // CI has PR context, so pr-only guardrails run here (unlike the local CLI).
+    const selected = selectGuardrails(guardrails, { hasPrContext: true });
+    const run = await runGuardrails(context, selected);
+    const verdict = buildVerdict(run, { pr_number: pr.number, head_sha: pr.head.sha });
+
+    writeFileSync(VERDICT_PATH, `${JSON.stringify(verdict, null, 2)}\n`);
+    core.info(`Verdict: ${verdict.verdict} (${verdict.guardrails.length} guardrail(s)).`);
+    core.setOutput('verdict', verdict.verdict);
+}
+
+main().catch((error: unknown) => {
+    core.setFailed(error instanceof Error ? error.message : String(error));
+});

--- a/fast_track/src/checks/verdict.test.ts
+++ b/fast_track/src/checks/verdict.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RunResult } from '../guardrails/run-guardrails';
+import { buildVerdict } from './verdict';
+
+const routing = { pr_number: 7, head_sha: 'deadbeef' };
+
+describe('buildVerdict', () => {
+    it('carries the status, breakdown, and routing on a pass, with no reason', () => {
+        const run: RunResult = {
+            status: 'pass',
+            guardrails: [{ name: 'dummy', status: 'pass', summary: 'Always passes.' }]
+        };
+        expect(buildVerdict(run, routing)).toEqual({
+            verdict: 'pass',
+            guardrails: [{ name: 'dummy', status: 'pass', summary: 'Always passes.' }],
+            pr_number: 7,
+            head_sha: 'deadbeef'
+        });
+    });
+
+    it('adds a reason naming the failing guardrails on a fail', () => {
+        const run: RunResult = {
+            status: 'fail',
+            guardrails: [
+                { name: 'size', status: 'fail', summary: 'too big' },
+                { name: 'other', status: 'pass', summary: '' }
+            ]
+        };
+        expect(buildVerdict(run, routing).reason).toBe('Failed guardrail(s): size');
+    });
+});

--- a/fast_track/src/checks/verdict.ts
+++ b/fast_track/src/checks/verdict.ts
@@ -1,0 +1,42 @@
+import type { RunResult } from '../guardrails/run-guardrails';
+import type { Verdict } from '../shared/verdict';
+
+/**
+ * Untrusted routing anchors written into the verdict. The Bot re-derives these
+ * from the trusted event and cross-checks them (design §2.2, §3) — Checks writes
+ * them only so a missing artifact and a routed one look the same on the wire.
+ */
+export interface VerdictRouting {
+    pr_number: number;
+    head_sha: string;
+}
+
+/**
+ * Wrap a {@link RunResult} into the on-the-wire {@link Verdict}: the run's
+ * status becomes the overall verdict, the per-guardrail breakdown carries over
+ * verbatim, and the routing anchors are attached. A non-pass run gets a
+ * human-readable `reason` for the PR status comment.
+ *
+ * `opt_out` is not produced here — it is an author-label override the Bot
+ * applies, never a guardrail-run outcome.
+ */
+export function buildVerdict(run: RunResult, routing: VerdictRouting): Verdict {
+    const verdict: Verdict = {
+        verdict: run.status,
+        guardrails: run.guardrails,
+        pr_number: routing.pr_number,
+        head_sha: routing.head_sha
+    };
+    const reason = failureReason(run);
+    if (reason !== undefined) {
+        verdict.reason = reason;
+    }
+    return verdict;
+}
+
+/** A summary of the failing guardrails, or undefined when the run passed. */
+function failureReason(run: RunResult): string | undefined {
+    if (run.status === 'pass') return undefined;
+    const failed = run.guardrails.filter((g) => g.status === 'fail').map((g) => g.name);
+    return `Failed guardrail(s): ${failed.join(', ')}`;
+}

--- a/fast_track/src/guardrails/context/api-context.test.ts
+++ b/fast_track/src/guardrails/context/api-context.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiGuardrailContext, toChangedFile, type ApiFile } from './api-context';
+import type { Octokit } from './types';
+
+/**
+ * A minimal Octokit stand-in: `paginate` resolves to the given files and
+ * records its arguments; `rest.pulls.listFiles` is an opaque marker that
+ * `paginate` is asked to walk.
+ */
+function fakeOctokit(files: ApiFile[]): {
+    octokit: Octokit;
+    paginate: ReturnType<typeof vi.fn>;
+    listFiles: unknown;
+} {
+    const listFiles = Symbol('pulls.listFiles');
+    const paginate = vi.fn(async () => files);
+    const octokit = {
+        paginate,
+        rest: { pulls: { listFiles } }
+    } as unknown as Octokit;
+    return { octokit, paginate, listFiles };
+}
+
+describe('toChangedFile', () => {
+    it('maps filename/additions/deletions and keeps the patch', () => {
+        expect(
+            toChangedFile({ filename: 'src/a.ts', additions: 3, deletions: 1, patch: '@@ hunk @@' })
+        ).toEqual({ path: 'src/a.ts', additions: 3, deletions: 1, patch: '@@ hunk @@' });
+    });
+
+    it('omits the patch field entirely when the API omits it (binary/large)', () => {
+        const result = toChangedFile({ filename: 'logo.png', additions: 0, deletions: 0 });
+        expect(result).toEqual({ path: 'logo.png', additions: 0, deletions: 0 });
+        expect('patch' in result).toBe(false);
+    });
+});
+
+describe('ApiGuardrailContext', () => {
+    const pr = { owner: 'acme', repo: 'widgets', pull_number: 42 };
+
+    it('paginates listFiles with the PR params and runs results through the mapper', async () => {
+        const { octokit, paginate, listFiles } = fakeOctokit([
+            { filename: 'a.ts', additions: 2, deletions: 0, patch: '@@ a @@' }
+        ]);
+        const context = new ApiGuardrailContext(octokit, pr, 'main');
+
+        // Mapping semantics (patch present/absent) are owned by the toChangedFile
+        // tests; here we only assert results are mapped (path, not filename).
+        expect(await context.changedFiles()).toEqual([
+            { path: 'a.ts', additions: 2, deletions: 0, patch: '@@ a @@' }
+        ]);
+        expect(paginate).toHaveBeenCalledWith(listFiles, {
+            owner: 'acme',
+            repo: 'widgets',
+            pull_number: 42,
+            per_page: 100
+        });
+    });
+
+    it('exposes the base ref and the octokit client to guardrails', () => {
+        const { octokit } = fakeOctokit([]);
+        const context = new ApiGuardrailContext(octokit, pr, 'release/2.0');
+        expect(context.baseRef).toBe('release/2.0');
+        expect(context.octokit).toBe(octokit);
+    });
+
+    it('fetches only once across repeated calls (memoized)', async () => {
+        const { octokit, paginate } = fakeOctokit([]);
+        const context = new ApiGuardrailContext(octokit, pr, 'main');
+        await context.changedFiles();
+        await context.changedFiles();
+        expect(paginate).toHaveBeenCalledTimes(1);
+    });
+});

--- a/fast_track/src/guardrails/context/api-context.ts
+++ b/fast_track/src/guardrails/context/api-context.ts
@@ -1,0 +1,69 @@
+import type { ChangedFile, GuardrailContext, Octokit } from './types';
+
+/** Identifies the PR whose files back the context. */
+export interface PullRequestRef {
+    owner: string;
+    repo: string;
+    pull_number: number;
+}
+
+/** The subset of a `pulls.listFiles` item this provider reads. */
+export interface ApiFile {
+    filename: string;
+    additions: number;
+    deletions: number;
+    /** Omitted by the API for binary and very large files. */
+    patch?: string;
+}
+
+/**
+ * CI {@link GuardrailContext} backed by the GitHub API. The changed files come
+ * from `pulls.listFiles`, which the API caps at ~3000 files (100 per page); a
+ * PR larger than that is silently truncated at the ceiling — the git provider
+ * never hits it, so the two providers diverge only on pathological PRs.
+ *
+ * `patch` is absent for binary/large files exactly as in the git provider, so
+ * guardrails treat it as optional on either side.
+ */
+export class ApiGuardrailContext implements GuardrailContext {
+    readonly baseRef: string;
+    readonly octokit: Octokit;
+    private readonly pr: PullRequestRef;
+    private cache?: Promise<ChangedFile[]>;
+
+    constructor(octokit: Octokit, pr: PullRequestRef, baseRef: string) {
+        this.octokit = octokit;
+        this.pr = pr;
+        this.baseRef = baseRef;
+    }
+
+    changedFiles(): Promise<ChangedFile[]> {
+        // The diff is fixed for one judgement; memoize (mirrors the git provider).
+        this.cache ??= this.fetch();
+        return this.cache;
+    }
+
+    private async fetch(): Promise<ChangedFile[]> {
+        const files: ApiFile[] = await this.octokit.paginate(this.octokit.rest.pulls.listFiles, {
+            owner: this.pr.owner,
+            repo: this.pr.repo,
+            pull_number: this.pr.pull_number,
+            per_page: 100
+        });
+        return files.map(toChangedFile);
+    }
+}
+
+/**
+ * Map a `pulls.listFiles` item to a {@link ChangedFile}. Renamed `filename` is
+ * already the new (b-side) path — matching the git provider's rename handling —
+ * and `patch` is dropped when the API omits it, so the field is simply absent.
+ */
+export function toChangedFile(file: ApiFile): ChangedFile {
+    return {
+        path: file.filename,
+        additions: file.additions,
+        deletions: file.deletions,
+        ...(file.patch !== undefined ? { patch: file.patch } : {})
+    };
+}

--- a/fast_track/src/guardrails/context/types.ts
+++ b/fast_track/src/guardrails/context/types.ts
@@ -1,4 +1,9 @@
+import type { getOctokit } from '@actions/github';
+
 import type { GuardrailResult } from '../../shared/verdict';
+
+/** An authenticated Octokit, as returned by `@actions/github`'s `getOctokit`. */
+export type Octokit = ReturnType<typeof getOctokit>;
 
 export interface ChangedFile {
     path: string;
@@ -12,6 +17,12 @@ export interface ChangedFile {
 export interface GuardrailContext {
     baseRef: string;
     changedFiles(): Promise<ChangedFile[]>;
+    /**
+     * The API client, present only under the API provider (CI). Local runs leave
+     * it undefined — a `needsPrContext` guardrail may assume it, but a `local`
+     * one must not, since it also runs from a plain checkout.
+     */
+    octokit?: Octokit;
 }
 
 /** A guardrail's `run` output; the runner adds the `name` from the definition. */


### PR DESCRIPTION
## What has changed and why?

Lands the judging half of Fast Track (C2): a read-only **Fast Track Checks** workflow that runs the guardrails on every non-draft PR and uploads a `verdict.json` artifact for the bot (later PR) to act on. No write token anywhere — the approval credential lives only in the bot's base-repo context.

Also lands the CI plumbing deferred out of C1: an API-backed guardrail context (`pulls.listFiles`, ~3000-file cap), an optional `octokit` on `GuardrailContext`, the `@actions/*` deps, and the CI entry that wraps the run result into the wire verdict — taking the base ref from the PR event so non-main bases diff correctly.

Not a required status check.

## How has it been tested?

- `make static-checks` and `make test` green — unit tests cover the verdict wrapper and the API context (via a fake Octokit).
- `make run-guardrails` still passes locally; the read-only git path is unaffected.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)
