### PR TITLE
Fast Track: Add API-backed guardrail context

### DIFF
--- a/fast_track/README.md
+++ b/fast_track/README.md
@@ -8,10 +8,11 @@ Runs via [`tsx`](https://tsx.is/) — no build step, no compiled artifact.
 
 > **Status:** early scaffolding. The verdict contract, the guardrail framework
 > (context types, an always-pass dummy guardrail, the registry + selector), the
-> runner, and the local git-backed context provider are in place with unit
-> tests — `make run-guardrails` runs the guardrails against your branch's
-> committed changes. The API context provider, the bot, and the two workflows land in subsequent,
-> independently reviewable PRs.
+> runner, the local git-backed context provider, and the API-backed context
+> provider (its Octokit client injected — no `@actions/*` runs here yet) are in
+> place with unit tests — `make run-guardrails` runs the guardrails against your
+> branch's committed changes. The CI entry point, the bot, and the two workflows
+> land in subsequent, independently reviewable PRs.
 
 ## Local commands
 

--- a/fast_track/package-lock.json
+++ b/fast_track/package-lock.json
@@ -7,6 +7,9 @@
         "": {
             "name": "fast_track",
             "version": "0.0.1",
+            "dependencies": {
+                "@actions/github": "6.0.1"
+            },
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
                 "@types/node": "^24.0.0",
@@ -21,6 +24,31 @@
             },
             "engines": {
                 "node": ">=24"
+            }
+        },
+        "node_modules/@actions/github": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+            "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+            "license": "MIT",
+            "dependencies": {
+                "@actions/http-client": "^2.2.0",
+                "@octokit/core": "^5.0.1",
+                "@octokit/plugin-paginate-rest": "^9.2.2",
+                "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "undici": "^5.28.5"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+            "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+            "license": "MIT",
+            "dependencies": {
+                "tunnel": "^0.0.6",
+                "undici": "^5.25.4"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -622,6 +650,15 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.2",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -694,6 +731,164 @@
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@octokit/auth-token": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+            "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.1.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "9.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+            "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+            "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/request": "^8.4.1",
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "24.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+            "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+            "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/endpoint": "^9.0.6",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+            "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^13.1.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "13.10.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^24.2.0"
+            }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.62.2",
@@ -1564,6 +1759,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.15",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -1715,6 +1916,12 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+            "license": "ISC"
         },
         "node_modules/es-module-lexer": {
             "version": "1.7.0",
@@ -2334,6 +2541,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2773,6 +2989,15 @@
                 "fsevents": "~2.3.3"
             }
         },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2824,12 +3049,30 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
+        },
         "node_modules/undici-types": {
             "version": "7.18.2",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
             "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+            "license": "ISC"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -3054,6 +3297,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",

--- a/fast_track/package.json
+++ b/fast_track/package.json
@@ -26,5 +26,8 @@
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.22.0",
         "vitest": "^3.0.4"
+    },
+    "dependencies": {
+        "@actions/github": "6.0.1"
     }
 }

--- a/fast_track/src/guardrails/context/api-context.test.ts
+++ b/fast_track/src/guardrails/context/api-context.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiGuardrailContext, toChangedFile } from './api-context';
+import type { Octokit } from './types';
+
+interface ApiFileLike {
+    filename: string;
+    additions: number;
+    deletions: number;
+    patch?: string;
+}
+
+interface ListFilesParams {
+    owner: string;
+    repo: string;
+    pull_number: number;
+    per_page: number;
+    page: number;
+}
+
+/**
+ * A minimal Octokit whose `pulls.listFiles` serves canned pages: `pages[0]` is
+ * page 1, `pages[1]` is page 2, and so on; a page past the end resolves empty.
+ * The `listFiles` mock is returned too so tests can assert the request params.
+ */
+function fakeOctokit(pages: ApiFileLike[][]): {
+    octokit: Octokit;
+    listFiles: ReturnType<typeof vi.fn>;
+} {
+    const listFiles = vi.fn(async (params: ListFilesParams) => ({
+        data: pages[params.page - 1] ?? []
+    }));
+    const octokit = { rest: { pulls: { listFiles } } } as unknown as Octokit;
+    return { octokit, listFiles };
+}
+
+function makeFile(name: string, overrides: Partial<ApiFileLike> = {}): ApiFileLike {
+    return { filename: name, additions: 1, deletions: 0, ...overrides };
+}
+
+function contextOver(pages: ApiFileLike[][]): {
+    context: ApiGuardrailContext;
+    listFiles: ReturnType<typeof vi.fn>;
+} {
+    const { octokit, listFiles } = fakeOctokit(pages);
+    const context = new ApiGuardrailContext({
+        octokit,
+        owner: 'acme',
+        repo: 'widgets',
+        pullNumber: 42,
+        baseRef: 'origin/main'
+    });
+    return { context, listFiles };
+}
+
+describe('ApiGuardrailContext.changedFiles', () => {
+    it('pages with the routing params until a short page, mapping each file', async () => {
+        const page1 = Array.from({ length: 100 }, (_, i) => makeFile(`f${i}.ts`));
+        const page2 = [makeFile('src/a.ts', { additions: 5, deletions: 2, patch: '@@ -1 +1 @@' })];
+        const { context, listFiles } = contextOver([page1, page2]);
+
+        const files = await context.changedFiles();
+
+        expect(files).toHaveLength(101);
+        expect(files[100]).toEqual({
+            path: 'src/a.ts',
+            additions: 5,
+            deletions: 2,
+            patch: '@@ -1 +1 @@'
+        });
+        expect(listFiles).toHaveBeenCalledTimes(2);
+        expect(listFiles.mock.calls[0]![0]).toEqual({
+            owner: 'acme',
+            repo: 'widgets',
+            pull_number: 42,
+            per_page: 100,
+            page: 1
+        });
+        expect(listFiles.mock.calls[1]![0]!.page).toBe(2);
+    });
+
+    it('caps at 3000 files and stops paging once the cap is reached', async () => {
+        // 31 full pages are available, but the loop must never request page 31:
+        // after 30 pages of 100 the cap is hit and paging stops.
+        const fullPages = Array.from({ length: 31 }, (_, p) =>
+            Array.from({ length: 100 }, (_, i) => makeFile(`p${p}-f${i}.ts`))
+        );
+        const { context, listFiles } = contextOver(fullPages);
+
+        const files = await context.changedFiles();
+
+        expect(files).toHaveLength(3000);
+        expect(listFiles).toHaveBeenCalledTimes(30);
+    });
+
+    it('memoizes: a second call pages the API no further', async () => {
+        const { context, listFiles } = contextOver([[makeFile('a.ts')]]);
+
+        await context.changedFiles();
+        await context.changedFiles();
+
+        expect(listFiles).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('toChangedFile', () => {
+    it('omits the patch field entirely when the API returned none (binary/large)', () => {
+        const result = toChangedFile({ filename: 'logo.png', additions: 0, deletions: 0 });
+        expect(result).toEqual({ path: 'logo.png', additions: 0, deletions: 0 });
+        expect('patch' in result).toBe(false);
+    });
+
+    it('preserves an empty patch, distinguishing it from an absent one', () => {
+        expect(toChangedFile({ filename: 'a.ts', additions: 0, deletions: 0, patch: '' })).toEqual({
+            path: 'a.ts',
+            additions: 0,
+            deletions: 0,
+            patch: ''
+        });
+    });
+});

--- a/fast_track/src/guardrails/context/api-context.ts
+++ b/fast_track/src/guardrails/context/api-context.ts
@@ -1,0 +1,82 @@
+import type { ChangedFile, GuardrailContext, Octokit } from './types';
+
+/**
+ * CI {@link GuardrailContext} backed by `pulls.listFiles`, mirroring the git
+ * provider's `ChangedFile` shape (optional `patch`, omitted for binary/large
+ * files). The Octokit client is injected, never constructed here, so this file
+ * touches no credential and runs no `@actions/*` code.
+ */
+export class ApiGuardrailContext implements GuardrailContext {
+    readonly baseRef: string;
+    readonly octokit: Octokit;
+    private readonly owner: string;
+    private readonly repo: string;
+    private readonly pullNumber: number;
+    private cache?: Promise<ChangedFile[]>;
+
+    constructor(options: ApiGuardrailContextOptions) {
+        this.octokit = options.octokit;
+        this.owner = options.owner;
+        this.repo = options.repo;
+        this.pullNumber = options.pullNumber;
+        this.baseRef = options.baseRef;
+    }
+
+    async changedFiles(): Promise<ChangedFile[]> {
+        // Memoize the promise: page the API once even across several guardrails
+        // or concurrent callers.
+        this.cache ??= this.fetchChangedFiles();
+        return this.cache;
+    }
+
+    private async fetchChangedFiles(): Promise<ChangedFile[]> {
+        const files: ChangedFile[] = [];
+        // Stop on a short page (the last one); MAX_FILES guards the API's own cap.
+        for (let page = 1; files.length < MAX_FILES; page++) {
+            const { data } = await this.octokit.rest.pulls.listFiles({
+                owner: this.owner,
+                repo: this.repo,
+                pull_number: this.pullNumber,
+                per_page: PER_PAGE,
+                page
+            });
+            for (const file of data) {
+                files.push(toChangedFile(file));
+            }
+            if (data.length < PER_PAGE) break;
+        }
+        return files.slice(0, MAX_FILES);
+    }
+}
+
+export interface ApiGuardrailContextOptions {
+    octokit: Octokit;
+    owner: string;
+    repo: string;
+    pullNumber: number;
+    /** The PR's base ref (from the event) so stacked/non-main bases diff correctly. */
+    baseRef: string;
+}
+
+/** `listFiles` returns at most 100 items per page. */
+const PER_PAGE = 100;
+/** GitHub's `pulls.listFiles` returns at most 3000 files for a PR. */
+const MAX_FILES = 3000;
+
+/** The subset of a `pulls.listFiles` item this provider reads. */
+interface ApiChangedFile {
+    filename: string;
+    additions: number;
+    deletions: number;
+    patch?: string;
+}
+
+/** Map an API file entry to a {@link ChangedFile}, keeping `patch` only when present. */
+export function toChangedFile(file: ApiChangedFile): ChangedFile {
+    return {
+        path: file.filename,
+        additions: file.additions,
+        deletions: file.deletions,
+        ...(file.patch !== undefined ? { patch: file.patch } : {})
+    };
+}

--- a/fast_track/src/guardrails/context/types.ts
+++ b/fast_track/src/guardrails/context/types.ts
@@ -1,4 +1,12 @@
+import type { getOctokit } from '@actions/github';
+
 import type { GuardrailResult } from '../../shared/verdict';
+
+/**
+ * The hydrated Octokit client `@actions/github` produces. `type`-only: erased at
+ * runtime, so referencing it never loads `@actions/*` on the local git path.
+ */
+export type Octokit = ReturnType<typeof getOctokit>;
 
 export interface ChangedFile {
     path: string;
@@ -12,6 +20,8 @@ export interface ChangedFile {
 export interface GuardrailContext {
     baseRef: string;
     changedFiles(): Promise<ChangedFile[]>;
+    /** Present only in CI (set by the API-backed context); a `pr-only` guardrail reaches the API through it. */
+    octokit?: Octokit;
 }
 
 /** A guardrail's `run` output; the runner adds the `name` from the definition. */


### PR DESCRIPTION
## What has changed and why?

Adds `ApiGuardrailContext` — the CI-side `GuardrailContext` backed by GitHub's `pulls.listFiles`, paginated with a 3000-file cap. It mirrors the local git provider's `ChangedFile` shape, keeping `patch` optional (the API omits it for binary/large files).

The Octokit client is **injected via the constructor**, never constructed here, so no `@actions/*` code runs in this PR and the local git path is untouched (the `Octokit` type is a type-only import, erased at runtime).

The API-backed context half of C2; the CI entry point and workflow that go live follow separately.

## How has it been tested?

- `make static-checks` and `make test` green (unit tests: pagination params, file mapping, 3000-file cap, memoization).
- Verified the local git path loads no `@actions/*` at runtime and `make list-guardrails` still runs.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)