### PR TITLE
[Prefactor] Return keyed BatchedEmbeddingResult from image embedding generators

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 from uuid import UUID
@@ -22,6 +23,24 @@ class ImageCrop:
     y: int
     width: int
     height: int
+
+
+@dataclass(frozen=True)
+class BatchedEmbeddingResult:
+    """Embeddings for the successfully embedded inputs, keyed by sample id.
+
+    Broken inputs are skipped per-item instead of aborting the batch, so this
+    may cover fewer inputs than were passed. ``keys[i]`` is the sample id of the
+    input that produced ``embeddings[i]`` — the id travels with the data through
+    batching and skipping, so callers never re-align by position.
+
+    Attributes:
+        embeddings: Float32 array of shape ``(len(keys), dimension)``.
+        keys: Sample id for each embedding row, in row order.
+    """
+
+    embeddings: NDArray[np.float32]
+    keys: list[UUID]
 
 
 @runtime_checkable
@@ -64,33 +83,43 @@ class ImageEmbeddingGenerator(EmbeddingGenerator, Protocol):
     for creating embeddings.
     """
 
-    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> NDArray[np.float32]:
+    def embed_images(
+        self,
+        keyed_filepaths: Sequence[tuple[UUID, str]],
+        show_progress: bool = True,
+    ) -> BatchedEmbeddingResult:
         """Generate embeddings for multiple image samples.
 
         TODO(Michal, 04/2025): Use DatasetLoader as input instead.
 
+        Each embedding is tagged with the sample id paired with its filepath, so
+        callers map results back by identity rather than by position.
+
         Args:
-            filepaths: A list of file paths to the images to embed.
+            keyed_filepaths: ``(sample_id, filepath)`` pairs to embed.
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            A numpy array representing the generated embeddings
-            in the same order as the input file paths.
+            Embeddings for the embedded inputs, keyed by sample id.
         """
         ...
 
     def embed_image_crops(
-        self, image_crops: list[ImageCrop], show_progress: bool = True
-    ) -> NDArray[np.float32]:
+        self,
+        keyed_crops: Sequence[tuple[UUID, ImageCrop]],
+        show_progress: bool = True,
+    ) -> BatchedEmbeddingResult:
         """Generate embeddings for image crops.
 
+        Each embedding is tagged with the sample id paired with its crop, so
+        callers map results back by identity rather than by position.
+
         Args:
-            image_crops: A list of image crop definitions to embed.
+            keyed_crops: ``(sample_id, crop)`` pairs to embed.
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            A numpy array representing the generated embeddings in the same order
-            as the input crops.
+            Embeddings for the embedded crops, keyed by sample id.
         """
         ...
 
@@ -148,17 +177,27 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         """Generate a random embedding for a text sample."""
         return [random.random() for _ in range(self._dimension)]
 
-    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> NDArray[np.float32]:
+    def embed_images(
+        self,
+        keyed_filepaths: Sequence[tuple[UUID, str]],
+        show_progress: bool = True,
+    ) -> BatchedEmbeddingResult:
         """Generate random embeddings for multiple image samples."""
         _ = show_progress  # Not used for random embeddings.
-        return np.random.rand(len(filepaths), self._dimension).astype(np.float32)
+        keys = [key for key, _ in keyed_filepaths]
+        embeddings = np.random.rand(len(keys), self._dimension).astype(np.float32)
+        return BatchedEmbeddingResult(embeddings=embeddings, keys=keys)
 
     def embed_image_crops(
-        self, image_crops: list[ImageCrop], show_progress: bool = True
-    ) -> NDArray[np.float32]:
+        self,
+        keyed_crops: Sequence[tuple[UUID, ImageCrop]],
+        show_progress: bool = True,
+    ) -> BatchedEmbeddingResult:
         """Generate random embeddings for multiple image crops."""
         _ = show_progress  # Not used for random embeddings.
-        return np.random.rand(len(image_crops), self._dimension).astype(np.float32)
+        keys = [key for key, _ in keyed_crops]
+        embeddings = np.random.rand(len(keys), self._dimension).astype(np.float32)
+        return BatchedEmbeddingResult(embeddings=embeddings, keys=keys)
 
     def embed_videos(self, filepaths: list[str]) -> NDArray[np.float32]:
         """Generate random embeddings for multiple video samples."""

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import numpy as np
 from numpy.typing import NDArray
@@ -179,17 +179,19 @@ class EmbeddingManager:
             )
         }
 
-        # Extract filepaths in the same order as sample_ids.
-        filepaths = [sample_id_to_filepath[sample_id] for sample_id in sample_ids]
-
-        # Generate embeddings for the samples.
-        embeddings = model.embed_images(filepaths=filepaths)
+        # Pair each sample id with its filepath so the id travels through
+        # embedding and the result comes back keyed by sample id, without the
+        # caller re-aligning embeddings to samples by position.
+        keyed_filepaths = [
+            (sample_id, sample_id_to_filepath[sample_id]) for sample_id in sample_ids
+        ]
+        result = model.embed_images(keyed_filepaths=keyed_filepaths)
 
         _store_embeddings(
             session=session,
             model_id=model_id,
-            sample_ids=sample_ids,
-            embeddings=embeddings,
+            sample_ids=result.keys,
+            embeddings=result.embeddings,
         )
 
     def embed_annotations(
@@ -239,16 +241,21 @@ class EmbeddingManager:
                 if not annotation_crops:
                     continue
 
-                embeddings = model.embed_image_crops(
-                    image_crops=[crop.image_crop for crop in annotation_crops],
+                # Pair each annotation sample id with its crop so the id travels
+                # through embedding and the result comes back keyed by sample id.
+                keyed_crops = [
+                    (crop.annotation_sample_id, crop.image_crop) for crop in annotation_crops
+                ]
+                result = model.embed_image_crops(
+                    keyed_crops=keyed_crops,
                     show_progress=False,
                 )
 
                 _store_embeddings(
                     session=session,
                     model_id=model_id,
-                    sample_ids=[crop.annotation_sample_id for crop in annotation_crops],
-                    embeddings=embeddings,
+                    sample_ids=result.keys,
+                    embeddings=result.embeddings,
                     show_progress=False,
                 )
                 progress.update(len(annotation_crops))
@@ -282,12 +289,13 @@ class EmbeddingManager:
         if not isinstance(model, ImageEmbeddingGenerator):
             raise ValueError("Embedding model not compatible with images.")
 
-        # Generate embedding for the image without progress bar.
-        embeddings = model.embed_images(filepaths=[filepath], show_progress=False)
+        # Generate embedding for the image without progress bar. The key is
+        # unused here (single item); a throwaway id pairs with the filepath.
+        result = model.embed_images(keyed_filepaths=[(uuid4(), filepath)], show_progress=False)
 
         # Return the single embedding as a list of floats.
-        result: list[float] = embeddings[0].tolist()
-        return result
+        embedding: list[float] = result.embeddings[0].tolist()
+        return embedding
 
     def embed_videos(
         self,

--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -19,11 +19,12 @@ from lightly_studio.dataset.image_embedding import EmbeddingContext
 
 
 @dataclass
-class _KeptCropEmbeddings:
-    """Accumulates encoded crop embeddings and their caller keys."""
+class _CropEmbeddingOutput:
+    """Tracks the preallocated output array and the next write position."""
 
+    embeddings: NDArray[np.float32]
     keys: list[UUID] = field(default_factory=list)
-    batches: list[NDArray[np.float32]] = field(default_factory=list)
+    position: int = 0
 
 
 def embed_image_crops_batched(
@@ -31,7 +32,7 @@ def embed_image_crops_batched(
     context: EmbeddingContext,
     show_progress: bool,
 ) -> BatchedEmbeddingResult:
-    """Embed image crops, opening each source file once and preserving input order.
+    """Embed image crops, opening each source file once.
 
     Each embedding is tagged with the sample id paired with its crop, so callers
     map results back by identity rather than by position.
@@ -61,7 +62,9 @@ def embed_image_crops_batched(
     # Reusable batch buffer, lazily sized from the first preprocessed crop.
     batch_buffer: torch.Tensor | None = None
     batch_keys: list[UUID] = []
-    kept: _KeptCropEmbeddings = _KeptCropEmbeddings()
+    output = _CropEmbeddingOutput(
+        embeddings=np.empty((total_crops, context.embedding_dimension), dtype=np.float32)
+    )
 
     with (
         tqdm(
@@ -96,7 +99,7 @@ def embed_image_crops_batched(
                         _flush_crop_batch(
                             batch_buffer=batch_buffer,
                             batch_keys=batch_keys,
-                            kept=kept,
+                            output=output,
                             context=context,
                             progress_bar=progress_bar,
                         )
@@ -104,33 +107,33 @@ def embed_image_crops_batched(
         _flush_crop_batch(
             batch_buffer=batch_buffer,
             batch_keys=batch_keys,
-            kept=kept,
+            output=output,
             context=context,
             progress_bar=progress_bar,
         )
 
-    embeddings = (
-        np.concatenate(kept.batches)
-        if kept.batches
-        else np.empty((0, context.embedding_dimension), dtype=np.float32)
+    return BatchedEmbeddingResult(
+        embeddings=output.embeddings[: output.position],
+        keys=output.keys,
     )
-    return BatchedEmbeddingResult(embeddings=embeddings, keys=kept.keys)
 
 
 def _flush_crop_batch(
     batch_buffer: torch.Tensor | None,
     batch_keys: list[UUID],
-    kept: _KeptCropEmbeddings,
+    output: _CropEmbeddingOutput,
     context: EmbeddingContext,
     progress_bar: Any,
 ) -> None:
-    """Encode the current crop batch, appending results to ``kept``."""
+    """Encode the current crop batch and write results into ``embeddings``."""
     if batch_buffer is None or not batch_keys:
         return
     filled = len(batch_keys)
     images_tensor = batch_buffer[:filled].to(context.device, non_blocking=True)
     batch_embeddings = context.encode_batch(images_tensor)
-    kept.batches.append(np.asarray(batch_embeddings, dtype=np.float32))
-    kept.keys.extend(batch_keys)
+    next_position = output.position + filled
+    output.embeddings[output.position : next_position] = batch_embeddings
+    output.position = next_position
+    output.keys.extend(batch_keys)
     progress_bar.update(filled)
     batch_keys.clear()

--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from dataclasses import dataclass, field
 from typing import Any
+from uuid import UUID
 
 import fsspec
 import numpy as np
@@ -11,40 +14,54 @@ from numpy.typing import NDArray
 from PIL import Image
 from tqdm import tqdm
 
-from lightly_studio.dataset.embedding_generator import ImageCrop
+from lightly_studio.dataset.embedding_generator import BatchedEmbeddingResult, ImageCrop
 from lightly_studio.dataset.image_embedding import EmbeddingContext
 
 
+@dataclass
+class _KeptCropEmbeddings:
+    """Accumulates encoded crop embeddings and their caller keys."""
+
+    keys: list[UUID] = field(default_factory=list)
+    batches: list[NDArray[np.float32]] = field(default_factory=list)
+
+
 def embed_image_crops_batched(
-    image_crops: list[ImageCrop],
+    keyed_crops: Sequence[tuple[UUID, ImageCrop]],
     context: EmbeddingContext,
     show_progress: bool,
-) -> NDArray[np.float32]:
+) -> BatchedEmbeddingResult:
     """Embed image crops, opening each source file once and preserving input order.
 
+    Each embedding is tagged with the sample id paired with its crop, so callers
+    map results back by identity rather than by position.
+
     Args:
-        image_crops: Crop definitions to embed.
+        keyed_crops: ``(sample_id, crop)`` pairs to embed.
         context: Model-specific embedding configuration.
         show_progress: Whether to show a tqdm progress bar.
 
     Returns:
-        Float32 array of shape ``(len(image_crops), embedding_dimension)``.
+        Embeddings for the embedded crops, keyed by sample id.
     """
-    total_crops = len(image_crops)
+    total_crops = len(keyed_crops)
     if not total_crops:
-        return np.empty((0, context.embedding_dimension), dtype=np.float32)
+        return BatchedEmbeddingResult(
+            embeddings=np.empty((0, context.embedding_dimension), dtype=np.float32),
+            keys=[],
+        )
 
     if context.max_batch_size <= 0:
         raise ValueError("max_batch_size must be positive.")
 
-    crops_by_filepath: dict[str, list[tuple[int, ImageCrop]]] = {}
-    for index, image_crop in enumerate(image_crops):
-        crops_by_filepath.setdefault(image_crop.filepath, []).append((index, image_crop))
+    crops_by_filepath: dict[str, list[tuple[UUID, ImageCrop]]] = {}
+    for key, image_crop in keyed_crops:
+        crops_by_filepath.setdefault(image_crop.filepath, []).append((key, image_crop))
 
-    embeddings = np.empty((total_crops, context.embedding_dimension), dtype=np.float32)
     # Reusable batch buffer, lazily sized from the first preprocessed crop.
     batch_buffer: torch.Tensor | None = None
-    batch_indices: list[int] = []
+    batch_keys: list[UUID] = []
+    kept: _KeptCropEmbeddings = _KeptCropEmbeddings()
 
     with (
         tqdm(
@@ -55,10 +72,10 @@ def embed_image_crops_batched(
         ) as progress_bar,
         torch.no_grad(),
     ):
-        for filepath, indexed_crops in crops_by_filepath.items():
+        for filepath, keyed_group in crops_by_filepath.items():
             with fsspec.open(filepath, "rb") as file:
                 image = Image.open(file).convert("RGB")
-                for index, image_crop in indexed_crops:
+                for key, image_crop in keyed_group:
                     cropped = image.crop(
                         (
                             image_crop.x,
@@ -73,42 +90,47 @@ def embed_image_crops_batched(
                             (context.max_batch_size, *preprocessed.shape),
                             dtype=preprocessed.dtype,
                         )
-                    batch_buffer[len(batch_indices)] = preprocessed
-                    batch_indices.append(index)
-                    if len(batch_indices) >= context.max_batch_size:
+                    batch_buffer[len(batch_keys)] = preprocessed
+                    batch_keys.append(key)
+                    if len(batch_keys) >= context.max_batch_size:
                         _flush_crop_batch(
                             batch_buffer=batch_buffer,
-                            batch_indices=batch_indices,
-                            embeddings=embeddings,
+                            batch_keys=batch_keys,
+                            kept=kept,
                             context=context,
                             progress_bar=progress_bar,
                         )
 
         _flush_crop_batch(
             batch_buffer=batch_buffer,
-            batch_indices=batch_indices,
-            embeddings=embeddings,
+            batch_keys=batch_keys,
+            kept=kept,
             context=context,
             progress_bar=progress_bar,
         )
 
-    return embeddings
+    embeddings = (
+        np.concatenate(kept.batches)
+        if kept.batches
+        else np.empty((0, context.embedding_dimension), dtype=np.float32)
+    )
+    return BatchedEmbeddingResult(embeddings=embeddings, keys=kept.keys)
 
 
 def _flush_crop_batch(
     batch_buffer: torch.Tensor | None,
-    batch_indices: list[int],
-    embeddings: NDArray[np.float32],
+    batch_keys: list[UUID],
+    kept: _KeptCropEmbeddings,
     context: EmbeddingContext,
     progress_bar: Any,
 ) -> None:
-    """Encode the current crop batch and write results into ``embeddings``."""
-    if batch_buffer is None or not batch_indices:
+    """Encode the current crop batch, appending results to ``kept``."""
+    if batch_buffer is None or not batch_keys:
         return
-    filled = len(batch_indices)
+    filled = len(batch_keys)
     images_tensor = batch_buffer[:filled].to(context.device, non_blocking=True)
     batch_embeddings = context.encode_batch(images_tensor)
-    for batch_position, crop_index in enumerate(batch_indices):
-        embeddings[crop_index] = batch_embeddings[batch_position]
+    kept.batches.append(np.asarray(batch_embeddings, dtype=np.float32))
+    kept.keys.extend(batch_keys)
     progress_bar.update(filled)
-    batch_indices.clear()
+    batch_keys.clear()

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -8,8 +8,9 @@ crop-specific path lives in ``image_crop_embedding.py`` and reuses the same
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from uuid import UUID
 
 import fsspec
 import numpy as np
@@ -18,6 +19,8 @@ from numpy.typing import NDArray
 from PIL import Image
 from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
+
+from lightly_studio.dataset.embedding_generator import BatchedEmbeddingResult
 
 
 @dataclass(frozen=True)
@@ -63,27 +66,35 @@ class _ImageFileDataset(Dataset[torch.Tensor]):
 
 
 def embed_image_files_batched(
-    filepaths: list[str],
+    keyed_filepaths: Sequence[tuple[UUID, str]],
     context: EmbeddingContext,
     show_progress: bool,
-) -> NDArray[np.float32]:
+) -> BatchedEmbeddingResult:
     """Embed image files in batches, preserving input order.
 
+    Each embedding is tagged with the sample id paired with its filepath, so
+    callers map results back by identity rather than by position.
+
     Args:
-        filepaths: Paths of the images to embed.
+        keyed_filepaths: ``(sample_id, filepath)`` pairs to embed.
         context: Model-specific embedding configuration.
         show_progress: Whether to show a tqdm progress bar.
 
     Returns:
-        Float32 array of shape ``(len(filepaths), embedding_dimension)``.
+        Embeddings for the embedded files, keyed by sample id.
     """
-    total_images = len(filepaths)
+    total_images = len(keyed_filepaths)
     if not total_images:
-        return np.empty((0, context.embedding_dimension), dtype=np.float32)
+        return BatchedEmbeddingResult(
+            embeddings=np.empty((0, context.embedding_dimension), dtype=np.float32),
+            keys=[],
+        )
 
     if context.max_batch_size <= 0:
         raise ValueError("max_batch_size must be positive.")
 
+    keys = [key for key, _ in keyed_filepaths]
+    filepaths = [filepath for _, filepath in keyed_filepaths]
     dataset = _ImageFileDataset(filepaths, context.preprocess)
 
     # To avoid issues with db locking and multiprocessing we set the number of
@@ -114,4 +125,4 @@ def embed_image_files_batched(
             position += batch_size
             progress_bar.update(batch_size)
 
-    return embeddings
+    return BatchedEmbeddingResult(embeddings=embeddings, keys=keys)

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -2,19 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from uuid import UUID
 
-import numpy as np
 import torch
-from numpy.typing import NDArray
 
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor import mobileclip
 
 from . import file_utils, image_crop_embedding, image_embedding
-from .embedding_generator import ImageCrop, ImageEmbeddingGenerator
+from .embedding_generator import BatchedEmbeddingResult, ImageCrop, ImageEmbeddingGenerator
 from .image_embedding import EmbeddingContext
 
 MODEL_NAME = "mobileclip_s0"
@@ -83,38 +82,42 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
         return embedding_list
 
-    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> NDArray[np.float32]:
+    def embed_images(
+        self,
+        keyed_filepaths: Sequence[tuple[UUID, str]],
+        show_progress: bool = True,
+    ) -> BatchedEmbeddingResult:
         """Embed images with MobileCLIP.
 
         Args:
-            filepaths: A list of file paths to the images to embed.
+            keyed_filepaths: ``(sample_id, filepath)`` pairs to embed.
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            A numpy array representing the generated embeddings
-            in the same order as the input file paths.
+            Embeddings for the embedded files, keyed by sample id.
         """
         return image_embedding.embed_image_files_batched(
-            filepaths=filepaths,
+            keyed_filepaths=keyed_filepaths,
             context=self._embedding_context(),
             show_progress=show_progress,
         )
 
     def embed_image_crops(
-        self, image_crops: list[ImageCrop], show_progress: bool = True
-    ) -> NDArray[np.float32]:
+        self,
+        keyed_crops: Sequence[tuple[UUID, ImageCrop]],
+        show_progress: bool = True,
+    ) -> BatchedEmbeddingResult:
         """Embed image crops with MobileCLIP.
 
         Args:
-            image_crops: A list of image crop definitions to embed.
+            keyed_crops: ``(sample_id, crop)`` pairs to embed.
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            A numpy array representing the generated embeddings in the same order
-            as the input crops.
+            Embeddings for the embedded crops, keyed by sample id.
         """
         return image_crop_embedding.embed_image_crops_batched(
-            image_crops=image_crops,
+            keyed_crops=keyed_crops,
             context=self._embedding_context(),
             show_progress=show_progress,
         )

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Callable
 from uuid import UUID
@@ -20,7 +21,12 @@ from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
 
 from . import file_utils, image_crop_embedding, image_embedding
-from .embedding_generator import ImageCrop, ImageEmbeddingGenerator, VideoEmbeddingGenerator
+from .embedding_generator import (
+    BatchedEmbeddingResult,
+    ImageCrop,
+    ImageEmbeddingGenerator,
+    VideoEmbeddingGenerator,
+)
 from .image_embedding import EmbeddingContext
 
 MODEL_NAME = "PE-Core-T16-384"
@@ -162,38 +168,42 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
         return embedding_list
 
-    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> NDArray[np.float32]:
+    def embed_images(
+        self,
+        keyed_filepaths: Sequence[tuple[UUID, str]],
+        show_progress: bool = True,
+    ) -> BatchedEmbeddingResult:
         """Embed images with Perception Encoder.
 
         Args:
-            filepaths: A list of file paths to the images to embed.
+            keyed_filepaths: ``(sample_id, filepath)`` pairs to embed.
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            A numpy array representing the generated embeddings
-            in the same order as the input file paths.
+            Embeddings for the embedded files, keyed by sample id.
         """
         return image_embedding.embed_image_files_batched(
-            filepaths=filepaths,
+            keyed_filepaths=keyed_filepaths,
             context=self._embedding_context(),
             show_progress=show_progress,
         )
 
     def embed_image_crops(
-        self, image_crops: list[ImageCrop], show_progress: bool = True
-    ) -> NDArray[np.float32]:
+        self,
+        keyed_crops: Sequence[tuple[UUID, ImageCrop]],
+        show_progress: bool = True,
+    ) -> BatchedEmbeddingResult:
         """Embed image crops with Perception Encoder.
 
         Args:
-            image_crops: A list of image crop definitions to embed.
+            keyed_crops: ``(sample_id, crop)`` pairs to embed.
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            A numpy array representing the generated embeddings in the same order
-            as the input crops.
+            Embeddings for the embedded crops, keyed by sample id.
         """
         return image_crop_embedding.embed_image_crops_batched(
-            image_crops=image_crops,
+            keyed_crops=keyed_crops,
             context=self._embedding_context(),
             show_progress=show_progress,
         )

--- a/lightly_studio/tests/dataset/test_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_embedding_generator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
 from lightly_studio.dataset.embedding_generator import (
     ImageCrop,
     RandomEmbeddingGenerator,
@@ -9,19 +11,22 @@ from lightly_studio.dataset.embedding_generator import (
 class TestRandomEmbeddingGeneratorCrops:
     def test_embed_image_crops__returns_one_embedding_per_crop(self) -> None:
         generator = RandomEmbeddingGenerator(dimension=4)
-        image_crops = [
-            ImageCrop(filepath="a.jpg", x=0, y=0, width=10, height=10),
-            ImageCrop(filepath="a.jpg", x=5, y=5, width=20, height=20),
-            ImageCrop(filepath="b.jpg", x=0, y=0, width=30, height=30),
+        keys = [uuid4(), uuid4(), uuid4()]
+        keyed_crops = [
+            (keys[0], ImageCrop(filepath="a.jpg", x=0, y=0, width=10, height=10)),
+            (keys[1], ImageCrop(filepath="a.jpg", x=5, y=5, width=20, height=20)),
+            (keys[2], ImageCrop(filepath="b.jpg", x=0, y=0, width=30, height=30)),
         ]
 
-        embeddings = generator.embed_image_crops(image_crops)
+        result = generator.embed_image_crops(keyed_crops)
 
-        assert embeddings.shape == (3, 4)
+        assert result.embeddings.shape == (3, 4)
+        assert result.keys == keys
 
     def test_embed_image_crops__empty_input_returns_empty_array(self) -> None:
         generator = RandomEmbeddingGenerator(dimension=4)
 
-        embeddings = generator.embed_image_crops([])
+        result = generator.embed_image_crops([])
 
-        assert embeddings.shape == (0, 4)
+        assert result.embeddings.shape == (0, 4)
+        assert result.keys == []

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from uuid import UUID, uuid4
 
-import numpy as np
 import pytest
-from numpy.typing import NDArray
 from pytest_mock import MockerFixture
 from sqlmodel import Session, select
 
 from lightly_studio.dataset import embedding_manager
 from lightly_studio.dataset.embedding_generator import (
+    BatchedEmbeddingResult,
     ImageCrop,
     ImageEmbeddingGenerator,
     RandomEmbeddingGenerator,
@@ -98,13 +98,17 @@ def test_register_multiple_models(
             raise NotImplementedError()
 
         def embed_images(
-            self, filepaths: list[str], show_progress: bool = True
-        ) -> NDArray[np.float32]:
+            self,
+            keyed_filepaths: Sequence[tuple[UUID, str]],
+            show_progress: bool = True,
+        ) -> BatchedEmbeddingResult:
             raise NotImplementedError()
 
         def embed_image_crops(
-            self, image_crops: list[ImageCrop], show_progress: bool = True
-        ) -> NDArray[np.float32]:
+            self,
+            keyed_crops: Sequence[tuple[UUID, ImageCrop]],
+            show_progress: bool = True,
+        ) -> BatchedEmbeddingResult:
             raise NotImplementedError()
 
     model_id2 = embedding_manager.register_embedding_model(

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -1,5 +1,5 @@
+import uuid
 from pathlib import Path
-from uuid import uuid4
 
 import numpy as np
 import torch
@@ -28,7 +28,7 @@ def test_embed_image_crops_batched__empty_input_returns_empty_array() -> None:
     assert result.keys == []
 
 
-def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
+def test_embed_image_crops_batched__returns_keys_in_embedding_row_order(
     tmp_path: Path,
 ) -> None:
     image_a_path = tmp_path / "image_a.png"
@@ -39,7 +39,7 @@ def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
     # Crops are interleaved across two files, each with a distinct width. The
     # helper groups crops by filepath before encoding, so the encode order
     # (a, a, b, b) differs from the input order.
-    key_0, key_1, key_2, key_3 = uuid4(), uuid4(), uuid4(), uuid4()
+    key_0, key_1, key_2, key_3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     keyed_crops = [
         (key_0, ImageCrop(filepath=str(image_a_path), x=0, y=0, width=5, height=10)),
         (key_1, ImageCrop(filepath=str(image_b_path), x=0, y=0, width=6, height=10)),
@@ -70,6 +70,6 @@ def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
     # batch spans both files and the last crop forms a partial final batch.
     assert encode_calls == [3, 1]
     assert result.embeddings.shape == (4, 1)
-    # keys follow the encode order, tagging each row with its sample id.
+    # Keys follow the encode order, tagging each row with its sample id.
     assert result.keys == [key_0, key_2, key_1, key_3]
     assert result.embeddings[:, 0].tolist() == [5.0, 7.0, 6.0, 8.0]

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from uuid import uuid4
 
 import numpy as np
 import torch
@@ -11,8 +12,8 @@ from lightly_studio.dataset.image_embedding import EmbeddingContext
 
 
 def test_embed_image_crops_batched__empty_input_returns_empty_array() -> None:
-    embeddings = image_crop_embedding.embed_image_crops_batched(
-        image_crops=[],
+    result = image_crop_embedding.embed_image_crops_batched(
+        keyed_crops=[],
         context=EmbeddingContext(
             embedding_dimension=4,
             max_batch_size=2,
@@ -23,7 +24,8 @@ def test_embed_image_crops_batched__empty_input_returns_empty_array() -> None:
         show_progress=False,
     )
 
-    assert embeddings.shape == (0, 4)
+    assert result.embeddings.shape == (0, 4)
+    assert result.keys == []
 
 
 def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
@@ -37,11 +39,12 @@ def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
     # Crops are interleaved across two files, each with a distinct width. The
     # helper groups crops by filepath before encoding, so the encode order
     # (a, a, b, b) differs from the input order.
-    image_crops = [
-        ImageCrop(filepath=str(image_a_path), x=0, y=0, width=5, height=10),
-        ImageCrop(filepath=str(image_b_path), x=0, y=0, width=6, height=10),
-        ImageCrop(filepath=str(image_a_path), x=0, y=0, width=7, height=10),
-        ImageCrop(filepath=str(image_b_path), x=0, y=0, width=8, height=10),
+    key_0, key_1, key_2, key_3 = uuid4(), uuid4(), uuid4(), uuid4()
+    keyed_crops = [
+        (key_0, ImageCrop(filepath=str(image_a_path), x=0, y=0, width=5, height=10)),
+        (key_1, ImageCrop(filepath=str(image_b_path), x=0, y=0, width=6, height=10)),
+        (key_2, ImageCrop(filepath=str(image_a_path), x=0, y=0, width=7, height=10)),
+        (key_3, ImageCrop(filepath=str(image_b_path), x=0, y=0, width=8, height=10)),
     ]
     encode_calls: list[int] = []
 
@@ -51,8 +54,8 @@ def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
         # expected (batch_size, 1) embedding; encode is the identity here.
         return images_tensor.numpy().astype(np.float32)
 
-    embeddings = image_crop_embedding.embed_image_crops_batched(
-        image_crops=image_crops,
+    result = image_crop_embedding.embed_image_crops_batched(
+        keyed_crops=keyed_crops,
         context=EmbeddingContext(
             embedding_dimension=1,
             max_batch_size=3,
@@ -66,6 +69,7 @@ def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
     # Encode order is [a:5, a:7, b:6, b:8]; with max_batch_size=3 the first
     # batch spans both files and the last crop forms a partial final batch.
     assert encode_calls == [3, 1]
-    assert embeddings.shape == (4, 1)
-    # Each embedding equals its crop width, in input order.
-    assert embeddings[:, 0].tolist() == [5.0, 6.0, 7.0, 8.0]
+    assert result.embeddings.shape == (4, 1)
+    # keys follow the encode order, tagging each row with its sample id.
+    assert result.keys == [key_0, key_2, key_1, key_3]
+    assert result.embeddings[:, 0].tolist() == [5.0, 7.0, 6.0, 8.0]

--- a/lightly_studio/tests/dataset/test_image_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_embedding.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from uuid import uuid4
 
 import numpy as np
 import torch
@@ -8,43 +9,46 @@ from lightly_studio.dataset import image_embedding
 from lightly_studio.dataset.image_embedding import EmbeddingContext
 
 
+def _width_context(embedding_dimension: int, max_batch_size: int) -> EmbeddingContext:
+    # preprocess encodes an image as its width, so each embedding equals the
+    # source image width and order behaviour is easy to assert.
+    return EmbeddingContext(
+        embedding_dimension=embedding_dimension,
+        max_batch_size=max_batch_size,
+        device=torch.device("cpu"),
+        preprocess=lambda image: torch.tensor([float(image.size[0])]),
+        encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
+    )
+
+
 def test_embed_image_files_batched__empty_input_returns_empty_array() -> None:
-    embeddings = image_embedding.embed_image_files_batched(
-        filepaths=[],
-        context=EmbeddingContext(
-            embedding_dimension=4,
-            max_batch_size=2,
-            device=torch.device("cpu"),
-            preprocess=lambda image: torch.tensor([float(image.size[0])]),
-            encode_batch=lambda images_tensor: images_tensor.cpu().numpy(),
-        ),
+    result = image_embedding.embed_image_files_batched(
+        keyed_filepaths=[],
+        context=_width_context(embedding_dimension=4, max_batch_size=2),
         show_progress=False,
     )
 
-    assert embeddings.shape == (0, 4)
+    assert result.embeddings.shape == (0, 4)
+    assert result.keys == []
 
 
 def test_embed_image_files_batched__preserves_input_order(tmp_path: Path) -> None:
-    # Each image has a distinct width, and preprocess encodes an image as its
-    # width, so the embeddings must come back in input order across batches.
+    # Each image has a distinct width, so the embeddings must come back in input
+    # order across batches, each tagged with its sample id.
     widths = [5, 6, 7]
-    filepaths = []
+    keys = [uuid4() for _ in widths]
+    keyed_filepaths = []
     for index, width in enumerate(widths):
         path = tmp_path / f"image_{index}.png"
         Image.new("RGB", (width, 10), color=(255, 0, 0)).save(path)
-        filepaths.append(str(path))
+        keyed_filepaths.append((keys[index], str(path)))
 
-    embeddings = image_embedding.embed_image_files_batched(
-        filepaths=filepaths,
-        context=EmbeddingContext(
-            embedding_dimension=1,
-            max_batch_size=2,
-            device=torch.device("cpu"),
-            preprocess=lambda image: torch.tensor([float(image.size[0])]),
-            encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
-        ),
+    result = image_embedding.embed_image_files_batched(
+        keyed_filepaths=keyed_filepaths,
+        context=_width_context(embedding_dimension=1, max_batch_size=2),
         show_progress=False,
     )
 
-    assert embeddings.shape == (3, 1)
-    assert embeddings[:, 0].tolist() == [float(width) for width in widths]
+    assert result.embeddings.shape == (3, 1)
+    assert result.keys == keys
+    assert result.embeddings[:, 0].tolist() == [float(width) for width in widths]

--- a/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
@@ -43,7 +43,8 @@ class TestMobileCLIPEmbeddingGenerator:
     def test_embed_images(self) -> None:
         mobileclip = MobileCLIPEmbeddingGenerator()
         cat_image_path = FIXTURES_DIR / "cat.jpg"
-        embeddings = mobileclip.embed_images([str(cat_image_path)])
+        result = mobileclip.embed_images([(uuid.uuid4(), str(cat_image_path))])
+        embeddings = result.embeddings
 
         assert len(embeddings) == 1
         cat_embedding = embeddings[0]
@@ -59,9 +60,9 @@ class TestMobileCLIPEmbeddingGenerator:
 
     def test_embed_image_crops__empty_input(self) -> None:
         mobileclip = MobileCLIPEmbeddingGenerator()
-        embeddings = mobileclip.embed_image_crops([])
+        result = mobileclip.embed_image_crops([])
 
-        assert embeddings.shape == (0, 512)
+        assert result.embeddings.shape == (0, 512)
 
     def test_embed_image_crops__full_image_crop_matches_embed_images(self) -> None:
         mobileclip = MobileCLIPEmbeddingGenerator()
@@ -70,8 +71,8 @@ class TestMobileCLIPEmbeddingGenerator:
             width, height = image.size
 
         full_crop = ImageCrop(filepath=str(cat_image_path), x=0, y=0, width=width, height=height)
-        crop_embeddings = mobileclip.embed_image_crops([full_crop])
-        image_embeddings = mobileclip.embed_images([str(cat_image_path)])
+        crop_embeddings = mobileclip.embed_image_crops([(uuid.uuid4(), full_crop)]).embeddings
+        image_embeddings = mobileclip.embed_images([(uuid.uuid4(), str(cat_image_path))]).embeddings
 
         assert crop_embeddings.shape == (1, 512)
         # A crop covering the entire image is preprocessed and encoded identically
@@ -99,7 +100,9 @@ class TestMobileCLIPEmbeddingGenerator:
 
         # Embed image.
         cat_image_path = FIXTURES_DIR / "cat.jpg"
-        cat_image_emb = torch.tensor(mobileclip.embed_images([str(cat_image_path)])[0])
+        cat_image_emb = torch.tensor(
+            mobileclip.embed_images([(uuid.uuid4(), str(cat_image_path))]).embeddings[0]
+        )
         cat_image_emb /= cat_image_emb.norm(dim=-1, keepdim=True)
 
         # Compute softmax similarity as in ml-mobileclip repo example.

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -45,7 +45,8 @@ class TestPerceptionEncoderEmbeddingGenerator:
     def test_embed_images(self) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
         cat_image_path = FIXTURES_DIR / "cat.jpg"
-        embeddings = perception_encoder.embed_images([str(cat_image_path)])
+        result = perception_encoder.embed_images([(uuid.uuid4(), str(cat_image_path))])
+        embeddings = result.embeddings
 
         assert len(embeddings) == 1
         cat_embedding = embeddings[0]
@@ -61,9 +62,9 @@ class TestPerceptionEncoderEmbeddingGenerator:
 
     def test_embed_image_crops__empty_input(self) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
-        embeddings = perception_encoder.embed_image_crops([])
+        result = perception_encoder.embed_image_crops([])
 
-        assert embeddings.shape == (0, 512)
+        assert result.embeddings.shape == (0, 512)
 
     def test_embed_image_crops__full_image_crop_matches_embed_images(self) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
@@ -72,8 +73,12 @@ class TestPerceptionEncoderEmbeddingGenerator:
             width, height = image.size
 
         full_crop = ImageCrop(filepath=str(cat_image_path), x=0, y=0, width=width, height=height)
-        crop_embeddings = perception_encoder.embed_image_crops([full_crop])
-        image_embeddings = perception_encoder.embed_images([str(cat_image_path)])
+        crop_embeddings = perception_encoder.embed_image_crops(
+            [(uuid.uuid4(), full_crop)]
+        ).embeddings
+        image_embeddings = perception_encoder.embed_images(
+            [(uuid.uuid4(), str(cat_image_path))]
+        ).embeddings
 
         assert crop_embeddings.shape == (1, 512)
         # A crop covering the entire image is preprocessed and encoded identically
@@ -119,7 +124,9 @@ class TestPerceptionEncoderEmbeddingGenerator:
 
         # Embed image.
         cat_image_path = FIXTURES_DIR / "cat.jpg"
-        cat_image_emb = torch.tensor(perception_encoder.embed_images([str(cat_image_path)])[0])
+        cat_image_emb = torch.tensor(
+            perception_encoder.embed_images([(uuid.uuid4(), str(cat_image_path))]).embeddings[0]
+        )
         cat_image_emb /= cat_image_emb.norm(dim=-1, keepdim=True)
 
         # Compute softmax similarity as in perception_encoder repo example.


### PR DESCRIPTION
## What

Prefactor for LIG-10034 (per-item broken-file tolerance). The image and image-crop embedding paths now take `(sample_id, filepath)` / `(sample_id, crop)` pairs and return `BatchedEmbeddingResult(embeddings, keys: list[UUID])`: each embedding is tagged with the sample id that produced it.

## Why

Today the embedding helpers return a bare array aligned by position, so the manager keeps parallel `sample_ids` / `filepaths` lists in lock-step and re-associates by integer index. That's brittle — any reordering silently mismaps embeddings to samples. Carrying the sample id *with* each input lets callers map results back by identity, which is what the upcoming broken-file skipping (LIG-10034) needs: a skipped file just omits its id from `keys`.

## Behavior

No behavior change. Every input is embedded and `keys` covers them all; the manager maps `result.keys` straight to storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding APIs now return both embeddings and matching item IDs to keep outputs traceable.
  * Image and crop embedding workflows accept keyed batches for more reliable mapping.

* **Bug Fixes**
  * Embeddings are stored and returned based on returned IDs, no longer on the original input order.
  * Empty embedding requests now produce a consistent empty result structure.

* **Tests**
  * Updated/expanded unit tests to verify keyed output, correct ordering behavior, and empty-input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->