### PR TITLE
Fast Track: Add API-backed guardrail context

### DIFF
--- a/fast_track/README.md
+++ b/fast_track/README.md
@@ -8,10 +8,10 @@ Runs via [`tsx`](https://tsx.is/) — no build step, no compiled artifact.
 
 > **Status:** early scaffolding. The verdict contract, the guardrail framework
 > (context types, an always-pass dummy guardrail, the registry + selector), the
-> runner, and the local git-backed context provider are in place with unit
-> tests — `make run-guardrails` runs the guardrails against your branch's
-> committed changes. The API context provider, the bot, and the two workflows land in subsequent,
-> independently reviewable PRs.
+> runner, the local git-backed context provider, and the API-backed context
+> provider are in place with unit tests — `make run-guardrails` runs the
+> guardrails against your branch's committed changes. The bot and the two
+> workflows land in subsequent, independently reviewable PRs.
 
 ## Local commands
 

--- a/fast_track/package-lock.json
+++ b/fast_track/package-lock.json
@@ -8,6 +8,7 @@
             "name": "fast_track",
             "version": "0.0.1",
             "dependencies": {
+                "@actions/github": "^6.0.1",
                 "simple-git": "^3.36.0"
             },
             "devDependencies": {
@@ -24,6 +25,31 @@
             },
             "engines": {
                 "node": ">=24"
+            }
+        },
+        "node_modules/@actions/github": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+            "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+            "license": "MIT",
+            "dependencies": {
+                "@actions/http-client": "^2.2.0",
+                "@octokit/core": "^5.0.1",
+                "@octokit/plugin-paginate-rest": "^9.2.2",
+                "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "undici": "^5.28.5"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+            "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+            "license": "MIT",
+            "dependencies": {
+                "tunnel": "^0.0.6",
+                "undici": "^5.25.4"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -625,6 +651,15 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.2",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -712,6 +747,164 @@
             "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
             "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
             "license": "MIT"
+        },
+        "node_modules/@octokit/auth-token": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+            "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.1.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "9.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+            "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+            "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/request": "^8.4.1",
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "24.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+            "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+            "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/endpoint": "^9.0.6",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+            "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^13.1.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "13.10.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^24.2.0"
+            }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.62.2",
@@ -1597,6 +1790,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.15",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -1747,6 +1946,12 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+            "license": "ISC"
         },
         "node_modules/es-module-lexer": {
             "version": "1.7.0",
@@ -2365,6 +2570,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2821,6 +3035,15 @@
                 "fsevents": "~2.3.3"
             }
         },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2872,12 +3095,30 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
+        },
         "node_modules/undici-types": {
             "version": "7.18.2",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
             "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+            "license": "ISC"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -3102,6 +3343,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",

--- a/fast_track/package.json
+++ b/fast_track/package.json
@@ -16,6 +16,7 @@
         "list-guardrails": "tsx src/guardrails/cli.ts --list"
     },
     "dependencies": {
+        "@actions/github": "^6.0.1",
         "simple-git": "^3.36.0"
     },
     "devDependencies": {

--- a/fast_track/src/guardrails/context/api-context.test.ts
+++ b/fast_track/src/guardrails/context/api-context.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Octokit } from './api-context';
+import { ApiGuardrailContext, toChangedFile } from './api-context';
+
+/** A `pulls.listFiles` entry, with the extra fields the mapper ignores. */
+function listedFile(filename: string, additions: number, deletions: number) {
+    return { filename, additions, deletions, status: 'modified', patch: '@@ ... @@' };
+}
+
+/**
+ * A fake Octokit whose `paginate` returns `files` (as the real one does after
+ * walking every page) and records each call in `paginateCalls`. `listFiles` is a
+ * sentinel so a test can assert we hand *that* endpoint to `paginate`.
+ */
+function fakeOctokit(files: ReturnType<typeof listedFile>[]) {
+    const paginateCalls: { endpoint: unknown; params: unknown }[] = [];
+    const octokit = {
+        rest: { pulls: { listFiles: 'listFiles-endpoint' } },
+        paginate: async (endpoint: unknown, params: unknown) => {
+            paginateCalls.push({ endpoint, params });
+            return files;
+        }
+    } as unknown as Octokit;
+    return { octokit, paginateCalls };
+}
+
+describe('toChangedFile', () => {
+    it('keeps counts and drops the rest', () => {
+        expect(toChangedFile(listedFile('src/foo.ts', 12, 3))).toEqual({
+            path: 'src/foo.ts',
+            additions: 12,
+            deletions: 3
+        });
+    });
+});
+
+describe('ApiGuardrailContext', () => {
+    it('rejects an empty base ref', () => {
+        const { octokit } = fakeOctokit([]);
+        expect(
+            () =>
+                new ApiGuardrailContext({
+                    octokit,
+                    owner: 'acme',
+                    repo: 'widgets',
+                    prNumber: 1,
+                    baseRef: '  '
+                })
+        ).toThrow(/must not be empty/);
+    });
+
+    it('paginates listFiles with the PR coordinates and maps to counts', async () => {
+        const { octokit, paginateCalls } = fakeOctokit([
+            listedFile('a.ts', 1, 0),
+            listedFile('b.ts', 0, 5)
+        ]);
+        const context = new ApiGuardrailContext({
+            octokit,
+            owner: 'acme',
+            repo: 'widgets',
+            prNumber: 42,
+            baseRef: 'main'
+        });
+
+        expect(await context.changedFiles()).toEqual([
+            { path: 'a.ts', additions: 1, deletions: 0 },
+            { path: 'b.ts', additions: 0, deletions: 5 }
+        ]);
+        expect(paginateCalls).toEqual([
+            {
+                endpoint: octokit.rest.pulls.listFiles,
+                params: { owner: 'acme', repo: 'widgets', pull_number: 42, per_page: 100 }
+            }
+        ]);
+    });
+
+    it('memoizes: repeated changedFiles() calls hit the API once', async () => {
+        const { octokit, paginateCalls } = fakeOctokit([listedFile('a.ts', 1, 0)]);
+        const context = new ApiGuardrailContext({
+            octokit,
+            owner: 'acme',
+            repo: 'widgets',
+            prNumber: 7,
+            baseRef: 'main'
+        });
+
+        const [first, second] = await Promise.all([context.changedFiles(), context.changedFiles()]);
+        await context.changedFiles();
+
+        expect(first).toEqual(second);
+        expect(paginateCalls).toHaveLength(1);
+    });
+});

--- a/fast_track/src/guardrails/context/api-context.ts
+++ b/fast_track/src/guardrails/context/api-context.ts
@@ -1,0 +1,66 @@
+import type { GitHub } from '@actions/github/lib/utils';
+
+import type { ChangedFile, GuardrailContext } from './types';
+
+/**
+ * A hydrated Octokit client, injected (never constructed here). Kept type-only so
+ * the import erases at runtime and the local git path never loads `@actions/github`.
+ */
+export type Octokit = InstanceType<typeof GitHub>;
+
+/** `pulls.listFiles` caps per_page at 100. */
+const PER_PAGE = 100;
+
+/** The `pulls.listFiles` fields we read — counts only, no patch. */
+type ListedFile = { filename: string; additions: number; deletions: number };
+
+export interface ApiGuardrailContextParams {
+    octokit: Octokit;
+    owner: string;
+    repo: string;
+    prNumber: number;
+    baseRef: string;
+}
+
+/**
+ * CI {@link GuardrailContext} backed by the GitHub API. `pulls.listFiles` is
+ * paginated (the endpoint itself caps at ~3000 files) and each file maps to a
+ * {@link ChangedFile} carrying counts only.
+ */
+export class ApiGuardrailContext implements GuardrailContext {
+    readonly baseRef: string;
+    readonly octokit: Octokit;
+    private readonly owner: string;
+    private readonly repo: string;
+    private readonly prNumber: number;
+    private cache?: Promise<ChangedFile[]>;
+
+    constructor(params: ApiGuardrailContextParams) {
+        // An empty base ref is a config error: a patch-fetching guardrail would
+        // range against nothing. Reject it as the git provider does.
+        if (params.baseRef.trim() === '') throw new Error('baseRef must not be empty');
+        this.octokit = params.octokit;
+        this.owner = params.owner;
+        this.repo = params.repo;
+        this.prNumber = params.prNumber;
+        this.baseRef = params.baseRef;
+    }
+
+    async changedFiles(): Promise<ChangedFile[]> {
+        // Memoize: the PR's file list is fixed for one run, read by many guardrails.
+        this.cache ??= (async () => {
+            const files = await this.octokit.paginate(this.octokit.rest.pulls.listFiles, {
+                owner: this.owner,
+                repo: this.repo,
+                pull_number: this.prNumber,
+                per_page: PER_PAGE
+            });
+            return files.map(toChangedFile);
+        })();
+        return this.cache;
+    }
+}
+
+export function toChangedFile(file: ListedFile): ChangedFile {
+    return { path: file.filename, additions: file.additions, deletions: file.deletions };
+}


### PR DESCRIPTION
## What has changed and why?

Compute context from a CI job using octokit. Not plugged in to CI yet.

Stacked on #1554.

## How has it been tested?

New tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local commands to run guardrails on committed changes and to list available guardrails.
  * Added support for running guardrails from the command line, including choosing specific checks and overriding the base branch.

* **Bug Fixes**
  * Improved change detection for renamed and binary files so results are more accurate.
  * Added validation to prevent guardrails from running with an invalid base branch.
  * Guardrail results are now cached during a run for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->