### PR TITLE
Embed COCO instance-segmentation crops

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -205,7 +205,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             input_labels: Labelformat input object (e.g. ``COCOObjectDetectionInput``).
             images_root: Root path used to construct absolute image paths for matching.
             annotation_source: Name of the annotation source.
-            embed_annotations: If True, generate embeddings for object-detection annotations.
+            embed_annotations: If True, generate embeddings for the annotation crops.
         """
         missing = add_annotations.add_annotations_from_labelformat(
             session=self.session,
@@ -237,7 +237,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             images_root: Root path used for matching image filenames.
             annotation_source: Name of the annotation source.
             annotation_type: ``OBJECT_DETECTION`` or ``SEGMENTATION_MASK``.
-            embed_annotations: If True, generate embeddings for object-detection annotations.
+            embed_annotations: If True, generate embeddings for the annotation crops.
         """
         label_input: COCOObjectDetectionInput | COCOInstanceSegmentationInput
         if annotation_type == AnnotationType.OBJECT_DETECTION:
@@ -266,7 +266,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             data_yaml: Path to the YOLO ``data.yaml`` file.
             annotation_source: Name of the annotation source.
             input_split: Specific split (e.g. ``"train"``). ``None`` loads all splits.
-            embed_annotations: If True, generate embeddings for object-detection annotations.
+            embed_annotations: If True, generate embeddings for the annotation crops.
         """
         data_yaml = Path(data_yaml).absolute()
         missing: list[str] = []
@@ -339,7 +339,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
-            embed_annotations: If True, generate embeddings for object-detection annotations.
+            embed_annotations: If True, generate embeddings for the annotation crops.
             limit: Maximum number of samples to load. By default, all samples are loaded.
 
         Raises:
@@ -390,7 +390,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
-            embed_annotations: If True, generate embeddings for object-detection annotations.
+            embed_annotations: If True, generate embeddings for the annotation crops.
             limit: Maximum number of samples to load, in total across all processed
                 splits. By default, all samples are loaded.
 
@@ -483,7 +483,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
-            embed_annotations: If True, generate embeddings for object-detection annotations.
+            embed_annotations: If True, generate embeddings for the annotation crops.
             limit: Maximum number of samples to load. By default, all samples are loaded.
 
         Raises:
@@ -610,7 +610,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             annotation_source: Name of the annotation source to add the annotations
                 to. Reusing the same source name appends to that source. If `None`,
                 a default source is used.
-            embed_annotations: If True, generate embeddings for object-detection annotations.
+            embed_annotations: If True, generate embeddings for the annotation crops.
             limit: Maximum number of samples to load. By default, all samples are loaded.
 
         Raises:
@@ -793,7 +793,9 @@ def _generate_embeddings_annotations(
     annotation_collection_name: str | None,
     embed: bool,
 ) -> None:
-    """Generate and store embeddings for object-detection annotation samples.
+    """Generate and store embeddings for annotation crops.
+
+    Object-detection and segmentation-mask annotations are both embedded.
 
     Args:
         session: Database session for resolver operations.

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -317,6 +317,7 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             input_labels=label_input,
             images_root=images_root,
             annotation_source=annotation_source,
+            embed_annotations=False,
         )
 
     def add_samples_from_labelformat(  # noqa: PLR0913

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -198,7 +198,9 @@ class EmbeddingManager:
         annotation_collection_id: UUID,
         embedding_model_id: UUID | None = None,
     ) -> None:
-        """Generate and store embeddings for object-detection annotations.
+        """Generate and store embeddings for annotation crops.
+
+        Object-detection and segmentation-mask annotations are both embedded.
 
         Args:
             session: Database session for resolver operations.

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_annotation_crops.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_annotation_crops.py
@@ -70,6 +70,8 @@ def get_annotation_crops_for_ids(
 
     annotation_crops: list[AnnotationCrop] = []
     for annotation, image, object_detection, segmentation in rows:
+        # An annotation has a detail row in exactly one table, set by its type in
+        # create_many, so at most one of these joins matches.
         box_source = object_detection or segmentation
         if box_source is None:
             logger.warning(

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_annotation_crops.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_annotation_crops.py
@@ -1,4 +1,4 @@
-"""Build image crops for object-detection annotations."""
+"""Build image crops for annotations from their bounding boxes."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from sqlmodel import Session, col, select
 from lightly_studio.dataset.embedding_generator import ImageCrop
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation.object_detection import ObjectDetectionAnnotationTable
+from lightly_studio.models.annotation.segmentation import SegmentationAnnotationTable
 from lightly_studio.models.image import ImageTable
 
 logger = logging.getLogger(__name__)
@@ -31,7 +32,11 @@ def get_annotation_crops_for_ids(
     session: Session,
     annotation_sample_ids: list[UUID],
 ) -> list[AnnotationCrop]:
-    """Build valid image crops for the given object-detection annotation IDs.
+    """Build valid image crops for the given annotation IDs.
+
+    The bounding box is read from whichever detail table holds it: object-detection
+    annotations store it in ``ObjectDetectionAnnotationTable`` and segmentation
+    annotations in ``SegmentationAnnotationTable`` (both expose ``x/y/width/height``).
 
     Crops whose box does not overlap the source image are skipped with a warning, so the
     returned list may be shorter than ``annotation_sample_ids``.
@@ -44,26 +49,41 @@ def get_annotation_crops_for_ids(
         Resolved annotation crops ready for embedding.
     """
     rows = session.exec(
-        select(AnnotationBaseTable, ImageTable, ObjectDetectionAnnotationTable)
-        .join(
+        select(
+            AnnotationBaseTable,
+            ImageTable,
+            ObjectDetectionAnnotationTable,
+            SegmentationAnnotationTable,
+        )
+        .join(ImageTable, col(ImageTable.sample_id) == col(AnnotationBaseTable.parent_sample_id))
+        .outerjoin(
             ObjectDetectionAnnotationTable,
             col(ObjectDetectionAnnotationTable.sample_id) == col(AnnotationBaseTable.sample_id),
         )
-        .join(ImageTable, col(ImageTable.sample_id) == col(AnnotationBaseTable.parent_sample_id))
+        .outerjoin(
+            SegmentationAnnotationTable,
+            col(SegmentationAnnotationTable.sample_id) == col(AnnotationBaseTable.sample_id),
+        )
         .where(col(AnnotationBaseTable.sample_id).in_(annotation_sample_ids))
         .order_by(col(ImageTable.file_path_abs))
     ).all()
 
     annotation_crops: list[AnnotationCrop] = []
-    for annotation, image, object_detection in rows:
+    for annotation, image, object_detection, segmentation in rows:
+        box_source = object_detection or segmentation
+        if box_source is None:
+            logger.warning(
+                "Skipping annotation crop %s without a bounding box.", annotation.sample_id
+            )
+            continue
         image_crop = _create_valid_image_crop(
             filepath=image.file_path_abs,
             image_size=(image.width, image.height),
             box=(
-                object_detection.x,
-                object_detection.y,
-                object_detection.width,
-                object_detection.height,
+                box_source.x,
+                box_source.y,
+                box_source.width,
+                box_source.height,
             ),
         )
         if image_crop is None:

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_unembedded_annotation_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_unembedded_annotation_ids.py
@@ -1,4 +1,4 @@
-"""Query for object-detection annotations lacking an embedding."""
+"""Query for croppable annotations lacking an embedding."""
 
 from __future__ import annotations
 
@@ -11,13 +11,23 @@ from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 
+# Annotation types whose crops are embedded. Both store a bounding box, so both are croppable;
+# classification-style annotations are excluded because they have no box.
+_CROPPABLE_ANNOTATION_TYPES = [
+    AnnotationType.OBJECT_DETECTION,
+    AnnotationType.SEGMENTATION_MASK,
+]
+
 
 def get_unembedded_annotation_ids(
     session: Session,
     annotation_collection_id: UUID,
     embedding_model_id: UUID,
 ) -> list[UUID]:
-    """Return IDs of object-detection annotations in the collection lacking an embedding.
+    """Return IDs of croppable annotations in the collection lacking an embedding.
+
+    Object-detection and segmentation-mask annotations are both included; each annotation
+    source is assumed to hold a single annotation type.
 
     Results are ordered by source image path so an image's annotations stay adjacent and tend to
     land in the same chunk, preserving the single-open-per-image behaviour of crop embedding.
@@ -38,7 +48,7 @@ def get_unembedded_annotation_ids(
         .join(SampleTable, col(SampleTable.sample_id) == col(AnnotationBaseTable.sample_id))
         .join(ImageTable, col(ImageTable.sample_id) == col(AnnotationBaseTable.parent_sample_id))
         .where(col(SampleTable.collection_id) == annotation_collection_id)
-        .where(col(AnnotationBaseTable.annotation_type) == AnnotationType.OBJECT_DETECTION)
+        .where(col(AnnotationBaseTable.annotation_type).in_(_CROPPABLE_ANNOTATION_TYPES))
         .where(col(AnnotationBaseTable.sample_id).notin_(embedded_ids_subquery))
         .order_by(col(ImageTable.file_path_abs))
     ).all()

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -267,11 +267,16 @@ def test_embed_images_with_incompatible_generator(
         )
 
 
+@pytest.mark.parametrize(
+    "annotation_type",
+    [AnnotationType.OBJECT_DETECTION, AnnotationType.SEGMENTATION_MASK],
+)
 def test_embed_annotations(
     db_session: Session,
     collection: CollectionTable,
+    annotation_type: AnnotationType,
 ) -> None:
-    """embed_annotations stores one embedding per object-detection annotation."""
+    """embed_annotations stores one embedding per croppable annotation, per type."""
     image = create_image(session=db_session, collection_id=collection.collection_id)
     label = create_annotation_label(session=db_session, root_collection_id=collection.collection_id)
     create_annotation(
@@ -279,48 +284,7 @@ def test_embed_annotations(
         collection_id=collection.collection_id,
         sample_id=image.sample_id,
         annotation_label_id=label.annotation_label_id,
-    )
-    annotation_collection_id = collection_resolver.get_or_create_child_collection(
-        session=db_session,
-        collection_id=collection.collection_id,
-        sample_type=SampleType.ANNOTATION,
-    )
-
-    manager = EmbeddingManager()
-    model_id = manager.register_embedding_model(
-        session=db_session,
-        embedding_generator=RandomEmbeddingGenerator(),
-        collection_id=annotation_collection_id,
-        set_as_default=True,
-    ).embedding_model_id
-
-    manager.embed_annotations(
-        session=db_session,
-        annotation_collection_id=annotation_collection_id,
-        embedding_model_id=model_id,
-    )
-
-    stored_embeddings = sample_embedding_resolver.get_all_by_collection_id(
-        session=db_session,
-        collection_id=annotation_collection_id,
-        embedding_model_id=model_id,
-    )
-    assert len(stored_embeddings) == 1
-
-
-def test_embed_annotations__embeds_segmentation_crops_by_default(
-    db_session: Session,
-    collection: CollectionTable,
-) -> None:
-    """Segmentation-mask crops are embedded by default, alongside object detection."""
-    image = create_image(session=db_session, collection_id=collection.collection_id)
-    label = create_annotation_label(session=db_session, root_collection_id=collection.collection_id)
-    create_annotation(
-        session=db_session,
-        collection_id=collection.collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.SEGMENTATION_MASK,
+        annotation_type=annotation_type,
     )
     annotation_collection_id = collection_resolver.get_or_create_child_collection(
         session=db_session,

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -20,6 +20,7 @@ from lightly_studio.dataset.embedding_manager import (
     EmbeddingManager,
     TextEmbedQuery,
 )
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
 from lightly_studio.models.image import ImageTable
@@ -278,6 +279,48 @@ def test_embed_annotations(
         collection_id=collection.collection_id,
         sample_id=image.sample_id,
         annotation_label_id=label.annotation_label_id,
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    manager = EmbeddingManager()
+    model_id = manager.register_embedding_model(
+        session=db_session,
+        embedding_generator=RandomEmbeddingGenerator(),
+        collection_id=annotation_collection_id,
+        set_as_default=True,
+    ).embedding_model_id
+
+    manager.embed_annotations(
+        session=db_session,
+        annotation_collection_id=annotation_collection_id,
+        embedding_model_id=model_id,
+    )
+
+    stored_embeddings = sample_embedding_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        embedding_model_id=model_id,
+    )
+    assert len(stored_embeddings) == 1
+
+
+def test_embed_annotations__embeds_segmentation_crops_by_default(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """Segmentation-mask crops are embedded by default, alongside object detection."""
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    label = create_annotation_label(session=db_session, root_collection_id=collection.collection_id)
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.SEGMENTATION_MASK,
     )
     annotation_collection_id = collection_resolver.get_or_create_child_collection(
         session=db_session,

--- a/lightly_studio/tests/resolvers/annotations/test_get_annotation_crops_for_ids.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_annotation_crops_for_ids.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+import pytest
 from sqlmodel import Session
 
 from lightly_studio.dataset.embedding_generator import ImageCrop
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.resolvers import annotation_resolver
 from tests.helpers_resolvers import (
     create_annotation,
@@ -14,10 +16,15 @@ from tests.helpers_resolvers import (
 )
 
 
+@pytest.mark.parametrize(
+    "annotation_type",
+    [AnnotationType.OBJECT_DETECTION, AnnotationType.SEGMENTATION_MASK],
+)
 def test_get_annotation_crops_for_ids__clamps_box_to_image_bounds(
     db_session: Session,
+    annotation_type: AnnotationType,
 ) -> None:
-    """Boxes extending outside the image are clamped to valid crop coordinates."""
+    """Boxes extending outside the image are clamped, for either detail table."""
     collection = create_collection(session=db_session)
     label = create_annotation_label(session=db_session, root_collection_id=collection.collection_id)
     image = create_image(
@@ -32,6 +39,7 @@ def test_get_annotation_crops_for_ids__clamps_box_to_image_bounds(
         collection_id=collection.collection_id,
         sample_id=image.sample_id,
         annotation_label_id=label.annotation_label_id,
+        annotation_type=annotation_type,
         annotation_data={"x": -10, "y": -5, "width": 50, "height": 120},
     )
 

--- a/lightly_studio_view/e2e/general/bugs/LIG-7691-plot-visible-only-in-samples.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/bugs/LIG-7691-plot-visible-only-in-samples.e2e-test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../../utils';
 
-test('Plot is visible only on samples page', async ({ samplesPage, page }) => {
+test('Plot is available on samples and annotations pages', async ({ samplesPage, page }) => {
     await samplesPage.goto();
 
     const togglePlotButton = page.getByTestId('side-panel-tabs-embed');
@@ -38,6 +38,7 @@ test('Plot is visible only on samples page', async ({ samplesPage, page }) => {
 
     await expect(page.getByTestId('annotations-grid')).toBeVisible({ timeout: 10000 });
 
-    await expect(page.getByTestId('side-panel-tabs-embed')).not.toBeVisible();
-    await expect(page.getByTestId('plot-panel')).not.toBeVisible();
+    await expect(togglePlotButton).toBeVisible();
+    await togglePlotButton.click();
+    await expect(plotPanel).toBeVisible();
 });


### PR DESCRIPTION
## What

Object-level embeddings previously covered only object-detection annotations. This extends the annotation embedding path to also embed **segmentation-mask crops** (e.g. COCO instance segmentation), using each object's bounding box.

- `get_annotation_crops` reads the box from either the object-detection or the segmentation detail table (outer-joins both).
- `get_unembedded_annotation_ids` now selects both croppable types (`OBJECT_DETECTION` and `SEGMENTATION_MASK`); classification-style annotations stay excluded as they have no box.

Each annotation source is assumed to hold a single annotation type.

## How tested

Manually: ran `src/lightly_studio/examples/example_coco.py`
Parametrised unittests 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Annotation embedding and cropping now work for both object-detection and segmentation-mask annotations.

* **Bug Fixes**
  * Missing-embedding detection now includes segmentation-mask annotations.
  * Importing Pascal VOC semantic segmentation masks no longer triggers automatic embedding generation.

* **Tests**
  * Updated/parameterized unit tests to validate crop and embedding behavior for both annotation types.
  * Improved an end-to-end UI test to confirm plot visibility on both samples and annotations pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->