### PR TITLE
Add frontend complexity guardrail

### DIFF
--- a/fast_track/src/guardrails/frontend/complexity.test.ts
+++ b/fast_track/src/guardrails/frontend/complexity.test.ts
@@ -40,6 +40,14 @@ describe('frontendComplexityGuardrail', () => {
         expect(result.summary).toContain('1 file(s) checked, no violations');
     });
 
+    it('passes when a deleted frontend file is in changedFiles', async () => {
+        vi.mocked(runEslint).mockResolvedValueOnce([]);
+        const result = await frontendComplexityGuardrail.run(
+            makeCtx([{ path: 'lightly_studio_view/src/deleted.ts', additions: 0, deletions: 10 }])
+        );
+        expect(result.status).toBe('pass');
+    });
+
     it('fails when ESLint reports an error-level violation', async () => {
         vi.mocked(runEslint).mockResolvedValueOnce([
             {

--- a/fast_track/src/guardrails/frontend/complexity.test.ts
+++ b/fast_track/src/guardrails/frontend/complexity.test.ts
@@ -4,12 +4,18 @@ import type { GuardrailContext } from '../context/types';
 import { frontendComplexityGuardrail } from './complexity';
 import { FRONTEND_ABS } from './eslint-runner';
 
+vi.mock('node:fs', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:fs')>();
+    return { ...actual, existsSync: vi.fn().mockReturnValue(true) };
+});
+
 vi.mock('./eslint-runner', async (importOriginal) => {
     const actual = await importOriginal<typeof import('./eslint-runner')>();
     return { ...actual, runEslint: vi.fn().mockResolvedValue([]) };
 });
 
 const { runEslint } = await import('./eslint-runner');
+const { existsSync } = await import('node:fs');
 
 const frontendFile = { path: 'lightly_studio_view/src/foo.ts', additions: 5, deletions: 0 };
 
@@ -31,6 +37,31 @@ describe('frontendComplexityGuardrail', () => {
         expect(result.summary).toContain('0 file(s)');
     });
 
+    it('passes when all changed frontend files are deleted', async () => {
+        vi.mocked(existsSync).mockReturnValueOnce(false);
+        const result = await frontendComplexityGuardrail.run(
+            makeCtx([{ path: 'lightly_studio_view/src/deleted.ts', additions: 0, deletions: 10 }])
+        );
+        expect(result.status).toBe('pass');
+        expect(result.summary).toBe('All changed frontend files were deleted.');
+    });
+
+    it('only lints existing files when some are deleted', async () => {
+        vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(false);
+        vi.mocked(runEslint).mockResolvedValueOnce([
+            { filePath: `${FRONTEND_ABS}/src/foo.ts`, messages: [] }
+        ] as unknown as ESLint.LintResult[]);
+        const result = await frontendComplexityGuardrail.run(
+            makeCtx([
+                { path: 'lightly_studio_view/src/foo.ts', additions: 5, deletions: 0 },
+                { path: 'lightly_studio_view/src/deleted.ts', additions: 0, deletions: 10 }
+            ])
+        );
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('1 file(s) checked, no violations');
+        expect(vi.mocked(runEslint)).toHaveBeenCalledWith(['src/foo.ts'], expect.any(String));
+    });
+
     it('passes when ESLint reports no violations', async () => {
         vi.mocked(runEslint).mockResolvedValueOnce([
             { filePath: `${FRONTEND_ABS}/src/foo.ts`, messages: [] }
@@ -38,14 +69,6 @@ describe('frontendComplexityGuardrail', () => {
         const result = await frontendComplexityGuardrail.run(makeCtx());
         expect(result.status).toBe('pass');
         expect(result.summary).toContain('1 file(s) checked, no violations');
-    });
-
-    it('passes when a deleted frontend file is in changedFiles', async () => {
-        vi.mocked(runEslint).mockResolvedValueOnce([]);
-        const result = await frontendComplexityGuardrail.run(
-            makeCtx([{ path: 'lightly_studio_view/src/deleted.ts', additions: 0, deletions: 10 }])
-        );
-        expect(result.status).toBe('pass');
     });
 
     it('passes when ESLint reports only warning-level messages', async () => {

--- a/fast_track/src/guardrails/frontend/complexity.test.ts
+++ b/fast_track/src/guardrails/frontend/complexity.test.ts
@@ -1,0 +1,54 @@
+import { vi, describe, expect, it } from 'vitest';
+import type { ESLint } from 'eslint';
+import type { GuardrailContext } from '../context/types';
+import { frontendComplexityGuardrail } from './complexity';
+import { FRONTEND_ABS } from './eslint-runner';
+
+vi.mock('./eslint-runner', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./eslint-runner')>();
+    return { ...actual, runEslint: vi.fn().mockResolvedValue([]) };
+});
+
+const { runEslint } = await import('./eslint-runner');
+
+const frontendFile = { path: 'lightly_studio_view/src/foo.ts', additions: 5, deletions: 0 };
+
+function makeCtx(files = [frontendFile]): GuardrailContext {
+    return { baseRef: 'origin/main', changedFiles: async () => files };
+}
+
+describe('frontendComplexityGuardrail', () => {
+    it('is required and runs locally', () => {
+        expect(frontendComplexityGuardrail.required).toBe(true);
+        expect(frontendComplexityGuardrail.needsPrContext).toBe(false);
+    });
+
+    it('passes immediately when no frontend files changed', async () => {
+        const result = await frontendComplexityGuardrail.run(
+            makeCtx([{ path: 'lightly_studio/src/model.py', additions: 5, deletions: 0 }])
+        );
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('0 file(s)');
+    });
+
+    it('passes when ESLint reports no violations', async () => {
+        vi.mocked(runEslint).mockResolvedValueOnce([
+            { filePath: `${FRONTEND_ABS}/src/foo.ts`, messages: [] }
+        ] as unknown as ESLint.LintResult[]);
+        const result = await frontendComplexityGuardrail.run(makeCtx());
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('1 file(s) checked, no violations');
+    });
+
+    it('fails when ESLint reports an error-level violation', async () => {
+        vi.mocked(runEslint).mockResolvedValueOnce([
+            {
+                filePath: `${FRONTEND_ABS}/src/foo.ts`,
+                messages: [{ ruleId: 'complexity', severity: 2, message: 'Too complex.', line: 10 }]
+            }
+        ] as unknown as ESLint.LintResult[]);
+        const result = await frontendComplexityGuardrail.run(makeCtx());
+        expect(result.status).toBe('fail');
+        expect(result.summary).toContain('lightly_studio_view/src/foo.ts:10 — Too complex.');
+    });
+});

--- a/fast_track/src/guardrails/frontend/complexity.test.ts
+++ b/fast_track/src/guardrails/frontend/complexity.test.ts
@@ -52,7 +52,9 @@ describe('frontendComplexityGuardrail', () => {
         vi.mocked(runEslint).mockResolvedValueOnce([
             {
                 filePath: `${FRONTEND_ABS}/src/foo.ts`,
-                messages: [{ ruleId: 'complexity', severity: 1, message: 'Somewhat complex.', line: 5 }]
+                messages: [
+                    { ruleId: 'complexity', severity: 1, message: 'Somewhat complex.', line: 5 }
+                ]
             }
         ] as unknown as ESLint.LintResult[]);
         const result = await frontendComplexityGuardrail.run(makeCtx());

--- a/fast_track/src/guardrails/frontend/complexity.test.ts
+++ b/fast_track/src/guardrails/frontend/complexity.test.ts
@@ -48,6 +48,18 @@ describe('frontendComplexityGuardrail', () => {
         expect(result.status).toBe('pass');
     });
 
+    it('passes when ESLint reports only warning-level messages', async () => {
+        vi.mocked(runEslint).mockResolvedValueOnce([
+            {
+                filePath: `${FRONTEND_ABS}/src/foo.ts`,
+                messages: [{ ruleId: 'complexity', severity: 1, message: 'Somewhat complex.', line: 5 }]
+            }
+        ] as unknown as ESLint.LintResult[]);
+        const result = await frontendComplexityGuardrail.run(makeCtx());
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('no violations');
+    });
+
     it('fails when ESLint reports an error-level violation', async () => {
         vi.mocked(runEslint).mockResolvedValueOnce([
             {

--- a/fast_track/src/guardrails/frontend/complexity.ts
+++ b/fast_track/src/guardrails/frontend/complexity.ts
@@ -1,7 +1,8 @@
-import { extname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { extname, resolve } from 'node:path';
 import type { ESLint } from 'eslint';
 import type { Guardrail, GuardrailContext, GuardrailOutcome } from '../context/types';
-import { FRONTEND_PREFIX, repoRelPath, runEslint } from './eslint-runner';
+import { FRONTEND_ABS, FRONTEND_PREFIX, repoRelPath, runEslint } from './eslint-runner';
 
 const EXTENSIONS = new Set(['.js', '.ts', '.svelte']);
 const ESLINT_CONFIG = 'eslint.complexity.config.js';
@@ -20,7 +21,16 @@ export const frontendComplexityGuardrail: Guardrail = {
             return { status: 'pass', summary: '0 file(s) checked.' };
         }
 
-        const relPaths = files.map((f) => f.path.slice(FRONTEND_PREFIX.length));
+        // Exclude deleted files — they no longer exist on disk and cannot be linted.
+        const existingFiles = files.filter((f) =>
+            existsSync(resolve(FRONTEND_ABS, f.path.slice(FRONTEND_PREFIX.length)))
+        );
+
+        if (existingFiles.length === 0) {
+            return { status: 'pass', summary: 'All changed frontend files were deleted.' };
+        }
+
+        const relPaths = existingFiles.map((f) => f.path.slice(FRONTEND_PREFIX.length));
         const results: ESLint.LintResult[] = await runEslint(relPaths, ESLINT_CONFIG);
         const violations = results.flatMap((file) =>
             file.messages
@@ -29,7 +39,10 @@ export const frontendComplexityGuardrail: Guardrail = {
         );
 
         if (violations.length === 0) {
-            return { status: 'pass', summary: `${files.length} file(s) checked, no violations.` };
+            return {
+                status: 'pass',
+                summary: `${existingFiles.length} file(s) checked, no violations.`
+            };
         }
 
         return { status: 'fail', summary: violations.join('\n') };

--- a/fast_track/src/guardrails/frontend/complexity.ts
+++ b/fast_track/src/guardrails/frontend/complexity.ts
@@ -5,6 +5,7 @@ import { FRONTEND_PREFIX, repoRelPath, runEslint } from './eslint-runner';
 
 const EXTENSIONS = new Set(['.js', '.ts', '.svelte']);
 const ESLINT_CONFIG = 'eslint.complexity.config.js';
+const ESLINT_ERROR_SEVERITY = 2;
 
 export const frontendComplexityGuardrail: Guardrail = {
     name: 'frontend/complexity',
@@ -22,7 +23,9 @@ export const frontendComplexityGuardrail: Guardrail = {
         const relPaths = files.map((f) => f.path.slice(FRONTEND_PREFIX.length));
         const results: ESLint.LintResult[] = await runEslint(relPaths, ESLINT_CONFIG);
         const violations = results.flatMap((file) =>
-            file.messages.map((msg) => `${repoRelPath(file.filePath)}:${msg.line} — ${msg.message}`)
+            file.messages
+                .filter((msg) => msg.severity === ESLINT_ERROR_SEVERITY)
+                .map((msg) => `${repoRelPath(file.filePath)}:${msg.line} — ${msg.message}`)
         );
 
         if (violations.length === 0) {

--- a/fast_track/src/guardrails/frontend/complexity.ts
+++ b/fast_track/src/guardrails/frontend/complexity.ts
@@ -1,0 +1,34 @@
+import { extname } from 'node:path';
+import type { ESLint } from 'eslint';
+import type { Guardrail, GuardrailContext, GuardrailOutcome } from '../context/types';
+import { FRONTEND_PREFIX, repoRelPath, runEslint } from './eslint-runner';
+
+const EXTENSIONS = new Set(['.js', '.ts', '.svelte']);
+const ESLINT_CONFIG = 'eslint.complexity.config.js';
+
+export const frontendComplexityGuardrail: Guardrail = {
+    name: 'frontend/complexity',
+    required: true,
+    needsPrContext: false,
+    async run(ctx: GuardrailContext): Promise<GuardrailOutcome> {
+        const files = (await ctx.changedFiles()).filter(
+            (f) => f.path.startsWith(FRONTEND_PREFIX) && EXTENSIONS.has(extname(f.path))
+        );
+
+        if (files.length === 0) {
+            return { status: 'pass', summary: '0 file(s) checked.' };
+        }
+
+        const relPaths = files.map((f) => f.path.slice(FRONTEND_PREFIX.length));
+        const results: ESLint.LintResult[] = await runEslint(relPaths, ESLINT_CONFIG);
+        const violations = results.flatMap((file) =>
+            file.messages.map((msg) => `${repoRelPath(file.filePath)}:${msg.line} — ${msg.message}`)
+        );
+
+        if (violations.length === 0) {
+            return { status: 'pass', summary: `${files.length} file(s) checked, no violations.` };
+        }
+
+        return { status: 'fail', summary: violations.join('\n') };
+    }
+};

--- a/fast_track/src/guardrails/frontend/eslint-runner.ts
+++ b/fast_track/src/guardrails/frontend/eslint-runner.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { ESLint } from 'eslint';
+import type { ESLint } from 'eslint';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/fast_track/src/guardrails/frontend/eslint-runner.ts
+++ b/fast_track/src/guardrails/frontend/eslint-runner.ts
@@ -23,8 +23,7 @@ export async function runEslint(relPaths: string[], config: string): Promise<ESL
     const { ESLint: FrontendESLint } = require('eslint') as { ESLint: typeof ESLint };
     const eslint = new FrontendESLint({
         cwd: FRONTEND_ABS,
-        overrideConfigFile: config,
-        errorOnUnmatchedPattern: false // deleted files still appear in changedFiles(); skip them silently
+        overrideConfigFile: config
     });
     return eslint.lintFiles(relPaths);
 }

--- a/fast_track/src/guardrails/frontend/eslint-runner.ts
+++ b/fast_track/src/guardrails/frontend/eslint-runner.ts
@@ -10,16 +10,17 @@ export const FRONTEND_DIR = 'lightly_studio_view';
 export const FRONTEND_ABS = resolve(__dirname, '../../../..', FRONTEND_DIR);
 export const FRONTEND_PREFIX = FRONTEND_DIR + '/';
 
-// Load ESLint from the frontend package so its config plugins resolve correctly.
-const require = createRequire(FRONTEND_ABS + '/package.json');
-const { ESLint: FrontendESLint } = require('eslint') as { ESLint: typeof ESLint };
-
 // Converts an absolute ESLint file path to a repo-relative path (e.g. lightly_studio_view/src/foo.ts).
 export function repoRelPath(absPath: string): string {
     return FRONTEND_DIR + '/' + absPath.slice(FRONTEND_ABS.length + 1);
 }
 
 export async function runEslint(relPaths: string[], config: string): Promise<ESLint.LintResult[]> {
+    // Load ESLint lazily from the frontend package so its config plugins resolve correctly.
+    // Lazy loading also avoids a top-level require at import time, which would break tests
+    // that mock this module via importOriginal (eslint is not installed in fast_track).
+    const require = createRequire(FRONTEND_ABS + '/package.json');
+    const { ESLint: FrontendESLint } = require('eslint') as { ESLint: typeof ESLint };
     const eslint = new FrontendESLint({
         cwd: FRONTEND_ABS,
         overrideConfigFile: config

--- a/fast_track/src/guardrails/frontend/eslint-runner.ts
+++ b/fast_track/src/guardrails/frontend/eslint-runner.ts
@@ -23,7 +23,8 @@ export async function runEslint(relPaths: string[], config: string): Promise<ESL
     const { ESLint: FrontendESLint } = require('eslint') as { ESLint: typeof ESLint };
     const eslint = new FrontendESLint({
         cwd: FRONTEND_ABS,
-        overrideConfigFile: config
+        overrideConfigFile: config,
+        errorOnUnmatchedPattern: false // deleted files still appear in changedFiles(); skip them silently
     });
     return eslint.lintFiles(relPaths);
 }

--- a/fast_track/src/guardrails/registry.ts
+++ b/fast_track/src/guardrails/registry.ts
@@ -1,8 +1,9 @@
 import type { Guardrail } from './context/types';
 import { dummyGuardrail } from './dummy';
+import { frontendComplexityGuardrail } from './frontend/complexity';
 
 /** The guardrail registry. */
-export const guardrails: Guardrail[] = [dummyGuardrail];
+export const guardrails: Guardrail[] = [dummyGuardrail, frontendComplexityGuardrail];
 
 export interface SelectOptions {
     /** False locally, true in CI. */


### PR DESCRIPTION
## What has changed and why?

Implements the frontendComplexityGuardrail and wires it into the fast track registry.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `frontend/complexity` guardrail that checks changed frontend files (JS/TS/Svelte) with ESLint and reports repository-relative `path:line` plus the error message.
* **Bug Fixes**
  * Excludes frontend files that were deleted from linting; returns clear pass summaries for “0 file(s) checked” or “All changed frontend files were deleted.”
* **Tests**
  * Expanded Vitest coverage for pass/fail behavior, including warnings vs errors and detailed failure summaries.
* **Refactor**
  * Improved ESLint loading to be lazy during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->