### PR TITLE
Fix plugin filter resolving to AnnotationsFilter instead of SampleFilter

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/operator.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/operator.py
@@ -26,7 +26,7 @@ class OperatorContextRequest(BaseModel):
     collection_id: UUID
     """The collection_id the operator shall be executed on."""
 
-    context_filter: AnyFilter = None
+    context_filter: AnyFilter | None = None
     """The filter for the provided collection."""
 
 

--- a/lightly_studio/src/lightly_studio/plugins/operator_context.py
+++ b/lightly_studio/src/lightly_studio/plugins/operator_context.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import Annotated, Union
 from uuid import UUID
+
+from pydantic import Field
 
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
@@ -15,8 +17,22 @@ from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from lightly_studio.resolvers.video_frame_resolver.video_frame_filter import VideoFrameFilter
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
 
-AnyFilter = Union[
-    ImageFilter, VideoFrameFilter, VideoFilter, AnnotationsFilter, GroupFilter, SampleFilter, None
+# Discriminated union: each member carries a unique ``filter_type`` literal so a
+# payload resolves to exactly one model by intent, not by structural fit. A plain
+# ``Union`` resolves overlapping payloads by declaration order — e.g. a bare
+# ``{"sample_ids": [...]}`` fits both SampleFilter and AnnotationsFilter, and the
+# first-listed member silently wins. The discriminator removes that ambiguity, so
+# every payload MUST include ``filter_type``.
+AnyFilter = Annotated[
+    Union[
+        ImageFilter,
+        VideoFrameFilter,
+        VideoFilter,
+        AnnotationsFilter,
+        GroupFilter,
+        SampleFilter,
+    ],
+    Field(discriminator="filter_type"),
 ]
 
 
@@ -29,7 +45,7 @@ class ExecutionContext:
     """
 
     collection_id: UUID
-    context_filter: AnyFilter = None
+    context_filter: AnyFilter | None = None
 
 
 class OperatorScope(str, Enum):

--- a/lightly_studio/src/lightly_studio/resolvers/group_resolver/group_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/group_resolver/group_filter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel
 
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
@@ -12,6 +14,7 @@ from lightly_studio.type_definitions import QueryType
 class GroupFilter(BaseModel):
     """Encapsulates filter parameters for querying groups."""
 
+    filter_type: Literal["group"] = "group"
     sample_filter: SampleFilter | None = None
 
     def apply(self, query: QueryType) -> QueryType:

--- a/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
@@ -1,6 +1,6 @@
 """SampleFilter class."""
 
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -27,6 +27,7 @@ from lightly_studio.type_definitions import QueryType
 class SampleFilter(BaseModel):
     """Encapsulates filter parameters for querying samples."""
 
+    filter_type: Literal["sample"] = "sample"
     tag_ids: Optional[list[UUID]] = None
     metadata_filters: Optional[list[MetadataFilter]] = None
     sample_ids: Optional[list[UUID]] = None

--- a/lightly_studio/tests/api/routes/api/test_operator.py
+++ b/lightly_studio/tests/api/routes/api/test_operator.py
@@ -21,6 +21,7 @@ from lightly_studio.plugins.operator_context import ExecutionContext, OperatorSc
 from lightly_studio.plugins.operator_registry import OperatorRegistry
 from lightly_studio.plugins.parameter import BaseParameter, BoolParameter, StringParameter
 from lightly_studio.resolvers.image_filter import FilterDimensions, ImageFilter
+from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests import helpers_resolvers
 
 
@@ -295,7 +296,7 @@ def test_execute_operator__filter_is_passed_through(
             "parameters": {},
             "context": {
                 "collection_id": str(collection_id),
-                "context_filter": {"width": {"min": 100, "max": 200}},
+                "context_filter": {"filter_type": "image", "width": {"min": 100, "max": 200}},
             },
         },
     )
@@ -303,6 +304,38 @@ def test_execute_operator__filter_is_passed_through(
     assert response.status_code == HTTP_STATUS_OK
     assert operator.captured_context is not None
     assert operator.captured_context.context_filter == expected_filter
+
+
+def test_execute_operator__sample_ids_filter_resolves_to_sample_filter(
+    test_client: TestClient,
+    collection_id: UUID,
+    isolated_operator_registry: OperatorRegistry,
+) -> None:
+    """A detail-view payload (bare ``sample_ids``) must resolve to SampleFilter.
+
+    Regression guard: ``sample_ids`` is structurally valid for both SampleFilter
+    and AnnotationsFilter. The ``filter_type`` discriminator must route it to
+    SampleFilter rather than letting union declaration order decide.
+    """
+    operator = ImageScopeOperator()
+    isolated_operator_registry.register(operator)
+    operator_id = _get_operator_id_by_name(isolated_operator_registry, "image-only")
+
+    sample_id = uuid4()
+    response = test_client.post(
+        f"/api/operators/{operator_id}/execute",
+        json={
+            "parameters": {},
+            "context": {
+                "collection_id": str(collection_id),
+                "context_filter": {"filter_type": "sample", "sample_ids": [str(sample_id)]},
+            },
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert operator.captured_context is not None
+    assert operator.captured_context.context_filter == SampleFilter(sample_ids=[sample_id])
 
 
 @dataclass

--- a/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.test.ts
@@ -115,6 +115,7 @@ describe('resolveContextFilter', () => {
                 annotationId: 'ann-1'
             };
             expect(resolveContextFilter(ctx, null, null, null, new Set(), new Set())).toEqual({
+                filter_type: 'sample',
                 sample_ids: ['ann-1']
             });
         });
@@ -126,6 +127,7 @@ describe('resolveContextFilter', () => {
                 sampleId: 'smp-1'
             };
             expect(resolveContextFilter(ctx, null, null, null, new Set(), new Set())).toEqual({
+                filter_type: 'sample',
                 sample_ids: ['smp-1']
             });
         });
@@ -135,6 +137,7 @@ describe('resolveContextFilter', () => {
         it('returns sampleId as sample_ids on image detail', () => {
             const ctx = { ...BASE_CONTEXT, routeId: APP_ROUTES.imageDetails, sampleId: 'smp-1' };
             expect(resolveContextFilter(ctx, null, null, null, new Set(), new Set())).toEqual({
+                filter_type: 'sample',
                 sample_ids: ['smp-1']
             });
         });
@@ -142,6 +145,7 @@ describe('resolveContextFilter', () => {
         it('returns sampleId as sample_ids on frame detail', () => {
             const ctx = { ...BASE_CONTEXT, routeId: APP_ROUTES.framesDetails, sampleId: 'frm-1' };
             expect(resolveContextFilter(ctx, null, null, null, new Set(), new Set())).toEqual({
+                filter_type: 'sample',
                 sample_ids: ['frm-1']
             });
         });
@@ -149,6 +153,7 @@ describe('resolveContextFilter', () => {
         it('returns sampleId as sample_ids on video detail', () => {
             const ctx = { ...BASE_CONTEXT, routeId: APP_ROUTES.videoDetails, sampleId: 'vid-1' };
             expect(resolveContextFilter(ctx, null, null, null, new Set(), new Set())).toEqual({
+                filter_type: 'sample',
                 sample_ids: ['vid-1']
             });
         });
@@ -166,21 +171,25 @@ describe('resolveContextFilter', () => {
             const ctx = { ...BASE_CONTEXT, routeId: APP_ROUTES.annotations };
             expect(
                 resolveContextFilter(ctx, null, null, null, new Set(['lbl-1', 'lbl-2']), new Set())
-            ).toEqual({ annotation_label_ids: ['lbl-1', 'lbl-2'] });
+            ).toEqual({ filter_type: 'annotations', annotation_label_ids: ['lbl-1', 'lbl-2'] });
         });
 
         it('returns AnnotationsFilter with tag_ids when tagsSelected is set', () => {
             const ctx = { ...BASE_CONTEXT, routeId: APP_ROUTES.annotations };
             expect(
                 resolveContextFilter(ctx, null, null, null, new Set(), new Set(['tag-1']))
-            ).toEqual({ tag_ids: ['tag-1'] });
+            ).toEqual({ filter_type: 'annotations', tag_ids: ['tag-1'] });
         });
 
         it('returns AnnotationsFilter with both when both are set', () => {
             const ctx = { ...BASE_CONTEXT, routeId: APP_ROUTES.annotations };
             expect(
                 resolveContextFilter(ctx, null, null, null, new Set(['lbl-1']), new Set(['tag-1']))
-            ).toEqual({ annotation_label_ids: ['lbl-1'], tag_ids: ['tag-1'] });
+            ).toEqual({
+                filter_type: 'annotations',
+                annotation_label_ids: ['lbl-1'],
+                tag_ids: ['tag-1']
+            });
         });
 
         it('returns undefined when no filters are set', () => {
@@ -195,6 +204,7 @@ describe('resolveContextFilter', () => {
         it('returns has_captions filter', () => {
             const ctx = { ...BASE_CONTEXT, routeId: APP_ROUTES.captions };
             expect(resolveContextFilter(ctx, null, null, null, new Set(), new Set())).toEqual({
+                filter_type: 'sample',
                 has_captions: true
             });
         });
@@ -205,11 +215,11 @@ describe('resolveContextFilter', () => {
         const videoFilter = { sample_filter: {} };
         const frameFilter = { sample_filter: {} };
 
-        it('returns imageFilter for images route', () => {
+        it('returns imageFilter with filter_type for images route', () => {
             const ctx = { ...BASE_CONTEXT, routeId: APP_ROUTES.images };
-            expect(resolveContextFilter(ctx, imageFilter, null, null, new Set(), new Set())).toBe(
-                imageFilter
-            );
+            expect(
+                resolveContextFilter(ctx, imageFilter, null, null, new Set(), new Set())
+            ).toEqual({ ...imageFilter, filter_type: 'image' });
         });
 
         it('returns undefined when imageFilter is null on images route', () => {
@@ -219,18 +229,18 @@ describe('resolveContextFilter', () => {
             ).toBeUndefined();
         });
 
-        it('returns videoFilter for videos route', () => {
+        it('returns videoFilter with filter_type for videos route', () => {
             const ctx = { ...BASE_CONTEXT, routeId: APP_ROUTES.videos };
-            expect(resolveContextFilter(ctx, null, videoFilter, null, new Set(), new Set())).toBe(
-                videoFilter
-            );
+            expect(
+                resolveContextFilter(ctx, null, videoFilter, null, new Set(), new Set())
+            ).toEqual({ ...videoFilter, filter_type: 'video' });
         });
 
-        it('returns frameFilter for frames route', () => {
+        it('returns frameFilter with filter_type for frames route', () => {
             const ctx = { ...BASE_CONTEXT, routeId: APP_ROUTES.frames };
-            expect(resolveContextFilter(ctx, null, null, frameFilter, new Set(), new Set())).toBe(
-                frameFilter
-            );
+            expect(
+                resolveContextFilter(ctx, null, null, frameFilter, new Set(), new Set())
+            ).toEqual({ ...frameFilter, filter_type: 'video_frame' });
         });
     });
 

--- a/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.ts
@@ -79,20 +79,15 @@ export function resolveContextFilter(
     if (isAnnotationsRoute(routeId)) {
         const labelIds = Array.from(annotationFilterIds);
         const tagIds = Array.from(tagsSelected);
-        const filter: AnnotationsFilter = {
+        if (labelIds.length === 0 && tagIds.length === 0) return undefined;
+        return {
             filter_type: 'annotations',
             ...(labelIds.length > 0 && { annotation_label_ids: labelIds }),
             ...(tagIds.length > 0 && { tag_ids: tagIds })
-        };
-        return Object.keys(filter).length > 1
-            ? { ...filter, filter_type: 'annotations' }
-            : undefined;
+        } satisfies AnnotationsFilter;
     }
     if (isCaptionsRoute(routeId))
         return { filter_type: 'sample', has_captions: true } satisfies SampleFilter;
-    // The filter hooks already stamp `filter_type`, but the generated model types
-    // mark it optional (it has a backend default); re-assert it so the value fits
-    // the discriminated union.
     if (isImagesRoute(routeId))
         return imageFilter ? { ...imageFilter, filter_type: 'image' } : undefined;
     if (isVideosRoute(routeId))

--- a/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorContext/useOperatorContext.ts
@@ -5,6 +5,7 @@ import type {
     ImageFilter,
     VideoFrameFilter,
     VideoFilter,
+    OperatorContextRequest,
     OperatorScope,
     SampleType
 } from '$lib/api/lightly_studio_local';
@@ -32,13 +33,7 @@ export type PageContext = {
     sampleType: SampleType | null;
 };
 
-export type OperatorContextFilter =
-    | ImageFilter
-    | VideoFrameFilter
-    | VideoFilter
-    | AnnotationsFilter
-    | SampleFilter
-    | undefined;
+export type OperatorContextFilter = OperatorContextRequest['context_filter'];
 
 export function resolveIsDetailPage(routeId: string | null): boolean {
     return (
@@ -76,24 +71,34 @@ export function resolveContextFilter(
     tagsSelected: Set<string>
 ): OperatorContextFilter {
     if (isAnnotationDetailsRoute(routeId) && annotationId) {
-        return { sample_ids: [annotationId] } satisfies SampleFilter;
+        return { filter_type: 'sample', sample_ids: [annotationId] } satisfies SampleFilter;
     }
     if (resolveIsDetailPage(routeId) && sampleId) {
-        return { sample_ids: [sampleId] } satisfies SampleFilter;
+        return { filter_type: 'sample', sample_ids: [sampleId] } satisfies SampleFilter;
     }
     if (isAnnotationsRoute(routeId)) {
         const labelIds = Array.from(annotationFilterIds);
         const tagIds = Array.from(tagsSelected);
         const filter: AnnotationsFilter = {
+            filter_type: 'annotations',
             ...(labelIds.length > 0 && { annotation_label_ids: labelIds }),
             ...(tagIds.length > 0 && { tag_ids: tagIds })
         };
-        return Object.keys(filter).length > 0 ? filter : undefined;
+        return Object.keys(filter).length > 1
+            ? { ...filter, filter_type: 'annotations' }
+            : undefined;
     }
-    if (isCaptionsRoute(routeId)) return { has_captions: true } satisfies SampleFilter;
-    if (isImagesRoute(routeId)) return imageFilter ?? undefined;
-    if (isVideosRoute(routeId)) return videoFilter ?? undefined;
-    if (isVideoFramesRoute(routeId)) return frameFilter ?? undefined;
+    if (isCaptionsRoute(routeId))
+        return { filter_type: 'sample', has_captions: true } satisfies SampleFilter;
+    // The filter hooks already stamp `filter_type`, but the generated model types
+    // mark it optional (it has a backend default); re-assert it so the value fits
+    // the discriminated union.
+    if (isImagesRoute(routeId))
+        return imageFilter ? { ...imageFilter, filter_type: 'image' } : undefined;
+    if (isVideosRoute(routeId))
+        return videoFilter ? { ...videoFilter, filter_type: 'video' } : undefined;
+    if (isVideoFramesRoute(routeId))
+        return frameFilter ? { ...frameFilter, filter_type: 'video_frame' } : undefined;
     return undefined;
 }
 


### PR DESCRIPTION
## What has changed and why?

Triggering a plugin from a detail view (image / video / frame / annotation) sent a
bare `{ sample_ids: [...] }` payload that the backend parsed as an `AnnotationsFilter`
instead of a `SampleFilter`, so the operator ran against the wrong query path.

Made `AnyFilter` a **discriminated union** on `filter_type` so a payload resolves by
intent, not by structural fit or declaration order.

## How has it been tested?

new tests and manual tests

https://github.com/user-attachments/assets/8c7ea6a5-0e31-42a7-a9a5-d7d18dd9e3c4


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved operator context filtering with consistent `filter_type` parsing and validation across sample, image, annotations, video, and video-frame contexts.

* **Bug Fixes**
  * Fixed request/response filtering so `context_filter` correctly resolves to the intended filter type (including sample-id based filters).
  * Improved handling when `context_filter` is omitted or explicitly set to `null`.

* **Tests**
  * Expanded API and hook tests to verify discriminator behavior and ensure resolved filters include the correct `filter_type`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->