### PR TITLE
Annotation/labelformat & COCO ingest: record missing/already-present/added outcomes (LIG-10031)

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/add_images.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_images.py
@@ -97,19 +97,19 @@ def load_into_dataset_from_paths(
 
             # Detect a missing path proactively: FileNotFoundError is unreliable across
             # fsspec backends and is a subclass of OSError, which we treat as broken.
-            fs, fs_path = fsspec.core.url_to_fs(normalized_path)
-            if not fs.exists(fs_path):
-                raise MissingInputFileError(normalized_path)
+            if not _file_exists(normalized_path):
+                raise MissingInputFileError()
 
             # Translate a failed header read into a broken-file signal at this I/O
             # boundary; any other exception propagates rather than being recorded.
+            fs, fs_path = fsspec.core.url_to_fs(normalized_path)
             try:
                 with fs.open(fs_path, "rb") as file:
                     image = PIL.Image.open(file)
                     width, height = image.size
                     image.close()
             except (PIL.UnidentifiedImageError, OSError) as e:
-                raise BrokenInputFileError(normalized_path) from e
+                raise BrokenInputFileError() from e
 
             sample = ImageCreate(
                 file_name=Path(normalized_path).name,
@@ -160,6 +160,12 @@ def load_into_dataset_from_labelformat(  # noqa: PLR0913
 
     Returns:
         A list of UUIDs of the created samples.
+
+    Notes:
+        Image dimensions come from the annotation metadata and the file is never
+        opened here, so a broken file cannot be detected on this path; that is
+        deferred to the embedding step. Only a missing referenced path is
+        classified as a failure (recorded as ``MISSING``).
     """
     images_root_abs = add_annotations.normalize_images_root(images_root=images_path)
 
@@ -197,6 +203,12 @@ def load_into_dataset_from_labelformat(  # noqa: PLR0913
             # Skip paths already in the database or already seen in this call.
             if sample.file_path_abs in seen_or_existing_paths:
                 raise AlreadyPresentInputFileError()
+
+            # Missing is the only failure classifiable here (see the docstring):
+            # detect it proactively because FileNotFoundError is unreliable across
+            # fsspec backends and is a subclass of OSError.
+            if not _file_exists(sample.file_path_abs):
+                raise MissingInputFileError()
 
             seen_or_existing_paths.add(sample.file_path_abs)
             samples_to_create.append(sample)
@@ -247,26 +259,21 @@ def load_into_dataset_from_coco_captions(
 
     Returns:
         The list of newly created sample identifiers.
+
+    Notes:
+        Image dimensions come from the annotation metadata and the file is never
+        opened here, so a broken file cannot be detected on this path; that is
+        deferred to the embedding step. Only a missing referenced path is
+        classified as a failure (recorded as ``MISSING``).
     """
     with fsspec.open(str(annotations_json), "r") as file:
         coco_payload = json.load(file)
 
     # A slice with limit=None returns the full list.
     images: list[dict[str, object]] = coco_payload.get("images", [])[:limit]
-    annotations: list[dict[str, object]] = coco_payload.get("annotations", [])
-
-    captions_by_image_id: dict[int, list[str]] = defaultdict(list)
-    for annotation in annotations:
-        image_id = annotation["image_id"]
-        caption = annotation["caption"]
-        if not isinstance(image_id, int):
-            continue
-        if not isinstance(caption, str):
-            continue
-        caption_text = caption.strip()
-        if not caption_text:
-            continue
-        captions_by_image_id[image_id].append(caption_text)
+    captions_by_image_id = _group_captions_by_image_id(
+        annotations=coco_payload.get("annotations", [])
+    )
 
     # The set starts with paths already in the database and grows with paths seen in this
     # call, so both already-present and in-run duplicate paths are skipped before batching.
@@ -306,6 +313,12 @@ def load_into_dataset_from_coco_captions(
             # Skip paths already in the database or already seen in this call.
             if sample.file_path_abs in seen_or_existing_paths:
                 raise AlreadyPresentInputFileError()
+
+            # Missing is the only failure classifiable here (see the docstring):
+            # detect it proactively because FileNotFoundError is unreliable across
+            # fsspec backends and is a subclass of OSError.
+            if not _file_exists(sample.file_path_abs):
+                raise MissingInputFileError()
 
             seen_or_existing_paths.add(sample.file_path_abs)
             samples_to_create.append(sample)
@@ -385,6 +398,49 @@ def tag_samples_by_directory(
             sample_ids=s_ids,
         )
     logger.info(f"Created {len(parent_dir_to_sample_ids)} tags from directories.")
+
+
+def _group_captions_by_image_id(
+    annotations: list[dict[str, object]],
+) -> dict[int, list[str]]:
+    """Group non-empty COCO caption strings by their image id.
+
+    Args:
+        annotations: The ``annotations`` entries from a COCO captions payload.
+
+    Returns:
+        A mapping from image id to its list of non-empty caption strings.
+    """
+    captions_by_image_id: dict[int, list[str]] = defaultdict(list)
+    for annotation in annotations:
+        image_id = annotation["image_id"]
+        caption = annotation["caption"]
+        if not isinstance(image_id, int):
+            continue
+        if not isinstance(caption, str):
+            continue
+        caption_text = caption.strip()
+        if not caption_text:
+            continue
+        captions_by_image_id[image_id].append(caption_text)
+    return captions_by_image_id
+
+
+def _file_exists(path: str) -> bool:
+    """Return whether ``path`` resolves to an existing file on its fsspec backend.
+
+    Shared by the ingest paths to classify a missing input file, so the
+    existence check stays consistent across path, labelformat, and COCO-caption
+    ingest.
+
+    Args:
+        path: The absolute file path to check.
+
+    Returns:
+        ``True`` if the path exists, ``False`` otherwise.
+    """
+    fs, fs_path = fsspec.core.url_to_fs(path)
+    return bool(fs.exists(fs_path))
 
 
 def _get_existing_paths_set(

--- a/lightly_studio/src/lightly_studio/core/image/add_images.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_images.py
@@ -161,6 +161,10 @@ def load_into_dataset_from_labelformat(  # noqa: PLR0913
     Returns:
         A list of UUIDs of the created samples.
 
+    Raises:
+        AllInputFilesFailedError: If at least one file was attempted and every
+            attempted file was missing.
+
     Notes:
         Image dimensions come from the annotation metadata and the file is never
         opened here, so a broken file cannot be detected on this path; that is
@@ -238,6 +242,7 @@ def load_into_dataset_from_labelformat(  # noqa: PLR0913
         )
 
     report.log_summary()
+    report.raise_if_all_failed()
     return created_sample_ids
 
 
@@ -259,6 +264,10 @@ def load_into_dataset_from_coco_captions(
 
     Returns:
         The list of newly created sample identifiers.
+
+    Raises:
+        AllInputFilesFailedError: If at least one file was attempted and every
+            attempted file was missing.
 
     Notes:
         Image dimensions come from the annotation metadata and the file is never
@@ -351,6 +360,7 @@ def load_into_dataset_from_coco_captions(
         )
 
     report.log_summary()
+    report.raise_if_all_failed()
     return created_sample_ids
 
 

--- a/lightly_studio/tests/core/image/test_add_images.py
+++ b/lightly_studio/tests/core/image/test_add_images.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import posixpath
 from argparse import ArgumentParser
 from collections.abc import Iterable
 from pathlib import Path
@@ -22,6 +23,7 @@ from labelformat.model.object_detection import (
     SingleObjectDetection,
 )
 from PIL import Image as PILImage
+from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.core import labelformat_helpers
@@ -167,11 +169,64 @@ def test_load_into_collection_from_paths__deduplicates_in_run_duplicates(
     assert len(sample_ids) == 1
 
 
+def test_load_into_dataset_from_labelformat__records_missing_already_present_added_outcomes(
+    db_session: Session, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: annotations referencing an added / already-present / missing file mix. Each
+    # outcome gets a distinct count so a mix-up between two outcomes cannot pass the asserts.
+    # Broken is not exercised: this path never opens the file, so it cannot detect broken.
+    collection = helpers_resolvers.create_collection(db_session)
+
+    # 1 added file: referenced by the annotations and present on disk.
+    added_name = "added.jpg"
+    PILImage.new("RGB", (100, 200)).save(str(tmp_path / added_name))
+
+    # 2 already-present files: only pre-inserted into the database. The already-present check
+    # short-circuits before the existence check, so these need not exist on disk.
+    already_present_names = ["present0.jpg", "present1.jpg"]
+    helpers_resolvers.create_images(
+        db_session,
+        collection.collection_id,
+        [ImageStub(path=posixpath.join(str(tmp_path), name)) for name in already_present_names],
+    )
+
+    # 3 missing files: referenced by the annotations but never created on disk.
+    missing_names = [f"missing{i}.jpg" for i in range(3)]
+
+    all_names = [added_name, *already_present_names, *missing_names]
+    label_input = _get_labelformat_input_obj_det_multi(filenames=all_names)
+
+    # Act
+    with caplog.at_level("INFO", logger="lightly_studio.core.file_outcome_report"):
+        sample_ids = add_images.load_into_dataset_from_labelformat(
+            session=db_session,
+            root_collection_id=collection.collection_id,
+            input_labels=label_input,
+            images_path=tmp_path,
+        )
+
+    # Assert: only the added file becomes a new sample.
+    assert len(sample_ids) == 1
+    samples = image_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    ).samples
+    assert {sample.file_name for sample in samples} == {added_name, *already_present_names}
+
+    # Assert: the end-of-run summary records the distinct per-outcome counts.
+    assert "added=1" in caplog.text
+    assert "already_present=2" in caplog.text
+    assert "missing=3" in caplog.text
+    assert "broken=0" in caplog.text
+
+
 def test_load_into_dataset_from_labelformat__calls_get_labels_once(
-    db_session: Session, tmp_path: Path
+    db_session: Session, tmp_path: Path, mocker: MockerFixture
 ) -> None:
     collection = helpers_resolvers.create_collection(db_session)
     label_input = CountingLabelInput()
+    # The referenced file is not on disk; treat it as present so a sample is created and the
+    # annotation phase (the second get_labels call) runs.
+    mocker.patch.object(add_images, "_file_exists", return_value=True)
 
     add_images.load_into_dataset_from_labelformat(
         session=db_session,
@@ -197,10 +252,14 @@ def test_load_into_dataset_from_labelformat__calls_get_labels_once(
 def test_load_into_collection_from_labelformat__obj_det(
     db_session: Session,
     images_path: str,
+    mocker: MockerFixture,
 ) -> None:
     # Arrange
     collection = helpers_resolvers.create_collection(db_session)
     label_input = _get_labelformat_input_obj_det(filename="image.jpg")
+    # This test covers path normalization across backends, not file existence: the referenced
+    # paths (including remote schemes) do not exist, so treat every file as present.
+    mocker.patch.object(add_images, "_file_exists", return_value=True)
 
     sample_ids = add_images.load_into_dataset_from_labelformat(
         session=db_session,
@@ -248,8 +307,12 @@ def test_load_into_collection_from_labelformat__obj_det(
     ],
 )
 def test_load_into_collection_from_labelformat__ins_seg(
-    db_session: Session, images_path: str
+    db_session: Session, images_path: str, mocker: MockerFixture
 ) -> None:
+    # This test covers path normalization across backends, not file existence: the referenced
+    # paths (including remote schemes) do not exist, so treat every file as present.
+    mocker.patch.object(add_images, "_file_exists", return_value=True)
+
     class TestLabelInput(InstanceSegmentationInput):
         def __init__(self) -> None:
             self.categories = [Category(id=0, name="dog")]
@@ -350,6 +413,9 @@ def test_load_into_collection_from_coco_captions(db_session: Session, tmp_path: 
     # Create and save the coco json file containing the captions
     annotations_path = tmp_path / "annotations.json"
     _get_captions_input(annotations_path=annotations_path)
+    # The referenced images must exist on disk to be added.
+    for file_name in ("image1.jpg", "image2.jpg"):
+        PILImage.new("RGB", (640, 480)).save(str(tmp_path / file_name))
 
     _ = add_images.load_into_dataset_from_coco_captions(
         session=db_session,
@@ -383,6 +449,64 @@ def test_load_into_collection_from_coco_captions(db_session: Session, tmp_path: 
     assert samples[0].sample.captions[1].text == "Caption 2 of image 1"
     assert len(samples[1].sample.captions) == 1
     assert samples[1].sample.captions[0].text == "Caption 1 of image 2"
+
+
+def test_load_into_dataset_from_coco_captions__records_missing_already_present_added_outcomes(
+    db_session: Session, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: a captions file referencing an added / already-present / missing file mix. Each
+    # outcome gets a distinct count so a mix-up between two outcomes cannot pass the asserts.
+    # Broken is not exercised: this path never opens the file, so it cannot detect broken.
+    collection = helpers_resolvers.create_collection(db_session)
+
+    # 1 added file: referenced by the captions and present on disk.
+    added_name = "added.jpg"
+    PILImage.new("RGB", (640, 480)).save(str(tmp_path / added_name))
+
+    # 2 already-present files: only pre-inserted into the database. The already-present check
+    # short-circuits before the existence check, so these need not exist on disk.
+    already_present_names = ["present0.jpg", "present1.jpg"]
+    helpers_resolvers.create_images(
+        db_session,
+        collection.collection_id,
+        [ImageStub(path=str(tmp_path / name)) for name in already_present_names],
+    )
+
+    # 3 missing files: referenced by the captions but never created on disk.
+    missing_names = [f"missing{i}.jpg" for i in range(3)]
+
+    all_names = [added_name, *already_present_names, *missing_names]
+    coco_dict = {
+        "images": [
+            {"id": i, "file_name": name, "width": 640, "height": 480}
+            for i, name in enumerate(all_names)
+        ],
+        "annotations": [{"id": 0, "image_id": 0, "caption": "Caption of added image"}],
+    }
+    annotations_path = tmp_path / "annotations.json"
+    annotations_path.write_text(json.dumps(coco_dict))
+
+    # Act
+    with caplog.at_level("INFO", logger="lightly_studio.core.file_outcome_report"):
+        sample_ids = add_images.load_into_dataset_from_coco_captions(
+            session=db_session,
+            root_collection_id=collection.collection_id,
+            annotations_json=annotations_path,
+            images_path=tmp_path,
+        )
+
+    # Assert: only the added file becomes a new sample.
+    assert len(sample_ids) == 1
+    samples = image_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    ).samples
+    assert {sample.file_name for sample in samples} == {added_name, *already_present_names}
+
+    # Assert: the end-of-run summary records the distinct per-outcome counts.
+    assert "added=1" in caplog.text
+    assert "already_present=2" in caplog.text
+    assert "missing=3" in caplog.text
+    assert "broken=0" in caplog.text
 
 
 def test_create_batch_samples(db_session: Session) -> None:
@@ -619,6 +743,41 @@ def _get_labelformat_input_obj_det(
         categories=categories,
         images=[image],
         labels=[ImageObjectDetection(image=image, objects=objects)],
+    )
+
+
+def _get_labelformat_input_obj_det_multi(
+    filenames: list[str],
+) -> LabelformatObjectDetectionInput:
+    """Creates a LabelformatObjectDetectionInput referencing multiple images.
+
+    Args:
+        filenames: The names of the image files, one image per filename.
+
+    Returns:
+        A LabelformatObjectDetectionInput object for testing.
+    """
+    categories = [Category(id=0, name="dog")]
+    images = [
+        Image(id=i, filename=filename, width=100, height=200)
+        for i, filename in enumerate(filenames)
+    ]
+    labels = [
+        ImageObjectDetection(
+            image=image,
+            objects=[
+                SingleObjectDetection(
+                    category=categories[0],
+                    box=BoundingBox(xmin=10.0, ymin=20.0, xmax=30.0, ymax=40.0),
+                ),
+            ],
+        )
+        for image in images
+    ]
+    return LabelformatObjectDetectionInput(
+        categories=categories,
+        images=images,
+        labels=labels,
     )
 
 

--- a/lightly_studio/tests/core/image/test_add_images.py
+++ b/lightly_studio/tests/core/image/test_add_images.py
@@ -716,10 +716,27 @@ def test_tag_samples_by_directory__file_url_normalization(
 def _get_labelformat_input_obj_det(
     filename: str = "image.jpg", category_names: list[str] | None = None
 ) -> LabelformatObjectDetectionInput:
-    """Creates a LabelformatObjectDetectionInput for testing.
+    """Creates a LabelformatObjectDetectionInput referencing a single image.
 
     Args:
         filename: The name of the image file.
+        category_names: The names of the categories. Default: ["dog", "cat"].
+
+    Returns:
+        A LabelformatObjectDetectionInput object for testing.
+    """
+    return _get_labelformat_input_obj_det_multi(
+        filenames=[filename], category_names=category_names
+    )
+
+
+def _get_labelformat_input_obj_det_multi(
+    filenames: list[str], category_names: list[str] | None = None
+) -> LabelformatObjectDetectionInput:
+    """Creates a LabelformatObjectDetectionInput referencing multiple images.
+
+    Args:
+        filenames: The names of the image files, one image per filename.
         category_names: The names of the categories. Default: ["dog", "cat"].
 
     Returns:
@@ -731,33 +748,6 @@ def _get_labelformat_input_obj_det(
     categories = [
         Category(id=i, name=category_name) for i, category_name in enumerate(category_names)
     ]
-    image = Image(id=0, filename=filename, width=100, height=200)
-    objects = [
-        SingleObjectDetection(
-            category=categories[0],
-            box=BoundingBox(xmin=10.0, ymin=20.0, xmax=30.0, ymax=40.0),
-        ),
-    ]
-
-    return LabelformatObjectDetectionInput(
-        categories=categories,
-        images=[image],
-        labels=[ImageObjectDetection(image=image, objects=objects)],
-    )
-
-
-def _get_labelformat_input_obj_det_multi(
-    filenames: list[str],
-) -> LabelformatObjectDetectionInput:
-    """Creates a LabelformatObjectDetectionInput referencing multiple images.
-
-    Args:
-        filenames: The names of the image files, one image per filename.
-
-    Returns:
-        A LabelformatObjectDetectionInput object for testing.
-    """
-    categories = [Category(id=0, name="dog")]
     images = [
         Image(id=i, filename=filename, width=100, height=200)
         for i, filename in enumerate(filenames)

--- a/lightly_studio/tests/core/image/test_add_images.py
+++ b/lightly_studio/tests/core/image/test_add_images.py
@@ -725,9 +725,7 @@ def _get_labelformat_input_obj_det(
     Returns:
         A LabelformatObjectDetectionInput object for testing.
     """
-    return _get_labelformat_input_obj_det_multi(
-        filenames=[filename], category_names=category_names
-    )
+    return _get_labelformat_input_obj_det_multi(filenames=[filename], category_names=category_names)
 
 
 def _get_labelformat_input_obj_det_multi(

--- a/lightly_studio/tests/core/image/test_image_dataset__coco.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__coco.py
@@ -8,8 +8,10 @@ from typing import Any
 import pytest
 from labelformat.types import ParseError
 from PIL import Image
+from pytest_mock import MockerFixture
 
 from lightly_studio import ImageDataset
+from lightly_studio.core.image import add_images
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.annotation.object_detection import ObjectDetectionAnnotationTable
 from lightly_studio.models.collection import SampleType
@@ -362,6 +364,7 @@ class TestDataset:
         annotations_path.write_text(json.dumps(get_coco_annotation_dict_valid()))
         images_path = tmp_path / "images"
         images_path.mkdir()
+        # The annotations reference image1.jpg and image2.jpg, but only image1.jpg is on disk.
         _create_sample_images([images_path / "image1.jpg"])
 
         dataset = ImageDataset.create(name="test_dataset")
@@ -370,9 +373,9 @@ class TestDataset:
             images_path=images_path,
             annotation_type=AnnotationType.OBJECT_DETECTION,
         )
-        assert len(list(dataset)) == 2
+        # The missing image2.jpg is recorded as missing and skipped; only image1.jpg is added.
+        assert len(list(dataset)) == 1
 
-    # TODO(Jonas 9/25): This case should be revisited in the future --> should warn and assert to 0
     def test_add_samples_from_coco__non_dir(
         self,
         patch_collection: None,  # noqa: ARG002
@@ -388,7 +391,8 @@ class TestDataset:
             images_path=images_path,
             annotation_type=AnnotationType.OBJECT_DETECTION,
         )
-        assert len(list(dataset)) == 2
+        # The images directory does not exist, so every referenced file is missing and skipped.
+        assert len(list(dataset)) == 0
 
     def test_add_samples_from_coco__annotations_json_no_file(
         self,
@@ -576,9 +580,13 @@ class TestDataset:
         self,
         patch_collection: None,  # noqa: ARG002
         tmp_path: Path,
+        mocker: MockerFixture,
     ) -> None:
         annotations_path = tmp_path / "annotations.json"
         annotations_path.write_text(json.dumps(get_coco_annotation_dict_valid()))
+        # This test covers relative-path normalization, not file existence: the referenced
+        # files do not exist on disk, so treat every file as present.
+        mocker.patch.object(add_images, "_file_exists", return_value=True)
 
         dataset = ImageDataset.create(name="test_dataset")
         dataset.add_samples_from_coco(

--- a/lightly_studio/tests/core/image/test_image_dataset__coco.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__coco.py
@@ -11,6 +11,7 @@ from PIL import Image
 from pytest_mock import MockerFixture
 
 from lightly_studio import ImageDataset
+from lightly_studio.core.file_outcome_report import AllInputFilesFailedError
 from lightly_studio.core.image import add_images
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.annotation.object_detection import ObjectDetectionAnnotationTable
@@ -386,12 +387,14 @@ class TestDataset:
         images_path = tmp_path / "images"
 
         dataset = ImageDataset.create(name="test_dataset")
-        dataset.add_samples_from_coco(
-            annotations_json=annotations_path,
-            images_path=images_path,
-            annotation_type=AnnotationType.OBJECT_DETECTION,
-        )
-        # The images directory does not exist, so every referenced file is missing and skipped.
+        # The images directory does not exist, so every referenced file is missing and the
+        # run raises loudly instead of silently adding nothing.
+        with pytest.raises(AllInputFilesFailedError):
+            dataset.add_samples_from_coco(
+                annotations_json=annotations_path,
+                images_path=images_path,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            )
         assert len(list(dataset)) == 0
 
     def test_add_samples_from_coco__annotations_json_no_file(

--- a/lightly_studio/tests/core/image/test_image_dataset__labelformat.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__labelformat.py
@@ -22,11 +22,8 @@ from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.image import ImageTable
 
 
-@pytest.fixture(autouse=True)
-def _assume_referenced_files_exist(mocker: MockerFixture) -> None:
-    # These tests use synthetic image paths that do not exist on disk and cover annotation
-    # ingest, not the missing-file detection. Treat every referenced file as present so the
-    # samples are created; missing-file recording is covered in test_add_images.py.
+@pytest.fixture
+def assume_referenced_files_exist(mocker: MockerFixture) -> None:
     mocker.patch.object(add_images, "_file_exists", return_value=True)
 
 
@@ -35,6 +32,7 @@ class TestDataset:
     def test_from_labelformat(
         self,
         patch_collection: None,  # noqa: ARG002
+        assume_referenced_files_exist: None,  # noqa: ARG002
         with_confidence: bool,
     ) -> None:
         # Arrange
@@ -101,6 +99,7 @@ class TestDataset:
     def test_from_labelformat__duplication(
         self,
         patch_collection: None,  # noqa: ARG002
+        assume_referenced_files_exist: None,  # noqa: ARG002
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         # Arrange
@@ -142,6 +141,7 @@ class TestDataset:
     def test_from_labelformat__annotations_synced_images(
         self,
         patch_collection: None,  # noqa: ARG002
+        assume_referenced_files_exist: None,  # noqa: ARG002
     ) -> None:
         # This test is to ensure that the images and annotations stay in sync while loading.
         # In the past, the image file paths got processed separately causing non matching pairs
@@ -175,6 +175,7 @@ class TestDataset:
     def test_from_labelformat__limit(
         self,
         patch_collection: None,  # noqa: ARG002
+        assume_referenced_files_exist: None,  # noqa: ARG002
     ) -> None:
         label_input = _get_input_multi()  # two images
 
@@ -204,6 +205,7 @@ class TestDataset:
     def test_from_labelformat__dont_embed(
         self,
         patch_collection: None,  # noqa: ARG002
+        assume_referenced_files_exist: None,  # noqa: ARG002
     ) -> None:
         dataset_name = "test_dataset"
         image_folder_path = "/fake/path/images"

--- a/lightly_studio/tests/core/image/test_image_dataset__labelformat.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__labelformat.py
@@ -12,12 +12,22 @@ from labelformat.model.object_detection import (
     ImageObjectDetection,
     SingleObjectDetection,
 )
+from pytest_mock import MockerFixture
 from sqlmodel import select
 
 from lightly_studio import ImageDataset
+from lightly_studio.core.image import add_images
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.image import ImageTable
+
+
+@pytest.fixture(autouse=True)
+def _assume_referenced_files_exist(mocker: MockerFixture) -> None:
+    # These tests use synthetic image paths that do not exist on disk and cover annotation
+    # ingest, not the missing-file detection. Treat every referenced file as present so the
+    # samples are created; missing-file recording is covered in test_add_images.py.
+    mocker.patch.object(add_images, "_file_exists", return_value=True)
 
 
 class TestDataset:


### PR DESCRIPTION
## What & why

Wires the metadata-only image ingest paths into the per-run `FileOutcomeReport`, so ingesting from annotations records one outcome per image and contributes to the same end-of-run summary as folder ingest (LIG-10031, part of LIG-9953).

These paths derive image dimensions from annotation metadata and **never open the file**, so they cannot detect a *broken* file — that is correctly deferred to the embedding step. What they can now record consistently:

- **missing** — referenced path does not resolve (detected proactively via `fs.exists()`, since `FileNotFoundError` is unreliable across fsspec backends).
- **already-present** — from the existing path-dedup.
- **added** — for the rest.

Previously, missing-referenced images were silently added as samples.

## Changes

- `load_into_dataset_from_labelformat`: add missing detection.
- `load_into_dataset_from_coco_captions`: add missing detection; extract `_group_captions_by_image_id` to keep complexity within limits.
- `load_into_dataset_from_paths`: reuse the new shared `_file_exists` helper.
- Drop the redundant path argument from the tolerated `InputFileError` signals — `FileOutcomeReport.track` already records with its own path.

## Tests

- New missing + already-present + added coverage for **labelformat** and **COCO-caption** ingest.
- `coco images_missing` (2→1) and `non_dir` (2→0) now assert the corrected missing behavior (the latter matching its long-standing TODO).
- Path-normalization tests that use synthetic/remote paths mock `_file_exists`; `test_load_into_collection_from_coco_captions` now creates the referenced files on disk.

## Validation

- Full backend suite: **1583 passed, 32 skipped**. (Two modules excluded due to a pre-existing missing optional `s3fs` dependency, unrelated to this change.)
- `ruff` lint + format and `mypy` clean.

## Note for reviewers

`_group_captions_by_image_id` was extracted solely to keep `load_into_dataset_from_coco_captions` under Ruff's C901 complexity limit after adding the existence check; happy to switch to a `# noqa` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label-format and COCO-caption image ingestion to more reliably detect missing referenced image files and prevent invalid samples.
  * Added clearer error handling when image files can’t be read (e.g., broken headers).
  * Enhanced COCO caption ingestion to group captions per image based on annotation data.
  * More consistent handling of relative image paths during loading.

* **Tests**
  * Expanded scenarios covering added / already present / missing outcomes and updated expectations.
  * Updated tests to mock filesystem checks and create referenced image files where required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->