### PR TITLE
Fast Track: Add Guardrails CI entry + workflow (judges only)

### DIFF
--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -1,0 +1,55 @@
+name: Fast Track Guardrails
+
+# The judging half: run guardrails on each non-draft PR and publish the verdict as
+# an artifact for the bot. Read-only, takes no action (design §2). Must NOT be a
+# required status check — requiring it would block every non-fast-track PR.
+on:
+  pull_request:
+    # labeled/unlabeled so toggling the opt-out label re-evaluates.
+    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+
+# Judge only the latest push per PR ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guardrails:
+    name: Fast Track Guardrails
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: fast_track
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      # Pin Node from .nvmrc, matching the local Makefile's nvm setup.
+      - name: Set Up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: fast_track/.nvmrc
+          cache: npm
+          cache-dependency-path: fast_track/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Writes fast_track/verdict.json. Non-zero exit = the run crashed, not a fail verdict.
+      - name: Run Fast Track Guardrails
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npm run guardrails-ci
+
+      # JS action, so defaults.run.working-directory doesn't apply — path is repo-root-relative.
+      - name: Upload verdict
+        uses: actions/upload-artifact@v4
+        with:
+          name: fast-track-verdict
+          path: fast_track/verdict.json
+          if-no-files-found: error

--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -1,8 +1,7 @@
 name: Fast Track Guardrails
 
-# The judging half: run guardrails on each non-draft PR and publish the verdict as
-# an artifact for the bot. Read-only, takes no action (design §2). Must NOT be a
-# required status check — requiring it would block every non-fast-track PR.
+# Run Fast Track guardrails on each non-draft PR and publish the verdict as
+# an artifact for the bot. NOT a required status check — else would block every non-fast-track PR.
 on:
   pull_request:
     # labeled/unlabeled so toggling the opt-out label re-evaluates.
@@ -28,6 +27,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+        # Runs untrusted PR code and never pushes — keep the token out of git config.
+        with:
+          persist-credentials: false
 
       # Pin Node from .nvmrc, matching the local Makefile's nvm setup.
       - name: Set Up Node

--- a/fast_track/.gitignore
+++ b/fast_track/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 *.tsbuildinfo
+
+# Verdict artifact written by the CI entry (src/guardrails/ci.ts).
+verdict.json

--- a/fast_track/README.md
+++ b/fast_track/README.md
@@ -2,16 +2,19 @@
 
 TypeScript package for the Fast Track Bot: **guardrails** that judge a PR and
 produce a machine-readable verdict, and a **bot** that acts on that verdict. Two
-thin GitHub workflows will launch it (added in later PRs).
+thin GitHub workflows launch it.
 
 Runs via [`tsx`](https://tsx.is/) — no build step, no compiled artifact.
 
-> **Status:** early scaffolding. The verdict contract, the guardrail framework
-> (context types, an always-pass dummy guardrail, the registry + selector), the
-> runner, the local git-backed context provider, and the API-backed context
-> provider are in place with unit tests — `make run-guardrails` runs the
-> guardrails against your branch's committed changes. The bot and the two
-> workflows land in subsequent, independently reviewable PRs.
+> **Status:** the judging half is live. The verdict contract, the guardrail
+> framework (context types, an always-pass dummy guardrail, the registry +
+> selector), the runner, and both context providers (local git + CI API) are in
+> place with unit tests. The **Fast Track Guardrails** workflow
+> (`.github/workflows/fast_track_guardrails.yml`) runs on every non-draft PR: its
+> CI entry (`src/guardrails/ci.ts`) judges the PR via the read-only GitHub API
+> and uploads a `verdict.json` artifact. Locally, `make run-guardrails` runs the
+> guardrails against your branch's committed changes. The bot (which reads the
+> verdict and approves) lands in subsequent, independently reviewable PRs.
 
 ## Local commands
 

--- a/fast_track/package.json
+++ b/fast_track/package.json
@@ -13,7 +13,8 @@
         "static-checks": "npm run lint && npm run check",
         "test": "vitest run",
         "guardrails": "tsx src/guardrails/cli.ts",
-        "list-guardrails": "tsx src/guardrails/cli.ts --list"
+        "list-guardrails": "tsx src/guardrails/cli.ts --list",
+        "guardrails-ci": "tsx src/guardrails/ci.ts"
     },
     "dependencies": {
         "@actions/github": "^6.0.1",

--- a/fast_track/src/guardrails/build-verdict.test.ts
+++ b/fast_track/src/guardrails/build-verdict.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RunResult } from './run-guardrails';
+import { buildVerdict } from './build-verdict';
+
+const routing = { prNumber: 42, headSha: 'deadbeef' };
+
+describe('buildVerdict', () => {
+    it('carries the status, breakdown, and routing on a pass — no reason', () => {
+        const run: RunResult = {
+            status: 'pass',
+            guardrails: [{ name: 'dummy', status: 'pass', summary: 'ok' }]
+        };
+
+        expect(buildVerdict(run, routing)).toEqual({
+            verdict: 'pass',
+            guardrails: [{ name: 'dummy', status: 'pass', summary: 'ok' }],
+            pr_number: 42,
+            head_sha: 'deadbeef'
+        });
+    });
+
+    it('names every failing guardrail on a fail, joined, excluding the passing ones', () => {
+        const run: RunResult = {
+            status: 'fail',
+            guardrails: [
+                { name: 'diff-size', status: 'fail', summary: 'too big' },
+                { name: 'passing', status: 'pass', summary: 'ok' },
+                { name: 'coverage', status: 'fail', summary: 'dropped 3%' }
+            ]
+        };
+
+        const verdict = buildVerdict(run, routing);
+        expect(verdict.verdict).toBe('fail');
+        expect(verdict.reason).toBe(
+            'Failed guardrails: diff-size (too big), coverage (dropped 3%)'
+        );
+    });
+
+    it('falls back to a generic reason if a fail reports no failing guardrail', () => {
+        const run: RunResult = { status: 'fail', guardrails: [] };
+        expect(buildVerdict(run, routing).reason).toBe(
+            'One or more required guardrails did not pass.'
+        );
+    });
+});

--- a/fast_track/src/guardrails/build-verdict.ts
+++ b/fast_track/src/guardrails/build-verdict.ts
@@ -1,0 +1,33 @@
+import type { GuardrailResult, Verdict } from '../shared/verdict';
+import type { RunResult } from './run-guardrails';
+
+/** UNTRUSTED: written in PR context, re-derived by the bot against the trusted commit (design §3). */
+export interface VerdictRouting {
+    prNumber: number;
+    headSha: string;
+}
+
+/**
+ * Wrap a {@link RunResult} into the wire {@link Verdict}, adding the routing
+ * fields and a {@link reason} for the PR comment on a non-pass. `opt_out` is
+ * never produced here — it's an author-label override the bot applies (design §2.3).
+ */
+export function buildVerdict(run: RunResult, routing: VerdictRouting): Verdict {
+    const verdict: Verdict = {
+        verdict: run.status,
+        guardrails: run.guardrails,
+        pr_number: routing.prNumber,
+        head_sha: routing.headSha
+    };
+    if (run.status !== 'pass') {
+        verdict.reason = buildReason(run.guardrails);
+    }
+    return verdict;
+}
+
+function buildReason(guardrails: GuardrailResult[]): string {
+    const failed = guardrails.filter((g) => g.status === 'fail');
+    // A `fail` implies a failing guardrail, but never emit an empty reason if not.
+    if (failed.length === 0) return 'One or more required guardrails did not pass.';
+    return `Failed guardrails: ${failed.map((g) => `${g.name} (${g.summary})`).join(', ')}`;
+}

--- a/fast_track/src/guardrails/ci.ts
+++ b/fast_track/src/guardrails/ci.ts
@@ -1,0 +1,67 @@
+import { writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import { context, getOctokit } from '@actions/github';
+
+import { ApiGuardrailContext } from './context/api-context';
+import { buildVerdict } from './build-verdict';
+import { guardrails, selectGuardrails } from './registry';
+import { runGuardrails } from './run-guardrails';
+
+// CI entry: runs the guardrails in a PR workflow. Mirrors the local cli.ts but
+// swaps git for the read-only GitHub API; it only judges, and writes the verdict
+// to a file the bot later consumes (design §2.2). Never holds a write token, never acts.
+
+// cwd-relative, so it lands at fast_track/verdict.json (the workflow's upload path).
+const VERDICT_PATH = 'verdict.json';
+
+interface PullRequestEvent {
+    number: number;
+    head: { sha: string };
+    base: { ref: string };
+}
+
+function readPullRequest(): PullRequestEvent {
+    const pr = context.payload.pull_request;
+    if (pr === undefined) {
+        throw new Error('No pull_request in the event payload.');
+    }
+    return pr as PullRequestEvent;
+}
+
+async function main(env: NodeJS.ProcessEnv): Promise<void> {
+    // Via env, not core.getInput: a `run:` step has no `with:` to feed it.
+    const token = env.GITHUB_TOKEN;
+    if (token === undefined || token === '') throw new Error('GITHUB_TOKEN is not set.');
+
+    const pr = readPullRequest();
+    const octokit = getOctokit(token);
+
+    // Base ref from the event, so stacked / non-main bases diff correctly.
+    const guardrailContext = new ApiGuardrailContext({
+        octokit,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        prNumber: pr.number,
+        baseRef: pr.base.ref
+    });
+
+    // hasPrContext: true — unlike the local CLI, pr-only guardrails run here.
+    const selected = selectGuardrails(guardrails, { hasPrContext: true });
+    const run = await runGuardrails(guardrailContext, selected);
+    const verdict = buildVerdict(run, { prNumber: pr.number, headSha: pr.head.sha });
+
+    await writeFile(VERDICT_PATH, `${JSON.stringify(verdict, null, 2)}\n`);
+    console.log(
+        `Verdict: ${verdict.verdict} (${verdict.guardrails.length} guardrail(s)) → ${VERDICT_PATH}`
+    );
+}
+
+// Only a crash exits non-zero. A `fail` verdict returns cleanly, so it publishes
+// as an artifact instead of a broken run masquerading as a passing verdict.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main(process.env).catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });
+}

--- a/fast_track/src/shared/verdict.ts
+++ b/fast_track/src/shared/verdict.ts
@@ -1,7 +1,7 @@
 /**
- * The verdict contract between Fast Track Checks and the Fast Track Bot: Checks
- * serializes a {@link Verdict} to JSON, the Bot reads it back. This JSON is the
- * wire format, so field names are snake_case with no serialization layer.
+ * The verdict contract between the Fast Track Guardrails and the Fast Track Bot:
+ * the Guardrails serialize a {@link Verdict} to JSON, the Bot reads it back. This
+ * JSON is the wire format, so field names are snake_case with no serialization layer.
  */
 
 export type GuardrailStatus = 'pass' | 'fail';


### PR DESCRIPTION
## What has changed and why?

Run Fast Track Guardrails in CI.

The output `verdict.json` is produced but not read yet.

## How has it been tested?

- New tests
- Ran Ci on this branch, inspected verdict.json.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Fast Track Guardrails” workflow that runs on every non-draft pull request and re-runs when labels change.
  * Added CI that generates a per-run verdict artifact for downstream bot use.
  * Updated guardrails verdict generation to include PR routing info and PR-aware context.
* **Bug Fixes**
  * Improved verdict reason reporting to list only failing guardrails.
  * Added a generic failure message when no specific failures are available.
* **Tests**
  * Added unit tests for verdict construction.
* **Documentation**
  * Refreshed the status description to reflect the live judging flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->