### PR TITLE
Add backend complexity guardrail

### DIFF
--- a/fast_track/src/guardrails/backend/complexity.test.ts
+++ b/fast_track/src/guardrails/backend/complexity.test.ts
@@ -1,0 +1,80 @@
+import { vi, describe, expect, it } from 'vitest';
+import { resolve } from 'node:path';
+import type { ChildProcess } from 'node:child_process';
+import type { GuardrailContext } from '../context/types';
+import { backendComplexityGuardrail } from './complexity';
+import { REPO_ROOT } from './shared';
+
+type PromisifyCb = (error: Error | null, result?: { stdout: string }) => void;
+
+vi.mock('node:child_process', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:child_process')>();
+    return { ...actual, execFile: vi.fn() };
+});
+
+vi.mock('node:fs', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:fs')>();
+    return { ...actual, existsSync: vi.fn().mockReturnValue(true) };
+});
+
+const { execFile } = await import('node:child_process');
+const { existsSync } = await import('node:fs');
+
+const backendFile = { path: 'lightly_studio/src/model.py', additions: 5, deletions: 0 };
+
+function makeCtx(files = [backendFile]): GuardrailContext {
+    return { baseRef: 'origin/main', changedFiles: async () => files };
+}
+
+describe('backendComplexityGuardrail', () => {
+    it('is required and runs locally', () => {
+        expect(backendComplexityGuardrail.required).toBe(true);
+        expect(backendComplexityGuardrail.needsPrContext).toBe(false);
+    });
+
+    it('passes immediately when no backend files changed', async () => {
+        const result = await backendComplexityGuardrail.run(
+            makeCtx([{ path: 'lightly_studio_view/src/foo.ts', additions: 5, deletions: 0 }])
+        );
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('0 file(s)');
+    });
+
+    it('passes when ruff reports no violations', async () => {
+        vi.mocked(execFile).mockImplementationOnce((_cmd, _args, _opts, cb) => {
+            (cb as unknown as PromisifyCb)(null, { stdout: '[]' });
+            return undefined as unknown as ChildProcess;
+        });
+        const result = await backendComplexityGuardrail.run(makeCtx());
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('1 file(s) checked, no violations');
+    });
+
+    it('fails when ruff reports a C901 violation', async () => {
+        const ruffOutput = JSON.stringify([
+            {
+                code: 'C901',
+                filename: resolve(REPO_ROOT, 'lightly_studio/src/model.py'),
+                message: 'Function `foo` is too complex (11 > 10)',
+                location: { row: 42, column: 0 }
+            }
+        ]);
+        const err = Object.assign(new Error(), { code: 1, stdout: ruffOutput });
+        vi.mocked(execFile).mockImplementationOnce((_cmd, _args, _opts, cb) => {
+            (cb as unknown as PromisifyCb)(err);
+            return undefined as unknown as ChildProcess;
+        });
+        const result = await backendComplexityGuardrail.run(makeCtx());
+        expect(result.status).toBe('fail');
+        expect(result.summary).toContain(
+            'lightly_studio/src/model.py:42 — Function `foo` is too complex (11 > 10)'
+        );
+    });
+
+    it('passes for a deleted backend file (does not exist on disk)', async () => {
+        vi.mocked(existsSync).mockReturnValueOnce(false);
+        const result = await backendComplexityGuardrail.run(makeCtx());
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('deleted');
+    });
+});

--- a/fast_track/src/guardrails/backend/complexity.test.ts
+++ b/fast_track/src/guardrails/backend/complexity.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, expect, it } from 'vitest';
 import { resolve } from 'node:path';
 import type { ChildProcess } from 'node:child_process';
-import type { GuardrailContext } from '../context/types';
+import type { ChangedFile, GuardrailContext } from '../context/types';
 import { backendComplexityGuardrail } from './complexity';
 import { REPO_ROOT } from './shared';
 
@@ -20,9 +20,14 @@ vi.mock('node:fs', async (importOriginal) => {
 const { execFile } = await import('node:child_process');
 const { existsSync } = await import('node:fs');
 
-const backendFile = { path: 'lightly_studio/src/model.py', additions: 5, deletions: 0 };
+const backendFile: ChangedFile = {
+    path: 'lightly_studio/src/model.py',
+    status: 'modified',
+    additions: 5,
+    deletions: 0
+};
 
-function makeCtx(files = [backendFile]): GuardrailContext {
+function makeCtx(files: ChangedFile[] = [backendFile]): GuardrailContext {
     return { baseRef: 'origin/main', changedFiles: async () => files };
 }
 
@@ -34,7 +39,14 @@ describe('backendComplexityGuardrail', () => {
 
     it('passes immediately when no backend files changed', async () => {
         const result = await backendComplexityGuardrail.run(
-            makeCtx([{ path: 'lightly_studio_view/src/foo.ts', additions: 5, deletions: 0 }])
+            makeCtx([
+                {
+                    path: 'lightly_studio_view/src/foo.ts',
+                    status: 'modified',
+                    additions: 5,
+                    deletions: 0
+                }
+            ])
         );
         expect(result.status).toBe('pass');
         expect(result.summary).toContain('0 file(s)');

--- a/fast_track/src/guardrails/backend/complexity.ts
+++ b/fast_track/src/guardrails/backend/complexity.ts
@@ -1,0 +1,75 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import type { Guardrail, GuardrailContext, GuardrailOutcome } from '../context/types';
+import { REPO_ROOT, RUFF_BIN } from './shared';
+import { extractStdoutOrThrow } from '../shared/utils';
+
+const execFileAsync = promisify(execFile);
+const BACKEND_PREFIX = 'lightly_studio/';
+const NAME = 'backend/complexity';
+const COMPLEXITY_RULE = 'C901';
+
+interface RuffViolation {
+    code: string;
+    filename: string;
+    message: string;
+    location: { row: number; column: number };
+}
+
+async function runLinter(paths: string[]): Promise<RuffViolation[]> {
+    let stdout: string;
+    try {
+        const result = await execFileAsync(
+            RUFF_BIN,
+            ['check', '--select', COMPLEXITY_RULE, '--output-format', 'json', ...paths],
+            { cwd: REPO_ROOT }
+        );
+        stdout = result.stdout;
+    } catch (err: unknown) {
+        // Ruff exits 1 when violations are found; stdout still contains valid JSON.
+        stdout = extractStdoutOrThrow(err);
+    }
+    if (!stdout.trim()) return [];
+    return JSON.parse(stdout) as RuffViolation[];
+}
+
+export const backendComplexityGuardrail: Guardrail = {
+    name: NAME,
+    required: true,
+    needsPrContext: false,
+    async run(ctx: GuardrailContext): Promise<GuardrailOutcome> {
+        const files = (await ctx.changedFiles()).filter(
+            (f) => f.path.startsWith(BACKEND_PREFIX) && f.path.endsWith('.py')
+        );
+
+        if (files.length === 0) {
+            return { status: 'pass', summary: '0 file(s) checked.' };
+        }
+
+        // Exclude deleted files — they no longer exist on disk and cannot be linted.
+        const existingFiles = files.filter((f) => existsSync(resolve(REPO_ROOT, f.path)));
+
+        if (existingFiles.length === 0) {
+            return {
+                status: 'pass',
+                summary: 'All changed backend files were deleted.'
+            };
+        }
+
+        const violations = (await runLinter(existingFiles.map((f) => f.path))).map(
+            (entry) =>
+                `${relative(REPO_ROOT, entry.filename)}:${entry.location.row} — ${entry.message}`
+        );
+
+        if (violations.length === 0) {
+            return {
+                status: 'pass',
+                summary: `${existingFiles.length} file(s) checked, no violations.`
+            };
+        }
+
+        return { status: 'fail', summary: violations.join('\n') };
+    }
+};

--- a/fast_track/src/guardrails/backend/complexity.ts
+++ b/fast_track/src/guardrails/backend/complexity.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import type { Guardrail, GuardrailContext, GuardrailOutcome } from '../context/types';
-import { REPO_ROOT, RUFF_BIN } from './shared';
+import { REPO_ROOT, BACKEND_DIR } from './shared';
 import { extractStdoutOrThrow } from '../shared/utils';
 
 const execFileAsync = promisify(execFile);
@@ -22,9 +22,18 @@ async function runLinter(paths: string[]): Promise<RuffViolation[]> {
     let stdout: string;
     try {
         const result = await execFileAsync(
-            RUFF_BIN,
-            ['check', '--select', COMPLEXITY_RULE, '--output-format', 'json', ...paths],
-            { cwd: REPO_ROOT }
+            'uv',
+            [
+                'run',
+                'ruff',
+                'check',
+                '--select',
+                COMPLEXITY_RULE,
+                '--output-format',
+                'json',
+                ...paths
+            ],
+            { cwd: BACKEND_DIR }
         );
         stdout = result.stdout;
     } catch (err: unknown) {
@@ -58,7 +67,9 @@ export const backendComplexityGuardrail: Guardrail = {
             };
         }
 
-        const violations = (await runLinter(existingFiles.map((f) => f.path))).map(
+        const violations = (
+            await runLinter(existingFiles.map((f) => resolve(REPO_ROOT, f.path)))
+        ).map(
             (entry) =>
                 `${relative(REPO_ROOT, entry.filename)}:${entry.location.row} — ${entry.message}`
         );

--- a/fast_track/src/guardrails/backend/complexity.ts
+++ b/fast_track/src/guardrails/backend/complexity.ts
@@ -10,6 +10,8 @@ const execFileAsync = promisify(execFile);
 const BACKEND_PREFIX = 'lightly_studio/';
 const NAME = 'backend/complexity';
 const COMPLEXITY_RULE = 'C901';
+const LINTER_TIMEOUT_MS = 60_000;
+const LINTER_MAX_BUFFER = 10 * 1024 * 1024;
 
 interface RuffViolation {
     code: string;
@@ -33,7 +35,7 @@ async function runLinter(paths: string[]): Promise<RuffViolation[]> {
                 'json',
                 ...paths
             ],
-            { cwd: BACKEND_DIR }
+            { cwd: BACKEND_DIR, timeout: LINTER_TIMEOUT_MS, maxBuffer: LINTER_MAX_BUFFER }
         );
         stdout = result.stdout;
     } catch (err: unknown) {

--- a/fast_track/src/guardrails/backend/shared.ts
+++ b/fast_track/src/guardrails/backend/shared.ts
@@ -5,5 +5,3 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // fast_track/src/guardrails/backend -> fast_track/src/guardrails -> fast_track -> repo root
 export const REPO_ROOT = resolve(__dirname, '../../../..');
 export const BACKEND_DIR = resolve(REPO_ROOT, 'lightly_studio');
-// Resolve ruff from the backend venv so it works regardless of the shell PATH.
-export const RUFF_BIN = resolve(BACKEND_DIR, '.venv/bin/ruff');

--- a/fast_track/src/guardrails/backend/shared.ts
+++ b/fast_track/src/guardrails/backend/shared.ts
@@ -1,0 +1,9 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// fast_track/src/guardrails/backend -> fast_track/src/guardrails -> fast_track -> repo root
+export const REPO_ROOT = resolve(__dirname, '../../../..');
+export const BACKEND_DIR = resolve(REPO_ROOT, 'lightly_studio');
+// Resolve ruff from the backend venv so it works regardless of the shell PATH.
+export const RUFF_BIN = resolve(BACKEND_DIR, '.venv/bin/ruff');

--- a/fast_track/src/guardrails/registry.ts
+++ b/fast_track/src/guardrails/registry.ts
@@ -1,8 +1,9 @@
 import type { Guardrail } from './context/types';
 import { dummyGuardrail } from './dummy';
+import { backendComplexityGuardrail } from './backend/complexity';
 
 /** The guardrail registry. */
-export const guardrails: Guardrail[] = [dummyGuardrail];
+export const guardrails: Guardrail[] = [dummyGuardrail, backendComplexityGuardrail];
 
 export interface SelectOptions {
     /** False locally, true in CI. */

--- a/fast_track/src/guardrails/registry.ts
+++ b/fast_track/src/guardrails/registry.ts
@@ -4,7 +4,11 @@ import { backendComplexityGuardrail } from './backend/complexity';
 import { frontendComplexityGuardrail } from './frontend/complexity';
 
 /** The guardrail registry. */
-export const guardrails: Guardrail[] = [dummyGuardrail, frontendComplexityGuardrail, backendComplexityGuardrail];
+export const guardrails: Guardrail[] = [
+    dummyGuardrail,
+    frontendComplexityGuardrail,
+    backendComplexityGuardrail
+];
 
 export interface SelectOptions {
     /** False locally, true in CI. */

--- a/fast_track/src/guardrails/shared/utils.test.ts
+++ b/fast_track/src/guardrails/shared/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { extractStdoutOrThrow } from './utils';
+
+describe('extractStdoutOrThrow', () => {
+    it('returns stdout when error has code 1 and string stdout', () => {
+        const err = Object.assign(new Error(), { code: 1, stdout: 'output text' });
+        expect(extractStdoutOrThrow(err)).toBe('output text');
+    });
+
+    it('re-throws when exit code is not 1', () => {
+        const err = Object.assign(new Error('bad'), { code: 2, stdout: 'output' });
+        expect(() => extractStdoutOrThrow(err)).toThrow(err);
+    });
+
+    it('re-throws when stdout is not a string', () => {
+        const err = Object.assign(new Error(), { code: 1, stdout: 42 });
+        expect(() => extractStdoutOrThrow(err)).toThrow(err);
+    });
+
+    it('re-throws when stdout is missing', () => {
+        const err = Object.assign(new Error(), { code: 1 });
+        expect(() => extractStdoutOrThrow(err)).toThrow(err);
+    });
+
+    it('re-throws a plain string error', () => {
+        expect(() => extractStdoutOrThrow('oops')).toThrow('oops');
+    });
+
+    it('re-throws null', () => {
+        expect(() => extractStdoutOrThrow(null)).toThrow();
+    });
+});

--- a/fast_track/src/guardrails/shared/utils.ts
+++ b/fast_track/src/guardrails/shared/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Extracts stdout from a process error when the exit code is 1.
+ * Some linters (e.g. Ruff) exit with code 1 when violations are found,
+ * but still write valid output to stdout.
+ * Returns the stdout string if the error matches, otherwise re-throws.
+ */
+export function extractStdoutOrThrow(err: unknown): string {
+    if (
+        err !== null &&
+        typeof err === 'object' &&
+        'code' in err &&
+        (err as { code: unknown }).code === 1 &&
+        'stdout' in err &&
+        typeof (err as { stdout: unknown }).stdout === 'string'
+    ) {
+        return (err as { stdout: string }).stdout;
+    }
+    throw err;
+}


### PR DESCRIPTION
## What has changed and why?

Adds a backendComplexityGuardrail that runs Ruff's C901 rule against changed Python files under lightly_studio/, and registered it in the guardrail registry.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a backend complexity guardrail that checks changed Python files for Ruff cyclomatic complexity (C901).
  * Included the new guardrail in the automatically run checks.
  * Improved backend path resolution for locating sources.
* **Bug Fixes**
  * Avoided false failures when targeted backend files are deleted.
  * Continued to collect/report violations even when Ruff exits non-zero.
* **Tests**
  * Added unit tests covering guardrail metadata, pass/fail cases (including deleted files), and violation formatting.
  * Added unit tests for the stdout/error extraction utility used by the guardrail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->