### PR TITLE
Add VideoFrameSample.parent_video (read parent-video fields from a frame)

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import Generic, cast
 
+from sqlalchemy.orm import joinedload
 from sqlmodel import Session, col, select
 from sqlmodel.sql.expression import SelectOfScalar
 from typing_extensions import Self, TypeVar
@@ -287,6 +288,9 @@ class DatasetQuery(Generic[T]):
                 select(VideoFrameTable)
                 .join(VideoFrameTable.sample)
                 .where(SampleTable.collection_id == self.dataset.collection_id)
+                # Eager-load the parent video so VideoFrameSample.parent_video does not
+                # trigger a query per frame (many-to-one, so no row multiplication).
+                .options(joinedload(VideoFrameTable.video))
             )
             video_frame_query = self._compose_query(video_frame_query)
             for video_frame_table in self.session.exec(video_frame_query):

--- a/lightly_studio/src/lightly_studio/core/video/video_frame_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/video/video_frame_dataset.py
@@ -24,7 +24,7 @@ class VideoFrameDataset(Dataset[VideoFrameSample]):
     frames = VideoDataset.load("my_dataset").frames()
     first_ten_frames = frames[:10]
     for frame in frames:
-        print(frame.frame_number, frame.frame_timestamp_s)
+        print(frame.frame_number, frame.parent_video.file_name)
     ```
 
     For filtering or ordering frames first, use the query interface:

--- a/lightly_studio/src/lightly_studio/core/video/video_frame_sample.py
+++ b/lightly_studio/src/lightly_studio/core/video/video_frame_sample.py
@@ -4,6 +4,7 @@ from sqlmodel import col
 
 from lightly_studio.core.db_field import DBField
 from lightly_studio.core.sample import Sample
+from lightly_studio.core.video.video_sample import VideoSample
 from lightly_studio.models.video import VideoFrameTable
 
 
@@ -14,6 +15,11 @@ class VideoFrameSample(Sample):
     ```python
     print(f"Frame number: {sample.frame_number}")
     print(f"Frame timestamp (seconds): {sample.frame_timestamp_s}")
+    ```
+
+    The parent video is accessible as a `VideoSample` via the `parent_video` property:
+    ```python
+    print(f"Parent video file path: {sample.parent_video.file_path_abs}")
     ```
     """
 
@@ -34,3 +40,8 @@ class VideoFrameSample(Sample):
         """
         self.inner = inner
         super().__init__(sample_table=inner.sample)
+
+    @property
+    def parent_video(self) -> VideoSample:
+        """The parent video this frame belongs to."""
+        return VideoSample(inner=self.inner.video)

--- a/lightly_studio/src/lightly_studio/examples/example_video_frames.py
+++ b/lightly_studio/src/lightly_studio/examples/example_video_frames.py
@@ -2,7 +2,8 @@
 
 It opens a video dataset, queries its frames by frame-level fields, tags the matches,
 runs a sampling strategy on the query, and exports the sampled frames as
-`(frame_number, frame_timestamp_s)` rows to a CSV file.
+`(video_path_abs, frame_number)` rows to a CSV file (the video path comes from each
+frame's parent video).
 """
 
 from __future__ import annotations
@@ -50,13 +51,14 @@ frames.match(VideoFrameSampleField.frame_number > 1).sampling().metadata_weighti
 )
 print("\nSampled the 5 frames with the highest metadata.score value.")
 
-# Export the sampled frames as (frame_number, frame_timestamp_s) rows to a CSV file.
+# Export the sampled frames as (video_path_abs, frame_number) rows to a CSV file.
+# The video path is read from each frame's parent video.
 out_csv = Path(tempfile.gettempdir()) / "sampled_video_frames.csv"
 with out_csv.open("w", newline="") as fh:
     writer = csv.writer(fh)
-    writer.writerow(["frame_number", "frame_timestamp_s"])
+    writer.writerow(["video_path_abs", "frame_number"])
     for frame in frames.match(VideoFrameSampleField.tags.contains("sampled")):
-        writer.writerow([frame.frame_number, frame.frame_timestamp_s])
+        writer.writerow([frame.parent_video.file_path_abs, frame.frame_number])
 
 print(f"\nExported sampled frames to {out_csv}")
 print(f"First 3 lines: {list(out_csv.read_text().splitlines())[:3]}")

--- a/lightly_studio/tests/core/video/test_video_frame_dataset.py
+++ b/lightly_studio/tests/core/video/test_video_frame_dataset.py
@@ -71,6 +71,8 @@ class TestVideoFrameDataset:
         dataset = VideoDataset.create(name="real_dataset")
         dataset.add_videos_from_path(path=tmp_path, embed=False)
 
-        frame_numbers = [frame.frame_number for frame in dataset.frames()]
-        assert len(frame_numbers) > 0
+        frame_list = list(dataset.frames())
+        assert len(frame_list) > 0
+        frame_numbers = [frame.frame_number for frame in frame_list]
         assert frame_numbers == sorted(frame_numbers)
+        assert all(frame.parent_video.file_name == "vid.mp4" for frame in frame_list)

--- a/lightly_studio/tests/core/video/test_video_frame_sample.py
+++ b/lightly_studio/tests/core/video/test_video_frame_sample.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from lightly_studio.core.video.video_dataset import VideoDataset
+from lightly_studio.core.video.video_sample import VideoSample
 from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
 
 
@@ -24,3 +25,22 @@ class TestVideoFrameSample:
         assert frame.frame_timestamp_s == pytest.approx(1 / 3.0)
         assert frame.frame_timestamp_pts == 1
         assert frame.rotation_deg == 0
+
+    def test_parent_video(
+        self,
+        patch_collection: None,  # noqa: ARG002
+    ) -> None:
+        dataset = VideoDataset.create(name="test_dataset")
+        result = create_video_with_frames(
+            session=dataset.session,
+            collection_id=dataset.collection_id,
+            video=VideoStub(path="/data/a.mp4", width=640, height=480, duration_s=1.0, fps=3.0),
+        )
+
+        frame = dataset.frames().get_sample(result.frame_sample_ids[1])
+
+        parent = frame.parent_video
+        assert isinstance(parent, VideoSample)
+        assert parent.file_path_abs == "/data/a.mp4"
+        assert parent.width == 640
+        assert parent.height == 480


### PR DESCRIPTION
## What has changed and why?

Adds runtime read access to a video frame's parent video. 

Query-side filtering of frames by parent-video fields will be done in a follow-up PR.

## How was it tested

new unittests, updated example script. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Video frame samples can now access their parent video details directly.
  * The sampled video-frames export now includes the source video path alongside the frame number.

* **Performance**
  * Improved iteration efficiency by eager-loading parent video data for video-frame queries.

* **Documentation**
  * Updated example output and CSV column semantics to match the new parent-video access and export format.

* **Tests**
  * Added/adjusted assertions to validate parent video associations in dataset and sample tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->