### PR TITLE
Fix AnnotationMetricQuery.confusion()

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from sqlalchemy import ColumnElement, exists
 from sqlalchemy.orm import aliased
@@ -81,22 +81,21 @@ class AnnotationMetricQuery(MatchExpression):
             .where(col(EvaluationRunTable.dataset_id) == sample_dataset_id)
             .where(col(EvaluationRunTable.name) == self.run_name)
         )
-        if not self.criteria:
-            return exists(subquery.where(self._matching_metric_exists_expression()))
+        return exists(subquery.where(self._matching_metric_exists_expression()))
 
-        for criterion in self.criteria:
-            subquery = subquery.where(self._matching_metric_exists_expression(criterion))
-        return exists(subquery)
-
-    def _matching_metric_exists_expression(
-        self, criterion: AnnotationEvaluationMetricMatchExpression | None = None
-    ) -> ColumnElement[bool]:
+    def _matching_metric_exists_expression(self) -> ColumnElement[bool]:
         if self.match_kind != "confusion":
             raise ValueError(f"Unsupported annotation metric match kind: {self.match_kind}")
 
-        metric_subquery = self._build_confusion_metric_subquery()
-        if criterion is not None:
-            metric_subquery = metric_subquery.where(criterion.get())
+        candidate_metric = aliased(EvaluationAnnotationMetricTable)
+        metric_subquery = self._build_confusion_metric_subquery(metric_table=candidate_metric)
+        for criterion in self.criteria:
+            metric_subquery = metric_subquery.where(
+                self._matching_metric_criterion_exists_expression(
+                    candidate_metric=candidate_metric,
+                    criterion=criterion,
+                )
+            )
         return exists(
             metric_subquery
             # Keep EvaluationRunTable and SampleTable as outer references so metrics are matched
@@ -104,7 +103,37 @@ class AnnotationMetricQuery(MatchExpression):
             .correlate(EvaluationRunTable, SampleTable)
         )
 
-    def _build_confusion_metric_subquery(self) -> Select[tuple[int]]:
+    def _matching_metric_criterion_exists_expression(
+        self,
+        candidate_metric: Any,
+        criterion: AnnotationEvaluationMetricMatchExpression,
+    ) -> ColumnElement[bool]:
+        return exists(
+            select(1)
+            .select_from(EvaluationAnnotationMetricTable)
+            .where(
+                col(EvaluationAnnotationMetricTable.evaluation_run_id)
+                == col(candidate_metric.evaluation_run_id)
+            )
+            .where(
+                col(EvaluationAnnotationMetricTable.sample_id) == col(candidate_metric.sample_id)
+            )
+            .where(
+                col(EvaluationAnnotationMetricTable.gt_annotation_id)
+                == col(candidate_metric.gt_annotation_id)
+            )
+            .where(
+                col(EvaluationAnnotationMetricTable.pred_annotation_id)
+                == col(candidate_metric.pred_annotation_id)
+            )
+            .where(criterion.get())
+            .correlate(candidate_metric)
+        )
+
+    def _build_confusion_metric_subquery(
+        self,
+        metric_table: Any = EvaluationAnnotationMetricTable,
+    ) -> Select[tuple[int]]:
         # TODO(lukas, 07/2026): This method is close to
         # _build_confusion_cell_subquery() from SampleFilter, consider joining/sharing code.
         gt_annotation = aliased(AnnotationBaseTable)
@@ -112,19 +141,21 @@ class AnnotationMetricQuery(MatchExpression):
         gt_label = aliased(AnnotationLabelTable)
         pred_label = aliased(AnnotationLabelTable)
 
+        # The joins act as recursive field accessors, e.g. to access
+        # `EvaluationAnnotationMetricTable.gt_annotation.annotation_label.name`, we need to join
+        # three tables. And note that EvaluationAnnotationMetricTable only has the
+        # `gt_annotation_id` field, which acts as a reference to ground truth annotation.
         return (
             select(1)
-            .select_from(EvaluationAnnotationMetricTable)
+            .select_from(metric_table)
             .join(
                 gt_annotation,
-                col(EvaluationAnnotationMetricTable.gt_annotation_id)
-                == col(gt_annotation.sample_id),
+                col(metric_table.gt_annotation_id) == col(gt_annotation.sample_id),
                 isouter=True,
             )
             .join(
                 pred_annotation,
-                col(EvaluationAnnotationMetricTable.pred_annotation_id)
-                == col(pred_annotation.sample_id),
+                col(metric_table.pred_annotation_id) == col(pred_annotation.sample_id),
                 isouter=True,
             )
             .join(
@@ -137,10 +168,8 @@ class AnnotationMetricQuery(MatchExpression):
                 col(pred_annotation.annotation_label_id) == col(pred_label.annotation_label_id),
                 isouter=True,
             )
-            .where(
-                col(EvaluationAnnotationMetricTable.evaluation_run_id) == col(EvaluationRunTable.id)
-            )
-            .where(col(EvaluationAnnotationMetricTable.sample_id) == col(SampleTable.sample_id))
+            .where(col(metric_table.evaluation_run_id) == col(EvaluationRunTable.id))
+            .where(col(metric_table.sample_id) == col(SampleTable.sample_id))
             .where(col(gt_label.annotation_label_name) == self.gt_label_name)
             .where(col(pred_label.annotation_label_name) == self.pred_label_name)
         )

--- a/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_query.py
@@ -46,15 +46,13 @@ def test_annotation_metric_query__filters_matching_samples(db_session: Session) 
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image_a.sample_id,
-                metric_name="score",
-                value=0.2,
+                metrics={"score": 0.2},
                 gt_annotation_label_id=cat_label.annotation_label_id,
                 pred_annotation_label_id=dog_label.annotation_label_id,
             ),
             TruePositiveMetricStub(
                 sample_id=image_b.sample_id,
-                metric_name="score",
-                value=0.9,
+                metrics={"score": 0.9},
                 gt_annotation_label_id=cat_label.annotation_label_id,
                 pred_annotation_label_id=dog_label.annotation_label_id,
             ),
@@ -104,14 +102,12 @@ def test_annotation_metric_query__scopes_run_name_to_dataset(db_session: Session
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image_a.sample_id,
-                metric_name="score",
-                value=0.9,
+                metrics={"score": 0.9},
                 gt_annotation_label_id=cat_label.annotation_label_id,
             ),
             TruePositiveMetricStub(
                 sample_id=image_b.sample_id,
-                metric_name="score",
-                value=0.1,
+                metrics={"score": 0.1},
                 gt_annotation_label_id=cat_label.annotation_label_id,
             ),
         ],
@@ -122,8 +118,7 @@ def test_annotation_metric_query__scopes_run_name_to_dataset(db_session: Session
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=other_image.sample_id,
-                metric_name="score",
-                value=0.0,
+                metrics={"score": 0.0},
                 gt_annotation_label_id=other_label.annotation_label_id,
             ),
         ],
@@ -158,27 +153,13 @@ def test_annotation_metric_query__matches_multiple_metrics(db_session: Session) 
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image_a.sample_id,
-                metric_name="precision",
-                value=0.9,
                 gt_annotation_label_id=cat_label.annotation_label_id,
-            ),
-            TruePositiveMetricStub(
-                sample_id=image_a.sample_id,
-                metric_name="recall",
-                value=0.3,
-                gt_annotation_label_id=cat_label.annotation_label_id,
+                metrics={"precision": 0.9, "recall": 0.3},
             ),
             TruePositiveMetricStub(
                 sample_id=image_b.sample_id,
-                metric_name="precision",
-                value=0.9,
                 gt_annotation_label_id=cat_label.annotation_label_id,
-            ),
-            TruePositiveMetricStub(
-                sample_id=image_b.sample_id,
-                metric_name="recall",
-                value=0.8,
-                gt_annotation_label_id=cat_label.annotation_label_id,
+                metrics={"precision": 0.9, "recall": 0.8},
             ),
         ],
     )
@@ -193,6 +174,49 @@ def test_annotation_metric_query__matches_multiple_metrics(db_session: Session) 
         )
     )
     assert [result.sample_id for result in results] == [image_b.sample_id]
+
+
+def test_annotation_metric_query__does_not_mix_criteria_across_annotation_pairs(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/a.jpg",
+    )
+    run = create_run(session=db_session, collection_id=collection.collection_id, name="run1")
+    cat_label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    create_annotation_metrics(
+        session=db_session,
+        run_id=run.id,
+        true_positive_metric_stubs=[
+            TruePositiveMetricStub(
+                sample_id=image.sample_id,
+                gt_annotation_label_id=cat_label.annotation_label_id,
+                metrics={"precision": 0.9, "recall": 0.3},
+            ),
+            TruePositiveMetricStub(
+                sample_id=image.sample_id,
+                gt_annotation_label_id=cat_label.annotation_label_id,
+                metrics={"precision": 0.3, "recall": 0.9},
+            ),
+        ],
+    )
+
+    results = DatasetQuery(dataset=collection, session=db_session).match(
+        AnnotationMetricQuery.confusion(
+            "run1",
+            "cat",
+            "cat",
+            AnnotationEvaluationMetricField("precision") > 0.5,
+            AnnotationEvaluationMetricField("recall") > 0.5,
+        )
+    )
+
+    assert [result.sample_id for result in results] == []
 
 
 def test_annotation_metric_query__matches_run_without_criteria(
@@ -219,8 +243,7 @@ def test_annotation_metric_query__matches_run_without_criteria(
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image_a.sample_id,
-                metric_name="score",
-                value=0.2,
+                metrics={"score": 0.2},
                 gt_annotation_label_id=cat_label.annotation_label_id,
             ),
         ],
@@ -259,8 +282,7 @@ def test_annotation_metric_query__matches_off_diagonal_confusion_cell(
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
-                metric_name="score",
-                value=0.8,
+                metrics={"score": 0.8},
                 gt_annotation_label_id=cat_label.annotation_label_id,
                 pred_annotation_label_id=dog_label.annotation_label_id,
             ),

--- a/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
+++ b/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
@@ -211,8 +211,7 @@ def test_delete_annotation__preserves_other_run_sample_metrics(
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
-                metric_name="iou",
-                value=0.75,
+                metrics={"iou": 0.75},
                 gt_annotation_label_id=label.annotation_label_id,
             )
         ],

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -786,8 +786,7 @@ def test_deep_copy__with_evaluation_annotation_metrics(db_session: Session) -> N
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
-                metric_name="iou",
-                value=0.8,
+                metrics={"iou": 0.8},
                 gt_annotation_label_id=label.annotation_label_id,
             )
         ],

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -235,8 +235,7 @@ def _build_full_dataset(session: Session, name: str) -> UUID:
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=eval_image.sample_id,
-                metric_name="iou",
-                value=0.8,
+                metrics={"iou": 0.8},
                 gt_annotation_label_id=label.annotation_label_id,
             )
         ],

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -359,8 +359,7 @@ def test_delete_dataset__with_evaluation_annotation_metrics(db_session: Session)
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
-                metric_name="iou",
-                value=0.8,
+                metrics={"iou": 0.8},
                 gt_annotation_label_id=label.annotation_label_id,
             )
         ],

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_get.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_get.py
@@ -47,8 +47,7 @@ def test_get_all_by_evaluation_run_id(db_session: Session) -> None:
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
-                metric_name="iou",
-                value=0.75,
+                metrics={"iou": 0.75},
                 gt_annotation_label_id=label.annotation_label_id,
             )
         ],

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
@@ -84,7 +84,8 @@ def test_get_confusion_matrix__aggregates_tp_fp_fn(
                 sample_id=image.sample_id,
                 pred_annotation_id=pred_a.sample_id,
                 gt_annotation_id=gt_a.sample_id,
-                metrics={"iou": 0.9},
+                metric_name="iou",
+                value=0.9,
             ),
             EvaluationAnnotationMetricCreate(
                 evaluation_run_id=run.id,

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
@@ -84,8 +84,7 @@ def test_get_confusion_matrix__aggregates_tp_fp_fn(
                 sample_id=image.sample_id,
                 pred_annotation_id=pred_a.sample_id,
                 gt_annotation_id=gt_a.sample_id,
-                metric_name="iou",
-                value=0.9,
+                metrics={"iou": 0.9},
             ),
             EvaluationAnnotationMetricCreate(
                 evaluation_run_id=run.id,
@@ -166,8 +165,7 @@ def test_get_confusion_matrix__class_only_in_gt(
                 sample_id=image.sample_id,
                 pred_annotation_id=pred_a.sample_id,
                 gt_annotation_id=gt_a.sample_id,
-                metric_name="iou",
-                value=0.9,
+                metrics={"iou": 0.9},
             ),
             EvaluationAnnotationMetricCreate(
                 evaluation_run_id=run.id,
@@ -235,8 +233,7 @@ def test_get_confusion_matrix__class_only_in_pred(
                 sample_id=image.sample_id,
                 pred_annotation_id=pred_a.sample_id,
                 gt_annotation_id=gt_a.sample_id,
-                metric_name="iou",
-                value=0.9,
+                metrics={"iou": 0.9},
             ),
             EvaluationAnnotationMetricCreate(
                 evaluation_run_id=run.id,
@@ -285,8 +282,7 @@ def test_get_confusion_matrix__no_fp_or_fn_keeps_synthetic_axes(
         true_positive_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
-                metric_name="iou",
-                value=0.9,
+                metrics={"iou": 0.9},
                 gt_annotation_label_id=label_a.annotation_label_id,
             )
         ],

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
@@ -166,7 +166,8 @@ def test_get_confusion_matrix__class_only_in_gt(
                 sample_id=image.sample_id,
                 pred_annotation_id=pred_a.sample_id,
                 gt_annotation_id=gt_a.sample_id,
-                metrics={"iou": 0.9},
+                metric_name="iou",
+                value=0.9,
             ),
             EvaluationAnnotationMetricCreate(
                 evaluation_run_id=run.id,
@@ -234,7 +235,8 @@ def test_get_confusion_matrix__class_only_in_pred(
                 sample_id=image.sample_id,
                 pred_annotation_id=pred_a.sample_id,
                 gt_annotation_id=gt_a.sample_id,
-                metrics={"iou": 0.9},
+                metric_name="iou",
+                value=0.9,
             ),
             EvaluationAnnotationMetricCreate(
                 evaluation_run_id=run.id,

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
@@ -38,19 +38,21 @@ class TruePositiveMetricStub:
     """Helper class to create a true-positive annotation metric.
 
     Creates matching prediction and ground-truth annotations in the evaluation
-    run's annotation collections, then stores a metric that links both.
+    run's annotation collections, then stores metric rows that link both.
     """
 
     sample_id: UUID
-    metric_name: str
-    value: float
+    metrics: dict[str, float]
     gt_annotation_label_id: UUID
     # Prediction annotation label. If None, assumed to be equal to annotation_label_id.
     pred_annotation_label_id: UUID | None = None
 
+    def metric_items(self) -> list[tuple[str, float]]:
+        return list(self.metrics.items())
+
     def to_annotation_metric_stub(
         self, session: Session, run: EvaluationRunTable
-    ) -> AnnotationMetricStub:
+    ) -> list[AnnotationMetricStub]:
         pred_collection = collection_resolver.get_by_id(
             session=session, collection_id=run.pred_annotation_collection_id
         )
@@ -81,13 +83,16 @@ class TruePositiveMetricStub:
             annotation_label_id=self.gt_annotation_label_id,
             annotation_collection_name=gt_collection.name,
         )
-        return AnnotationMetricStub(
-            sample_id=self.sample_id,
-            metric_name=self.metric_name,
-            value=self.value,
-            pred_annotation_id=pred_annotation.sample_id,
-            gt_annotation_id=gt_annotation.sample_id,
-        )
+        return [
+            AnnotationMetricStub(
+                sample_id=self.sample_id,
+                metric_name=metric_name,
+                value=value,
+                pred_annotation_id=pred_annotation.sample_id,
+                gt_annotation_id=gt_annotation.sample_id,
+            )
+            for metric_name, value in self.metric_items()
+        ]
 
 
 @dataclass
@@ -171,7 +176,7 @@ def create_annotation_metrics(
         raise ValueError(f"Evaluation run {run_id} doesn't exist")
 
     for stub in true_positive_metric_stubs:
-        annotation_metrics_to_create.append(
+        annotation_metrics_to_create.extend(
             stub.to_annotation_metric_stub(session=session, run=run)
         )
 


### PR DESCRIPTION
## What has changed and why?
Previous set of SQL queries used independent EXISTS subqueries, so different annotations pairs could satisfy different criteria (the `criteria` parameter of `confusion()`). However, the criteria should be regarding the same annotation pair.

Note, I've also refactored TruePositiveMetricStub to accept `dict[str, float]`, and updated tests.

## How has it been tested?
Added tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed annotation metric matching for confusion evaluations so multiple criteria are applied correctly without mixing results across different annotation pairs.
  * Deleting annotations or datasets continues to remove only the affected evaluation metrics while preserving unrelated results.
  * Deep-copy, retrieval, and round-trip behavior for evaluation metrics remains consistent across runs and datasets.
* **Tests**
  * Updated metric stubs to use a `metrics` map and adjusted confusion-matrix, deletion, deep-copy, and metric retrieval tests accordingly.
  * Added coverage to ensure criteria are not incorrectly combined across annotation pairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->