### PR TITLE
Add batched embedding helper for in-memory PIL images.

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -95,44 +95,13 @@ def embed_image_files_batched(
     Returns:
         Float32 array of shape ``(len(filepaths), embedding_dimension)``.
     """
-    total_images = len(filepaths)
-    if not total_images:
-        return np.empty((0, context.embedding_dimension), dtype=np.float32)
-
-    if context.max_batch_size <= 0:
-        raise ValueError("max_batch_size must be positive.")
-
-    dataset = _ImageFileDataset(filepaths, context.preprocess)
-
-    # To avoid issues with db locking and multiprocessing we set the number of
-    # workers to 0 (no multiprocessing). The DataLoader is still very useful for
-    # batching and async prefetching of images.
-    loader = DataLoader(
-        dataset,
-        batch_size=context.max_batch_size,
-        num_workers=0,  # must be 0 to avoid multiprocessing issues
+    return _embed_dataset_batched(
+        _ImageFileDataset(filepaths, context.preprocess),
+        context,
+        show_progress,
+        progress_desc="Generating embeddings",
+        progress_unit=" images",
     )
-
-    embeddings = np.empty((total_images, context.embedding_dimension), dtype=np.float32)
-    position = 0
-    with (
-        tqdm(
-            total=total_images,
-            desc="Generating embeddings",
-            unit=" images",
-            disable=not show_progress,
-        ) as progress_bar,
-        torch.no_grad(),
-    ):
-        for images_tensor in loader:
-            imgs = images_tensor.to(context.device, non_blocking=True)
-            batch_embeddings = context.encode_batch(imgs)
-            batch_size = imgs.size(0)
-            embeddings[position : position + batch_size] = batch_embeddings
-            position += batch_size
-            progress_bar.update(batch_size)
-
-    return embeddings
 
 
 def embed_pil_images_batched(
@@ -150,17 +119,37 @@ def embed_pil_images_batched(
     Returns:
         Float32 array of shape ``(len(images), embedding_dimension)``.
     """
-    total_images = len(images)
+    return _embed_dataset_batched(
+        _PILImageDataset(images, context.preprocess),
+        context,
+        show_progress,
+        progress_desc="Generating frame embeddings",
+        progress_unit=" frames",
+    )
+
+
+def _embed_dataset_batched(
+    dataset: Dataset[torch.Tensor],
+    context: EmbeddingContext,
+    show_progress: bool,
+    progress_desc: str,
+    progress_unit: str,
+) -> NDArray[np.float32]:
+    """Embed items from a preprocessed image dataset in batches, preserving order."""
+    total_images = len(dataset)
     if not total_images:
         return np.empty((0, context.embedding_dimension), dtype=np.float32)
 
     if context.max_batch_size <= 0:
         raise ValueError("max_batch_size must be positive.")
 
+    # To avoid issues with db locking and multiprocessing we set the number of
+    # workers to 0 (no multiprocessing). The DataLoader is still very useful for
+    # batching and async prefetching of images.
     loader = DataLoader(
-        _PILImageDataset(images, context.preprocess),
+        dataset,
         batch_size=context.max_batch_size,
-        num_workers=0,
+        num_workers=0,  # must be 0 to avoid multiprocessing issues
     )
 
     embeddings = np.empty((total_images, context.embedding_dimension), dtype=np.float32)
@@ -168,8 +157,8 @@ def embed_pil_images_batched(
     with (
         tqdm(
             total=total_images,
-            desc="Generating frame embeddings",
-            unit=" frames",
+            desc=progress_desc,
+            unit=progress_unit,
             disable=not show_progress,
         ) as progress_bar,
         torch.no_grad(),

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -39,6 +39,14 @@ class EmbeddingContext:
     encode_batch: Callable[[torch.Tensor], NDArray[np.float32]]
 
 
+@dataclass(frozen=True)
+class _EmbeddingProgress:
+    """tqdm label configuration for batched embedding."""
+
+    desc: str
+    unit: str
+
+
 class _PILImageDataset(Dataset[torch.Tensor]):
     """Dataset wrapping in-memory PIL images and a preprocess function."""
 
@@ -97,10 +105,10 @@ def embed_image_files_batched(
     """
     return _embed_dataset_batched(
         _ImageFileDataset(filepaths, context.preprocess),
+        len(filepaths),
         context,
         show_progress,
-        progress_desc="Generating embeddings",
-        progress_unit=" images",
+        _EmbeddingProgress(desc="Generating embeddings", unit=" images"),
     )
 
 
@@ -121,22 +129,21 @@ def embed_pil_images_batched(
     """
     return _embed_dataset_batched(
         _PILImageDataset(images, context.preprocess),
+        len(images),
         context,
         show_progress,
-        progress_desc="Generating frame embeddings",
-        progress_unit=" frames",
+        _EmbeddingProgress(desc="Generating frame embeddings", unit=" frames"),
     )
 
 
 def _embed_dataset_batched(
     dataset: Dataset[torch.Tensor],
+    total_images: int,
     context: EmbeddingContext,
     show_progress: bool,
-    progress_desc: str,
-    progress_unit: str,
+    progress: _EmbeddingProgress,
 ) -> NDArray[np.float32]:
     """Embed items from a preprocessed image dataset in batches, preserving order."""
-    total_images = len(dataset)
     if not total_images:
         return np.empty((0, context.embedding_dimension), dtype=np.float32)
 
@@ -157,8 +164,8 @@ def _embed_dataset_batched(
     with (
         tqdm(
             total=total_images,
-            desc=progress_desc,
-            unit=progress_unit,
+            desc=progress.desc,
+            unit=progress.unit,
             disable=not show_progress,
         ) as progress_bar,
         torch.no_grad(),

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -39,6 +39,24 @@ class EmbeddingContext:
     encode_batch: Callable[[torch.Tensor], NDArray[np.float32]]
 
 
+class _PILImageDataset(Dataset[torch.Tensor]):
+    """Dataset wrapping in-memory PIL images and a preprocess function."""
+
+    def __init__(
+        self,
+        images: list[Image.Image],
+        preprocess: Callable[[Image.Image], torch.Tensor],
+    ) -> None:
+        self.images = images
+        self.preprocess = preprocess
+
+    def __len__(self) -> int:
+        return len(self.images)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        return self.preprocess(self.images[idx])
+
+
 class _ImageFileDataset(Dataset[torch.Tensor]):
     """Dataset wrapping image file paths and a preprocess function.
 
@@ -102,6 +120,56 @@ def embed_image_files_batched(
             total=total_images,
             desc="Generating embeddings",
             unit=" images",
+            disable=not show_progress,
+        ) as progress_bar,
+        torch.no_grad(),
+    ):
+        for images_tensor in loader:
+            imgs = images_tensor.to(context.device, non_blocking=True)
+            batch_embeddings = context.encode_batch(imgs)
+            batch_size = imgs.size(0)
+            embeddings[position : position + batch_size] = batch_embeddings
+            position += batch_size
+            progress_bar.update(batch_size)
+
+    return embeddings
+
+
+def embed_pil_images_batched(
+    images: list[Image.Image],
+    context: EmbeddingContext,
+    show_progress: bool,
+) -> NDArray[np.float32]:
+    """Embed in-memory PIL images in batches, preserving input order.
+
+    Args:
+        images: PIL images to embed.
+        context: Model-specific embedding configuration.
+        show_progress: Whether to show a tqdm progress bar.
+
+    Returns:
+        Float32 array of shape ``(len(images), embedding_dimension)``.
+    """
+    total_images = len(images)
+    if not total_images:
+        return np.empty((0, context.embedding_dimension), dtype=np.float32)
+
+    if context.max_batch_size <= 0:
+        raise ValueError("max_batch_size must be positive.")
+
+    loader = DataLoader(
+        _PILImageDataset(images, context.preprocess),
+        batch_size=context.max_batch_size,
+        num_workers=0,
+    )
+
+    embeddings = np.empty((total_images, context.embedding_dimension), dtype=np.float32)
+    position = 0
+    with (
+        tqdm(
+            total=total_images,
+            desc="Generating frame embeddings",
+            unit=" frames",
             disable=not show_progress,
         ) as progress_bar,
         torch.no_grad(),

--- a/lightly_studio/tests/dataset/test_image_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_embedding.py
@@ -48,3 +48,39 @@ def test_embed_image_files_batched__preserves_input_order(tmp_path: Path) -> Non
 
     assert embeddings.shape == (3, 1)
     assert embeddings[:, 0].tolist() == [float(width) for width in widths]
+
+
+def test_embed_pil_images_batched__empty_input_returns_empty_array() -> None:
+    embeddings = image_embedding.embed_pil_images_batched(
+        images=[],
+        context=EmbeddingContext(
+            embedding_dimension=4,
+            max_batch_size=2,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=lambda images_tensor: images_tensor.cpu().numpy(),
+        ),
+        show_progress=False,
+    )
+
+    assert embeddings.shape == (0, 4)
+
+
+def test_embed_pil_images_batched__preserves_input_order() -> None:
+    widths = [5, 6, 7]
+    images = [Image.new("RGB", (width, 10), color=(255, 0, 0)) for width in widths]
+
+    embeddings = image_embedding.embed_pil_images_batched(
+        images=images,
+        context=EmbeddingContext(
+            embedding_dimension=1,
+            max_batch_size=2,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
+        ),
+        show_progress=False,
+    )
+
+    assert embeddings.shape == (3, 1)
+    assert embeddings[:, 0].tolist() == [float(width) for width in widths]


### PR DESCRIPTION
## What has changed and why?

Introduce `embed_pil_images_batched` for embedding decoded frames and other in-memory PIL images .


## How has it been tested?

new tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for embedding PIL images directly from memory.
  * Introduced batched PIL embedding with optional progress display while preserving input order.
* **Tests**
  * Added tests to verify empty-input behavior returns an appropriately shaped empty array.
  * Added tests to confirm embeddings are returned in the same order as the input images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->