### PR TITLE
Add tests/docs for video frame sampling

### DIFF
--- a/lightly_studio/docs/docs/concepts_and_tools/sampling.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/sampling.md
@@ -12,7 +12,7 @@ Open the dialog from the `Menu` button in the top-right corner and select `Sampl
 
 ## Sampling in Python
 
-Each strategy is configured directly from a [`DatasetQuery`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery) via [`sampling()`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery.sampling). The sampled items are stored under the tag passed as `sampling_result_tag_name`, so you can filter or export them later. `sampling_result_tag_name` must be a tag name that does not yet exist in the dataset.
+Each strategy is configured directly from a [`DatasetQuery`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery) via [`sampling()`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery.sampling). This works for image datasets, video datasets, and video-frame datasets returned by [`VideoDataset.frames()`](../api/dataset.md#lightly_studio.VideoDataset.frames). The sampled items are stored under the tag passed as `sampling_result_tag_name`, so you can filter or export them later. `sampling_result_tag_name` must be a tag name that does not yet exist in the dataset.
 
 ### Filtering before sampling
 
@@ -32,6 +32,25 @@ dataset.match(ImageSampleField.width >= 1920).sampling().diverse(
 ```
 
 See [Search and Filter](search_and_filter.md#query-in-python) for more filtering options.
+
+Video frames can be sampled the same way through `VideoDataset.frames()`:
+
+```py
+import lightly_studio as ls
+from lightly_studio.core.dataset_query import VideoFrameSampleField
+
+dataset = ls.VideoDataset.load("my_video_dataset")
+frames = dataset.frames()
+
+for frame in frames.match(VideoFrameSampleField.frame_number > 1):
+    frame.metadata["score"] = float(frame.frame_number)
+
+frames.match(VideoFrameSampleField.frame_number > 1).sampling().metadata_weighting(
+    n_samples_to_select=5,
+    sampling_result_tag_name="sampled_frames",
+    metadata_key="score",
+)
+```
 
 ### Sampling Strategies
 

--- a/lightly_studio/docs/docs/concepts_and_tools/sampling.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/sampling.md
@@ -31,9 +31,7 @@ dataset.match(ImageSampleField.width >= 1920).sampling().diverse(
 )
 ```
 
-See [Search and Filter](search_and_filter.md#query-in-python) for more filtering options.
-
-Video frames can be sampled the same way through `VideoDataset.frames()`:
+Videos can be filtered and sampled using `VideoDataset.match(...).sampling()` and video frames can be sampled through `VideoDataset.frames().match(...).sampling()`:
 
 ```py
 import lightly_studio as ls
@@ -51,6 +49,8 @@ frames.match(VideoFrameSampleField.frame_number > 1).sampling().metadata_weighti
     metadata_key="score",
 )
 ```
+
+See [Search and Filter](search_and_filter.md#query-in-python) for more filtering options.
 
 ### Sampling Strategies
 

--- a/lightly_studio/tests/sampling/test_sampling.py
+++ b/lightly_studio/tests/sampling/test_sampling.py
@@ -70,7 +70,6 @@ class TestSampling:
             video=VideoStub(path="/data/b.mp4", duration_s=1.0, fps=2.0),
         )
         frames = dataset.frames()
-        query = frames.query()
         embedding_model = helpers_resolvers.create_embedding_model(
             session=dataset.session,
             collection_id=frames.collection_id,

--- a/lightly_studio/tests/sampling/test_sampling.py
+++ b/lightly_studio/tests/sampling/test_sampling.py
@@ -76,8 +76,7 @@ class TestSampling:
             collection_id=frames.collection_id,
             embedding_model_name="embedding_model_1",
         )
-        filtered_frames = query.to_list()
-        for i, frame in enumerate(filtered_frames):
+        for i, frame in enumerate(frames):
             helpers_resolvers.create_sample_embedding(
                 session=dataset.session,
                 sample_id=frame.sample_id,
@@ -92,7 +91,7 @@ class TestSampling:
             sampling_result_tag_name="diverse_frames",
         )
 
-        expected_sample_ids = [frame.sample_id for frame in filtered_frames]
+        expected_sample_ids = [frame.sample_id for frame in frames]
         spy_sampling_via_db.assert_called_once_with(
             session=dataset.session,
             config=SamplingConfig(

--- a/lightly_studio/tests/sampling/test_sampling.py
+++ b/lightly_studio/tests/sampling/test_sampling.py
@@ -86,7 +86,7 @@ class TestSampling:
 
         spy_sampling_via_db = mocker.spy(sampling_file, "sampling_via_database")
 
-        query.sampling().diverse(
+        frames.query().sampling().diverse(
             n_samples_to_select=2,
             sampling_result_tag_name="diverse_frames",
         )

--- a/lightly_studio/tests/sampling/test_sampling.py
+++ b/lightly_studio/tests/sampling/test_sampling.py
@@ -6,6 +6,7 @@ from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
+from lightly_studio.core.video.video_dataset import VideoDataset
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationType,
 )
@@ -20,6 +21,7 @@ from lightly_studio.sampling.sampling_config import (
 )
 from tests import helpers_resolvers
 from tests.helpers_resolvers import AnnotationDetails
+from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
 from tests.sampling import helpers_sampling
 
 
@@ -46,6 +48,57 @@ class TestSampling:
                 collection_id=collection_id,
                 n_samples_to_select=3,
                 sampling_result_tag_name="diverse_sampling",
+                strategies=[EmbeddingDiversityStrategy(embedding_model_name=None)],
+            ),
+            input_sample_ids=expected_sample_ids,
+        )
+
+    def test_diverse__embedding_model_name_unspecified__video_frames(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        mocker: MockerFixture,
+    ) -> None:
+        dataset = VideoDataset.create(name="video_dataset")
+        create_video_with_frames(
+            session=dataset.session,
+            collection_id=dataset.collection_id,
+            video=VideoStub(path="/data/a.mp4", duration_s=1.0, fps=3.0),
+        )
+        create_video_with_frames(
+            session=dataset.session,
+            collection_id=dataset.collection_id,
+            video=VideoStub(path="/data/b.mp4", duration_s=1.0, fps=2.0),
+        )
+        frames = dataset.frames()
+        query = frames.query()
+        embedding_model = helpers_resolvers.create_embedding_model(
+            session=dataset.session,
+            collection_id=frames.collection_id,
+            embedding_model_name="embedding_model_1",
+        )
+        filtered_frames = query.to_list()
+        for i, frame in enumerate(filtered_frames):
+            helpers_resolvers.create_sample_embedding(
+                session=dataset.session,
+                sample_id=frame.sample_id,
+                embedding_model_id=embedding_model.embedding_model_id,
+                embedding=[i, i],
+            )
+
+        spy_sampling_via_db = mocker.spy(sampling_file, "sampling_via_database")
+
+        query.sampling().diverse(
+            n_samples_to_select=2,
+            sampling_result_tag_name="diverse_frames",
+        )
+
+        expected_sample_ids = [frame.sample_id for frame in filtered_frames]
+        spy_sampling_via_db.assert_called_once_with(
+            session=dataset.session,
+            config=SamplingConfig(
+                collection_id=frames.collection_id,
+                n_samples_to_select=2,
+                sampling_result_tag_name="diverse_frames",
                 strategies=[EmbeddingDiversityStrategy(embedding_model_name=None)],
             ),
             input_sample_ids=expected_sample_ids,
@@ -165,6 +218,51 @@ class TestSampling:
         )
         spy_mundig_add_weighting.assert_called_once_with(
             self=mocker.ANY, weights=[16.0, 50.0, 35.0], strength=1.0
+        )
+
+    def test_metadata_weighting__video_frames(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        mocker: MockerFixture,
+    ) -> None:
+        dataset = VideoDataset.create(name="video_dataset")
+        create_video_with_frames(
+            session=dataset.session,
+            collection_id=dataset.collection_id,
+            video=VideoStub(path="/data/a.mp4", duration_s=1.0, fps=3.0),
+        )
+        create_video_with_frames(
+            session=dataset.session,
+            collection_id=dataset.collection_id,
+            video=VideoStub(path="/data/b.mp4", duration_s=1.0, fps=2.0),
+        )
+        frames = dataset.frames()
+        query = frames.query()
+        for frame in frames:
+            frame.metadata["score"] = float(frame.frame_number)
+
+        spy_sampling_via_db = mocker.spy(sampling_file, "sampling_via_database")
+        spy_mundig_add_weighting = mocker.spy(Mundig, "add_weighting")
+
+        query.sampling().metadata_weighting(
+            n_samples_to_select=2,
+            metadata_key="score",
+            sampling_result_tag_name="weighted_frames",
+        )
+
+        expected_sample_ids = [frame.sample_id for frame in frames]
+        spy_sampling_via_db.assert_called_once_with(
+            session=dataset.session,
+            config=SamplingConfig(
+                collection_id=frames.collection_id,
+                n_samples_to_select=2,
+                sampling_result_tag_name="weighted_frames",
+                strategies=[MetadataWeightingStrategy(metadata_key="score")],
+            ),
+            input_sample_ids=expected_sample_ids,
+        )
+        spy_mundig_add_weighting.assert_called_once_with(
+            self=mocker.ANY, weights=[0.0, 1.0, 2.0, 0.0, 1.0], strength=1.0
         )
 
     def test_multi_strategies(self, db_session: Session, mocker: MockerFixture) -> None:


### PR DESCRIPTION
## What has changed and why?
It's been already working out of the box, yay for our generic API! We've only added tests and docs for it.

## How has it been tested?
Added tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated “Sampling in Python” to clarify that sampling configurations apply to image datasets, video datasets, and frame collections produced from video frames.
  * Reiterated that sampled outputs are written to `sampling_result_tag_name`, which must be a tag name that does not already exist in the dataset.
  * Added an end-to-end example for sampling video frames, including frame filtering and metadata-based weighting.
* **Tests**
  * Added coverage for diverse sampling on video-frame collections when the embedding model name is not specified.
  * Added coverage for metadata-weighted sampling on video frames using numeric per-frame metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->