### PR TITLE
Kondrat lig 9903 embedding plot selection doesnt scale send lassorectangle

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -22,6 +22,7 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationWithPayloadAndCountView,
 )
 from lightly_studio.models.collection import AnnotationCollectionView, CollectionTable
+from lightly_studio.models.embedding_region import EmbeddingRegion
 from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
@@ -86,6 +87,9 @@ class ReadAnnotationsWithPayloadRequest(BaseModel):
     annotation_label_ids: list[UUID] | None = None
     tag_ids: list[UUID] | None = None
     sample_ids: list[UUID] | None = None
+    # Embedding-plot lasso/rectangle selection sent as geometry (a few KB) instead of the full
+    # list of selected annotation sample ids; resolved to sample ids server-side (LIG-9903).
+    embedding_region: EmbeddingRegion | None = None
     text_embedding: list[float] | None = None
 
 
@@ -159,6 +163,7 @@ def read_annotations_with_payload(
             annotation_label_ids=body.annotation_label_ids,
             tag_ids=body.tag_ids,
             sample_ids=body.sample_ids,
+            embedding_region=body.embedding_region,
         ),
         collection_id=collection_id,
         text_embedding=body.text_embedding,

--- a/lightly_studio/src/lightly_studio/models/embedding_region.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_region.py
@@ -1,0 +1,42 @@
+"""Geometry of an embedding-plot region selection.
+
+The frontend sends the lasso/rectangle geometry (a handful of vertices, a few KB) instead
+of the full list of selected sample ids. The backend reproduces the exact selection by
+running point-in-polygon over the cached 2D projection, so the request body stays
+constant-size regardless of how many points are selected (see LIG-9903).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+# A polygon needs at least three vertices to enclose any area.
+_MIN_POLYGON_VERTICES = 3
+
+
+class Point2D(BaseModel):
+    """A single vertex in embedding-plot (raw data) coordinate space."""
+
+    x: float
+    y: float
+
+
+class EmbeddingRegion(BaseModel):
+    """A closed region in embedding-plot space, expressed as polygon vertices.
+
+    Rectangle selections are normalized to their four corner vertices on the frontend, so
+    both lasso and rectangle selections arrive here as a polygon. Coordinates are in the
+    same raw data space as the cached 2D projection, so no additional transform is needed
+    before the point-in-polygon test.
+    """
+
+    polygon: list[Point2D] = Field(
+        description="Ordered polygon vertices in embedding-plot data space (>= 3 vertices)."
+    )
+
+    @field_validator("polygon")
+    @classmethod
+    def _validate_polygon(cls, polygon: list[Point2D]) -> list[Point2D]:
+        if len(polygon) < _MIN_POLYGON_VERTICES:
+            raise ValueError("An embedding region polygon must have at least 3 vertices.")
+        return polygon

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_with_payload.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_with_payload.py
@@ -24,7 +24,7 @@ from lightly_studio.models.collection import SampleType
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.video import VideoFrameTable, VideoTable
-from lightly_studio.resolvers import collection_resolver
+from lightly_studio.resolvers import collection_resolver, embedding_region_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
 )
@@ -67,6 +67,11 @@ def get_all_with_payload(
     base_query = _build_base_query(sample_type=sample_type)
 
     if filters:
+        # Resolve any embedding-plot region selection to concrete annotation sample ids
+        # before applying the filter (the point-in-polygon test needs the session).
+        embedding_region_resolver.resolve_annotation_embedding_region(
+            session=session, collection_id=collection_id, filters=filters
+        )
         base_query = filters.apply(base_query)
 
     embedding_model_id, distance_expr = get_distance_expression(

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_sample_ids.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from sqlmodel import Session
 from sqlmodel.sql.expression import SelectOfScalar
 
+from lightly_studio.resolvers import embedding_region_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 
 
@@ -41,5 +42,8 @@ def get_sample_ids(
     Returns:
         Set of annotation sample ids matching the given filters.
     """
+    embedding_region_resolver.resolve_annotation_embedding_region(
+        session=session, collection_id=collection_id, filters=filters
+    )
     query = build_sample_ids_query(collection_id=collection_id, filters=filters)
     return set(session.exec(query).all())

--- a/lightly_studio/src/lightly_studio/resolvers/annotations/annotations_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotations/annotations_filter.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from typing import Literal
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
+from sqlalchemy import false
 from sqlalchemy.orm import Mapped, aliased
 from sqlmodel import col, select
 from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.database import db_array
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
+from lightly_studio.models.embedding_region import EmbeddingRegion
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.tag import TagTable
 from lightly_studio.resolvers.grid_filter_base import GridFilterBase
@@ -34,6 +36,23 @@ class AnnotationsFilter(GridFilterBase):
     sample_ids: list[UUID] | None = Field(
         default=None, description="List of annotation sample UUIDs to restrict to"
     )
+    # Lasso/rectangle selection from the embedding plot, sent as geometry (a few KB) instead
+    # of the full list of selected annotation sample ids (see LIG-9903). It is resolved to
+    # concrete sample ids server-side via point-in-polygon over the cached 2D projection; the
+    # resolver must call `set_resolved_region_sample_ids` before this filter is applied.
+    embedding_region: EmbeddingRegion | None = None
+
+    # Sample ids the `embedding_region` resolves to, populated server-side. `None` means the
+    # region has not been resolved yet; an empty list means the region encloses no points.
+    _resolved_region_sample_ids: list[UUID] | None = PrivateAttr(default=None)
+
+    def set_resolved_region_sample_ids(self, sample_ids: list[UUID]) -> None:
+        """Store the annotation sample ids that ``embedding_region`` resolves to.
+
+        Called by the region resolver before the filter is applied, since the point-in-polygon
+        test needs a database session that ``apply`` does not have access to.
+        """
+        self._resolved_region_sample_ids = sample_ids
 
     def apply(
         self,
@@ -91,6 +110,7 @@ class AnnotationsFilter(GridFilterBase):
             or self.tag_ids
             or self.annotation_types
             or self.sample_ids
+            or self.embedding_region is not None
         )
 
     def _apply_annotation_filters(
@@ -112,7 +132,7 @@ class AnnotationsFilter(GridFilterBase):
                 )
             )
 
-        # Filter by annotation sample ids (e.g. embedding plot selection)
+        # Filter by annotation sample ids (e.g. manual selection)
         if self.sample_ids:
             query = query.where(
                 db_array.in_array(
@@ -120,6 +140,24 @@ class AnnotationsFilter(GridFilterBase):
                     values=self.sample_ids,
                 )
             )
+
+        # Filter by embedding-plot region selection, resolved server-side to sample ids.
+        if self.embedding_region is not None:
+            if self._resolved_region_sample_ids is None:
+                raise RuntimeError(
+                    "embedding_region must be resolved with set_resolved_region_sample_ids() "
+                    "before the filter is applied."
+                )
+            if not self._resolved_region_sample_ids:
+                # An empty region encloses no points and must match nothing (not everything).
+                query = query.where(false())
+            else:
+                query = query.where(
+                    db_array.in_array(
+                        column=col(annotation_sample.sample_id),
+                        values=self._resolved_region_sample_ids,
+                    )
+                )
 
         # Filter by annotation label
         if self.annotation_label_ids:

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -18,6 +18,7 @@ from sqlmodel import Session, select
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.embedding_region import EmbeddingRegion
 from lightly_studio.resolvers import twodim_embedding_resolver
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.image_filter import ImageFilter
 
 
@@ -26,7 +27,7 @@ def resolve_embedding_region(
     collection_id: UUID,
     filters: ImageFilter | None,
 ) -> None:
-    """Resolve any embedding region on ``filters`` to concrete sample ids, in place.
+    """Resolve any embedding region on an image ``filters`` to concrete sample ids, in place.
 
     No-op unless the filter carries a ``sample_filter.embedding_region``. Safe to call more
     than once. Must run before ``filters.apply(...)`` because the point-in-polygon test needs
@@ -42,6 +43,28 @@ def resolve_embedding_region(
         region=sample_filter.embedding_region,
     )
     sample_filter.set_resolved_region_sample_ids(sample_ids)
+
+
+def resolve_annotation_embedding_region(
+    session: Session,
+    collection_id: UUID,
+    filters: AnnotationsFilter | None,
+) -> None:
+    """Resolve any embedding region on an annotation ``filters`` to sample ids, in place.
+
+    Mirrors :func:`resolve_embedding_region` for the annotation grid: the region is tested
+    against the annotation collection's cached 2D projection, so the resolved ids are
+    annotation sample ids. No-op unless ``filters.embedding_region`` is set.
+    """
+    if filters is None or filters.embedding_region is None:
+        return
+
+    sample_ids = get_sample_ids_in_region(
+        session=session,
+        collection_id=collection_id,
+        region=filters.embedding_region,
+    )
+    filters.set_resolved_region_sample_ids(sample_ids)
 
 
 def get_sample_ids_in_region(

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -1,0 +1,110 @@
+"""Resolve an embedding-plot region selection to the sample ids it encloses.
+
+The frontend sends the lasso/rectangle geometry (a handful of vertices) instead of the full
+list of selected sample ids, keeping the request body constant-size regardless of selection
+size (see LIG-9903). Here we reproduce the exact client-side selection server-side: load the
+cached, deterministic 2D projection the user lassoed over and run a vectorized point-in-polygon
+test, then feed the resulting ids into the existing ``= ANY(...)`` filter path.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import numpy as np
+from numpy.typing import NDArray
+from sqlmodel import Session, select
+
+from lightly_studio.models.embedding_model import EmbeddingModelTable
+from lightly_studio.models.embedding_region import EmbeddingRegion
+from lightly_studio.resolvers import twodim_embedding_resolver
+from lightly_studio.resolvers.image_filter import ImageFilter
+
+
+def resolve_embedding_region(
+    session: Session,
+    collection_id: UUID,
+    filters: ImageFilter | None,
+) -> None:
+    """Resolve any embedding region on ``filters`` to concrete sample ids, in place.
+
+    No-op unless the filter carries a ``sample_filter.embedding_region``. Safe to call more
+    than once. Must run before ``filters.apply(...)`` because the point-in-polygon test needs
+    a database session that ``apply`` cannot access.
+    """
+    sample_filter = filters.sample_filter if filters is not None else None
+    if sample_filter is None or sample_filter.embedding_region is None:
+        return
+
+    sample_ids = get_sample_ids_in_region(
+        session=session,
+        collection_id=collection_id,
+        region=sample_filter.embedding_region,
+    )
+    sample_filter.set_resolved_region_sample_ids(sample_ids)
+
+
+def get_sample_ids_in_region(
+    session: Session,
+    collection_id: UUID,
+    region: EmbeddingRegion,
+) -> list[UUID]:
+    """Return the sample ids whose cached 2D coordinates fall inside ``region``."""
+    # Mirror the embeddings2d endpoint: use the collection's first embedding model.
+    # TODO(Kondrat, 07/2026): Select the embedding model via API parameter once supported,
+    # matching embeddings2d.get_2d_embeddings.
+    embedding_model = session.exec(
+        select(EmbeddingModelTable)
+        .where(EmbeddingModelTable.collection_id == collection_id)
+        .limit(1)
+    ).first()
+    if embedding_model is None:
+        return []
+
+    x_array, y_array, sample_ids = twodim_embedding_resolver.get_twodim_embeddings(
+        session=session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+    if len(sample_ids) == 0:
+        return []
+
+    inside_mask = _points_in_polygon(x=x_array, y=y_array, region=region)
+    return [sample_id for sample_id, inside in zip(sample_ids, inside_mask) if inside]
+
+
+def _points_in_polygon(
+    x: NDArray[np.float32],
+    y: NDArray[np.float32],
+    region: EmbeddingRegion,
+) -> NDArray[np.bool_]:
+    """Vectorized even-odd ray-casting point-in-polygon test.
+
+    Matches the frontend's ``isPointInPolygon`` (ray cast to the right, edges counted when
+    exactly one endpoint is strictly above the point's y) so the server selects exactly the
+    points the user saw highlighted.
+    """
+    vertices_x = np.asarray([vertex.x for vertex in region.polygon], dtype=np.float64)
+    vertices_y = np.asarray([vertex.y for vertex in region.polygon], dtype=np.float64)
+
+    px = np.asarray(x, dtype=np.float64)
+    py = np.asarray(y, dtype=np.float64)
+
+    inside = np.zeros(px.shape, dtype=np.bool_)
+
+    # Previous vertex of each edge: (vertices[j], vertices[i]) with j = i - 1 (wrapping).
+    prev_x = np.roll(vertices_x, 1)
+    prev_y = np.roll(vertices_y, 1)
+
+    for xi, yi, xj, yj in zip(vertices_x, vertices_y, prev_x, prev_y):
+        # Edge straddles the horizontal ray at py (one endpoint strictly above, one not).
+        straddles = (yi > py) != (yj > py)
+        denominator = yj - yi
+        # Guard against a horizontal edge (denominator == 0); those never straddle, so the
+        # value used here is irrelevant, but avoid dividing by zero.
+        safe_denominator = np.where(denominator == 0, 1.0, denominator)
+        intersection_x = (xj - xi) * (py - yi) / safe_denominator + xi
+        crosses = straddles & (px < intersection_x)
+        inside ^= crosses
+
+    return inside

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
@@ -10,6 +10,7 @@ from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers import embedding_region_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
 
 
@@ -24,6 +25,9 @@ def count_image_annotations_by_collection(
     label name and counted for total and filtered.
     Returns a list of (label_name, current_count, total_count) tuples.
     """
+    embedding_region_resolver.resolve_embedding_region(
+        session=session, collection_id=collection_id, filters=image_filter
+    )
     total_counts = _get_total_counts(session=session, collection_id=collection_id)
     current_counts = _get_current_counts(
         session=session,

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_all_by_collection_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_all_by_collection_id.py
@@ -24,6 +24,7 @@ from lightly_studio.database import db_array
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers import embedding_region_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.similarity_utils import (
     apply_similarity_join,
@@ -97,6 +98,12 @@ def get_all_by_collection_id(  # noqa: PLR0913
     order_by: list[OrderByExpression] | None = None,
 ) -> GetAllSamplesByCollectionIdResult:
     """Retrieve samples for a specific collection with optional filtering."""
+    # Resolve any embedding-plot region selection to concrete sample ids before the filter
+    # is applied (the point-in-polygon test needs the session, which `apply` lacks).
+    embedding_region_resolver.resolve_embedding_region(
+        session=session, collection_id=collection_id, filters=filters
+    )
+
     embedding_model_id, distance_expr = get_distance_expression(
         session=session,
         collection_id=collection_id,

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_sample_ids.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from sqlmodel import Session
 from sqlmodel.sql.expression import SelectOfScalar
 
+from lightly_studio.resolvers import embedding_region_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
 
 
@@ -41,5 +42,8 @@ def get_sample_ids(
     Returns:
         List of sample ids matching the given filters.
     """
+    embedding_region_resolver.resolve_embedding_region(
+        session=session, collection_id=collection_id, filters=filters
+    )
     query = build_sample_ids_query(collection_id=collection_id, filters=filters)
     return set(session.exec(query).all())

--- a/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_resolver/sample_filter.py
@@ -3,7 +3,8 @@
 from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
+from sqlalchemy import false
 from sqlalchemy.orm import aliased
 from sqlmodel import col, select
 from sqlmodel.sql.expression import SelectOfScalar
@@ -12,6 +13,7 @@ from lightly_studio.core.dataset_query import query_translation
 from lightly_studio.database import db_array
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_label import AnnotationLabelTable
+from lightly_studio.models.embedding_region import EmbeddingRegion
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_confusion_matrix import ConfusionCell
 from lightly_studio.models.metadata import SampleMetadataTable
@@ -35,6 +37,16 @@ class SampleFilter(BaseModel):
     annotations_filter: Optional[AnnotationsFilter] = None
     confusion_cell: Optional[ConfusionCell] = None
 
+    # Lasso/rectangle selection from the embedding plot, sent as geometry (a few KB) instead
+    # of the full list of selected sample ids (see LIG-9903). It is resolved to concrete
+    # sample ids server-side via point-in-polygon over the cached 2D projection; the resolver
+    # must call `set_resolved_region_sample_ids` before this filter is applied to a query.
+    embedding_region: Optional[EmbeddingRegion] = None
+
+    # Sample ids the `embedding_region` resolves to, populated server-side. `None` means the
+    # region has not been resolved yet; an empty list means the region encloses no points.
+    _resolved_region_sample_ids: Optional[list[UUID]] = PrivateAttr(default=None)
+
     # Query expression filter
     #
     # Adds an arbitrary "where" condition that can be expressed with QueryExpr.
@@ -44,9 +56,18 @@ class SampleFilter(BaseModel):
     # before applying this filter.
     query_expr: Optional[QueryExpr] = None
 
+    def set_resolved_region_sample_ids(self, sample_ids: list[UUID]) -> None:
+        """Store the sample ids that ``embedding_region`` resolves to.
+
+        Called by the region resolver before the filter is applied, since the point-in-polygon
+        test needs a database session that ``apply`` does not have access to.
+        """
+        self._resolved_region_sample_ids = sample_ids
+
     def apply(self, query: QueryType) -> QueryType:
         """Apply the filters to the given query."""
         query = self._apply_sample_ids_filter(query)
+        query = self._apply_embedding_region_filter(query)
         query = self._apply_annotation_filters(query)
         query = self._apply_tag_filters(query)
         query = self._apply_confusion_cell_filter(query)
@@ -60,6 +81,23 @@ class SampleFilter(BaseModel):
                 db_array.in_array(column=col(SampleTable.sample_id), values=self.sample_ids)
             )
         return query
+
+    def _apply_embedding_region_filter(self, query: QueryType) -> QueryType:
+        if self.embedding_region is None:
+            return query
+        if self._resolved_region_sample_ids is None:
+            raise RuntimeError(
+                "embedding_region must be resolved with set_resolved_region_sample_ids() "
+                "before the filter is applied."
+            )
+        # An empty region encloses no points and must match nothing (not everything).
+        if not self._resolved_region_sample_ids:
+            return query.where(false())
+        return query.where(
+            db_array.in_array(
+                column=col(SampleTable.sample_id), values=self._resolved_region_sample_ids
+            )
+        )
 
     def _apply_annotation_filters(self, query: QueryType) -> QueryType:
         if self.annotations_filter is None:

--- a/lightly_studio/tests/resolvers/annotations/test_annotations_filters.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotations_filters.py
@@ -15,6 +15,7 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
     AnnotationType,
 )
+from lightly_studio.models.embedding_region import EmbeddingRegion, Point2D
 from lightly_studio.resolvers import annotation_resolver
 from lightly_studio.resolvers import annotation_resolver as annotations_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import (
@@ -202,6 +203,63 @@ def test_combined_filters(
     ).annotations
     assert len(filtered_annotations) == 1
     assert filtered_annotations[0].sample_id == annotation1.sample_id
+
+
+def test_filter_by_embedding_region__resolved_ids(
+    db_session: Session,
+    filter_test_data: tuple[AnnotationBaseTable, AnnotationBaseTable],
+) -> None:
+    """A resolved embedding region restricts annotations to the enclosed sample ids."""
+    annotation1, _ = filter_test_data
+
+    region_filter = AnnotationsFilter(embedding_region=_square_region())
+    # The resolver would populate this from the cached 2D projection.
+    region_filter.set_resolved_region_sample_ids([annotation1.sample_id])
+
+    filtered_annotations = annotations_resolver.get_all(
+        session=db_session, filters=region_filter
+    ).annotations
+
+    assert len(filtered_annotations) == 1
+    assert filtered_annotations[0].sample_id == annotation1.sample_id
+
+
+def test_filter_by_embedding_region__empty_matches_nothing(
+    db_session: Session,
+    filter_test_data: tuple[AnnotationBaseTable, AnnotationBaseTable],  # noqa: ARG001
+) -> None:
+    """An empty resolved region must return no annotations, not all of them."""
+    # The fixture seeds annotations, so an empty result proves the region excluded them
+    # rather than the collection simply being empty.
+    assert annotations_resolver.get_all(session=db_session).annotations
+
+    region_filter = AnnotationsFilter(embedding_region=_square_region())
+    region_filter.set_resolved_region_sample_ids([])
+
+    filtered_annotations = annotations_resolver.get_all(
+        session=db_session, filters=region_filter
+    ).annotations
+
+    assert filtered_annotations == []
+
+
+def test_filter_by_embedding_region__unresolved_raises(db_session: Session) -> None:
+    """Applying an unresolved embedding region is a programming error."""
+    region_filter = AnnotationsFilter(embedding_region=_square_region())
+
+    with pytest.raises(RuntimeError, match="must be resolved"):
+        annotations_resolver.get_all(session=db_session, filters=region_filter)
+
+
+def _square_region() -> EmbeddingRegion:
+    return EmbeddingRegion(
+        polygon=[
+            Point2D(x=0, y=0),
+            Point2D(x=1, y=0),
+            Point2D(x=1, y=1),
+            Point2D(x=0, y=1),
+        ]
+    )
 
 
 def _count_sample_joins(query: SelectOfScalar[UUID]) -> int:

--- a/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
+++ b/lightly_studio/tests/resolvers/sample_resolver/test_sample_filter.py
@@ -10,6 +10,7 @@ from sqlmodel import Session, col, select
 
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionCreate
+from lightly_studio.models.embedding_region import EmbeddingRegion, Point2D
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricCreate
 from lightly_studio.models.evaluation_confusion_matrix import ConfusionCell
 from lightly_studio.models.image import ImageTable
@@ -95,6 +96,57 @@ class TestSampleFilter:
         # Should only return one sample
         assert len(result) == 1
         assert result[0].sample_id == filtered_sample_id
+
+    def test_apply__embedding_region__resolved_ids(self, db_session: Session) -> None:
+        collection = create_collection(session=db_session)
+        samples = create_images(
+            db_session=db_session,
+            collection_id=collection.collection_id,
+            images=[
+                ImageStub(path="sample_0.png"),
+                ImageStub(path="sample_1.png"),
+            ],
+        )
+        region = EmbeddingRegion(
+            polygon=[Point2D(x=0, y=0), Point2D(x=1, y=0), Point2D(x=1, y=1), Point2D(x=0, y=1)]
+        )
+        sample_filter = SampleFilter(embedding_region=region)
+        # The resolver would populate this from the cached 2D projection.
+        sample_filter.set_resolved_region_sample_ids([samples[0].sample_id])
+
+        filtered_query = sample_filter.apply(query=select(SampleTable))
+        result = db_session.exec(filtered_query).all()
+
+        assert len(result) == 1
+        assert result[0].sample_id == samples[0].sample_id
+
+    def test_apply__embedding_region__empty_matches_nothing(self, db_session: Session) -> None:
+        collection = create_collection(session=db_session)
+        create_images(
+            db_session=db_session,
+            collection_id=collection.collection_id,
+            images=[ImageStub(path="sample_0.png"), ImageStub(path="sample_1.png")],
+        )
+        region = EmbeddingRegion(
+            polygon=[Point2D(x=0, y=0), Point2D(x=1, y=0), Point2D(x=1, y=1), Point2D(x=0, y=1)]
+        )
+        sample_filter = SampleFilter(embedding_region=region)
+        # An empty region encloses no points and must return nothing, not everything.
+        sample_filter.set_resolved_region_sample_ids([])
+
+        filtered_query = sample_filter.apply(query=select(SampleTable))
+        result = db_session.exec(filtered_query).all()
+
+        assert result == []
+
+    def test_apply__embedding_region__unresolved_raises(self) -> None:
+        region = EmbeddingRegion(
+            polygon=[Point2D(x=0, y=0), Point2D(x=1, y=0), Point2D(x=1, y=1), Point2D(x=0, y=1)]
+        )
+        sample_filter = SampleFilter(embedding_region=region)
+
+        with pytest.raises(RuntimeError, match="must be resolved"):
+            sample_filter.apply(query=select(SampleTable))
 
     def test_apply__annotations_filter__image_sample(self, db_session: Session) -> None:
         # Create samples

--- a/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
@@ -1,0 +1,191 @@
+"""Tests for the embedding-region resolver (server-side point-in-polygon)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import numpy as np
+from sqlmodel import Session
+
+from lightly_studio.models.embedding_region import EmbeddingRegion, Point2D
+from lightly_studio.models.two_dim_embedding import TwoDimEmbeddingTable
+from lightly_studio.resolvers import embedding_region_resolver, sample_embedding_resolver
+from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
+from tests import helpers_resolvers
+from tests.helpers_resolvers import ImageStub
+
+
+def _square(x_min: float, y_min: float, x_max: float, y_max: float) -> EmbeddingRegion:
+    return EmbeddingRegion(
+        polygon=[
+            Point2D(x=x_min, y=y_min),
+            Point2D(x=x_max, y=y_min),
+            Point2D(x=x_max, y=y_max),
+            Point2D(x=x_min, y=y_max),
+        ]
+    )
+
+
+def _seed_2d_coordinates(
+    session: Session,
+    collection_id: UUID,
+    embedding_model_id: UUID,
+    coordinates: dict[UUID, tuple[float, float]],
+) -> list[UUID]:
+    """Seed the cached 2D projection with deterministic coordinates.
+
+    Returns the ordered sample ids as ``get_twodim_embeddings`` would return them.
+    """
+    cache_key, sample_ids = sample_embedding_resolver.get_hash_by_collection_id(
+        session=session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model_id,
+    )
+    session.add(
+        TwoDimEmbeddingTable(
+            hash=cache_key,
+            x=[coordinates[sample_id][0] for sample_id in sample_ids],
+            y=[coordinates[sample_id][1] for sample_id in sample_ids],
+        )
+    )
+    session.commit()
+    return sample_ids
+
+
+def _setup_collection_with_coordinates(
+    session: Session,
+    coordinates: list[tuple[float, float]],
+) -> tuple[UUID, list[UUID]]:
+    collection = helpers_resolvers.create_collection(session=session)
+    embedding_model = helpers_resolvers.create_embedding_model(
+        session=session,
+        collection_id=collection.collection_id,
+        embedding_dimension=3,
+    )
+    images = helpers_resolvers.create_samples_with_embeddings(
+        session=session,
+        collection_id=collection.collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        # Distinct first dimensions keep the deterministic cache key stable across samples.
+        images_and_embeddings=[
+            (ImageStub(path=f"sample_{index}.png"), [float(index) + 0.1, 0.2, 0.3])
+            for index in range(len(coordinates))
+        ],
+    )
+    coordinates_by_sample = {
+        image.sample_id: coordinate for image, coordinate in zip(images, coordinates)
+    }
+    ordered_sample_ids = _seed_2d_coordinates(
+        session=session,
+        collection_id=collection.collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        coordinates=coordinates_by_sample,
+    )
+    return collection.collection_id, ordered_sample_ids
+
+
+class TestPointsInPolygon:
+    def test_square_selects_only_inside_points(self) -> None:
+        region = _square(0, 0, 10, 10)
+        x = np.array([5, 15, -1, 9.9, 5], dtype=np.float32)
+        y = np.array([5, 5, 5, 9.9, 20], dtype=np.float32)
+
+        mask = embedding_region_resolver._points_in_polygon(x=x, y=y, region=region)
+
+        assert mask.tolist() == [True, False, False, True, False]
+
+    def test_concave_polygon(self) -> None:
+        # An arrow-shaped concave polygon with a notch at the top center.
+        region = EmbeddingRegion(
+            polygon=[
+                Point2D(x=0, y=0),
+                Point2D(x=10, y=0),
+                Point2D(x=10, y=10),
+                Point2D(x=5, y=4),
+                Point2D(x=0, y=10),
+            ]
+        )
+        # (5, 8) sits in the notch (outside); (5, 2) is well inside.
+        x = np.array([5, 5, 1], dtype=np.float32)
+        y = np.array([8, 2, 1], dtype=np.float32)
+
+        mask = embedding_region_resolver._points_in_polygon(x=x, y=y, region=region)
+
+        assert mask.tolist() == [False, True, True]
+
+
+class TestGetSampleIdsInRegion:
+    def test_selects_points_inside_region(self, db_session: Session) -> None:
+        collection_id, sample_ids = _setup_collection_with_coordinates(
+            session=db_session,
+            coordinates=[(1.0, 1.0), (5.0, 5.0), (100.0, 100.0)],
+        )
+
+        selected = embedding_region_resolver.get_sample_ids_in_region(
+            session=db_session,
+            collection_id=collection_id,
+            region=_square(0, 0, 10, 10),
+        )
+
+        assert set(selected) == {sample_ids[0], sample_ids[1]}
+
+    def test_empty_region_selects_nothing(self, db_session: Session) -> None:
+        collection_id, _ = _setup_collection_with_coordinates(
+            session=db_session,
+            coordinates=[(1.0, 1.0), (5.0, 5.0)],
+        )
+
+        selected = embedding_region_resolver.get_sample_ids_in_region(
+            session=db_session,
+            collection_id=collection_id,
+            region=_square(50, 50, 60, 60),
+        )
+
+        assert selected == []
+
+    def test_no_embedding_model_returns_empty(self, db_session: Session) -> None:
+        collection = helpers_resolvers.create_collection(session=db_session)
+
+        selected = embedding_region_resolver.get_sample_ids_in_region(
+            session=db_session,
+            collection_id=collection.collection_id,
+            region=_square(0, 0, 10, 10),
+        )
+
+        assert selected == []
+
+
+class TestResolveEmbeddingRegion:
+    def test_populates_resolved_sample_ids(self, db_session: Session) -> None:
+        collection_id, sample_ids = _setup_collection_with_coordinates(
+            session=db_session,
+            coordinates=[(1.0, 1.0), (100.0, 100.0)],
+        )
+        sample_filter = SampleFilter(embedding_region=_square(0, 0, 10, 10))
+        filters = ImageFilter(sample_filter=sample_filter)
+
+        embedding_region_resolver.resolve_embedding_region(
+            session=db_session, collection_id=collection_id, filters=filters
+        )
+
+        assert sample_filter._resolved_region_sample_ids == [sample_ids[0]]
+
+    def test_no_region_is_noop(self, db_session: Session) -> None:
+        collection = helpers_resolvers.create_collection(session=db_session)
+        sample_filter = SampleFilter()
+        filters = ImageFilter(sample_filter=sample_filter)
+
+        embedding_region_resolver.resolve_embedding_region(
+            session=db_session, collection_id=collection.collection_id, filters=filters
+        )
+
+        assert sample_filter._resolved_region_sample_ids is None
+
+    def test_none_filters_is_noop(self, db_session: Session) -> None:
+        collection = helpers_resolvers.create_collection(session=db_session)
+
+        # Should not raise.
+        embedding_region_resolver.resolve_embedding_region(
+            session=db_session, collection_id=collection.collection_id, filters=None
+        )

--- a/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import numpy as np
 from sqlmodel import Session
@@ -10,6 +10,7 @@ from sqlmodel import Session
 from lightly_studio.models.embedding_region import EmbeddingRegion, Point2D
 from lightly_studio.models.two_dim_embedding import TwoDimEmbeddingTable
 from lightly_studio.resolvers import embedding_region_resolver, sample_embedding_resolver
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests import helpers_resolvers
@@ -189,3 +190,27 @@ class TestResolveEmbeddingRegion:
         embedding_region_resolver.resolve_embedding_region(
             session=db_session, collection_id=collection.collection_id, filters=None
         )
+
+
+class TestResolveAnnotationEmbeddingRegion:
+    def test_populates_resolved_sample_ids(self, db_session: Session) -> None:
+        collection_id, sample_ids = _setup_collection_with_coordinates(
+            session=db_session,
+            coordinates=[(1.0, 1.0), (100.0, 100.0)],
+        )
+        filters = AnnotationsFilter(embedding_region=_square(0, 0, 10, 10))
+
+        embedding_region_resolver.resolve_annotation_embedding_region(
+            session=db_session, collection_id=collection_id, filters=filters
+        )
+
+        assert filters._resolved_region_sample_ids == [sample_ids[0]]
+
+    def test_no_region_is_noop(self, db_session: Session) -> None:
+        filters = AnnotationsFilter()
+
+        embedding_region_resolver.resolve_annotation_embedding_region(
+            session=db_session, collection_id=uuid4(), filters=filters
+        )
+
+        assert filters._resolved_region_sample_ids is None

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -58,9 +58,10 @@
         textEmbedding
     } = useGlobalStorage();
 
-    // The embedding plot lasso selection on the annotations route.
-    const { annotationPlotSampleIds } = useAnnotationPlotSelection();
-    const plotSelectedAnnotationIds = $derived($annotationPlotSampleIds);
+    // The embedding plot lasso selection on the annotations route, kept as geometry and sent
+    // to the backend instead of a resolved sample-id list (see LIG-9903).
+    const { annotationPlotRegion } = useAnnotationPlotSelection();
+    const plotSelectedRegion = $derived($annotationPlotRegion);
 
     // The text embedding search is shared with the images tab and persists across the tab switch.
     // Only apply it when this annotation collection actually has embeddings.
@@ -126,8 +127,8 @@
         annotation_label_ids:
             $selectedAnnotationFilterIds.length > 0 ? $selectedAnnotationFilterIds : undefined,
         tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined,
-        // Embedding plot lasso selection narrows the grid to the selected annotations.
-        sample_ids: plotSelectedAnnotationIds.length > 0 ? plotSelectedAnnotationIds : undefined,
+        // Embedding plot lasso selection narrows the grid to annotations inside the region.
+        embedding_region: plotSelectedRegion ?? undefined,
         // Embedding text search reorders the grid by similarity (shared with images tab).
         text_embedding: searchEmbedding?.embedding ?? undefined
     });
@@ -145,7 +146,7 @@
     let infiniteLoaderIdentifier = $derived(
         $selectedAnnotationFilterIds.join(',') +
             Array.from($tagsSelected).join(',') +
-            plotSelectedAnnotationIds.join(',') +
+            (plotSelectedRegion ? JSON.stringify(plotSelectedRegion) : '') +
             (searchEmbedding ? `search:${searchEmbedding.queryText}` : '')
     );
 

--- a/lightly_studio_view/src/lib/components/Images/syncFilterParams.test.ts
+++ b/lightly_studio_view/src/lib/components/Images/syncFilterParams.test.ts
@@ -10,6 +10,14 @@ const confusionCell = {
     pred_label: 'dog'
 };
 
+const embeddingRegion = {
+    polygon: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 1 }
+    ]
+};
+
 const normalParams = (collection_id: string, filters: NormalModeFilters): ImagesInfiniteParams => ({
     collection_id,
     mode: 'normal',
@@ -30,11 +38,12 @@ describe('paramsWithoutExternalFilters', () => {
         expect(paramsWithoutExternalFilters(params).filters).toEqual({ tag_ids: ['tag-1'] });
     });
 
-    it('treats params that differ only in sample_ids/confusion_cell as equal', () => {
+    it('treats params that differ only in sample_ids/embedding_region/confusion_cell as equal', () => {
         const base = baseNormalParams();
         const withExternal = normalParams('col-1', {
             tag_ids: ['tag-1'],
             sample_ids: ['s1'],
+            embedding_region: embeddingRegion,
             confusion_cell: confusionCell
         });
 
@@ -77,6 +86,17 @@ describe('mergeExternalFilters', () => {
         if (result.mode === 'normal') {
             expect(result.filters?.sample_ids).toEqual(['s1', 's2']);
             expect(result.filters?.tag_ids).toEqual(['tag-1']);
+        }
+    });
+
+    it('carries the embedding_region forward across collections', () => {
+        const baseParams = baseNormalParams('col-2');
+        const currentParams = normalParams('col-1', { embedding_region: embeddingRegion });
+
+        const result = mergeExternalFilters(baseParams, currentParams);
+
+        if (result.mode === 'normal') {
+            expect(result.filters?.embedding_region).toEqual(embeddingRegion);
         }
     });
 

--- a/lightly_studio_view/src/lib/components/Images/syncFilterParams.ts
+++ b/lightly_studio_view/src/lib/components/Images/syncFilterParams.ts
@@ -2,24 +2,24 @@ import { omit } from 'lodash-es';
 import type { ImagesInfiniteParams } from '$lib/hooks/useImagesInfinite/useImagesInfinite';
 import type { NormalModeFilters } from '$lib/hooks/useImagesInfinite/types';
 
-// sample_ids and confusion_cell are set externally (selection / confusion matrix),
-// not from the component's filter controls, so they are excluded from the
-// base-params comparison and merged back instead of being overwritten.
+// sample_ids, embedding_region and confusion_cell are set externally (plot selection /
+// confusion matrix), not from the component's filter controls, so they are excluded from
+// the base-params comparison and merged back instead of being overwritten.
 export const paramsWithoutExternalFilters = (params: ImagesInfiniteParams) => {
     return {
         ...params,
         filters:
             params.mode === 'normal'
-                ? omit(params.filters, ['sample_ids', 'confusion_cell'])
+                ? omit(params.filters, ['sample_ids', 'embedding_region', 'confusion_cell'])
                 : undefined
     };
 };
 
-// Merge the externally-set selection (sample_ids) and confusion cell from the
-// previous filter params into the new base params. sample_ids are always carried
-// forward; the confusion cell is only carried when the collection matches, because
-// the cell belongs to a specific evaluation run/collection and must be dropped when
-// navigating to a different collection to avoid wrongly filtering the new grid.
+// Merge the externally-set selection (sample_ids, embedding_region) and confusion cell from
+// the previous filter params into the new base params. The selection is always carried
+// forward; the confusion cell is only carried when the collection matches, because the cell
+// belongs to a specific evaluation run/collection and must be dropped when navigating to a
+// different collection to avoid wrongly filtering the new grid.
 export const mergeExternalFilters = (
     baseParams: ImagesInfiniteParams,
     currentParams: ImagesInfiniteParams
@@ -27,20 +27,26 @@ export const mergeExternalFilters = (
     let nextParams = baseParams;
 
     let currentSampleIds: string[] = [];
+    let currentEmbeddingRegion: NormalModeFilters['embedding_region'];
     let currentConfusionCell: NormalModeFilters['confusion_cell'];
     if (currentParams.mode === 'normal') {
         currentSampleIds = currentParams.filters?.sample_ids ?? [];
+        currentEmbeddingRegion = currentParams.filters?.embedding_region;
         if (currentParams.collection_id === baseParams.collection_id) {
             currentConfusionCell = currentParams.filters?.confusion_cell;
         }
     }
 
-    if (nextParams.mode === 'normal' && (currentSampleIds.length > 0 || currentConfusionCell)) {
+    if (
+        nextParams.mode === 'normal' &&
+        (currentSampleIds.length > 0 || currentEmbeddingRegion || currentConfusionCell)
+    ) {
         nextParams = {
             ...nextParams,
             filters: {
                 ...(nextParams.filters ?? {}),
                 sample_ids: currentSampleIds.length > 0 ? currentSampleIds : undefined,
+                embedding_region: currentEmbeddingRegion,
                 confusion_cell: currentConfusionCell
             }
         };

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -11,6 +11,10 @@
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
     import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
     import { useAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
+    import {
+        clearPlotSelectionCount,
+        setPlotSelectionCount
+    } from '$lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection';
     import { useArrowData } from './useArrowData/useArrowData';
     import { usePlotData } from './usePlotData/usePlotData';
     import PlotPanelLegend from './PlotPanelLegend.svelte';
@@ -53,30 +57,35 @@
     // Use appropriate filter hook based on route
     const imageFilters = useImageFilters();
     const videoFilters = useVideoFilters();
-    const { annotationPlotSampleIds, saveSampleIds: saveAnnotationPlotSampleIds } =
+    const { annotationPlotRegion, saveRegion: saveAnnotationPlotRegion } =
         useAnnotationPlotSelection();
 
-    const updateSampleIds = $derived(
-        isAnnotations
-            ? saveAnnotationPlotSampleIds
-            : isVideos
-              ? videoFilters.updateSampleIds
-              : imageFilters.updateSampleIds
-    );
+    // Videos still commit resolved sample ids client-side.
+    const updateSampleIds = $derived(videoFilters.updateSampleIds);
     const imageFilter = $derived(isVideos ? null : imageFilters.imageFilter);
     const videoFilter = $derived(isVideos ? videoFilters.videoFilter : null);
     const activeSampleIds = $derived(
-        isAnnotations
-            ? $annotationPlotSampleIds
-            : ((isVideos ? $videoFilter : $imageFilter)?.sample_filter?.sample_ids ?? [])
+        isVideos ? ($videoFilter?.sample_filter?.sample_ids ?? []) : []
     );
 
-    // Images send the lasso/rectangle as geometry (embedding_region) instead of the full list
-    // of selected sample ids, so the request body stays small at scale (see LIG-9903). Videos
-    // and annotations keep committing resolved sample ids for now.
-    const isRegionMode = $derived(!isAnnotations && !isVideos);
+    // Images and annotations send the lasso/rectangle as geometry (embedding_region) instead
+    // of the full list of selected sample ids, so the request body stays small at scale (see
+    // LIG-9903). Videos still commit resolved sample ids for now.
+    const isRegionMode = $derived(!isVideos);
+    // Commit the drawn polygon to the right store for the active tab.
+    const commitRegion = (region: { polygon: Point[] } | null) => {
+        if (isAnnotations) {
+            saveAnnotationPlotRegion(region);
+        } else {
+            imageFilters.updateEmbeddingRegion(region);
+        }
+    };
     const committedRegionPolygon = $derived(
-        isRegionMode ? ($imageFilter?.sample_filter?.embedding_region?.polygon ?? null) : null
+        isAnnotations
+            ? ($annotationPlotRegion?.polygon ?? null)
+            : isRegionMode
+              ? ($imageFilter?.sample_filter?.embedding_region?.polygon ?? null)
+              : null
     );
 
     // The active annotation label/tag filter, mirroring what the annotations grid applies.
@@ -225,19 +234,21 @@
         if (isRegionMode) {
             if (isEmptySelection || isFullSelection) {
                 if (committedRegionPolygon !== null) {
-                    imageFilters.updateEmbeddingRegion(null);
+                    commitRegion(null);
                 }
+                clearPlotSelectionCount(collectionId);
             } else {
-                imageFilters.updateEmbeddingRegion({ polygon: drawnPolygon });
+                commitRegion({ polygon: drawnPolygon });
+                // Propagate the client-computed in-polygon count so the sidebar filter chip
+                // can show how many items are selected (the ids stay on the client).
+                setPlotSelectionCount(collectionId, $selectedSampleIds.length);
             }
             setRangeSelection(null);
             return;
         }
 
-        // Videos and annotations still commit the resolved sample ids client-side.
-        const currentSampleIds = isAnnotations
-            ? $annotationPlotSampleIds
-            : ($videoFilter?.sample_filter?.sample_ids ?? []);
+        // Videos still commit the resolved sample ids client-side.
+        const currentSampleIds = $videoFilter?.sample_filter?.sample_ids ?? [];
 
         if (isEmptySelection || isFullSelection) {
             if (currentSampleIds.length > 0) {
@@ -324,7 +335,8 @@
     const clearSelection = () => {
         setRangeSelection(null);
         if (isRegionMode) {
-            imageFilters.updateEmbeddingRegion(null);
+            commitRegion(null);
+            clearPlotSelectionCount(collectionId);
         } else {
             updateSampleIds([]);
         }

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -71,6 +71,14 @@
             : ((isVideos ? $videoFilter : $imageFilter)?.sample_filter?.sample_ids ?? [])
     );
 
+    // Images send the lasso/rectangle as geometry (embedding_region) instead of the full list
+    // of selected sample ids, so the request body stays small at scale (see LIG-9903). Videos
+    // and annotations keep committing resolved sample ids for now.
+    const isRegionMode = $derived(!isAnnotations && !isVideos);
+    const committedRegionPolygon = $derived(
+        isRegionMode ? ($imageFilter?.sample_filter?.embedding_region?.polygon ?? null) : null
+    );
+
     // The active annotation label/tag filter, mirroring what the annotations grid applies.
     const { annotationFilter: selectedAnnotationsFilter } =
         useSelectedAnnotationsFilter(collectionId);
@@ -93,7 +101,10 @@
             ...currentFilter,
             sample_filter: {
                 ...currentFilter.sample_filter,
-                sample_ids: []
+                sample_ids: [],
+                // The plot renders every point and only marks which fulfil the filter, so the
+                // lasso selection itself must not restrict the returned points.
+                embedding_region: undefined
             }
         };
     });
@@ -175,10 +186,13 @@
         return next;
     });
 
+    // While drawing, highlight the in-progress polygon; once committed (region mode) keep
+    // highlighting the stored region so the selection stays visible without the lasso outline.
+    const highlightSelection = $derived($rangeSelection ?? committedRegionPolygon);
     let { data: plotData, selectedSampleIds } = $derived(
         usePlotData({
             arrowData: $arrowData,
-            rangeSelection: $rangeSelection,
+            rangeSelection: highlightSelection,
             highlightedSampleIds: activeSampleIds,
             hasActiveFilter: hasActiveFilter,
             hiddenCategories: effectiveHiddenCategories
@@ -193,28 +207,39 @@
         getLegendEntries($colorLegend, $hiddenCategories, useLabelColors)
     );
     const handleMouseUp = () => {
-        const hadRangeSelection = $rangeSelection !== null;
-        if (!hadRangeSelection) {
+        const drawnPolygon = $rangeSelection;
+        if (drawnPolygon === null) {
             return;
         }
 
-        const currentSampleIds = isAnnotations
-            ? $annotationPlotSampleIds
-            : ((isVideos ? $videoFilter : $imageFilter)?.sample_filter?.sample_ids ?? []);
         const selectableCount =
             ($arrowData?.fulfils_filter as Uint8Array | undefined)?.reduce((count, fulfils) => {
                 return fulfils !== 0 ? count + 1 : count;
             }, 0) ?? null;
+        // An empty selection is a cleared selection; a full selection is equivalent to no
+        // selection at all. In both cases we drop the selection instead of committing it.
+        const isEmptySelection = $selectedSampleIds.length === 0;
+        const isFullSelection =
+            selectableCount !== null && $selectedSampleIds.length === selectableCount;
 
-        if ($selectedSampleIds.length === 0) {
-            if (currentSampleIds.length > 0) {
-                updateSampleIds([]);
+        if (isRegionMode) {
+            if (isEmptySelection || isFullSelection) {
+                if (committedRegionPolygon !== null) {
+                    imageFilters.updateEmbeddingRegion(null);
+                }
+            } else {
+                imageFilters.updateEmbeddingRegion({ polygon: drawnPolygon });
             }
             setRangeSelection(null);
             return;
         }
 
-        if (selectableCount !== null && $selectedSampleIds.length === selectableCount) {
+        // Videos and annotations still commit the resolved sample ids client-side.
+        const currentSampleIds = isAnnotations
+            ? $annotationPlotSampleIds
+            : ($videoFilter?.sample_filter?.sample_ids ?? []);
+
+        if (isEmptySelection || isFullSelection) {
             if (currentSampleIds.length > 0) {
                 updateSampleIds([]);
             }
@@ -298,9 +323,15 @@
 
     const clearSelection = () => {
         setRangeSelection(null);
-        updateSampleIds([]);
+        if (isRegionMode) {
+            imageFilters.updateEmbeddingRegion(null);
+        } else {
+            updateSampleIds([]);
+        }
     };
-    const hasActiveSelection = $derived($rangeSelection !== null || activeSampleIds.length > 0);
+    const hasActiveSelection = $derived(
+        $rangeSelection !== null || activeSampleIds.length > 0 || committedRegionPolygon !== null
+    );
 
     const onWindowKeyDown = (event: KeyboardEvent) => {
         if (event.key !== 'Escape') {

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
@@ -25,6 +25,7 @@ const tagsStore = writable([
 const mockSetShowEmbeddingPlot = vi.fn();
 const mockSetRangeSelectionForCollection = vi.fn();
 const mockUpdateSampleIds = vi.fn();
+const mockUpdateEmbeddingRegion = vi.fn();
 
 class ResizeObserverMock {
     observe() {}
@@ -86,7 +87,8 @@ vi.mock('$lib/hooks/useImageFilters/useImageFilters', () => ({
         filterParams: writable({ mode: 'normal', filters: {} }),
         imageFilter: imageFilterStore,
         updateFilterParams: vi.fn(),
-        updateSampleIds: mockUpdateSampleIds
+        updateSampleIds: mockUpdateSampleIds,
+        updateEmbeddingRegion: mockUpdateEmbeddingRegion
     })
 }));
 vi.mock('$lib/hooks/useMetadataFilters/useMetadataFilters', () => ({
@@ -192,16 +194,18 @@ describe('PlotPanel.svelte', () => {
         await fireEvent.keyDown(window, { key: 'Escape' });
 
         expect(mockSetRangeSelectionForCollection).toHaveBeenCalledWith('test-collection-id', null);
-        expect(mockUpdateSampleIds).toHaveBeenCalledWith([]);
+        // Images commit the selection as geometry, so clearing drops the embedding region.
+        expect(mockUpdateEmbeddingRegion).toHaveBeenCalledWith(null);
     });
 
-    it('should clear range selection geometry after applying mouse selection', async () => {
-        rangeSelectionStore = writable([
+    it('should commit the selection geometry as an embedding region on mouse up', async () => {
+        const polygon = [
             { x: 0, y: 0 },
             { x: 1, y: 0 },
             { x: 1, y: 1 },
             { x: 0, y: 1 }
-        ]);
+        ];
+        rangeSelectionStore = writable(polygon);
         selectedSampleIdsStore = writable(['sample-1']);
         (useEmbeddings as vi.Mock).mockReturnValue({
             isError: false,
@@ -213,7 +217,9 @@ describe('PlotPanel.svelte', () => {
         render(PlotPanel, { props: { collectionId: 'test-collection-id' } });
         await fireEvent.mouseUp(window);
 
-        expect(mockUpdateSampleIds).toHaveBeenCalledWith(['sample-1']);
+        // The polygon is sent to the backend instead of the resolved sample ids (LIG-9903).
+        expect(mockUpdateEmbeddingRegion).toHaveBeenCalledWith({ polygon });
+        expect(mockUpdateSampleIds).not.toHaveBeenCalled();
         expect(mockSetRangeSelectionForCollection).toHaveBeenCalledWith('test-collection-id', null);
     });
 
@@ -247,7 +253,7 @@ describe('PlotPanel.svelte', () => {
         expect(mockUpdateSampleIds).not.toHaveBeenCalled();
     });
 
-    it('should clear sample_ids when selecting all selectable points', async () => {
+    it('should clear the embedding region when selecting all selectable points', async () => {
         rangeSelectionStore = writable([
             { x: 0, y: 0 },
             { x: 1, y: 0 },
@@ -255,7 +261,18 @@ describe('PlotPanel.svelte', () => {
             { x: 0, y: 1 }
         ]);
         selectedSampleIdsStore = writable(['sample-1', 'sample-2']);
-        imageFilterStore = writable({ sample_filter: { sample_ids: ['stale-id'] } });
+        // A previously committed region exists, so a full selection should drop it.
+        imageFilterStore = writable({
+            sample_filter: {
+                embedding_region: {
+                    polygon: [
+                        { x: 0, y: 0 },
+                        { x: 1, y: 0 },
+                        { x: 1, y: 1 }
+                    ]
+                }
+            }
+        });
         arrowDataStore = writable({
             x: new Float32Array([1, 2, 3]),
             y: new Float32Array([1, 2, 3]),
@@ -267,8 +284,10 @@ describe('PlotPanel.svelte', () => {
         render(PlotPanel, { props: { collectionId: 'test-collection-id' } });
         await fireEvent.mouseUp(window);
 
-        expect(mockUpdateSampleIds).toHaveBeenCalledWith([]);
-        expect(mockUpdateSampleIds).not.toHaveBeenCalledWith(['sample-1', 'sample-2']);
+        expect(mockUpdateEmbeddingRegion).toHaveBeenCalledWith(null);
+        expect(mockUpdateEmbeddingRegion).not.toHaveBeenCalledWith(
+            expect.objectContaining({ polygon: expect.anything() })
+        );
         expect(mockSetRangeSelectionForCollection).toHaveBeenCalledWith('test-collection-id', null);
     });
 

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.test.ts
@@ -68,6 +68,18 @@ describe('createAnnotationsInfiniteOptions', () => {
             });
             expect(options1.queryKey).not.toEqual(options2.queryKey);
         });
+
+        it('produces different keys for different embedding_region values', () => {
+            const options1 = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                embedding_region: { polygon: [{ x: 0, y: 0 }] }
+            });
+            const options2 = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                embedding_region: { polygon: [{ x: 1, y: 1 }] }
+            });
+            expect(options1.queryKey).not.toEqual(options2.queryKey);
+        });
     });
 
     describe('pagination', () => {
@@ -129,6 +141,22 @@ describe('createAnnotationsInfiniteOptions', () => {
                         sample_ids: ['s1'],
                         text_embedding: [0.5, 0.5]
                     }
+                })
+            );
+        });
+
+        it('passes the embedding region geometry to readAnnotationsWithPayload body', async () => {
+            const embedding_region = { polygon: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }] };
+            const options = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                embedding_region
+            });
+
+            await callQueryFn(options, { pageParam: 0, signal: new AbortController().signal });
+
+            expect(readAnnotationsWithPayloadMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.objectContaining({ embedding_region })
                 })
             );
         });

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.ts
@@ -17,6 +17,7 @@ export const createAnnotationsInfiniteOptions = (params: AnnotationsInfinitePara
             annotation_label_ids: params.annotation_label_ids,
             tag_ids: params.tag_ids,
             sample_ids: params.sample_ids,
+            embedding_region: params.embedding_region,
             text_embedding: params.text_embedding
         }
     ];
@@ -37,6 +38,7 @@ export const createAnnotationsInfiniteOptions = (params: AnnotationsInfinitePara
                     annotation_label_ids: params.annotation_label_ids,
                     tag_ids: params.tag_ids,
                     sample_ids: params.sample_ids,
+                    embedding_region: params.embedding_region,
                     text_embedding: params.text_embedding
                 },
                 signal,

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilter.test.ts
@@ -3,6 +3,7 @@ import { get, writable } from 'svelte/store';
 import { useHiddenFilters } from './useHiddenFilters';
 import { useEmbeddingFilterForImages } from './useEmbeddingFilterForImages';
 import { useEmbeddingFilterForVideos } from './useEmbeddingFilterForVideos';
+import { clearPlotSelectionCount, setPlotSelectionCount } from './useEmbeddingPlotSelection';
 import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
 import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
 
@@ -82,40 +83,21 @@ describe('useEmbeddingFilterForImages', () => {
         vi.clearAllMocks();
         const { updateFilterParams } = useImageFilters();
         updateFilterParams({ collection_id: 'coll-1', mode: 'normal' });
-        const { clearHidden } = useHiddenFilters(collectionId);
-        clearHidden();
+        clearPlotSelectionCount('coll-1');
+        collectionId.set('coll-1');
     });
 
-    it('isVisible is false when collection_id does not match', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'other-coll',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1'] }
-        });
-
-        const { isVisible } = useEmbeddingFilterForImages(collectionId, setRangeSelection);
+    it('isVisible is false when no region is selected', () => {
+        const { isVisible, effectiveCount } = useEmbeddingFilterForImages(
+            collectionId,
+            setRangeSelection
+        );
         expect(get(isVisible)).toBe(false);
+        expect(get(effectiveCount)).toBe(0);
     });
 
-    it('isVisible is false when mode is not normal', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'classifier'
-        });
-
-        const { isVisible } = useEmbeddingFilterForImages(collectionId, setRangeSelection);
-        expect(get(isVisible)).toBe(false);
-    });
-
-    it('isVisible is true when collection matches and sample_ids are set', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1', 'id-2'] }
-        });
+    it('isVisible reflects the propagated plot selection count', () => {
+        setPlotSelectionCount('coll-1', 2);
 
         const { isVisible, effectiveCount } = useEmbeddingFilterForImages(
             collectionId,
@@ -125,13 +107,8 @@ describe('useEmbeddingFilterForImages', () => {
         expect(get(effectiveCount)).toBe(2);
     });
 
-    it('setVisibility(false) moves active IDs to hidden and clears the filter', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1', 'id-2'] }
-        });
+    it('setVisibility(false) clears the selection', () => {
+        setPlotSelectionCount('coll-1', 2);
 
         const { isVisible, effectiveCount, setVisibility } = useEmbeddingFilterForImages(
             collectionId,
@@ -140,74 +117,17 @@ describe('useEmbeddingFilterForImages', () => {
         setVisibility(false);
 
         expect(get(isVisible)).toBe(false);
-        expect(get(effectiveCount)).toBe(2);
-    });
-
-    it('setVisibility(true) restores previously hidden IDs', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1', 'id-2'] }
-        });
-
-        const { isVisible, effectiveCount, setVisibility } = useEmbeddingFilterForImages(
-            collectionId,
-            setRangeSelection
-        );
-        setVisibility(false);
-        setVisibility(true);
-
-        expect(get(isVisible)).toBe(true);
-        expect(get(effectiveCount)).toBe(2);
-    });
-
-    it('setVisibility(true) keeps hidden IDs when restore cannot be applied', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1'] }
-        });
-
-        const { isVisible, effectiveCount, setVisibility } = useEmbeddingFilterForImages(
-            collectionId,
-            setRangeSelection
-        );
-        setVisibility(false);
-
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'classifier'
-        });
-        setVisibility(true);
-
-        expect(get(isVisible)).toBe(false);
-        expect(get(effectiveCount)).toBe(1);
-    });
-
-    it('setVisibility(false) does nothing when there are no active IDs', () => {
-        const { effectiveCount, setVisibility } = useEmbeddingFilterForImages(
-            collectionId,
-            setRangeSelection
-        );
-        setVisibility(false);
         expect(get(effectiveCount)).toBe(0);
+        expect(setRangeSelection).toHaveBeenCalledWith('coll-1', null);
     });
 
-    it('clearFilter clears both active and hidden IDs and calls setRangeSelection', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1'] }
-        });
+    it('clearFilter clears the count and calls setRangeSelection', () => {
+        setPlotSelectionCount('coll-1', 3);
 
-        const { effectiveCount, setVisibility, clearFilter } = useEmbeddingFilterForImages(
+        const { effectiveCount, clearFilter } = useEmbeddingFilterForImages(
             collectionId,
             setRangeSelection
         );
-        setVisibility(false);
         clearFilter();
 
         expect(get(effectiveCount)).toBe(0);

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.test.ts
@@ -1,27 +1,37 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { get, writable } from 'svelte/store';
+import type { EmbeddingRegion } from '$lib/api/lightly_studio_local';
 import {
     clearAnnotationPlotSelection,
     useAnnotationPlotSelection,
     useEmbeddingFilterForAnnotations
 } from './useEmbeddingFilterForAnnotations';
+import { clearPlotSelectionCount, setPlotSelectionCount } from './useEmbeddingPlotSelection';
+
+const region: EmbeddingRegion = {
+    polygon: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 1 }
+    ]
+};
 
 describe('useAnnotationPlotSelection', () => {
     beforeEach(() => {
         clearAnnotationPlotSelection();
     });
 
-    it('stores plot sample IDs in a shared store', () => {
-        const { annotationPlotSampleIds, saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['a-1', 'a-2']);
-        expect(get(annotationPlotSampleIds)).toEqual(['a-1', 'a-2']);
+    it('stores the plot region in a shared store', () => {
+        const { annotationPlotRegion, saveRegion } = useAnnotationPlotSelection();
+        saveRegion(region);
+        expect(get(annotationPlotRegion)).toEqual(region);
     });
 
     it('clearAnnotationPlotSelection resets the store', () => {
-        const { annotationPlotSampleIds, saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['a-1']);
+        const { annotationPlotRegion, saveRegion } = useAnnotationPlotSelection();
+        saveRegion(region);
         clearAnnotationPlotSelection();
-        expect(get(annotationPlotSampleIds)).toEqual([]);
+        expect(get(annotationPlotRegion)).toBeNull();
     });
 });
 
@@ -32,12 +42,12 @@ describe('useEmbeddingFilterForAnnotations', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         clearAnnotationPlotSelection();
+        clearPlotSelectionCount('coll-1');
         collectionId.set('coll-1');
     });
 
-    it('isVisible is true when plot sample IDs are set', () => {
-        const { saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['id-1', 'id-2']);
+    it('isVisible reflects the propagated selection count', () => {
+        setPlotSelectionCount('coll-1', 2);
 
         const { isVisible, effectiveCount } = useEmbeddingFilterForAnnotations(
             collectionId,
@@ -47,9 +57,10 @@ describe('useEmbeddingFilterForAnnotations', () => {
         expect(get(effectiveCount)).toBe(2);
     });
 
-    it('clearFilter clears plot sample IDs and range selection', () => {
-        const { saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['id-1']);
+    it('clearFilter clears the region, count and range selection', () => {
+        const { saveRegion } = useAnnotationPlotSelection();
+        saveRegion(region);
+        setPlotSelectionCount('coll-1', 3);
 
         const { clearFilter, effectiveCount } = useEmbeddingFilterForAnnotations(
             collectionId,
@@ -57,6 +68,8 @@ describe('useEmbeddingFilterForAnnotations', () => {
         );
         clearFilter();
 
+        const { annotationPlotRegion } = useAnnotationPlotSelection();
+        expect(get(annotationPlotRegion)).toBeNull();
         expect(get(effectiveCount)).toBe(0);
         expect(setRangeSelection).toHaveBeenCalledWith('coll-1', null);
     });

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.ts
@@ -1,38 +1,33 @@
 import { writable, type Readable } from 'svelte/store';
-import { useFilterVisibility } from './useFilterVisibility';
+import type { EmbeddingRegion } from '$lib/api/lightly_studio_local';
+import { useRegionFilterVisibility } from './useRegionFilterVisibility';
 
-// For images and videos the lasso selection already lives inside a
-// backend-driven filter store (useImageFilters / useVideoFilters), so the
-// "active sample ids" can be derived straight from those filter params.
-// Annotations have no such filter store, so we keep the lasso selection in
-// this small module-level writable instead. The plot (writer) and the grid
-// (reader) share it, which is why it lives at module scope rather than being
-// created per-component.
-const annotationPlotSampleIds = writable<string[]>([]);
+// For images the lasso selection lives inside the image filter store; annotations have no such
+// store, so we keep the plot region here at module scope. The plot (writer) and the grid
+// (reader) share it. The selection is sent to the backend as geometry (see LIG-9903), so we
+// store the polygon, not the resolved sample ids.
+const annotationPlotRegion = writable<EmbeddingRegion | null>(null);
 
 export function useAnnotationPlotSelection() {
     return {
-        annotationPlotSampleIds,
-        saveSampleIds: (ids: string[]) => annotationPlotSampleIds.set(ids)
+        annotationPlotRegion,
+        saveRegion: (region: EmbeddingRegion | null) => annotationPlotRegion.set(region)
     };
 }
 
 export function clearAnnotationPlotSelection() {
-    annotationPlotSampleIds.set([]);
+    annotationPlotRegion.set(null);
 }
 
-// Adapts the local annotation selection store to the shared useFilterVisibility
-// functionality, so the annotations route gets the same show/hide/clear behaviour as
-// the image and video embedding filters.
+// Adapts the local annotation region selection to the shared region-based visibility, so the
+// annotations route gets the same count/clear behaviour as the image embedding filter.
 export function useEmbeddingFilterForAnnotations(
     collectionId: Readable<string>,
     setRangeSelectionForCollection: (collectionId: string, selection: null) => void
 ) {
-    const { saveSampleIds } = useAnnotationPlotSelection();
-    return useFilterVisibility(
+    return useRegionFilterVisibility(
         collectionId,
-        annotationPlotSampleIds,
-        saveSampleIds,
+        () => annotationPlotRegion.set(null),
         setRangeSelectionForCollection
     );
 }

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForImages.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForImages.ts
@@ -1,30 +1,19 @@
-import { derived, type Readable } from 'svelte/store';
+import { type Readable } from 'svelte/store';
 import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
-import { useFilterVisibility } from './useFilterVisibility';
+import { useRegionFilterVisibility } from './useRegionFilterVisibility';
 
 export function useEmbeddingFilterForImages(
     collectionId: Readable<string>,
     setRangeSelectionForCollection: (collectionId: string, selection: null) => void
 ) {
-    const { filterParams, updateSampleIds } = useImageFilters();
+    const { updateEmbeddingRegion } = useImageFilters();
 
-    const activeSampleIds = derived(
-        [filterParams, collectionId],
-        ([$filterParams, $collectionId]) => {
-            if (!$filterParams?.collection_id || $filterParams.collection_id !== $collectionId) {
-                return [];
-            }
-            if ($filterParams.mode !== 'normal') {
-                return [];
-            }
-            return $filterParams.filters?.sample_ids ?? [];
-        }
-    );
-
-    return useFilterVisibility(
+    // The image lasso selection is stored as geometry (embedding_region) and sent to the
+    // backend rather than as a resolved sample-id list (see LIG-9903), so the chip count comes
+    // from the plot-propagated count and clearing removes the region.
+    return useRegionFilterVisibility(
         collectionId,
-        activeSampleIds,
-        updateSampleIds,
+        () => updateEmbeddingRegion(null),
         setRangeSelectionForCollection
     );
 }

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get, writable } from 'svelte/store';
+import {
+    clearPlotSelectionCount,
+    getPlotSelectionCount,
+    setPlotSelectionCount
+} from './useEmbeddingPlotSelection';
+
+describe('useEmbeddingPlotSelection', () => {
+    beforeEach(() => {
+        clearPlotSelectionCount('coll-1');
+        clearPlotSelectionCount('coll-2');
+    });
+
+    it('defaults to zero for an unknown collection', () => {
+        const count = getPlotSelectionCount(writable('coll-1'));
+        expect(get(count)).toBe(0);
+    });
+
+    it('reflects the count set for a collection', () => {
+        setPlotSelectionCount('coll-1', 42);
+        const count = getPlotSelectionCount(writable('coll-1'));
+        expect(get(count)).toBe(42);
+    });
+
+    it('keeps counts isolated per collection', () => {
+        setPlotSelectionCount('coll-1', 5);
+        expect(get(getPlotSelectionCount(writable('coll-1')))).toBe(5);
+        expect(get(getPlotSelectionCount(writable('coll-2')))).toBe(0);
+    });
+
+    it('clears the count back to zero', () => {
+        setPlotSelectionCount('coll-1', 7);
+        clearPlotSelectionCount('coll-1');
+        expect(get(getPlotSelectionCount(writable('coll-1')))).toBe(0);
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection.ts
@@ -1,0 +1,31 @@
+import { derived, writable, type Readable } from 'svelte/store';
+
+// Per-collection count of items currently selected by the embedding-plot lasso/rectangle.
+//
+// The selection itself is sent to the backend as geometry (see LIG-9903), so the frontend no
+// longer keeps the selected sample-id list in the query filter. The plot still computes the
+// in-polygon count client-side for highlighting, and propagates just that number here so the
+// sidebar "Embedding Plot Filter" chip can show how many items are selected.
+const selectionCountByCollection = writable<Record<string, number>>({});
+
+export function setPlotSelectionCount(collectionId: string, count: number): void {
+    selectionCountByCollection.update((counts) => ({ ...counts, [collectionId]: count }));
+}
+
+export function clearPlotSelectionCount(collectionId: string): void {
+    selectionCountByCollection.update((counts) => {
+        if (!(collectionId in counts)) {
+            return counts;
+        }
+        const next = { ...counts };
+        delete next[collectionId];
+        return next;
+    });
+}
+
+export function getPlotSelectionCount(collectionId: Readable<string>): Readable<number> {
+    return derived(
+        [selectionCountByCollection, collectionId],
+        ([$counts, $collectionId]) => $counts[$collectionId] ?? 0
+    );
+}

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useRegionFilterVisibility.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useRegionFilterVisibility.ts
@@ -1,0 +1,31 @@
+import { derived, get, type Readable } from 'svelte/store';
+import { clearPlotSelectionCount, getPlotSelectionCount } from './useEmbeddingPlotSelection';
+
+// Visibility/count behaviour for embedding-plot selections that are sent to the backend as
+// geometry (images and annotations). Unlike the sample-id based `useFilterVisibility`, the
+// frontend no longer holds the resolved ids, so the chip count comes from the plot-propagated
+// count and the selection is toggled off by clearing the region entirely.
+export function useRegionFilterVisibility(
+    collectionId: Readable<string>,
+    clearRegion: () => void,
+    setRangeSelectionForCollection: (collectionId: string, selection: null) => void
+) {
+    const effectiveCount = getPlotSelectionCount(collectionId);
+    const isVisible = derived(effectiveCount, ($count) => $count > 0);
+
+    function clearFilter() {
+        setRangeSelectionForCollection(get(collectionId), null);
+        clearRegion();
+        clearPlotSelectionCount(get(collectionId));
+    }
+
+    // The geometry selection has no separate "hidden" state to restore, so turning it off
+    // simply clears it.
+    function setVisibility(shouldShow: boolean) {
+        if (!shouldShow) {
+            clearFilter();
+        }
+    }
+
+    return { effectiveCount, isVisible, setVisibility, clearFilter };
+}

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -6,6 +6,7 @@ import { SortDirection } from '$lib/api/lightly_studio_local';
 import type {
     AnnotationsFilter,
     ConfusionCell,
+    EmbeddingRegion,
     ImageFilter,
     QueryExpr,
     SampleFilter
@@ -73,6 +74,15 @@ const imageFilter = derived(
         const sampleIds = $filterParams.filters?.sample_ids;
         if (sampleIds && sampleIds.length > 0) {
             sampleFilter.sample_ids = sampleIds;
+        }
+
+        // Embedding-plot lasso/rectangle selections are sent as geometry (a few KB) rather
+        // than the full list of selected sample ids, so the request body stays constant-size
+        // regardless of selection size (see LIG-9903). The backend resolves the polygon to
+        // sample ids server-side.
+        const embeddingRegion = $filterParams.filters?.embedding_region;
+        if (embeddingRegion) {
+            sampleFilter.embedding_region = embeddingRegion;
         }
 
         const annotationLabelIds = $filterParams.filters?.annotation_label_ids;
@@ -151,6 +161,27 @@ export const useImageFilters = () => {
         filterParams.set(newParams);
     };
 
+    // updates only the embedding-plot region selection in the existing filter params
+    const updateEmbeddingRegion = (embeddingRegion: EmbeddingRegion | null) => {
+        const params: ImagesInfiniteParams = {
+            ...get(filterParams)
+        };
+
+        if (params.mode !== 'normal') {
+            return;
+        }
+
+        const newParams: ImagesInfiniteParams = {
+            ...params,
+            filters: {
+                ...params.filters,
+                embedding_region: embeddingRegion ?? undefined
+            }
+        };
+
+        filterParams.set(newParams);
+    };
+
     // updates only the confusion-matrix cell in the existing filter params
     const updateConfusionCell = (confusionCell: ConfusionCell | null) => {
         const params: ImagesInfiniteParams = {
@@ -184,6 +215,7 @@ export const useImageFilters = () => {
         updateFilterParams,
         updateQueryExpr,
         updateSampleIds,
+        updateEmbeddingRegion,
         updateConfusionCell,
         updateSortBy
     };

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
@@ -41,7 +41,10 @@ const withNormalFilters = (
             annotations_filter: getAnnotationsFilter(filters),
             tag_ids: filters.tag_ids?.length ? filters.tag_ids : undefined,
             sample_ids: filters.sample_ids?.length ? filters.sample_ids : undefined,
-            confusion_cell: filters.confusion_cell ?? undefined
+            confusion_cell: filters.confusion_cell ?? undefined,
+            // Lasso/rectangle selection sent as geometry; the backend resolves it to sample
+            // ids server-side so the request body stays small at scale (see LIG-9903).
+            embedding_region: filters.embedding_region ?? undefined
         },
         // TODO(Malte, 10/2025): Share the width/height mapping with useImageFilters to avoid drift.
         width: filters.dimensions

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -15,7 +15,7 @@ export interface ClassifierSamples {
 }
 
 export type NormalModeFilters = Pick<AnnotationsFilter, 'annotation_label_ids' | 'collection_ids'> &
-    Pick<SampleFilter, 'tag_ids' | 'sample_ids' | 'confusion_cell'> & {
+    Pick<SampleFilter, 'tag_ids' | 'sample_ids' | 'confusion_cell' | 'embedding_region'> & {
         dimensions?: DimensionBounds;
     };
 

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
@@ -161,4 +161,33 @@ describe('buildRequestBody', () => {
             filter_type: 'annotations'
         });
     });
+
+    it('propagates the embedding region geometry to the sample filter', () => {
+        const polygon = [
+            { x: 0, y: 0 },
+            { x: 1, y: 0 },
+            { x: 1, y: 1 }
+        ];
+        const params: ImagesInfiniteParams = {
+            collection_id: 'col-1',
+            mode: 'normal',
+            filters: { embedding_region: { polygon } }
+        };
+
+        const result = buildRequestBody(params, 0);
+
+        expect(result.filters?.sample_filter?.embedding_region).toEqual({ polygon });
+    });
+
+    it('omits embedding_region when no region is selected', () => {
+        const params: ImagesInfiniteParams = {
+            collection_id: 'col-1',
+            mode: 'normal',
+            filters: { sample_ids: ['sample-1'] }
+        };
+
+        const result = buildRequestBody(params, 0);
+
+        expect(result.filters?.sample_filter?.embedding_region).toBeUndefined();
+    });
 });

--- a/lightly_studio_view/src/lib/hooks/useSelectAll/useSelectAll.ts
+++ b/lightly_studio_view/src/lib/hooks/useSelectAll/useSelectAll.ts
@@ -37,7 +37,7 @@ export function useSelectAll(collectionId: string, gridType: GridType) {
     const { filterParams: videoFilterParams } = useVideoFilters();
     const { filterParams: frameFilterParams } = useFramesFilter();
     const { annotationFilter } = useSelectedAnnotationsFilter(collectionId);
-    const { annotationPlotSampleIds } = useAnnotationPlotSelection();
+    const { annotationPlotRegion } = useAnnotationPlotSelection();
 
     let isLoading = false;
 
@@ -81,13 +81,15 @@ export function useSelectAll(collectionId: string, gridType: GridType) {
                 };
             }
             case 'annotations': {
-                const plotSampleIds = get(annotationPlotSampleIds);
+                // The plot selection is geometry; the backend resolves it to sample ids when
+                // fetching / tagging, so select-all also carries the region, not a list.
+                const plotRegion = get(annotationPlotRegion);
                 const filter =
-                    plotSampleIds.length > 0
+                    plotRegion !== null
                         ? {
                               ...get(annotationFilter),
                               filter_type: GRID_FILTER_TYPE.annotations,
-                              sample_ids: plotSampleIds
+                              embedding_region: plotRegion
                           }
                         : get(annotationFilter);
                 return {


### PR DESCRIPTION
## What has changed and why?

(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added polygon-based embedding-region selection support for images and annotations (lasso/rectangle), with geometry sent to the server and resolved into concrete filtering.
  * Introduced plot-selection-count based UI visibility for region mode.
* **Bug Fixes**
  * Rejects invalid/too-small regions, and ensures empty regions match no results.
  * Region mode now keeps selections visible after commit and supports Escape to clear.
* **Tests**
  * Expanded coverage for region validation, server-side resolution, filter application, and request payload/query-key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->