### PR TITLE
Fast Track: Add file status to ChangedFile

### DIFF
--- a/fast_track/src/guardrails/context/api-context.test.ts
+++ b/fast_track/src/guardrails/context/api-context.test.ts
@@ -34,6 +34,12 @@ describe('toChangedFile', () => {
             deletions: 3
         });
     });
+
+    it("normalises GitHub's 'removed' status to 'deleted'", () => {
+        expect(
+            toChangedFile({ filename: 'src/foo.ts', status: 'removed', additions: 0, deletions: 5 })
+        ).toEqual({ path: 'src/foo.ts', status: 'deleted', additions: 0, deletions: 5 });
+    });
 });
 
 describe('ApiGuardrailContext', () => {

--- a/fast_track/src/guardrails/context/api-context.test.ts
+++ b/fast_track/src/guardrails/context/api-context.test.ts
@@ -26,9 +26,10 @@ function fakeOctokit(files: ReturnType<typeof listedFile>[]) {
 }
 
 describe('toChangedFile', () => {
-    it('keeps counts and drops the rest', () => {
+    it('keeps path, status, and counts, dropping the rest', () => {
         expect(toChangedFile(listedFile('src/foo.ts', 12, 3))).toEqual({
             path: 'src/foo.ts',
+            status: 'modified',
             additions: 12,
             deletions: 3
         });
@@ -64,8 +65,8 @@ describe('ApiGuardrailContext', () => {
         });
 
         expect(await context.changedFiles()).toEqual([
-            { path: 'a.ts', additions: 1, deletions: 0 },
-            { path: 'b.ts', additions: 0, deletions: 5 }
+            { path: 'a.ts', status: 'modified', additions: 1, deletions: 0 },
+            { path: 'b.ts', status: 'modified', additions: 0, deletions: 5 }
         ]);
         expect(paginateCalls).toEqual([
             {

--- a/fast_track/src/guardrails/context/api-context.ts
+++ b/fast_track/src/guardrails/context/api-context.ts
@@ -64,8 +64,13 @@ export class ApiGuardrailContext implements GuardrailContext {
 export function toChangedFile(file: ListedFile): ChangedFile {
     return {
         path: file.filename,
-        status: file.status as FileStatus,
+        status: toFileStatus(file.status),
         additions: file.additions,
         deletions: file.deletions
     };
+}
+
+/** GitHub's API uses 'removed' for deleted files; normalise to the shared FileStatus value. */
+function toFileStatus(status: string): FileStatus {
+    return status === 'removed' ? 'deleted' : (status as FileStatus);
 }

--- a/fast_track/src/guardrails/context/api-context.ts
+++ b/fast_track/src/guardrails/context/api-context.ts
@@ -1,6 +1,6 @@
 import type { GitHub } from '@actions/github/lib/utils';
 
-import type { ChangedFile, GuardrailContext } from './types';
+import type { ChangedFile, FileStatus, GuardrailContext } from './types';
 
 /**
  * A hydrated Octokit client, injected (never constructed here). Kept type-only so
@@ -11,8 +11,8 @@ export type Octokit = InstanceType<typeof GitHub>;
 /** `pulls.listFiles` caps per_page at 100. */
 const PER_PAGE = 100;
 
-/** The `pulls.listFiles` fields we read — counts only, no patch. */
-type ListedFile = { filename: string; additions: number; deletions: number };
+/** The `pulls.listFiles` fields we read — counts and status only, no patch. */
+type ListedFile = { filename: string; status: string; additions: number; deletions: number };
 
 export interface ApiGuardrailContextParams {
     octokit: Octokit;
@@ -62,5 +62,10 @@ export class ApiGuardrailContext implements GuardrailContext {
 }
 
 export function toChangedFile(file: ListedFile): ChangedFile {
-    return { path: file.filename, additions: file.additions, deletions: file.deletions };
+    return {
+        path: file.filename,
+        status: file.status as FileStatus,
+        additions: file.additions,
+        deletions: file.deletions
+    };
 }

--- a/fast_track/src/guardrails/context/git-context.test.ts
+++ b/fast_track/src/guardrails/context/git-context.test.ts
@@ -1,49 +1,112 @@
-import type { DiffResult } from 'simple-git';
+import { DiffNameStatus } from 'simple-git';
 import { describe, expect, it } from 'vitest';
 
-import { GitGuardrailContext, renameTarget, toChangedFiles } from './git-context';
+import { GitGuardrailContext, toChangedFile } from './git-context';
 
-type DiffFiles = DiffResult['files'];
+describe('toChangedFile', () => {
+    it('maps M to modified', () => {
+        expect(
+            toChangedFile({
+                file: 'src/foo.ts',
+                changes: 0,
+                insertions: 0,
+                deletions: 0,
+                binary: false,
+                status: DiffNameStatus.MODIFIED,
+                similarity: 0
+            })
+        ).toEqual({ path: 'src/foo.ts', status: 'modified', additions: 0, deletions: 0 });
+    });
 
-/** A text-file diff entry as simple-git's `diffSummary` reports it. */
-function textFile(file: string, insertions: number, deletions: number): DiffFiles[number] {
-    return { file, changes: insertions + deletions, insertions, deletions, binary: false };
-}
+    it('maps A to added', () => {
+        expect(
+            toChangedFile({
+                file: 'src/new.ts',
+                changes: 0,
+                insertions: 0,
+                deletions: 0,
+                binary: false,
+                status: DiffNameStatus.ADDED,
+                similarity: 0
+            })
+        ).toEqual({ path: 'src/new.ts', status: 'added', additions: 0, deletions: 0 });
+    });
 
-/** A binary diff entry: no line counts, byte sizes instead. */
-function binaryFile(file: string): DiffFiles[number] {
-    return { file, before: 0, after: 0, binary: true };
-}
+    it('maps D to deleted', () => {
+        expect(
+            toChangedFile({
+                file: 'src/gone.ts',
+                changes: 0,
+                insertions: 0,
+                deletions: 0,
+                binary: false,
+                status: DiffNameStatus.DELETED,
+                similarity: 0
+            })
+        ).toEqual({ path: 'src/gone.ts', status: 'deleted', additions: 0, deletions: 0 });
+    });
 
-describe('toChangedFiles', () => {
-    it('maps text files to their add/delete counts', () => {
-        const files: DiffFiles = [textFile('src/foo.ts', 12, 3), textFile('docs/readme.md', 0, 7)];
-        expect(toChangedFiles(files)).toEqual([
-            { path: 'src/foo.ts', additions: 12, deletions: 3 },
-            { path: 'docs/readme.md', additions: 0, deletions: 7 }
-        ]);
+    it('maps R to renamed using the destination path', () => {
+        expect(
+            toChangedFile({
+                file: 'new/b.ts',
+                changes: 0,
+                insertions: 0,
+                deletions: 0,
+                binary: false,
+                status: DiffNameStatus.RENAMED,
+                from: 'old/a.ts',
+                similarity: 100
+            })
+        ).toEqual({ path: 'new/b.ts', status: 'renamed', additions: 0, deletions: 0 });
+    });
+
+    it('maps C to copied using the destination path', () => {
+        expect(
+            toChangedFile({
+                file: 'src/copy.ts',
+                changes: 0,
+                insertions: 0,
+                deletions: 0,
+                binary: false,
+                status: DiffNameStatus.COPIED,
+                from: 'src/orig.ts',
+                similarity: 100
+            })
+        ).toEqual({ path: 'src/copy.ts', status: 'copied', additions: 0, deletions: 0 });
+    });
+
+    it('defaults to modified for other status letters (T, U, X, B)', () => {
+        expect(
+            toChangedFile({
+                file: 'src/foo.ts',
+                changes: 0,
+                insertions: 0,
+                deletions: 0,
+                binary: false,
+                status: DiffNameStatus.CHANGED,
+                similarity: 0
+            })
+        ).toEqual({ path: 'src/foo.ts', status: 'modified', additions: 0, deletions: 0 });
+    });
+
+    it('defaults to modified when no status is present', () => {
+        expect(
+            toChangedFile({
+                file: 'src/foo.ts',
+                changes: 0,
+                insertions: 0,
+                deletions: 0,
+                binary: false,
+                similarity: 0
+            })
+        ).toEqual({ path: 'src/foo.ts', status: 'modified', additions: 0, deletions: 0 });
     });
 
     it('normalises binary files to 0/0', () => {
-        expect(toChangedFiles([binaryFile('assets/logo.png')])).toEqual([
-            { path: 'assets/logo.png', additions: 0, deletions: 0 }
-        ]);
-    });
-
-    it('keeps the new path for a braced rename', () => {
-        expect(toChangedFiles([textFile('src/{old => new}/bar.ts', 2, 1)])).toEqual([
-            { path: 'src/new/bar.ts', additions: 2, deletions: 1 }
-        ]);
-    });
-
-    it('keeps the new path for a whole-path rename', () => {
-        expect(toChangedFiles([textFile('old/a.ts => new/b.ts', 0, 0)])).toEqual([
-            { path: 'new/b.ts', additions: 0, deletions: 0 }
-        ]);
-    });
-
-    it('returns an empty list for no changes', () => {
-        expect(toChangedFiles([])).toEqual([]);
+        expect(
+            toChangedFile({ file: 'assets/logo.png', before: 0, after: 0, binary: true })
+        ).toEqual({ path: 'assets/logo.png', status: 'modified', additions: 0, deletions: 0 });
     });
 });
 
@@ -51,19 +114,5 @@ describe('GitGuardrailContext', () => {
     it('rejects an empty base ref (would diff against nothing)', () => {
         expect(() => new GitGuardrailContext('')).toThrow(/must not be empty/);
         expect(() => new GitGuardrailContext('   ')).toThrow(/must not be empty/);
-    });
-});
-
-describe('renameTarget', () => {
-    it('returns a plain path unchanged', () => {
-        expect(renameTarget('src/foo.ts')).toBe('src/foo.ts');
-    });
-
-    it('resolves a braced rename with a shared prefix', () => {
-        expect(renameTarget('src/{old => new}/bar.ts')).toBe('src/new/bar.ts');
-    });
-
-    it('resolves a whole-path rename', () => {
-        expect(renameTarget('old/a.ts => new/b.ts')).toBe('new/b.ts');
     });
 });

--- a/fast_track/src/guardrails/context/git-context.test.ts
+++ b/fast_track/src/guardrails/context/git-context.test.ts
@@ -1,112 +1,121 @@
 import { DiffNameStatus } from 'simple-git';
+import type { DiffResult } from 'simple-git';
 import { describe, expect, it } from 'vitest';
 
-import { GitGuardrailContext, toChangedFile } from './git-context';
+import { GitGuardrailContext, renameTarget, toChangedFile } from './git-context';
+
+type DiffFiles = DiffResult['files'];
+
+/** A name-status text-file entry as simple-git reports for `diffSummary --name-status`. */
+function textFile(
+    file: string,
+    status: DiffNameStatus,
+    insertions: number,
+    deletions: number
+): DiffFiles[number] {
+    return {
+        file,
+        changes: insertions + deletions,
+        insertions,
+        deletions,
+        binary: false,
+        status,
+        similarity: 0
+    };
+}
+
+/** A binary diff entry: no line counts, byte sizes instead. */
+function binaryFile(file: string): DiffFiles[number] {
+    return { file, before: 0, after: 0, binary: true };
+}
 
 describe('toChangedFile', () => {
     it('maps M to modified', () => {
-        expect(
-            toChangedFile({
-                file: 'src/foo.ts',
-                changes: 0,
-                insertions: 0,
-                deletions: 0,
-                binary: false,
-                status: DiffNameStatus.MODIFIED,
-                similarity: 0
-            })
-        ).toEqual({ path: 'src/foo.ts', status: 'modified', additions: 0, deletions: 0 });
+        expect(toChangedFile(textFile('src/foo.ts', DiffNameStatus.MODIFIED, 12, 3))).toEqual({
+            path: 'src/foo.ts',
+            status: 'modified',
+            additions: 12,
+            deletions: 3
+        });
     });
 
     it('maps A to added', () => {
-        expect(
-            toChangedFile({
-                file: 'src/new.ts',
-                changes: 0,
-                insertions: 0,
-                deletions: 0,
-                binary: false,
-                status: DiffNameStatus.ADDED,
-                similarity: 0
-            })
-        ).toEqual({ path: 'src/new.ts', status: 'added', additions: 0, deletions: 0 });
+        expect(toChangedFile(textFile('src/new.ts', DiffNameStatus.ADDED, 5, 0))).toEqual({
+            path: 'src/new.ts',
+            status: 'added',
+            additions: 5,
+            deletions: 0
+        });
     });
 
     it('maps D to deleted', () => {
-        expect(
-            toChangedFile({
-                file: 'src/gone.ts',
-                changes: 0,
-                insertions: 0,
-                deletions: 0,
-                binary: false,
-                status: DiffNameStatus.DELETED,
-                similarity: 0
-            })
-        ).toEqual({ path: 'src/gone.ts', status: 'deleted', additions: 0, deletions: 0 });
+        expect(toChangedFile(textFile('src/gone.ts', DiffNameStatus.DELETED, 0, 7))).toEqual({
+            path: 'src/gone.ts',
+            status: 'deleted',
+            additions: 0,
+            deletions: 7
+        });
     });
 
     it('maps R to renamed using the destination path', () => {
         expect(
             toChangedFile({
                 file: 'new/b.ts',
-                changes: 0,
-                insertions: 0,
+                changes: 2,
+                insertions: 2,
                 deletions: 0,
                 binary: false,
                 status: DiffNameStatus.RENAMED,
                 from: 'old/a.ts',
                 similarity: 100
             })
-        ).toEqual({ path: 'new/b.ts', status: 'renamed', additions: 0, deletions: 0 });
+        ).toEqual({ path: 'new/b.ts', status: 'renamed', additions: 2, deletions: 0 });
     });
 
     it('maps C to copied using the destination path', () => {
         expect(
             toChangedFile({
                 file: 'src/copy.ts',
-                changes: 0,
-                insertions: 0,
+                changes: 4,
+                insertions: 4,
                 deletions: 0,
                 binary: false,
                 status: DiffNameStatus.COPIED,
                 from: 'src/orig.ts',
                 similarity: 100
             })
-        ).toEqual({ path: 'src/copy.ts', status: 'copied', additions: 0, deletions: 0 });
+        ).toEqual({ path: 'src/copy.ts', status: 'copied', additions: 4, deletions: 0 });
     });
 
     it('defaults to modified for other status letters (T, U, X, B)', () => {
-        expect(
-            toChangedFile({
-                file: 'src/foo.ts',
-                changes: 0,
-                insertions: 0,
-                deletions: 0,
-                binary: false,
-                status: DiffNameStatus.CHANGED,
-                similarity: 0
-            })
-        ).toEqual({ path: 'src/foo.ts', status: 'modified', additions: 0, deletions: 0 });
+        expect(toChangedFile(textFile('src/foo.ts', DiffNameStatus.CHANGED, 1, 2))).toEqual({
+            path: 'src/foo.ts',
+            status: 'modified',
+            additions: 1,
+            deletions: 2
+        });
     });
 
     it('defaults to modified when no status is present', () => {
         expect(
             toChangedFile({
                 file: 'src/foo.ts',
-                changes: 0,
-                insertions: 0,
-                deletions: 0,
+                changes: 8,
+                insertions: 6,
+                deletions: 2,
                 binary: false,
                 similarity: 0
             })
-        ).toEqual({ path: 'src/foo.ts', status: 'modified', additions: 0, deletions: 0 });
+        ).toEqual({ path: 'src/foo.ts', status: 'modified', additions: 6, deletions: 2 });
     });
 
     it('normalises binary files to 0/0', () => {
-        expect(
-            toChangedFile({ file: 'assets/logo.png', before: 0, after: 0, binary: true })
-        ).toEqual({ path: 'assets/logo.png', status: 'modified', additions: 0, deletions: 0 });
+        expect(toChangedFile(binaryFile('assets/logo.png'))).toEqual({
+            path: 'assets/logo.png',
+            status: 'modified',
+            additions: 0,
+            deletions: 0
+        });
     });
 });
 
@@ -114,5 +123,19 @@ describe('GitGuardrailContext', () => {
     it('rejects an empty base ref (would diff against nothing)', () => {
         expect(() => new GitGuardrailContext('')).toThrow(/must not be empty/);
         expect(() => new GitGuardrailContext('   ')).toThrow(/must not be empty/);
+    });
+});
+
+describe('renameTarget', () => {
+    it('returns a plain path unchanged', () => {
+        expect(renameTarget('src/foo.ts')).toBe('src/foo.ts');
+    });
+
+    it('resolves a braced rename with a shared prefix', () => {
+        expect(renameTarget('src/{old => new}/bar.ts')).toBe('src/new/bar.ts');
+    });
+
+    it('resolves a whole-path rename', () => {
+        expect(renameTarget('old/a.ts => new/b.ts')).toBe('new/b.ts');
     });
 });

--- a/fast_track/src/guardrails/context/git-context.ts
+++ b/fast_track/src/guardrails/context/git-context.ts
@@ -39,8 +39,8 @@ export class GitGuardrailContext implements GuardrailContext {
         this.cache ??= (async () => {
             const range = `${this.baseRef}...HEAD`;
             const [nameStatus, stat] = await Promise.all([
-                this.git.diffSummary(['--name-status', range]),
-                this.git.diffSummary([range])
+                this.git.diffSummary(['--name-status', '-M', '-C', range]),
+                this.git.diffSummary(['-M', '-C', range])
             ]);
 
             // name-status gives the correct destination path for renames/copies.

--- a/fast_track/src/guardrails/context/git-context.ts
+++ b/fast_track/src/guardrails/context/git-context.ts
@@ -5,9 +5,9 @@ import type { ChangedFile, FileStatus, GuardrailContext } from './types';
 
 /**
  * Local {@link GuardrailContext} backed by `simple-git`. Diffs `baseRef...HEAD`
- * (three-dot, matching GitHub's Files-changed view). `diffSummary --name-status`
- * gives the status and destination path for each file in one call; line counts
- * are not provided by that format and default to 0.
+ * (three-dot, matching GitHub's Files-changed view). Two parallel `diffSummary`
+ * calls are made: `--name-status` for file status and destination paths, and the
+ * default stat format for line counts. Results are merged by path.
  */
 export class GitGuardrailContext implements GuardrailContext {
     readonly baseRef: string;
@@ -37,8 +37,27 @@ export class GitGuardrailContext implements GuardrailContext {
     async changedFiles(): Promise<ChangedFile[]> {
         // Memoize: the committed diff is fixed for one run, read by many guardrails.
         this.cache ??= (async () => {
-            const summary = await this.git.diffSummary(['--name-status', `${this.baseRef}...HEAD`]);
-            return summary.files.map(toChangedFile);
+            const range = `${this.baseRef}...HEAD`;
+            const [nameStatus, stat] = await Promise.all([
+                this.git.diffSummary(['--name-status', range]),
+                this.git.diffSummary([range])
+            ]);
+
+            // name-status gives the correct destination path for renames/copies.
+            const statusByPath = new Map(
+                nameStatus.files.map((f) => [f.file, toChangedFile(f).status])
+            );
+
+            // stat gives line counts; renames use brace notation — resolve to destination.
+            return stat.files.map((file) => {
+                const path = renameTarget(file.file);
+                return {
+                    path,
+                    status: statusByPath.get(path) ?? 'modified',
+                    additions: file.binary ? 0 : file.insertions,
+                    deletions: file.binary ? 0 : file.deletions
+                };
+            });
         })();
         return this.cache;
     }
@@ -47,7 +66,8 @@ export class GitGuardrailContext implements GuardrailContext {
 /**
  * Map a `diffSummary --name-status` file entry to a {@link ChangedFile}.
  * For renames and copies `file` is already the destination path — no path
- * rewriting needed. Line counts default to 0 (not provided by `--name-status`).
+ * rewriting needed. Line counts default to 0; merge with a stat pass for
+ * real counts (see {@link GitGuardrailContext.changedFiles}).
  */
 export function toChangedFile(file: DiffResult['files'][number]): ChangedFile {
     return {
@@ -56,6 +76,17 @@ export function toChangedFile(file: DiffResult['files'][number]): ChangedFile {
         additions: file.binary ? 0 : file.insertions,
         deletions: file.binary ? 0 : file.deletions
     };
+}
+
+/**
+ * Post-rename path. Git writes renames as `src/{old => new}/f.ts` (shared
+ * prefix) or `old.ts => new.ts` (whole path); a plain path passes through.
+ */
+export function renameTarget(rawPath: string): string {
+    const braced = rawPath.replace(/\{.*? => (.*?)\}/g, '$1').replace(/\/{2,}/g, '/');
+    if (braced !== rawPath) return braced;
+    const arrow = rawPath.indexOf(' => ');
+    return arrow === -1 ? rawPath : rawPath.slice(arrow + ' => '.length);
 }
 
 function toFileStatus(status: DiffNameStatus | undefined): FileStatus {

--- a/fast_track/src/guardrails/context/git-context.ts
+++ b/fast_track/src/guardrails/context/git-context.ts
@@ -1,12 +1,13 @@
-import { simpleGit } from 'simple-git';
+import { DiffNameStatus, simpleGit } from 'simple-git';
 import type { DiffResult } from 'simple-git';
 
-import type { ChangedFile, GuardrailContext } from './types';
+import type { ChangedFile, FileStatus, GuardrailContext } from './types';
 
 /**
  * Local {@link GuardrailContext} backed by `simple-git`. Diffs `baseRef...HEAD`
- * (three-dot, matching GitHub's Files-changed view). `diffSummary` gives exact
- * per-file line counts — all a guardrail needs; no patch text is carried.
+ * (three-dot, matching GitHub's Files-changed view). `diffSummary --name-status`
+ * gives the status and destination path for each file in one call; line counts
+ * are not provided by that format and default to 0.
  */
 export class GitGuardrailContext implements GuardrailContext {
     readonly baseRef: string;
@@ -36,33 +37,38 @@ export class GitGuardrailContext implements GuardrailContext {
     async changedFiles(): Promise<ChangedFile[]> {
         // Memoize: the committed diff is fixed for one run, read by many guardrails.
         this.cache ??= (async () => {
-            const summary = await this.git.diffSummary([`${this.baseRef}...HEAD`]);
-            return toChangedFiles(summary.files);
+            const summary = await this.git.diffSummary(['--name-status', `${this.baseRef}...HEAD`]);
+            return summary.files.map(toChangedFile);
         })();
         return this.cache;
     }
 }
 
 /**
- * Map `diffSummary` files to {@link ChangedFile}s. Binary files have no line
- * counts (simple-git reports byte sizes), so they become 0/0; renames keep the
- * new path.
+ * Map a `diffSummary --name-status` file entry to a {@link ChangedFile}.
+ * For renames and copies `file` is already the destination path — no path
+ * rewriting needed. Line counts default to 0 (not provided by `--name-status`).
  */
-export function toChangedFiles(files: DiffResult['files']): ChangedFile[] {
-    return files.map((file) => ({
-        path: renameTarget(file.file),
+export function toChangedFile(file: DiffResult['files'][number]): ChangedFile {
+    return {
+        path: file.file,
+        status: 'status' in file ? toFileStatus(file.status) : 'modified',
         additions: file.binary ? 0 : file.insertions,
         deletions: file.binary ? 0 : file.deletions
-    }));
+    };
 }
 
-/**
- * Post-rename path. Git writes renames as `src/{old => new}/f.ts` (shared
- * prefix) or `old.ts => new.ts` (whole path); a plain path passes through.
- */
-export function renameTarget(rawPath: string): string {
-    const braced = rawPath.replace(/\{.*? => (.*?)\}/g, '$1').replace(/\/{2,}/g, '/');
-    if (braced !== rawPath) return braced;
-    const arrow = rawPath.indexOf(' => ');
-    return arrow === -1 ? rawPath : rawPath.slice(arrow + ' => '.length);
+function toFileStatus(status: DiffNameStatus | undefined): FileStatus {
+    switch (status) {
+        case DiffNameStatus.ADDED:
+            return 'added';
+        case DiffNameStatus.DELETED:
+            return 'deleted';
+        case DiffNameStatus.RENAMED:
+            return 'renamed';
+        case DiffNameStatus.COPIED:
+            return 'copied';
+        default:
+            return 'modified';
+    }
 }

--- a/fast_track/src/guardrails/context/types.ts
+++ b/fast_track/src/guardrails/context/types.ts
@@ -1,7 +1,10 @@
 import type { GuardrailResult } from '../../shared/verdict';
 
+export type FileStatus = 'added' | 'deleted' | 'modified' | 'renamed' | 'copied';
+
 export interface ChangedFile {
     path: string;
+    status: FileStatus;
     additions: number;
     deletions: number;
 }

--- a/fast_track/src/guardrails/frontend/complexity.test.ts
+++ b/fast_track/src/guardrails/frontend/complexity.test.ts
@@ -1,6 +1,6 @@
 import { vi, describe, expect, it } from 'vitest';
 import type { ESLint } from 'eslint';
-import type { GuardrailContext } from '../context/types';
+import type { ChangedFile, GuardrailContext } from '../context/types';
 import { frontendComplexityGuardrail } from './complexity';
 import { FRONTEND_ABS } from './eslint-runner';
 
@@ -17,9 +17,14 @@ vi.mock('./eslint-runner', async (importOriginal) => {
 const { runEslint } = await import('./eslint-runner');
 const { existsSync } = await import('node:fs');
 
-const frontendFile = { path: 'lightly_studio_view/src/foo.ts', additions: 5, deletions: 0 };
+const frontendFile = {
+    path: 'lightly_studio_view/src/foo.ts',
+    status: 'modified' as const,
+    additions: 5,
+    deletions: 0
+};
 
-function makeCtx(files = [frontendFile]): GuardrailContext {
+function makeCtx(files: ChangedFile[] = [frontendFile]): GuardrailContext {
     return { baseRef: 'origin/main', changedFiles: async () => files };
 }
 
@@ -31,7 +36,14 @@ describe('frontendComplexityGuardrail', () => {
 
     it('passes immediately when no frontend files changed', async () => {
         const result = await frontendComplexityGuardrail.run(
-            makeCtx([{ path: 'lightly_studio/src/model.py', additions: 5, deletions: 0 }])
+            makeCtx([
+                {
+                    path: 'lightly_studio/src/model.py',
+                    status: 'modified',
+                    additions: 5,
+                    deletions: 0
+                }
+            ])
         );
         expect(result.status).toBe('pass');
         expect(result.summary).toContain('0 file(s)');
@@ -40,7 +52,14 @@ describe('frontendComplexityGuardrail', () => {
     it('passes when all changed frontend files are deleted', async () => {
         vi.mocked(existsSync).mockReturnValueOnce(false);
         const result = await frontendComplexityGuardrail.run(
-            makeCtx([{ path: 'lightly_studio_view/src/deleted.ts', additions: 0, deletions: 10 }])
+            makeCtx([
+                {
+                    path: 'lightly_studio_view/src/deleted.ts',
+                    status: 'deleted',
+                    additions: 0,
+                    deletions: 10
+                }
+            ])
         );
         expect(result.status).toBe('pass');
         expect(result.summary).toBe('All changed frontend files were deleted.');
@@ -53,8 +72,18 @@ describe('frontendComplexityGuardrail', () => {
         ] as unknown as ESLint.LintResult[]);
         const result = await frontendComplexityGuardrail.run(
             makeCtx([
-                { path: 'lightly_studio_view/src/foo.ts', additions: 5, deletions: 0 },
-                { path: 'lightly_studio_view/src/deleted.ts', additions: 0, deletions: 10 }
+                {
+                    path: 'lightly_studio_view/src/foo.ts',
+                    status: 'modified',
+                    additions: 5,
+                    deletions: 0
+                },
+                {
+                    path: 'lightly_studio_view/src/deleted.ts',
+                    status: 'deleted',
+                    additions: 0,
+                    deletions: 10
+                }
             ])
         );
         expect(result.status).toBe('pass');


### PR DESCRIPTION
## What has changed and why?

Adds a status field (added | deleted | modified | renamed | copied) to the ChangedFile type so guardrails can act on how a file changed.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guardrail context file change entries now include an explicit `status` plus `additions` and `deletions`.
* **Bug Fixes**
  * Normalized Git “removed” file state to a “deleted” status.
  * Renamed and copied files now report the correct destination paths.
  * Missing/unknown statuses fall back to a default, and binary changes are reported as `0` additions/deletions.
* **Tests**
  * Updated and expanded coverage for the new status/additions/deletions mapping behavior.
* **Documentation**
  * Clarified how file stats are derived versus file status information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->