### PR TITLE
Fix plugins doc register

### DIFF
--- a/lightly_studio/docs/docs/concepts_and_tools/plugins.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/plugins.md
@@ -84,7 +84,7 @@ Replace `<plugin_name>` with the folder name of the plugin you want to install:
     pip install "git+https://github.com/lightly-ai/lightly-studio-plugins.git#subdirectory=plugins/<plugin_name>/"
     ```
 
-Once installed, register the plugin through the Python API and it will appear in the GUI automatically.
+Once installed, the plugin will be auto-registered and will appear in the GUI automatically.
 
 To remove a plugin, uninstall its package with `uv pip uninstall` or `pip uninstall`,
 using the package name defined in the plugin's `pyproject.toml` (typically matching the

--- a/lightly_studio/docs/docs/concepts_and_tools/plugins.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/plugins.md
@@ -84,7 +84,7 @@ Replace `<plugin_name>` with the folder name of the plugin you want to install:
     pip install "git+https://github.com/lightly-ai/lightly-studio-plugins.git#subdirectory=plugins/<plugin_name>/"
     ```
 
-Once installed, the plugin will be auto-registered and will appear in the GUI automatically.
+Once installed, the plugin is auto-registered and will appear in the GUI automatically.
 
 To remove a plugin, uninstall its package with `uv pip uninstall` or `pip uninstall`,
 using the package name defined in the plugin's `pyproject.toml` (typically matching the


### PR DESCRIPTION
## What has changed and why?

Fixing the explanation how to register pip installed plugins.

## How has it been tested?

not requred

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the plugin installation guide to clarify that installed plugins are automatically registered and appear in the app without any extra setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->