### PR TITLE
Add embedding-region model and point-in-polygon core

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
@@ -11,15 +11,14 @@ import pyarrow as pa
 from fastapi import APIRouter, HTTPException, Path, Response
 from pyarrow import ipc
 from pydantic import BaseModel, Field
-from sqlmodel import select
 
 from lightly_studio.api.routes.api.embedding_coloring import ColorBy, build_color_data
 from lightly_studio.api.routes.api.status import HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_NOT_FOUND
 from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.collection import CollectionTable, SampleType
-from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.resolvers import (
     annotation_resolver,
+    embedding_model_resolver,
     image_resolver,
     twodim_embedding_resolver,
     video_resolver,
@@ -56,11 +55,10 @@ def get_2d_embeddings(
     _validate_filter_type(collection=collection, filters=body.filters)
 
     # TODO(Malte, 09/2025): Support choosing the embedding model via API parameter.
-    embedding_model = session.exec(
-        select(EmbeddingModelTable)
-        .where(EmbeddingModelTable.collection_id == collection_id)
-        .limit(1)
-    ).first()
+    embedding_model = embedding_model_resolver.get_default_by_collection_id(
+        session=session,
+        collection_id=collection_id,
+    )
     if embedding_model is None:
         raise ValueError("No embedding model configured.")
 

--- a/lightly_studio/src/lightly_studio/models/embedding_region.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_region.py
@@ -3,7 +3,7 @@
 The frontend sends the lasso/rectangle geometry (a handful of vertices, a few KB) instead
 of the full list of selected sample ids. The backend reproduces the exact selection by
 running point-in-polygon over the cached 2D projection, so the request body stays
-constant-size regardless of how many points are selected (see LIG-9903).
+constant-size regardless of how many points are selected.
 """
 
 from __future__ import annotations

--- a/lightly_studio/src/lightly_studio/models/embedding_region.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_region.py
@@ -1,0 +1,42 @@
+"""Geometry of an embedding-plot region selection.
+
+The frontend sends the lasso/rectangle geometry (a handful of vertices, a few KB) instead
+of the full list of selected sample ids. The backend reproduces the exact selection by
+running point-in-polygon over the cached 2D projection, so the request body stays
+constant-size regardless of how many points are selected (see LIG-9903).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+# A polygon needs at least three vertices to enclose any area.
+_MIN_POLYGON_VERTICES = 3
+
+
+class Point2D(BaseModel):
+    """A single vertex in embedding-plot (raw data) coordinate space."""
+
+    x: float
+    y: float
+
+
+class EmbeddingRegion(BaseModel):
+    """A closed region in embedding-plot space, expressed as polygon vertices.
+
+    Rectangle selections are normalized to their four corner vertices on the frontend, so
+    both lasso and rectangle selections arrive here as a polygon. Coordinates are in the
+    same raw data space as the cached 2D projection, so no additional transform is needed
+    before the point-in-polygon test.
+    """
+
+    polygon: list[Point2D] = Field(
+        description="Ordered polygon vertices in embedding-plot data space (>= 3 vertices)."
+    )
+
+    @field_validator("polygon")
+    @classmethod
+    def _validate_polygon(cls, polygon: list[Point2D]) -> list[Point2D]:
+        if len(polygon) < _MIN_POLYGON_VERTICES:
+            raise ValueError("An embedding region polygon must have at least 3 vertices.")
+        return polygon

--- a/lightly_studio/src/lightly_studio/models/embedding_region.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_region.py
@@ -8,7 +8,7 @@ constant-size regardless of how many points are selected (see LIG-9903).
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 # A polygon needs at least three vertices to enclose any area.
 _MIN_POLYGON_VERTICES = 3
@@ -30,13 +30,9 @@ class EmbeddingRegion(BaseModel):
     before the point-in-polygon test.
     """
 
+    # Declaring the constraint on the field (not a custom validator) keeps runtime validation,
+    # the generated OpenAPI schema (`minItems`), and generated clients in sync.
     polygon: list[Point2D] = Field(
-        description="Ordered polygon vertices in embedding-plot data space (>= 3 vertices)."
+        min_length=_MIN_POLYGON_VERTICES,
+        description="Ordered polygon vertices in embedding-plot data space (>= 3 vertices).",
     )
-
-    @field_validator("polygon")
-    @classmethod
-    def _validate_polygon(cls, polygon: list[Point2D]) -> list[Point2D]:
-        if len(polygon) < _MIN_POLYGON_VERTICES:
-            raise ValueError("An embedding region polygon must have at least 3 vertices.")
-        return polygon

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -53,6 +53,24 @@ def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[Embe
     return list(embedding_models)
 
 
+def get_default_by_collection_id(
+    session: Session, collection_id: UUID
+) -> EmbeddingModelTable | None:
+    """Return the collection's default embedding model, or None if it has none.
+
+    The default is the oldest model (``created_at`` ascending), which makes the choice
+    deterministic when a collection has multiple embedding models. Endpoints that resolve
+    a selection against a cached 2D projection (embeddings2d, embedding regions) must all
+    agree on this same model so the projections line up.
+    """
+    return session.exec(
+        select(EmbeddingModelTable)
+        .where(EmbeddingModelTable.collection_id == collection_id)
+        .order_by(col(EmbeddingModelTable.created_at).asc())
+        .limit(1)
+    ).first()
+
+
 def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable | None:
     """Retrieve a single embedding model by ID."""
     return session.exec(

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -61,12 +61,16 @@ def get_default_by_collection_id(
     The default is the oldest model (``created_at`` ascending), which makes the choice
     deterministic when a collection has multiple embedding models. Endpoints that resolve
     a selection against a cached 2D projection (embeddings2d, embedding regions) must all
-    agree on this same model so the projections line up.
+    agree on this same model so the projections line up. ``embedding_model_id`` breaks ties
+    when models share the same ``created_at`` (e.g. bulk-created in one transaction).
     """
     return session.exec(
         select(EmbeddingModelTable)
         .where(EmbeddingModelTable.collection_id == collection_id)
-        .order_by(col(EmbeddingModelTable.created_at).asc())
+        .order_by(
+            col(EmbeddingModelTable.created_at).asc(),
+            col(EmbeddingModelTable.embedding_model_id).asc(),
+        )
         .limit(1)
     ).first()
 

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -13,11 +13,10 @@ from uuid import UUID
 
 import numpy as np
 from numpy.typing import NDArray
-from sqlmodel import Session, select
+from sqlmodel import Session
 
-from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.embedding_region import EmbeddingRegion
-from lightly_studio.resolvers import twodim_embedding_resolver
+from lightly_studio.resolvers import embedding_model_resolver, twodim_embedding_resolver
 
 
 def get_sample_ids_in_region(
@@ -26,14 +25,14 @@ def get_sample_ids_in_region(
     region: EmbeddingRegion,
 ) -> list[UUID]:
     """Return the sample ids whose cached 2D coordinates fall inside ``region``."""
-    # Mirror the embeddings2d endpoint: use the collection's first embedding model.
+    # Resolve against the same deterministic default model as embeddings2d.get_2d_embeddings,
+    # so the region is tested against the exact projection the user lassoed over.
     # TODO(Kondrat, 07/2026): Select the embedding model via API parameter once supported,
     # matching embeddings2d.get_2d_embeddings.
-    embedding_model = session.exec(
-        select(EmbeddingModelTable)
-        .where(EmbeddingModelTable.collection_id == collection_id)
-        .limit(1)
-    ).first()
+    embedding_model = embedding_model_resolver.get_default_by_collection_id(
+        session=session,
+        collection_id=collection_id,
+    )
     if embedding_model is None:
         return []
 

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -2,7 +2,7 @@
 
 The frontend sends the lasso/rectangle geometry (a handful of vertices) instead of the full
 list of selected sample ids, keeping the request body constant-size regardless of selection
-size (see LIG-9903). Here we reproduce the exact client-side selection server-side: load the
+size. Here we reproduce the exact client-side selection server-side: load the
 cached, deterministic 2D projection the user lassoed over and run a vectorized point-in-polygon
 test, then feed the resulting ids into the existing ``= ANY(...)`` filter path.
 """

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -1,10 +1,9 @@
-"""Resolve an embedding-plot region selection to the sample ids it encloses.
+"""Resolve an embedding-plot region (a polygon of 2D vertices) to the sample ids it encloses.
 
-The frontend sends the lasso/rectangle geometry (a handful of vertices) instead of the full
-list of selected sample ids, keeping the request body constant-size regardless of selection
-size. Here we reproduce the exact client-side selection server-side: load the
-cached, deterministic 2D projection the user lassoed over and run a vectorized point-in-polygon
-test, then feed the resulting ids into the existing ``= ANY(...)`` filter path.
+Given a polygon and a collection, load the cached, deterministic 2D projection of that
+collection's embeddings and return the ids of the samples whose coordinates fall inside the
+polygon. Taking the geometry (a handful of vertices) rather than an explicit id list keeps the
+input constant-size regardless of how many samples the region covers.
 """
 
 from __future__ import annotations
@@ -55,9 +54,10 @@ def _points_in_polygon(
 ) -> NDArray[np.bool_]:
     """Vectorized even-odd ray-casting point-in-polygon test.
 
-    Matches the frontend's ``isPointInPolygon`` (ray cast to the right, edges counted when
-    exactly one endpoint is strictly above the point's y) so the server selects exactly the
-    points the user saw highlighted.
+    A ray is cast to the right (+x); an edge is counted when exactly one endpoint is strictly
+    above the point's y. This intentionally reproduces the frontend's ``isPointInPolygon`` so
+    that a region selected in the plot maps to the same set of samples on the server:
+    https://github.com/lightly-ai/lightly-studio/blob/7c44af936d1193a0fcedf91644bf91f5c9e9ef55/lightly_studio_view/src/lib/components/PlotPanel/isPointInPolygon/isPointInPolygon.ts#L18-L49
     """
     vertices_x = np.asarray([vertex.x for vertex in region.polygon], dtype=np.float64)
     vertices_y = np.asarray([vertex.y for vertex in region.polygon], dtype=np.float64)

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -1,0 +1,86 @@
+"""Resolve an embedding-plot region selection to the sample ids it encloses.
+
+The frontend sends the lasso/rectangle geometry (a handful of vertices) instead of the full
+list of selected sample ids, keeping the request body constant-size regardless of selection
+size (see LIG-9903). Here we reproduce the exact client-side selection server-side: load the
+cached, deterministic 2D projection the user lassoed over and run a vectorized point-in-polygon
+test, then feed the resulting ids into the existing ``= ANY(...)`` filter path.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import numpy as np
+from numpy.typing import NDArray
+from sqlmodel import Session, select
+
+from lightly_studio.models.embedding_model import EmbeddingModelTable
+from lightly_studio.models.embedding_region import EmbeddingRegion
+from lightly_studio.resolvers import twodim_embedding_resolver
+
+
+def get_sample_ids_in_region(
+    session: Session,
+    collection_id: UUID,
+    region: EmbeddingRegion,
+) -> list[UUID]:
+    """Return the sample ids whose cached 2D coordinates fall inside ``region``."""
+    # Mirror the embeddings2d endpoint: use the collection's first embedding model.
+    # TODO(Kondrat, 07/2026): Select the embedding model via API parameter once supported,
+    # matching embeddings2d.get_2d_embeddings.
+    embedding_model = session.exec(
+        select(EmbeddingModelTable)
+        .where(EmbeddingModelTable.collection_id == collection_id)
+        .limit(1)
+    ).first()
+    if embedding_model is None:
+        return []
+
+    x_array, y_array, sample_ids = twodim_embedding_resolver.get_twodim_embeddings(
+        session=session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+    if len(sample_ids) == 0:
+        return []
+
+    inside_mask = _points_in_polygon(x=x_array, y=y_array, region=region)
+    return [sample_id for sample_id, inside in zip(sample_ids, inside_mask) if inside]
+
+
+def _points_in_polygon(
+    x: NDArray[np.float32],
+    y: NDArray[np.float32],
+    region: EmbeddingRegion,
+) -> NDArray[np.bool_]:
+    """Vectorized even-odd ray-casting point-in-polygon test.
+
+    Matches the frontend's ``isPointInPolygon`` (ray cast to the right, edges counted when
+    exactly one endpoint is strictly above the point's y) so the server selects exactly the
+    points the user saw highlighted.
+    """
+    vertices_x = np.asarray([vertex.x for vertex in region.polygon], dtype=np.float64)
+    vertices_y = np.asarray([vertex.y for vertex in region.polygon], dtype=np.float64)
+
+    px = np.asarray(x, dtype=np.float64)
+    py = np.asarray(y, dtype=np.float64)
+
+    inside = np.zeros(px.shape, dtype=np.bool_)
+
+    # Previous vertex of each edge: (vertices[j], vertices[i]) with j = i - 1 (wrapping).
+    prev_x = np.roll(vertices_x, 1)
+    prev_y = np.roll(vertices_y, 1)
+
+    for xi, yi, xj, yj in zip(vertices_x, vertices_y, prev_x, prev_y):
+        # Edge straddles the horizontal ray at py (one endpoint strictly above, one not).
+        straddles = (yi > py) != (yj > py)
+        denominator = yj - yi
+        # Guard against a horizontal edge (denominator == 0); those never straddle, so the
+        # value used here is irrelevant, but avoid dividing by zero.
+        safe_denominator = np.where(denominator == 0, 1.0, denominator)
+        intersection_x = (xj - xi) * (py - yi) / safe_denominator + xi
+        crosses = straddles & (px < intersection_x)
+        inside ^= crosses
+
+    return inside

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -59,11 +59,11 @@ def _points_in_polygon(
     that a region selected in the plot maps to the same set of samples on the server:
     https://github.com/lightly-ai/lightly-studio/blob/7c44af936d1193a0fcedf91644bf91f5c9e9ef55/lightly_studio_view/src/lib/components/PlotPanel/isPointInPolygon/isPointInPolygon.ts#L18-L49
     """
-    vertices_x = np.asarray([vertex.x for vertex in region.polygon], dtype=np.float64)
-    vertices_y = np.asarray([vertex.y for vertex in region.polygon], dtype=np.float64)
+    vertices_x = np.asarray([vertex.x for vertex in region.polygon], dtype=np.float32)
+    vertices_y = np.asarray([vertex.y for vertex in region.polygon], dtype=np.float32)
 
-    px = np.asarray(x, dtype=np.float64)
-    py = np.asarray(y, dtype=np.float64)
+    px = np.asarray(x, dtype=np.float32)
+    py = np.asarray(y, dtype=np.float32)
 
     inside = np.zeros(px.shape, dtype=np.bool_)
 

--- a/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
@@ -85,7 +85,7 @@ def _setup_collection_with_coordinates(
 
 class TestPointsInPolygon:
     def test_square_selects_only_inside_points(self) -> None:
-        region = _square(0, 0, 10, 10)
+        region = _square(x_min=0, y_min=0, x_max=10, y_max=10)
         x = np.array([5, 15, -1, 9.9, 5], dtype=np.float32)
         y = np.array([5, 5, 5, 9.9, 20], dtype=np.float32)
 
@@ -123,7 +123,7 @@ class TestGetSampleIdsInRegion:
         selected = embedding_region_resolver.get_sample_ids_in_region(
             session=db_session,
             collection_id=collection_id,
-            region=_square(0, 0, 10, 10),
+            region=_square(x_min=0, y_min=0, x_max=10, y_max=10),
         )
 
         assert set(selected) == {sample_ids[0], sample_ids[1]}
@@ -137,7 +137,7 @@ class TestGetSampleIdsInRegion:
         selected = embedding_region_resolver.get_sample_ids_in_region(
             session=db_session,
             collection_id=collection_id,
-            region=_square(50, 50, 60, 60),
+            region=_square(x_min=50, y_min=50, x_max=60, y_max=60),
         )
 
         assert selected == []
@@ -148,7 +148,7 @@ class TestGetSampleIdsInRegion:
         selected = embedding_region_resolver.get_sample_ids_in_region(
             session=db_session,
             collection_id=collection.collection_id,
-            region=_square(0, 0, 10, 10),
+            region=_square(x_min=0, y_min=0, x_max=10, y_max=10),
         )
 
         assert selected == []

--- a/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
@@ -74,13 +74,16 @@ def _setup_collection_with_coordinates(
     coordinates_by_sample = {
         image.sample_id: coordinate for image, coordinate in zip(images, coordinates)
     }
-    ordered_sample_ids = _seed_2d_coordinates(
+    _seed_2d_coordinates(
         session=session,
         collection_id=collection.collection_id,
         embedding_model_id=embedding_model.embedding_model_id,
         coordinates=coordinates_by_sample,
     )
-    return collection.collection_id, ordered_sample_ids
+    # Return sample ids in the same order as ``coordinates`` so callers can index by
+    # coordinate. ``_seed_2d_coordinates`` seeds by sample id, so its own (hash-ordered)
+    # return value need not match the coordinate order.
+    return collection.collection_id, [image.sample_id for image in images]
 
 
 class TestPointsInPolygon:

--- a/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
@@ -1,0 +1,154 @@
+"""Tests for the embedding-region resolver (server-side point-in-polygon)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import numpy as np
+from sqlmodel import Session
+
+from lightly_studio.models.embedding_region import EmbeddingRegion, Point2D
+from lightly_studio.models.two_dim_embedding import TwoDimEmbeddingTable
+from lightly_studio.resolvers import embedding_region_resolver, sample_embedding_resolver
+from tests import helpers_resolvers
+from tests.helpers_resolvers import ImageStub
+
+
+def _square(x_min: float, y_min: float, x_max: float, y_max: float) -> EmbeddingRegion:
+    return EmbeddingRegion(
+        polygon=[
+            Point2D(x=x_min, y=y_min),
+            Point2D(x=x_max, y=y_min),
+            Point2D(x=x_max, y=y_max),
+            Point2D(x=x_min, y=y_max),
+        ]
+    )
+
+
+def _seed_2d_coordinates(
+    session: Session,
+    collection_id: UUID,
+    embedding_model_id: UUID,
+    coordinates: dict[UUID, tuple[float, float]],
+) -> list[UUID]:
+    """Seed the cached 2D projection with deterministic coordinates.
+
+    Returns the ordered sample ids as ``get_twodim_embeddings`` would return them.
+    """
+    cache_key, sample_ids = sample_embedding_resolver.get_hash_by_collection_id(
+        session=session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model_id,
+    )
+    session.add(
+        TwoDimEmbeddingTable(
+            hash=cache_key,
+            x=[coordinates[sample_id][0] for sample_id in sample_ids],
+            y=[coordinates[sample_id][1] for sample_id in sample_ids],
+        )
+    )
+    session.commit()
+    return sample_ids
+
+
+def _setup_collection_with_coordinates(
+    session: Session,
+    coordinates: list[tuple[float, float]],
+) -> tuple[UUID, list[UUID]]:
+    collection = helpers_resolvers.create_collection(session=session)
+    embedding_model = helpers_resolvers.create_embedding_model(
+        session=session,
+        collection_id=collection.collection_id,
+        embedding_dimension=3,
+    )
+    images = helpers_resolvers.create_samples_with_embeddings(
+        session=session,
+        collection_id=collection.collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        # Distinct first dimensions keep the deterministic cache key stable across samples.
+        images_and_embeddings=[
+            (ImageStub(path=f"sample_{index}.png"), [float(index) + 0.1, 0.2, 0.3])
+            for index in range(len(coordinates))
+        ],
+    )
+    coordinates_by_sample = {
+        image.sample_id: coordinate for image, coordinate in zip(images, coordinates)
+    }
+    ordered_sample_ids = _seed_2d_coordinates(
+        session=session,
+        collection_id=collection.collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        coordinates=coordinates_by_sample,
+    )
+    return collection.collection_id, ordered_sample_ids
+
+
+class TestPointsInPolygon:
+    def test_square_selects_only_inside_points(self) -> None:
+        region = _square(0, 0, 10, 10)
+        x = np.array([5, 15, -1, 9.9, 5], dtype=np.float32)
+        y = np.array([5, 5, 5, 9.9, 20], dtype=np.float32)
+
+        mask = embedding_region_resolver._points_in_polygon(x=x, y=y, region=region)
+
+        assert mask.tolist() == [True, False, False, True, False]
+
+    def test_concave_polygon(self) -> None:
+        # An arrow-shaped concave polygon with a notch at the top center.
+        region = EmbeddingRegion(
+            polygon=[
+                Point2D(x=0, y=0),
+                Point2D(x=10, y=0),
+                Point2D(x=10, y=10),
+                Point2D(x=5, y=4),
+                Point2D(x=0, y=10),
+            ]
+        )
+        # (5, 8) sits in the notch (outside); (5, 2) is well inside.
+        x = np.array([5, 5, 1], dtype=np.float32)
+        y = np.array([8, 2, 1], dtype=np.float32)
+
+        mask = embedding_region_resolver._points_in_polygon(x=x, y=y, region=region)
+
+        assert mask.tolist() == [False, True, True]
+
+
+class TestGetSampleIdsInRegion:
+    def test_selects_points_inside_region(self, db_session: Session) -> None:
+        collection_id, sample_ids = _setup_collection_with_coordinates(
+            session=db_session,
+            coordinates=[(1.0, 1.0), (5.0, 5.0), (100.0, 100.0)],
+        )
+
+        selected = embedding_region_resolver.get_sample_ids_in_region(
+            session=db_session,
+            collection_id=collection_id,
+            region=_square(0, 0, 10, 10),
+        )
+
+        assert set(selected) == {sample_ids[0], sample_ids[1]}
+
+    def test_empty_region_selects_nothing(self, db_session: Session) -> None:
+        collection_id, _ = _setup_collection_with_coordinates(
+            session=db_session,
+            coordinates=[(1.0, 1.0), (5.0, 5.0)],
+        )
+
+        selected = embedding_region_resolver.get_sample_ids_in_region(
+            session=db_session,
+            collection_id=collection_id,
+            region=_square(50, 50, 60, 60),
+        )
+
+        assert selected == []
+
+    def test_no_embedding_model_returns_empty(self, db_session: Session) -> None:
+        collection = helpers_resolvers.create_collection(session=db_session)
+
+        selected = embedding_region_resolver.get_sample_ids_in_region(
+            session=db_session,
+            collection_id=collection.collection_id,
+            region=_square(0, 0, 10, 10),
+        )
+
+        assert selected == []

--- a/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
@@ -14,6 +14,78 @@ from tests import helpers_resolvers
 from tests.helpers_resolvers import ImageStub
 
 
+def test_get_sample_ids_in_region(db_session: Session) -> None:
+    collection_id, sample_ids = _setup_collection_with_coordinates(
+        session=db_session,
+        coordinates=[(1.0, 1.0), (5.0, 5.0), (100.0, 100.0)],
+    )
+
+    selected = embedding_region_resolver.get_sample_ids_in_region(
+        session=db_session,
+        collection_id=collection_id,
+        region=_square(x_min=0, y_min=0, x_max=10, y_max=10),
+    )
+
+    assert set(selected) == {sample_ids[0], sample_ids[1]}
+
+
+def test_get_sample_ids_in_region__empty_region(db_session: Session) -> None:
+    collection_id, _ = _setup_collection_with_coordinates(
+        session=db_session,
+        coordinates=[(1.0, 1.0), (5.0, 5.0)],
+    )
+
+    selected = embedding_region_resolver.get_sample_ids_in_region(
+        session=db_session,
+        collection_id=collection_id,
+        region=_square(x_min=50, y_min=50, x_max=60, y_max=60),
+    )
+
+    assert selected == []
+
+
+def test_get_sample_ids_in_region__no_embedding_model(db_session: Session) -> None:
+    collection = helpers_resolvers.create_collection(session=db_session)
+
+    selected = embedding_region_resolver.get_sample_ids_in_region(
+        session=db_session,
+        collection_id=collection.collection_id,
+        region=_square(x_min=0, y_min=0, x_max=10, y_max=10),
+    )
+
+    assert selected == []
+
+
+def test_points_in_polygon() -> None:
+    region = _square(x_min=0, y_min=0, x_max=10, y_max=10)
+    x = np.array([5, 15, -1, 9.9, 5], dtype=np.float32)
+    y = np.array([5, 5, 5, 9.9, 20], dtype=np.float32)
+
+    mask = embedding_region_resolver._points_in_polygon(x=x, y=y, region=region)
+
+    assert mask.tolist() == [True, False, False, True, False]
+
+
+def test_points_in_polygon__concave() -> None:
+    # An arrow-shaped concave polygon with a notch at the top center.
+    region = EmbeddingRegion(
+        polygon=[
+            Point2D(x=0, y=0),
+            Point2D(x=10, y=0),
+            Point2D(x=10, y=10),
+            Point2D(x=5, y=4),
+            Point2D(x=0, y=10),
+        ]
+    )
+    # (5, 8) sits in the notch (outside); (5, 2) is well inside.
+    x = np.array([5, 5, 1], dtype=np.float32)
+    y = np.array([8, 2, 1], dtype=np.float32)
+
+    mask = embedding_region_resolver._points_in_polygon(x=x, y=y, region=region)
+
+    assert mask.tolist() == [False, True, True]
+
+
 def _square(x_min: float, y_min: float, x_max: float, y_max: float) -> EmbeddingRegion:
     return EmbeddingRegion(
         polygon=[
@@ -84,74 +156,3 @@ def _setup_collection_with_coordinates(
     # coordinate. ``_seed_2d_coordinates`` seeds by sample id, so its own (hash-ordered)
     # return value need not match the coordinate order.
     return collection.collection_id, [image.sample_id for image in images]
-
-
-class TestPointsInPolygon:
-    def test_square_selects_only_inside_points(self) -> None:
-        region = _square(x_min=0, y_min=0, x_max=10, y_max=10)
-        x = np.array([5, 15, -1, 9.9, 5], dtype=np.float32)
-        y = np.array([5, 5, 5, 9.9, 20], dtype=np.float32)
-
-        mask = embedding_region_resolver._points_in_polygon(x=x, y=y, region=region)
-
-        assert mask.tolist() == [True, False, False, True, False]
-
-    def test_concave_polygon(self) -> None:
-        # An arrow-shaped concave polygon with a notch at the top center.
-        region = EmbeddingRegion(
-            polygon=[
-                Point2D(x=0, y=0),
-                Point2D(x=10, y=0),
-                Point2D(x=10, y=10),
-                Point2D(x=5, y=4),
-                Point2D(x=0, y=10),
-            ]
-        )
-        # (5, 8) sits in the notch (outside); (5, 2) is well inside.
-        x = np.array([5, 5, 1], dtype=np.float32)
-        y = np.array([8, 2, 1], dtype=np.float32)
-
-        mask = embedding_region_resolver._points_in_polygon(x=x, y=y, region=region)
-
-        assert mask.tolist() == [False, True, True]
-
-
-class TestGetSampleIdsInRegion:
-    def test_selects_points_inside_region(self, db_session: Session) -> None:
-        collection_id, sample_ids = _setup_collection_with_coordinates(
-            session=db_session,
-            coordinates=[(1.0, 1.0), (5.0, 5.0), (100.0, 100.0)],
-        )
-
-        selected = embedding_region_resolver.get_sample_ids_in_region(
-            session=db_session,
-            collection_id=collection_id,
-            region=_square(x_min=0, y_min=0, x_max=10, y_max=10),
-        )
-
-        assert set(selected) == {sample_ids[0], sample_ids[1]}
-
-    def test_empty_region_selects_nothing(self, db_session: Session) -> None:
-        collection_id, _ = _setup_collection_with_coordinates(
-            session=db_session,
-            coordinates=[(1.0, 1.0), (5.0, 5.0)],
-        )
-
-        selected = embedding_region_resolver.get_sample_ids_in_region(
-            session=db_session,
-            collection_id=collection_id,
-            region=_square(x_min=50, y_min=50, x_max=60, y_max=60),
-        )
-
-        assert selected == []
-
-    def test_no_embedding_model_returns_empty(self, db_session: Session) -> None:
-        collection = helpers_resolvers.create_collection(session=db_session)
-
-        selected = embedding_region_resolver.get_sample_ids_in_region(
-            session=db_session,
-            collection_id=collection.collection_id,
-            region=_square(x_min=0, y_min=0, x_max=10, y_max=10),
-        )
-
-        assert selected == []


### PR DESCRIPTION


### Why

When a user lassos points in the embedding plot, the frontend currently sends the
**full list of selected sample ids** in the request body. That list grows with the
selection and doesn't scale — a large lasso produces a huge request.

The fix is to send the **selection geometry** (a handful of polygon
vertices, a few KB) instead, and reproduce the exact selection server-side by running
point-in-polygon over the cached 2D projection.

This PR lands the **shared foundation** used by both the images and annotations
filtering that follow in the stack. It adds no wiring into any resolver yet, so it's
inert on its own.

### What

- **`models/embedding_region.py`** — `Point2D` and `EmbeddingRegion` Pydantic models.
  Rectangle selections are normalized to four corner vertices on the frontend, so both
  lasso and rectangle arrive as a polygon. Validates ≥ 3 vertices.
- **`resolvers/embedding_region_resolver.py`** — the geometry core:
  - `get_sample_ids_in_region(...)` — loads the collection's cached 2D embedding and
    returns the sample ids inside the region.
  - `_points_in_polygon(...)` — vectorized even-odd ray-casting test, deliberately
    mirroring the frontend's `isPointInPolygon` so the server selects exactly the points
    the user saw highlighted.
- Tests covering the polygon math (convex + concave) and `get_sample_ids_in_region`
  (inside points, empty region, missing embedding model).

### Notes for reviewers

- No public route or resolver calls this code yet — the image/annotation resolve
  functions and filter wiring come in the next PRs in the stack (this file gains two more
  functions there).
- The embedding-model selection reuses the "first embedding model" convention from the
  `embeddings2d` endpoint; a `TODO(Kondrat, 07/2026)` marks making it an API parameter.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added region-based sample selection on embedding plots using polygon geometry, returning the samples that fall inside the drawn region.

* **Bug Fixes**
  * Enforced minimum region polygon size (at least 3 vertices) for valid selections.
  * Improved empty-state behavior by returning no results when an embedding model or 2D projections are unavailable.

* **Tests**
  * Added automated coverage for point-in-polygon behavior (convex/concave) and region-to-sample selection edge cases.

* **Other**
  * Updated the embeddings 2D endpoint to use centralized default embedding model selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->