### PR TITLE
Send image embedding-plot selection as geometry

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -58,9 +58,10 @@
         textEmbedding
     } = useGlobalStorage();
 
-    // The embedding plot lasso selection on the annotations route.
-    const { annotationPlotSampleIds } = useAnnotationPlotSelection();
-    const plotSelectedAnnotationIds = $derived($annotationPlotSampleIds);
+    // The embedding plot lasso selection on the annotations route, kept as geometry and sent
+    // to the backend instead of a resolved sample-id list (see LIG-9903).
+    const { annotationPlotRegion } = useAnnotationPlotSelection();
+    const plotSelectedRegion = $derived($annotationPlotRegion);
 
     // The text embedding search is shared with the images tab and persists across the tab switch.
     // Only apply it when this annotation collection actually has embeddings.
@@ -126,8 +127,8 @@
         annotation_label_ids:
             $selectedAnnotationFilterIds.length > 0 ? $selectedAnnotationFilterIds : undefined,
         tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined,
-        // Embedding plot lasso selection narrows the grid to the selected annotations.
-        sample_ids: plotSelectedAnnotationIds.length > 0 ? plotSelectedAnnotationIds : undefined,
+        // Embedding plot lasso selection narrows the grid to annotations inside the region.
+        embedding_region: plotSelectedRegion ?? undefined,
         // Embedding text search reorders the grid by similarity (shared with images tab).
         text_embedding: searchEmbedding?.embedding ?? undefined
     });
@@ -145,7 +146,7 @@
     let infiniteLoaderIdentifier = $derived(
         $selectedAnnotationFilterIds.join(',') +
             Array.from($tagsSelected).join(',') +
-            plotSelectedAnnotationIds.join(',') +
+            (plotSelectedRegion ? JSON.stringify(plotSelectedRegion) : '') +
             (searchEmbedding ? `search:${searchEmbedding.queryText}` : '')
     );
 

--- a/lightly_studio_view/src/lib/components/Images/syncFilterParams.test.ts
+++ b/lightly_studio_view/src/lib/components/Images/syncFilterParams.test.ts
@@ -10,6 +10,14 @@ const confusionCell = {
     pred_label: 'dog'
 };
 
+const embeddingRegion = {
+    polygon: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 1 }
+    ]
+};
+
 const normalParams = (collection_id: string, filters: NormalModeFilters): ImagesInfiniteParams => ({
     collection_id,
     mode: 'normal',
@@ -30,11 +38,12 @@ describe('paramsWithoutExternalFilters', () => {
         expect(paramsWithoutExternalFilters(params).filters).toEqual({ tag_ids: ['tag-1'] });
     });
 
-    it('treats params that differ only in sample_ids/confusion_cell as equal', () => {
+    it('treats params that differ only in sample_ids/embedding_region/confusion_cell as equal', () => {
         const base = baseNormalParams();
         const withExternal = normalParams('col-1', {
             tag_ids: ['tag-1'],
             sample_ids: ['s1'],
+            embedding_region: embeddingRegion,
             confusion_cell: confusionCell
         });
 
@@ -77,6 +86,17 @@ describe('mergeExternalFilters', () => {
         if (result.mode === 'normal') {
             expect(result.filters?.sample_ids).toEqual(['s1', 's2']);
             expect(result.filters?.tag_ids).toEqual(['tag-1']);
+        }
+    });
+
+    it('carries the embedding_region forward across collections', () => {
+        const baseParams = baseNormalParams('col-2');
+        const currentParams = normalParams('col-1', { embedding_region: embeddingRegion });
+
+        const result = mergeExternalFilters(baseParams, currentParams);
+
+        if (result.mode === 'normal') {
+            expect(result.filters?.embedding_region).toEqual(embeddingRegion);
         }
     });
 

--- a/lightly_studio_view/src/lib/components/Images/syncFilterParams.ts
+++ b/lightly_studio_view/src/lib/components/Images/syncFilterParams.ts
@@ -2,24 +2,24 @@ import { omit } from 'lodash-es';
 import type { ImagesInfiniteParams } from '$lib/hooks/useImagesInfinite/useImagesInfinite';
 import type { NormalModeFilters } from '$lib/hooks/useImagesInfinite/types';
 
-// sample_ids and confusion_cell are set externally (selection / confusion matrix),
-// not from the component's filter controls, so they are excluded from the
-// base-params comparison and merged back instead of being overwritten.
+// sample_ids, embedding_region and confusion_cell are set externally (plot selection /
+// confusion matrix), not from the component's filter controls, so they are excluded from
+// the base-params comparison and merged back instead of being overwritten.
 export const paramsWithoutExternalFilters = (params: ImagesInfiniteParams) => {
     return {
         ...params,
         filters:
             params.mode === 'normal'
-                ? omit(params.filters, ['sample_ids', 'confusion_cell'])
+                ? omit(params.filters, ['sample_ids', 'embedding_region', 'confusion_cell'])
                 : undefined
     };
 };
 
-// Merge the externally-set selection (sample_ids) and confusion cell from the
-// previous filter params into the new base params. sample_ids are always carried
-// forward; the confusion cell is only carried when the collection matches, because
-// the cell belongs to a specific evaluation run/collection and must be dropped when
-// navigating to a different collection to avoid wrongly filtering the new grid.
+// Merge the externally-set selection (sample_ids, embedding_region) and confusion cell from
+// the previous filter params into the new base params. The selection is always carried
+// forward; the confusion cell is only carried when the collection matches, because the cell
+// belongs to a specific evaluation run/collection and must be dropped when navigating to a
+// different collection to avoid wrongly filtering the new grid.
 export const mergeExternalFilters = (
     baseParams: ImagesInfiniteParams,
     currentParams: ImagesInfiniteParams
@@ -27,20 +27,26 @@ export const mergeExternalFilters = (
     let nextParams = baseParams;
 
     let currentSampleIds: string[] = [];
+    let currentEmbeddingRegion: NormalModeFilters['embedding_region'];
     let currentConfusionCell: NormalModeFilters['confusion_cell'];
     if (currentParams.mode === 'normal') {
         currentSampleIds = currentParams.filters?.sample_ids ?? [];
+        currentEmbeddingRegion = currentParams.filters?.embedding_region;
         if (currentParams.collection_id === baseParams.collection_id) {
             currentConfusionCell = currentParams.filters?.confusion_cell;
         }
     }
 
-    if (nextParams.mode === 'normal' && (currentSampleIds.length > 0 || currentConfusionCell)) {
+    if (
+        nextParams.mode === 'normal' &&
+        (currentSampleIds.length > 0 || currentEmbeddingRegion || currentConfusionCell)
+    ) {
         nextParams = {
             ...nextParams,
             filters: {
                 ...(nextParams.filters ?? {}),
                 sample_ids: currentSampleIds.length > 0 ? currentSampleIds : undefined,
+                embedding_region: currentEmbeddingRegion,
                 confusion_cell: currentConfusionCell
             }
         };

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -8,9 +8,14 @@
         type ViewportState
     } from 'embedding-atlas/svelte';
     import { useEmbeddings } from '$lib/hooks/useEmbeddings/useEmbeddings';
+    import type { EmbeddingRegion } from '$lib/api/lightly_studio_local';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
     import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
     import { useAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
+    import {
+        clearPlotSelectionCount,
+        setPlotSelectionCount
+    } from '$lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection';
     import { useArrowData } from './useArrowData/useArrowData';
     import { usePlotData } from './usePlotData/usePlotData';
     import PlotPanelLegend from './PlotPanelLegend.svelte';
@@ -49,26 +54,20 @@
     const isVideos = $derived(isVideosRoute(page.route?.id ?? null));
     // Detect if we're on the annotations route
     const isAnnotations = $derived(isAnnotationsRoute(page.route?.id ?? null));
+    // Everything that isn't videos or annotations is the images grid.
+    const isImages = $derived(!isVideos && !isAnnotations);
 
     // Use appropriate filter hook based on route
     const imageFilters = useImageFilters();
     const videoFilters = useVideoFilters();
-    const { annotationPlotSampleIds, saveSampleIds: saveAnnotationPlotSampleIds } =
-        useAnnotationPlotSelection();
+    const { annotationPlotRegion, saveRegion: saveAnnotationRegion } = useAnnotationPlotSelection();
 
-    const updateSampleIds = $derived(
-        isAnnotations
-            ? saveAnnotationPlotSampleIds
-            : isVideos
-              ? videoFilters.updateSampleIds
-              : imageFilters.updateSampleIds
-    );
     const imageFilter = $derived(isVideos ? null : imageFilters.imageFilter);
     const videoFilter = $derived(isVideos ? videoFilters.videoFilter : null);
+    // Only videos still track their lasso selection as a resolved sample-id list; images and
+    // annotations send it to the backend as region geometry (see LIG-9903).
     const activeSampleIds = $derived(
-        isAnnotations
-            ? $annotationPlotSampleIds
-            : ((isVideos ? $videoFilter : $imageFilter)?.sample_filter?.sample_ids ?? [])
+        isVideos ? ($videoFilter?.sample_filter?.sample_ids ?? []) : []
     );
 
     // The active annotation label/tag filter, mirroring what the annotations grid applies.
@@ -93,7 +92,10 @@
             ...currentFilter,
             sample_filter: {
                 ...currentFilter.sample_filter,
-                sample_ids: []
+                sample_ids: [],
+                // The lasso only scopes the grid, not the plot: the plot shows every point and
+                // highlights the in-selection ones, so drop the region from this request.
+                embedding_region: undefined
             }
         };
     });
@@ -163,11 +165,24 @@
 
     const hasActiveFilter = $derived(filter !== null || activeSampleIds.length > 0);
 
-    // Activating a lasso unhides the Excluded category, otherwise out-of-selection points (which
-    // get demoted to Excluded) would vanish and blank out the canvas mid-draw. The legend keeps
-    // showing the user's real toggle state.
+    // Images and annotations commit the lasso as region geometry, not as sample ids. After the
+    // selection is committed the live rangeSelection is cleared, so the plot re-derives the
+    // highlight from the stored polygon to keep reflecting the actually selected points. Images
+    // keep the region on the image filter store; annotations in the shared plot region store.
+    const committedHighlightRegion = $derived(
+        isImages
+            ? ($imageFilter?.sample_filter?.embedding_region?.polygon ?? null)
+            : isAnnotations
+              ? ($annotationPlotRegion?.polygon ?? null)
+              : null
+    );
+
+    // Activating a lasso (or a committed region) unhides the Excluded category, otherwise
+    // out-of-selection points (which get demoted to Excluded) would vanish and blank out the
+    // canvas. The legend keeps showing the user's real toggle state.
     const effectiveHiddenCategories = $derived.by(() => {
-        if ($rangeSelection === null || !$hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)) {
+        const hasSelectionHighlight = $rangeSelection !== null || committedHighlightRegion !== null;
+        if (!hasSelectionHighlight || !$hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)) {
             return $hiddenCategories;
         }
         const next = new Set($hiddenCategories);
@@ -179,6 +194,7 @@
         usePlotData({
             arrowData: $arrowData,
             rangeSelection: $rangeSelection,
+            highlightRegion: committedHighlightRegion,
             highlightedSampleIds: activeSampleIds,
             hasActiveFilter: hasActiveFilter,
             hiddenCategories: effectiveHiddenCategories
@@ -192,38 +208,60 @@
     const legendEntries = $derived.by(() =>
         getLegendEntries($colorLegend, $hiddenCategories, useLabelColors)
     );
+    // Images and annotations send the lasso to the backend as region geometry rather than a
+    // resolved sample-id list (see LIG-9903); the sidebar chip reads the selected count from the
+    // plot-propagated count store, and clearing removes the region entirely. Images keep the
+    // region on the image filter store; annotations have no such store, so it lives in the
+    // shared annotation-plot region store instead.
+    const saveRegion = (region: EmbeddingRegion | null) => {
+        if (isImages) {
+            imageFilters.updateEmbeddingRegion(region);
+        } else {
+            saveAnnotationRegion(region);
+        }
+    };
+    const commitRegion = (polygon: Point[], count: number) => {
+        saveRegion({ polygon });
+        setPlotSelectionCount(collectionId, count);
+    };
+    const clearRegion = () => {
+        saveRegion(null);
+        clearPlotSelectionCount(collectionId);
+    };
+
     const handleMouseUp = () => {
-        const hadRangeSelection = $rangeSelection !== null;
-        if (!hadRangeSelection) {
+        if ($rangeSelection === null) {
             return;
         }
+        const polygon = $rangeSelection;
 
-        const currentSampleIds = isAnnotations
-            ? $annotationPlotSampleIds
-            : ((isVideos ? $videoFilter : $imageFilter)?.sample_filter?.sample_ids ?? []);
         const selectableCount =
             ($arrowData?.fulfils_filter as Uint8Array | undefined)?.reduce((count, fulfils) => {
                 return fulfils !== 0 ? count + 1 : count;
             }, 0) ?? null;
+        const selectedCount = $selectedSampleIds.length;
+        // Selecting nothing, or every selectable point, is equivalent to no filter at all.
+        const selectsNothingOrEverything =
+            selectedCount === 0 || (selectableCount !== null && selectedCount === selectableCount);
 
-        if ($selectedSampleIds.length === 0) {
-            if (currentSampleIds.length > 0) {
-                updateSampleIds([]);
+        // Videos still commit the resolved sample-id list; images and annotations send geometry.
+        if (isVideos) {
+            const currentSampleIds = $videoFilter?.sample_filter?.sample_ids ?? [];
+            if (selectsNothingOrEverything) {
+                if (currentSampleIds.length > 0) {
+                    videoFilters.updateSampleIds([]);
+                }
+            } else if (!isEqual($selectedSampleIds, currentSampleIds)) {
+                videoFilters.updateSampleIds($selectedSampleIds);
             }
             setRangeSelection(null);
             return;
         }
 
-        if (selectableCount !== null && $selectedSampleIds.length === selectableCount) {
-            if (currentSampleIds.length > 0) {
-                updateSampleIds([]);
-            }
-            setRangeSelection(null);
-            return;
-        }
-
-        if (!isEqual($selectedSampleIds, currentSampleIds)) {
-            updateSampleIds($selectedSampleIds);
+        if (selectsNothingOrEverything) {
+            clearRegion();
+        } else {
+            commitRegion(polygon, selectedCount);
         }
         setRangeSelection(null);
     };
@@ -298,9 +336,24 @@
 
     const clearSelection = () => {
         setRangeSelection(null);
-        updateSampleIds([]);
+        if (isVideos) {
+            videoFilters.updateSampleIds([]);
+        } else {
+            clearRegion();
+        }
     };
-    const hasActiveSelection = $derived($rangeSelection !== null || activeSampleIds.length > 0);
+    // Images and annotations track their committed selection as region geometry, not sample ids:
+    // images on the image filter store, annotations in the shared annotation-plot region store.
+    const regionSelected = $derived(
+        isImages
+            ? ($imageFilter?.sample_filter?.embedding_region ?? null) !== null
+            : isAnnotations
+              ? $annotationPlotRegion !== null
+              : false
+    );
+    const hasActiveSelection = $derived(
+        $rangeSelection !== null || activeSampleIds.length > 0 || regionSelected
+    );
 
     const onWindowKeyDown = (event: KeyboardEvent) => {
         if (event.key !== 'Escape') {

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
@@ -3,7 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import PlotPanel from './PlotPanel.svelte';
 import { useEmbeddings } from '$lib/hooks/useEmbeddings/useEmbeddings';
-import { writable, type Writable } from 'svelte/store';
+import { get, writable, type Writable } from 'svelte/store';
+import {
+    clearAnnotationPlotSelection,
+    useAnnotationPlotSelection
+} from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
 import { tick } from 'svelte';
 import { usePlotColorByType } from './PlotColorByPopover/usePlotColorByType/usePlotColorByType';
 import { EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY } from './plotCategories';
@@ -25,6 +29,9 @@ const tagsStore = writable([
 const mockSetShowEmbeddingPlot = vi.fn();
 const mockSetRangeSelectionForCollection = vi.fn();
 const mockUpdateSampleIds = vi.fn();
+const mockUpdateEmbeddingRegion = vi.fn();
+const mockSetPlotSelectionCount = vi.fn();
+const mockClearPlotSelectionCount = vi.fn();
 
 class ResizeObserverMock {
     observe() {}
@@ -39,12 +46,15 @@ const originalResizeObserver = globalThis.ResizeObserver;
 
 vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 
+const IMAGES_ROUTE = '/datasets/[dataset_id]/[collection_type]/[collection_id]/images';
+const ANNOTATIONS_ROUTE = '/datasets/[dataset_id]/[collection_type]/[collection_id]/annotations';
+// Route is read per-render, so tests set `routeState.id` before rendering to pick a grid type.
+const routeState = vi.hoisted(() => ({ id: '' }));
+
 vi.mock('$app/state', () => ({
     page: {
         params: { collection_id: 'test-collection-id' },
-        route: {
-            id: '/datasets/[dataset_id]/[collection_type]/[collection_id]/images'
-        }
+        route: routeState
     }
 }));
 
@@ -68,12 +78,16 @@ vi.mock('./useCategoryVisibility/useCategoryVisibility', () => ({
         resetCategoryVisibility: mockResetCategoryVisibility
     })
 }));
+const usePlotDataSpy = vi.hoisted(() => vi.fn());
 vi.mock('./usePlotData/usePlotData', () => ({
-    usePlotData: () => ({
-        data: writable(undefined),
-        selectedSampleIds: selectedSampleIdsStore,
-        error: writable(undefined)
-    })
+    usePlotData: (args: unknown) => {
+        usePlotDataSpy(args);
+        return {
+            data: writable(undefined),
+            selectedSampleIds: selectedSampleIdsStore,
+            error: writable(undefined)
+        };
+    }
 }));
 vi.mock('$lib/hooks/useVideoFilters/useVideoFilters', () => ({
     useVideoFilters: () => ({
@@ -86,8 +100,13 @@ vi.mock('$lib/hooks/useImageFilters/useImageFilters', () => ({
         filterParams: writable({ mode: 'normal', filters: {} }),
         imageFilter: imageFilterStore,
         updateFilterParams: vi.fn(),
-        updateSampleIds: mockUpdateSampleIds
+        updateSampleIds: mockUpdateSampleIds,
+        updateEmbeddingRegion: mockUpdateEmbeddingRegion
     })
+}));
+vi.mock('$lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection', () => ({
+    setPlotSelectionCount: (...args: [string, number]) => mockSetPlotSelectionCount(...args),
+    clearPlotSelectionCount: (...args: [string]) => mockClearPlotSelectionCount(...args)
 }));
 vi.mock('$lib/hooks/useMetadataFilters/useMetadataFilters', () => ({
     useMetadataFilters: () => ({
@@ -137,6 +156,8 @@ describe('PlotPanel.svelte', () => {
     beforeEach(() => {
         vi.resetAllMocks();
         vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+        routeState.id = IMAGES_ROUTE;
+        clearAnnotationPlotSelection('test-collection-id');
         usePlotColorByType('test-collection-id').clearSelectedColorByType();
         rangeSelectionStore = writable(null);
         selectedSampleIdsStore = writable([]);
@@ -192,16 +213,20 @@ describe('PlotPanel.svelte', () => {
         await fireEvent.keyDown(window, { key: 'Escape' });
 
         expect(mockSetRangeSelectionForCollection).toHaveBeenCalledWith('test-collection-id', null);
-        expect(mockUpdateSampleIds).toHaveBeenCalledWith([]);
+        // Images clear the region geometry, not a sample-id list.
+        expect(mockUpdateEmbeddingRegion).toHaveBeenCalledWith(null);
+        expect(mockClearPlotSelectionCount).toHaveBeenCalledWith('test-collection-id');
+        expect(mockUpdateSampleIds).not.toHaveBeenCalled();
     });
 
-    it('should clear range selection geometry after applying mouse selection', async () => {
-        rangeSelectionStore = writable([
+    it('should send the lasso as region geometry after applying mouse selection', async () => {
+        const polygon = [
             { x: 0, y: 0 },
             { x: 1, y: 0 },
             { x: 1, y: 1 },
             { x: 0, y: 1 }
-        ]);
+        ];
+        rangeSelectionStore = writable(polygon);
         selectedSampleIdsStore = writable(['sample-1']);
         (useEmbeddings as vi.Mock).mockReturnValue({
             isError: false,
@@ -213,7 +238,9 @@ describe('PlotPanel.svelte', () => {
         render(PlotPanel, { props: { collectionId: 'test-collection-id' } });
         await fireEvent.mouseUp(window);
 
-        expect(mockUpdateSampleIds).toHaveBeenCalledWith(['sample-1']);
+        expect(mockUpdateEmbeddingRegion).toHaveBeenCalledWith({ polygon });
+        expect(mockSetPlotSelectionCount).toHaveBeenCalledWith('test-collection-id', 1);
+        expect(mockUpdateSampleIds).not.toHaveBeenCalled();
         expect(mockSetRangeSelectionForCollection).toHaveBeenCalledWith('test-collection-id', null);
     });
 
@@ -245,9 +272,10 @@ describe('PlotPanel.svelte', () => {
         await tick();
         expect(mockSetRangeSelectionForCollection).not.toHaveBeenCalled();
         expect(mockUpdateSampleIds).not.toHaveBeenCalled();
+        expect(mockUpdateEmbeddingRegion).not.toHaveBeenCalled();
     });
 
-    it('should clear sample_ids when selecting all selectable points', async () => {
+    it('should clear the region when selecting all selectable points', async () => {
         rangeSelectionStore = writable([
             { x: 0, y: 0 },
             { x: 1, y: 0 },
@@ -267,9 +295,60 @@ describe('PlotPanel.svelte', () => {
         render(PlotPanel, { props: { collectionId: 'test-collection-id' } });
         await fireEvent.mouseUp(window);
 
-        expect(mockUpdateSampleIds).toHaveBeenCalledWith([]);
-        expect(mockUpdateSampleIds).not.toHaveBeenCalledWith(['sample-1', 'sample-2']);
+        // Selecting every selectable point is equivalent to no filter, so the region is cleared.
+        expect(mockUpdateEmbeddingRegion).toHaveBeenCalledWith(null);
+        expect(mockClearPlotSelectionCount).toHaveBeenCalledWith('test-collection-id');
+        expect(mockSetPlotSelectionCount).not.toHaveBeenCalled();
         expect(mockSetRangeSelectionForCollection).toHaveBeenCalledWith('test-collection-id', null);
+    });
+
+    it('saves the lasso to the annotation region store on the annotations route', async () => {
+        routeState.id = ANNOTATIONS_ROUTE;
+        const polygon = [
+            { x: 0, y: 0 },
+            { x: 1, y: 0 },
+            { x: 1, y: 1 },
+            { x: 0, y: 1 }
+        ];
+        rangeSelectionStore = writable(polygon);
+        selectedSampleIdsStore = writable(['annotation-1']);
+        (useEmbeddings as vi.Mock).mockReturnValue({
+            isError: false,
+            error: null,
+            isLoading: true,
+            data: null
+        });
+
+        render(PlotPanel, { props: { collectionId: 'test-collection-id' } });
+        await fireEvent.mouseUp(window);
+
+        // Annotations have no filter store, so the geometry goes to the shared region store.
+        expect(get(useAnnotationPlotSelection().annotationPlotRegion)).toEqual({ polygon });
+        expect(mockSetPlotSelectionCount).toHaveBeenCalledWith('test-collection-id', 1);
+        // The image filter path must stay untouched on the annotations route.
+        expect(mockUpdateEmbeddingRegion).not.toHaveBeenCalled();
+        expect(mockSetRangeSelectionForCollection).toHaveBeenCalledWith('test-collection-id', null);
+    });
+
+    it('highlights the committed annotation region after the live selection clears', async () => {
+        routeState.id = ANNOTATIONS_ROUTE;
+        const polygon = [
+            { x: 0, y: 0 },
+            { x: 1, y: 0 },
+            { x: 1, y: 1 },
+            { x: 0, y: 1 }
+        ];
+        // The selection is already committed: no live rangeSelection, region in the shared store.
+        rangeSelectionStore = writable(null);
+        useAnnotationPlotSelection().saveRegion({ polygon });
+
+        render(PlotPanel, { props: { collectionId: 'test-collection-id' } });
+        await tick();
+
+        // The plot must re-derive the highlight from the committed region so the selected
+        // annotations stay highlighted instead of collapsing to "all included".
+        const lastArgs = usePlotDataSpy.mock.calls.at(-1)?.[0];
+        expect(lastArgs?.highlightRegion).toEqual(polygon);
     });
 
     it('passes derived colorBy to useEmbeddings when a metadata field is selected', async () => {

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.test.ts
@@ -298,6 +298,48 @@ describe('usePlotData', () => {
         expect(Array.from(data.category)).toEqual([0, 0, 0, 0]);
     });
 
+    it('highlights points inside a committed region when there is no live range selection', () => {
+        const mockData = createMockArrowData();
+        const region: Point[] = [
+            { x: 0, y: 0 },
+            { x: 2, y: 0 },
+            { x: 2, y: 6 },
+            { x: 0, y: 6 }
+        ];
+
+        const result = usePlotData({
+            arrowData: mockData,
+            rangeSelection: null,
+            highlightRegion: region
+        });
+
+        const data = get(result.data) as { category: Uint8Array };
+        // First two points are inside the region (keep their category); the rest are demoted to
+        // EXCLUDED (1), so the plot reflects the committed selection.
+        expect(Array.from(data.category)).toEqual([2, 3, 1, 1]);
+        // The resolved ids live server-side; the region path must not recompute them client-side.
+        expect(get(result.selectedSampleIds)).toEqual([]);
+    });
+
+    it('prefers the live range selection over a committed region', () => {
+        const mockData = createMockArrowData();
+        const selection: Point[] = [
+            { x: 0, y: 0 },
+            { x: 2, y: 0 },
+            { x: 2, y: 6 },
+            { x: 0, y: 6 }
+        ];
+
+        const result = usePlotData({
+            arrowData: mockData,
+            rangeSelection: selection,
+            highlightRegion: selection
+        });
+
+        // The range-selection branch still populates selectedSampleIds for the pending commit.
+        expect(get(result.selectedSampleIds)).toEqual(['sample1', 'sample2']);
+    });
+
     it('should return error store', () => {
         const mockData = createMockArrowData();
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/usePlotData/usePlotData.ts
@@ -38,12 +38,14 @@ type Selection = Point[] | null;
 export function usePlotData({
     arrowData,
     rangeSelection,
+    highlightRegion = null,
     highlightedSampleIds = [],
     hasActiveFilter = true,
     hiddenCategories = new Set()
 }: {
     arrowData: ArrowData;
     rangeSelection: Selection;
+    highlightRegion?: Selection;
     highlightedSampleIds?: string[];
     hasActiveFilter?: boolean;
     hiddenCategories?: ReadonlySet<number>;
@@ -92,6 +94,12 @@ export function usePlotData({
             return acc;
         }, []);
         selectedSampleIds.update(() => _ids);
+    } else if (highlightRegion) {
+        // A region committed to the filter (e.g. the image lasso stored as embedding_region) has
+        // no live rangeSelection to draw, but the plot must still reflect it: demote points
+        // outside the polygon to Excluded so the in-selection points stay highlighted. The
+        // resolved sample ids live server-side, so we don't recompute selectedSampleIds here.
+        category = category.map(getCategoryBySelection(highlightRegion, data));
     } else if (highlightedSampleIds.length > 0) {
         const highlightedSampleIdSet = new Set(highlightedSampleIds);
         category = category.map((pointCategory, index) => {

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.test.ts
@@ -68,6 +68,18 @@ describe('createAnnotationsInfiniteOptions', () => {
             });
             expect(options1.queryKey).not.toEqual(options2.queryKey);
         });
+
+        it('produces different keys for different embedding_region values', () => {
+            const options1 = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                embedding_region: { polygon: [{ x: 0, y: 0 }] }
+            });
+            const options2 = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                embedding_region: { polygon: [{ x: 1, y: 1 }] }
+            });
+            expect(options1.queryKey).not.toEqual(options2.queryKey);
+        });
     });
 
     describe('pagination', () => {
@@ -129,6 +141,28 @@ describe('createAnnotationsInfiniteOptions', () => {
                         sample_ids: ['s1'],
                         text_embedding: [0.5, 0.5]
                     }
+                })
+            );
+        });
+
+        it('passes the embedding region geometry to readAnnotationsWithPayload body', async () => {
+            const embedding_region = {
+                polygon: [
+                    { x: 0, y: 0 },
+                    { x: 1, y: 0 },
+                    { x: 1, y: 1 }
+                ]
+            };
+            const options = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                embedding_region
+            });
+
+            await callQueryFn(options, { pageParam: 0, signal: new AbortController().signal });
+
+            expect(readAnnotationsWithPayloadMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.objectContaining({ embedding_region })
                 })
             );
         });

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.ts
@@ -17,6 +17,7 @@ export const createAnnotationsInfiniteOptions = (params: AnnotationsInfinitePara
             annotation_label_ids: params.annotation_label_ids,
             tag_ids: params.tag_ids,
             sample_ids: params.sample_ids,
+            embedding_region: params.embedding_region,
             text_embedding: params.text_embedding
         }
     ];
@@ -37,6 +38,7 @@ export const createAnnotationsInfiniteOptions = (params: AnnotationsInfinitePara
                     annotation_label_ids: params.annotation_label_ids,
                     tag_ids: params.tag_ids,
                     sample_ids: params.sample_ids,
+                    embedding_region: params.embedding_region,
                     text_embedding: params.text_embedding
                 },
                 signal,

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilter.test.ts
@@ -3,6 +3,7 @@ import { get, writable } from 'svelte/store';
 import { useHiddenFilters } from './useHiddenFilters';
 import { useEmbeddingFilterForImages } from './useEmbeddingFilterForImages';
 import { useEmbeddingFilterForVideos } from './useEmbeddingFilterForVideos';
+import { clearPlotSelectionCount, setPlotSelectionCount } from './useEmbeddingPlotSelection';
 import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
 import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
 
@@ -82,40 +83,21 @@ describe('useEmbeddingFilterForImages', () => {
         vi.clearAllMocks();
         const { updateFilterParams } = useImageFilters();
         updateFilterParams({ collection_id: 'coll-1', mode: 'normal' });
-        const { clearHidden } = useHiddenFilters(collectionId);
-        clearHidden();
+        clearPlotSelectionCount('coll-1');
+        collectionId.set('coll-1');
     });
 
-    it('isVisible is false when collection_id does not match', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'other-coll',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1'] }
-        });
-
-        const { isVisible } = useEmbeddingFilterForImages(collectionId, setRangeSelection);
+    it('isVisible is false when no region is selected', () => {
+        const { isVisible, effectiveCount } = useEmbeddingFilterForImages(
+            collectionId,
+            setRangeSelection
+        );
         expect(get(isVisible)).toBe(false);
+        expect(get(effectiveCount)).toBe(0);
     });
 
-    it('isVisible is false when mode is not normal', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'classifier'
-        });
-
-        const { isVisible } = useEmbeddingFilterForImages(collectionId, setRangeSelection);
-        expect(get(isVisible)).toBe(false);
-    });
-
-    it('isVisible is true when collection matches and sample_ids are set', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1', 'id-2'] }
-        });
+    it('isVisible reflects the propagated plot selection count', () => {
+        setPlotSelectionCount('coll-1', 2);
 
         const { isVisible, effectiveCount } = useEmbeddingFilterForImages(
             collectionId,
@@ -125,13 +107,8 @@ describe('useEmbeddingFilterForImages', () => {
         expect(get(effectiveCount)).toBe(2);
     });
 
-    it('setVisibility(false) moves active IDs to hidden and clears the filter', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1', 'id-2'] }
-        });
+    it('setVisibility(false) clears the selection', () => {
+        setPlotSelectionCount('coll-1', 2);
 
         const { isVisible, effectiveCount, setVisibility } = useEmbeddingFilterForImages(
             collectionId,
@@ -140,74 +117,17 @@ describe('useEmbeddingFilterForImages', () => {
         setVisibility(false);
 
         expect(get(isVisible)).toBe(false);
-        expect(get(effectiveCount)).toBe(2);
-    });
-
-    it('setVisibility(true) restores previously hidden IDs', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1', 'id-2'] }
-        });
-
-        const { isVisible, effectiveCount, setVisibility } = useEmbeddingFilterForImages(
-            collectionId,
-            setRangeSelection
-        );
-        setVisibility(false);
-        setVisibility(true);
-
-        expect(get(isVisible)).toBe(true);
-        expect(get(effectiveCount)).toBe(2);
-    });
-
-    it('setVisibility(true) keeps hidden IDs when restore cannot be applied', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1'] }
-        });
-
-        const { isVisible, effectiveCount, setVisibility } = useEmbeddingFilterForImages(
-            collectionId,
-            setRangeSelection
-        );
-        setVisibility(false);
-
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'classifier'
-        });
-        setVisibility(true);
-
-        expect(get(isVisible)).toBe(false);
-        expect(get(effectiveCount)).toBe(1);
-    });
-
-    it('setVisibility(false) does nothing when there are no active IDs', () => {
-        const { effectiveCount, setVisibility } = useEmbeddingFilterForImages(
-            collectionId,
-            setRangeSelection
-        );
-        setVisibility(false);
         expect(get(effectiveCount)).toBe(0);
+        expect(setRangeSelection).toHaveBeenCalledWith('coll-1', null);
     });
 
-    it('clearFilter clears both active and hidden IDs and calls setRangeSelection', () => {
-        const { updateFilterParams } = useImageFilters();
-        updateFilterParams({
-            collection_id: 'coll-1',
-            mode: 'normal',
-            filters: { sample_ids: ['id-1'] }
-        });
+    it('clearFilter clears the count and calls setRangeSelection', () => {
+        setPlotSelectionCount('coll-1', 3);
 
-        const { effectiveCount, setVisibility, clearFilter } = useEmbeddingFilterForImages(
+        const { effectiveCount, clearFilter } = useEmbeddingFilterForImages(
             collectionId,
             setRangeSelection
         );
-        setVisibility(false);
         clearFilter();
 
         expect(get(effectiveCount)).toBe(0);

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.test.ts
@@ -1,27 +1,50 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { get, writable } from 'svelte/store';
+import type { EmbeddingRegion } from '$lib/api/lightly_studio_local';
 import {
     clearAnnotationPlotSelection,
     useAnnotationPlotSelection,
     useEmbeddingFilterForAnnotations
 } from './useEmbeddingFilterForAnnotations';
+import {
+    clearPlotSelectionCount,
+    getPlotSelectionCount,
+    setPlotSelectionCount
+} from './useEmbeddingPlotSelection';
+
+const region: EmbeddingRegion = {
+    polygon: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 1 }
+    ]
+};
 
 describe('useAnnotationPlotSelection', () => {
     beforeEach(() => {
-        clearAnnotationPlotSelection();
+        clearAnnotationPlotSelection('coll-1');
     });
 
-    it('stores plot sample IDs in a shared store', () => {
-        const { annotationPlotSampleIds, saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['a-1', 'a-2']);
-        expect(get(annotationPlotSampleIds)).toEqual(['a-1', 'a-2']);
+    it('stores the plot region in a shared store', () => {
+        const { annotationPlotRegion, saveRegion } = useAnnotationPlotSelection();
+        saveRegion(region);
+        expect(get(annotationPlotRegion)).toEqual(region);
     });
 
     it('clearAnnotationPlotSelection resets the store', () => {
-        const { annotationPlotSampleIds, saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['a-1']);
-        clearAnnotationPlotSelection();
-        expect(get(annotationPlotSampleIds)).toEqual([]);
+        const { annotationPlotRegion, saveRegion } = useAnnotationPlotSelection();
+        saveRegion(region);
+        clearAnnotationPlotSelection('coll-1');
+        expect(get(annotationPlotRegion)).toBeNull();
+    });
+
+    it('clearAnnotationPlotSelection also clears the plot-selection count', () => {
+        const collectionId = writable('coll-1');
+        setPlotSelectionCount('coll-1', 5);
+
+        clearAnnotationPlotSelection('coll-1');
+
+        expect(get(getPlotSelectionCount(collectionId))).toBe(0);
     });
 });
 
@@ -31,13 +54,13 @@ describe('useEmbeddingFilterForAnnotations', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        clearAnnotationPlotSelection();
+        clearAnnotationPlotSelection('coll-1');
+        clearPlotSelectionCount('coll-1');
         collectionId.set('coll-1');
     });
 
-    it('isVisible is true when plot sample IDs are set', () => {
-        const { saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['id-1', 'id-2']);
+    it('isVisible reflects the propagated selection count', () => {
+        setPlotSelectionCount('coll-1', 2);
 
         const { isVisible, effectiveCount } = useEmbeddingFilterForAnnotations(
             collectionId,
@@ -47,9 +70,10 @@ describe('useEmbeddingFilterForAnnotations', () => {
         expect(get(effectiveCount)).toBe(2);
     });
 
-    it('clearFilter clears plot sample IDs and range selection', () => {
-        const { saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['id-1']);
+    it('clearFilter clears the region, count and range selection', () => {
+        const { saveRegion } = useAnnotationPlotSelection();
+        saveRegion(region);
+        setPlotSelectionCount('coll-1', 3);
 
         const { clearFilter, effectiveCount } = useEmbeddingFilterForAnnotations(
             collectionId,
@@ -57,6 +81,8 @@ describe('useEmbeddingFilterForAnnotations', () => {
         );
         clearFilter();
 
+        const { annotationPlotRegion } = useAnnotationPlotSelection();
+        expect(get(annotationPlotRegion)).toBeNull();
         expect(get(effectiveCount)).toBe(0);
         expect(setRangeSelection).toHaveBeenCalledWith('coll-1', null);
     });

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.ts
@@ -1,38 +1,38 @@
 import { writable, type Readable } from 'svelte/store';
-import { useFilterVisibility } from './useFilterVisibility';
+import type { EmbeddingRegion } from '$lib/api/lightly_studio_local';
+import { useRegionFilterVisibility } from './useRegionFilterVisibility';
+import { clearPlotSelectionCount } from './useEmbeddingPlotSelection';
 
-// For images and videos the lasso selection already lives inside a
-// backend-driven filter store (useImageFilters / useVideoFilters), so the
-// "active sample ids" can be derived straight from those filter params.
-// Annotations have no such filter store, so we keep the lasso selection in
-// this small module-level writable instead. The plot (writer) and the grid
-// (reader) share it, which is why it lives at module scope rather than being
-// created per-component.
-const annotationPlotSampleIds = writable<string[]>([]);
+// For images the lasso selection lives inside the image filter store; annotations have no such
+// store, so we keep the plot region here at module scope. The plot (writer) and the grid
+// (reader) share it. The selection is sent to the backend as geometry (see LIG-9903), so we
+// store the polygon, not the resolved sample ids.
+const annotationPlotRegion = writable<EmbeddingRegion | null>(null);
 
 export function useAnnotationPlotSelection() {
     return {
-        annotationPlotSampleIds,
-        saveSampleIds: (ids: string[]) => annotationPlotSampleIds.set(ids)
+        annotationPlotRegion,
+        saveRegion: (region: EmbeddingRegion | null) => annotationPlotRegion.set(region)
     };
 }
 
-export function clearAnnotationPlotSelection() {
-    annotationPlotSampleIds.set([]);
+// Clears the shared annotation plot region and the plot-selection count for `collectionId`.
+// The region store is global, but the count is per-collection, so leaving it set would keep the
+// Embedding Plot Filter chip visible after switching away from and back to the collection.
+export function clearAnnotationPlotSelection(collectionId: string) {
+    annotationPlotRegion.set(null);
+    clearPlotSelectionCount(collectionId);
 }
 
-// Adapts the local annotation selection store to the shared useFilterVisibility
-// functionality, so the annotations route gets the same show/hide/clear behaviour as
-// the image and video embedding filters.
+// Adapts the local annotation region selection to the shared region-based visibility, so the
+// annotations route gets the same count/clear behaviour as the image embedding filter.
 export function useEmbeddingFilterForAnnotations(
     collectionId: Readable<string>,
     setRangeSelectionForCollection: (collectionId: string, selection: null) => void
 ) {
-    const { saveSampleIds } = useAnnotationPlotSelection();
-    return useFilterVisibility(
+    return useRegionFilterVisibility(
         collectionId,
-        annotationPlotSampleIds,
-        saveSampleIds,
+        () => annotationPlotRegion.set(null),
         setRangeSelectionForCollection
     );
 }

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForImages.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForImages.ts
@@ -1,30 +1,19 @@
-import { derived, type Readable } from 'svelte/store';
+import { type Readable } from 'svelte/store';
 import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
-import { useFilterVisibility } from './useFilterVisibility';
+import { useRegionFilterVisibility } from './useRegionFilterVisibility';
 
 export function useEmbeddingFilterForImages(
     collectionId: Readable<string>,
     setRangeSelectionForCollection: (collectionId: string, selection: null) => void
 ) {
-    const { filterParams, updateSampleIds } = useImageFilters();
+    const { updateEmbeddingRegion } = useImageFilters();
 
-    const activeSampleIds = derived(
-        [filterParams, collectionId],
-        ([$filterParams, $collectionId]) => {
-            if (!$filterParams?.collection_id || $filterParams.collection_id !== $collectionId) {
-                return [];
-            }
-            if ($filterParams.mode !== 'normal') {
-                return [];
-            }
-            return $filterParams.filters?.sample_ids ?? [];
-        }
-    );
-
-    return useFilterVisibility(
+    // The image lasso selection is stored as geometry (embedding_region) and sent to the
+    // backend rather than as a resolved sample-id list (see LIG-9903), so the chip count comes
+    // from the plot-propagated count and clearing removes the region.
+    return useRegionFilterVisibility(
         collectionId,
-        activeSampleIds,
-        updateSampleIds,
+        () => updateEmbeddingRegion(null),
         setRangeSelectionForCollection
     );
 }

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get, writable } from 'svelte/store';
+import {
+    clearPlotSelectionCount,
+    getPlotSelectionCount,
+    setPlotSelectionCount
+} from './useEmbeddingPlotSelection';
+
+describe('useEmbeddingPlotSelection', () => {
+    beforeEach(() => {
+        clearPlotSelectionCount('coll-1');
+        clearPlotSelectionCount('coll-2');
+    });
+
+    it('defaults to zero for an unknown collection', () => {
+        const count = getPlotSelectionCount(writable('coll-1'));
+        expect(get(count)).toBe(0);
+    });
+
+    it('reflects the count set for a collection', () => {
+        setPlotSelectionCount('coll-1', 42);
+        const count = getPlotSelectionCount(writable('coll-1'));
+        expect(get(count)).toBe(42);
+    });
+
+    it('keeps counts isolated per collection', () => {
+        setPlotSelectionCount('coll-1', 5);
+        expect(get(getPlotSelectionCount(writable('coll-1')))).toBe(5);
+        expect(get(getPlotSelectionCount(writable('coll-2')))).toBe(0);
+    });
+
+    it('clears the count back to zero', () => {
+        setPlotSelectionCount('coll-1', 7);
+        clearPlotSelectionCount('coll-1');
+        expect(get(getPlotSelectionCount(writable('coll-1')))).toBe(0);
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingPlotSelection.ts
@@ -1,0 +1,26 @@
+import { derived, writable, type Readable } from 'svelte/store';
+
+// Per-collection count of items currently selected by the embedding-plot lasso/rectangle.
+const selectionCountByCollection = writable<Record<string, number>>({});
+
+export function setPlotSelectionCount(collectionId: string, count: number): void {
+    selectionCountByCollection.update((counts) => ({ ...counts, [collectionId]: count }));
+}
+
+export function clearPlotSelectionCount(collectionId: string): void {
+    selectionCountByCollection.update((counts) => {
+        if (!(collectionId in counts)) {
+            return counts;
+        }
+        const next = { ...counts };
+        delete next[collectionId];
+        return next;
+    });
+}
+
+export function getPlotSelectionCount(collectionId: Readable<string>): Readable<number> {
+    return derived(
+        [selectionCountByCollection, collectionId],
+        ([$counts, $collectionId]) => $counts[$collectionId] ?? 0
+    );
+}

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useRegionFilterVisibility.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useRegionFilterVisibility.ts
@@ -1,0 +1,31 @@
+import { derived, get, type Readable } from 'svelte/store';
+import { clearPlotSelectionCount, getPlotSelectionCount } from './useEmbeddingPlotSelection';
+
+// Visibility/count behaviour for embedding-plot selections that are sent to the backend as
+// geometry (images and annotations). Unlike the sample-id based `useFilterVisibility`, the
+// frontend no longer holds the resolved ids, so the chip count comes from the plot-propagated
+// count and the selection is toggled off by clearing the region entirely.
+export function useRegionFilterVisibility(
+    collectionId: Readable<string>,
+    clearRegion: () => void,
+    setRangeSelectionForCollection: (collectionId: string, selection: null) => void
+) {
+    const effectiveCount = getPlotSelectionCount(collectionId);
+    const isVisible = derived(effectiveCount, ($count) => $count > 0);
+
+    function clearFilter() {
+        setRangeSelectionForCollection(get(collectionId), null);
+        clearRegion();
+        clearPlotSelectionCount(get(collectionId));
+    }
+
+    // The geometry selection has no separate "hidden" state to restore, so turning it off
+    // simply clears it.
+    function setVisibility(shouldShow: boolean) {
+        if (!shouldShow) {
+            clearFilter();
+        }
+    }
+
+    return { effectiveCount, isVisible, setVisibility, clearFilter };
+}

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -6,6 +6,7 @@ import { SortDirection } from '$lib/api/lightly_studio_local';
 import type {
     AnnotationsFilter,
     ConfusionCell,
+    EmbeddingRegion,
     ImageFilter,
     QueryExpr,
     SampleFilter
@@ -73,6 +74,15 @@ const imageFilter = derived(
         const sampleIds = $filterParams.filters?.sample_ids;
         if (sampleIds && sampleIds.length > 0) {
             sampleFilter.sample_ids = sampleIds;
+        }
+
+        // Embedding-plot lasso/rectangle selections are sent as geometry (a few KB) rather
+        // than the full list of selected sample ids, so the request body stays constant-size
+        // regardless of selection size (see LIG-9903). The backend resolves the polygon to
+        // sample ids server-side.
+        const embeddingRegion = $filterParams.filters?.embedding_region;
+        if (embeddingRegion) {
+            sampleFilter.embedding_region = embeddingRegion;
         }
 
         const annotationLabelIds = $filterParams.filters?.annotation_label_ids;
@@ -151,6 +161,27 @@ export const useImageFilters = () => {
         filterParams.set(newParams);
     };
 
+    // updates only the embedding-plot region selection in the existing filter params
+    const updateEmbeddingRegion = (embeddingRegion: EmbeddingRegion | null) => {
+        const params: ImagesInfiniteParams = {
+            ...get(filterParams)
+        };
+
+        if (params.mode !== 'normal') {
+            return;
+        }
+
+        const newParams: ImagesInfiniteParams = {
+            ...params,
+            filters: {
+                ...params.filters,
+                embedding_region: embeddingRegion ?? undefined
+            }
+        };
+
+        filterParams.set(newParams);
+    };
+
     // updates only the confusion-matrix cell in the existing filter params
     const updateConfusionCell = (confusionCell: ConfusionCell | null) => {
         const params: ImagesInfiniteParams = {
@@ -184,6 +215,7 @@ export const useImageFilters = () => {
         updateFilterParams,
         updateQueryExpr,
         updateSampleIds,
+        updateEmbeddingRegion,
         updateConfusionCell,
         updateSortBy
     };

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
@@ -41,7 +41,10 @@ const withNormalFilters = (
             annotations_filter: getAnnotationsFilter(filters),
             tag_ids: filters.tag_ids?.length ? filters.tag_ids : undefined,
             sample_ids: filters.sample_ids?.length ? filters.sample_ids : undefined,
-            confusion_cell: filters.confusion_cell ?? undefined
+            confusion_cell: filters.confusion_cell ?? undefined,
+            // Lasso/rectangle selection sent as geometry; the backend resolves it to sample
+            // ids server-side so the request body stays small at scale (see LIG-9903).
+            embedding_region: filters.embedding_region ?? undefined
         },
         // TODO(Malte, 10/2025): Share the width/height mapping with useImageFilters to avoid drift.
         width: filters.dimensions

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -15,7 +15,7 @@ export interface ClassifierSamples {
 }
 
 export type NormalModeFilters = Pick<AnnotationsFilter, 'annotation_label_ids' | 'collection_ids'> &
-    Pick<SampleFilter, 'tag_ids' | 'sample_ids' | 'confusion_cell'> & {
+    Pick<SampleFilter, 'tag_ids' | 'sample_ids' | 'confusion_cell' | 'embedding_region'> & {
         dimensions?: DimensionBounds;
     };
 

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
@@ -161,4 +161,33 @@ describe('buildRequestBody', () => {
             filter_type: 'annotations'
         });
     });
+
+    it('propagates the embedding region geometry to the sample filter', () => {
+        const polygon = [
+            { x: 0, y: 0 },
+            { x: 1, y: 0 },
+            { x: 1, y: 1 }
+        ];
+        const params: ImagesInfiniteParams = {
+            collection_id: 'col-1',
+            mode: 'normal',
+            filters: { embedding_region: { polygon } }
+        };
+
+        const result = buildRequestBody(params, 0);
+
+        expect(result.filters?.sample_filter?.embedding_region).toEqual({ polygon });
+    });
+
+    it('omits embedding_region when no region is selected', () => {
+        const params: ImagesInfiniteParams = {
+            collection_id: 'col-1',
+            mode: 'normal',
+            filters: { sample_ids: ['sample-1'] }
+        };
+
+        const result = buildRequestBody(params, 0);
+
+        expect(result.filters?.sample_filter?.embedding_region).toBeUndefined();
+    });
 });

--- a/lightly_studio_view/src/lib/hooks/useSelectAll/useSelectAll.ts
+++ b/lightly_studio_view/src/lib/hooks/useSelectAll/useSelectAll.ts
@@ -37,7 +37,7 @@ export function useSelectAll(collectionId: string, gridType: GridType) {
     const { filterParams: videoFilterParams } = useVideoFilters();
     const { filterParams: frameFilterParams } = useFramesFilter();
     const { annotationFilter } = useSelectedAnnotationsFilter(collectionId);
-    const { annotationPlotSampleIds } = useAnnotationPlotSelection();
+    const { annotationPlotRegion } = useAnnotationPlotSelection();
 
     let isLoading = false;
 
@@ -81,13 +81,15 @@ export function useSelectAll(collectionId: string, gridType: GridType) {
                 };
             }
             case 'annotations': {
-                const plotSampleIds = get(annotationPlotSampleIds);
+                // The plot selection is geometry; the backend resolves it to sample ids when
+                // fetching / tagging, so select-all also carries the region, not a list.
+                const plotRegion = get(annotationPlotRegion);
                 const filter =
-                    plotSampleIds.length > 0
+                    plotRegion !== null
                         ? {
                               ...get(annotationFilter),
                               filter_type: GRID_FILTER_TYPE.annotations,
-                              sample_ids: plotSampleIds
+                              embedding_region: plotRegion
                           }
                         : get(annotationFilter);
                 return {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -247,7 +247,7 @@
         if (lastCollectionId && lastCollectionId !== collectionId) {
             clearSelectedSamples(lastCollectionId);
             clearSelectedSampleAnnotationCrops(lastCollectionId);
-            clearAnnotationPlotSelection();
+            clearAnnotationPlotSelection(lastCollectionId);
         }
 
         gridType = nextGridType;


### PR DESCRIPTION
## What has changed and why?

Image embedding-plot lasso/rectangle selections are now stored and sent to the backend as **region geometry** (`embedding_region`) instead of a resolved list of `sample_ids`. The backend resolves the polygon to sample ids server-side, so the request body stays small and constant-size regardless of how many items are selected.

Key pieces:

- **New shared plumbing** — `useEmbeddingPlotSelection` (a per-collection selection-count store: `setPlotSelectionCount` / `clearPlotSelectionCount` / `getPlotSelectionCount`) and `useRegionFilterVisibility`, which drives the sidebar chip's count/visibility from the plot-propagated count rather than a resolved id list. Clearing the filter removes the region entirely (geometry has no separate "hidden"/restore state).
- **`useImageFilters`** — adds `updateEmbeddingRegion(...)` to set/clear only the region in the existing filter params, and threads `embedding_region` into the derived `imageFilter` sent to the API.
- **Request/type wiring** — `embedding_region` is added to `NormalModeFilters`, `buildRequestBody`, and the external-filter sync (`syncFilterParams`) so the region is excluded from base-param comparison and carried forward across collections alongside `sample_ids`.
- **`useEmbeddingFilterForImages`** — switched from the `sample_ids`-based `useFilterVisibility` to the new `useRegionFilterVisibility`.

## How has it been tested?

Unit tests updated/added:

- `useEmbeddingPlotSelection.test.ts` — per-collection count isolation, defaults, set/clear.
- `useEmbeddingFilter.test.ts` — chip visibility/count now driven by propagated plot-selection count; `setVisibility(false)` / `clearFilter` clear the region and call `setRangeSelection`.
- `useImagesInfinite.test.ts` — `embedding_region` geometry is propagated to `sample_filter`, and omitted when no region is selected.
- `syncFilterParams.test.ts` — `embedding_region` treated as an external filter and carried forward across collections.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lasso and region selections now work consistently across images and annotations, with selection state preserved as highlighted regions.
  * Selection counts are now tracked per collection, improving visibility of active filters.

* **Bug Fixes**
  * Fixed selection handling so clearing or switching collections resets the correct region state.
  * Improved filter syncing so region-based selections remain accurate when navigating or reloading.
  * Select-all behavior now respects annotation regions instead of only item lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->