### PR TITLE
Frontend: Filter annotations by embedding-plot region selection 

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -58,9 +58,10 @@
         textEmbedding
     } = useGlobalStorage();
 
-    // The embedding plot lasso selection on the annotations route.
-    const { annotationPlotSampleIds } = useAnnotationPlotSelection();
-    const plotSelectedAnnotationIds = $derived($annotationPlotSampleIds);
+    // The embedding plot lasso selection on the annotations route, kept as geometry and sent
+    // to the backend instead of a resolved sample-id list (see LIG-9903).
+    const { annotationPlotRegion } = useAnnotationPlotSelection();
+    const plotSelectedRegion = $derived($annotationPlotRegion);
 
     // The text embedding search is shared with the images tab and persists across the tab switch.
     // Only apply it when this annotation collection actually has embeddings.
@@ -126,8 +127,8 @@
         annotation_label_ids:
             $selectedAnnotationFilterIds.length > 0 ? $selectedAnnotationFilterIds : undefined,
         tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined,
-        // Embedding plot lasso selection narrows the grid to the selected annotations.
-        sample_ids: plotSelectedAnnotationIds.length > 0 ? plotSelectedAnnotationIds : undefined,
+        // Embedding plot lasso selection narrows the grid to annotations inside the region.
+        embedding_region: plotSelectedRegion ?? undefined,
         // Embedding text search reorders the grid by similarity (shared with images tab).
         text_embedding: searchEmbedding?.embedding ?? undefined
     });
@@ -145,7 +146,7 @@
     let infiniteLoaderIdentifier = $derived(
         $selectedAnnotationFilterIds.join(',') +
             Array.from($tagsSelected).join(',') +
-            plotSelectedAnnotationIds.join(',') +
+            (plotSelectedRegion ? JSON.stringify(plotSelectedRegion) : '') +
             (searchEmbedding ? `search:${searchEmbedding.queryText}` : '')
     );
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -165,19 +165,24 @@
 
     const hasActiveFilter = $derived(filter !== null || activeSampleIds.length > 0);
 
-    // Images commit the lasso as region geometry on the filter, not as sample ids. After the
+    // Images and annotations commit the lasso as region geometry, not as sample ids. After the
     // selection is committed the live rangeSelection is cleared, so the plot re-derives the
-    // highlight from the stored polygon to keep reflecting the actually selected points.
-    const imageHighlightRegion = $derived(
-        isImages ? ($imageFilter?.sample_filter?.embedding_region?.polygon ?? null) : null
+    // highlight from the stored polygon to keep reflecting the actually selected points. Images
+    // keep the region on the image filter store; annotations in the shared plot region store.
+    const committedHighlightRegion = $derived(
+        isImages
+            ? ($imageFilter?.sample_filter?.embedding_region?.polygon ?? null)
+            : isAnnotations
+              ? ($annotationPlotRegion?.polygon ?? null)
+              : null
     );
 
-    // Activating a lasso (or a committed image region) unhides the Excluded category, otherwise
+    // Activating a lasso (or a committed region) unhides the Excluded category, otherwise
     // out-of-selection points (which get demoted to Excluded) would vanish and blank out the
     // canvas. The legend keeps showing the user's real toggle state.
     const effectiveHiddenCategories = $derived.by(() => {
         const hasSelectionHighlight =
-            $rangeSelection !== null || imageHighlightRegion !== null;
+            $rangeSelection !== null || committedHighlightRegion !== null;
         if (!hasSelectionHighlight || !$hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)) {
             return $hiddenCategories;
         }
@@ -190,7 +195,7 @@
         usePlotData({
             arrowData: $arrowData,
             rangeSelection: $rangeSelection,
-            highlightRegion: imageHighlightRegion,
+            highlightRegion: committedHighlightRegion,
             highlightedSampleIds: activeSampleIds,
             hasActiveFilter: hasActiveFilter,
             hiddenCategories: effectiveHiddenCategories

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -8,6 +8,7 @@
         type ViewportState
     } from 'embedding-atlas/svelte';
     import { useEmbeddings } from '$lib/hooks/useEmbeddings/useEmbeddings';
+    import type { EmbeddingRegion } from '$lib/api/lightly_studio_local';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
     import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
     import { useAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
@@ -59,22 +60,14 @@
     // Use appropriate filter hook based on route
     const imageFilters = useImageFilters();
     const videoFilters = useVideoFilters();
-    const { annotationPlotSampleIds, saveSampleIds: saveAnnotationPlotSampleIds } =
-        useAnnotationPlotSelection();
+    const { annotationPlotRegion, saveRegion: saveAnnotationRegion } = useAnnotationPlotSelection();
 
-    const updateSampleIds = $derived(
-        isAnnotations
-            ? saveAnnotationPlotSampleIds
-            : isVideos
-              ? videoFilters.updateSampleIds
-              : imageFilters.updateSampleIds
-    );
     const imageFilter = $derived(isVideos ? null : imageFilters.imageFilter);
     const videoFilter = $derived(isVideos ? videoFilters.videoFilter : null);
+    // Only videos still track their lasso selection as a resolved sample-id list; images and
+    // annotations send it to the backend as region geometry (see LIG-9903).
     const activeSampleIds = $derived(
-        isAnnotations
-            ? $annotationPlotSampleIds
-            : ((isVideos ? $videoFilter : $imageFilter)?.sample_filter?.sample_ids ?? [])
+        isVideos ? ($videoFilter?.sample_filter?.sample_ids ?? []) : []
     );
 
     // The active annotation label/tag filter, mirroring what the annotations grid applies.
@@ -201,15 +194,24 @@
     const legendEntries = $derived.by(() =>
         getLegendEntries($colorLegend, $hiddenCategories, useLabelColors)
     );
-    // Images send the lasso to the backend as region geometry rather than a resolved sample-id
-    // list; the sidebar chip reads the selected count from the plot-propagated
-    // count store, and clearing removes the region entirely.
-    const commitImageRegion = (polygon: Point[], count: number) => {
-        imageFilters.updateEmbeddingRegion({ polygon });
+    // Images and annotations send the lasso to the backend as region geometry rather than a
+    // resolved sample-id list (see LIG-9903); the sidebar chip reads the selected count from the
+    // plot-propagated count store, and clearing removes the region entirely. Images keep the
+    // region on the image filter store; annotations have no such store, so it lives in the
+    // shared annotation-plot region store instead.
+    const saveRegion = (region: EmbeddingRegion | null) => {
+        if (isImages) {
+            imageFilters.updateEmbeddingRegion(region);
+        } else {
+            saveAnnotationRegion(region);
+        }
+    };
+    const commitRegion = (polygon: Point[], count: number) => {
+        saveRegion({ polygon });
         setPlotSelectionCount(collectionId, count);
     };
-    const clearImageRegion = () => {
-        imageFilters.updateEmbeddingRegion(null);
+    const clearRegion = () => {
+        saveRegion(null);
         clearPlotSelectionCount(collectionId);
     };
 
@@ -228,25 +230,24 @@
         const selectsNothingOrEverything =
             selectedCount === 0 || (selectableCount !== null && selectedCount === selectableCount);
 
-        if (isImages) {
+        // Videos still commit the resolved sample-id list; images and annotations send geometry.
+        if (isVideos) {
+            const currentSampleIds = $videoFilter?.sample_filter?.sample_ids ?? [];
             if (selectsNothingOrEverything) {
-                clearImageRegion();
-            } else {
-                commitImageRegion(polygon, selectedCount);
+                if (currentSampleIds.length > 0) {
+                    videoFilters.updateSampleIds([]);
+                }
+            } else if (!isEqual($selectedSampleIds, currentSampleIds)) {
+                videoFilters.updateSampleIds($selectedSampleIds);
             }
             setRangeSelection(null);
             return;
         }
 
-        const currentSampleIds = isAnnotations
-            ? $annotationPlotSampleIds
-            : ($videoFilter?.sample_filter?.sample_ids ?? []);
         if (selectsNothingOrEverything) {
-            if (currentSampleIds.length > 0) {
-                updateSampleIds([]);
-            }
-        } else if (!isEqual($selectedSampleIds, currentSampleIds)) {
-            updateSampleIds($selectedSampleIds);
+            clearRegion();
+        } else {
+            commitRegion(polygon, selectedCount);
         }
         setRangeSelection(null);
     };
@@ -321,18 +322,23 @@
 
     const clearSelection = () => {
         setRangeSelection(null);
-        if (isImages) {
-            clearImageRegion();
+        if (isVideos) {
+            videoFilters.updateSampleIds([]);
         } else {
-            updateSampleIds([]);
+            clearRegion();
         }
     };
-    // Images track their committed selection as a region on the filter, not as sample ids.
-    const imageRegionSelected = $derived(
-        isImages && ($imageFilter?.sample_filter?.embedding_region ?? null) !== null
+    // Images and annotations track their committed selection as region geometry, not sample ids:
+    // images on the image filter store, annotations in the shared annotation-plot region store.
+    const regionSelected = $derived(
+        isImages
+            ? ($imageFilter?.sample_filter?.embedding_region ?? null) !== null
+            : isAnnotations
+              ? $annotationPlotRegion !== null
+              : false
     );
     const hasActiveSelection = $derived(
-        $rangeSelection !== null || activeSampleIds.length > 0 || imageRegionSelected
+        $rangeSelection !== null || activeSampleIds.length > 0 || regionSelected
     );
 
     const onWindowKeyDown = (event: KeyboardEvent) => {

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -181,8 +181,7 @@
     // out-of-selection points (which get demoted to Excluded) would vanish and blank out the
     // canvas. The legend keeps showing the user's real toggle state.
     const effectiveHiddenCategories = $derived.by(() => {
-        const hasSelectionHighlight =
-            $rangeSelection !== null || committedHighlightRegion !== null;
+        const hasSelectionHighlight = $rangeSelection !== null || committedHighlightRegion !== null;
         if (!hasSelectionHighlight || !$hiddenCategories.has(EXCLUDED_BY_FILTERS_CATEGORY)) {
             return $hiddenCategories;
         }

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
@@ -3,7 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import PlotPanel from './PlotPanel.svelte';
 import { useEmbeddings } from '$lib/hooks/useEmbeddings/useEmbeddings';
-import { writable, type Writable } from 'svelte/store';
+import { get, writable, type Writable } from 'svelte/store';
+import {
+    clearAnnotationPlotSelection,
+    useAnnotationPlotSelection
+} from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
 import { tick } from 'svelte';
 import { usePlotColorByType } from './PlotColorByPopover/usePlotColorByType/usePlotColorByType';
 import { EXCLUDED_BY_FILTERS_CATEGORY, INCLUDED_BY_FILTERS_CATEGORY } from './plotCategories';
@@ -42,12 +46,15 @@ const originalResizeObserver = globalThis.ResizeObserver;
 
 vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 
+const IMAGES_ROUTE = '/datasets/[dataset_id]/[collection_type]/[collection_id]/images';
+const ANNOTATIONS_ROUTE = '/datasets/[dataset_id]/[collection_type]/[collection_id]/annotations';
+// Route is read per-render, so tests set `routeState.id` before rendering to pick a grid type.
+const routeState = vi.hoisted(() => ({ id: '' }));
+
 vi.mock('$app/state', () => ({
     page: {
         params: { collection_id: 'test-collection-id' },
-        route: {
-            id: '/datasets/[dataset_id]/[collection_type]/[collection_id]/images'
-        }
+        route: routeState
     }
 }));
 
@@ -145,6 +152,8 @@ describe('PlotPanel.svelte', () => {
     beforeEach(() => {
         vi.resetAllMocks();
         vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+        routeState.id = IMAGES_ROUTE;
+        clearAnnotationPlotSelection();
         usePlotColorByType('test-collection-id').clearSelectedColorByType();
         rangeSelectionStore = writable(null);
         selectedSampleIdsStore = writable([]);
@@ -286,6 +295,34 @@ describe('PlotPanel.svelte', () => {
         expect(mockUpdateEmbeddingRegion).toHaveBeenCalledWith(null);
         expect(mockClearPlotSelectionCount).toHaveBeenCalledWith('test-collection-id');
         expect(mockSetPlotSelectionCount).not.toHaveBeenCalled();
+        expect(mockSetRangeSelectionForCollection).toHaveBeenCalledWith('test-collection-id', null);
+    });
+
+    it('saves the lasso to the annotation region store on the annotations route', async () => {
+        routeState.id = ANNOTATIONS_ROUTE;
+        const polygon = [
+            { x: 0, y: 0 },
+            { x: 1, y: 0 },
+            { x: 1, y: 1 },
+            { x: 0, y: 1 }
+        ];
+        rangeSelectionStore = writable(polygon);
+        selectedSampleIdsStore = writable(['annotation-1']);
+        (useEmbeddings as vi.Mock).mockReturnValue({
+            isError: false,
+            error: null,
+            isLoading: true,
+            data: null
+        });
+
+        render(PlotPanel, { props: { collectionId: 'test-collection-id' } });
+        await fireEvent.mouseUp(window);
+
+        // Annotations have no filter store, so the geometry goes to the shared region store.
+        expect(get(useAnnotationPlotSelection().annotationPlotRegion)).toEqual({ polygon });
+        expect(mockSetPlotSelectionCount).toHaveBeenCalledWith('test-collection-id', 1);
+        // The image filter path must stay untouched on the annotations route.
+        expect(mockUpdateEmbeddingRegion).not.toHaveBeenCalled();
         expect(mockSetRangeSelectionForCollection).toHaveBeenCalledWith('test-collection-id', null);
     });
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.test.ts
@@ -78,12 +78,16 @@ vi.mock('./useCategoryVisibility/useCategoryVisibility', () => ({
         resetCategoryVisibility: mockResetCategoryVisibility
     })
 }));
+const usePlotDataSpy = vi.hoisted(() => vi.fn());
 vi.mock('./usePlotData/usePlotData', () => ({
-    usePlotData: () => ({
-        data: writable(undefined),
-        selectedSampleIds: selectedSampleIdsStore,
-        error: writable(undefined)
-    })
+    usePlotData: (args: unknown) => {
+        usePlotDataSpy(args);
+        return {
+            data: writable(undefined),
+            selectedSampleIds: selectedSampleIdsStore,
+            error: writable(undefined)
+        };
+    }
 }));
 vi.mock('$lib/hooks/useVideoFilters/useVideoFilters', () => ({
     useVideoFilters: () => ({
@@ -153,7 +157,7 @@ describe('PlotPanel.svelte', () => {
         vi.resetAllMocks();
         vi.stubGlobal('ResizeObserver', ResizeObserverMock);
         routeState.id = IMAGES_ROUTE;
-        clearAnnotationPlotSelection();
+        clearAnnotationPlotSelection('test-collection-id');
         usePlotColorByType('test-collection-id').clearSelectedColorByType();
         rangeSelectionStore = writable(null);
         selectedSampleIdsStore = writable([]);
@@ -324,6 +328,27 @@ describe('PlotPanel.svelte', () => {
         // The image filter path must stay untouched on the annotations route.
         expect(mockUpdateEmbeddingRegion).not.toHaveBeenCalled();
         expect(mockSetRangeSelectionForCollection).toHaveBeenCalledWith('test-collection-id', null);
+    });
+
+    it('highlights the committed annotation region after the live selection clears', async () => {
+        routeState.id = ANNOTATIONS_ROUTE;
+        const polygon = [
+            { x: 0, y: 0 },
+            { x: 1, y: 0 },
+            { x: 1, y: 1 },
+            { x: 0, y: 1 }
+        ];
+        // The selection is already committed: no live rangeSelection, region in the shared store.
+        rangeSelectionStore = writable(null);
+        useAnnotationPlotSelection().saveRegion({ polygon });
+
+        render(PlotPanel, { props: { collectionId: 'test-collection-id' } });
+        await tick();
+
+        // The plot must re-derive the highlight from the committed region so the selected
+        // annotations stay highlighted instead of collapsing to "all included".
+        const lastArgs = usePlotDataSpy.mock.calls.at(-1)?.[0];
+        expect(lastArgs?.highlightRegion).toEqual(polygon);
     });
 
     it('passes derived colorBy to useEmbeddings when a metadata field is selected', async () => {

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.test.ts
@@ -68,6 +68,18 @@ describe('createAnnotationsInfiniteOptions', () => {
             });
             expect(options1.queryKey).not.toEqual(options2.queryKey);
         });
+
+        it('produces different keys for different embedding_region values', () => {
+            const options1 = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                embedding_region: { polygon: [{ x: 0, y: 0 }] }
+            });
+            const options2 = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                embedding_region: { polygon: [{ x: 1, y: 1 }] }
+            });
+            expect(options1.queryKey).not.toEqual(options2.queryKey);
+        });
     });
 
     describe('pagination', () => {
@@ -129,6 +141,22 @@ describe('createAnnotationsInfiniteOptions', () => {
                         sample_ids: ['s1'],
                         text_embedding: [0.5, 0.5]
                     }
+                })
+            );
+        });
+
+        it('passes the embedding region geometry to readAnnotationsWithPayload body', async () => {
+            const embedding_region = { polygon: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }] };
+            const options = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                embedding_region
+            });
+
+            await callQueryFn(options, { pageParam: 0, signal: new AbortController().signal });
+
+            expect(readAnnotationsWithPayloadMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.objectContaining({ embedding_region })
                 })
             );
         });

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.test.ts
@@ -146,7 +146,13 @@ describe('createAnnotationsInfiniteOptions', () => {
         });
 
         it('passes the embedding region geometry to readAnnotationsWithPayload body', async () => {
-            const embedding_region = { polygon: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }] };
+            const embedding_region = {
+                polygon: [
+                    { x: 0, y: 0 },
+                    { x: 1, y: 0 },
+                    { x: 1, y: 1 }
+                ]
+            };
             const options = createAnnotationsInfiniteOptions({
                 collection_id: 'col-1',
                 embedding_region

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.ts
@@ -17,6 +17,7 @@ export const createAnnotationsInfiniteOptions = (params: AnnotationsInfinitePara
             annotation_label_ids: params.annotation_label_ids,
             tag_ids: params.tag_ids,
             sample_ids: params.sample_ids,
+            embedding_region: params.embedding_region,
             text_embedding: params.text_embedding
         }
     ];
@@ -37,6 +38,7 @@ export const createAnnotationsInfiniteOptions = (params: AnnotationsInfinitePara
                     annotation_label_ids: params.annotation_label_ids,
                     tag_ids: params.tag_ids,
                     sample_ids: params.sample_ids,
+                    embedding_region: params.embedding_region,
                     text_embedding: params.text_embedding
                 },
                 signal,

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.test.ts
@@ -6,7 +6,11 @@ import {
     useAnnotationPlotSelection,
     useEmbeddingFilterForAnnotations
 } from './useEmbeddingFilterForAnnotations';
-import { clearPlotSelectionCount, setPlotSelectionCount } from './useEmbeddingPlotSelection';
+import {
+    clearPlotSelectionCount,
+    getPlotSelectionCount,
+    setPlotSelectionCount
+} from './useEmbeddingPlotSelection';
 
 const region: EmbeddingRegion = {
     polygon: [
@@ -18,7 +22,7 @@ const region: EmbeddingRegion = {
 
 describe('useAnnotationPlotSelection', () => {
     beforeEach(() => {
-        clearAnnotationPlotSelection();
+        clearAnnotationPlotSelection('coll-1');
     });
 
     it('stores the plot region in a shared store', () => {
@@ -30,8 +34,17 @@ describe('useAnnotationPlotSelection', () => {
     it('clearAnnotationPlotSelection resets the store', () => {
         const { annotationPlotRegion, saveRegion } = useAnnotationPlotSelection();
         saveRegion(region);
-        clearAnnotationPlotSelection();
+        clearAnnotationPlotSelection('coll-1');
         expect(get(annotationPlotRegion)).toBeNull();
+    });
+
+    it('clearAnnotationPlotSelection also clears the plot-selection count', () => {
+        const collectionId = writable('coll-1');
+        setPlotSelectionCount('coll-1', 5);
+
+        clearAnnotationPlotSelection('coll-1');
+
+        expect(get(getPlotSelectionCount(collectionId))).toBe(0);
     });
 });
 
@@ -41,7 +54,7 @@ describe('useEmbeddingFilterForAnnotations', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        clearAnnotationPlotSelection();
+        clearAnnotationPlotSelection('coll-1');
         clearPlotSelectionCount('coll-1');
         collectionId.set('coll-1');
     });

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.test.ts
@@ -1,27 +1,37 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { get, writable } from 'svelte/store';
+import type { EmbeddingRegion } from '$lib/api/lightly_studio_local';
 import {
     clearAnnotationPlotSelection,
     useAnnotationPlotSelection,
     useEmbeddingFilterForAnnotations
 } from './useEmbeddingFilterForAnnotations';
+import { clearPlotSelectionCount, setPlotSelectionCount } from './useEmbeddingPlotSelection';
+
+const region: EmbeddingRegion = {
+    polygon: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 1 }
+    ]
+};
 
 describe('useAnnotationPlotSelection', () => {
     beforeEach(() => {
         clearAnnotationPlotSelection();
     });
 
-    it('stores plot sample IDs in a shared store', () => {
-        const { annotationPlotSampleIds, saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['a-1', 'a-2']);
-        expect(get(annotationPlotSampleIds)).toEqual(['a-1', 'a-2']);
+    it('stores the plot region in a shared store', () => {
+        const { annotationPlotRegion, saveRegion } = useAnnotationPlotSelection();
+        saveRegion(region);
+        expect(get(annotationPlotRegion)).toEqual(region);
     });
 
     it('clearAnnotationPlotSelection resets the store', () => {
-        const { annotationPlotSampleIds, saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['a-1']);
+        const { annotationPlotRegion, saveRegion } = useAnnotationPlotSelection();
+        saveRegion(region);
         clearAnnotationPlotSelection();
-        expect(get(annotationPlotSampleIds)).toEqual([]);
+        expect(get(annotationPlotRegion)).toBeNull();
     });
 });
 
@@ -32,12 +42,12 @@ describe('useEmbeddingFilterForAnnotations', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         clearAnnotationPlotSelection();
+        clearPlotSelectionCount('coll-1');
         collectionId.set('coll-1');
     });
 
-    it('isVisible is true when plot sample IDs are set', () => {
-        const { saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['id-1', 'id-2']);
+    it('isVisible reflects the propagated selection count', () => {
+        setPlotSelectionCount('coll-1', 2);
 
         const { isVisible, effectiveCount } = useEmbeddingFilterForAnnotations(
             collectionId,
@@ -47,9 +57,10 @@ describe('useEmbeddingFilterForAnnotations', () => {
         expect(get(effectiveCount)).toBe(2);
     });
 
-    it('clearFilter clears plot sample IDs and range selection', () => {
-        const { saveSampleIds } = useAnnotationPlotSelection();
-        saveSampleIds(['id-1']);
+    it('clearFilter clears the region, count and range selection', () => {
+        const { saveRegion } = useAnnotationPlotSelection();
+        saveRegion(region);
+        setPlotSelectionCount('coll-1', 3);
 
         const { clearFilter, effectiveCount } = useEmbeddingFilterForAnnotations(
             collectionId,
@@ -57,6 +68,8 @@ describe('useEmbeddingFilterForAnnotations', () => {
         );
         clearFilter();
 
+        const { annotationPlotRegion } = useAnnotationPlotSelection();
+        expect(get(annotationPlotRegion)).toBeNull();
         expect(get(effectiveCount)).toBe(0);
         expect(setRangeSelection).toHaveBeenCalledWith('coll-1', null);
     });

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.ts
@@ -1,6 +1,7 @@
 import { writable, type Readable } from 'svelte/store';
 import type { EmbeddingRegion } from '$lib/api/lightly_studio_local';
 import { useRegionFilterVisibility } from './useRegionFilterVisibility';
+import { clearPlotSelectionCount } from './useEmbeddingPlotSelection';
 
 // For images the lasso selection lives inside the image filter store; annotations have no such
 // store, so we keep the plot region here at module scope. The plot (writer) and the grid
@@ -15,8 +16,12 @@ export function useAnnotationPlotSelection() {
     };
 }
 
-export function clearAnnotationPlotSelection() {
+// Clears the shared annotation plot region and the plot-selection count for `collectionId`.
+// The region store is global, but the count is per-collection, so leaving it set would keep the
+// Embedding Plot Filter chip visible after switching away from and back to the collection.
+export function clearAnnotationPlotSelection(collectionId: string) {
     annotationPlotRegion.set(null);
+    clearPlotSelectionCount(collectionId);
 }
 
 // Adapts the local annotation region selection to the shared region-based visibility, so the

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations.ts
@@ -1,38 +1,33 @@
 import { writable, type Readable } from 'svelte/store';
-import { useFilterVisibility } from './useFilterVisibility';
+import type { EmbeddingRegion } from '$lib/api/lightly_studio_local';
+import { useRegionFilterVisibility } from './useRegionFilterVisibility';
 
-// For images and videos the lasso selection already lives inside a
-// backend-driven filter store (useImageFilters / useVideoFilters), so the
-// "active sample ids" can be derived straight from those filter params.
-// Annotations have no such filter store, so we keep the lasso selection in
-// this small module-level writable instead. The plot (writer) and the grid
-// (reader) share it, which is why it lives at module scope rather than being
-// created per-component.
-const annotationPlotSampleIds = writable<string[]>([]);
+// For images the lasso selection lives inside the image filter store; annotations have no such
+// store, so we keep the plot region here at module scope. The plot (writer) and the grid
+// (reader) share it. The selection is sent to the backend as geometry (see LIG-9903), so we
+// store the polygon, not the resolved sample ids.
+const annotationPlotRegion = writable<EmbeddingRegion | null>(null);
 
 export function useAnnotationPlotSelection() {
     return {
-        annotationPlotSampleIds,
-        saveSampleIds: (ids: string[]) => annotationPlotSampleIds.set(ids)
+        annotationPlotRegion,
+        saveRegion: (region: EmbeddingRegion | null) => annotationPlotRegion.set(region)
     };
 }
 
 export function clearAnnotationPlotSelection() {
-    annotationPlotSampleIds.set([]);
+    annotationPlotRegion.set(null);
 }
 
-// Adapts the local annotation selection store to the shared useFilterVisibility
-// functionality, so the annotations route gets the same show/hide/clear behaviour as
-// the image and video embedding filters.
+// Adapts the local annotation region selection to the shared region-based visibility, so the
+// annotations route gets the same count/clear behaviour as the image embedding filter.
 export function useEmbeddingFilterForAnnotations(
     collectionId: Readable<string>,
     setRangeSelectionForCollection: (collectionId: string, selection: null) => void
 ) {
-    const { saveSampleIds } = useAnnotationPlotSelection();
-    return useFilterVisibility(
+    return useRegionFilterVisibility(
         collectionId,
-        annotationPlotSampleIds,
-        saveSampleIds,
+        () => annotationPlotRegion.set(null),
         setRangeSelectionForCollection
     );
 }

--- a/lightly_studio_view/src/lib/hooks/useSelectAll/useSelectAll.ts
+++ b/lightly_studio_view/src/lib/hooks/useSelectAll/useSelectAll.ts
@@ -37,7 +37,7 @@ export function useSelectAll(collectionId: string, gridType: GridType) {
     const { filterParams: videoFilterParams } = useVideoFilters();
     const { filterParams: frameFilterParams } = useFramesFilter();
     const { annotationFilter } = useSelectedAnnotationsFilter(collectionId);
-    const { annotationPlotSampleIds } = useAnnotationPlotSelection();
+    const { annotationPlotRegion } = useAnnotationPlotSelection();
 
     let isLoading = false;
 
@@ -81,13 +81,15 @@ export function useSelectAll(collectionId: string, gridType: GridType) {
                 };
             }
             case 'annotations': {
-                const plotSampleIds = get(annotationPlotSampleIds);
+                // The plot selection is geometry; the backend resolves it to sample ids when
+                // fetching / tagging, so select-all also carries the region, not a list.
+                const plotRegion = get(annotationPlotRegion);
                 const filter =
-                    plotSampleIds.length > 0
+                    plotRegion !== null
                         ? {
                               ...get(annotationFilter),
                               filter_type: GRID_FILTER_TYPE.annotations,
-                              sample_ids: plotSampleIds
+                              embedding_region: plotRegion
                           }
                         : get(annotationFilter);
                 return {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -247,7 +247,7 @@
         if (lastCollectionId && lastCollectionId !== collectionId) {
             clearSelectedSamples(lastCollectionId);
             clearSelectedSampleAnnotationCrops(lastCollectionId);
-            clearAnnotationPlotSelection();
+            clearAnnotationPlotSelection(lastCollectionId);
         }
 
         gridType = nextGridType;


### PR DESCRIPTION
## What has changed and why?

Extends the region-geometry selection approach from images to the **annotations** route. The embedding-plot lasso/rectangle selection is kept as polygon geometry and sent to the backend, which resolves it to sample ids server-side — instead of resolving to a sample-id list on the frontend and shipping that list in every request. This keeps the request body constant-size regardless of selection size and makes annotations consistent with images.

**Selection stored as geometry**
- `useEmbeddingFilterForAnnotations.ts`: replaced the module-level `annotationPlotSampleIds` writable with `annotationPlotRegion` (`EmbeddingRegion | null`); exposes `saveRegion(...)` and adapts to the shared `useRegionFilterVisibility` for count/clear behaviour.
- `AnnotationsGrid.svelte`: reads `annotationPlotRegion` and passes `embedding_region` (not `sample_ids`) into the infinite-query params; the loader identity key hashes the region polygon.
- `createAnnotationsInfiniteOptions.ts`: forwards `embedding_region` in the query key and the `readAnnotationsWithPayload` body.
- `useSelectAll.ts`: the annotations branch carries the region geometry so bulk fetch/tag operations resolve the same server-side selection.

**Plot writer**
- `PlotPanel.svelte`: generalized the image-only region commit into route-aware `commitRegion`/`clearRegion`/`saveRegion`. Images write to the image filter store, annotations to the shared plot region store; only videos still commit a resolved sample-id list.

**Plot reflects the committed selection**
- After a selection is committed the live `rangeSelection` clears, and `activeSampleIds` is empty for images and annotations — so the plot previously stopped highlighting the selected points. Added `committedHighlightRegion`, derived from the stored polygon (image filter store for images, `annotationPlotRegion` for annotations), which feeds `usePlotData`'s `highlightRegion` to demote out-of-region points to Excluded, and keeps the Excluded category visible via `effectiveHiddenCategories` so those points don't blank out.

## How has it been tested?

- Added/updated unit tests: `usePlotData` region-highlight paths, `PlotPanel` (commits the region on the annotations route; re-derives the highlight from the committed region after the live selection clears), `createAnnotationsInfiniteOptions` (region geometry reaches the request body), and `useEmbeddingFilterForAnnotations`.
- Manual: draw a lasso on the annotations plot → grid narrows to in-region annotations, selected points stay highlighted after the lasso is released, sidebar chip shows the count, select-all operates on the region, and Escape/clear removes it.

https://github.com/user-attachments/assets/b4ab1190-51cc-48ea-a0a1-6cadb6956b00


## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)