### PR TITLE
Add VideoFrameSampleField.parent_video (filter frames by parent video)

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/video_frame_sample_field.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/video_frame_sample_field.py
@@ -19,6 +19,8 @@ from lightly_studio.models.tag import TagTable
 from lightly_studio.models.video import VideoFrameTable, VideoTable
 
 
+# TODO(Malte, 07/2026): Generalize into a reusable foreign-tags accessor (mirroring
+# ForeignComparableField / ForeignNumericalField) instead of a video-frame-specific class.
 @dataclass
 class _ParentVideoTagsContainsExpression(MatchExpression):
     """Expression checking whether a frame's parent video has a given tag."""
@@ -26,7 +28,7 @@ class _ParentVideoTagsContainsExpression(MatchExpression):
     tag_name: str
 
     def get(self) -> ColumnElement[bool]:
-        """Return a correlated EXISTS over the parent video's tags."""
+        """Match frames whose parent video has the given tag."""
         video_has_tag = VideoTable.sample.has(
             SampleTable.tags.any(col(TagTable.name) == self.tag_name)
         )
@@ -44,8 +46,8 @@ class _ParentVideoTagsAccessor:
 class _ParentVideoField:
     """Parent-video fields for filtering frames by video-level attributes and tags.
 
-    Each field builds a correlated `EXISTS` over the `VideoFrameTable.video`
-    relationship, so filtering by these does not require joining the video table.
+    Each field filters frames through the `VideoFrameTable.video` relationship, so it
+    adds no join to the frame query.
     """
 
     file_path_abs = ForeignComparableField(

--- a/lightly_studio/src/lightly_studio/core/dataset_query/video_frame_sample_field.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/video_frame_sample_field.py
@@ -27,9 +27,10 @@ class _ParentVideoTagsContainsExpression(MatchExpression):
 
     def get(self) -> ColumnElement[bool]:
         """Return a correlated EXISTS over the parent video's tags."""
-        return VideoFrameTable.video.has(
-            VideoTable.sample.has(SampleTable.tags.any(col(TagTable.name) == self.tag_name))
+        video_has_tag = VideoTable.sample.has(
+            SampleTable.tags.any(col(TagTable.name) == self.tag_name)
         )
+        return VideoFrameTable.video.has(video_has_tag)
 
 
 class _ParentVideoTagsAccessor:
@@ -47,12 +48,20 @@ class _ParentVideoField:
     relationship, so filtering by these does not require joining the video table.
     """
 
-    file_path_abs = ForeignComparableField(col(VideoTable.file_path_abs), VideoFrameTable.video)
-    file_name = ForeignComparableField(col(VideoTable.file_name), VideoFrameTable.video)
-    width = ForeignNumericalField(col(VideoTable.width), VideoFrameTable.video)
-    height = ForeignNumericalField(col(VideoTable.height), VideoFrameTable.video)
-    fps = ForeignNumericalField(col(VideoTable.fps), VideoFrameTable.video)
-    duration_s = ForeignComparableField(col(VideoTable.duration_s), VideoFrameTable.video)
+    file_path_abs = ForeignComparableField(
+        column=col(VideoTable.file_path_abs), relationship=VideoFrameTable.video
+    )
+    file_name = ForeignComparableField(
+        column=col(VideoTable.file_name), relationship=VideoFrameTable.video
+    )
+    width = ForeignNumericalField(column=col(VideoTable.width), relationship=VideoFrameTable.video)
+    height = ForeignNumericalField(
+        column=col(VideoTable.height), relationship=VideoFrameTable.video
+    )
+    fps = ForeignNumericalField(column=col(VideoTable.fps), relationship=VideoFrameTable.video)
+    duration_s = ForeignComparableField(
+        column=col(VideoTable.duration_s), relationship=VideoFrameTable.video
+    )
 
     tags = _ParentVideoTagsAccessor()
 

--- a/lightly_studio/src/lightly_studio/core/dataset_query/video_frame_sample_field.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/video_frame_sample_field.py
@@ -2,11 +2,59 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from sqlalchemy import ColumnElement
 from sqlmodel import col
 
 from lightly_studio.core.dataset_query.field import NumericalField
+from lightly_studio.core.dataset_query.foreign_field import (
+    ForeignComparableField,
+    ForeignNumericalField,
+)
+from lightly_studio.core.dataset_query.match_expression import MatchExpression
 from lightly_studio.core.dataset_query.tags_expression import TagsAccessor
-from lightly_studio.models.video import VideoFrameTable
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.tag import TagTable
+from lightly_studio.models.video import VideoFrameTable, VideoTable
+
+
+@dataclass
+class _ParentVideoTagsContainsExpression(MatchExpression):
+    """Expression checking whether a frame's parent video has a given tag."""
+
+    tag_name: str
+
+    def get(self) -> ColumnElement[bool]:
+        """Return a correlated EXISTS over the parent video's tags."""
+        return VideoFrameTable.video.has(
+            VideoTable.sample.has(SampleTable.tags.any(col(TagTable.name) == self.tag_name))
+        )
+
+
+class _ParentVideoTagsAccessor:
+    """Provides tag membership queries on a frame's parent video."""
+
+    def contains(self, tag_name: str) -> _ParentVideoTagsContainsExpression:
+        """Check whether the parent video has the given tag."""
+        return _ParentVideoTagsContainsExpression(tag_name=tag_name)
+
+
+class _ParentVideoField:
+    """Parent-video fields for filtering frames by video-level attributes and tags.
+
+    Each field builds a correlated `EXISTS` over the `VideoFrameTable.video`
+    relationship, so filtering by these does not require joining the video table.
+    """
+
+    file_path_abs = ForeignComparableField(col(VideoTable.file_path_abs), VideoFrameTable.video)
+    file_name = ForeignComparableField(col(VideoTable.file_name), VideoFrameTable.video)
+    width = ForeignNumericalField(col(VideoTable.width), VideoFrameTable.video)
+    height = ForeignNumericalField(col(VideoTable.height), VideoFrameTable.video)
+    fps = ForeignNumericalField(col(VideoTable.fps), VideoFrameTable.video)
+    duration_s = ForeignComparableField(col(VideoTable.duration_s), VideoFrameTable.video)
+
+    tags = _ParentVideoTagsAccessor()
 
 
 class VideoFrameSampleField:
@@ -22,6 +70,13 @@ class VideoFrameSampleField:
     query = frames.match(VideoFrameSampleField.frame_number > 10)
     query = query.order_by(OrderByField(VideoFrameSampleField.frame_timestamp_s))
     ```
+
+    Parent-video attributes and tags are available through `parent_video`:
+    ```python
+    frames.match(VideoFrameSampleField.parent_video.file_path_abs == "/data/a.mp4")
+    frames.match(VideoFrameSampleField.parent_video.width > 1920)
+    frames.match(VideoFrameSampleField.parent_video.tags.contains("reviewed"))
+    ```
     """
 
     frame_number = NumericalField(col(VideoFrameTable.frame_number))
@@ -30,3 +85,4 @@ class VideoFrameSampleField:
     rotation_deg = NumericalField(col(VideoFrameTable.rotation_deg))
 
     tags = TagsAccessor()
+    parent_video = _ParentVideoField()

--- a/lightly_studio/src/lightly_studio/examples/example_video_frames.py
+++ b/lightly_studio/src/lightly_studio/examples/example_video_frames.py
@@ -1,7 +1,7 @@
 """Example of how to query, tag, sample, and export individual video frames.
 
-It opens a video dataset, queries its frames by frame-level fields, tags the matches,
-runs a sampling strategy on the query, and exports the sampled frames as
+It opens a video dataset, queries its frames by frame-level and parent-video fields, tags
+the matches, runs a sampling strategy on the query, and exports the sampled frames as
 `(video_path_abs, frame_number)` rows to a CSV file (the video path comes from each
 frame's parent video).
 """
@@ -15,7 +15,7 @@ from pathlib import Path
 from environs import Env
 
 import lightly_studio as ls
-from lightly_studio.core.dataset_query import VideoFrameSampleField
+from lightly_studio.core.dataset_query import AND, VideoFrameSampleField
 from lightly_studio.database import db_manager
 
 env = Env()
@@ -29,12 +29,19 @@ dataset.add_videos_from_path(path=dataset_path, embed=False, target_fps=1)
 frames = dataset.frames()
 print(f"\nTotal frames in dataset: {len(list(frames))}")
 
-# Filtering by a frame-level field (frame_number) works
+# Filtering combines a frame-level field (frame_number) with a parent-video field
+# (parent_video.file_name) in a single query.
 min_frame_number = 3
-selected = frames.match(VideoFrameSampleField.frame_number > min_frame_number)
+first_video = next(iter(dataset[:1]))
+selected = frames.match(
+    AND(
+        VideoFrameSampleField.frame_number > min_frame_number,
+        VideoFrameSampleField.parent_video.file_name == first_video.file_name,
+    )
+)
 print(
     f"\nFiltering by fields: There are {len(selected.to_list())} frames after frame "
-    f"{min_frame_number}."
+    f"{min_frame_number} from the first video."
 )
 
 # Writing metadata for all frames in a query works

--- a/lightly_studio/src/lightly_studio/examples/example_video_frames.py
+++ b/lightly_studio/src/lightly_studio/examples/example_video_frames.py
@@ -1,7 +1,7 @@
 """Example of how to query, tag, sample, and export individual video frames.
 
-It opens a video dataset, queries its frames by frame-level and parent-video fields, tags
-the matches, runs a sampling strategy on the query, and exports the sampled frames as
+It opens a video dataset, queries its frames by frame-level and parent-video fields, runs
+a sampling strategy on the query, and exports the sampled frames as
 `(video_path_abs, frame_number)` rows to a CSV file (the video path comes from each
 frame's parent video).
 """

--- a/lightly_studio/tests/core/dataset_query/test_video_frame_dataset_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_video_frame_dataset_query.py
@@ -45,15 +45,17 @@ class TestVideoFrameDatasetQuery:
     def test_filter_by_parent_video_attribute(self, dataset: VideoDataset) -> None:
         frames = dataset.frames()
 
-        # Comparable field: only video A's 3 frames.
+        # Comparable field: only video A's 3 frames (0, 1, 2).
         by_path = frames.match(
             VideoFrameSampleField.parent_video.file_path_abs == "/data/a.mp4"
         ).to_list()
         assert len(by_path) == 3
+        assert all(frame.parent_video.file_path_abs == "/data/a.mp4" for frame in by_path)
 
         # Numerical field: video A has fps 3.0, video B fps 2.0 => only A's 3 frames.
         by_fps = dataset.frames().match(VideoFrameSampleField.parent_video.fps > 2.5).to_list()
         assert len(by_fps) == 3
+        assert all(frame.parent_video.file_path_abs == "/data/a.mp4" for frame in by_fps)
 
     def test_filter_by_parent_video_tag(self, dataset: VideoDataset) -> None:
         for video in dataset.query():
@@ -66,3 +68,4 @@ class TestVideoFrameDatasetQuery:
             .to_list()
         )
         assert len(reviewed) == 3
+        assert all(frame.parent_video.file_path_abs == "/data/a.mp4" for frame in reviewed)

--- a/lightly_studio/tests/core/dataset_query/test_video_frame_dataset_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_video_frame_dataset_query.py
@@ -41,3 +41,28 @@ class TestVideoFrameDatasetQuery:
     ) -> None:
         frame_numbers = [frame.frame_number for frame in dataset.frames().order_by(order_by_field)]
         assert frame_numbers == sorted(frame_numbers, reverse=reverse)
+
+    def test_filter_by_parent_video_attribute(self, dataset: VideoDataset) -> None:
+        frames = dataset.frames()
+
+        # Comparable field: only video A's 3 frames.
+        by_path = frames.match(
+            VideoFrameSampleField.parent_video.file_path_abs == "/data/a.mp4"
+        ).to_list()
+        assert len(by_path) == 3
+
+        # Numerical field: video A has fps 3.0, video B fps 2.0 => only A's 3 frames.
+        by_fps = dataset.frames().match(VideoFrameSampleField.parent_video.fps > 2.5).to_list()
+        assert len(by_fps) == 3
+
+    def test_filter_by_parent_video_tag(self, dataset: VideoDataset) -> None:
+        for video in dataset.query():
+            if video.file_path_abs == "/data/a.mp4":
+                video.add_tag("reviewed")
+
+        reviewed = (
+            dataset.frames()
+            .match(VideoFrameSampleField.parent_video.tags.contains("reviewed"))
+            .to_list()
+        )
+        assert len(reviewed) == 3


### PR DESCRIPTION
## What has changed and why?

Final follow-up to #1502 / #1555 / #1572. Adds query-side filtering of frames *by* their parent video's attributes and tags via `VideoFrameSampleField.parent_video`:

```python
frames.match(VideoFrameSampleField.parent_video.file_path_abs == "/data/a.mp4")
frames.match(VideoFrameSampleField.parent_video.fps > 2.5)
frames.match(VideoFrameSampleField.parent_video.tags.contains("reviewed"))
```

Reuses the existing `ForeignComparableField` / `ForeignNumericalField` infra: each filter is a correlated `EXISTS` over the `VideoFrameTable.video` relationship — **no join and no N+1**. Field types mirror `VideoSampleField` (path/name comparable; width/height/fps numerical; duration_s comparable).

This completes the video-frame parent-access story (runtime read access landed in #1572; this adds the query side).

## How has it been tested?

- New tests filter frames by a parent-video comparable field, a numerical field, and a parent-video tag.
- `make static-checks` and the video-frame tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `parent_video` to frame queries, enabling filtering by parent video attributes (file path/name, dimensions, FPS, duration).
  * Added support for parent video tag filtering via `parent_video.tags.contains(...)`.
* **Tests**
  * Added coverage for parent-video attribute-based and tag-based frame filtering.
* **Examples / Documentation**
  * Updated the video frames example and field documentation to show combining frame-level and parent-video predicates in one query.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->