### PR TITLE
Video ingest: record missing/broken/already-present in the per-run report (LIG-10032)

### DIFF
--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -148,7 +148,7 @@ def load_into_collection_from_paths(  # noqa: PLR0913
             # fsspec backends and is a subclass of OSError, which we treat as broken.
             fs, fs_path = fsspec.core.url_to_fs(url=video_path)
             if not fs.exists(fs_path):
-                raise MissingInputFileError(video_path)
+                raise MissingInputFileError()
 
             video_file = fs.open(path=fs_path, mode="rb")
             try:
@@ -168,7 +168,7 @@ def load_into_collection_from_paths(  # noqa: PLR0913
                     else:
                         video_duration = None
                 except (OSError, IndexError, FFmpegError) as e:
-                    raise BrokenInputFileError(video_path) from e
+                    raise BrokenInputFileError() from e
 
                 # Create video sample
                 video_sample_ids = video_resolver.create_many(

--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -291,12 +291,14 @@ def load_video_annotations_from_labelformat(  # noqa: PLR0913
         video_path_without_suffix = str((root_path / video_annotation_filename).with_suffix(""))
         video_sample_id = video_path_without_suffix_to_sample_id.get(video_path_without_suffix)
         if video_sample_id is None:
-            if limit is not None:
-                # The video was not loaded because it is beyond the limit.
-                continue
-            raise ValueError(
-                f"No matching video ({video_annotation_filename}) for annotations found"
+            # The video was not created: it is beyond the limit, or the per-run report
+            # already recorded it as missing/broken/already-present. Skip its annotations
+            # rather than crashing the run, in line with tolerate-don't-crash handling.
+            logger.warning(
+                f"Skipping annotations for video '{video_annotation_filename}': "
+                "no matching loaded video found."
             )
+            continue
 
         video_with_frames = video_resolver.get_by_id(session=session, sample_id=video_sample_id)
         if video_with_frames is None:

--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -36,7 +36,9 @@ from tqdm import tqdm
 from lightly_studio.core import labelformat_helpers
 from lightly_studio.core.file_outcome_report import (
     AlreadyPresentInputFileError,
+    BrokenInputFileError,
     FileOutcomeReport,
+    MissingInputFileError,
 )
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
@@ -142,10 +144,16 @@ def load_into_collection_from_paths(  # noqa: PLR0913
                 raise AlreadyPresentInputFileError()
             seen_or_existing_paths.add(video_path)
 
+            # Detect a missing path proactively: FileNotFoundError is unreliable across
+            # fsspec backends and is a subclass of OSError, which we treat as broken.
+            fs, fs_path = fsspec.core.url_to_fs(url=video_path)
+            if not fs.exists(fs_path):
+                raise MissingInputFileError(video_path)
+
+            video_file = fs.open(path=fs_path, mode="rb")
             try:
-                # Open video and extract metadata
-                fs, fs_path = fsspec.core.url_to_fs(url=video_path)
-                video_file = fs.open(path=fs_path, mode="rb")
+                # Translate a failed open/header read into a broken-file signal at this
+                # I/O boundary; any other exception propagates rather than being recorded.
                 try:
                     # Open video container for reading (returns InputContainer)
                     video_container = container.open(file=video_file)
@@ -159,55 +167,52 @@ def load_into_collection_from_paths(  # noqa: PLR0913
                         video_duration = float(video_stream.duration * video_stream.time_base)
                     else:
                         video_duration = None
+                except (OSError, IndexError, FFmpegError) as e:
+                    raise BrokenInputFileError(video_path) from e
 
-                    # Create video sample
-                    video_sample_ids = video_resolver.create_many(
-                        session=session,
-                        collection_id=collection_id,
-                        samples=[
-                            VideoCreate(
-                                file_path_abs=video_path,
-                                width=video_width,
-                                height=video_height,
-                                duration_s=video_duration,
-                                fps=framerate,
-                                file_name=Path(video_path).name,
-                            )
-                        ],
-                    )
-
-                    if len(video_sample_ids) != 1:
-                        video_container.close()
-                        raise RuntimeError(
-                            f"There was an error adding {video_path} to the dataset."
+                # Create video sample
+                video_sample_ids = video_resolver.create_many(
+                    session=session,
+                    collection_id=collection_id,
+                    samples=[
+                        VideoCreate(
+                            file_path_abs=video_path,
+                            width=video_width,
+                            height=video_height,
+                            duration_s=video_duration,
+                            fps=framerate,
+                            file_name=Path(video_path).name,
                         )
-                    created_video_sample_ids.append(video_sample_ids[0])
+                    ],
+                )
 
-                    # Create video frame samples by parsing all frames
-                    extraction_context = FrameExtractionContext(
-                        session=session,
-                        collection_id=video_frames_collection_id,
-                        video_sample_id=video_sample_ids[0],
-                    )
-                    frame_sample_ids = _create_video_frame_samples(
-                        context=extraction_context,
-                        video_container=video_container,
-                        video_channel=video_channel,
-                        num_decode_threads=num_decode_threads,
-                        target_fps=target_fps,
-                    )
-                    created_video_frame_sample_ids.extend(frame_sample_ids)
-
+                if len(video_sample_ids) != 1:
                     video_container.close()
-                finally:
-                    # Ensure file is closed even if container operations fail
-                    video_file.close()
+                    raise RuntimeError(f"There was an error adding {video_path} to the dataset.")
+                created_video_sample_ids.append(video_sample_ids[0])
 
-            except (FileNotFoundError, OSError, IndexError, FFmpegError) as e:
-                logger.error(f"Error processing video {video_path}: {e}")
-                continue
+                # Create video frame samples by parsing all frames
+                extraction_context = FrameExtractionContext(
+                    session=session,
+                    collection_id=video_frames_collection_id,
+                    video_sample_id=video_sample_ids[0],
+                )
+                frame_sample_ids = _create_video_frame_samples(
+                    context=extraction_context,
+                    video_container=video_container,
+                    video_channel=video_channel,
+                    num_decode_threads=num_decode_threads,
+                    target_fps=target_fps,
+                )
+                created_video_frame_sample_ids.extend(frame_sample_ids)
+
+                video_container.close()
+            finally:
+                # Ensure file is closed even if container operations fail
+                video_file.close()
 
     report.log_summary()
+    report.raise_if_all_failed()
 
     return created_video_sample_ids, created_video_frame_sample_ids
 

--- a/lightly_studio/tests/core/video/test_add_videos.py
+++ b/lightly_studio/tests/core/video/test_add_videos.py
@@ -39,7 +39,7 @@ from lightly_studio.resolvers import (
     video_resolver,
 )
 from tests.helpers_resolvers import create_collection
-from tests.resolvers.video.helpers import create_video_file
+from tests.resolvers.video.helpers import VideoStub, create_video_file, create_videos
 
 
 def test_load_into_collection_from_paths(db_session: Session, tmp_path: Path) -> None:
@@ -97,6 +97,65 @@ def test_load_into_collection_from_paths(db_session: Session, tmp_path: Path) ->
         collection_id=collection_hierarchy[1].collection_id,
     ).samples
     assert len(video_frames) == 60
+
+
+def test_load_into_collection_from_paths__records_missing_broken_already_present_outcomes(
+    db_session: Session, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: a folder mixing good / already-present / missing / broken videos. Each outcome
+    # gets a distinct count so a mix-up between two outcomes cannot pass the assertions.
+    collection = create_collection(db_session, sample_type=SampleType.VIDEO)
+
+    # 1 good video -> added=1.
+    good_paths = [
+        create_video_file(output_path=tmp_path / "good0.mp4", num_frames=2, fps=1),
+    ]
+
+    # 2 already-present videos: created on disk and pre-inserted into the database.
+    already_present_paths = [tmp_path / "present0.mp4", tmp_path / "present1.mp4"]
+    for path in already_present_paths:
+        create_video_file(output_path=path, num_frames=2, fps=1)
+    create_videos(
+        db_session,
+        collection.collection_id,
+        [VideoStub(path=str(path)) for path in already_present_paths],
+    )
+
+    # 3 missing videos: never created on disk.
+    missing_paths = [tmp_path / f"missing{i}.mp4" for i in range(3)]
+
+    # 4 broken videos: present on disk but not decodable.
+    broken_paths = [tmp_path / f"broken{i}.mp4" for i in range(4)]
+    for path in broken_paths:
+        path.write_bytes(b"not a real video")
+
+    # Act
+    with caplog.at_level("INFO"):
+        video_sample_ids, _ = add_videos.load_into_collection_from_paths(
+            session=db_session,
+            collection_id=collection.collection_id,
+            video_paths=[
+                str(path)
+                for path in good_paths + already_present_paths + missing_paths + broken_paths
+            ],
+        )
+
+    # Assert: only the good video is added.
+    assert len(video_sample_ids) == len(good_paths)
+    videos = video_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    ).samples
+    assert {video.file_name for video in videos} == {
+        "good0.mp4",
+        "present0.mp4",
+        "present1.mp4",
+    }
+
+    # Assert: the end-of-run summary records the distinct per-outcome counts.
+    assert "added=1" in caplog.text
+    assert "already_present=2" in caplog.text
+    assert "missing=3" in caplog.text
+    assert "broken=4" in caplog.text
 
 
 def test__create_video_frame_samples(db_session: Session, tmp_path: Path) -> None:

--- a/lightly_studio/tests/core/video/test_add_videos.py
+++ b/lightly_studio/tests/core/video/test_add_videos.py
@@ -686,6 +686,58 @@ def test_load_video_annotations_from_labelformat__raises_on_missing_video(
         )
 
 
+def test_load_video_annotations_from_labelformat__skips_annotations_for_broken_video(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    # Arrange: a good video plus a broken one, each referenced by annotations. The broken
+    # video is recorded by the per-run report and never created, so its annotations must be
+    # skipped instead of crashing the run.
+    create_video_file(
+        output_path=tmp_path / "good.mp4",
+        width=640,
+        height=480,
+        num_frames=2,
+        fps=2,
+    )
+    (tmp_path / "broken.mp4").write_bytes(b"not a real video")
+
+    categories = [Category(id=0, name="cat")]
+    good_annotation = _get_object_detection_track(
+        filename="good.mp4",
+        number_of_frames=2,
+        categories=categories,
+        boxes_by_object=[[[1.0, 2.0, 3.0, 4.0], None]],
+    )
+    broken_annotation = _get_object_detection_track(
+        filename="broken.mp4",
+        number_of_frames=2,
+        categories=categories,
+        boxes_by_object=[[[5.0, 6.0, 7.0, 8.0], None]],
+    )
+    input_labels = _ObjectDetectionTrackInput(
+        categories=categories,
+        video_annotations=[good_annotation, broken_annotation],
+    )
+
+    # Act: no exception is raised even though the broken video was not created.
+    collection = create_collection(db_session, sample_type=SampleType.VIDEO)
+    created_video_sample_ids, _ = add_videos.load_video_annotations_from_labelformat(
+        session=db_session,
+        collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
+        video_paths=[str(tmp_path / "good.mp4"), str(tmp_path / "broken.mp4")],
+        input_labels=input_labels,
+        input_labels_paths_root=tmp_path,
+    )
+
+    # Assert: only the good video is created, and only its annotation is added.
+    assert len(created_video_sample_ids) == 1
+    annotations = annotation_resolver.get_all(db_session).annotations
+    assert len(annotations) == 1
+    assert annotations[0].annotation_label.annotation_label_name == "cat"
+
+
 def test_process_video_annotations_object_detection() -> None:
     # Arrange
     frame_number_to_id = {0: uuid4(), 1: uuid4()}


### PR DESCRIPTION
## What

Wires video ingest into the central `FileOutcomeReport`, so a folder of videos records one outcome per file — **missing** vs **broken** distinguished, **already-present** from path-dedup, **added** for the rest — feeding the same end-of-run summary as image ingest.

### `load_into_collection_from_paths`
- **Missing** detected proactively via `fs.exists()` → `MissingInputFileError` (not `FileNotFoundError`, which is unreliable across fsspec backends and a subclass of `OSError`).
- **Broken** translated at the I/O boundary: a failed `container.open` / header read → `BrokenInputFileError(...) from e`.
- Removed the catch-all `except (FileNotFoundError, OSError, IndexError, FFmpegError)` block that logged-and-skipped, so bad input files are now *recorded* instead of silently dropped and any unexpected exception propagates (a bug/infra failure is not a broken file).
- Closes the run with `report.log_summary()` then `report.raise_if_all_failed()`, matching image ingest.

### `load_video_annotations_from_labelformat`
- The annotation-matching loop raised `ValueError` when a referenced video had no created sample. A video is not created when it is beyond the limit or when the report already recorded it as missing/broken/already-present — so the run recorded the outcome and then crashed anyway. It now logs a warning and skips those annotations, in line with tolerate-don't-crash.

## Out of scope / follow-up

Adding annotations to *already-present* videos (rather than skipping) is deliberately left as-is: it would expose annotation/object-track duplication on rerun (annotation ingest appends with no dedup), which is annotation-rerun semantics best handled under LIG-9908 / a dedicated annotation slice.

## Tests

- `test_load_into_collection_from_paths__records_missing_broken_already_present_outcomes` — good / missing / broken / already-present mix, each with a distinct count.
- `test_load_video_annotations_from_labelformat__skips_annotations_for_broken_video` — a broken video's annotations are skipped while the good video's annotations still process.

Full backend suite passes (pre-existing unrelated failures in `test_server`/`test_enterprise`/`test_fsspec_lister` only); mypy, ruff check, and format-check clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Video imports now proactively distinguish missing vs unreadable files and report per-outcome results (including clearer end-of-run failure signals).
  * The import run now fails if all selected videos cannot be loaded.
  * Annotation imports now skip annotations that can’t be matched to loaded videos, rather than erroring or using previous fallback behavior.
  * Improved cleanup of opened video resources during loading.
* **Tests**
  * Added coverage for missing, broken, and already-present video import outcomes.
  * Added coverage ensuring annotations for broken/unreadable videos are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->