### PR TITLE
Make the left filter panel collapsible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The left filter panel can now be collapsed to a narrow icon rail to reclaim horizontal space. The collapsed/expanded state is remembered for the session.
+
 ### Deprecated
 
 ### Removed

--- a/lightly_studio_view/src/lib/components/FilterPanel/FilterPanel.svelte
+++ b/lightly_studio_view/src/lib/components/FilterPanel/FilterPanel.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte';
+    import { PanelLeftClose, SlidersHorizontal } from '@lucide/svelte';
+    import Button from '$lib/components/Button/Button.svelte';
+    import { Tooltip } from '$lib/components/ui/tooltip';
+    import { cn } from '$lib/utils/shadcn';
+    import { useGlobalStorage } from '$lib/hooks';
+
+    interface Props {
+        /** Filter controls rendered inside the expanded panel body. */
+        children: Snippet;
+    }
+
+    const { children }: Props = $props();
+
+    const { filterPanelCollapsed, toggleFilterPanelCollapsed } = useGlobalStorage();
+</script>
+
+{#if $filterPanelCollapsed}
+    <div class="flex h-full min-h-0 w-14 flex-col">
+        <div class="flex min-h-0 flex-1 flex-col rounded-[1vw] bg-card p-1.5">
+            <Tooltip content="Show filters" position="right" triggerClass="w-full" class="w-max">
+                <button
+                    class={cn(
+                        'flex aspect-square w-full flex-col items-center justify-center gap-0.5 rounded-md p-1.5 text-[10px] font-medium transition-colors',
+                        'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+                    )}
+                    data-testid="filter-panel-expand"
+                    aria-label="Show filters"
+                    aria-pressed={true}
+                    onclick={toggleFilterPanelCollapsed}
+                >
+                    <SlidersHorizontal class="size-4" />
+                    <span>Filters</span>
+                </button>
+            </Tooltip>
+        </div>
+    </div>
+{:else}
+    <div class="flex h-full min-h-0 w-80 flex-col">
+        <div class="flex min-h-0 flex-1 flex-col rounded-[1vw] bg-card py-4">
+            <div
+                class="min-h-0 flex-1 space-y-2 overflow-y-auto px-4 pb-2 dark:[color-scheme:dark]"
+            >
+                <h2 class="flex items-center justify-between py-2 text-lg font-semibold">
+                    <span class="flex items-center space-x-2">
+                        <SlidersHorizontal class="size-5" />
+                        <span>Filters</span>
+                    </span>
+                    <Tooltip content="Hide filters" position="bottom" class="w-max">
+                        <Button
+                            variant="ghost"
+                            icon={PanelLeftClose}
+                            ariaLabel="Hide filters"
+                            buttonProps={{
+                                onclick: toggleFilterPanelCollapsed,
+                                'aria-pressed': false,
+                                'data-testid': 'filter-panel-collapse'
+                            }}
+                        />
+                    </Tooltip>
+                </h2>
+
+                {@render children()}
+            </div>
+        </div>
+    </div>
+{/if}

--- a/lightly_studio_view/src/lib/components/FilterPanel/FilterPanel.svelte
+++ b/lightly_studio_view/src/lib/components/FilterPanel/FilterPanel.svelte
@@ -16,18 +16,19 @@
     const { filterPanelCollapsed, toggleFilterPanelCollapsed } = useGlobalStorage();
 </script>
 
-{#if $filterPanelCollapsed}
-    <div class="flex h-full min-h-0 w-14 flex-col">
+<div class={cn('flex h-full min-h-0 flex-col', $filterPanelCollapsed ? 'w-14' : 'w-80')}>
+    {#if $filterPanelCollapsed}
         <div class="flex min-h-0 flex-1 flex-col rounded-[1vw] bg-card p-1.5">
             <Tooltip content="Show filters" position="right" triggerClass="w-full" class="w-max">
                 <button
+                    type="button"
                     class={cn(
                         'flex aspect-square w-full flex-col items-center justify-center gap-0.5 rounded-md p-1.5 text-[10px] font-medium transition-colors',
                         'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                     )}
                     data-testid="filter-panel-expand"
                     aria-label="Show filters"
-                    aria-pressed={true}
+                    aria-expanded={false}
                     onclick={toggleFilterPanelCollapsed}
                 >
                     <SlidersHorizontal class="size-4" />
@@ -35,34 +36,39 @@
                 </button>
             </Tooltip>
         </div>
-    </div>
-{:else}
-    <div class="flex h-full min-h-0 w-80 flex-col">
-        <div class="flex min-h-0 flex-1 flex-col rounded-[1vw] bg-card py-4">
-            <div
-                class="min-h-0 flex-1 space-y-2 overflow-y-auto px-4 pb-2 dark:[color-scheme:dark]"
-            >
-                <h2 class="flex items-center justify-between py-2 text-lg font-semibold">
-                    <span class="flex items-center space-x-2">
-                        <SlidersHorizontal class="size-5" />
-                        <span>Filters</span>
-                    </span>
-                    <Tooltip content="Hide filters" position="bottom" class="w-max">
-                        <Button
-                            variant="ghost"
-                            icon={PanelLeftClose}
-                            ariaLabel="Hide filters"
-                            buttonProps={{
-                                onclick: toggleFilterPanelCollapsed,
-                                'aria-pressed': false,
-                                'data-testid': 'filter-panel-collapse'
-                            }}
-                        />
-                    </Tooltip>
-                </h2>
+    {/if}
 
-                {@render children()}
-            </div>
+    <!-- Kept mounted (only visually hidden) while collapsed so the filter children run
+         their initialization effects on load — e.g. AnnotationCollectionsMenu seeding the
+         selected annotation sources. -->
+    <div
+        data-testid="filter-panel-body"
+        class={cn(
+            'min-h-0 flex-1 flex-col rounded-[1vw] bg-card py-4',
+            $filterPanelCollapsed ? 'hidden' : 'flex'
+        )}
+    >
+        <div class="min-h-0 flex-1 space-y-2 overflow-y-auto px-4 pb-2 dark:[color-scheme:dark]">
+            <h2 class="flex items-center justify-between py-2 text-lg font-semibold">
+                <span class="flex items-center space-x-2">
+                    <SlidersHorizontal class="size-5" />
+                    <span>Filters</span>
+                </span>
+                <Tooltip content="Hide filters" position="bottom" class="w-max">
+                    <Button
+                        variant="ghost"
+                        icon={PanelLeftClose}
+                        ariaLabel="Hide filters"
+                        buttonProps={{
+                            onclick: toggleFilterPanelCollapsed,
+                            'aria-expanded': true,
+                            'data-testid': 'filter-panel-collapse'
+                        }}
+                    />
+                </Tooltip>
+            </h2>
+
+            {@render children()}
         </div>
     </div>
-{/if}
+</div>

--- a/lightly_studio_view/src/lib/components/FilterPanel/FilterPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/FilterPanel/FilterPanel.test.ts
@@ -29,7 +29,7 @@ describe('FilterPanel', () => {
         renderPanel();
 
         expect(screen.getByTestId('filter-content')).toBeInTheDocument();
-        expect(screen.getByText('Filters')).toBeInTheDocument();
+        expect(screen.getByTestId('filter-panel-body')).not.toHaveClass('hidden');
         expect(screen.getByTestId('filter-panel-collapse')).toBeInTheDocument();
         expect(screen.queryByTestId('filter-panel-expand')).not.toBeInTheDocument();
     });
@@ -39,13 +39,16 @@ describe('FilterPanel', () => {
 
         await fireEvent.click(screen.getByTestId('filter-panel-collapse'));
 
-        expect(screen.queryByTestId('filter-content')).not.toBeInTheDocument();
+        // Children stay mounted (so their init effects keep running) but the body is hidden.
+        // Tailwind classes carry no styles in jsdom, so assert the hidden toggle directly.
+        expect(screen.getByTestId('filter-content')).toBeInTheDocument();
+        expect(screen.getByTestId('filter-panel-body')).toHaveClass('hidden');
         const expandButton = screen.getByTestId('filter-panel-expand');
         expect(expandButton).toBeInTheDocument();
 
         await fireEvent.click(expandButton);
 
-        expect(screen.getByTestId('filter-content')).toBeInTheDocument();
+        expect(screen.getByTestId('filter-panel-body')).not.toHaveClass('hidden');
         expect(screen.queryByTestId('filter-panel-expand')).not.toBeInTheDocument();
     });
 
@@ -76,6 +79,8 @@ describe('FilterPanel', () => {
         });
 
         expect(screen.getByTestId('filter-panel-expand')).toBeInTheDocument();
-        expect(screen.queryByTestId('filter-content')).not.toBeInTheDocument();
+        // Children remain mounted (init effects run on load) but the body starts hidden.
+        expect(screen.getByTestId('filter-content')).toBeInTheDocument();
+        expect(screen.getByTestId('filter-panel-body')).toHaveClass('hidden');
     });
 });

--- a/lightly_studio_view/src/lib/components/FilterPanel/FilterPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/FilterPanel/FilterPanel.test.ts
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import FilterPanel from './FilterPanel.svelte';
+import { useGlobalStorage } from '$lib/hooks';
+
+const STORAGE_KEY = 'lightlyStudio_filterPanelCollapsed';
+
+// Filter body rendered as the panel's children so we can assert it is hidden when collapsed.
+const children = createRawSnippet(() => ({
+    render: () => `<div data-testid="filter-content">Filter body</div>`
+}));
+
+const renderPanel = () => render(FilterPanel, { props: { children } });
+
+describe('FilterPanel', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+        // Reset the shared (module-singleton) store to the default expanded state.
+        useGlobalStorage().filterPanelCollapsed.set(false);
+    });
+
+    afterEach(() => {
+        useGlobalStorage().filterPanelCollapsed.set(false);
+    });
+
+    it('renders expanded by default with the filter content and a collapse control', () => {
+        renderPanel();
+
+        expect(screen.getByTestId('filter-content')).toBeInTheDocument();
+        expect(screen.getByText('Filters')).toBeInTheDocument();
+        expect(screen.getByTestId('filter-panel-collapse')).toBeInTheDocument();
+        expect(screen.queryByTestId('filter-panel-expand')).not.toBeInTheDocument();
+    });
+
+    it('collapses to the rail (hiding content) and expands again from the rail', async () => {
+        renderPanel();
+
+        await fireEvent.click(screen.getByTestId('filter-panel-collapse'));
+
+        expect(screen.queryByTestId('filter-content')).not.toBeInTheDocument();
+        const expandButton = screen.getByTestId('filter-panel-expand');
+        expect(expandButton).toBeInTheDocument();
+
+        await fireEvent.click(expandButton);
+
+        expect(screen.getByTestId('filter-content')).toBeInTheDocument();
+        expect(screen.queryByTestId('filter-panel-expand')).not.toBeInTheDocument();
+    });
+
+    it('persists the collapsed state to sessionStorage', async () => {
+        renderPanel();
+
+        await fireEvent.click(screen.getByTestId('filter-panel-collapse'));
+
+        expect(sessionStorage.getItem(STORAGE_KEY)).toBe('true');
+    });
+
+    it('restores the collapsed state from sessionStorage on a fresh mount', async () => {
+        // A fresh module graph re-reads sessionStorage when the store is created,
+        // mirroring a full page (re)load with a previously collapsed panel.
+        vi.resetModules();
+        sessionStorage.setItem(STORAGE_KEY, 'true');
+
+        const { render: freshRender } = await import('@testing-library/svelte');
+        const { createRawSnippet: freshSnippet } = await import('svelte');
+        const { default: FreshFilterPanel } = await import('./FilterPanel.svelte');
+
+        freshRender(FreshFilterPanel, {
+            props: {
+                children: freshSnippet(() => ({
+                    render: () => `<div data-testid="filter-content">Filter body</div>`
+                }))
+            }
+        });
+
+        expect(screen.getByTestId('filter-panel-expand')).toBeInTheDocument();
+        expect(screen.queryByTestId('filter-content')).not.toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -48,6 +48,7 @@ export { default as VideoSampleMetadata } from '$lib/components/VideoSampleMetad
 export { default as GridHeader } from '$lib/components/GridHeader/GridHeader.svelte';
 export { default as DatasetGridHeader } from '$lib/components/DatasetGridHeader/DatasetGridHeader.svelte';
 export { default as SidePanelTabs } from '$lib/components/SidePanelTabs/SidePanelTabs.svelte';
+export { default as FilterPanel } from '$lib/components/FilterPanel/FilterPanel.svelte';
 export { default as CaptionsItem } from '$lib/components/Captions/CaptionsItem/CaptionsItem.svelte';
 export { default as Typography } from '$lib/components/Typography/Typography.svelte';
 export { default as GroupsGrid } from '$lib/components/GroupsGrid/GroupsGrid.svelte';

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
@@ -50,6 +50,12 @@ const sampleSize = useSessionStorage<{
     height: 6
 });
 
+// Whether the left filter panel is collapsed to a thin icon rail.
+const filterPanelCollapsed = useSessionStorage<boolean>(
+    'lightlyStudio_filterPanelCollapsed',
+    false
+);
+
 // Metadata stores
 const metadataBounds = useSessionStorage<MetadataBounds>('lightlyStudio_metadata_bounds', {});
 const metadataValues = useSessionStorage<MetadataValues>('lightlyStudio_metadata_values', {});
@@ -374,6 +380,11 @@ export const useGlobalStorage = () => {
 
         isEditingMode,
         setIsEditingMode,
+
+        // Left filter panel collapse state (persisted in sessionStorage).
+        filterPanelCollapsed,
+        toggleFilterPanelCollapsed: () => filterPanelCollapsed.update((collapsed) => !collapsed),
+
         activePanel,
         setActivePanel: (panel: PanelType) => activePanel.set(panel),
         showEmbeddingPlot,

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -4,6 +4,7 @@
     import {
         CombinedMetadataDimensionsFilters,
         DatasetGridHeader,
+        FilterPanel,
         Footer,
         LabelsMenu,
         SelectionPill,
@@ -12,7 +13,7 @@
     import QueryEditorPanel from '$lib/components/QueryEditorPanel/QueryEditorPanel.svelte';
     import { SidePanelTabs } from '$lib/components';
     import Separator from '$lib/components/ui/separator/separator.svelte';
-    import { GripVertical, SlidersHorizontal } from '@lucide/svelte';
+    import { GripVertical } from '@lucide/svelte';
     import { onDestroy, onMount } from 'svelte';
     import { toStore } from 'svelte/store';
     import { Header } from '$lib/components';
@@ -386,56 +387,45 @@
     {:else}
         <div class="flex min-h-0 flex-1 space-x-4 px-4">
             {#if isCollectionGrid}
-                <div class="flex h-full min-h-0 w-80 flex-col">
-                    <div class="flex min-h-0 flex-1 flex-col rounded-[1vw] bg-card py-4">
-                        <div
-                            class="min-h-0 flex-1 space-y-2 overflow-y-auto px-4 pb-2 dark:[color-scheme:dark]"
-                        >
-                            <h2 class="flex items-center space-x-2 py-2 text-lg font-semibold">
-                                <SlidersHorizontal class="size-5" />
-                                <span>Filters</span>
-                            </h2>
+                <FilterPanel>
+                    {#if isImages}
+                        <QueryControl
+                            onOpen={() => {
+                                setActivePanel(
+                                    $activePanel === 'queryEditor' ? 'none' : 'queryEditor'
+                                );
+                            }}
+                        />
+                    {/if}
 
-                            {#if isImages}
-                                <QueryControl
-                                    onOpen={() => {
-                                        setActivePanel(
-                                            $activePanel === 'queryEditor' ? 'none' : 'queryEditor'
-                                        );
-                                    }}
-                                />
-                            {/if}
-
-                            <div>
-                                <TagsMenu collection_id={collectionId} {gridType} />
-                            </div>
-
-                            <EmbeddingSelectionFilterItem
-                                {collectionIdStore}
-                                {isVideos}
-                                {isImages}
-                                {isAnnotations}
-                            />
-                            {#if isImages}
-                                <ConfusionCellFilterItem />
-                            {/if}
-                            {#if isImages}
-                                <AnnotationCollectionsMenu {collectionId} />
-                            {/if}
-                            <LabelsMenu
-                                {annotationFilterRows}
-                                onToggleAnnotationFilter={toggleAnnotationFilterSelection}
-                                showVisibilityToggle={showAnnotationVisibilityToggle}
-                            />
-
-                            {#if isImages || isVideos || isVideoFrames}
-                                {#key collectionId}
-                                    <CombinedMetadataDimensionsFilters {isVideos} {isVideoFrames} />
-                                {/key}
-                            {/if}
-                        </div>
+                    <div>
+                        <TagsMenu collection_id={collectionId} {gridType} />
                     </div>
-                </div>
+
+                    <EmbeddingSelectionFilterItem
+                        {collectionIdStore}
+                        {isVideos}
+                        {isImages}
+                        {isAnnotations}
+                    />
+                    {#if isImages}
+                        <ConfusionCellFilterItem />
+                    {/if}
+                    {#if isImages}
+                        <AnnotationCollectionsMenu {collectionId} />
+                    {/if}
+                    <LabelsMenu
+                        {annotationFilterRows}
+                        onToggleAnnotationFilter={toggleAnnotationFilterSelection}
+                        showVisibilityToggle={showAnnotationVisibilityToggle}
+                    />
+
+                    {#if isImages || isVideos || isVideoFrames}
+                        {#key collectionId}
+                            <CombinedMetadataDimensionsFilters {isVideos} {isVideoFrames} />
+                        {/key}
+                    {/if}
+                </FilterPanel>
             {/if}
 
             {#snippet mainContent()}


### PR DESCRIPTION
## What has changed and why?

The left filter panel takes up a lot of horizontal space (fixed `w-80` / 320px). Per the request, it can now be **collapsed to a narrow `w-14` icon rail** and expanded again, reclaiming space for the grid.

- The rail mirrors the existing right-side `SidePanelTabs` idiom: a `SlidersHorizontal` icon with a small **"Filters"** label below it. Clicking it expands the panel.
- When expanded, a ghost `PanelLeftClose` button in the "Filters" header collapses it.
- The collapsed/expanded state is persisted for the session via `useSessionStorage` (`lightlyStudio_filterPanelCollapsed`), added to `useGlobalStorage`.
- The panel markup was extracted from the collection `+layout.svelte` into a dedicated, testable `FilterPanel` component.
- Toggle snaps instantly (no animation), consistent with the right-side panels.

**Deferred (fast-follow):** an active-filter indicator dot on the collapsed rail. It requires a per-grid-type `hasActiveFilters` signal with default-aware logic (annotation collections default to all-selected; metadata bounds), which is more involved and warrants its own change.

## How has it been tested?

- New `FilterPanel.test.ts` (Vitest + Testing Library): default-expanded renders content + collapse control, collapsing hides content and shows the rail, expanding restores, and the collapsed state is restored from sessionStorage on a fresh mount. 4/4 pass.
- `npm run check` (svelte-check/tsc): 0 errors, 0 warnings.
- prettier + eslint on changed files: pass.
- Existing `layout.test.ts`: 7/7 pass, no regression.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The left filter panel can now be collapsed into a compact icon rail to save horizontal space.
  * The panel’s collapsed or expanded state is remembered for the session.
  * The filter sidebar now uses a shared, consistent panel layout across the app.

* **Bug Fixes**
  * Improved the filter panel’s expand/collapse behavior so it restores correctly after revisiting the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->