### PR TITLE
Fast Track: Add diff size guardrail

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
-lightly_studio/uv.lock -diff linguist-generated=true 
-lightly_studio_view/package-lock.json -diff linguist-generated=true 
-fast_track/package-lock.json -diff linguist-generated=true 
+lightly_studio/uv.lock -diff linguist-generated=true
+lightly_studio_view/package-lock.json -diff linguist-generated=true
+fast_track/package-lock.json -diff linguist-generated=true
 
 lightly_studio/tests/benchmarks/** -diff linguist-generated=true
 
-lightly_studio/src/lightly_studio/vendor/** -diff linguist-vendored=true 
+lightly_studio/src/lightly_studio/vendor/** -diff linguist-vendored=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+lightly_studio/uv.lock -diff linguist-generated=true 
+lightly_studio_view/package-lock.json -diff linguist-generated=true 
+fast_track/package-lock.json -diff linguist-generated=true 
+
+lightly_studio/tests/benchmarks/** -diff linguist-generated=true
+
+lightly_studio/src/lightly_studio/vendor/** -diff linguist-vendored=true 

--- a/fast_track/src/guardrails/diff-size.test.ts
+++ b/fast_track/src/guardrails/diff-size.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { ChangedFile, GuardrailContext } from './context/types';
+import { diffSizeGuardrail, MAX_ADDED_LOC } from './diff-size';
+
+function makeCtx(files: ChangedFile[]): GuardrailContext {
+    return { baseRef: 'origin/main', changedFiles: async () => files };
+}
+
+describe('diffSizeGuardrail', () => {
+    it('is required and runs locally', () => {
+        expect(diffSizeGuardrail.required).toBe(true);
+        expect(diffSizeGuardrail.needsPrContext).toBe(false);
+    });
+
+    it('passes when total additions are below the limit', async () => {
+        const result = await diffSizeGuardrail.run(
+            makeCtx([
+                { path: 'a.py', status: 'modified', additions: 100, deletions: 0 },
+                { path: 'b.py', status: 'modified', additions: 50, deletions: 5 }
+            ])
+        );
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('150');
+    });
+
+    it('passes when total additions are exactly the limit', async () => {
+        const result = await diffSizeGuardrail.run(
+            makeCtx([{ path: 'a.py', status: 'modified', additions: MAX_ADDED_LOC, deletions: 0 }])
+        );
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain(`${MAX_ADDED_LOC}`);
+    });
+
+    it('fails when total additions exceed the limit', async () => {
+        const result = await diffSizeGuardrail.run(
+            makeCtx([
+                { path: 'a.py', status: 'modified', additions: 200, deletions: 0 },
+                { path: 'b.py', status: 'added', additions: 50, deletions: 0 }
+            ])
+        );
+        expect(result.status).toBe('fail');
+        expect(result.summary).toContain('250');
+        expect(result.summary).toContain(`${MAX_ADDED_LOC}`);
+    });
+});

--- a/fast_track/src/guardrails/diff-size.test.ts
+++ b/fast_track/src/guardrails/diff-size.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ChangedFile, GuardrailContext } from './context/types';
-import { diffSizeGuardrail, MAX_ADDED_LOC } from './diff-size';
+import { diffSizeGuardrail, isExcluded, MAX_ADDED_LOC } from './diff-size';
 
 function makeCtx(files: ChangedFile[]): GuardrailContext {
     return { baseRef: 'origin/main', changedFiles: async () => files };
@@ -41,5 +41,77 @@ describe('diffSizeGuardrail', () => {
         expect(result.status).toBe('fail');
         expect(result.summary).toContain('250');
         expect(result.summary).toContain(`${MAX_ADDED_LOC}`);
+    });
+
+    it('ignores generated lock files even when their additions would exceed the limit', async () => {
+        const result = await diffSizeGuardrail.run(
+            makeCtx([
+                { path: 'a.py', status: 'modified', additions: 10, deletions: 0 },
+                {
+                    path: 'lightly_studio/uv.lock',
+                    status: 'modified',
+                    additions: 5000,
+                    deletions: 0
+                },
+                {
+                    path: 'lightly_studio_view/package-lock.json',
+                    status: 'modified',
+                    additions: 3000,
+                    deletions: 0
+                },
+                {
+                    path: 'fast_track/package-lock.json',
+                    status: 'modified',
+                    additions: 2000,
+                    deletions: 0
+                }
+            ])
+        );
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('10');
+    });
+
+    it('ignores files under excluded directory prefixes', async () => {
+        const result = await diffSizeGuardrail.run(
+            makeCtx([
+                { path: 'a.py', status: 'modified', additions: 10, deletions: 0 },
+                {
+                    path: 'lightly_studio/tests/benchmarks/bench_foo.py',
+                    status: 'added',
+                    additions: 500,
+                    deletions: 0
+                },
+                {
+                    path: 'lightly_studio/src/lightly_studio/vendor/some_lib.py',
+                    status: 'added',
+                    additions: 1000,
+                    deletions: 0
+                }
+            ])
+        );
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('10');
+    });
+});
+
+describe('isExcluded', () => {
+    it('matches exact lock file paths', () => {
+        expect(isExcluded('lightly_studio/uv.lock')).toBe(true);
+        expect(isExcluded('lightly_studio_view/package-lock.json')).toBe(true);
+        expect(isExcluded('fast_track/package-lock.json')).toBe(true);
+    });
+
+    it('matches files under excluded directory prefixes', () => {
+        expect(isExcluded('lightly_studio/tests/benchmarks/bench_foo.py')).toBe(true);
+        expect(isExcluded('lightly_studio/src/lightly_studio/vendor/lib.py')).toBe(true);
+    });
+
+    it('does not match unrelated paths', () => {
+        expect(isExcluded('lightly_studio/src/main.py')).toBe(false);
+        expect(isExcluded('fast_track/src/index.ts')).toBe(false);
+    });
+
+    it('does not match a path that only shares a prefix with an excluded directory', () => {
+        expect(isExcluded('lightly_studio/tests/benchmarks_extra/file.py')).toBe(false);
     });
 });

--- a/fast_track/src/guardrails/diff-size.ts
+++ b/fast_track/src/guardrails/diff-size.ts
@@ -1,6 +1,7 @@
 import type { Guardrail, GuardrailContext, GuardrailOutcome } from './context/types';
 
 const NAME = 'diff-size';
+// Hard cap of 200 added lines plus a 15-line buffer for minor overruns (e.g. boilerplate).
 export const MAX_ADDED_LOC = 215;
 
 /**

--- a/fast_track/src/guardrails/diff-size.ts
+++ b/fast_track/src/guardrails/diff-size.ts
@@ -1,0 +1,26 @@
+import type { Guardrail, GuardrailContext, GuardrailOutcome } from './context/types';
+
+const NAME = 'diff-size';
+export const MAX_ADDED_LOC = 215;
+
+export const diffSizeGuardrail: Guardrail = {
+    name: NAME,
+    required: true,
+    needsPrContext: false,
+    async run(ctx: GuardrailContext): Promise<GuardrailOutcome> {
+        const files = await ctx.changedFiles();
+        const totalAdditions = files.reduce((sum, f) => sum + f.additions, 0);
+
+        if (totalAdditions > MAX_ADDED_LOC) {
+            return {
+                status: 'fail',
+                summary: `PR adds ${totalAdditions} line(s), which exceeds the limit of ${MAX_ADDED_LOC}.`
+            };
+        }
+
+        return {
+            status: 'pass',
+            summary: `PR adds ${totalAdditions} line(s) (limit: ${MAX_ADDED_LOC}).`
+        };
+    }
+};

--- a/fast_track/src/guardrails/diff-size.ts
+++ b/fast_track/src/guardrails/diff-size.ts
@@ -3,13 +3,33 @@ import type { Guardrail, GuardrailContext, GuardrailOutcome } from './context/ty
 const NAME = 'diff-size';
 export const MAX_ADDED_LOC = 215;
 
+/**
+ * Paths and directory prefixes mirroring the linguist-generated / linguist-vendored
+ * entries in .gitattributes. The GitHub API counts lines in these files even though
+ * they are auto-generated, so we exclude them before comparing against the limit.
+ * Directory prefixes end with '/' and match any file underneath them.
+ */
+const EXCLUDED: string[] = [
+    'lightly_studio/uv.lock',
+    'lightly_studio_view/package-lock.json',
+    'fast_track/package-lock.json',
+    'lightly_studio/tests/benchmarks/',
+    'lightly_studio/src/lightly_studio/vendor/'
+];
+
+export function isExcluded(path: string): boolean {
+    return EXCLUDED.some((e) => (e.endsWith('/') ? path.startsWith(e) : path === e));
+}
+
 export const diffSizeGuardrail: Guardrail = {
     name: NAME,
     required: true,
     needsPrContext: false,
     async run(ctx: GuardrailContext): Promise<GuardrailOutcome> {
         const files = await ctx.changedFiles();
-        const totalAdditions = files.reduce((sum, f) => sum + f.additions, 0);
+        const totalAdditions = files
+            .filter((f) => !isExcluded(f.path))
+            .reduce((sum, f) => sum + f.additions, 0);
 
         if (totalAdditions > MAX_ADDED_LOC) {
             return {

--- a/fast_track/src/guardrails/registry.ts
+++ b/fast_track/src/guardrails/registry.ts
@@ -2,12 +2,14 @@ import type { Guardrail } from './context/types';
 import { dummyGuardrail } from './dummy';
 import { backendComplexityGuardrail } from './backend/complexity';
 import { frontendComplexityGuardrail } from './frontend/complexity';
+import { diffSizeGuardrail } from './diff-size';
 
 /** The guardrail registry. */
 export const guardrails: Guardrail[] = [
     dummyGuardrail,
     frontendComplexityGuardrail,
-    backendComplexityGuardrail
+    backendComplexityGuardrail,
+    diffSizeGuardrail
 ];
 
 export interface SelectOptions {


### PR DESCRIPTION
## What has changed and why?

Adds a new `diffSizeGuardrail` that fails if the total number of added lines in a PR exceeds a configured limit. The limit is set to 215 lines: 200 as the hard cap plus 15 lines of buffer. A `.gitattributes` file is included to hide generated or irrelevant files from the diff count.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new change-size guardrail that flags pull requests when added lines exceed a fixed limit.
  * The guardrail ignores generated lock/vendor artifacts and excluded directory prefixes, and is now included in the active guardrail set.
* **Tests**
  * Expanded automated coverage for pass/fail thresholds and path-exclusion matching rules.
* **Chores**
  * Updated repository Linguist attributes to better categorize generated and vendored files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->