### PR TITLE
Docs for object-level embeddings

### DIFF
--- a/lightly_studio/docs/docs/concepts_and_tools/annotations.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/annotations.md
@@ -35,8 +35,8 @@ Annotations are shown in sample detail view and in the annotation-focused views.
 
 ## Object-level embeddings
 
-LightlyStudio computes embeddings not only for whole images, but also for individual 
-objects defined by object detection boxes or segmentation masks. This unlocks the 
+LightlyStudio computes embeddings not only for whole images, but also for individual
+objects defined by object-detection boxes or segmentation masks. This unlocks the
 **embedding plot** and **similarity search** on individual objects, working exactly the
 same way they do for whole images.
 Open the `Annotations` view in the GUI to browse objects in a grid, search them, and

--- a/lightly_studio/docs/docs/concepts_and_tools/annotations.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/annotations.md
@@ -33,6 +33,27 @@ Annotations are shown in sample detail view and in the annotation-focused views.
   ></iframe>
 </div>
 
+## Object-level embeddings
+
+LightlyStudio computes embeddings not only for whole images, but also for individual 
+objects defined by object detection boxes or segmentation masks. This unlocks the 
+**embedding plot** and **similarity search** on individual objects, working exactly the
+same way they do for whole images.
+Open the `Annotations` view in the GUI to browse objects in a grid, search them, and
+explore them in the embedding plot. For how search, filter, and the embedding plot
+behave, see [Search and Filter](search_and_filter.md).
+
+
+Object embeddings are created automatically when object detection or segmentation annotations are imported. The
+`add_annotations_from_*` methods accept `embed_annotations=True` by default. Pass
+`embed_annotations=False` to skip it.
+
+!!! warning "Editing an annotation does not update its embedding"
+    Object-level embeddings are generated only for annotations that do not yet have one. Editing an
+    existing annotation — for example moving or resizing its bounding box — does **not** regenerate
+    its embedding, so the object keeps the embedding of its original crop. We plan to add support
+    for recomputing object embeddings after edits.
+
 ## Annotations in Python
 
 Use the [Python API](../api/annotation.md) to create annotations and predictions directly, import them from model

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -23,6 +23,10 @@ The screen recording below shows the search both by text query "dog" and by past
 !!! note "Search requires embeddings"
     Search is available only when embeddings were generated during data loading.
 
+Search works the same way in the `Annotations` view, where it finds similar objects using
+object-level embeddings. See
+[Object-level embeddings](annotations.md#object-level-embeddings) for details.
+
 ## Filter in GUI
 
 The left sidebar combines the most common ways to narrow down the visible samples:


### PR DESCRIPTION
## What has changed and why?

Add docs for object-level embeddings. Keep them minimal, cause it works the same as for images.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Object-level embeddings” section covering embeddings for individual detection boxes and segmentation masks.
  * Enabled/outlined object-level embedding plots and similarity search from the GUI’s Annotations view.
  * Documented that object embeddings are generated automatically during object annotation import, with an option to skip embedding creation.
  * Added a warning that editing existing object annotations doesn’t regenerate embeddings yet.
  * Updated search documentation to clarify Annotations-view search via object-level embeddings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->