### PR TITLE
use annotation_type

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/image.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/image.py
@@ -14,6 +14,7 @@ from lightly_studio.api.routes.api.status import (
 )
 from lightly_studio.api.routes.api.validators import Paginated
 from lightly_studio.database.db_manager import SessionDep
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.image import (
     ImageView,
@@ -134,6 +135,10 @@ class ReadCountImageAnnotationsRequest(BaseModel):
     """Request body for reading image annotation counts."""
 
     filter: ImageFilter | None = None
+    annotation_type: AnnotationType | None = Field(
+        None,
+        description="Restrict counts to a single annotation type (e.g. classification).",
+    )
 
 
 @image_router.post("/collections/{collection_id}/images/sample_ids", response_model=list[UUID])
@@ -164,10 +169,12 @@ def count_image_annotations_by_collection(
 ) -> list[dict[str, str | int]]:
     """Get image annotation counts for a specific collection."""
     image_filter = body.filter if body and body.filter else None
+    annotation_type = body.annotation_type if body else None
     counts = image_resolver.count_image_annotations_by_collection(
         session=session,
         collection_id=collection.collection_id,
         image_filter=image_filter,
+        annotation_type=annotation_type,
     )
 
     return [

--- a/lightly_studio/src/lightly_studio/api/routes/api/video.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/video.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from lightly_studio.api.routes.api.validators import Paginated, PaginatedWithCursor
 from lightly_studio.database.db_manager import SessionDep
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.video import VideoFieldsBoundsView, VideoView, VideoViewsWithCount
 from lightly_studio.resolvers import video_resolver
 from lightly_studio.resolvers.video_resolver.count_video_frame_annotations_by_collection import (
@@ -43,6 +44,10 @@ class ReadVideoCountAnnotationsRequest(BaseModel):
     filter: Optional[VideoFilter] = Field(
         None, description="Filter parameters for video annotations counter"
     )
+    annotation_type: Optional[AnnotationType] = Field(
+        None,
+        description="Restrict counts to a single annotation type (e.g. classification).",
+    )
 
 
 @video_router.post(
@@ -68,6 +73,7 @@ def count_video_frame_annotations_by_video_collection(
         session=session,
         collection_id=collection_id,
         filters=body.filter,
+        annotation_type=body.annotation_type,
     )
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
@@ -6,7 +6,10 @@ from uuid import UUID
 
 from sqlmodel import Session, col, func, select
 
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.annotation_base import (
+    AnnotationBaseTable,
+    AnnotationType,
+)
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
@@ -18,12 +21,18 @@ def count_image_annotations_by_collection(
     session: Session,
     collection_id: UUID,
     image_filter: ImageFilter | None = None,
+    annotation_type: AnnotationType | None = None,
 ) -> list[tuple[str, int, int]]:
     """Count annotations for a specific image collection.
 
     Annotations for a specific collection are grouped by annotation
     label name and counted for total and filtered.
     Returns a list of (label_name, current_count, total_count) tuples.
+
+    When ``annotation_type`` is provided, both the total and filtered counts are
+    restricted to annotations of that type (e.g. only CLASSIFICATION or only
+    OBJECT_DETECTION). When it is not provided, counts include all types and the
+    behaviour is unchanged.
     """
     # Resolve any embedding-plot region selection to concrete sample ids on the filter before the
     # query is built (the point-in-polygon test needs the session, which `apply` lacks).
@@ -34,11 +43,16 @@ def count_image_annotations_by_collection(
             collection_id=collection_id,
             region=sample_filter.embedding_region,
         )
-    total_counts = _get_total_counts(session=session, collection_id=collection_id)
+    total_counts = _get_total_counts(
+        session=session,
+        collection_id=collection_id,
+        annotation_type=annotation_type,
+    )
     current_counts = _get_current_counts(
         session=session,
         collection_id=collection_id,
         image_filter=image_filter,
+        annotation_type=annotation_type,
     )
 
     return [
@@ -47,7 +61,11 @@ def count_image_annotations_by_collection(
     ]
 
 
-def _get_total_counts(session: Session, collection_id: UUID) -> dict[str, int]:
+def _get_total_counts(
+    session: Session,
+    collection_id: UUID,
+    annotation_type: AnnotationType | None = None,
+) -> dict[str, int]:
     """Returns total annotation counts per label for the collection."""
     total_counts_query = (
         select(
@@ -68,9 +86,16 @@ def _get_total_counts(session: Session, collection_id: UUID) -> dict[str, int]:
             col(SampleTable.sample_id) == col(ImageTable.sample_id),
         )
         .where(SampleTable.collection_id == collection_id)
-        .group_by(AnnotationLabelTable.annotation_label_name)
-        .order_by(col(AnnotationLabelTable.annotation_label_name).asc())
     )
+
+    if annotation_type is not None:
+        total_counts_query = total_counts_query.where(
+            col(AnnotationBaseTable.annotation_type) == annotation_type
+        )
+
+    total_counts_query = total_counts_query.group_by(
+        AnnotationLabelTable.annotation_label_name
+    ).order_by(col(AnnotationLabelTable.annotation_label_name).asc())
 
     return {row[0]: row[1] for row in session.exec(total_counts_query).all()}
 
@@ -79,6 +104,7 @@ def _get_current_counts(
     session: Session,
     collection_id: UUID,
     image_filter: ImageFilter | None,
+    annotation_type: AnnotationType | None = None,
 ) -> dict[str, int]:
     """Returns filtered annotation counts per label for the collection."""
     filtered_query = (
@@ -101,6 +127,11 @@ def _get_current_counts(
         )
         .where(SampleTable.collection_id == collection_id)
     )
+
+    if annotation_type is not None:
+        filtered_query = filtered_query.where(
+            col(AnnotationBaseTable.annotation_type) == annotation_type
+        )
 
     if image_filter is not None:
         filtered_query = image_filter.apply(filtered_query)

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
@@ -31,8 +31,7 @@ def count_image_annotations_by_collection(
 
     When ``annotation_type`` is provided, both the total and filtered counts are
     restricted to annotations of that type (e.g. only CLASSIFICATION or only
-    OBJECT_DETECTION). When it is not provided, counts include all types and the
-    behaviour is unchanged.
+    OBJECT_DETECTION).
     """
     # Resolve any embedding-plot region selection to concrete sample ids on the filter before the
     # query is built (the point-in-polygon test needs the session, which `apply` lacks).

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/count_video_frame_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/count_video_frame_annotations_by_collection.py
@@ -7,7 +7,10 @@ from pydantic import BaseModel
 from sqlmodel import Session, asc, col, func, select
 from sqlmodel.sql.expression import Select
 
-from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation.annotation_base import (
+    AnnotationBaseTable,
+    AnnotationType,
+)
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.video import VideoFrameTable, VideoTable
@@ -23,16 +26,31 @@ class CountAnnotationsView(BaseModel):
 
 
 def count_video_frame_annotations_by_video_collection(
-    session: Session, collection_id: UUID, filters: Optional[VideoFilter] = None
+    session: Session,
+    collection_id: UUID,
+    filters: Optional[VideoFilter] = None,
+    annotation_type: Optional[AnnotationType] = None,
 ) -> list[CountAnnotationsView]:
-    """Count the annotations by video frames."""
+    """Count the annotations by video frames.
+
+    When ``annotation_type`` is provided, both the total and filtered counts are
+    restricted to annotations of that type (e.g. only CLASSIFICATION or only
+    OBJECT_DETECTION). When it is not provided, counts include all types and the
+    behaviour is unchanged.
+    """
     unfiltered_query = (
-        _build_base_query(collection_id=collection_id, count_column_name="total")
+        _build_base_query(
+            collection_id=collection_id,
+            count_column_name="total",
+            annotation_type=annotation_type,
+        )
         .group_by(col(AnnotationBaseTable.annotation_label_id))
         .subquery("unfiltered")
     )
     filtered_query = _build_base_query(
-        collection_id=collection_id, count_column_name="filtered_count"
+        collection_id=collection_id,
+        count_column_name="filtered_count",
+        annotation_type=annotation_type,
     )
 
     if filters is not None:
@@ -69,8 +87,12 @@ def count_video_frame_annotations_by_video_collection(
     ]
 
 
-def _build_base_query(collection_id: UUID, count_column_name: str) -> Select[tuple[Any, int]]:
-    return (
+def _build_base_query(
+    collection_id: UUID,
+    count_column_name: str,
+    annotation_type: Optional[AnnotationType] = None,
+) -> Select[tuple[Any, int]]:
+    query = (
         select(
             col(AnnotationBaseTable.annotation_label_id).label("label_id"),
             func.count(func.distinct(VideoTable.sample_id)).label(count_column_name),
@@ -84,3 +106,8 @@ def _build_base_query(collection_id: UUID, count_column_name: str) -> Select[tup
         .join(VideoTable, col(VideoTable.sample_id) == col(SampleTable.sample_id))
         .where(col(SampleTable.collection_id) == collection_id)
     )
+
+    if annotation_type is not None:
+        query = query.where(col(AnnotationBaseTable.annotation_type) == annotation_type)
+
+    return query

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/count_video_frame_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/count_video_frame_annotations_by_collection.py
@@ -92,7 +92,7 @@ def _build_base_query(
     count_column_name: str,
     annotation_type: Optional[AnnotationType] = None,
 ) -> Select[tuple[Any, int]]:
-    query = (
+    query: Select[tuple[Any, int]] = (
         select(
             col(AnnotationBaseTable.annotation_label_id).label("label_id"),
             func.count(func.distinct(VideoTable.sample_id)).label(count_column_name),

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/count_video_frame_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/count_video_frame_annotations_by_collection.py
@@ -35,8 +35,7 @@ def count_video_frame_annotations_by_video_collection(
 
     When ``annotation_type`` is provided, both the total and filtered counts are
     restricted to annotations of that type (e.g. only CLASSIFICATION or only
-    OBJECT_DETECTION). When it is not provided, counts include all types and the
-    behaviour is unchanged.
+    OBJECT_DETECTION).
     """
     unfiltered_query = (
         _build_base_query(

--- a/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from uuid import UUID
 
 import pytest
 from sqlmodel import Session
@@ -134,9 +135,8 @@ def test_count_image_annotations_by_collection_with_filtering(
     assert filtered_dict["cat"] == (1, 1)
 
 
-def test_count_image_annotations_by_collection_filters_by_annotation_type(
-    db_session: Session,
-) -> None:
+@pytest.fixture
+def typed_collection_id(db_session: Session) -> UUID:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
@@ -174,30 +174,28 @@ def test_count_image_annotations_by_collection_filters_by_annotation_type(
         ],
     )
 
-    # Without the filter both types are counted.
-    all_counts = image_resolver.count_image_annotations_by_collection(
-        session=db_session,
-        collection_id=collection_id,
-    )
-    all_dict = {label: (current, total) for label, current, total in all_counts}
-    assert all_dict == {"scene": (1, 1), "dog": (1, 1)}
+    return collection_id
 
-    # Classification only isolates the classification label.
-    classification_counts = image_resolver.count_image_annotations_by_collection(
-        session=db_session,
-        collection_id=collection_id,
-        annotation_type=AnnotationType.CLASSIFICATION,
-    )
-    classification_dict = {
-        label: (current, total) for label, current, total in classification_counts
-    }
-    assert classification_dict == {"scene": (1, 1)}
 
-    # Object detection only isolates the detection label.
-    detection_counts = image_resolver.count_image_annotations_by_collection(
+@pytest.mark.parametrize(
+    ("annotation_type", "expected_counts"),
+    [
+        (None, {"scene": (1, 1), "dog": (1, 1)}),
+        (AnnotationType.CLASSIFICATION, {"scene": (1, 1)}),
+        (AnnotationType.OBJECT_DETECTION, {"dog": (1, 1)}),
+    ],
+)
+def test_count_image_annotations_by_collection_filters_by_annotation_type(
+    db_session: Session,
+    typed_collection_id: UUID,
+    annotation_type: AnnotationType | None,
+    expected_counts: dict[str, tuple[int, int]],
+) -> None:
+    counts = image_resolver.count_image_annotations_by_collection(
         session=db_session,
-        collection_id=collection_id,
-        annotation_type=AnnotationType.OBJECT_DETECTION,
+        collection_id=typed_collection_id,
+        annotation_type=annotation_type,
     )
-    detection_dict = {label: (current, total) for label, current, total in detection_counts}
-    assert detection_dict == {"dog": (1, 1)}
+
+    counts_dict = {label: (current, total) for label, current, total in counts}
+    assert counts_dict == expected_counts

--- a/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import pytest
 from sqlmodel import Session
 
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.resolvers import image_resolver
@@ -131,3 +132,72 @@ def test_count_image_annotations_by_collection_with_filtering(
     filtered_dict = {label: (current, total) for label, current, total in filtered_counts}
     assert filtered_dict["dog"] == (1, 2)
     assert filtered_dict["cat"] == (1, 1)
+
+
+def test_count_image_annotations_by_collection_filters_by_annotation_type(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    image = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/sample1.png",
+    )
+
+    classification_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="scene",
+    )
+    detection_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="dog",
+    )
+
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=classification_label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+            ),
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=detection_label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            ),
+        ],
+    )
+
+    # Without the filter both types are counted.
+    all_counts = image_resolver.count_image_annotations_by_collection(
+        session=db_session,
+        collection_id=collection_id,
+    )
+    all_dict = {label: (current, total) for label, current, total in all_counts}
+    assert all_dict == {"scene": (1, 1), "dog": (1, 1)}
+
+    # Classification only isolates the classification label.
+    classification_counts = image_resolver.count_image_annotations_by_collection(
+        session=db_session,
+        collection_id=collection_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+    classification_dict = {
+        label: (current, total) for label, current, total in classification_counts
+    }
+    assert classification_dict == {"scene": (1, 1)}
+
+    # Object detection only isolates the detection label.
+    detection_counts = image_resolver.count_image_annotations_by_collection(
+        session=db_session,
+        collection_id=collection_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+    detection_dict = {label: (current, total) for label, current, total in detection_counts}
+    assert detection_dict == {"dog": (1, 1)}

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_count_video_frame_annotations_by_video_dataset.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_count_video_frame_annotations_by_video_dataset.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
 from sqlmodel import Session
 
 from lightly_studio.models.annotation.annotation_base import AnnotationType
@@ -195,9 +200,8 @@ def test_count_video_frame_annotations_by_video_collection_with_annotation_filte
     assert annotations[1].current_count == 0
 
 
-def test_count_video_frame_annotations_by_video_collection_filters_by_annotation_type(
-    db_session: Session,
-) -> None:
+@pytest.fixture
+def typed_collection_id(db_session: Session) -> UUID:
     collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
     collection_id = collection.collection_id
 
@@ -236,31 +240,28 @@ def test_count_video_frame_annotations_by_video_collection_filters_by_annotation
         ],
     )
 
-    # Without the filter both types are counted.
-    all_annotations = video_resolver.count_video_frame_annotations_by_video_collection(
-        session=db_session,
-        collection_id=collection_id,
-    )
-    assert {a.label_name for a in all_annotations} == {"scene", "car"}
+    return collection_id
 
-    # Classification only isolates the classification label.
-    classification_annotations = video_resolver.count_video_frame_annotations_by_video_collection(
-        session=db_session,
-        collection_id=collection_id,
-        annotation_type=AnnotationType.CLASSIFICATION,
-    )
-    assert len(classification_annotations) == 1
-    assert classification_annotations[0].label_name == "scene"
-    assert classification_annotations[0].total_count == 1
-    assert classification_annotations[0].current_count == 1
 
-    # Object detection only isolates the detection label.
-    detection_annotations = video_resolver.count_video_frame_annotations_by_video_collection(
+@pytest.mark.parametrize(
+    ("annotation_type", "expected_counts"),
+    [
+        (None, {"scene": (1, 1), "car": (1, 1)}),
+        (AnnotationType.CLASSIFICATION, {"scene": (1, 1)}),
+        (AnnotationType.OBJECT_DETECTION, {"car": (1, 1)}),
+    ],
+)
+def test_count_video_frame_annotations_by_video_collection_filters_by_annotation_type(
+    db_session: Session,
+    typed_collection_id: UUID,
+    annotation_type: AnnotationType | None,
+    expected_counts: dict[str, tuple[int, int]],
+) -> None:
+    annotations = video_resolver.count_video_frame_annotations_by_video_collection(
         session=db_session,
-        collection_id=collection_id,
-        annotation_type=AnnotationType.OBJECT_DETECTION,
+        collection_id=typed_collection_id,
+        annotation_type=annotation_type,
     )
-    assert len(detection_annotations) == 1
-    assert detection_annotations[0].label_name == "car"
-    assert detection_annotations[0].total_count == 1
-    assert detection_annotations[0].current_count == 1
+
+    counts = {a.label_name: (a.total_count, a.current_count) for a in annotations}
+    assert counts == expected_counts

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_count_video_frame_annotations_by_video_dataset.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_count_video_frame_annotations_by_video_dataset.py
@@ -1,5 +1,6 @@
 from sqlmodel import Session
 
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import video_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
@@ -192,3 +193,74 @@ def test_count_video_frame_annotations_by_video_collection_with_annotation_filte
     assert annotations[1].label_name == "car"
     assert annotations[1].total_count == 1
     assert annotations[1].current_count == 0
+
+
+def test_count_video_frame_annotations_by_video_collection_filters_by_annotation_type(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    collection_id = collection.collection_id
+
+    video_frames_data = create_video_with_frames(
+        session=db_session,
+        collection_id=collection_id,
+        video=VideoStub(path="/path/to/sample1.mp4"),
+    )
+    video_frame_id = video_frames_data.frame_sample_ids[0]
+
+    scene_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="scene",
+    )
+    car_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="car",
+    )
+
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=video_frame_id,
+                annotation_label_id=scene_label.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+            ),
+            AnnotationDetails(
+                sample_id=video_frame_id,
+                annotation_label_id=car_label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            ),
+        ],
+    )
+
+    # Without the filter both types are counted.
+    all_annotations = video_resolver.count_video_frame_annotations_by_video_collection(
+        session=db_session,
+        collection_id=collection_id,
+    )
+    assert {a.label_name for a in all_annotations} == {"scene", "car"}
+
+    # Classification only isolates the classification label.
+    classification_annotations = video_resolver.count_video_frame_annotations_by_video_collection(
+        session=db_session,
+        collection_id=collection_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+    assert len(classification_annotations) == 1
+    assert classification_annotations[0].label_name == "scene"
+    assert classification_annotations[0].total_count == 1
+    assert classification_annotations[0].current_count == 1
+
+    # Object detection only isolates the detection label.
+    detection_annotations = video_resolver.count_video_frame_annotations_by_video_collection(
+        session=db_session,
+        collection_id=collection_id,
+        annotation_type=AnnotationType.OBJECT_DETECTION,
+    )
+    assert len(detection_annotations) == 1
+    assert detection_annotations[0].label_name == "car"
+    assert detection_annotations[0].total_count == 1
+    assert detection_annotations[0].current_count == 1


### PR DESCRIPTION
## What has changed and why?

Adds an optional `annotation_type` filter to the two annotation count resolvers.

**Motivation.** The count resolvers (`count_image_annotations_by_collection` and `count_video_frame_annotations_by_video_collection`) group annotations by label and return per-label totals, but they never distinguish between annotation types. A single sample can carry both a CLASSIFICATION annotation and OBJECT_DETECTION annotations, so the counts silently merge the two. For the upcoming class-distribution panel (frontend prototype in #1542), that mix is wrong: on a dataset with both types, a classification class distribution would be polluted by detection labels (and vice versa). To render a correct per-type distribution, the frontend needs to request counts scoped to one annotation type — and that scoping has to happen in the query, since the type dimension isn't present in the response payload and can't be reconstructed client-side.

**Change.** Both resolvers now accept an optional `annotation_type` parameter. When provided, it applies a `WHERE annotation_base.annotation_type == <type>` to **both** the total and the filtered/current count queries, so a requested type is isolated across the whole result (total column included). When omitted, the queries are unchanged and existing behaviour is fully preserved. The parameter is surfaced through the REST layer on the existing count endpoints (`ReadCountImageAnnotationsRequest` / `ReadVideoCountAnnotationsRequest`), accepting the standard `AnnotationType` enum values (e.g. `classification`, `object_detection`).

This is a small, backend-only change (~90 logic lines + tests) that unblocks the class-distribution work; the frontend wiring is tracked separately in LIG-9581.

Files touched: image/video count resolvers, the two REST route bodies, and a new test in each resolver's test file.

## How has it been tested?

- Added a unit test to each resolver covering: no filter (both types counted), `CLASSIFICATION` (isolates the classification label), and `OBJECT_DETECTION` (isolates the detection label), asserting both total and current counts.
- Existing resolver tests still pass unchanged, confirming behaviour is identical when `annotation_type` is not passed.
- Ran `make static-checks` (ruff lint + format + type-check) locally.

Reproduce: `cd lightly_studio && make static-checks && make test`

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional annotation-type filtering for image annotation count results.
  * Added optional annotation-type filtering for video frame annotation count results.
  * When an annotation type is provided, both “current” and “total” counts are restricted to that type; otherwise results include all types.

* **Tests**
  * Added coverage to verify image count filtering by annotation type.
  * Added coverage to verify video frame count filtering by annotation type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->