### PR TITLE
Remove unnecessary export wrapper functions.

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -43,6 +43,11 @@ def export_collection_annotations(
     """Export collection annotations in the selected export format."""
     # Query to export - all samples in the collection.
     dataset_query = DatasetQuery(dataset=collection, session=session)
+    exporter = image_dataset_export.ImageDatasetExport(
+        session=session,
+        dataset_id=collection.dataset_id,
+        samples=dataset_query,
+    )
 
     # Create the export in a temporary directory. We cannot use a context manager
     # because the directory should be deleted only after the file has finished streaming.
@@ -51,10 +56,7 @@ def export_collection_annotations(
     if export_format == ExportFormat.OBJECT_DETECTION_COCO:
         output_path = PathlibPath(temp_dir.name) / "coco_export.json"
         try:
-            image_dataset_export.to_coco_object_detections(
-                session=session,
-                dataset_id=collection.dataset_id,
-                samples=dataset_query,
+            exporter.to_coco_object_detections(
                 output_json=output_path,
                 annotation_collection_id=annotation_collection_id,
             )
@@ -66,10 +68,7 @@ def export_collection_annotations(
         output_path = PathlibPath(temp_dir.name) / "yolo"
 
         try:
-            image_dataset_export.to_yolo_object_detections(
-                session=session,
-                dataset_id=collection.dataset_id,
-                samples=dataset_query,
+            exporter.to_yolo_object_detections(
                 output_folder=output_path,
                 annotation_collection_id=annotation_collection_id,
             )
@@ -95,10 +94,7 @@ def export_collection_annotations(
         output_path = PathlibPath(temp_dir.name) / "coco_segmentation_mask_export.json"
 
         try:
-            image_dataset_export.to_coco_segmentation_masks(
-                session=session,
-                dataset_id=collection.dataset_id,
-                samples=dataset_query,
+            exporter.to_coco_segmentation_masks(
                 output_json=output_path,
                 annotation_collection_id=annotation_collection_id,
             )
@@ -110,10 +106,7 @@ def export_collection_annotations(
         output_path = PathlibPath(temp_dir.name) / "pascalvoc"
 
         try:
-            image_dataset_export.to_pascalvoc_segmentation_mask(
-                session=session,
-                dataset_id=collection.dataset_id,
-                samples=dataset_query,
+            exporter.to_pascalvoc_segmentation_mask(
                 output_folder=output_path,
                 annotation_collection_id=annotation_collection_id,
             )
@@ -173,10 +166,11 @@ def export_collection_captions(
     output_path = PathlibPath(temp_dir.name) / "coco_captions_export.json"
 
     try:
-        image_dataset_export.to_coco_captions(
+        image_dataset_export.ImageDatasetExport(
+            session=session,
+            dataset_id=collection.dataset_id,
             samples=dataset_query,
-            output_json=output_path,
-        )
+        ).to_coco_captions(output_json=output_path)
     except Exception:
         temp_dir.cleanup()
         # Reraise.

--- a/lightly_studio/src/lightly_studio/export/image_dataset_export.py
+++ b/lightly_studio/src/lightly_studio/export/image_dataset_export.py
@@ -72,13 +72,13 @@ class ImageDatasetExport:
         """
         if output_json is None:
             output_json = DEFAULT_EXPORT_FILENAME
-        to_coco_object_detections(
+        export_input = LightlyStudioObjectDetectionInput(
             session=self.session,
             dataset_id=self._dataset_id,
             samples=self.samples,
-            output_json=Path(output_json),
             annotation_collection_id=annotation_collection_id,
         )
+        COCOObjectDetectionOutput(output_file=Path(output_json)).save(label_input=export_input)
 
     def to_yolo_object_detections(
         self,
@@ -96,13 +96,16 @@ class ImageDatasetExport:
             annotation_collection_id: If provided, only annotations from this collection
                 are exported. If None, all annotations are exported.
         """
-        to_yolo_object_detections(
+        export_input = LightlyStudioYOLOObjectDetectionInput(
             session=self.session,
             dataset_id=self._dataset_id,
             samples=self.samples,
-            output_folder=Path(output_folder),
             annotation_collection_id=annotation_collection_id,
         )
+        YOLOv8ObjectDetectionOutput(
+            output_file=Path(output_folder) / YOLO_DATASET_CONFIG_FILENAME,
+            output_split=YOLO_DEFAULT_SPLIT,
+        ).save(label_input=export_input)
 
     def to_coco_captions(self, output_json: PathLike | None = None) -> None:
         """Exports captions to a COCO format JSON file.
@@ -113,7 +116,9 @@ class ImageDatasetExport:
         """
         if output_json is None:
             output_json = DEFAULT_EXPORT_FILENAME
-        to_coco_captions(samples=self.samples, output_json=Path(output_json))
+        coco_captions_dict = coco_captions.to_coco_captions_dict(samples=self.samples)
+        with Path(output_json).open("w") as f:
+            json.dump(coco_captions_dict, f, indent=2)
 
     def to_coco_segmentation_masks(
         self,
@@ -130,13 +135,13 @@ class ImageDatasetExport:
         """
         if output_json is None:
             output_json = DEFAULT_EXPORT_FILENAME
-        to_coco_segmentation_masks(
+        export_input = LightlyStudioInstanceSegmentationInput(
             session=self.session,
             dataset_id=self._dataset_id,
             samples=self.samples,
-            output_json=Path(output_json),
             annotation_collection_id=annotation_collection_id,
         )
+        COCOInstanceSegmentationOutput(output_file=Path(output_json)).save(label_input=export_input)
 
     def to_pascalvoc_segmentation_mask(
         self,
@@ -154,155 +159,14 @@ class ImageDatasetExport:
             annotation_collection_id: If provided, only annotations from this collection
                 are exported. If None, all annotations are exported.
         """
-        to_pascalvoc_segmentation_mask(
+        export_input = LightlyStudioPascalVOCInstanceSegmentationInput(
             session=self.session,
             dataset_id=self._dataset_id,
             samples=self.samples,
-            output_folder=Path(output_folder),
             annotation_collection_id=annotation_collection_id,
         )
-
-
-def to_coco_object_detections(
-    session: Session,
-    dataset_id: UUID,
-    samples: Iterable[ImageSample],
-    output_json: Path,
-    annotation_collection_id: UUID | None,
-) -> None:
-    """Exports object detection annotations to a COCO format JSON file.
-
-    This function is for internal use. Use `Dataset.export().to_coco_object_detections()`
-    instead.
-
-    Args:
-        session: The database session.
-        dataset_id: The dataset ID for label retrieval.
-        samples: The samples to export.
-        output_json: The path to save the output JSON file.
-        annotation_collection_id: If provided, only annotations from this collection
-            are exported. If None, all annotations are exported.
-    """
-    export_input = LightlyStudioObjectDetectionInput(
-        session=session,
-        dataset_id=dataset_id,
-        samples=samples,
-        annotation_collection_id=annotation_collection_id,
-    )
-    COCOObjectDetectionOutput(output_file=output_json).save(label_input=export_input)
-
-
-def to_yolo_object_detections(
-    session: Session,
-    dataset_id: UUID,
-    samples: Iterable[ImageSample],
-    output_folder: Path,
-    annotation_collection_id: UUID | None,
-) -> None:
-    """Exports object detection annotations to YOLO (Ultralytics YOLOv8) format.
-
-    This function is for internal use. Use `Dataset.export().to_yolo_object_detections()`
-    instead.
-
-    Writes a ``data.yaml`` dataset config and a ``labels`` subfolder with one ``.txt``
-    file per image into ``output_folder``.
-
-    Args:
-        session: The database session.
-        dataset_id: The dataset ID for label retrieval.
-        samples: The samples to export.
-        output_folder: The folder where YOLO files are written.
-        annotation_collection_id: If provided, only annotations from this collection
-            are exported. If None, all annotations are exported.
-    """
-    export_input = LightlyStudioYOLOObjectDetectionInput(
-        session=session,
-        dataset_id=dataset_id,
-        samples=samples,
-        annotation_collection_id=annotation_collection_id,
-    )
-    YOLOv8ObjectDetectionOutput(
-        output_file=output_folder / YOLO_DATASET_CONFIG_FILENAME,
-        output_split=YOLO_DEFAULT_SPLIT,
-    ).save(label_input=export_input)
-
-
-def to_coco_segmentation_masks(
-    session: Session,
-    dataset_id: UUID,
-    samples: Iterable[ImageSample],
-    output_json: Path,
-    annotation_collection_id: UUID | None,
-) -> None:
-    """Exports segmentation mask annotations to a COCO format JSON file.
-
-    This function is for internal use. Use `Dataset.export().to_coco_segmentation_masks()`
-    instead.
-
-    Args:
-        session: The database session.
-        dataset_id: The dataset ID for label retrieval.
-        samples: The samples to export.
-        output_json: The path to save the output JSON file.
-        annotation_collection_id: If provided, only annotations from this collection
-            are exported. If None, all annotations are exported.
-    """
-    export_input = LightlyStudioInstanceSegmentationInput(
-        session=session,
-        dataset_id=dataset_id,
-        samples=samples,
-        annotation_collection_id=annotation_collection_id,
-    )
-    COCOInstanceSegmentationOutput(output_file=output_json).save(label_input=export_input)
-
-
-def to_pascalvoc_segmentation_mask(
-    session: Session,
-    dataset_id: UUID,
-    samples: Iterable[ImageSample],
-    output_folder: Path,
-    annotation_collection_id: UUID | None,
-) -> None:
-    """Exports segmentation mask annotations to a Pascal VOC segmentation folder.
-
-    This function is for internal use. Use
-    `Dataset.export().to_pascalvoc_segmentation_mask()` instead.
-
-    Args:
-        session: The database session.
-        dataset_id: The dataset ID for label retrieval.
-        samples: The samples to export.
-        output_folder: The folder where Pascal VOC segmentation files are written.
-        annotation_collection_id: If provided, only annotations from this collection
-            are exported. If None, all annotations are exported.
-    """
-    export_input = LightlyStudioPascalVOCInstanceSegmentationInput(
-        session=session,
-        dataset_id=dataset_id,
-        samples=samples,
-        annotation_collection_id=annotation_collection_id,
-    )
-
-    # Keep `background_class_id` unchanged: the label input defines category IDs and
-    # reserves class 0 for background.
-    PascalVOCSemanticSegmentationOutput(
-        output_folder=output_folder,
-    ).save(label_input=export_input)
-
-
-def to_coco_captions(
-    samples: Iterable[ImageSample],
-    output_json: Path,
-) -> None:
-    """Exports captions to a COCO format JSON file.
-
-    This function is for internal use. Use `Dataset.export().to_coco_captions()`
-    instead.
-
-    Args:
-        samples: The samples to export.
-        output_json: The path to save the output JSON file.
-    """
-    coco_captions_dict = coco_captions.to_coco_captions_dict(samples=samples)
-    with output_json.open("w") as f:
-        json.dump(coco_captions_dict, f, indent=2)
+        # Keep `background_class_id` unchanged: the label input defines category IDs and
+        # reserves class 0 for background.
+        PascalVOCSemanticSegmentationOutput(output_folder=Path(output_folder)).save(
+            label_input=export_input
+        )

--- a/lightly_studio/tests/export/test_image_dataset_export.py
+++ b/lightly_studio/tests/export/test_image_dataset_export.py
@@ -111,22 +111,13 @@ class TestImageDatasetExport:
     ) -> None:
         dataset = ImageDataset.create(name="test_dataset")
 
-        # Mock the actual export function to avoid creating a file
-        mock_to_coco_object_detections = mocker.patch.object(
-            image_dataset_export, "to_coco_object_detections"
-        )
+        # Patch the writer so no file is created and assert the default path is used.
+        mock_output = mocker.patch.object(image_dataset_export, "COCOObjectDetectionOutput")
 
-        # Don't provide the export path
+        # Don't provide the export path.
         dataset.export().to_coco_object_detections()
 
-        # Check that a default output path was used
-        mock_to_coco_object_detections.assert_called_once_with(
-            session=dataset.session,
-            dataset_id=dataset.dataset_id,
-            samples=mocker.ANY,
-            output_json=Path("coco_export.json"),
-            annotation_collection_id=None,
-        )
+        mock_output.assert_called_once_with(output_file=Path("coco_export.json"))
 
     def test_to_coco_captions(
         self,
@@ -180,18 +171,15 @@ class TestImageDatasetExport:
         mocker: MockerFixture,
         patch_collection: None,  # noqa: ARG002
     ) -> None:
-        mock_to_coco_captions = mocker.patch.object(image_dataset_export, "to_coco_captions")
-
         dataset = ImageDataset.create(name="test_dataset")
 
-        # Call the function under test
+        # Patch Path.open so no file is created and assert the default path is used.
+        mock_open = mocker.patch.object(Path, "open", autospec=True)
+
+        # Don't provide the export path.
         dataset.export().to_coco_captions()
 
-        # Check that a default output path was used
-        mock_to_coco_captions.assert_called_once_with(
-            samples=mocker.ANY,
-            output_json=Path("coco_export.json"),
-        )
+        assert mock_open.call_args.args[0] == Path("coco_export.json")
 
     def test_to_coco_segmentation_masks(
         self,
@@ -284,44 +272,6 @@ class TestImageDatasetExport:
             "annotations": [],
         }
 
-    def test_to_pascalvoc_segmentation_mask__via_class(
-        self,
-        tmp_path: Path,
-        patch_collection: None,  # noqa: ARG002
-    ) -> None:
-        dataset = ImageDataset.create(name="test_dataset")
-        create_images(
-            db_session=dataset.session,
-            collection_id=dataset.collection_id,
-            images=[ImageStub(path="image0.jpg", width=3, height=2)],
-        )
-
-        samples = list(dataset)
-        samples[0].add_annotation(
-            CreateSegmentationMask.from_rle_mask(
-                class_name="dog",
-                sample_2d=samples[0],
-                segmentation_mask=[1, 1, 4],
-            )
-        )
-
-        output_folder = tmp_path / "pascalvoc"
-        dataset.export().to_pascalvoc_segmentation_mask(
-            output_folder=output_folder,
-        )
-
-        class_map_path = output_folder / "class_id_to_name.json"
-        with class_map_path.open() as f:
-            class_map = json.load(f)
-        assert class_map == {"0": "background", "1": "dog"}
-
-        mask_path = output_folder / "SegmentationClass" / "image0.png"
-        with PILImage.open(mask_path) as mask:
-            mask_values = list(mask.getdata())
-        assert mask_values == [0, 1, 0, 0, 0, 0]
-
-    # TODO(Michal, 04/2026): The tests below test the module method, not the ImageDatasetExport
-    # class method. They should move outside of this tests class and not use patch_collection.
     def test_to_pascalvoc_segmentation_mask(
         self,
         tmp_path: Path,
@@ -344,13 +294,7 @@ class TestImageDatasetExport:
         )
 
         output_folder = tmp_path / "pascalvoc"
-        image_dataset_export.to_pascalvoc_segmentation_mask(
-            session=dataset.session,
-            dataset_id=dataset.dataset_id,
-            samples=dataset.query(),
-            output_folder=output_folder,
-            annotation_collection_id=None,
-        )
+        dataset.export().to_pascalvoc_segmentation_mask(output_folder=output_folder)
 
         class_map_path = output_folder / "class_id_to_name.json"
         with class_map_path.open() as f:
@@ -401,13 +345,7 @@ class TestImageDatasetExport:
         )
 
         output_folder = tmp_path / "pascalvoc"
-        image_dataset_export.to_pascalvoc_segmentation_mask(
-            session=dataset.session,
-            dataset_id=dataset.dataset_id,
-            samples=dataset.query(),
-            output_folder=output_folder,
-            annotation_collection_id=None,
-        )
+        dataset.export().to_pascalvoc_segmentation_mask(output_folder=output_folder)
 
         class_map_path = output_folder / "class_id_to_name.json"
         with class_map_path.open() as f:
@@ -450,13 +388,7 @@ class TestImageDatasetExport:
         )
 
         output_folder = tmp_path / "pascalvoc"
-        image_dataset_export.to_pascalvoc_segmentation_mask(
-            session=dataset.session,
-            dataset_id=dataset.dataset_id,
-            samples=dataset.query(),
-            output_folder=output_folder,
-            annotation_collection_id=None,
-        )
+        dataset.export().to_pascalvoc_segmentation_mask(output_folder=output_folder)
 
         class_map_path = output_folder / "class_id_to_name.json"
         with class_map_path.open() as f:
@@ -498,13 +430,7 @@ class TestImageDatasetExport:
         )
 
         output_folder = tmp_path / "pascalvoc"
-        image_dataset_export.to_pascalvoc_segmentation_mask(
-            session=dataset.session,
-            dataset_id=dataset.dataset_id,
-            samples=dataset.query(),
-            output_folder=output_folder,
-            annotation_collection_id=None,
-        )
+        dataset.export().to_pascalvoc_segmentation_mask(output_folder=output_folder)
 
         class_map_path = output_folder / "class_id_to_name.json"
         with class_map_path.open() as f:
@@ -550,13 +476,7 @@ class TestImageDatasetExport:
         )
 
         output_folder = tmp_path / "pascalvoc"
-        image_dataset_export.to_pascalvoc_segmentation_mask(
-            session=dataset.session,
-            dataset_id=dataset.dataset_id,
-            samples=dataset.query(),
-            output_folder=output_folder,
-            annotation_collection_id=None,
-        )
+        dataset.export().to_pascalvoc_segmentation_mask(output_folder=output_folder)
 
         class_map_path = output_folder / "class_id_to_name.json"
         with class_map_path.open() as f:
@@ -584,10 +504,11 @@ def test_to_coco_object_detections(
 
     # Test for task_obj_det_1
     output_json = tmp_path / "task_obj_det_1.json"
-    image_dataset_export.to_coco_object_detections(
+    image_dataset_export.ImageDatasetExport(
         session=db_session,
         dataset_id=dataset.dataset_id,
         samples=DatasetQuery(dataset=dataset, session=db_session),
+    ).to_coco_object_detections(
         output_json=output_json,
         annotation_collection_id=None,
     )
@@ -627,10 +548,11 @@ def test_to_coco_object_detections__no_annotations(
     create_images(db_session=db_session, collection_id=dataset.collection_id, images=images)
 
     output_json = tmp_path / "task_no_ann.json"
-    image_dataset_export.to_coco_object_detections(
+    image_dataset_export.ImageDatasetExport(
         session=db_session,
         dataset_id=dataset.dataset_id,
         samples=DatasetQuery(dataset=dataset, session=db_session),
+    ).to_coco_object_detections(
         output_json=output_json,
         annotation_collection_id=None,
     )
@@ -682,10 +604,11 @@ def test_to_yolo_object_detections(
     )
 
     output_folder = tmp_path / "yolo"
-    image_dataset_export.to_yolo_object_detections(
+    image_dataset_export.ImageDatasetExport(
         session=db_session,
         dataset_id=dataset.dataset_id,
         samples=DatasetQuery(dataset=dataset, session=db_session),
+    ).to_yolo_object_detections(
         output_folder=output_folder,
         annotation_collection_id=None,
     )
@@ -732,50 +655,14 @@ def test_to_yolo_object_detections__filters_by_annotation_collection(
     )
 
     output_folder = tmp_path / "yolo"
-    image_dataset_export.to_yolo_object_detections(
+    image_dataset_export.ImageDatasetExport(
         session=db_session,
         dataset_id=dataset.dataset_id,
         samples=DatasetQuery(dataset=dataset, session=db_session),
+    ).to_yolo_object_detections(
         output_folder=output_folder,
         annotation_collection_id=uuid.uuid4(),
     )
 
     # The annotation belongs to a different collection, so it is filtered out.
     assert (output_folder / "labels" / "image0.txt").read_text() == ""
-
-
-def test_to_coco_captions(
-    db_session: Session,
-    tmp_path: Path,
-) -> None:
-    dataset = create_collection(session=db_session)
-    image = create_images(
-        db_session=db_session,
-        collection_id=dataset.collection_id,
-        images=[ImageStub(path="/path/image0.jpg", width=100, height=100)],
-    )[0]
-    create_caption(
-        session=db_session,
-        collection_id=dataset.collection_id,
-        parent_sample_id=image.sample_id,
-        text="caption one",
-    )
-
-    # Call the function under test
-    output_json = tmp_path / "coco_annotations.json"
-    image_dataset_export.to_coco_captions(
-        samples=DatasetQuery(dataset=dataset, session=db_session),
-        output_json=output_json,
-    )
-
-    # Load the generated JSON and verify its content
-    with open(output_json) as f:
-        coco_data = json.load(f)
-    assert coco_data == {
-        "images": [
-            {"id": 0, "file_name": "/path/image0.jpg", "width": 100, "height": 100},
-        ],
-        "annotations": [
-            {"id": 0, "image_id": 0, "caption": "caption one"},
-        ],
-    }


### PR DESCRIPTION
## What has changed and why

Remove the duplicate `to_*` export functions. Also remove the duplicate tests.

Context: Refactoring PR 1 of multiple to make adding video frame export easier.

## How tested

unittests