### PR TITLE
Delete Annotation embedding when deleting a annotation

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotation.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotation.py
@@ -81,14 +81,12 @@ def delete_annotation(
                 col(SampleTagLinkTable.sample_id) == annotation_sample_id
             )
         )
-        # Explicitly delete embeddings before the sample. The sample_id column is part of
-        # SampleEmbeddingTable's primary key, so the ORM cannot null it out via the default
-        # relationship cascade when the sample is deleted.
-        # session.exec(
-        #     delete(SampleEmbeddingTable).where(
-        #         col(SampleEmbeddingTable.sample_id) == annotation_sample_id
-        #     )
-        # )
+        # Explicitly delete embeddings before the sample.
+        session.exec(
+            delete(SampleEmbeddingTable).where(
+                col(SampleEmbeddingTable.sample_id) == annotation_sample_id
+            )
+        )
         session.commit()
 
         annotation_sample = session.get(SampleTable, annotation_sample_id)

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotation.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotation.py
@@ -17,6 +17,7 @@ from lightly_studio.models.annotation.segmentation import (
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricTable
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import annotation_resolver
 from lightly_studio.utils import batching
 
@@ -80,6 +81,14 @@ def delete_annotation(
                 col(SampleTagLinkTable.sample_id) == annotation_sample_id
             )
         )
+        # Explicitly delete embeddings before the sample. The sample_id column is part of
+        # SampleEmbeddingTable's primary key, so the ORM cannot null it out via the default
+        # relationship cascade when the sample is deleted.
+        # session.exec(
+        #     delete(SampleEmbeddingTable).where(
+        #         col(SampleEmbeddingTable.sample_id) == annotation_sample_id
+        #     )
+        # )
         session.commit()
 
         annotation_sample = session.get(SampleTable, annotation_sample_id)

--- a/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
+++ b/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
@@ -4,6 +4,7 @@ import pytest
 from sqlmodel import Session, col, select
 
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import (
     annotation_resolver,
     evaluation_annotation_metric_resolver,
@@ -14,7 +15,9 @@ from tests.helpers_resolvers import (
     create_annotation,
     create_annotation_label,
     create_collection,
+    create_embedding_model,
     create_image,
+    create_sample_embedding,
     create_tag,
 )
 from tests.resolvers.evaluation_sample_metric_resolver import (
@@ -92,6 +95,40 @@ def test_delete_annotation__deletes_sample_tag_links(
         select(SampleTagLinkTable).where(col(SampleTagLinkTable.sample_id) == annotation.sample_id)
     ).all()
     assert not links_after
+    assert db_session.get(SampleTable, annotation.sample_id) is None
+
+
+def test_delete_annotation__deletes_sample_embeddings(
+    db_session: Session,
+    annotations_test_data: AnnotationsTestData,
+) -> None:
+    """Test deleting an annotation whose sample has an embedding.
+
+    Regression test: the sample_id column is part of SampleEmbeddingTable's primary key,
+    so deleting the sample previously failed when the ORM tried to null it out.
+    """
+    annotation = annotations_test_data.annotations[0]
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=annotation.sample.collection_id,
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=annotation.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[0.1] * embedding_model.embedding_dimension,
+    )
+
+    annotation_resolver.delete_annotation(db_session, annotation.sample_id)
+
+    # Verify both annotation and its embedding were deleted.
+    assert annotation_resolver.get_by_id(db_session, annotation.sample_id) is None
+    embeddings_after = db_session.exec(
+        select(SampleEmbeddingTable).where(
+            col(SampleEmbeddingTable.sample_id) == annotation.sample_id
+        )
+    ).all()
+    assert not embeddings_after
     assert db_session.get(SampleTable, annotation.sample_id) is None
 
 

--- a/lightly_studio_view/e2e/general/annotation-details.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/annotation-details.e2e-test.ts
@@ -219,13 +219,12 @@ test('user can delete annotation and navigate to next annotation', async ({
 }) => {
     await annotationsPage.startEditing();
 
-    // Open an annotation. Wait for navigation to settle before capturing the URL,
-    // otherwise we capture the grid URL and the later assertion passes trivially.
+    // Open an annotation.
     await annotationsPage.clickAnnotation(5);
     await annotationDetailsPage.waitForNavigation();
     const annotationUrlBeforeDelete = page.url();
 
-    // Delete the annotation, asserting the backend returned 200 (not just that the UI moved).
+    // Delete the annotation, asserting the backend returned 200.
     await annotationDetailsPage.deleteCurrentAnnotation();
 
     await annotationDetailsPage.waitForNavigation();

--- a/lightly_studio_view/e2e/general/annotation-details.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/annotation-details.e2e-test.ts
@@ -219,15 +219,15 @@ test('user can delete annotation and navigate to next annotation', async ({
 }) => {
     await annotationsPage.startEditing();
 
-    // Open an annotation
+    // Open an annotation. Wait for navigation to settle before capturing the URL,
+    // otherwise we capture the grid URL and the later assertion passes trivially.
     await annotationsPage.clickAnnotation(5);
+    await annotationDetailsPage.waitForNavigation();
     const annotationUrlBeforeDelete = page.url();
 
-    // Click "Delete annotation" button to open confirmation
-    await annotationDetailsPage.getAnnotationDeleteButton().click();
+    // Delete the annotation, asserting the backend returned 200 (not just that the UI moved).
+    await annotationDetailsPage.deleteCurrentAnnotation();
 
-    // Confirm deletion in popup
-    await annotationDetailsPage.getAnnotationConfirmDeleteButton().click();
     await annotationDetailsPage.waitForNavigation();
     await expect(page).not.toHaveURL(annotationUrlBeforeDelete);
 

--- a/lightly_studio_view/e2e/general/annotation-details.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/annotation-details.e2e-test.ts
@@ -227,8 +227,8 @@ test('user can delete annotation and navigate to next annotation', async ({
     // Delete the annotation, asserting the backend returned 200.
     await annotationDetailsPage.deleteCurrentAnnotation();
 
-    await annotationDetailsPage.waitForNavigation();
     await expect(page).not.toHaveURL(annotationUrlBeforeDelete);
+    await annotationDetailsPage.waitForNavigation();
 
     await annotationDetailsPage.clickEditLabelButton();
 

--- a/lightly_studio_view/e2e/pages/annotation-details-page.ts
+++ b/lightly_studio_view/e2e/pages/annotation-details-page.ts
@@ -55,8 +55,7 @@ export class AnnotationDetailsPage {
         await this.getAnnotationDeleteButton().click();
 
         // Assert the backend actually deleted the annotation. A failed delete
-        // returns a non-200 status, so requiring 200 here makes the test fail
-        // instead of silently passing when only the UI navigates.
+        // returns a non-200 status.
         const responsePromise = this.page.waitForResponse(
             (response) =>
                 response.request().method() === 'DELETE' &&

--- a/lightly_studio_view/e2e/pages/annotation-details-page.ts
+++ b/lightly_studio_view/e2e/pages/annotation-details-page.ts
@@ -50,6 +50,25 @@ export class AnnotationDetailsPage {
         return this.page.getByTestId('confirm-delete-annotation');
     }
 
+    async deleteCurrentAnnotation() {
+        // Open the confirmation popover.
+        await this.getAnnotationDeleteButton().click();
+
+        // Assert the backend actually deleted the annotation. A failed delete
+        // returns a non-200 status, so requiring 200 here makes the test fail
+        // instead of silently passing when only the UI navigates.
+        const responsePromise = this.page.waitForResponse(
+            (response) =>
+                response.request().method() === 'DELETE' &&
+                response.url().includes('/annotations/') &&
+                response.status() === 200
+        );
+
+        await this.getAnnotationConfirmDeleteButton().click();
+
+        await responsePromise;
+    }
+
     getAnnotationHeight() {
         return this.page.getByTestId('annotation-metadata-height');
     }


### PR DESCRIPTION
## What has changed and why?

Delete sample embeddings before deleting the annotation sample to prevent duckdb AssertionError

## How has it been tested?

New unit test and fixed existing e2e test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved annotation deletion to also remove associated stored embedding data and the related sample record, ensuring full cleanup.

* **Testing**
  * Added a unit test covering embedding deletion when an annotation is removed.
  * Updated the end-to-end annotation deletion flow to use a dedicated delete helper, wait for navigation, and verify the backend deletion succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->