### PR TITLE
Introduce FalsePositiveMetricStub

### DIFF
--- a/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_query.py
@@ -43,7 +43,7 @@ def test_annotation_metric_query__filters_matching_samples(db_session: Session) 
         annotation_metrics=[
             AnnotationMetricStub(sample_id=image_a.sample_id, metric_name="score", value=0.95),
         ],
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image_a.sample_id,
                 metrics={"score": 0.2},
@@ -99,7 +99,7 @@ def test_annotation_metric_query__scopes_run_name_to_dataset(db_session: Session
     create_annotation_metrics(
         session=db_session,
         run_id=run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image_a.sample_id,
                 metrics={"score": 0.9},
@@ -115,7 +115,7 @@ def test_annotation_metric_query__scopes_run_name_to_dataset(db_session: Session
     create_annotation_metrics(
         session=db_session,
         run_id=other_run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=other_image.sample_id,
                 metrics={"score": 0.0},
@@ -150,7 +150,7 @@ def test_annotation_metric_query__matches_multiple_metrics(db_session: Session) 
     create_annotation_metrics(
         session=db_session,
         run_id=run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image_a.sample_id,
                 gt_annotation_label_id=cat_label.annotation_label_id,
@@ -192,7 +192,7 @@ def test_annotation_metric_query__does_not_mix_criteria_across_annotation_pairs(
     create_annotation_metrics(
         session=db_session,
         run_id=run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
                 gt_annotation_label_id=cat_label.annotation_label_id,
@@ -240,7 +240,7 @@ def test_annotation_metric_query__matches_run_without_criteria(
     create_annotation_metrics(
         session=db_session,
         run_id=run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image_a.sample_id,
                 metrics={"score": 0.2},
@@ -279,7 +279,7 @@ def test_annotation_metric_query__matches_off_diagonal_confusion_cell(
     create_annotation_metrics(
         session=db_session,
         run_id=run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
                 metrics={"score": 0.8},

--- a/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
+++ b/lightly_studio/tests/resolvers/annotations/test_delete_annotation.py
@@ -208,7 +208,7 @@ def test_delete_annotation__preserves_other_run_sample_metrics(
     create_annotation_metrics(
         session=db_session,
         run_id=other_run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
                 metrics={"iou": 0.75},

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -783,7 +783,7 @@ def test_deep_copy__with_evaluation_annotation_metrics(db_session: Session) -> N
     create_annotation_metrics(
         session=db_session,
         run_id=run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
                 metrics={"iou": 0.8},

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -232,7 +232,7 @@ def _build_full_dataset(session: Session, name: str) -> UUID:
     create_annotation_metrics(
         session=session,
         run_id=run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=eval_image.sample_id,
                 metrics={"iou": 0.8},

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -356,7 +356,7 @@ def test_delete_dataset__with_evaluation_annotation_metrics(db_session: Session)
     create_annotation_metrics(
         session=db_session,
         run_id=run_id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
                 metrics={"iou": 0.8},

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_get.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_evaluation_annotation_metric_get.py
@@ -44,7 +44,7 @@ def test_get_all_by_evaluation_run_id(db_session: Session) -> None:
     [tp_stub] = create_annotation_metrics(
         session=db_session,
         run_id=run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
                 metrics={"iou": 0.75},

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
@@ -282,7 +282,7 @@ def test_get_confusion_matrix__no_fp_or_fn_keeps_synthetic_axes(
     create_annotation_metrics(
         session=db_session,
         run_id=run.id,
-        true_positive_metric_stubs=[
+        pair_metric_stubs=[
             TruePositiveMetricStub(
                 sample_id=image.sample_id,
                 metrics={"iou": 0.9},

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
@@ -23,6 +23,7 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
 )
 from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
+    FalsePositiveMetricStub,
     TruePositiveMetricStub,
     create_annotation_metrics,
 )
@@ -301,6 +302,44 @@ def test_get_confusion_matrix__no_fp_or_fn_keeps_synthetic_axes(
     assert matrix.counts == [
         [1, 0],
         [0, 0],
+    ]
+
+
+def test_get_confusion_matrix__counts_metricless_false_positive_stub(
+    db_session: Session,
+) -> None:
+    dataset = create_collection(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(
+        session=db_session,
+        collection_id=dataset.collection_id,
+    )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
+    label_a = create_annotation_label(
+        session=db_session,
+        root_collection_id=dataset.collection_id,
+        label_name="class_a",
+    )
+    create_annotation_metrics(
+        session=db_session,
+        run_id=run.id,
+        pair_metric_stubs=[
+            FalsePositiveMetricStub(
+                sample_id=image.sample_id,
+                pred_annotation_label_id=label_a.annotation_label_id,
+            )
+        ],
+    )
+
+    matrix = evaluation_annotation_metric_resolver.get_confusion_matrix(
+        session=db_session,
+        evaluation_run_id=run.id,
+    )
+
+    assert matrix.row_labels == ["class_a", NO_GROUND_TRUTH_ROW_LABEL]
+    assert matrix.col_labels == ["class_a", NO_PREDICTION_COL_LABEL]
+    assert matrix.counts == [
+        [0, 0],
+        [1, 0],
     ]
 
 

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -27,8 +28,8 @@ class AnnotationMetricStub:
     """Helper class to represent an annotation-level evaluation metric."""
 
     sample_id: UUID
-    metric_name: str
-    value: float
+    metric_name: str | None = None
+    value: float | None = None
     pred_annotation_id: UUID | None = None
     gt_annotation_id: UUID | None = None
 
@@ -104,11 +105,11 @@ class FalsePositiveMetricStub:
     """
 
     sample_id: UUID
-    metrics: dict[str, float]
     pred_annotation_label_id: UUID
+    metrics: dict[str, float] | None = None
 
-    def metric_items(self) -> list[tuple[str, float]]:
-        return list(self.metrics.items())
+    def metric_items(self) -> Iterable[tuple[str, float]]:
+        return (self.metrics or {}).items()
 
     def to_annotation_metric_stub(
         self, session: Session, run: EvaluationRunTable
@@ -132,6 +133,15 @@ class FalsePositiveMetricStub:
             annotation_label_id=self.pred_annotation_label_id,
             annotation_collection_name=pred_collection.name,
         )
+        metrics = self.metric_items()
+        if not metrics:
+            return [
+                AnnotationMetricStub(
+                    sample_id=self.sample_id,
+                    pred_annotation_id=pred_annotation.sample_id,
+                    gt_annotation_id=None,
+                )
+            ]
         return [
             AnnotationMetricStub(
                 sample_id=self.sample_id,

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
@@ -96,6 +96,55 @@ class TruePositiveMetricStub:
 
 
 @dataclass
+class FalsePositiveMetricStub:
+    """Helper class to create a false-positive annotation metric.
+
+    Creates a prediction annotation in the evaluation run's prediction collection,
+    then stores metric rows that link the prediction with no ground truth.
+    """
+
+    sample_id: UUID
+    metrics: dict[str, float]
+    pred_annotation_label_id: UUID
+
+    def metric_items(self) -> list[tuple[str, float]]:
+        return list(self.metrics.items())
+
+    def to_annotation_metric_stub(
+        self, session: Session, run: EvaluationRunTable
+    ) -> list[AnnotationMetricStub]:
+        pred_collection = collection_resolver.get_by_id(
+            session=session, collection_id=run.pred_annotation_collection_id
+        )
+        if pred_collection is None:
+            raise ValueError(
+                f"Evaluation run {run.id} references missing prediction annotation collection"
+            )
+        if pred_collection.parent_collection_id is None:
+            raise ValueError(
+                f"Evaluation run {run.id} prediction annotation collection must have a parent"
+            )
+
+        pred_annotation = create_annotation(
+            session=session,
+            collection_id=pred_collection.parent_collection_id,
+            sample_id=self.sample_id,
+            annotation_label_id=self.pred_annotation_label_id,
+            annotation_collection_name=pred_collection.name,
+        )
+        return [
+            AnnotationMetricStub(
+                sample_id=self.sample_id,
+                metric_name=metric_name,
+                value=value,
+                pred_annotation_id=pred_annotation.sample_id,
+                gt_annotation_id=None,
+            )
+            for metric_name, value in self.metric_items()
+        ]
+
+
+@dataclass
 class SampleMetricStub:
     """Helper class to represent a sample-level evaluation metric."""
 
@@ -167,15 +216,15 @@ def create_annotation_metrics(
     session: Session,
     run_id: UUID,
     annotation_metrics: list[AnnotationMetricStub] | None = None,
-    true_positive_metric_stubs: list[TruePositiveMetricStub] | None = None,
+    pair_metric_stubs: list[TruePositiveMetricStub | FalsePositiveMetricStub] | None = None,
 ) -> list[AnnotationMetricStub]:
     annotation_metrics_to_create = list(annotation_metrics) if annotation_metrics else []
-    true_positive_metric_stubs = true_positive_metric_stubs or []
+    pair_metric_stubs = pair_metric_stubs or []
     run = evaluation_run_resolver.get_by_id(session=session, evaluation_id=run_id)
     if run is None:
         raise ValueError(f"Evaluation run {run_id} doesn't exist")
 
-    for stub in true_positive_metric_stubs:
+    for stub in pair_metric_stubs:
         annotation_metrics_to_create.extend(
             stub.to_annotation_metric_stub(session=session, run=run)
         )


### PR DESCRIPTION
## What has changed and why?
It's unused but it will be used in the followup PR.

## How has it been tested?
In a followup PR, I'll post a link in a comment.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of evaluation annotation metrics across query and resolver flows, ensuring correct FP/FN behavior for confusion matrices.
  * Added support for false-positive annotation metric stubs so confusion matrices include the FP/FN axes with stable row/column layout.

* **Tests**
  * Updated annotation-metric test setups to use the pair-based metric stub interface.
  * Extended resolver and confusion-matrix test coverage to include false-positive metric scenarios.
  * Kept dataset copy, delete, and deep-copy round-trip coverage consistent when evaluation annotation metrics are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->