### PR TITLE
Preserve user-entered percentage

### DIFF
--- a/lightly_studio_view/src/lib/components/Sampling/SampleCountInput/SampleCountInput.svelte
+++ b/lightly_studio_view/src/lib/components/Sampling/SampleCountInput/SampleCountInput.svelte
@@ -2,8 +2,8 @@
     import { Input } from '$lib/components/ui/input';
 
     interface Props {
-        count: number;
-        percentage: number;
+        count: number | null;
+        percentage: number | null;
         onCountChange: (value: number) => void;
         onPercentageChange: (value: number) => void;
     }
@@ -15,7 +15,7 @@
     <Input
         id="n-samples"
         type="number"
-        value={count}
+        value={count ?? ''}
         oninput={(e) => onCountChange((e.target as HTMLInputElement).valueAsNumber)}
         min="1"
         placeholder="Enter the number of samples"
@@ -28,7 +28,7 @@
             id="n-samples-percentage"
             type="number"
             aria-label="Percentage of filtered samples"
-            value={percentage}
+            value={percentage ?? ''}
             oninput={(e) => onPercentageChange((e.target as HTMLInputElement).valueAsNumber)}
             min="0"
             step="any"

--- a/lightly_studio_view/src/lib/components/Sampling/useSamplingCombinationDialog/useSamplingCombinationDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/useSamplingCombinationDialog/useSamplingCombinationDialog.test.ts
@@ -94,6 +94,15 @@ describe('useSamplingCombinationDialog', () => {
     });
 
     describe('notEnoughSamples', () => {
+        it('is false when nSamplesToSelect is null', () => {
+            filteredSampleCount.set(5);
+            const { notEnoughSamples, nSamplesToSelect } =
+                useSamplingCombinationDialog(defaultParams);
+            nSamplesToSelect.set(null);
+
+            expect(get(notEnoughSamples)).toBe(false);
+        });
+
         it('is true when nSamplesToSelect exceeds a positive filteredSampleCount', () => {
             filteredSampleCount.set(5);
             const { notEnoughSamples, nSamplesToSelect } =
@@ -187,6 +196,19 @@ describe('useSamplingCombinationDialog', () => {
             expect(get(isFormValid)).toBe(false);
         });
 
+        it('is false when nSamplesToSelect is null', () => {
+            instances.set([
+                { id: 'a', type: 'diversity', params: { strength: 1 }, isExpanded: true }
+            ]);
+
+            const { isFormValid, nSamplesToSelect, selectionResultTagName } =
+                useSamplingCombinationDialog(defaultParams);
+            nSamplesToSelect.set(null);
+            selectionResultTagName.set('my-tag');
+
+            expect(get(isFormValid)).toBe(false);
+        });
+
         it('is false when selectionResultTagName is blank', () => {
             instances.set([
                 { id: 'a', type: 'diversity', params: { strength: 1 }, isExpanded: true }
@@ -238,6 +260,18 @@ describe('useSamplingCombinationDialog', () => {
             expect(get(createButtonTooltip)).toBe(
                 'Complete the required fields in all strategies.'
             );
+        });
+
+        it('returns message about sample count when nSamplesToSelect is null', () => {
+            instances.set([
+                { id: 'a', type: 'diversity', params: { strength: 1 }, isExpanded: true }
+            ]);
+            const { createButtonTooltip, nSamplesToSelect, selectionResultTagName } =
+                useSamplingCombinationDialog(defaultParams);
+            nSamplesToSelect.set(null);
+            selectionResultTagName.set('my-tag');
+
+            expect(get(createButtonTooltip)).toBe('Enter a number of samples greater than 0.');
         });
 
         it('returns message about sample count when nSamplesToSelect is 0', () => {
@@ -400,6 +434,17 @@ describe('useSamplingCombinationDialog', () => {
 
             expect(get(percentageToSelect)).toBe(0);
         });
+
+        it('sets nSamplesToSelect and percentageToSelect to null when input is cleared', () => {
+            filteredSampleCount.set(1000);
+            const { updateAbsolute, nSamplesToSelect, percentageToSelect } =
+                useSamplingCombinationDialog(defaultParams);
+
+            updateAbsolute(NaN);
+
+            expect(get(nSamplesToSelect)).toBeNull();
+            expect(get(percentageToSelect)).toBeNull();
+        });
     });
 
     describe('updatePercentage', () => {
@@ -443,6 +488,29 @@ describe('useSamplingCombinationDialog', () => {
 
             expect(get(percentageToSelect)).toBe(150);
             expect(get(nSamplesToSelect)).toBe(150);
+        });
+
+        it('sets nSamplesToSelect and percentageToSelect to null when input is cleared', () => {
+            filteredSampleCount.set(1000);
+            const { updatePercentage, nSamplesToSelect, percentageToSelect } =
+                useSamplingCombinationDialog(defaultParams);
+
+            updatePercentage(NaN);
+
+            expect(get(nSamplesToSelect)).toBeNull();
+            expect(get(percentageToSelect)).toBeNull();
+        });
+
+        it('preserves the user-entered percentage when filteredSampleCount changes after entry', () => {
+            filteredSampleCount.set(121);
+            const { updatePercentage, nSamplesToSelect, percentageToSelect } =
+                useSamplingCombinationDialog(defaultParams);
+
+            updatePercentage(100);
+            filteredSampleCount.set(116);
+
+            expect(get(percentageToSelect)).toBe(100);
+            expect(get(nSamplesToSelect)).toBe(121);
         });
     });
 

--- a/lightly_studio_view/src/lib/components/Sampling/useSamplingCombinationDialog/useSamplingCombinationDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/useSamplingCombinationDialog/useSamplingCombinationDialog.test.ts
@@ -445,6 +445,15 @@ describe('useSamplingCombinationDialog', () => {
             expect(get(nSamplesToSelect)).toBeNull();
             expect(get(percentageToSelect)).toBeNull();
         });
+
+        it('updates percentageToSelect reactively when filteredSampleCount changes and user has not entered a percentage', () => {
+            filteredSampleCount.set(0);
+            const { percentageToSelect } = useSamplingCombinationDialog(defaultParams);
+
+            filteredSampleCount.set(100);
+
+            expect(get(percentageToSelect)).toBe(10); // default nSamplesToSelect=10, 10/100*100=10
+        });
     });
 
     describe('updatePercentage', () => {

--- a/lightly_studio_view/src/lib/components/Sampling/useSamplingCombinationDialog/useSamplingCombinationDialog.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/useSamplingCombinationDialog/useSamplingCombinationDialog.ts
@@ -13,6 +13,10 @@ interface UseSamplingCombinationDialogParams {
     onSubmitSuccess: () => void;
 }
 
+function computePercentage(count: number, total: number): number {
+    return total > 0 ? Math.round((count / total) * 100) : 0;
+}
+
 export function useSamplingCombinationDialog({
     getCollectionId,
     getIsVideoCollection,
@@ -35,27 +39,43 @@ export function useSamplingCombinationDialog({
         closeSelectionDialog: closeSamplingDialog
     });
 
-    const nSamplesToSelect = writable<number>(10);
-    const percentageToSelect = derived([nSamplesToSelect, filteredSampleCount], ([$n, $total]) =>
-        $total > 0 ? Math.round(($n / $total) * 100) : 0
+    const nSamplesToSelect = writable<number | null>(10);
+    // Writable rather than derived so the user-entered percentage value is preserved
+    // when filteredSampleCount changes in the background (e.g. from a grid refetch).
+    const percentageToSelect = writable<number | null>(
+        computePercentage(10, get(filteredSampleCount))
     );
     const selectionResultTagName = writable('');
 
     function updateAbsolute(count: number) {
-        nSamplesToSelect.set(Number.isFinite(count) ? count : 0);
+        if (!Number.isFinite(count)) {
+            nSamplesToSelect.set(null);
+            percentageToSelect.set(null);
+            return;
+        }
+        nSamplesToSelect.set(count);
+        percentageToSelect.set(computePercentage(count, get(filteredSampleCount)));
     }
 
     function updatePercentage(percentage: number) {
+        if (!Number.isFinite(percentage)) {
+            nSamplesToSelect.set(null);
+            percentageToSelect.set(null);
+            return;
+        }
         const total = get(filteredSampleCount);
         const result = total > 0 ? Math.round((percentage / 100) * total) : 0;
-        nSamplesToSelect.set(Number.isFinite(result) ? result : 0);
+        nSamplesToSelect.set(result);
+        // Preserve the exact value the user typed instead of re-deriving it from the
+        // rounded count.
+        percentageToSelect.set(percentage);
     }
 
     const noSamples = derived(filteredSampleCount, ($count) => $count === 0);
 
     const notEnoughSamples = derived(
         [filteredSampleCount, nSamplesToSelect],
-        ([$count, $n]) => $count > 0 && $n > $count
+        ([$count, $n]) => $count > 0 && $n !== null && $n > $count
     );
 
     const sampleCountLabel = derived(
@@ -68,6 +88,7 @@ export function useSamplingCombinationDialog({
         ([$instances, $n, $name]) =>
             $instances.length > 0 &&
             $instances.every(isStrategyInstanceValid) &&
+            $n !== null &&
             $n > 0 &&
             $name.trim().length > 0
     );
@@ -78,7 +99,7 @@ export function useSamplingCombinationDialog({
             if ($instances.length === 0) return 'Add at least 1 strategy to create a selection.';
             if (!$instances.every(isStrategyInstanceValid))
                 return 'Complete the required fields in all strategies.';
-            if ($n <= 0) return 'Enter a number of samples greater than 0.';
+            if ($n === null || $n <= 0) return 'Enter a number of samples greater than 0.';
             if ($name.trim().length === 0) return 'Enter a tag name.';
             return '';
         }
@@ -87,6 +108,7 @@ export function useSamplingCombinationDialog({
     function resetForm() {
         onSubmitSuccess();
         nSamplesToSelect.set(10);
+        percentageToSelect.set(computePercentage(10, get(filteredSampleCount)));
         selectionResultTagName.set('');
     }
 
@@ -95,7 +117,7 @@ export function useSamplingCombinationDialog({
             collectionId: getCollectionId(),
             isVideoCollection: getIsVideoCollection(),
             instances: get(instances),
-            nSamplesToSelect: get(nSamplesToSelect),
+            nSamplesToSelect: get(nSamplesToSelect) ?? 0,
             selectionResultTagName: get(selectionResultTagName),
             selectionFilter: buildSelectionFilter()
         });

--- a/lightly_studio_view/src/lib/components/Sampling/useSamplingCombinationDialog/useSamplingCombinationDialog.ts
+++ b/lightly_studio_view/src/lib/components/Sampling/useSamplingCombinationDialog/useSamplingCombinationDialog.ts
@@ -40,35 +40,45 @@ export function useSamplingCombinationDialog({
     });
 
     const nSamplesToSelect = writable<number | null>(10);
-    // Writable rather than derived so the user-entered percentage value is preserved
-    // when filteredSampleCount changes in the background (e.g. from a grid refetch).
-    const percentageToSelect = writable<number | null>(
-        computePercentage(10, get(filteredSampleCount))
+    // Null means the user hasn't explicitly typed a percentage; percentageToSelect
+    // then derives reactively from nSamplesToSelect and filteredSampleCount so that
+    // the display stays correct when filteredSampleCount loads after mount.
+    // A non-null value locks the display to what the user typed, preventing
+    // background filteredSampleCount updates (e.g. grid refetches) from overwriting it.
+    const userEnteredPercentage = writable<number | null>(null);
+
+    const percentageToSelect = derived(
+        [nSamplesToSelect, filteredSampleCount, userEnteredPercentage],
+        ([$n, $total, $userPct]) => {
+            if ($userPct !== null) return $userPct;
+            if ($n === null) return null;
+            return computePercentage($n, $total);
+        }
     );
     const selectionResultTagName = writable('');
 
     function updateAbsolute(count: number) {
         if (!Number.isFinite(count)) {
             nSamplesToSelect.set(null);
-            percentageToSelect.set(null);
+            userEnteredPercentage.set(null);
             return;
         }
         nSamplesToSelect.set(count);
-        percentageToSelect.set(computePercentage(count, get(filteredSampleCount)));
+        userEnteredPercentage.set(null); // let percentage re-derive from count
     }
 
     function updatePercentage(percentage: number) {
         if (!Number.isFinite(percentage)) {
             nSamplesToSelect.set(null);
-            percentageToSelect.set(null);
+            userEnteredPercentage.set(null);
             return;
         }
         const total = get(filteredSampleCount);
         const result = total > 0 ? Math.round((percentage / 100) * total) : 0;
         nSamplesToSelect.set(result);
-        // Preserve the exact value the user typed instead of re-deriving it from the
-        // rounded count.
-        percentageToSelect.set(percentage);
+        // Lock the display to what the user typed so that background
+        // filteredSampleCount changes don't overwrite their entry.
+        userEnteredPercentage.set(percentage);
     }
 
     const noSamples = derived(filteredSampleCount, ($count) => $count === 0);
@@ -108,7 +118,7 @@ export function useSamplingCombinationDialog({
     function resetForm() {
         onSubmitSuccess();
         nSamplesToSelect.set(10);
-        percentageToSelect.set(computePercentage(10, get(filteredSampleCount)));
+        userEnteredPercentage.set(null); // let percentage re-derive from count
         selectionResultTagName.set('');
     }
 


### PR DESCRIPTION
## What has changed and why?

Change `percentageToSelect` from `derived` to `writable`. Its value is now set explicitly only when the user changes an input.

Additionally, clearing either input now leaves it empty instead of resetting to 0.

## How has it been tested?

Unit test + Manual test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty sample-count and percentage fields now clear correctly (no invalid numeric display).
  * Validation now treats cleared inputs as invalid, updating the create-button tooltip accordingly.
  * User-entered percentage is preserved during background sample-count changes.
  * Form reset and submit now align with what’s shown in the inputs, including proper handling of cleared/empty values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->