### PR TITLE
Invalidate evaluation metrics on annotation bbox/mask update

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotation.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/delete_annotation.py
@@ -15,6 +15,7 @@ from lightly_studio.models.annotation.segmentation import (
     SegmentationAnnotationTable,
 )
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
+from lightly_studio.models.evaluation_run import EvaluationRunTable
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricTable
 from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
 from lightly_studio.resolvers import annotation_resolver
@@ -93,7 +94,12 @@ def delete_evaluation_metrics(
     annotation_ids: list[UUID],
     parent_sample_ids: list[UUID],
 ) -> None:
-    """Delete evaluation data invalidated by annotation deletion or mutation."""
+    """Delete evaluation data invalidated by annotation deletion or mutation.
+
+    Invalidates both per-annotation metrics (matched by annotation id) and per-sample metrics
+    of any run whose annotation collections hold the changed annotations. The latter covers
+    sample-only runs such as semantic segmentation, which store no per-annotation rows.
+    """
     if not annotation_ids and not parent_sample_ids:
         return
 
@@ -109,6 +115,36 @@ def delete_evaluation_metrics(
                         ),
                         col(EvaluationAnnotationMetricTable.gt_annotation_id).in_(
                             annotation_id_batch
+                        ),
+                    )
+                )
+                .distinct()
+            ).all()
+        )
+
+    # Runs that store only per-sample metrics (e.g. semantic segmentation `miou`) have no
+    # annotation-metric rows to match on, so also find runs whose ground-truth or prediction
+    # collection holds the changed annotations.
+    annotation_collection_ids: set[UUID] = set()
+    for annotation_id_batch in batching.batched(items=annotation_ids):
+        annotation_collection_ids.update(
+            session.exec(
+                select(SampleTable.collection_id)
+                .where(col(SampleTable.sample_id).in_(annotation_id_batch))
+                .distinct()
+            ).all()
+        )
+    for collection_id_batch in batching.batched(items=annotation_collection_ids):
+        affected_evaluation_run_ids.update(
+            session.exec(
+                select(EvaluationRunTable.id)
+                .where(
+                    sqlalchemy.or_(
+                        col(EvaluationRunTable.gt_annotation_collection_id).in_(
+                            collection_id_batch
+                        ),
+                        col(EvaluationRunTable.pred_annotation_collection_id).in_(
+                            collection_id_batch
                         ),
                     )
                 )

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_bounding_box.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_bounding_box.py
@@ -9,6 +9,9 @@ from sqlmodel import Session
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.resolvers.annotation_resolver.delete_annotation import (
+    delete_evaluation_metrics,
+)
 
 
 @dataclass
@@ -44,6 +47,13 @@ def update_bounding_box(
         raise ValueError(f"Annotation with ID {annotation_id} not found.")
 
     try:
+        # TODO(Malte, 07/2026): Replace eager deletion with explicit evaluation invalidation
+        # once evaluation results can be recomputed or marked stale independently from updates.
+        delete_evaluation_metrics(
+            session=session,
+            annotation_ids=[annotation.sample_id],
+            parent_sample_ids=[annotation.parent_sample_id],
+        )
         if annotation.object_detection_details:
             annotation.object_detection_details.x = coordinates.x
             annotation.object_detection_details.y = coordinates.y

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_bounding_box.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_bounding_box.py
@@ -47,8 +47,6 @@ def update_bounding_box(
         raise ValueError(f"Annotation with ID {annotation_id} not found.")
 
     try:
-        # TODO(Malte, 07/2026): Replace eager deletion with explicit evaluation invalidation
-        # once evaluation results can be recomputed or marked stale independently from updates.
         delete_evaluation_metrics(
             session=session,
             annotation_ids=[annotation.sample_id],

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_segmentation_mask.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_segmentation_mask.py
@@ -8,6 +8,9 @@ from sqlmodel import Session
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.resolvers.annotation_resolver.delete_annotation import (
+    delete_evaluation_metrics,
+)
 
 
 def update_segmentation_mask(
@@ -34,6 +37,13 @@ def update_segmentation_mask(
         raise ValueError("Annotation type does not support segmentation mask.")
 
     try:
+        # TODO(Malte, 07/2026): Replace eager deletion with explicit evaluation invalidation
+        # once evaluation results can be recomputed or marked stale independently from updates.
+        delete_evaluation_metrics(
+            session=session,
+            annotation_ids=[annotation.sample_id],
+            parent_sample_ids=[annotation.parent_sample_id],
+        )
         annotation.segmentation_details.segmentation_mask = segmentation_mask
 
         session.commit()

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_segmentation_mask.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_segmentation_mask.py
@@ -37,8 +37,6 @@ def update_segmentation_mask(
         raise ValueError("Annotation type does not support segmentation mask.")
 
     try:
-        # TODO(Malte, 07/2026): Replace eager deletion with explicit evaluation invalidation
-        # once evaluation results can be recomputed or marked stale independently from updates.
         delete_evaluation_metrics(
             session=session,
             annotation_ids=[annotation.sample_id],

--- a/lightly_studio/tests/resolvers/annotations/test_annotations_update_bounding_box.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotations_update_bounding_box.py
@@ -4,12 +4,27 @@ import pytest
 from sqlmodel import Session
 
 from lightly_studio import AnnotationType
-from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricCreate
+from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    evaluation_annotation_metric_resolver,
+    evaluation_sample_metric_resolver,
+)
 from lightly_studio.resolvers.annotation_resolver.update_bounding_box import (
     BoundingBoxCoordinates,
 )
 from tests.conftest import AnnotationsTestData
-from tests.helpers_resolvers import get_annotation_by_type
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+    get_annotation_by_type,
+)
+from tests.resolvers.evaluation_sample_metric_resolver import (
+    helpers as evaluation_sample_metric_helpers,
+)
 
 
 def test_update_bounding_box__object_detection(
@@ -122,3 +137,73 @@ def test_update_bounding_box__invalid_annotation_id(
 
     with pytest.raises(ValueError, match=f"Annotation with ID {invalid_annotation_id} not found."):
         annotation_resolver.update_bounding_box(db_session, invalid_annotation_id, new_coordinates)
+
+
+def test_update_bounding_box__deletes_evaluation_metrics(
+    db_session: Session,
+) -> None:
+    """Test bounding box updates remove invalidated evaluation annotation and sample metrics."""
+    dataset = create_collection(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(
+        session=db_session,
+        collection_id=dataset.collection_id,
+    )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
+    collection_id = dataset.collection_id
+    label = create_annotation_label(session=db_session, root_collection_id=collection_id)
+    pred_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    gt_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    evaluation_annotation_metric_resolver.create_many(
+        session=db_session,
+        records=[
+            EvaluationAnnotationMetricCreate(
+                evaluation_run_id=run.id,
+                sample_id=image.sample_id,
+                pred_annotation_id=pred_annotation.sample_id,
+                gt_annotation_id=gt_annotation.sample_id,
+                metric_name="iou",
+                value=0.75,
+            )
+        ],
+    )
+    evaluation_sample_metric_resolver.create_many(
+        session=db_session,
+        records=[
+            EvaluationSampleMetricCreate(
+                evaluation_run_id=run.id,
+                sample_id=image.sample_id,
+                metric_name="score",
+                value=0.5,
+            )
+        ],
+    )
+
+    updated_annotation = annotation_resolver.update_bounding_box(
+        db_session,
+        gt_annotation.sample_id,
+        BoundingBoxCoordinates(x=11, y=22, width=111, height=222),
+    )
+
+    annotation_metrics = evaluation_annotation_metric_resolver.get_all_by_evaluation_run_id(
+        session=db_session,
+        evaluation_run_id=run.id,
+    )
+    sample_metrics = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(
+        session=db_session,
+        evaluation_run_id=run.id,
+    )
+
+    assert updated_annotation.object_detection_details is not None
+    assert updated_annotation.object_detection_details.x == 11
+    assert annotation_metrics == []
+    assert sample_metrics == []

--- a/lightly_studio/tests/resolvers/annotations/test_annotations_update_bounding_box.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotations_update_bounding_box.py
@@ -188,7 +188,7 @@ def test_update_bounding_box__deletes_evaluation_metrics(
         ],
     )
 
-    updated_annotation = annotation_resolver.update_bounding_box(
+    annotation_resolver.update_bounding_box(
         db_session,
         gt_annotation.sample_id,
         BoundingBoxCoordinates(x=11, y=22, width=111, height=222),
@@ -203,7 +203,5 @@ def test_update_bounding_box__deletes_evaluation_metrics(
         evaluation_run_id=run.id,
     )
 
-    assert updated_annotation.object_detection_details is not None
-    assert updated_annotation.object_detection_details.x == 11
     assert annotation_metrics == []
     assert sample_metrics == []

--- a/lightly_studio/tests/resolvers/annotations/test_update_segmentation_mask.py
+++ b/lightly_studio/tests/resolvers/annotations/test_update_segmentation_mask.py
@@ -8,11 +8,9 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationType,
 )
 from lightly_studio.models.collection import SampleType
-from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricCreate
-from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
 from lightly_studio.resolvers import (
     annotation_resolver,
-    evaluation_annotation_metric_resolver,
+    collection_resolver,
     evaluation_sample_metric_resolver,
 )
 from tests.helpers_resolvers import (
@@ -24,6 +22,7 @@ from tests.helpers_resolvers import (
 from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
 )
+from tests.resolvers.evaluation_sample_metric_resolver.helpers import SampleMetricStub
 
 
 def test_update_segmentation_mask(db_session: Session) -> None:
@@ -106,73 +105,50 @@ def test_update_segmentation_mask__unsupported_annotation_type(db_session: Sessi
         )
 
 
-def test_update_segmentation_mask__deletes_evaluation_metrics(db_session: Session) -> None:
-    """Test mask updates remove invalidated evaluation annotation and sample metrics."""
+def test_update_segmentation_mask__deletes_sample_only_evaluation_metrics(
+    db_session: Session,
+) -> None:
+    """Test mask updates invalidate sample-only runs (e.g. semantic segmentation miou).
+
+    Such runs store no per-annotation metrics, so the affected run is found via its ground
+    truth / prediction collection rather than an annotation-metric match.
+    """
     dataset = create_collection(session=db_session)
     run = evaluation_sample_metric_helpers.create_run(
         session=db_session,
         collection_id=dataset.collection_id,
     )
     image = create_image(session=db_session, collection_id=dataset.collection_id)
-    collection_id = dataset.collection_id
-    label = create_annotation_label(session=db_session, root_collection_id=collection_id)
-    pred_annotation = create_annotation(
-        session=db_session,
-        collection_id=collection_id,
-        sample_id=image.sample_id,
-        annotation_label_id=label.annotation_label_id,
-        annotation_type=AnnotationType.SEGMENTATION_MASK,
-        annotation_data={"segmentation_mask": [0, 2, 4]},
+    label = create_annotation_label(session=db_session, root_collection_id=dataset.collection_id)
+    # Place the annotation in the run's ground-truth collection, as a real evaluation would.
+    gt_collection = collection_resolver.get_by_id(
+        session=db_session, collection_id=run.gt_annotation_collection_id
     )
+    assert gt_collection is not None
+    assert gt_collection.parent_collection_id is not None
     gt_annotation = create_annotation(
         session=db_session,
-        collection_id=collection_id,
+        collection_id=gt_collection.parent_collection_id,
+        annotation_collection_name=gt_collection.name,
         sample_id=image.sample_id,
         annotation_label_id=label.annotation_label_id,
         annotation_type=AnnotationType.SEGMENTATION_MASK,
         annotation_data={"segmentation_mask": [0, 2, 4]},
     )
-    evaluation_annotation_metric_resolver.create_many(
+    evaluation_sample_metric_helpers.create_sample_metrics(
         session=db_session,
-        records=[
-            EvaluationAnnotationMetricCreate(
-                evaluation_run_id=run.id,
-                sample_id=image.sample_id,
-                pred_annotation_id=pred_annotation.sample_id,
-                gt_annotation_id=gt_annotation.sample_id,
-                metric_name="iou",
-                value=0.75,
-            )
-        ],
-    )
-    evaluation_sample_metric_resolver.create_many(
-        session=db_session,
-        records=[
-            EvaluationSampleMetricCreate(
-                evaluation_run_id=run.id,
-                sample_id=image.sample_id,
-                metric_name="score",
-                value=0.5,
-            )
-        ],
+        run_id=run.id,
+        sample_metrics=[SampleMetricStub(sample_id=image.sample_id, metrics={"miou": 0.6})],
     )
 
-    updated_annotation = annotation_resolver.update_segmentation_mask(
+    annotation_resolver.update_segmentation_mask(
         session=db_session,
         annotation_id=gt_annotation.sample_id,
         segmentation_mask=[1, 2, 3, 4],
     )
 
-    annotation_metrics = evaluation_annotation_metric_resolver.get_all_by_evaluation_run_id(
-        session=db_session,
-        evaluation_run_id=run.id,
-    )
     sample_metrics = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(
         session=db_session,
         evaluation_run_id=run.id,
     )
-
-    assert updated_annotation.segmentation_details is not None
-    assert updated_annotation.segmentation_details.segmentation_mask == [1, 2, 3, 4]
-    assert annotation_metrics == []
     assert sample_metrics == []

--- a/lightly_studio/tests/resolvers/annotations/test_update_segmentation_mask.py
+++ b/lightly_studio/tests/resolvers/annotations/test_update_segmentation_mask.py
@@ -8,8 +8,22 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationType,
 )
 from lightly_studio.models.collection import SampleType
-from lightly_studio.resolvers import annotation_resolver
-from tests.helpers_resolvers import create_annotation_label, create_collection, create_image
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricCreate
+from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    evaluation_annotation_metric_resolver,
+    evaluation_sample_metric_resolver,
+)
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
+from tests.resolvers.evaluation_sample_metric_resolver import (
+    helpers as evaluation_sample_metric_helpers,
+)
 
 
 def test_update_segmentation_mask(db_session: Session) -> None:
@@ -90,3 +104,75 @@ def test_update_segmentation_mask__unsupported_annotation_type(db_session: Sessi
         annotation_resolver.update_segmentation_mask(
             session=db_session, annotation_id=annotation_id, segmentation_mask=[1, 2, 3, 4]
         )
+
+
+def test_update_segmentation_mask__deletes_evaluation_metrics(db_session: Session) -> None:
+    """Test mask updates remove invalidated evaluation annotation and sample metrics."""
+    dataset = create_collection(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(
+        session=db_session,
+        collection_id=dataset.collection_id,
+    )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
+    collection_id = dataset.collection_id
+    label = create_annotation_label(session=db_session, root_collection_id=collection_id)
+    pred_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.SEGMENTATION_MASK,
+        annotation_data={"segmentation_mask": [0, 2, 4]},
+    )
+    gt_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.SEGMENTATION_MASK,
+        annotation_data={"segmentation_mask": [0, 2, 4]},
+    )
+    evaluation_annotation_metric_resolver.create_many(
+        session=db_session,
+        records=[
+            EvaluationAnnotationMetricCreate(
+                evaluation_run_id=run.id,
+                sample_id=image.sample_id,
+                pred_annotation_id=pred_annotation.sample_id,
+                gt_annotation_id=gt_annotation.sample_id,
+                metric_name="iou",
+                value=0.75,
+            )
+        ],
+    )
+    evaluation_sample_metric_resolver.create_many(
+        session=db_session,
+        records=[
+            EvaluationSampleMetricCreate(
+                evaluation_run_id=run.id,
+                sample_id=image.sample_id,
+                metric_name="score",
+                value=0.5,
+            )
+        ],
+    )
+
+    updated_annotation = annotation_resolver.update_segmentation_mask(
+        session=db_session,
+        annotation_id=gt_annotation.sample_id,
+        segmentation_mask=[1, 2, 3, 4],
+    )
+
+    annotation_metrics = evaluation_annotation_metric_resolver.get_all_by_evaluation_run_id(
+        session=db_session,
+        evaluation_run_id=run.id,
+    )
+    sample_metrics = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(
+        session=db_session,
+        evaluation_run_id=run.id,
+    )
+
+    assert updated_annotation.segmentation_details is not None
+    assert updated_annotation.segmentation_details.segmentation_mask == [1, 2, 3, 4]
+    assert annotation_metrics == []
+    assert sample_metrics == []


### PR DESCRIPTION
## What has changed and why?

Per-annotation model evaluation results are precomputed. When updating the bbox and segmentation mask, they did not update. This PR deletes the them, cause they are invalid.

### Design decision: Delete them instead of marking them as stale

Delete the invalid rows. This is easiest and automatically makes all consumers work.

Marking stale would only be needed if we would want to recompute only the invalid evaluation metrics instead of directly all metrics. I don't see a need for that.

## How has it been tested?

new unittests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation metrics are now automatically cleared when annotation bounding boxes or segmentation masks are updated.
  * Updates also invalidate sample-level metrics for affected evaluation runs, including runs without annotation-level metrics.
  * Removing or changing annotations now more reliably clears metrics for all related evaluation runs.

* **Tests**
  * Added coverage for metric invalidation after bounding-box and segmentation-mask updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->