### PR TITLE
feat: introduce bar chart configuration

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { buildEchartsOption } from './buildEchartsOption';
+import { balanced } from './fixtures';
+
+describe('buildEchartsOption', () => {
+    it('maps labels to the category axis and counts to the bar series', () => {
+        const option = buildEchartsOption(balanced) as {
+            xAxis: { data: string[] };
+            series: [{ type: string; data: number[] }];
+        };
+
+        expect(option.xAxis.data).toEqual(balanced.map((item) => item.label));
+        expect(option.series[0].type).toBe('bar');
+        expect(option.series[0].data).toEqual(balanced.map((item) => item.count));
+    });
+
+    it('puts categories on the value axis when horizontal, keeping the bar series', () => {
+        const option = buildEchartsOption(balanced, { orientation: 'horizontal' }) as {
+            xAxis: { type: string };
+            yAxis: { type: string; data: string[]; inverse: boolean };
+            series: [{ type: string; data: number[] }];
+        };
+
+        expect(option.xAxis.type).toBe('value');
+        expect(option.yAxis.type).toBe('category');
+        expect(option.yAxis.data).toEqual(balanced.map((item) => item.label));
+        // Highest bar (first, pre-sorted) stays at the top.
+        expect(option.yAxis.inverse).toBe(true);
+        expect(option.series[0].data).toEqual(balanced.map((item) => item.count));
+    });
+
+    const getFormatter = (option: unknown) =>
+        (
+            option as {
+                tooltip: { formatter: (params: { name: string; value: number }[]) => string };
+            }
+        ).tooltip.formatter;
+
+    it('shows the percentage of the data sum in the tooltip', () => {
+        const formatter = getFormatter(
+            buildEchartsOption([
+                { label: 'car', count: 25 },
+                { label: 'dog', count: 75 }
+            ])
+        );
+
+        expect(formatter([{ name: 'car', value: 25 }])).toBe(
+            '<b>car</b><br/>Count: <b>25</b> (25.0%)'
+        );
+    });
+
+    it('uses the provided totalCount as the percentage denominator', () => {
+        const formatter = getFormatter(
+            buildEchartsOption([{ label: 'car', count: 25 }], { totalCount: 1000 })
+        );
+
+        expect(formatter([{ name: 'car', value: 25 }])).toBe(
+            '<b>car</b><br/>Count: <b>25</b> (2.5%)'
+        );
+    });
+
+    it('renders tiny shares as <0.1% and omits percentages for an empty total', () => {
+        const small = getFormatter(
+            buildEchartsOption([{ label: 'car', count: 1 }], { totalCount: 10000 })
+        );
+        expect(small([{ name: 'car', value: 1 }])).toBe('<b>car</b><br/>Count: <b>1</b> (<0.1%)');
+
+        const empty = getFormatter(buildEchartsOption([]));
+        expect(empty([{ name: 'car', value: 0 }])).toBe('<b>car</b><br/>Count: <b>0</b>');
+    });
+});

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -10,8 +10,7 @@ import {
 import type { CategoryCount } from './';
 
 // Single accent color (the Lightly primary green, --color-lightly-primary #3bd99f):
-// per-class colors carry no meaning in a count distribution, mirroring FiftyOne's
-// histograms panel.
+// per-class colors carry no meaning in a count distribution.
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -1,0 +1,93 @@
+import type { EChartsCoreOption } from 'echarts/core';
+import { truncate } from 'lodash-es';
+import {
+    CHART_AXIS_LABEL,
+    CHART_EMPHASIS,
+    CHART_LINE_COLOR,
+    CHART_TEXT_COLOR,
+    formatPercent
+} from '$lib/utils';
+import type { CategoryCount } from './';
+
+// Single accent color (the Lightly primary green, --color-lightly-primary #3bd99f):
+// per-class colors carry no meaning in a count distribution, mirroring FiftyOne's
+// histograms panel.
+const BAR_COLOR = 'rgba(59,217,159,0.85)';
+
+/** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
+export type BarChartOrientation = 'vertical' | 'horizontal';
+
+interface BuildEchartsOptionOptions {
+    /**
+     * Denominator for tooltip percentages. Pass the sum over all categories
+     * when `data` is a subset (e.g. top-N), so percentages stay relative to
+     * the full dataset. Defaults to the sum of `data`.
+     */
+    totalCount?: number;
+    /** Bar orientation (default 'vertical'). */
+    orientation?: BarChartOrientation;
+}
+
+/** Builds the ECharts option for a category-count bar chart (pass to `setOption`). */
+export function buildEchartsOption(
+    data: CategoryCount[],
+    options: BuildEchartsOptionOptions = {}
+): EChartsCoreOption {
+    const totalCount = options.totalCount ?? data.reduce((sum, item) => sum + item.count, 0);
+    const orientation = options.orientation ?? 'vertical';
+    const isHorizontal = orientation === 'horizontal';
+
+    const labels = data.map((item) => item.label);
+
+    const categoryAxis = {
+        type: 'category' as const,
+        data: labels,
+        axisLabel: {
+            // Vertical layout rotates long labels so they don't overflow the
+            // canvas edge (echarts containLabel ignores rotation); horizontal
+            // layout has room for flat labels down the left gutter.
+            rotate: isHorizontal ? 0 : 60,
+            interval: 0,
+            color: CHART_TEXT_COLOR,
+            fontSize: 12,
+            // Cap long labels on the axis; the tooltip still shows the full name.
+            formatter: (label: string) => truncate(label, { length: 24, omission: '…' })
+        },
+        axisLine: { lineStyle: { color: CHART_LINE_COLOR } },
+        axisTick: { alignWithLabel: true },
+        // Keep the highest bar at the top when horizontal (data is pre-sorted).
+        inverse: isHorizontal
+    };
+
+    const valueAxis = {
+        type: 'value' as const,
+        axisLabel: CHART_AXIS_LABEL,
+        splitLine: { lineStyle: { color: CHART_LINE_COLOR } }
+    };
+
+    return {
+        backgroundColor: 'transparent',
+        tooltip: {
+            trigger: 'axis',
+            axisPointer: { type: 'shadow' },
+            formatter: (params: { name: string; value: number }[]) => {
+                const [{ name, value }] = params;
+                const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
+                return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
+            }
+        },
+        grid: { left: 8, right: 8, top: 16, bottom: 8, containLabel: true },
+        // Swap which axis holds the categories so bars grow rightward when horizontal.
+        xAxis: isHorizontal ? valueAxis : categoryAxis,
+        yAxis: isHorizontal ? categoryAxis : valueAxis,
+        series: [
+            {
+                type: 'bar',
+                data: data.map((item) => item.count),
+                itemStyle: { color: BAR_COLOR },
+                barCategoryGap: '25%',
+                emphasis: CHART_EMPHASIS
+            }
+        ]
+    };
+}

--- a/lightly_studio_view/src/lib/components/BarChart/fixtures.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/fixtures.ts
@@ -1,0 +1,10 @@
+import type { CategoryCount } from './types';
+
+/** Few classes, similar counts. */
+export const balanced: CategoryCount[] = [
+    { label: 'chair', count: 112 },
+    { label: 'dog', count: 104 },
+    { label: 'bike', count: 96 },
+    { label: 'person', count: 91 },
+    { label: 'car', count: 88 }
+];

--- a/lightly_studio_view/src/lib/components/BarChart/index.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/index.ts
@@ -1,0 +1,2 @@
+export type { CategoryCount } from './types';
+export type { BarChartOrientation } from './buildEchartsOption';

--- a/lightly_studio_view/src/lib/components/BarChart/types.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/types.ts
@@ -1,0 +1,5 @@
+/** A single category (e.g. a class name) with its count. */
+export interface CategoryCount {
+    label: string;
+    count: number;
+}

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
@@ -1,4 +1,10 @@
 import type { EChartsCoreOption } from 'echarts/core';
+import {
+    CHART_AXIS_LABEL,
+    CHART_EMPHASIS,
+    CHART_LINE_COLOR,
+    CHART_TEXT_COLOR
+} from '$lib/utils';
 import { SENTINELS } from './topNMatrix';
 import { type ConfusionMatrix } from './types';
 
@@ -89,9 +95,9 @@ export function buildEchartsOption(
             name: 'Prediction',
             nameLocation: 'middle',
             nameGap,
-            nameTextStyle: { color: '#9ca3af', fontSize: 13, fontWeight: 'bold' },
-            axisLabel: { rotate: 45, interval: 0, color: '#9ca3af', fontSize: 12 },
-            axisLine: { lineStyle: { color: '#374151' } },
+            nameTextStyle: { color: CHART_TEXT_COLOR, fontSize: 13, fontWeight: 'bold' },
+            axisLabel: { ...CHART_AXIS_LABEL, rotate: 45, interval: 0 },
+            axisLine: { lineStyle: { color: CHART_LINE_COLOR } },
             splitArea: { show: false }
         },
         yAxis: {
@@ -101,9 +107,9 @@ export function buildEchartsOption(
             nameLocation: 'middle',
             nameGap,
             nameRotate: 90,
-            nameTextStyle: { color: '#9ca3af', fontSize: 13, fontWeight: 'bold' },
-            axisLabel: { interval: 0, color: '#9ca3af', fontSize: 12 },
-            axisLine: { lineStyle: { color: '#374151' } },
+            nameTextStyle: { color: CHART_TEXT_COLOR, fontSize: 13, fontWeight: 'bold' },
+            axisLabel: { ...CHART_AXIS_LABEL, interval: 0 },
+            axisLine: { lineStyle: { color: CHART_LINE_COLOR } },
             splitArea: { show: false }
         },
         visualMap: [
@@ -130,14 +136,14 @@ export function buildEchartsOption(
                 name: 'TP',
                 data: tpData,
                 label: { show: false },
-                emphasis: { itemStyle: { shadowBlur: 6, shadowColor: 'rgba(0,0,0,0.3)' } }
+                emphasis: CHART_EMPHASIS
             },
             {
                 type: 'heatmap',
                 name: 'FP/FN',
                 data: fpFnData,
                 label: { show: false },
-                emphasis: { itemStyle: { shadowBlur: 6, shadowColor: 'rgba(0,0,0,0.3)' } }
+                emphasis: CHART_EMPHASIS
             }
         ]
     };

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/buildEchartsOption.ts
@@ -1,10 +1,5 @@
 import type { EChartsCoreOption } from 'echarts/core';
-import {
-    CHART_AXIS_LABEL,
-    CHART_EMPHASIS,
-    CHART_LINE_COLOR,
-    CHART_TEXT_COLOR
-} from '$lib/utils';
+import { CHART_AXIS_LABEL, CHART_EMPHASIS, CHART_LINE_COLOR, CHART_TEXT_COLOR } from '$lib/utils';
 import { SENTINELS } from './topNMatrix';
 import { type ConfusionMatrix } from './types';
 

--- a/lightly_studio_view/src/lib/utils/echartsTheme.ts
+++ b/lightly_studio_view/src/lib/utils/echartsTheme.ts
@@ -1,0 +1,17 @@
+// Shared dark-theme constants for ECharts option builders. ECharts renders to a
+// canvas, so it can't use CSS classes/variables — these mirror the Tailwind
+// gray palette as literals (gray-400 for text, gray-700 for lines).
+
+/** Muted gray for axis labels and axis names (Tailwind gray-400). */
+export const CHART_TEXT_COLOR = '#9ca3af';
+
+/** Axis and split line color (Tailwind gray-700). */
+export const CHART_LINE_COLOR = '#374151';
+
+/** Default axis label style shared across charts. */
+export const CHART_AXIS_LABEL = { color: CHART_TEXT_COLOR, fontSize: 12 } as const;
+
+/** Hover emphasis shadow shared across chart series. */
+export const CHART_EMPHASIS = {
+    itemStyle: { shadowBlur: 6, shadowColor: 'rgba(0,0,0,0.3)' }
+} as const;

--- a/lightly_studio_view/src/lib/utils/formatter/formatConfidence.test.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/formatConfidence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatConfidence } from './formatter';
+import { formatConfidence } from './formatConfidence';
 
 describe('formatConfidence', () => {
     it('formats confidence with two decimal places', () => {

--- a/lightly_studio_view/src/lib/utils/formatter/formatConfidence.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/formatConfidence.ts
@@ -1,0 +1,9 @@
+import { formatFloat2 } from './formatFloat';
+
+export const formatConfidence = (confidence?: number | null): string | null => {
+    if (confidence == null) {
+        return null;
+    }
+
+    return formatFloat2(confidence);
+};

--- a/lightly_studio_view/src/lib/utils/formatter/formatFloat.test.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/formatFloat.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { formatFloat, formatFloat2 } from './formatFloat';
+
+describe('formatFloat', () => {
+    it('rounds to three fractional digits by default', () => {
+        expect(formatFloat(1.23456)).toBe('1.235');
+    });
+
+    it('omits fractional digits when the value is whole', () => {
+        expect(formatFloat(2)).toBe('2');
+    });
+
+    it('respects a custom maximum digit count', () => {
+        expect(formatFloat(1.23456, 1)).toBe('1.2');
+    });
+});
+
+describe('formatFloat2', () => {
+    it('formats with two fractional digits', () => {
+        expect(formatFloat2(0.876)).toBe('0.88');
+    });
+});

--- a/lightly_studio_view/src/lib/utils/formatter/formatFloat.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/formatFloat.ts
@@ -1,0 +1,14 @@
+import { locale } from './locale';
+
+export const formatFloat = (num: number, maxDigits = 3, minDigits = 0): string => {
+    return new Intl.NumberFormat(locale, {
+        maximumFractionDigits: maxDigits,
+        minimumFractionDigits: minDigits
+    })
+        .format(num)
+        .toString();
+};
+
+export const formatFloat2 = (num: number): string => {
+    return formatFloat(num, 2);
+};

--- a/lightly_studio_view/src/lib/utils/formatter/formatInteger.test.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/formatInteger.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { formatInteger } from './formatInteger';
+
+describe('formatInteger', () => {
+    it('groups thousands with separators', () => {
+        expect(formatInteger(1234567)).toBe('1,234,567');
+    });
+
+    it('leaves small integers unchanged', () => {
+        expect(formatInteger(42)).toBe('42');
+    });
+});

--- a/lightly_studio_view/src/lib/utils/formatter/formatInteger.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/formatInteger.ts
@@ -1,0 +1,5 @@
+import { locale } from './locale';
+
+export const formatInteger = (num: number): string => {
+    return new Intl.NumberFormat(locale, {}).format(num).toString();
+};

--- a/lightly_studio_view/src/lib/utils/formatter/formatMetadataValue.test.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/formatMetadataValue.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { formatMetadataValue } from './formatMetadataValue';
+
+describe('formatMetadataValue', () => {
+    it('renders null and undefined as "null"', () => {
+        expect(formatMetadataValue(null)).toBe('null');
+        expect(formatMetadataValue(undefined)).toBe('null');
+    });
+
+    it('returns strings unchanged', () => {
+        expect(formatMetadataValue('hello')).toBe('hello');
+    });
+
+    it('formats integers with separators and floats with decimals', () => {
+        expect(formatMetadataValue(1234)).toBe('1,234');
+        expect(formatMetadataValue(1.23456)).toBe('1.235');
+    });
+
+    it('formats booleans as words', () => {
+        expect(formatMetadataValue(true)).toBe('true');
+        expect(formatMetadataValue(false)).toBe('false');
+    });
+
+    it('formats short primitive arrays inline', () => {
+        expect(formatMetadataValue([1, 2, 3])).toBe('[1, 2, 3]');
+        expect(formatMetadataValue([])).toBe('[]');
+    });
+
+    it('formats small objects on one line', () => {
+        expect(formatMetadataValue({ a: 1, b: 'x' })).toBe('{a: 1, b: x}');
+        expect(formatMetadataValue({})).toBe('{}');
+    });
+});

--- a/lightly_studio_view/src/lib/utils/formatter/formatMetadataValue.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/formatMetadataValue.ts
@@ -1,27 +1,5 @@
-const locale = 'en-US';
-
-export const formatInteger = (num: number): string => {
-    return new Intl.NumberFormat(locale, {}).format(num).toString();
-};
-export const formatFloat = (num: number, maxDigits = 3, minDigits = 0): string => {
-    return new Intl.NumberFormat(locale, {
-        maximumFractionDigits: maxDigits,
-        minimumFractionDigits: minDigits
-    })
-        .format(num)
-        .toString();
-};
-export const formatFloat2 = (num: number): string => {
-    return formatFloat(num, 2);
-};
-
-export const formatConfidence = (confidence?: number | null): string | null => {
-    if (confidence == null) {
-        return null;
-    }
-
-    return formatFloat2(confidence);
-};
+import { formatFloat } from './formatFloat';
+import { formatInteger } from './formatInteger';
 
 /**
  * Format a metadata value for display

--- a/lightly_studio_view/src/lib/utils/formatter/formatPercent.test.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/formatPercent.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { formatPercent } from './formatPercent';
+
+describe('formatPercent', () => {
+    it('formats a ratio as a percentage with one decimal', () => {
+        expect(formatPercent(0.25)).toBe('25.0%');
+    });
+
+    it('renders tiny non-zero shares as <0.1%', () => {
+        expect(formatPercent(0.0001)).toBe('<0.1%');
+    });
+
+    it('formats zero as 0.0%', () => {
+        expect(formatPercent(0)).toBe('0.0%');
+    });
+});

--- a/lightly_studio_view/src/lib/utils/formatter/formatPercent.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/formatPercent.ts
@@ -1,0 +1,6 @@
+/** Formats a ratio (0–1) as a percentage; tiny non-zero shares render as `<0.1%`. */
+export const formatPercent = (ratio: number): string => {
+    const percent = ratio * 100;
+    if (percent > 0 && percent < 0.1) return '<0.1%';
+    return `${percent.toFixed(1)}%`;
+};

--- a/lightly_studio_view/src/lib/utils/formatter/index.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/index.ts
@@ -1,0 +1,5 @@
+export { formatInteger } from './formatInteger';
+export { formatFloat, formatFloat2 } from './formatFloat';
+export { formatPercent } from './formatPercent';
+export { formatConfidence } from './formatConfidence';
+export { formatMetadataValue } from './formatMetadataValue';

--- a/lightly_studio_view/src/lib/utils/formatter/locale.ts
+++ b/lightly_studio_view/src/lib/utils/formatter/locale.ts
@@ -1,0 +1,1 @@
+export const locale = 'en-US';

--- a/lightly_studio_view/src/lib/utils/index.ts
+++ b/lightly_studio_view/src/lib/utils/index.ts
@@ -6,6 +6,7 @@ export * from './getColorByLabel';
 export * from './getSimilarityColor';
 export * from './formatter';
 export * from './formatDate';
+export * from './echartsTheme';
 export * from './shadcn';
 export * from './isInputElement';
 export * from './isTextInputTarget';


### PR DESCRIPTION
## What has changed and why?

- refactoring of existing formatters - it was "spagetti-code style", I touched it by introducing new helper to format percentage
- introduced `formatPercentage`
- introduced configuration for echarts
- introduced shared them to echarts to avoid duplication (we have confugration for confusion matrix as well)
- 

## How has it been tested?

All changes covered by test there is not need to manual testing

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category-based bar chart option builder with vertical and horizontal layouts, including count/percentage tooltips.
  * Introduced shared chart styling utilities for consistent dark-mode visuals.
  * Added new formatting helpers (integer, float, percent, confidence) and a formatter index for unified access.
* **Bug Fixes**
  * Improved tooltip percentage handling for tiny values and empty/zero totals.
* **Tests**
  * Added/expanded coverage for chart option building and numeric formatting utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->