### PR TITLE
Make export functions/classes take a sample_to_image callable to generalise better

### DIFF
--- a/lightly_studio/src/lightly_studio/export/coco_captions.py
+++ b/lightly_studio/src/lightly_studio/export/coco_captions.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import TypedDict
 
-from lightly_studio.core.image.image_sample import ImageSample
+from lightly_studio.core.sample import Sample
+from lightly_studio.export.lightly_studio_label_input import SampleToImage
 
 
 class CocoCaptionImage(TypedDict):
@@ -32,11 +33,16 @@ class CocoCaptionsJson(TypedDict):
     annotations: list[CocoCaptionAnnotation]
 
 
-def to_coco_captions_dict(samples: Iterable[ImageSample]) -> CocoCaptionsJson:
+def to_coco_captions_dict(
+    samples: Iterable[Sample],
+    sample_to_image: SampleToImage,
+) -> CocoCaptionsJson:
     """Convert samples with captions to a COCO captions dictionary.
 
     Args:
         samples: The samples to export.
+        sample_to_image: Strategy mapping a sample to a labelformat `Image` (used for the
+            file name and dimensions).
 
     Returns:
         A dictionary in COCO captions format.
@@ -45,16 +51,17 @@ def to_coco_captions_dict(samples: Iterable[ImageSample]) -> CocoCaptionsJson:
     coco_annotations: list[CocoCaptionAnnotation] = []
     annotation_id = 0
 
-    for image_id, image in enumerate(samples):
+    for image_id, sample in enumerate(samples):
+        image = sample_to_image(sample=sample, image_id=image_id, use_relative_filename=False)
         coco_images.append(
             {
                 "id": image_id,
-                "file_name": image.file_path_abs,
+                "file_name": image.filename,
                 "width": image.width,
                 "height": image.height,
             }
         )
-        for caption in image.captions:
+        for caption in sample.captions:
             coco_annotations.append(
                 {
                     "id": annotation_id,

--- a/lightly_studio/src/lightly_studio/export/image_dataset_export.py
+++ b/lightly_studio/src/lightly_studio/export/image_dataset_export.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable
 from pathlib import Path
+from typing import cast
 from uuid import UUID
 
 from labelformat.formats import (
@@ -13,9 +14,11 @@ from labelformat.formats import (
     PascalVOCSemanticSegmentationOutput,
     YOLOv8ObjectDetectionOutput,
 )
+from labelformat.model.image import Image
 from sqlmodel import Session
 
 from lightly_studio.core.image.image_sample import ImageSample
+from lightly_studio.core.sample import Sample
 from lightly_studio.export import coco_captions
 from lightly_studio.export.lightly_studio_label_input import (
     LightlyStudioInstanceSegmentationInput,
@@ -77,6 +80,7 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             annotation_collection_id=annotation_collection_id,
+            sample_to_image=image_sample_to_image,
         )
         COCOObjectDetectionOutput(output_file=Path(output_json)).save(label_input=export_input)
 
@@ -101,6 +105,7 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             annotation_collection_id=annotation_collection_id,
+            sample_to_image=image_sample_to_image,
         )
         YOLOv8ObjectDetectionOutput(
             output_file=Path(output_folder) / YOLO_DATASET_CONFIG_FILENAME,
@@ -116,7 +121,9 @@ class ImageDatasetExport:
         """
         if output_json is None:
             output_json = DEFAULT_EXPORT_FILENAME
-        coco_captions_dict = coco_captions.to_coco_captions_dict(samples=self.samples)
+        coco_captions_dict = coco_captions.to_coco_captions_dict(
+            samples=self.samples, sample_to_image=image_sample_to_image
+        )
         with Path(output_json).open("w") as f:
             json.dump(coco_captions_dict, f, indent=2)
 
@@ -140,6 +147,7 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             annotation_collection_id=annotation_collection_id,
+            sample_to_image=image_sample_to_image,
         )
         COCOInstanceSegmentationOutput(output_file=Path(output_json)).save(label_input=export_input)
 
@@ -164,9 +172,28 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             annotation_collection_id=annotation_collection_id,
+            sample_to_image=image_sample_to_image,
         )
         # Keep `background_class_id` unchanged: the label input defines category IDs and
         # reserves class 0 for background.
         PascalVOCSemanticSegmentationOutput(output_folder=Path(output_folder)).save(
             label_input=export_input
         )
+
+
+def image_sample_to_image(sample: Sample, image_id: int, use_relative_filename: bool) -> Image:
+    """Maps an image sample to a labelformat `Image`.
+
+    Conforms to the `SampleToImage` strategy, so `sample` is typed as `Sample`; it is always
+    an `ImageSample` here because this strategy is only used by `ImageDatasetExport`.
+
+    COCO stores the absolute path verbatim; YOLO and Pascal VOC need a relative file name.
+    """
+    image_sample = cast(ImageSample, sample)
+    filename = image_sample.file_name if use_relative_filename else image_sample.file_path_abs
+    return Image(
+        id=image_id,
+        filename=filename,
+        width=image_sample.width,
+        height=image_sample.height,
+    )

--- a/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
+++ b/lightly_studio/src/lightly_studio/export/lightly_studio_label_input.py
@@ -1,9 +1,16 @@
-"""Converts annotations from Lightly Studio to Labelformat format."""
+"""Converts annotations from Lightly Studio to Labelformat format.
+
+The adapters here are sample-type-agnostic: they iterate over `Sample` objects and their
+annotations and delegate the sample-to-image mapping (filename and dimensions) to a
+`sample_to_image` strategy. This lets image samples and video frame samples share the same
+export logic while differing only in how a sample maps to a labelformat `Image`.
+"""
 
 from __future__ import annotations
 
 from argparse import ArgumentParser
 from collections.abc import Iterable
+from typing import Protocol
 from uuid import UUID
 
 from labelformat.model.binary_mask_segmentation import BinaryMaskSegmentation
@@ -22,35 +29,57 @@ from labelformat.model.object_detection import (
 )
 from sqlmodel import Session
 
-from lightly_studio.core.image.image_sample import ImageSample
+from lightly_studio.core.sample import Sample
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable, AnnotationType
 from lightly_studio.resolvers import annotation_label_resolver
+
+
+class SampleToImage(Protocol):
+    """Strategy mapping a sample to a labelformat `Image` (its file name and dimensions)."""
+
+    def __call__(self, sample: Sample, image_id: int, use_relative_filename: bool) -> Image:
+        """Returns the labelformat `Image` for `sample`.
+
+        Args:
+            sample: The sample to map.
+            image_id: The id to assign to the returned image.
+            use_relative_filename: Whether to use a relative file name (YOLO, Pascal VOC)
+                rather than the absolute path (COCO).
+        """
+        ...
 
 
 class LightlyStudioInputBase:
     """Base class for Lightly Studio labelformat adapters."""
 
     CATEGORY_ID_START = 0
+    # Whether images are referenced by a relative file name. COCO stores the (absolute) path
+    # verbatim, while YOLO and Pascal VOC join the file name with the output directory, so
+    # those must use a relative name.
+    USE_RELATIVE_FILENAME = False
 
     def __init__(
         self,
         session: Session,
         dataset_id: UUID,
-        samples: Iterable[ImageSample],
+        samples: Iterable[Sample],
         annotation_collection_id: UUID | None,
+        sample_to_image: SampleToImage,
     ) -> None:
         """Initializes the adapter.
 
         Args:
             session: The SQLModel session to use for database access. Used only in the
-                constructor to fetch the labels for the given annotation source.
+                constructor to fetch the labels for the given dataset.
             dataset_id: The dataset ID for label retrieval.
             samples: Dataset samples.
             annotation_collection_id: If provided, only annotations belonging to this
                 annotation collection are exported. If None, all annotations are exported.
+            sample_to_image: Strategy mapping a sample to a labelformat `Image`.
         """
         self._samples = list(samples)
         self._annotation_collection_id = annotation_collection_id
+        self._sample_to_image = sample_to_image
         self._label_id_to_category = _build_label_id_to_category(
             session=session,
             dataset_id=dataset_id,
@@ -71,7 +100,23 @@ class LightlyStudioInputBase:
     def get_images(self) -> Iterable[Image]:
         """Returns the images for export."""
         for idx, sample in enumerate(self._samples):
-            yield _sample_to_image(sample=sample, image_id=idx)
+            yield self._sample_to_image(
+                sample=sample, image_id=idx, use_relative_filename=self.USE_RELATIVE_FILENAME
+            )
+
+    def _annotations_of_collection_and_type(
+        self, sample: Sample, annotation_type: AnnotationType
+    ) -> Iterable[AnnotationBaseTable]:
+        # TODO(malte, 07/2026): We can optimise in the future to filter annotations in a DB
+        # query instead of loading every annotation per sample and filtering in Python.
+        for annotation in sample.sample_table.annotations:
+            if annotation.annotation_type != annotation_type:
+                continue
+            if (
+                self._annotation_collection_id is None
+                or annotation.annotation_collection_id == self._annotation_collection_id
+            ):
+                yield annotation
 
 
 class LightlyStudioObjectDetectionInput(LightlyStudioInputBase, ObjectDetectionInput):
@@ -80,11 +125,20 @@ class LightlyStudioObjectDetectionInput(LightlyStudioInputBase, ObjectDetectionI
     def get_labels(self) -> Iterable[ImageObjectDetection]:
         """Returns the labels for export."""
         for idx, sample in enumerate(self._samples):
-            yield _sample_to_image_obj_det(
-                sample=sample,
-                image_id=idx,
-                label_id_to_category=self._label_id_to_category,
-                annotation_collection_id=self._annotation_collection_id,
+            objects = [
+                _annotation_to_single_obj_det(
+                    annotation=annotation,
+                    label_id_to_category=self._label_id_to_category,
+                )
+                for annotation in self._annotations_of_collection_and_type(
+                    sample=sample, annotation_type=AnnotationType.OBJECT_DETECTION
+                )
+            ]
+            yield ImageObjectDetection(
+                image=self._sample_to_image(
+                    sample=sample, image_id=idx, use_relative_filename=self.USE_RELATIVE_FILENAME
+                ),
+                objects=objects,
             )
 
 
@@ -98,128 +152,44 @@ class LightlyStudioYOLOObjectDetectionInput(LightlyStudioObjectDetectionInput):
     escape that directory.
     """
 
-    def get_images(self) -> Iterable[Image]:
-        """Returns the images for export with relative filenames."""
-        for idx, sample in enumerate(self._samples):
-            yield _sample_to_image(sample=sample, image_id=idx, filename=sample.file_name)
-
-    def get_labels(self) -> Iterable[ImageObjectDetection]:
-        """Returns the labels for export with relative filenames."""
-        for idx, sample in enumerate(self._samples):
-            yield _sample_to_image_obj_det(
-                sample=sample,
-                image_id=idx,
-                label_id_to_category=self._label_id_to_category,
-                annotation_collection_id=self._annotation_collection_id,
-                filename=sample.file_name,
-            )
+    USE_RELATIVE_FILENAME = True
 
 
 class LightlyStudioInstanceSegmentationInput(LightlyStudioInputBase, InstanceSegmentationInput):
     """Labelformat adapter for segmentation mask backed by dataset samples and annotations."""
 
-    @staticmethod
-    def _sample_to_image_inst_seg(
-        sample: ImageSample,
-        image_id: int,
-        label_id_to_category: dict[UUID, Category],
-        annotation_collection_id: UUID | None,
-    ) -> ImageInstanceSegmentation:
-        # TODO(lukas, 02/2026): We can optimise in the future to filter annotations in a DB query.
-        objects = []
-        for annotation in sample.sample_table.annotations:
-            if annotation.annotation_type == AnnotationType.SEGMENTATION_MASK and (
-                annotation_collection_id is None
-                or annotation.annotation_collection_id == annotation_collection_id
+    def get_labels(self) -> Iterable[ImageInstanceSegmentation]:
+        """Returns the labels for export."""
+        for idx, sample in enumerate(self._samples):
+            image = self._sample_to_image(
+                sample=sample, image_id=idx, use_relative_filename=self.USE_RELATIVE_FILENAME
+            )
+            objects = []
+            for annotation in self._annotations_of_collection_and_type(
+                sample=sample, annotation_type=AnnotationType.SEGMENTATION_MASK
             ):
                 obj = _annotation_to_single_inst_seg(
                     annotation=annotation,
-                    label_id_to_category=label_id_to_category,
-                    image_width=sample.width,
-                    image_height=sample.height,
+                    label_id_to_category=self._label_id_to_category,
+                    image_width=image.width,
+                    image_height=image.height,
                 )
-                # TODO(lukas 3/2026): workaround needed because
+                # TODO(lukas, 03/2026): workaround needed because
                 # annotation.segmentation_details.segmentation_mask can be None.
                 # See lightly_studio/src/lightly_studio/models/annotation/segmentation.py.
                 if obj is not None:
                     objects.append(obj)
-
-        return ImageInstanceSegmentation(
-            image=_sample_to_image(sample=sample, image_id=image_id),
-            objects=objects,
-        )
-
-    def get_labels(self) -> Iterable[ImageInstanceSegmentation]:
-        """Returns the labels for export."""
-        for idx, sample in enumerate(self._samples):
-            yield LightlyStudioInstanceSegmentationInput._sample_to_image_inst_seg(
-                sample=sample,
-                image_id=idx,
-                label_id_to_category=self._label_id_to_category,
-                annotation_collection_id=self._annotation_collection_id,
-            )
+            yield ImageInstanceSegmentation(image=image, objects=objects)
 
 
-class LightlyStudioPascalVOCInstanceSegmentationInput(
-    LightlyStudioInputBase, InstanceSegmentationInput
-):
+class LightlyStudioPascalVOCInstanceSegmentationInput(LightlyStudioInstanceSegmentationInput):
     """Labelformat adapter for Pascal VOC export from segmentation mask annotations."""
 
-    # TODO(Leonardo, 03/26): Ensure Pascal VOC export maps user-defined background to class ID 0
+    # TODO(Leonardo, 03/2026): Ensure Pascal VOC export maps user-defined background to class ID 0
     # and void/ignore to 255 for spec compliance.
     CATEGORY_ID_START = 1
-
-    @staticmethod
-    def _sample_to_image_pascalvoc_segmentation_mask(
-        sample: ImageSample,
-        image_id: int,
-        label_id_to_category: dict[UUID, Category],
-        annotation_collection_id: UUID | None,
-    ) -> ImageInstanceSegmentation:
-        objects = []
-        for annotation in sample.sample_table.annotations:
-            if annotation.annotation_type == AnnotationType.SEGMENTATION_MASK and (
-                annotation_collection_id is None
-                or annotation.annotation_collection_id == annotation_collection_id
-            ):
-                obj = _annotation_to_single_inst_seg(
-                    annotation=annotation,
-                    label_id_to_category=label_id_to_category,
-                    image_width=sample.width,
-                    image_height=sample.height,
-                )
-                if obj is not None:
-                    objects.append(obj)
-
-        return ImageInstanceSegmentation(
-            image=_sample_to_image(
-                sample=sample,
-                image_id=image_id,
-                filename=sample.file_name,
-            ),
-            objects=objects,
-        )
-
-    def get_images(self) -> Iterable[Image]:
-        """Returns the images for export."""
-        for idx, sample in enumerate(self._samples):
-            # Pascal VOC derives mask filenames from image names,
-            # so an absolute path cannot be used.
-            yield _sample_to_image(
-                sample=sample,
-                image_id=idx,
-                filename=sample.file_name,
-            )
-
-    def get_labels(self) -> Iterable[ImageInstanceSegmentation]:
-        """Returns the labels for Pascal VOC export."""
-        for idx, sample in enumerate(self._samples):
-            yield self._sample_to_image_pascalvoc_segmentation_mask(
-                sample=sample,
-                image_id=idx,
-                label_id_to_category=self._label_id_to_category,
-                annotation_collection_id=self._annotation_collection_id,
-            )
+    # Pascal VOC derives mask filenames from image names, so an absolute path cannot be used.
+    USE_RELATIVE_FILENAME = True
 
 
 def _build_label_id_to_category(
@@ -240,43 +210,6 @@ def _build_label_id_to_category(
         )
         for idx, label in enumerate(labels)
     }
-
-
-def _sample_to_image(sample: ImageSample, image_id: int, filename: str | None = None) -> Image:
-    if filename is None:
-        filename = sample.file_path_abs
-    return Image(
-        id=image_id,
-        filename=filename,
-        width=sample.width,
-        height=sample.height,
-    )
-
-
-def _sample_to_image_obj_det(
-    sample: ImageSample,
-    image_id: int,
-    label_id_to_category: dict[UUID, Category],
-    annotation_collection_id: UUID | None,
-    filename: str | None = None,
-) -> ImageObjectDetection:
-    # TODO(Michal, 09/2025): We can optimise in the future to filter annotations in a DB query.
-    objects = [
-        _annotation_to_single_obj_det(
-            annotation=annotation,
-            label_id_to_category=label_id_to_category,
-        )
-        for annotation in sample.sample_table.annotations
-        if annotation.annotation_type == AnnotationType.OBJECT_DETECTION
-        and (
-            annotation_collection_id is None
-            or annotation.annotation_collection_id == annotation_collection_id
-        )
-    ]
-    return ImageObjectDetection(
-        image=_sample_to_image(sample=sample, image_id=image_id, filename=filename),
-        objects=objects,
-    )
 
 
 def _annotation_to_single_obj_det(

--- a/lightly_studio/tests/export/test_coco_captions.py
+++ b/lightly_studio/tests/export/test_coco_captions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlmodel import Session
 
 from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
-from lightly_studio.export import coco_captions
+from lightly_studio.export import coco_captions, image_dataset_export
 from tests.helpers_resolvers import (
     ImageStub,
     create_caption,
@@ -42,7 +42,9 @@ def test_to_coco_captions_dict(
 
     # Call the function under test
     samples = DatasetQuery(dataset=collection, session=db_session)
-    coco_dict = coco_captions.to_coco_captions_dict(samples=samples)
+    coco_dict = coco_captions.to_coco_captions_dict(
+        samples=samples, sample_to_image=image_dataset_export.image_sample_to_image
+    )
 
     assert coco_dict == {
         "images": [
@@ -64,6 +66,8 @@ def test_to_coco_captions_dict__empty(
 
     # Call the function under test
     samples = DatasetQuery(dataset=collection, session=db_session)
-    coco_dict = coco_captions.to_coco_captions_dict(samples=samples)
+    coco_dict = coco_captions.to_coco_captions_dict(
+        samples=samples, sample_to_image=image_dataset_export.image_sample_to_image
+    )
 
     assert coco_dict == {"images": [], "annotations": []}

--- a/lightly_studio/tests/export/test_lightly_studio_label_input.py
+++ b/lightly_studio/tests/export/test_lightly_studio_label_input.py
@@ -9,6 +9,7 @@ from labelformat.model.object_detection import ImageObjectDetection, SingleObjec
 from sqlmodel import Session
 
 from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
+from lightly_studio.export import image_dataset_export
 from lightly_studio.export.lightly_studio_label_input import (
     LightlyStudioObjectDetectionInput,
     LightlyStudioPascalVOCInstanceSegmentationInput,
@@ -42,6 +43,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=None,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         assert list(label_input.get_categories()) == [
             Category(id=0, name="cat"),
@@ -61,6 +63,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=None,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         assert list(label_input.get_categories()) == [
             Category(id=1, name="cat"),
@@ -83,6 +86,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=None,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         assert list(label_input.get_categories()) == []
 
@@ -96,6 +100,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=None,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         assert list(label_input.get_images()) == [
             Image(id=0, filename="img1", width=100, height=100),
@@ -110,6 +115,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=None,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         assert list(label_input.get_images()) == []
 
@@ -123,6 +129,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=None,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         labels = list(label_input.get_labels())
 
@@ -171,6 +178,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=None,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         labels = list(label_input.get_labels())
 
@@ -236,6 +244,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=source_1_id,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         assert list(label_input_source_1.get_labels()) == [
             ImageObjectDetection(
@@ -255,6 +264,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=source_2_id,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         assert list(label_input_source_2.get_labels()) == [
             ImageObjectDetection(
@@ -310,6 +320,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=None,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         labels = list(label_input.get_labels())
         assert len(labels) == 1
@@ -363,6 +374,7 @@ class TestLightlyStudioLabelInput:
             dataset_id=collection.dataset_id,
             samples=DatasetQuery(dataset=collection, session=db_session),
             annotation_collection_id=None,
+            sample_to_image=image_dataset_export.image_sample_to_image,
         )
         labels = list(label_input.get_labels())
 


### PR DESCRIPTION
## What has changed and why

Refactor `to_coco_captions_dict` and `ImageDatasetExport` and the helper functions to take a `sample_to_image` function in, which transforms the `LightlyStudio` sample into a labelformat `Image`. 

Already in this PR, it allows to remove duplicate code between COCO (absolute paths) and yolo+voc (relative paths). Net LOC change is thus negative.

In a follow-up PR it will then allow to add VideoFrame export with very little extra code.

## How tested

unittests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export workflows now use a configurable image-mapping step so exports work across generic sample types for COCO captions, object detection, instance segmentation, and Pascal VOC segmentation.
  * Filename formatting is configurable per export type (relative vs absolute) while keeping consistent image metadata.

* **Bug Fixes**
  * Improved alignment of exported image metadata (IDs, filenames, width/height) with caption and annotation generation.
  * Instance segmentation now derives mask-based instances from the mapped image dimensions more reliably.
  * Object/category and annotation export respects annotation type and optional collection filtering.

* **Tests**
  * Updated COCO captions and label export tests to provide the new image-mapping dependency explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->