### PR TITLE
Add count_mode to image annotation count endpoint

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/image.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/image.py
@@ -27,6 +27,9 @@ from lightly_studio.resolvers import (
 from lightly_studio.resolvers.image_filter import (
     ImageFilter,
 )
+from lightly_studio.resolvers.image_resolver.count_image_annotations_by_collection import (
+    AnnotationCountMode,
+)
 
 image_router = APIRouter(tags=["image"])
 
@@ -139,6 +142,10 @@ class ReadCountImageAnnotationsRequest(BaseModel):
         None,
         description="Restrict counts to a single annotation type (e.g. classification).",
     )
+    count_mode: AnnotationCountMode = Field(
+        AnnotationCountMode.OBJECTS,
+        description="Whether to count annotation objects or distinct annotated samples.",
+    )
 
 
 @image_router.post("/collections/{collection_id}/images/sample_ids", response_model=list[UUID])
@@ -170,11 +177,13 @@ def count_image_annotations_by_collection(
     """Get image annotation counts for a specific collection."""
     image_filter = body.filter if body and body.filter else None
     annotation_type = body.annotation_type if body else None
+    count_mode = body.count_mode if body else AnnotationCountMode.OBJECTS
     counts = image_resolver.count_image_annotations_by_collection(
         session=session,
         collection_id=collection.collection_id,
         image_filter=image_filter,
         annotation_type=annotation_type,
+        count_mode=count_mode,
     )
 
     return [

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
@@ -42,6 +42,11 @@ def count_image_annotations_by_collection(
     When ``annotation_type`` is provided, both the total and filtered counts are
     restricted to annotations of that type (e.g. only CLASSIFICATION or only
     OBJECT_DETECTION).
+
+    When ``count_mode`` is ``OBJECTS`` (default), each annotation row is counted
+    individually.  When ``count_mode`` is ``SAMPLES``, the count reflects the
+    number of distinct parent samples that carry at least one matching annotation,
+    so a sample with multiple annotations of the same label is counted only once.
     """
     # Resolve any embedding-plot region selection to concrete sample ids on the filter before the
     # query is built (the point-in-polygon test needs the session, which `apply` lacks).

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from uuid import UUID
 
+from sqlalchemy import ColumnElement
 from sqlmodel import Session, col, func, select
 
 from lightly_studio.models.annotation.annotation_base import (
@@ -17,11 +19,19 @@ from lightly_studio.resolvers import embedding_region_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
 
 
+class AnnotationCountMode(str, Enum):
+    """Controls what the annotation count represents."""
+
+    OBJECTS = "objects"
+    SAMPLES = "samples"
+
+
 def count_image_annotations_by_collection(
     session: Session,
     collection_id: UUID,
     image_filter: ImageFilter | None = None,
     annotation_type: AnnotationType | None = None,
+    count_mode: AnnotationCountMode = AnnotationCountMode.OBJECTS,
 ) -> list[tuple[str, int, int]]:
     """Count annotations for a specific image collection.
 
@@ -46,12 +56,14 @@ def count_image_annotations_by_collection(
         session=session,
         collection_id=collection_id,
         annotation_type=annotation_type,
+        count_mode=count_mode,
     )
     current_counts = _get_current_counts(
         session=session,
         collection_id=collection_id,
         image_filter=image_filter,
         annotation_type=annotation_type,
+        count_mode=count_mode,
     )
 
     return [
@@ -60,16 +72,23 @@ def count_image_annotations_by_collection(
     ]
 
 
+def _build_count_expression(count_mode: AnnotationCountMode) -> ColumnElement[int]:
+    if count_mode == AnnotationCountMode.SAMPLES:
+        return func.count(func.distinct(col(AnnotationBaseTable.parent_sample_id)))
+    return func.count(col(AnnotationBaseTable.sample_id))
+
+
 def _get_total_counts(
     session: Session,
     collection_id: UUID,
     annotation_type: AnnotationType | None = None,
+    count_mode: AnnotationCountMode = AnnotationCountMode.OBJECTS,
 ) -> dict[str, int]:
     """Returns total annotation counts per label for the collection."""
     total_counts_query = (
         select(
             AnnotationLabelTable.annotation_label_name,
-            func.count(col(AnnotationBaseTable.sample_id)).label("total_count"),
+            _build_count_expression(count_mode).label("total_count"),
         )
         .join(
             AnnotationBaseTable,
@@ -104,12 +123,13 @@ def _get_current_counts(
     collection_id: UUID,
     image_filter: ImageFilter | None,
     annotation_type: AnnotationType | None = None,
+    count_mode: AnnotationCountMode = AnnotationCountMode.OBJECTS,
 ) -> dict[str, int]:
     """Returns filtered annotation counts per label for the collection."""
     filtered_query = (
         select(
             AnnotationLabelTable.annotation_label_name,
-            func.count(col(AnnotationBaseTable.sample_id)).label("current_count"),
+            _build_count_expression(count_mode).label("current_count"),
         )
         .join(
             AnnotationBaseTable,

--- a/lightly_studio/tests/api/routes/api/test_image.py
+++ b/lightly_studio/tests/api/routes/api/test_image.py
@@ -463,6 +463,162 @@ def test_count_image_annotations_by_collection__without_body(
     ]
 
 
+def test_count_image_annotations_by_collection__count_mode_samples(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/image_a.png",
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/image_b.png",
+    )
+
+    car_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="car",
+    )
+    person_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="person",
+    )
+
+    # image_a: car, car, person — image_b: car
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=person_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+        ],
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/images/annotations/count",
+        json={"count_mode": "samples"},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    result = {row["label_name"]: row["total_count"] for row in response.json()}
+    assert result["car"] == 2
+    assert result["person"] == 1
+
+
+def test_count_image_annotations_by_collection__count_mode_samples_with_filter(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/image_a.png",
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/image_b.png",
+    )
+
+    car_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="car",
+    )
+    person_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="person",
+    )
+
+    # image_a: car, car, person — image_b: car
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=person_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+        ],
+    )
+
+    # Filter to images with a person annotation (only image_a) + samples count mode.
+    response = test_client.post(
+        f"/api/collections/{collection_id}/images/annotations/count",
+        json={
+            "count_mode": "samples",
+            "filter": {
+                "sample_filter": {
+                    "annotations_filter": {
+                        "annotation_label_ids": [str(person_label.annotation_label_id)]
+                    }
+                }
+            },
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    result = {
+        row["label_name"]: (row["current_count"], row["total_count"]) for row in response.json()
+    }
+    # current: only image_a passes the filter — 1 distinct sample for car, 1 for person
+    assert result["car"] == (1, 2)
+    assert result["person"] == (1, 1)
+
+
+def test_count_image_annotations_by_collection__count_mode_invalid(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/images/annotations/count",
+        json={"count_mode": "invalid"},
+    )
+
+    assert response.status_code == 422
+
+
 def test_get_image_sample_ids(
     test_client: TestClient,
     db_session: Session,

--- a/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
@@ -12,6 +12,9 @@ from lightly_studio.models.collection import CollectionTable
 from lightly_studio.resolvers import image_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.resolvers.image_resolver.count_image_annotations_by_collection import (
+    AnnotationCountMode,
+)
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import (
     AnnotationDetails,
@@ -199,3 +202,136 @@ def test_count_image_annotations_by_collection_filters_by_annotation_type(
 
     counts_dict = {label: (current, total) for label, current, total in counts}
     assert counts_dict == expected_counts
+
+
+def test_count_image_annotations_by_collection__samples_mode(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/image_a.png",
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/image_b.png",
+    )
+
+    car_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="car",
+    )
+    person_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="person",
+    )
+
+    # image_a: car, car, person — image_b: car
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=person_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+        ],
+    )
+
+    counts = image_resolver.count_image_annotations_by_collection(
+        session=db_session,
+        collection_id=collection_id,
+        count_mode=AnnotationCountMode.SAMPLES,
+    )
+
+    counts_dict = {label: total for label, _, total in counts}
+    assert counts_dict["car"] == 2
+    assert counts_dict["person"] == 1
+
+
+def test_count_image_annotations_by_collection__samples_mode_with_filter(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/image_a.png",
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/image_b.png",
+    )
+
+    car_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="car",
+    )
+    person_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection_id,
+        label_name="person",
+    )
+
+    # image_a: car, car, person — image_b: car
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=person_label.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=car_label.annotation_label_id,
+            ),
+        ],
+    )
+
+    # Filter to only images that have a person annotation — only image_a matches.
+    counts = image_resolver.count_image_annotations_by_collection(
+        session=db_session,
+        collection_id=collection_id,
+        image_filter=ImageFilter(
+            sample_filter=SampleFilter(
+                annotations_filter=AnnotationsFilter(
+                    annotation_label_ids=[person_label.annotation_label_id]
+                )
+            )
+        ),
+        count_mode=AnnotationCountMode.SAMPLES,
+    )
+
+    counts_dict = {label: (current, total) for label, current, total in counts}
+    # current: only image_a is in filter — 1 distinct sample for car, 1 for person
+    assert counts_dict["car"] == (1, 2)
+    assert counts_dict["person"] == (1, 1)


### PR DESCRIPTION
## What has changed and why?

Adds a count_mode parameter to the image annotation count resolver and the POST `/collections/{collection_id}/images/annotations/count` endpoint.

Accepted values:
                                                                     
- objects (default): total annotation instance count per class. Preserves existing behavior.
- samples: number of distinct images containing each class. 

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `count_mode` option for annotation counts to choose between counting annotation objects or distinct annotated samples.
  * The annotation count endpoint supports this selection while preserving the existing response format.
* **Bug Fixes**
  * Counting results now correctly follow the selected mode, including when image/sample filters are applied.
  * Invalid `count_mode` values are rejected with a validation error.
* **Tests**
  * Added integration and resolver tests covering sample-based counting and filtering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->