### PR TITLE
Add collection_filter support to image export endpoints

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -24,6 +24,7 @@ from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.export_format import ExportFormat
 from lightly_studio.resolvers import collection_resolver
 from lightly_studio.resolvers.collection_resolver.export import ExportFilter
+from lightly_studio.resolvers.image_filter import ImageFilter
 
 export_router = APIRouter(prefix="/collections/{collection_id}", tags=["export"])
 _STREAM_CHUNK_SIZE_BYTES = 64 * 1024
@@ -198,6 +199,9 @@ class ExportBody(BaseModel):
     exclude: ExportFilter | None = Field(
         None, description="exclude filter for sample_ids or tag_ids"
     )
+    collection_filter: ImageFilter | None = Field(
+        None, description="active view filter applied on top of include/exclude"
+    )
 
 
 # This endpoint should be a GET, however due to the potential huge size
@@ -223,6 +227,7 @@ def export_collection_to_absolute_paths(
         collection_id=collection.collection_id,
         include=body.include,
         exclude=body.exclude,
+        collection_filter=body.collection_filter,
     )
 
     # Create a response with the exported data
@@ -254,6 +259,7 @@ def export_collection_stats(
         collection_id=collection.collection_id,
         include=body.include,
         exclude=body.exclude,
+        collection_filter=body.collection_filter,
     )
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/export.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/export.py
@@ -15,6 +15,7 @@ from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.tag import TagTable
+from lightly_studio.resolvers import embedding_region_resolver
 from lightly_studio.resolvers.dataset_resolver.get_hierarchy import get_hierarchy
 from lightly_studio.resolvers.image_filter import ImageFilter
 
@@ -69,8 +70,19 @@ def export(
     Returns:
         List of file paths
     """
+    # Resolve any embedding-plot region selection to concrete sample ids before the query is
+    # built (the point-in-polygon test needs the session, which `_build_export_query` lacks).
+    sample_filter = collection_filter.sample_filter if collection_filter is not None else None
+    if sample_filter is not None and sample_filter.embedding_region is not None:
+        sample_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
+            session=session,
+            collection_id=collection_id,
+            region=sample_filter.embedding_region,
+        )
     # Get all child collection IDs that could contain annotations
-    annotation_collection_ids = _get_annotation_collection_ids(session, collection_id)
+    annotation_collection_ids = _get_annotation_collection_ids(
+        session=session, collection_id=collection_id
+    )
     query = _build_export_query(
         collection_id=collection_id,
         annotation_collection_ids=annotation_collection_ids,
@@ -106,8 +118,19 @@ def get_filtered_samples_count(
     Returns:
         Count of files to be exported
     """
+    # Resolve any embedding-plot region selection to concrete sample ids before the query is
+    # built (the point-in-polygon test needs the session, which `_build_export_query` lacks).
+    sample_filter = collection_filter.sample_filter if collection_filter is not None else None
+    if sample_filter is not None and sample_filter.embedding_region is not None:
+        sample_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
+            session=session,
+            collection_id=collection_id,
+            region=sample_filter.embedding_region,
+        )
     # Get all child collection IDs that could contain annotations
-    annotation_collection_ids = _get_annotation_collection_ids(session, collection_id)
+    annotation_collection_ids = _get_annotation_collection_ids(
+        session=session, collection_id=collection_id
+    )
     query = _build_export_query(
         collection_id=collection_id,
         annotation_collection_ids=annotation_collection_ids,

--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/export.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/export.py
@@ -16,6 +16,7 @@ from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.tag import TagTable
 from lightly_studio.resolvers.dataset_resolver.get_hierarchy import get_hierarchy
+from lightly_studio.resolvers.image_filter import ImageFilter
 
 
 class ExportFilter(BaseModel):
@@ -49,6 +50,7 @@ def export(
     collection_id: UUID,
     include: ExportFilter | None = None,
     exclude: ExportFilter | None = None,
+    collection_filter: ImageFilter | None = None,
 ) -> list[str]:
     # TODO(lukas, 03/2026): take dataset_id instead of collection_id
     """Retrieve samples for exporting from a collection.
@@ -62,6 +64,7 @@ def export(
         collection_id: UUID of the collection.
         include: Filter to include samples.
         exclude: Filter to exclude samples.
+        collection_filter: Active view filter applied on top of include/exclude.
 
     Returns:
         List of file paths
@@ -73,6 +76,7 @@ def export(
         annotation_collection_ids=annotation_collection_ids,
         include=include,
         exclude=exclude,
+        collection_filter=collection_filter,
     )
     result = session.exec(query).all()
     return [sample.file_path_abs for sample in result]
@@ -83,6 +87,7 @@ def get_filtered_samples_count(
     collection_id: UUID,
     include: ExportFilter | None = None,
     exclude: ExportFilter | None = None,
+    collection_filter: ImageFilter | None = None,
 ) -> int:
     # TODO(lukas, 03/2026): take dataset_id instead of collection_id
     """Get statistics about the export query.
@@ -96,6 +101,7 @@ def get_filtered_samples_count(
         collection_id: UUID of the collection.
         include: Filter to include samples.
         exclude: Filter to exclude samples.
+        collection_filter: Active view filter applied on top of include/exclude.
 
     Returns:
         Count of files to be exported
@@ -107,6 +113,7 @@ def get_filtered_samples_count(
         annotation_collection_ids=annotation_collection_ids,
         include=include,
         exclude=exclude,
+        collection_filter=collection_filter,
     )
     count_query = select(func.count()).select_from(query.subquery())
     return session.exec(count_query).one() or 0
@@ -140,6 +147,7 @@ def _build_export_query(  # noqa: C901
     annotation_collection_ids: list[UUID],
     include: ExportFilter | None = None,
     exclude: ExportFilter | None = None,
+    collection_filter: ImageFilter | None = None,
 ) -> SelectOfScalar[ImageTable]:
     """Build the export query based on filters.
 
@@ -148,6 +156,7 @@ def _build_export_query(  # noqa: C901
         annotation_collection_ids: List of collection IDs that could contain annotations.
         include: Filter to include samples.
         exclude: Filter to exclude samples.
+        collection_filter: Active view filter applied on top of include/exclude as an intersection.
 
     Returns:
         SQLModel select query
@@ -156,6 +165,12 @@ def _build_export_query(  # noqa: C901
         raise ValueError("Include or exclude filter is required.")
     if include and exclude:
         raise ValueError("Cannot include and exclude at the same time.")
+
+    active_view_subquery = (
+        collection_filter.build_sample_ids_query(collection_id)
+        if collection_filter is not None
+        else None
+    )
 
     # include tags or sample_ids or annotation_ids from result
     if include:
@@ -174,7 +189,7 @@ def _build_export_query(  # noqa: C901
                 )
             )
 
-            return (
+            query = (
                 select(ImageTable)
                 .join(ImageTable.sample)
                 .where(SampleTable.collection_id == collection_id)
@@ -198,8 +213,8 @@ def _build_export_query(  # noqa: C901
             )
 
         # get samples by specific sample_ids
-        if include.sample_ids:
-            return (
+        elif include.sample_ids:
+            query = (
                 select(ImageTable)
                 .join(ImageTable.sample)
                 .where(SampleTable.collection_id == collection_id)
@@ -211,7 +226,7 @@ def _build_export_query(  # noqa: C901
             )
 
         # get samples by specific annotation_ids
-        if include.annotation_ids:
+        elif include.annotation_ids:
             # Annotations are stored in child collections, so filter by all annotation collection
             # IDs
             # Filter by checking if the annotation's sample_id belongs to a sample in
@@ -224,7 +239,7 @@ def _build_export_query(  # noqa: C901
                 if annotation_collection_ids
                 else false()
             )
-            return (
+            query = (
                 select(ImageTable)
                 .join(ImageTable.sample)
                 .join(SampleTable.annotations)
@@ -256,7 +271,7 @@ def _build_export_query(  # noqa: C901
                 )
             )
 
-            return (
+            query = (
                 select(ImageTable)
                 .join(ImageTable.sample)
                 .where(SampleTable.collection_id == collection_id)
@@ -276,8 +291,8 @@ def _build_export_query(  # noqa: C901
                 .order_by(col(ImageTable.created_at).asc())
                 .distinct()
             )
-        if exclude.sample_ids:
-            return (
+        elif exclude.sample_ids:
+            query = (
                 select(ImageTable)
                 .join(ImageTable.sample)
                 .where(SampleTable.collection_id == collection_id)
@@ -287,8 +302,8 @@ def _build_export_query(  # noqa: C901
                 .order_by(col(ImageTable.created_at).asc())
                 .distinct()
             )
-        if exclude.annotation_ids:
-            return (
+        elif exclude.annotation_ids:
+            query = (
                 select(ImageTable)
                 .join(ImageTable.sample)
                 .where(SampleTable.collection_id == collection_id)
@@ -307,4 +322,7 @@ def _build_export_query(  # noqa: C901
                 .distinct()
             )
 
-    raise ValueError("Invalid include or export filter combination.")
+    if active_view_subquery is not None:
+        query = query.where(col(SampleTable.sample_id).in_(active_view_subquery))
+
+    return query

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -321,6 +321,40 @@ def test_export_collection_captions(
     )
 
 
+def test_export_collection_samples__image_filter__tag__returns_intersection(
+    db_session: Session, test_client: TestClient
+) -> None:
+    # Tag covers A and B; ImageFilter covers B and C → export returns B only.
+    collection_id = create_collection(session=db_session).collection_id
+    image_a = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="path/a.png"
+    )
+    image_b = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="path/b.png"
+    )
+    image_c = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="path/c.png"
+    )
+
+    tag = create_tag(session=db_session, collection_id=collection_id)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_a.sample)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_b.sample)
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/export",
+        json={
+            "include": {"tag_ids": [str(tag.tag_id)]},
+            "collection_filter": {
+                "filter_type": "image",
+                "sample_filter": {"sample_ids": [str(image_b.sample_id), str(image_c.sample_id)]},
+            },
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.text == image_b.file_path_abs
+
+
 def test_export_collection_samples(db_session: Session, test_client: TestClient) -> None:
     client = test_client
     collection_id = create_collection(

--- a/lightly_studio/tests/resolvers/collection_resolver/test_export.py
+++ b/lightly_studio/tests/resolvers/collection_resolver/test_export.py
@@ -12,6 +12,8 @@ from lightly_studio.models.image import ImageTable
 from lightly_studio.models.tag import TagTable
 from lightly_studio.resolvers import collection_resolver, tag_resolver
 from lightly_studio.resolvers.collection_resolver.export import ExportFilter
+from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import (
     create_annotation,
     create_annotation_label,
@@ -865,6 +867,71 @@ def test_export__exclude_by_multiple_annotation_ids(
     assert len(samples_exported) == len(samples) - 2
     assert samples[0].file_path_abs not in samples_exported
     assert samples[1].file_path_abs not in samples_exported
+
+
+def test_export__image_filter__tag_ids__returns_intersection(
+    db_session: Session,
+) -> None:
+    # include.tag_ids covers A and B; ImageFilter covers B and C → intersection is B.
+    collection_id = create_collection(session=db_session).collection_id
+    image_a = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="/path/a.png"
+    )
+    image_b = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="/path/b.png"
+    )
+    image_c = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="/path/c.png"
+    )
+
+    tag_ab = create_tag(
+        session=db_session, collection_id=collection_id, tag_name="ab", kind="sample"
+    )
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=tag_ab.tag_id,
+        sample_ids=[image_a.sample_id, image_b.sample_id],
+    )
+
+    image_filter = ImageFilter(
+        sample_filter=SampleFilter(sample_ids=[image_b.sample_id, image_c.sample_id])
+    )
+    result = collection_resolver.export(
+        session=db_session,
+        collection_id=collection_id,
+        include=ExportFilter(tag_ids=[tag_ab.tag_id]),
+        collection_filter=image_filter,
+    )
+
+    assert result == [image_b.file_path_abs]
+
+
+def test_export__image_filter__sample_ids__returns_intersection(
+    db_session: Session,
+) -> None:
+    # include.sample_ids covers A and B; ImageFilter covers B and C → intersection is B.
+    collection_id = create_collection(session=db_session).collection_id
+    image_a = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="/path/a.png"
+    )
+    image_b = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="/path/b.png"
+    )
+    image_c = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="/path/c.png"
+    )
+
+    image_filter = ImageFilter(
+        sample_filter=SampleFilter(sample_ids=[image_b.sample_id, image_c.sample_id])
+    )
+    result = collection_resolver.export(
+        session=db_session,
+        collection_id=collection_id,
+        include=ExportFilter(sample_ids=[image_a.sample_id, image_b.sample_id]),
+        collection_filter=image_filter,
+    )
+
+    assert result == [image_b.file_path_abs]
 
 
 def test_get_filtered_samples_count__include_single_sample_tag(

--- a/lightly_studio/tests/resolvers/collection_resolver/test_export.py
+++ b/lightly_studio/tests/resolvers/collection_resolver/test_export.py
@@ -8,17 +8,22 @@ from sqlmodel import Session
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.embedding_region import EmbeddingRegion, Point2D
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.tag import TagTable
-from lightly_studio.resolvers import collection_resolver, tag_resolver
+from lightly_studio.models.two_dim_embedding import TwoDimEmbeddingTable
+from lightly_studio.resolvers import collection_resolver, sample_embedding_resolver, tag_resolver
 from lightly_studio.resolvers.collection_resolver.export import ExportFilter
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import (
+    ImageStub,
     create_annotation,
     create_annotation_label,
     create_collection,
+    create_embedding_model,
     create_image,
+    create_samples_with_embeddings,
     create_tag,
 )
 
@@ -1049,3 +1054,121 @@ def test_get_filtered_samples_count__exclude_multiple_annotation_ids(
         ),
     )
     assert count == len(samples) - 2
+
+
+def test_export__embedding_region_filter__returns_samples_inside_region(
+    db_session: Session,
+) -> None:
+    # Three samples: a=(1,1) and b=(5,5) inside a [0,10]x[0,10] square; c=(100,100) outside.
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_dimension=3,
+    )
+    image_a, image_b, image_c = create_samples_with_embeddings(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        images_and_embeddings=[
+            (ImageStub(path="sample_a.png"), [0.1, 0.2, 0.3]),
+            (ImageStub(path="sample_b.png"), [1.1, 0.2, 0.3]),
+            (ImageStub(path="sample_c.png"), [2.1, 0.2, 0.3]),
+        ],
+    )
+    # Seed 2D coordinates so that a and b are inside the lasso region, c is not.
+    cache_key, ordered_sample_ids = sample_embedding_resolver.get_hash_by_collection_id(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+    coordinates = {
+        image_a.sample_id: (1.0, 1.0),
+        image_b.sample_id: (5.0, 5.0),
+        image_c.sample_id: (100.0, 100.0),
+    }
+    db_session.add(
+        TwoDimEmbeddingTable(
+            hash=cache_key,
+            x=[coordinates[sid][0] for sid in ordered_sample_ids],
+            y=[coordinates[sid][1] for sid in ordered_sample_ids],
+        )
+    )
+    db_session.commit()
+
+    region = EmbeddingRegion(
+        polygon=[
+            Point2D(x=0, y=0),
+            Point2D(x=10, y=0),
+            Point2D(x=10, y=10),
+            Point2D(x=0, y=10),
+        ]
+    )
+    result = collection_resolver.export(
+        session=db_session,
+        collection_id=collection_id,
+        include=ExportFilter(sample_ids=[image_a.sample_id, image_b.sample_id, image_c.sample_id]),
+        collection_filter=ImageFilter(sample_filter=SampleFilter(embedding_region=region)),
+    )
+
+    assert sorted(result) == sorted([image_a.file_path_abs, image_b.file_path_abs])
+
+
+def test_get_filtered_samples_count__embedding_region_filter__returns_count_inside_region(
+    db_session: Session,
+) -> None:
+    # Three samples: a=(1,1) and b=(5,5) inside a [0,10]x[0,10] square; c=(100,100) outside.
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_dimension=3,
+    )
+    image_a, image_b, image_c = create_samples_with_embeddings(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        images_and_embeddings=[
+            (ImageStub(path="sample_a.png"), [0.1, 0.2, 0.3]),
+            (ImageStub(path="sample_b.png"), [1.1, 0.2, 0.3]),
+            (ImageStub(path="sample_c.png"), [2.1, 0.2, 0.3]),
+        ],
+    )
+    # Seed 2D coordinates so that a and b are inside the lasso region, c is not.
+    cache_key, ordered_sample_ids = sample_embedding_resolver.get_hash_by_collection_id(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+    coordinates = {
+        image_a.sample_id: (1.0, 1.0),
+        image_b.sample_id: (5.0, 5.0),
+        image_c.sample_id: (100.0, 100.0),
+    }
+    db_session.add(
+        TwoDimEmbeddingTable(
+            hash=cache_key,
+            x=[coordinates[sid][0] for sid in ordered_sample_ids],
+            y=[coordinates[sid][1] for sid in ordered_sample_ids],
+        )
+    )
+    db_session.commit()
+
+    region = EmbeddingRegion(
+        polygon=[
+            Point2D(x=0, y=0),
+            Point2D(x=10, y=0),
+            Point2D(x=10, y=10),
+            Point2D(x=0, y=10),
+        ]
+    )
+    count = collection_resolver.get_filtered_samples_count(
+        session=db_session,
+        collection_id=collection_id,
+        include=ExportFilter(sample_ids=[image_a.sample_id, image_b.sample_id, image_c.sample_id]),
+        collection_filter=ImageFilter(sample_filter=SampleFilter(embedding_region=region)),
+    )
+
+    assert count == 2


### PR DESCRIPTION
## What has changed and why?

Adds an optional `collection_filter` field to the image `/export/` and `/export/stats` endpoints. When provided, it is applied as an intersection on top of the existing include/exclude filters. So, only samples that satisfy both the include/exclude selection and the active view filters are exported.


## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Collection exports now accept an optional view filter to further constrain which samples are included.
  - Exported files and stats are computed as the intersection of export criteria (e.g., tags or explicit sample lists) and the active view filter, including embedding region–based filtering.
- **Tests**
  - Added API and resolver tests covering intersections between tag/sample filters and image-based view filters.
  - Added tests validating embedding region filtering for both exported content and sample counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->