### PR TITLE
Invalidate evaluation metrics on annotation bounding-box update

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
@@ -3,6 +3,7 @@
 from lightly_studio.resolvers.annotation_resolver.create_many import create_many
 from lightly_studio.resolvers.annotation_resolver.delete_annotation import (
     delete_annotation,
+    delete_evaluation_metrics,
 )
 from lightly_studio.resolvers.annotation_resolver.delete_annotations import (
     delete_annotations,
@@ -57,6 +58,7 @@ __all__ = [
     "create_many",
     "delete_annotation",
     "delete_annotations",
+    "delete_evaluation_metrics",
     "get_adjacent_annotations",
     "get_all",
     "get_all_by_collection_id_and_parent_sample_ids",

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_bounding_box.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/update_bounding_box.py
@@ -44,6 +44,11 @@ def update_bounding_box(
         raise ValueError(f"Annotation with ID {annotation_id} not found.")
 
     try:
+        annotation_resolver.delete_evaluation_metrics(
+            session=session,
+            annotation_ids=[annotation.sample_id],
+            parent_sample_ids=[annotation.parent_sample_id],
+        )
         if annotation.object_detection_details:
             annotation.object_detection_details.x = coordinates.x
             annotation.object_detection_details.y = coordinates.y

--- a/lightly_studio/tests/resolvers/annotations/test_annotations_update_bounding_box.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotations_update_bounding_box.py
@@ -4,12 +4,27 @@ import pytest
 from sqlmodel import Session
 
 from lightly_studio import AnnotationType
-from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricCreate
+from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    evaluation_annotation_metric_resolver,
+    evaluation_sample_metric_resolver,
+)
 from lightly_studio.resolvers.annotation_resolver.update_bounding_box import (
     BoundingBoxCoordinates,
 )
 from tests.conftest import AnnotationsTestData
-from tests.helpers_resolvers import get_annotation_by_type
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+    get_annotation_by_type,
+)
+from tests.resolvers.evaluation_sample_metric_resolver import (
+    helpers as evaluation_sample_metric_helpers,
+)
 
 
 def test_update_bounding_box__object_detection(
@@ -122,3 +137,71 @@ def test_update_bounding_box__invalid_annotation_id(
 
     with pytest.raises(ValueError, match=f"Annotation with ID {invalid_annotation_id} not found."):
         annotation_resolver.update_bounding_box(db_session, invalid_annotation_id, new_coordinates)
+
+
+def test_update_bounding_box__deletes_evaluation_metrics(
+    db_session: Session,
+) -> None:
+    """Test bounding box updates remove invalidated evaluation annotation and sample metrics."""
+    dataset = create_collection(session=db_session)
+    run = evaluation_sample_metric_helpers.create_run(
+        session=db_session,
+        collection_id=dataset.collection_id,
+    )
+    image = create_image(session=db_session, collection_id=dataset.collection_id)
+    collection_id = dataset.collection_id
+    label = create_annotation_label(session=db_session, root_collection_id=collection_id)
+    pred_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    gt_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    evaluation_annotation_metric_resolver.create_many(
+        session=db_session,
+        records=[
+            EvaluationAnnotationMetricCreate(
+                evaluation_run_id=run.id,
+                sample_id=image.sample_id,
+                pred_annotation_id=pred_annotation.sample_id,
+                gt_annotation_id=gt_annotation.sample_id,
+                metric_name="iou",
+                value=0.75,
+            )
+        ],
+    )
+    evaluation_sample_metric_resolver.create_many(
+        session=db_session,
+        records=[
+            EvaluationSampleMetricCreate(
+                evaluation_run_id=run.id,
+                sample_id=image.sample_id,
+                metric_name="score",
+                value=0.5,
+            )
+        ],
+    )
+
+    annotation_resolver.update_bounding_box(
+        session=db_session,
+        annotation_id=gt_annotation.sample_id,
+        coordinates=BoundingBoxCoordinates(x=11, y=22, width=111, height=222),
+    )
+
+    annotation_metrics = evaluation_annotation_metric_resolver.get_all_by_evaluation_run_id(
+        session=db_session,
+        evaluation_run_id=run.id,
+    )
+    sample_metrics = evaluation_sample_metric_resolver.get_all_by_evaluation_run_id(
+        session=db_session,
+        evaluation_run_id=run.id,
+    )
+
+    assert annotation_metrics == []
+    assert sample_metrics == []


### PR DESCRIPTION
## What has changed and why?

Per-annotation model evaluation results are precomputed. When updating the bbox, they did not update. This PR deletes them, because they are invalid.

Split out of #1612; the segmentation-mask half follows in a separate PR.

### Design decision: Delete them instead of marking them as stale

Delete the invalid rows. This is easiest and automatically makes all consumers work.

Marking stale would only be needed if we would want to recompute only the invalid evaluation metrics instead of directly all metrics. I don't see a need for that.

## How has it been tested?

new unittests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating an annotation’s bounding box now clears related evaluation metrics tied to the affected samples, so follow-up evaluations use the new bounding box values.
  * Ensures both annotation-level and sample-level evaluation metrics are refreshed accordingly.

* **Tests**
  * Added coverage to verify that evaluation metrics are deleted when bounding boxes are updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->