### PR TITLE
Split a generic DatasetExport base out of ImageDatasetExport

### DIFF
--- a/lightly_studio/src/lightly_studio/export/image_dataset_export.py
+++ b/lightly_studio/src/lightly_studio/export/image_dataset_export.py
@@ -35,17 +35,12 @@ YOLO_DEFAULT_SPLIT = "train"
 
 
 class DatasetExport:
-    """Provides methods to export a dataset or a subset of it in various formats.
+    """Provides methods to export a dataset or a subset of it.
 
-    The export logic here is sample-type-agnostic: subclasses bind a `sample_to_image`
-    strategy for their sample type (image or video frame), which is the only part that
-    differs between them.
+    Subclasses set the `sample_to_image` attribute,
     """
 
-    # TODO(malte, 07/2026): Move `DatasetExport` into its own `dataset_export.py` module. It lives
-    # in `image_dataset_export.py` for now so this split stays a small, in-place diff; the move
-    # will be a separate, behavior-preserving PR.
-
+    # TODO(malte, 07/2026): Move `DatasetExport` into its own `dataset_export.py` module.
     def __init__(
         self,
         session: Session,

--- a/lightly_studio/src/lightly_studio/export/image_dataset_export.py
+++ b/lightly_studio/src/lightly_studio/export/image_dataset_export.py
@@ -25,6 +25,7 @@ from lightly_studio.export.lightly_studio_label_input import (
     LightlyStudioObjectDetectionInput,
     LightlyStudioPascalVOCInstanceSegmentationInput,
     LightlyStudioYOLOObjectDetectionInput,
+    SampleToImage,
 )
 from lightly_studio.type_definitions import PathLike
 
@@ -33,29 +34,37 @@ YOLO_DATASET_CONFIG_FILENAME = "data.yaml"
 YOLO_DEFAULT_SPLIT = "train"
 
 
-class ImageDatasetExport:
-    """Provides methods to export a dataset or a subset of it.
+class DatasetExport:
+    """Provides methods to export a dataset or a subset of it in various formats.
 
-    This class is typically not instantiated directly but returned by `Dataset.export()`.
-    It allows exporting data in various formats.
+    The export logic here is sample-type-agnostic: subclasses bind a `sample_to_image`
+    strategy for their sample type (image or video frame), which is the only part that
+    differs between them.
     """
+
+    # TODO(malte, 07/2026): Move `DatasetExport` into its own `dataset_export.py` module. It lives
+    # in `image_dataset_export.py` for now so this split stays a small, in-place diff; the move
+    # will be a separate, behavior-preserving PR.
 
     def __init__(
         self,
         session: Session,
         dataset_id: UUID,
-        samples: Iterable[ImageSample],
+        samples: Iterable[Sample],
+        sample_to_image: SampleToImage,
     ):
-        """Initializes the ImageDatasetExport object.
+        """Initializes the DatasetExport object.
 
         Args:
             session: The database session.
             dataset_id: The dataset ID for label retrieval.
             samples: Samples to export.
+            sample_to_image: Strategy mapping a sample to a labelformat `Image`.
         """
         self.session = session
         self._dataset_id = dataset_id
         self.samples = samples
+        self._sample_to_image = sample_to_image
 
     def to_coco_object_detections(
         self,
@@ -80,7 +89,7 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             annotation_collection_id=annotation_collection_id,
-            sample_to_image=image_sample_to_image,
+            sample_to_image=self._sample_to_image,
         )
         COCOObjectDetectionOutput(output_file=Path(output_json)).save(label_input=export_input)
 
@@ -105,7 +114,7 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             annotation_collection_id=annotation_collection_id,
-            sample_to_image=image_sample_to_image,
+            sample_to_image=self._sample_to_image,
         )
         YOLOv8ObjectDetectionOutput(
             output_file=Path(output_folder) / YOLO_DATASET_CONFIG_FILENAME,
@@ -122,7 +131,7 @@ class ImageDatasetExport:
         if output_json is None:
             output_json = DEFAULT_EXPORT_FILENAME
         coco_captions_dict = coco_captions.to_coco_captions_dict(
-            samples=self.samples, sample_to_image=image_sample_to_image
+            samples=self.samples, sample_to_image=self._sample_to_image
         )
         with Path(output_json).open("w") as f:
             json.dump(coco_captions_dict, f, indent=2)
@@ -147,7 +156,7 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             annotation_collection_id=annotation_collection_id,
-            sample_to_image=image_sample_to_image,
+            sample_to_image=self._sample_to_image,
         )
         COCOInstanceSegmentationOutput(output_file=Path(output_json)).save(label_input=export_input)
 
@@ -172,12 +181,40 @@ class ImageDatasetExport:
             dataset_id=self._dataset_id,
             samples=self.samples,
             annotation_collection_id=annotation_collection_id,
-            sample_to_image=image_sample_to_image,
+            sample_to_image=self._sample_to_image,
         )
         # Keep `background_class_id` unchanged: the label input defines category IDs and
         # reserves class 0 for background.
         PascalVOCSemanticSegmentationOutput(output_folder=Path(output_folder)).save(
             label_input=export_input
+        )
+
+
+class ImageDatasetExport(DatasetExport):
+    """Provides methods to export an image dataset or a subset of it.
+
+    This class is typically not instantiated directly but returned by `Dataset.export()`.
+    It allows exporting data in various formats.
+    """
+
+    def __init__(
+        self,
+        session: Session,
+        dataset_id: UUID,
+        samples: Iterable[ImageSample],
+    ):
+        """Initializes the ImageDatasetExport object.
+
+        Args:
+            session: The database session.
+            dataset_id: The dataset ID for label retrieval.
+            samples: Samples to export.
+        """
+        super().__init__(
+            session=session,
+            dataset_id=dataset_id,
+            samples=samples,
+            sample_to_image=image_sample_to_image,
         )
 
 

--- a/lightly_studio/src/lightly_studio/export/image_dataset_export.py
+++ b/lightly_studio/src/lightly_studio/export/image_dataset_export.py
@@ -35,10 +35,7 @@ YOLO_DEFAULT_SPLIT = "train"
 
 
 class DatasetExport:
-    """Provides methods to export a dataset or a subset of it.
-
-    Subclasses set the `sample_to_image` attribute,
-    """
+    """Provides methods to export a dataset or a subset of it."""
 
     # TODO(malte, 07/2026): Move `DatasetExport` into its own `dataset_export.py` module.
     def __init__(


### PR DESCRIPTION
## What has changed an why

Split the ImageDatasetExport into two parts. Almost all go into `DatasetExport` that now has `sample_to_image`  as configurable attribute.
ImageDatasetExport itself stays a child class setting the sample_to_image to image_sample_to_image

Next PRs will
- Move `DatasetExport` into its own file. Not done in the PR to allow an easily reviewable diff
- Create a VideoFrameDatasetExport as sibling to ImageDatasetExport, but setting a different sample_to_image

## How was it tested

unittests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable export foundation that standardizes dataset export behavior across multiple sample types.
  * Export flows now support configurable sample-to-image conversion strategies.
  * Image dataset exports still support COCO, YOLO, captions, instance segmentation, and Pascal VOC formats.
* **Refactor**
  * Centralized shared export logic to improve consistency and reduce duplication across supported export formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->