### PR TITLE
Add AnnotationMetricQuery.false_negative()

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
@@ -21,8 +21,7 @@ from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotat
 from lightly_studio.models.evaluation_run import EvaluationRunTable
 from lightly_studio.models.sample import SampleTable
 
-# TODO(lukas, 07/2026): More match kinds will be added later.
-AnnotationMetricMatchKind = Literal["confusion", "false_positive"]
+AnnotationMetricMatchKind = Literal["confusion", "false_positive", "false_negative"]
 
 
 @dataclass
@@ -47,7 +46,7 @@ class AnnotationMetricQuery(MatchExpression):
     match_kind: AnnotationMetricMatchKind
     run_name: str
     gt_label_name: str | None
-    pred_label_name: str
+    pred_label_name: str | None
     criteria: list[AnnotationEvaluationMetricMatchExpression]
 
     @classmethod
@@ -113,6 +112,34 @@ class AnnotationMetricQuery(MatchExpression):
             criteria=[],
         )
 
+    @classmethod
+    def false_negative(
+        cls,
+        run_name: str,
+        ground_truth: str,
+    ) -> AnnotationMetricQuery:
+        """Match samples with false-negative ground truths within an evaluation run.
+
+        Example:
+            ```python
+            AnnotationMetricQuery.false_negative(
+                run_name="run1",
+                ground_truth="cat",
+            )
+            ```
+
+        Args:
+            run_name: The evaluation run name to match metrics against.
+            ground_truth: Ground-truth annotation class name.
+        """
+        return cls(
+            match_kind="false_negative",
+            run_name=run_name,
+            gt_label_name=ground_truth,
+            pred_label_name=None,
+            criteria=[],
+        )
+
     def get(self) -> ColumnElement[bool]:
         """Get the annotation evaluation match expression."""
         sample_dataset_id = (
@@ -137,6 +164,10 @@ class AnnotationMetricQuery(MatchExpression):
             metric_subquery = self._build_confusion_metric_subquery(metric_table=candidate_metric)
         elif self.match_kind == "false_positive":
             metric_subquery = self._build_false_positive_metric_subquery(
+                metric_table=candidate_metric
+            )
+        elif self.match_kind == "false_negative":
+            metric_subquery = self._build_false_negative_metric_subquery(
                 metric_table=candidate_metric
             )
         else:
@@ -207,6 +238,30 @@ class AnnotationMetricQuery(MatchExpression):
             .where(col(metric_table.sample_id) == col(SampleTable.sample_id))
             .where(col(metric_table.gt_annotation_id).is_(None))
             .where(col(pred_label.annotation_label_name) == self.pred_label_name)
+        )
+
+    def _build_false_negative_metric_subquery(
+        self,
+        metric_table: Any = EvaluationAnnotationMetricTable,
+    ) -> Select[tuple[int]]:
+        gt_annotation = aliased(AnnotationBaseTable)
+        gt_label = aliased(AnnotationLabelTable)
+
+        return (
+            select(1)
+            .select_from(metric_table)
+            .join(
+                gt_annotation,
+                col(metric_table.gt_annotation_id) == col(gt_annotation.sample_id),
+            )
+            .join(
+                gt_label,
+                col(gt_annotation.annotation_label_id) == col(gt_label.annotation_label_id),
+            )
+            .where(col(metric_table.evaluation_run_id) == col(EvaluationRunTable.id))
+            .where(col(metric_table.sample_id) == col(SampleTable.sample_id))
+            .where(col(metric_table.pred_annotation_id).is_(None))
+            .where(col(gt_label.annotation_label_name) == self.gt_label_name)
         )
 
     def _build_confusion_metric_subquery(

--- a/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_query.py
+++ b/lightly_studio/tests/core/dataset_query/test_annotation_evaluation_query.py
@@ -16,6 +16,7 @@ from tests.helpers_resolvers import (
 )
 from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
     AnnotationMetricStub,
+    FalseNegativeMetricStub,
     FalsePositiveMetricStub,
     TruePositiveMetricStub,
     create_annotation_metrics,
@@ -343,6 +344,57 @@ def test_annotation_metric_query__matches_false_positive_bucket(
 
     results = DatasetQuery(dataset=collection, session=db_session).match(
         AnnotationMetricQuery.false_positive(run_name="run1", prediction="dog")
+    )
+
+    assert [result.sample_id for result in results] == [image_a.sample_id]
+
+
+def test_annotation_metric_query__matches_false_negative_bucket(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    [image_a, image_b, image_c] = create_images(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        images=[
+            ImageStub(path="/path/to/fn-dog.jpg"),
+            ImageStub(path="/path/to/fn-cat.jpg"),
+            ImageStub(path="/path/to/tp-dog.jpg"),
+        ],
+    )
+    run = create_run(session=db_session, collection_id=collection.collection_id, name="run1")
+    dog_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    cat_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="cat",
+    )
+    create_annotation_metrics(
+        session=db_session,
+        run_id=run.id,
+        pair_metric_stubs=[
+            FalseNegativeMetricStub(
+                sample_id=image_a.sample_id,
+                gt_annotation_label_id=dog_label.annotation_label_id,
+            ),
+            FalseNegativeMetricStub(
+                sample_id=image_b.sample_id,
+                gt_annotation_label_id=cat_label.annotation_label_id,
+            ),
+            TruePositiveMetricStub(
+                sample_id=image_c.sample_id,
+                metrics={"confidence": 0.7},
+                gt_annotation_label_id=dog_label.annotation_label_id,
+            ),
+        ],
+    )
+
+    results = DatasetQuery(dataset=collection, session=db_session).match(
+        AnnotationMetricQuery.false_negative(run_name="run1", ground_truth="dog")
     )
 
     assert [result.sample_id for result in results] == [image_a.sample_id]

--- a/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
+++ b/lightly_studio/tests/resolvers/evaluation_annotation_metric_resolver/test_get_confusion_matrix.py
@@ -4,18 +4,13 @@ import uuid
 
 from sqlmodel import Session
 
-from lightly_studio.models.evaluation_annotation_metric import (
-    EvaluationAnnotationMetricCreate,
-)
 from lightly_studio.models.evaluation_confusion_matrix import (
     NO_GROUND_TRUTH_ROW_LABEL,
     NO_PREDICTION_COL_LABEL,
 )
 from lightly_studio.resolvers import evaluation_annotation_metric_resolver
 from tests.helpers_resolvers import (
-    AnnotationDetails,
     create_annotation_label,
-    create_annotations,
     create_collection,
     create_image,
 )
@@ -23,6 +18,7 @@ from tests.resolvers.evaluation_sample_metric_resolver import (
     helpers as evaluation_sample_metric_helpers,
 )
 from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
+    FalseNegativeMetricStub,
     FalsePositiveMetricStub,
     TruePositiveMetricStub,
     create_annotation_metrics,
@@ -66,37 +62,23 @@ def test_get_confusion_matrix__aggregates_tp_fp_fn(
         root_collection_id=dataset.collection_id,
         label_name="class_b",
     )
-    [gt_a, gt_b, pred_a, pred_b] = create_annotations(
+    create_annotation_metrics(
         session=db_session,
-        collection_id=dataset.collection_id,
-        annotations=[
-            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
-            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_b.annotation_label_id),
-            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
-            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_b.annotation_label_id),
-        ],
-    )
-
-    evaluation_annotation_metric_resolver.create_many(
-        session=db_session,
-        records=[
-            EvaluationAnnotationMetricCreate(
-                evaluation_run_id=run.id,
-                sample_id=image.sample_id,
-                pred_annotation_id=pred_a.sample_id,
-                gt_annotation_id=gt_a.sample_id,
-                metric_name="iou",
-                value=0.9,
+        run_id=run.id,
+        pair_metric_stubs=[
+            TruePositiveMetricStub(
+                sample_id=sample_id,
+                metrics={"iou": 0.9},
+                gt_annotation_label_id=label_a.annotation_label_id,
+                pred_annotation_label_id=label_a.annotation_label_id,
             ),
-            EvaluationAnnotationMetricCreate(
-                evaluation_run_id=run.id,
-                sample_id=image.sample_id,
-                pred_annotation_id=pred_b.sample_id,
+            FalsePositiveMetricStub(
+                sample_id=sample_id,
+                pred_annotation_label_id=label_b.annotation_label_id,
             ),
-            EvaluationAnnotationMetricCreate(
-                evaluation_run_id=run.id,
-                sample_id=image.sample_id,
-                gt_annotation_id=gt_b.sample_id,
+            FalseNegativeMetricStub(
+                sample_id=sample_id,
+                gt_annotation_label_id=label_b.annotation_label_id,
             ),
         ],
     )
@@ -148,32 +130,19 @@ def test_get_confusion_matrix__class_only_in_gt(
         root_collection_id=dataset.collection_id,
         label_name="class_b",
     )
-    sample_id = image.sample_id
-    [gt_a, gt_b, pred_a] = create_annotations(
+    create_annotation_metrics(
         session=db_session,
-        collection_id=dataset.collection_id,
-        annotations=[
-            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
-            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_b.annotation_label_id),
-            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
-        ],
-    )
-
-    evaluation_annotation_metric_resolver.create_many(
-        session=db_session,
-        records=[
-            EvaluationAnnotationMetricCreate(
-                evaluation_run_id=run.id,
+        run_id=run.id,
+        pair_metric_stubs=[
+            TruePositiveMetricStub(
                 sample_id=image.sample_id,
-                pred_annotation_id=pred_a.sample_id,
-                gt_annotation_id=gt_a.sample_id,
-                metric_name="iou",
-                value=0.9,
+                metrics={"iou": 0.9},
+                gt_annotation_label_id=label_a.annotation_label_id,
+                pred_annotation_label_id=label_a.annotation_label_id,
             ),
-            EvaluationAnnotationMetricCreate(
-                evaluation_run_id=run.id,
+            FalseNegativeMetricStub(
                 sample_id=image.sample_id,
-                gt_annotation_id=gt_b.sample_id,
+                gt_annotation_label_id=label_b.annotation_label_id,
             ),
         ],
     )
@@ -217,32 +186,19 @@ def test_get_confusion_matrix__class_only_in_pred(
         root_collection_id=dataset.collection_id,
         label_name="class_b",
     )
-    sample_id = image.sample_id
-    [gt_a, pred_a, pred_b] = create_annotations(
+    create_annotation_metrics(
         session=db_session,
-        collection_id=dataset.collection_id,
-        annotations=[
-            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
-            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_a.annotation_label_id),
-            AnnotationDetails(sample_id=sample_id, annotation_label_id=label_b.annotation_label_id),
-        ],
-    )
-
-    evaluation_annotation_metric_resolver.create_many(
-        session=db_session,
-        records=[
-            EvaluationAnnotationMetricCreate(
-                evaluation_run_id=run.id,
+        run_id=run.id,
+        pair_metric_stubs=[
+            TruePositiveMetricStub(
                 sample_id=image.sample_id,
-                pred_annotation_id=pred_a.sample_id,
-                gt_annotation_id=gt_a.sample_id,
-                metric_name="iou",
-                value=0.9,
+                metrics={"iou": 0.9},
+                gt_annotation_label_id=label_a.annotation_label_id,
+                pred_annotation_label_id=label_a.annotation_label_id,
             ),
-            EvaluationAnnotationMetricCreate(
-                evaluation_run_id=run.id,
+            FalsePositiveMetricStub(
                 sample_id=image.sample_id,
-                pred_annotation_id=pred_b.sample_id,
+                pred_annotation_label_id=label_b.annotation_label_id,
             ),
         ],
     )

--- a/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
+++ b/lightly_studio/tests/resolvers/evaluation_sample_metric_resolver/helpers.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import Literal
 from uuid import UUID
 
 from sqlmodel import Session
 
-from lightly_studio.models.collection import SampleType
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricCreate
 from lightly_studio.models.evaluation_run import (
     EvaluationRunCreate,
@@ -54,35 +56,21 @@ class TruePositiveMetricStub:
     def to_annotation_metric_stub(
         self, session: Session, run: EvaluationRunTable
     ) -> list[AnnotationMetricStub]:
-        pred_collection = collection_resolver.get_by_id(
-            session=session, collection_id=run.pred_annotation_collection_id
-        )
-        gt_collection = collection_resolver.get_by_id(
-            session=session, collection_id=run.gt_annotation_collection_id
-        )
-        if pred_collection is None or gt_collection is None:
-            raise ValueError(f"Evaluation run {run.id} references missing annotation collections")
-        if (
-            pred_collection.parent_collection_id is None
-            or gt_collection.parent_collection_id is None
-        ):
-            raise ValueError(f"Evaluation run {run.id} annotation collections must have parents")
-
-        # Note: `test_sample_filter.py` has the `_seed_pair()` helper function almost identical to
-        # the following code block.
-        pred_annotation = create_annotation(
+        pred_annotation = _create_evaluation_annotation(
             session=session,
-            collection_id=pred_collection.parent_collection_id,
+            collection=_get_evaluation_annotation_collection(
+                session=session, run=run, collection_kind="prediction"
+            ),
             sample_id=self.sample_id,
             annotation_label_id=self.pred_annotation_label_id or self.gt_annotation_label_id,
-            annotation_collection_name=pred_collection.name,
         )
-        gt_annotation = create_annotation(
+        gt_annotation = _create_evaluation_annotation(
             session=session,
-            collection_id=gt_collection.parent_collection_id,
+            collection=_get_evaluation_annotation_collection(
+                session=session, run=run, collection_kind="ground-truth"
+            ),
             sample_id=self.sample_id,
             annotation_label_id=self.gt_annotation_label_id,
-            annotation_collection_name=gt_collection.name,
         )
         return [
             AnnotationMetricStub(
@@ -114,24 +102,13 @@ class FalsePositiveMetricStub:
     def to_annotation_metric_stub(
         self, session: Session, run: EvaluationRunTable
     ) -> list[AnnotationMetricStub]:
-        pred_collection = collection_resolver.get_by_id(
-            session=session, collection_id=run.pred_annotation_collection_id
-        )
-        if pred_collection is None:
-            raise ValueError(
-                f"Evaluation run {run.id} references missing prediction annotation collection"
-            )
-        if pred_collection.parent_collection_id is None:
-            raise ValueError(
-                f"Evaluation run {run.id} prediction annotation collection must have a parent"
-            )
-
-        pred_annotation = create_annotation(
+        pred_annotation = _create_evaluation_annotation(
             session=session,
-            collection_id=pred_collection.parent_collection_id,
+            collection=_get_evaluation_annotation_collection(
+                session=session, run=run, collection_kind="prediction"
+            ),
             sample_id=self.sample_id,
             annotation_label_id=self.pred_annotation_label_id,
-            annotation_collection_name=pred_collection.name,
         )
         metrics = self.metric_items()
         if not metrics:
@@ -151,6 +128,37 @@ class FalsePositiveMetricStub:
                 gt_annotation_id=None,
             )
             for metric_name, value in self.metric_items()
+        ]
+
+
+@dataclass
+class FalseNegativeMetricStub:
+    """Helper class to create a false-negative annotation metric.
+
+    Creates a ground-truth annotation in the evaluation run's ground-truth collection,
+    then stores metric rows that link the ground truth with no prediction.
+    """
+
+    sample_id: UUID
+    gt_annotation_label_id: UUID
+
+    def to_annotation_metric_stub(
+        self, session: Session, run: EvaluationRunTable
+    ) -> list[AnnotationMetricStub]:
+        gt_annotation = _create_evaluation_annotation(
+            session=session,
+            collection=_get_evaluation_annotation_collection(
+                session=session, run=run, collection_kind="ground-truth"
+            ),
+            sample_id=self.sample_id,
+            annotation_label_id=self.gt_annotation_label_id,
+        )
+        return [
+            AnnotationMetricStub(
+                sample_id=self.sample_id,
+                pred_annotation_id=None,
+                gt_annotation_id=gt_annotation.sample_id,
+            )
         ]
 
 
@@ -201,6 +209,45 @@ def create_run(
     )
 
 
+def _get_evaluation_annotation_collection(
+    session: Session,
+    run: EvaluationRunTable,
+    collection_kind: Literal["ground-truth", "prediction"],
+) -> CollectionTable:
+    collection_id = (
+        run.pred_annotation_collection_id
+        if collection_kind == "prediction"
+        else run.gt_annotation_collection_id
+    )
+    collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+    if collection is None:
+        raise ValueError(
+            f"Evaluation run {run.id} references missing {collection_kind} annotation collection"
+        )
+    if collection.parent_collection_id is None:
+        raise ValueError(
+            f"Evaluation run {run.id} {collection_kind} annotation collection must have a parent"
+        )
+    return collection
+
+
+def _create_evaluation_annotation(
+    session: Session,
+    collection: CollectionTable,
+    sample_id: UUID,
+    annotation_label_id: UUID,
+) -> AnnotationBaseTable:
+    if collection.parent_collection_id is None:
+        raise ValueError(f"Annotation collection {collection.collection_id} must have a parent")
+    return create_annotation(
+        session=session,
+        collection_id=collection.parent_collection_id,
+        sample_id=sample_id,
+        annotation_label_id=annotation_label_id,
+        annotation_collection_name=collection.name,
+    )
+
+
 def create_sample_metrics(
     session: Session,
     run_id: UUID,
@@ -226,7 +273,10 @@ def create_annotation_metrics(
     session: Session,
     run_id: UUID,
     annotation_metrics: list[AnnotationMetricStub] | None = None,
-    pair_metric_stubs: list[TruePositiveMetricStub | FalsePositiveMetricStub] | None = None,
+    pair_metric_stubs: list[
+        TruePositiveMetricStub | FalsePositiveMetricStub | FalseNegativeMetricStub
+    ]
+    | None = None,
 ) -> list[AnnotationMetricStub]:
     annotation_metrics_to_create = list(annotation_metrics) if annotation_metrics else []
     pair_metric_stubs = pair_metric_stubs or []


### PR DESCRIPTION
## What has changed and why?
The last missing constructor of `AnnotationMetricQuery`.

I've also added `FalseNegativeMetricStub` and modified existing tests to use it.

## How has it been tested?
Added tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying and querying false-negative annotation matches.
  * False-negative results can now be filtered by evaluation run and ground-truth label.

* **Bug Fixes**
  * Confusion matrices now correctly account for false negatives, including classes that appear only in ground truth.

* **Tests**
  * Added query coverage for false-negative buckets.
  * Updated confusion-matrix fixtures to use dedicated false-negative metric stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->