### PR TITLE
Pass active view filter to image export endpoints

### DIFF
--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -22,8 +22,10 @@
     import * as Alert from '$lib/components/ui/alert/index.js';
     import { fade } from 'svelte/transition';
     import { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
+    import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
 
     const { isExportDialogOpen, openExportDialog, closeExportDialog } = useExportDialog();
+    const { imageFilter } = useImageFilters();
 
     $effect(() => {
         if ($isExportDialogOpen) {
@@ -89,7 +91,9 @@
     );
 
     // Enable info panel if there are selected samples or annotations or tag is selected
-    const isInfoEnabled = $derived(exportType === 'samples' ? tagIdToExport : false);
+    const isInfoEnabled = $derived(
+        exportType === 'samples' ? tagIdToExport || $imageFilter != null : false
+    );
 
     const filter = $derived.by(() => {
         const filter: ExportFilter = {};
@@ -100,8 +104,12 @@
         return filter;
     });
 
-    const includeFilter = $derived(isSelectionInverted ? undefined : filter);
-    const excludeFilter = $derived(isSelectionInverted ? filter : undefined);
+    const includeFilter = $derived(
+        !isSelectionInverted && Object.keys(filter).length > 0 ? filter : undefined
+    );
+    const excludeFilter = $derived(
+        isSelectionInverted && Object.keys(filter).length > 0 ? filter : undefined
+    );
 
     const {
         count,
@@ -111,7 +119,8 @@
         useExportSamplesCount({
             collection_id: collectionId,
             includeFilter,
-            excludeFilter
+            excludeFilter,
+            collectionFilter: $imageFilter
         })
     );
 
@@ -119,10 +128,10 @@
         return $statError ? $statError : '';
     });
 
-    // Disable submit button if no tags are available for samples tab or no tag is selected
+    // Disable submit button if neither a tag nor a collection filter is set
     const isSubmitDisabled = $derived.by(() => {
         if (exportType === 'samples') {
-            if ($tags.length === 0 || !tagIdToExport) {
+            if (!tagIdToExport && $imageFilter == null) {
                 return true;
             }
         }
@@ -133,7 +142,8 @@
         const response = await exportCollection({
             collection_id: collectionId,
             includeFilter,
-            excludeFilter
+            excludeFilter,
+            collectionFilter: $imageFilter
         });
         if (response.error) {
             errorMessage = `Export failed: ${response.error}`;

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -91,9 +91,7 @@
     );
 
     // Enable info panel if there are selected samples or annotations or tag is selected
-    const isInfoEnabled = $derived(
-        exportType === 'samples' ? tagIdToExport || $imageFilter != null : false
-    );
+    const isInfoEnabled = $derived(exportType === 'samples' ? !!tagIdToExport : false);
 
     const filter = $derived.by(() => {
         const filter: ExportFilter = {};
@@ -131,7 +129,7 @@
     // Disable submit button if neither a tag nor a collection filter is set
     const isSubmitDisabled = $derived.by(() => {
         if (exportType === 'samples') {
-            if (!tagIdToExport && $imageFilter == null) {
+            if (!tagIdToExport) {
                 return true;
             }
         }

--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportSamplesCount/useExportSamplesCount.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportSamplesCount/useExportSamplesCount.test.ts
@@ -27,7 +27,8 @@ describe('useExportStats', () => {
             path: { collection_id: 'test-collection' },
             body: {
                 include: defaultProps.includeFilter,
-                exclude: undefined
+                exclude: undefined,
+                collection_filter: undefined
             }
         });
     });
@@ -60,6 +61,34 @@ describe('useExportStats', () => {
             expect(get(isLoading)).toBe(false);
             expect(get(count)).toBe(0);
             expect(get(error)).toBe(errorMessage);
+        });
+    });
+
+    it('should return count when collectionFilter is provided with includeFilter', async () => {
+        mocks.exportCollectionStats.mockResolvedValueOnce({ data: 10 });
+        const collectionFilter = {
+            filter_type: 'image' as const,
+            sample_filter: { tag_ids: ['t1'] }
+        };
+        const { count } = useExportSamplesCount({
+            collection_id: 'test-collection',
+            includeFilter: { tag_ids: ['tag1'] },
+            collectionFilter
+        });
+        await vi.waitFor(() => {
+            expect(get(count)).toBe(10);
+        });
+    });
+
+    it('should return count when only collectionFilter is set', async () => {
+        mocks.exportCollectionStats.mockResolvedValueOnce({ data: 5 });
+        const collectionFilter = { filter_type: 'image' as const };
+        const { count } = useExportSamplesCount({
+            collection_id: 'test-collection',
+            collectionFilter
+        });
+        await vi.waitFor(() => {
+            expect(get(count)).toBe(5);
         });
     });
 });

--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportSamplesCount/useExportSamplesCount.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportSamplesCount/useExportSamplesCount.ts
@@ -1,4 +1,4 @@
-import { exportCollectionStats } from '$lib/api/lightly_studio_local';
+import { exportCollectionStats, type ImageFilter } from '$lib/api/lightly_studio_local';
 import type { ExportFilter } from '$lib/services/types';
 import { writable, type Readable } from 'svelte/store';
 
@@ -6,6 +6,7 @@ interface UseExportSamplesCountProps {
     collection_id: string;
     includeFilter?: ExportFilter;
     excludeFilter?: ExportFilter;
+    collectionFilter?: ImageFilter | null;
 }
 
 interface UseExportSamplesCountReturn {
@@ -22,7 +23,8 @@ interface UseExportSamplesCountReturn {
 export function useExportSamplesCount({
     collection_id,
     includeFilter,
-    excludeFilter
+    excludeFilter,
+    collectionFilter
 }: UseExportSamplesCountProps): UseExportSamplesCountReturn {
     const count = writable(0);
     const error = writable<string | undefined>(undefined);
@@ -30,14 +32,16 @@ export function useExportSamplesCount({
 
     const hasIncludeFilter = includeFilter && Object.keys(includeFilter).length > 0;
     const hasExcludeFilter = excludeFilter && Object.keys(excludeFilter).length > 0;
-    if (hasIncludeFilter || hasExcludeFilter) {
+    const hasCollectionFilter = collectionFilter != null;
+    if (hasIncludeFilter || hasExcludeFilter || hasCollectionFilter) {
         isLoading.set(true);
 
         exportCollectionStats({
             path: { collection_id },
             body: {
                 include: includeFilter,
-                exclude: excludeFilter
+                exclude: excludeFilter,
+                collection_filter: collectionFilter
             }
         })
             .then((response) => {

--- a/lightly_studio_view/src/lib/services/exportCollection.ts
+++ b/lightly_studio_view/src/lib/services/exportCollection.ts
@@ -1,4 +1,4 @@
-import { exportCollectionToAbsolutePaths } from '$lib/api/lightly_studio_local';
+import { exportCollectionToAbsolutePaths, type ImageFilter } from '$lib/api/lightly_studio_local';
 import type { ExportFilter, LoadResult } from '$lib/services/types';
 import { triggerDownloadBlob } from '$lib/utils';
 
@@ -8,13 +8,15 @@ type ExportCollectionParams = {
     filename?: string;
     includeFilter?: ExportFilter;
     excludeFilter?: ExportFilter;
+    collectionFilter?: ImageFilter | null;
 };
 
 export const exportCollection = async ({
     collection_id,
     filename = '',
     includeFilter,
-    excludeFilter
+    excludeFilter,
+    collectionFilter
 }: ExportCollectionParams): Promise<ExportCollectionResult> => {
     const result: ExportCollectionResult = { data: undefined, error: undefined };
     try {
@@ -22,7 +24,8 @@ export const exportCollection = async ({
             path: { collection_id },
             body: {
                 include: includeFilter,
-                exclude: excludeFilter
+                exclude: excludeFilter,
+                collection_filter: collectionFilter
             },
             headers: {
                 'Access-Control-Expose-Headers': 'Content-Disposition'


### PR DESCRIPTION
## What has changed and why?

The backend already accepts an optional `collection_filter` (the active `ImageFilter`) on both the export and stats endpoints. This PR wires the active view filter into the frontend export flow so that exports and sample counts reflect the currently applied filter.

## How has it been tested?

Unit tests + manual test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image-filter support to sample exports, including forwarding the selected image collection filter to export and count statistics.
  * Sample export counts and submission state now account for image collection filters in addition to include/exclude tag filters.
* **Bug Fixes**
  * Avoid sending include/exclude tag filters when the tag selection is empty.
  * Prevented the download button from being incorrectly disabled when an image-based collection filter is present.
* **Tests**
  * Updated and expanded `useExportSamplesCount` tests to verify correct count updates with collection filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->