### PR TITLE
Add "Count by" toggle to the detection distribution panel

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -9,6 +9,7 @@
     import PanelHeader from './PanelHeader/PanelHeader.svelte';
     import { selectVisibleCounts } from './selectVisibleCounts';
     import type { DistributionConfig, DistributionSource } from './types';
+    import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 
     interface Props {
         /**
@@ -29,6 +30,10 @@
         onClose?: () => void;
         /** Called with the clicked class. */
         onBarClick?: (item: CategoryCount) => void;
+        /**
+         * Called when the user switches the count mode via the config dialog.
+         */
+        onCountModeChange?: (mode: AnnotationCountMode) => void;
     }
 
     const {
@@ -37,7 +42,8 @@
         title = 'Class distribution',
         topN = 20,
         onClose,
-        onBarClick
+        onBarClick,
+        onCountModeChange
     }: Props = $props();
 
     // Normalise to a source list so the rest of the panel has one code path.
@@ -59,13 +65,6 @@
     const activeData = $derived<CategoryCount[]>(activeGroup?.data ?? activeSource.data ?? []);
     const valueNoun = $derived(activeSource.valueNoun ?? 'annotations');
 
-    const sourceItems = $derived<SelectItem[]>(
-        resolvedSources.map((source) => ({ value: source.id, label: source.label }))
-    );
-    const groupItems = $derived<SelectItem[]>(
-        (activeSource.groups ?? []).map((group) => ({ value: group.id, label: group.label }))
-    );
-
     // Default to horizontal bars: categories stack down the left gutter and the
     // chart scrolls vertically, avoiding the initial horizontal scroll that
     // vertical bars produce once there are more than a handful of classes.
@@ -74,7 +73,8 @@
         n: topN,
         sortBy: 'count',
         manualClasses: [],
-        orientation: 'horizontal'
+        orientation: 'horizontal',
+        countMode: AnnotationCountMode.OBJECTS
     });
     let configDialogOpen = $state(false);
     let expandOpen = $state(false);
@@ -83,8 +83,25 @@
     let chartHeight = $state(0);
     let clientWidth = $state(0);
 
+    const activeCountMode = $derived(config.countMode ?? AnnotationCountMode.OBJECTS);
+    const showTotalCount = $derived(activeCountMode !== AnnotationCountMode.SAMPLES);
+
+    const sourceItems = $derived<SelectItem[]>(
+        resolvedSources.map((source) => ({ value: source.id, label: source.label }))
+    );
+    const groupItems = $derived<SelectItem[]>(
+        (activeSource.groups ?? []).map((group) => ({ value: group.id, label: group.label }))
+    );
+
     const visible = $derived(selectVisibleCounts(activeData, config));
     const totalCount = $derived(activeData.reduce((sum, item) => sum + item.count, 0));
+
+    function applyConfig(next: DistributionConfig) {
+        if (next.countMode !== config.countMode) {
+            onCountModeChange?.(next.countMode ?? AnnotationCountMode.OBJECTS);
+        }
+        config = next;
+    }
 </script>
 
 <div
@@ -146,7 +163,7 @@
             {config}
             classCount={activeData.length}
             visibleClassCount={visible.length}
-            {totalCount}
+            totalCount={showTotalCount ? totalCount : undefined}
             {valueNoun}
             onConfigure={() => (configDialogOpen = true)}
             onShowAll={() => (config = { ...config, mode: 'topN', n: activeData.length })}
@@ -161,6 +178,7 @@
     <div
         class="min-h-0 flex-1 overflow-y-auto dark:[color-scheme:dark]"
         bind:clientHeight={chartHeight}
+        bind:clientWidth
     >
         <BarChart
             data={visible}
@@ -176,13 +194,13 @@
     bind:open={configDialogOpen}
     allClasses={activeData.map((item) => item.label)}
     {config}
-    onApply={(next) => (config = next)}
+    onApply={applyConfig}
 />
 <ExpandDialog
     bind:open={expandOpen}
     data={activeData}
     {config}
     {valueNoun}
-    onConfigChange={(next) => (config = next)}
+    onConfigChange={applyConfig}
     {onBarClick}
 />

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -34,6 +34,11 @@
          * Called when the user switches the count mode via the config dialog.
          */
         onCountModeChange?: (mode: AnnotationCountMode) => void;
+        /**
+         * Initial count mode to use when the panel first mounts. Lets the
+         * parent preserve the mode across close/reopen cycles.
+         */
+        initialCountMode?: AnnotationCountMode;
     }
 
     const {
@@ -43,7 +48,8 @@
         topN = 20,
         onClose,
         onBarClick,
-        onCountModeChange
+        onCountModeChange,
+        initialCountMode = AnnotationCountMode.OBJECTS
     }: Props = $props();
 
     // Normalise to a source list so the rest of the panel has one code path.
@@ -74,7 +80,7 @@
         sortBy: 'count',
         manualClasses: [],
         orientation: 'horizontal',
-        countMode: AnnotationCountMode.OBJECTS
+        countMode: initialCountMode
     });
     let configDialogOpen = $state(false);
     let expandOpen = $state(false);

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -1,8 +1,10 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import DatasetDistributionPanel from './DatasetDistributionPanel.svelte';
 import { balanced, empty, longTail } from '../BarChart/fixtures';
 import type { DistributionSource } from './types';
+import { AnnotationCountMode, AnnotationType } from '$lib/api/lightly_studio_local/types.gen';
 
 const echartsMock = vi.hoisted(() => {
     const instance = {
@@ -36,6 +38,13 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
 const defaultProps = { data: balanced };
 
 describe('DatasetDistributionPanel', () => {
+    beforeAll(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+        Element.prototype.hasPointerCapture = vi.fn(() => false);
+        Element.prototype.setPointerCapture = vi.fn();
+        Element.prototype.releasePointerCapture = vi.fn();
+    });
+
     afterEach(() => {
         // bits-ui dialogs portal into the body and can leave styles behind.
         document.body.innerHTML = '';
@@ -183,5 +192,126 @@ describe('DatasetDistributionPanel', () => {
         await fireEvent.click(screen.getByTestId('dataset-distribution-close-button'));
 
         expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('shows the count by select in the config dialog with Objects selected by default', async () => {
+        render(DatasetDistributionPanel, {
+            props: {
+                sources: [
+                    {
+                        id: AnnotationType.OBJECT_DETECTION,
+                        label: 'Object detection',
+                        data: [{ label: 'car', count: 5 }]
+                    }
+                ]
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+
+        const countBySelect = await waitFor(() =>
+            screen.getByTestId('distribution-config-count-mode')
+        );
+        expect(countBySelect).toBeInTheDocument();
+        expect(countBySelect).toHaveTextContent('Objects');
+    });
+
+    it('shows the count by select for All types source too', async () => {
+        render(DatasetDistributionPanel, {
+            props: {
+                sources: [
+                    {
+                        id: 'all',
+                        label: 'All types',
+                        data: [{ label: 'car', count: 5 }]
+                    },
+                    {
+                        id: AnnotationType.OBJECT_DETECTION,
+                        label: 'Object detection',
+                        data: [{ label: 'car', count: 5 }]
+                    }
+                ]
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+
+        await waitFor(() =>
+            expect(screen.getByTestId('distribution-config-count-mode')).toBeInTheDocument()
+        );
+    });
+
+    it('calls onCountModeChange when count mode changes via the config dialog', async () => {
+        const user = userEvent.setup();
+        const onCountModeChange = vi.fn();
+        render(DatasetDistributionPanel, {
+            props: {
+                sources: [
+                    {
+                        id: AnnotationType.OBJECT_DETECTION,
+                        label: 'Object detection',
+                        data: [{ label: 'car', count: 5 }]
+                    }
+                ],
+                onCountModeChange
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        const countBySelect = await waitFor(() =>
+            screen.getByTestId('distribution-config-count-mode')
+        );
+        await user.click(countBySelect);
+        const samplesOption = await waitFor(() => screen.getByRole('option', { name: 'Samples' }));
+        await user.click(samplesOption);
+        await fireEvent.click(screen.getByTestId('distribution-config-apply'));
+
+        expect(onCountModeChange).toHaveBeenCalledWith(AnnotationCountMode.SAMPLES);
+    });
+
+    it('hides the total count in the header when count mode is changed to Samples', async () => {
+        const user = userEvent.setup();
+        render(DatasetDistributionPanel, {
+            props: {
+                sources: [
+                    {
+                        id: AnnotationType.OBJECT_DETECTION,
+                        label: 'Object detection',
+                        data: [{ label: 'car', count: 10 }],
+                        valueNoun: 'instances'
+                    }
+                ]
+            }
+        });
+
+        expect(screen.getByText(/10 instances/)).toBeInTheDocument();
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        const countBySelect = await waitFor(() =>
+            screen.getByTestId('distribution-config-count-mode')
+        );
+        await user.click(countBySelect);
+        const samplesOption = await waitFor(() => screen.getByRole('option', { name: 'Samples' }));
+        await user.click(samplesOption);
+        await fireEvent.click(screen.getByTestId('distribution-config-apply'));
+
+        await waitFor(() => expect(screen.queryByText(/instances/)).not.toBeInTheDocument());
+    });
+
+    it('shows the total count in the header by default (Objects mode)', () => {
+        render(DatasetDistributionPanel, {
+            props: {
+                sources: [
+                    {
+                        id: AnnotationType.OBJECT_DETECTION,
+                        label: 'Object detection',
+                        data: [{ label: 'car', count: 10 }],
+                        valueNoun: 'instances'
+                    }
+                ]
+            }
+        });
+
+        expect(screen.getByText(/10 instances/)).toBeInTheDocument();
     });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
     import { ClassSetConfigDialog } from '$lib/components/ClassSetConfig';
-    import type { SelectItem } from '$lib/components/Select';
+    import { Select, type SelectItem } from '$lib/components/Select';
     import {
         DISTRIBUTION_SORT_LABELS,
         type DistributionConfig,
         type DistributionSortOption
     } from '../types';
+    import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 
     interface Props {
         /** Two-way bound flag controlling dialog visibility. */
@@ -14,15 +15,29 @@
         allClasses: string[];
         /** The currently applied config. */
         config: DistributionConfig;
+        /** Whether to show the Count by selector (default true). */
+        showCountMode?: boolean;
         /** Invoked with the new config when the user clicks Apply. */
         onApply: (config: DistributionConfig) => void;
     }
 
-    let { open = $bindable(), allClasses, config, onApply }: Props = $props();
+    let { open = $bindable(), allClasses, config, showCountMode = true, onApply }: Props = $props();
 
     const sortItems: SelectItem[] = (
         Object.keys(DISTRIBUTION_SORT_LABELS) as DistributionSortOption[]
     ).map((value) => ({ value, label: DISTRIBUTION_SORT_LABELS[value] }));
+
+    const countModeItems: SelectItem[] = [
+        { value: AnnotationCountMode.OBJECTS, label: 'Objects' },
+        { value: AnnotationCountMode.SAMPLES, label: 'Samples' }
+    ];
+
+    let draftCountMode = $state<AnnotationCountMode>(
+        config.countMode ?? AnnotationCountMode.OBJECTS
+    );
+    $effect(() => {
+        if (open) draftCountMode = config.countMode ?? AnnotationCountMode.OBJECTS;
+    });
 </script>
 
 <ClassSetConfigDialog
@@ -33,5 +48,22 @@
     description="Choose which classes the distribution chart shows."
     testIdPrefix="distribution-config"
     showAllButton
-    onApply={(selection) => onApply({ ...config, ...selection } as DistributionConfig)}
-/>
+    onApply={(selection) =>
+        onApply({ ...config, ...selection, countMode: draftCountMode } as DistributionConfig)}
+>
+    {#snippet extraSections()}
+        {#if showCountMode}
+            <label class="flex items-center justify-between gap-2 text-sm">
+                Count by
+                <Select
+                    items={countModeItems}
+                    value={draftCountMode}
+                    size="xs"
+                    class="w-44"
+                    testId="distribution-config-count-mode"
+                    onValueChange={(value) => (draftCountMode = value as AnnotationCountMode)}
+                />
+            </label>
+        {/if}
+    {/snippet}
+</ClassSetConfigDialog>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.test.ts
@@ -1,14 +1,17 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import DistributionConfigDialog from './DistributionConfigDialog.svelte';
 import type { DistributionConfig } from '../types';
+import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 
 const baseConfig: DistributionConfig = {
     mode: 'topN',
     n: 5,
     sortBy: 'count',
     manualClasses: [],
-    orientation: 'vertical'
+    orientation: 'vertical',
+    countMode: AnnotationCountMode.OBJECTS
 };
 
 const allClasses = Array.from({ length: 30 }, (_, i) => `class-${i}`);
@@ -22,6 +25,13 @@ const renderDialog = (overrides: Partial<Parameters<typeof render>[1]> = {}) => 
 };
 
 describe('DistributionConfigDialog', () => {
+    beforeAll(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+        Element.prototype.hasPointerCapture = vi.fn(() => false);
+        Element.prototype.setPointerCapture = vi.fn();
+        Element.prototype.releasePointerCapture = vi.fn();
+    });
+
     afterEach(() => {
         // bits-ui dialogs portal into the body and can leave styles behind.
         document.body.innerHTML = '';
@@ -39,6 +49,28 @@ describe('DistributionConfigDialog', () => {
         renderDialog({ open: false });
 
         expect(screen.queryByText('Configure classes')).not.toBeInTheDocument();
+    });
+
+    it('shows the Count by select with Objects selected by default', () => {
+        renderDialog();
+
+        const countBySelect = screen.getByTestId('distribution-config-count-mode');
+        expect(countBySelect).toBeInTheDocument();
+        expect(countBySelect).toHaveTextContent('Objects');
+    });
+
+    it('applies the selected count mode on Apply', async () => {
+        const user = userEvent.setup();
+        const { onApply } = renderDialog();
+
+        await user.click(screen.getByTestId('distribution-config-count-mode'));
+        const samplesOption = await waitFor(() => screen.getByRole('option', { name: 'Samples' }));
+        await user.click(samplesOption);
+        await fireEvent.click(screen.getByTestId('distribution-config-apply'));
+
+        expect(onApply).toHaveBeenCalledWith(
+            expect.objectContaining({ countMode: AnnotationCountMode.SAMPLES })
+        );
     });
 
     it('applies the edited top-N and closes', async () => {

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
@@ -15,8 +15,8 @@
         classCount: number;
         /** Number of classes currently shown after top-N selection. */
         visibleClassCount: number;
-        /** Sum of counts across all classes, for the summary line. */
-        totalCount: number;
+        /** Sum of counts across all classes, for the summary line. Omit to hide the count. */
+        totalCount?: number;
         /** Noun for the total count summary (e.g. 'annotations', 'samples'). */
         valueNoun?: string;
         /** Opens the view-config dialog (top-N and sort order). */
@@ -55,8 +55,10 @@
             {classCount === 1 ? 'class' : 'classes'}
         {/if}
         · sorted by {DISTRIBUTION_SORT_LABELS[config.sortBy].toLowerCase()}
-        · {totalCount.toLocaleString('en-US')}
-        {valueNoun}
+        {#if totalCount !== undefined}
+            · {totalCount.toLocaleString('en-US')}
+            {valueNoun}
+        {/if}
         {#if onShowAll && visibleClassCount < classCount}
             ·
             <button

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -1,5 +1,6 @@
 import type { CategoryCount } from '$lib/components/BarChart';
 import type { ClassSetSelection } from '$lib/components/ClassSetConfig';
+import { type AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 
 export type DistributionSortOption = 'count' | 'name';
 
@@ -43,4 +44,6 @@ export interface DistributionSource {
 export interface DistributionConfig extends ClassSetSelection<DistributionSortOption> {
     /** Bar orientation (default 'vertical'). */
     orientation: DistributionOrientation;
+    /** Whether to count annotation objects or distinct annotated samples (default OBJECTS). */
+    countMode?: AnnotationCountMode;
 }

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -43,3 +43,7 @@ export { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDi
 export { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
 export { useSettings } from '$lib/hooks/useSettings';
 export { useAnnotationClassVisibility } from '$lib/hooks/useAnnotationClassVisibility/useAnnotationClassVisibility';
+export {
+    useImageAnnotationCounts,
+    useImageAnnotationCountsQueryKey
+} from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';

--- a/lightly_studio_view/src/lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { buildImageAnnotationCountsRequest } from './useImageAnnotationCounts';
+import { AnnotationCountMode, AnnotationType } from '$lib/api/lightly_studio_local/types.gen';
+
+describe('buildImageAnnotationCountsRequest', () => {
+    it('includes count_mode in the request body when countMode is provided', () => {
+        const request = buildImageAnnotationCountsRequest({
+            collectionId: 'col-1',
+            annotationType: AnnotationType.OBJECT_DETECTION,
+            countMode: AnnotationCountMode.SAMPLES
+        });
+
+        expect(request.body).toEqual(
+            expect.objectContaining({ count_mode: AnnotationCountMode.SAMPLES })
+        );
+    });
+
+    it('omits count_mode from the request body when countMode is not provided', () => {
+        const request = buildImageAnnotationCountsRequest({
+            collectionId: 'col-1',
+            annotationType: AnnotationType.OBJECT_DETECTION
+        });
+
+        expect(request.body).toEqual(
+            expect.objectContaining({ annotation_type: AnnotationType.OBJECT_DETECTION })
+        );
+        expect(request.body).not.toHaveProperty('count_mode');
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts.ts
@@ -1,5 +1,9 @@
 import { createQuery } from '@tanstack/svelte-query';
-import type { AnnotationType, ImageFilter } from '$lib/api/lightly_studio_local';
+import type {
+    AnnotationCountMode,
+    AnnotationType,
+    ImageFilter
+} from '$lib/api/lightly_studio_local';
 import {
     countImageAnnotationsByCollectionOptions,
     countImageAnnotationsByCollectionQueryKey
@@ -10,49 +14,97 @@ export const useImageAnnotationCountsQueryKey = countImageAnnotationsByCollectio
     path: { collection_id: '__static_value__' }
 });
 
-export const useImageAnnotationCounts = ({
+export function buildImageAnnotationCountsRequest({
     collectionId,
     filter,
-    annotationType
+    annotationType,
+    countMode
 }: {
     collectionId: string;
     filter?: ImageFilter;
-    /** Restrict counts to a single annotation type (e.g. classification). */
     annotationType?: AnnotationType;
-}) => {
-    const requestOptions = {
+    countMode?: AnnotationCountMode;
+}) {
+    return {
         path: { collection_id: collectionId },
-        ...(filter || annotationType
+        ...(filter || annotationType || countMode
             ? {
                   body: {
                       ...(filter ? { filter } : {}),
-                      ...(annotationType ? { annotation_type: annotationType } : {})
+                      ...(annotationType ? { annotation_type: annotationType } : {}),
+                      ...(countMode ? { count_mode: countMode } : {})
                   }
               }
             : {})
-    } as const;
+    };
+}
 
-    const options = countImageAnnotationsByCollectionOptions(requestOptions);
-    // Keep the collection id static so annotation mutations invalidate every
-    // variant, but discriminate by annotation type so the per-type queries
-    // don't collide in the cache.
-    const queryKey = annotationType
-        ? countImageAnnotationsByCollectionQueryKey({
-              path: { collection_id: '__static_value__' },
-              body: { annotation_type: annotationType }
-          })
-        : useImageAnnotationCountsQueryKey;
+export const useImageAnnotationCounts = (
+    getParams: () => {
+        collectionId: string;
+        filter?: ImageFilter;
+        /** Restrict counts to a single annotation type (e.g. classification). */
+        annotationType?: AnnotationType;
+        /** Controls whether objects or samples are counted. */
+        countMode?: AnnotationCountMode;
+        /**
+         * Override the cache key. Pass a key that is a suffix-extension of
+         * `useImageAnnotationCountsQueryKey` so that mutation invalidations still
+         * reach this query while avoiding cache collisions with other callers.
+         */
+        // unknown[] intentionally: callers may extend the base key with extra
+        // segments (e.g. [...baseKey, 'distribution']). The cast inside the hook
+        // bridges this to the specific tuple type createQuery expects.
+        queryKey?: unknown[];
+        /** Set to false to prevent the query from fetching. Default: true. */
+        enabled?: boolean;
+    }
+) => {
+    return createQuery(() => {
+        const {
+            collectionId,
+            filter,
+            annotationType,
+            countMode,
+            queryKey: queryKeyOverride,
+            enabled
+        } = getParams();
 
-    return createQuery(() => ({
-        ...options,
-        queryKey,
-        queryFn: async ({ signal }) => {
-            const { data } = await countImageAnnotationsByCollection({
-                ...requestOptions,
-                signal,
-                throwOnError: true
-            });
-            return data;
-        }
-    }));
+        const requestOptions = buildImageAnnotationCountsRequest({
+            collectionId,
+            filter,
+            annotationType,
+            countMode
+        });
+
+        const options = countImageAnnotationsByCollectionOptions(requestOptions);
+        // Keep the collection id static so annotation mutations invalidate every
+        // variant, but discriminate by annotation type so the per-type queries
+        // don't collide in the cache. count_mode is intentionally excluded from
+        // the key: when it changes, TanStack Query returns cached data immediately
+        // and refetches in the background, preventing sources from disappearing
+        // during the mode transition.
+        const queryKey =
+            (queryKeyOverride as ReturnType<typeof countImageAnnotationsByCollectionQueryKey>) ??
+            (annotationType
+                ? countImageAnnotationsByCollectionQueryKey({
+                      path: { collection_id: '__static_value__' },
+                      body: { annotation_type: annotationType }
+                  })
+                : useImageAnnotationCountsQueryKey);
+
+        return {
+            ...options,
+            queryKey,
+            queryFn: async ({ signal }: { signal: AbortSignal }) => {
+                const { data } = await countImageAnnotationsByCollection({
+                    ...requestOptions,
+                    signal,
+                    throwOnError: true
+                });
+                return data;
+            },
+            ...(enabled !== undefined ? { enabled } : {})
+        };
+    });
 };

--- a/lightly_studio_view/src/lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts.ts
@@ -14,6 +14,35 @@ export const useImageAnnotationCountsQueryKey = countImageAnnotationsByCollectio
     path: { collection_id: '__static_value__' }
 });
 
+export function buildImageAnnotationCountsQueryKey({
+    annotationType,
+    countMode,
+    queryKeyOverride
+}: {
+    annotationType?: AnnotationType;
+    countMode?: AnnotationCountMode;
+    // unknown[] intentionally: callers may extend the base key with extra
+    // segments (e.g. [...baseKey, 'distribution']). The cast bridges this to
+    // the specific tuple type createQuery expects.
+    queryKeyOverride?: unknown[];
+}): ReturnType<typeof countImageAnnotationsByCollectionQueryKey> {
+    if (queryKeyOverride) {
+        return [...queryKeyOverride, ...(countMode ? [countMode] : [])] as ReturnType<
+            typeof countImageAnnotationsByCollectionQueryKey
+        >;
+    }
+    if (annotationType || countMode) {
+        return countImageAnnotationsByCollectionQueryKey({
+            path: { collection_id: '__static_value__' },
+            body: {
+                ...(annotationType ? { annotation_type: annotationType } : {}),
+                ...(countMode ? { count_mode: countMode } : {})
+            }
+        });
+    }
+    return useImageAnnotationCountsQueryKey;
+}
+
 export function buildImageAnnotationCountsRequest({
     collectionId,
     filter,
@@ -52,9 +81,6 @@ export const useImageAnnotationCounts = (
          * `useImageAnnotationCountsQueryKey` so that mutation invalidations still
          * reach this query while avoiding cache collisions with other callers.
          */
-        // unknown[] intentionally: callers may extend the base key with extra
-        // segments (e.g. [...baseKey, 'distribution']). The cast inside the hook
-        // bridges this to the specific tuple type createQuery expects.
         queryKey?: unknown[];
         /** Set to false to prevent the query from fetching. Default: true. */
         enabled?: boolean;
@@ -78,20 +104,11 @@ export const useImageAnnotationCounts = (
         });
 
         const options = countImageAnnotationsByCollectionOptions(requestOptions);
-        // Keep the collection id static so annotation mutations invalidate every
-        // variant, but discriminate by annotation type so the per-type queries
-        // don't collide in the cache. count_mode is intentionally excluded from
-        // the key: when it changes, TanStack Query returns cached data immediately
-        // and refetches in the background, preventing sources from disappearing
-        // during the mode transition.
-        const queryKey =
-            (queryKeyOverride as ReturnType<typeof countImageAnnotationsByCollectionQueryKey>) ??
-            (annotationType
-                ? countImageAnnotationsByCollectionQueryKey({
-                      path: { collection_id: '__static_value__' },
-                      body: { annotation_type: annotationType }
-                  })
-                : useImageAnnotationCountsQueryKey);
+        const queryKey = buildImageAnnotationCountsQueryKey({
+            annotationType,
+            countMode,
+            queryKeyOverride
+        });
 
         return {
             ...options,
@@ -104,6 +121,11 @@ export const useImageAnnotationCounts = (
                 });
                 return data;
             },
+            // Keep showing previous data while the new key's request is in-flight
+            // so the panel doesn't flash empty during a count_mode transition.
+            placeholderData: (
+                previousData: Array<{ [key: string]: string | number }> | undefined
+            ) => previousData,
             ...(enabled !== undefined ? { enabled } : {})
         };
     });

--- a/lightly_studio_view/src/lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts.ts
@@ -27,9 +27,11 @@ export function buildImageAnnotationCountsQueryKey({
     queryKeyOverride?: unknown[];
 }): ReturnType<typeof countImageAnnotationsByCollectionQueryKey> {
     if (queryKeyOverride) {
-        return [...queryKeyOverride, ...(countMode ? [countMode] : [])] as ReturnType<
-            typeof countImageAnnotationsByCollectionQueryKey
-        >;
+        return [
+            ...queryKeyOverride,
+            ...(annotationType ? [annotationType] : []),
+            ...(countMode ? [countMode] : [])
+        ] as ReturnType<typeof countImageAnnotationsByCollectionQueryKey>;
     }
     if (annotationType || countMode) {
         return countImageAnnotationsByCollectionQueryKey({

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -358,7 +358,8 @@
 
     const imageAnnotationCountsQuery = useImageAnnotationCounts(() => ({
         collectionId: datasetId,
-        filter: imageAnnotationCountsFilter
+        filter: imageAnnotationCountsFilter,
+        enabled: !isVideos && !isVideoFrames
     }));
 
     const annotationCounts = $derived.by(() => {
@@ -726,6 +727,7 @@
                             {#await import('$lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte') then { default: DatasetDistributionPanel }}
                                 <DatasetDistributionPanel
                                     sources={distributionSources}
+                                    initialCountMode={distributionCountMode}
                                     onClose={() => setActivePanel('none')}
                                     onCountModeChange={(mode) => {
                                         distributionCountMode = mode;

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -467,6 +467,7 @@
         collectionId: datasetId,
         annotationType: AnnotationType.CLASSIFICATION,
         filter: imageAnnotationCountsFilter,
+        countMode: distributionCountMode,
         enabled: distributionPanelVisible
     }));
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -40,7 +40,6 @@
         isVideoDetailsRoute
     } from '$lib/routes';
     import type { GridType } from '$lib/types';
-    import { useImageAnnotationCounts } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage.js';
     import QueryControl from '$lib/components/QueryControl/QueryControl.svelte';
     import { PaneGroup, Pane, PaneResizer } from 'paneforge';
@@ -54,7 +53,11 @@
     import { useVideoBounds } from '$lib/hooks/useVideosBounds/useVideosBounds.js';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
     import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
-    import { AnnotationType, SampleType } from '$lib/api/lightly_studio_local/types.gen';
+    import {
+        AnnotationCountMode,
+        AnnotationType,
+        SampleType
+    } from '$lib/api/lightly_studio_local/types.gen';
     import type { AnnotationsFilter } from '$lib/api/lightly_studio_local/types.gen';
     import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
     import type { DistributionSource } from '$lib/components/DatasetDistributionPanel';
@@ -65,7 +68,11 @@
     } from '$lib/utils/buildAnnotationCountsFilters';
     import EmbeddingSelectionFilterItem from '$lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte';
     import ConfusionCellFilterItem from '$lib/components/ConfusionCellFilterItem';
-    import { useSelectionSummary } from '$lib/hooks';
+    import {
+        useSelectionSummary,
+        useImageAnnotationCounts,
+        useImageAnnotationCountsQueryKey
+    } from '$lib/hooks';
     import { useSelectAll } from '$lib/hooks/useSelectAll/useSelectAll';
     import { isInputElement } from '$lib/utils';
     import { shutdownMaskRendererPool } from '$lib/workers/maskRendererPool';
@@ -349,6 +356,11 @@
         })
     );
 
+    const imageAnnotationCountsQuery = useImageAnnotationCounts(() => ({
+        collectionId: datasetId,
+        filter: imageAnnotationCountsFilter
+    }));
+
     const annotationCounts = $derived.by(() => {
         if (
             isVideoFrames ||
@@ -377,10 +389,7 @@
                 })
             });
         }
-        return useImageAnnotationCounts({
-            collectionId: datasetId,
-            filter: imageAnnotationCountsFilter
-        });
+        return imageAnnotationCountsQuery;
     });
 
     // Feed annotation counts back into the hook for UI-ready filter rows.
@@ -436,28 +445,46 @@
 
     const distributionPanelVisible = $derived($activePanel === 'distribution' && isImages);
 
+    // Global count mode for the distribution panel (applies to all sources).
+    let distributionCountMode = $state<AnnotationCountMode>(AnnotationCountMode.OBJECTS);
+
     // Only create the per-type queries while the panel is open so we don't fetch
-    // three extra count queries on every collection view.
-    const distributionTypeQueries = $derived.by(() => {
-        if (!distributionPanelVisible) return null;
-        return {
-            [AnnotationType.CLASSIFICATION]: useImageAnnotationCounts({
-                collectionId: datasetId,
-                annotationType: AnnotationType.CLASSIFICATION,
-                filter: imageAnnotationCountsFilter
-            }),
-            [AnnotationType.OBJECT_DETECTION]: useImageAnnotationCounts({
-                collectionId: datasetId,
-                annotationType: AnnotationType.OBJECT_DETECTION,
-                filter: imageAnnotationCountsFilter
-            }),
-            [AnnotationType.SEGMENTATION_MASK]: useImageAnnotationCounts({
-                collectionId: datasetId,
-                annotationType: AnnotationType.SEGMENTATION_MASK,
-                filter: imageAnnotationCountsFilter
-            })
-        };
-    });
+    // extra count queries on every collection view.
+    // The 'all' query uses a suffixed key so its cache entry is isolated from
+    // the shared annotationCounts query (labels filter). TanStack's prefix
+    // matching ensures mutation invalidations still reach it.
+    const distributionAllQueryKey = [...useImageAnnotationCountsQueryKey, 'distribution'];
+
+    const distributionAllQuery = useImageAnnotationCounts(() => ({
+        collectionId: datasetId,
+        filter: imageAnnotationCountsFilter,
+        countMode: distributionCountMode,
+        queryKey: distributionAllQueryKey,
+        enabled: distributionPanelVisible
+    }));
+
+    const distributionClassificationQuery = useImageAnnotationCounts(() => ({
+        collectionId: datasetId,
+        annotationType: AnnotationType.CLASSIFICATION,
+        filter: imageAnnotationCountsFilter,
+        enabled: distributionPanelVisible
+    }));
+
+    const distributionObjectDetectionQuery = useImageAnnotationCounts(() => ({
+        collectionId: datasetId,
+        annotationType: AnnotationType.OBJECT_DETECTION,
+        filter: imageAnnotationCountsFilter,
+        countMode: distributionCountMode,
+        enabled: distributionPanelVisible
+    }));
+
+    const distributionSegmentationQuery = useImageAnnotationCounts(() => ({
+        collectionId: datasetId,
+        annotationType: AnnotationType.SEGMENTATION_MASK,
+        filter: imageAnnotationCountsFilter,
+        countMode: distributionCountMode,
+        enabled: distributionPanelVisible
+    }));
 
     const allTypesSource = $derived<DistributionSource>({
         id: 'all',
@@ -466,26 +493,62 @@
     });
 
     const distributionSources = $derived.by<DistributionSource[]>(() => {
-        const typeQueries = distributionTypeQueries;
-        if (!typeQueries) return [allTypesSource];
-        const perType = [
-            { id: AnnotationType.CLASSIFICATION, label: 'Classification' },
-            { id: AnnotationType.OBJECT_DETECTION, label: 'Object detection' },
-            { id: AnnotationType.SEGMENTATION_MASK, label: 'Segmentation' }
+        if (!distributionPanelVisible) return [allTypesSource];
+
+        // Use the distribution-specific "all" query so the "All types" source
+        // respects distributionCountMode. Fall back to the shared counts while
+        // the distribution query is still loading (data === undefined).
+        const allDistributionData =
+            distributionAllQuery.data !== undefined
+                ? toCategoryCounts(
+                      distributionAllQuery.data as { label_name: string; current_count: number }[]
+                  )
+                : classDistributionCounts;
+        const allTypesDistributionSource: DistributionSource = {
+            id: 'all',
+            label: 'All types',
+            data: allDistributionData
+        };
+
+        const perType: {
+            id: AnnotationType;
+            label: string;
+            valueNoun?: string;
+            query: ReturnType<typeof useImageAnnotationCounts>;
+        }[] = [
+            {
+                id: AnnotationType.CLASSIFICATION,
+                label: 'Classification',
+                query: distributionClassificationQuery
+            },
+            {
+                id: AnnotationType.OBJECT_DETECTION,
+                label: 'Object detection',
+                valueNoun:
+                    distributionCountMode === AnnotationCountMode.SAMPLES ? 'samples' : 'instances',
+                query: distributionObjectDetectionQuery
+            },
+            {
+                id: AnnotationType.SEGMENTATION_MASK,
+                label: 'Segmentation',
+                valueNoun:
+                    distributionCountMode === AnnotationCountMode.SAMPLES ? 'samples' : 'instances',
+                query: distributionSegmentationQuery
+            }
         ];
         const typeSources: DistributionSource[] = [];
-        for (const { id, label } of perType) {
+        for (const { id, label, valueNoun, query } of perType) {
             const data = toCategoryCounts(
-                typeQueries[id].data as { label_name: string; current_count: number }[]
+                query.data as { label_name: string; current_count: number }[]
             );
             // Skip types with no matches in the current view so the selector stays clean.
-            if (data.length > 0) typeSources.push({ id, label, data });
+            if (data.length > 0) typeSources.push({ id, label, data, valueNoun });
         }
         // With a single type, "All types" would just duplicate it — show only
         // the type so the panel's selector stays hidden.
         if (typeSources.length <= 1)
-            return typeSources.length === 1 ? typeSources : [allTypesSource];
-        return [allTypesSource, ...typeSources];
+            return typeSources.length === 1 ? typeSources : [allTypesDistributionSource];
+        return [allTypesDistributionSource, ...typeSources];
     });
 </script>
 
@@ -663,6 +726,9 @@
                                 <DatasetDistributionPanel
                                     sources={distributionSources}
                                     onClose={() => setActivePanel('none')}
+                                    onCountModeChange={(mode) => {
+                                        distributionCountMode = mode;
+                                    }}
                                 />
                             {/await}
                         {/if}


### PR DESCRIPTION
## What has changed and why?

Adds a **Count by** selector to the class distribution panel for detection-type sources (Object detection, Segmentation). Users can now switch between counting annotation instances ("Objects") and counting distinct annotated images ("Samples").

https://github.com/user-attachments/assets/0b99ac55-f41e-4988-af38-1b382a23450a





## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Count by” selector (Objects vs Samples) to distribution configuration.
  * Distribution panel supports an initial count mode and notifies selection changes to consumers.
  * Headers and totals update to reflect the chosen counting mode (including omitting total count in Samples mode).
  * Chart sizing now adapts to available panel width for improved rendering.
* **Bug Fixes**
  * Improved distribution count query behavior and loading for the “all types” distribution view.
* **Tests**
  * Extended tests to cover count-mode selection, callback behavior, and header display changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->