### PR TITLE
Update docs for AnnotationMetricQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Python SDK: Allow embedding video frames by adding the `embed_frames` parameter to `VideoDataset.add_videos_from_path` and `VideoDataset.add_videos_from_youtube_vis`.
+- Python dataset queries can now filter annotation evaluation results for false positives and false negatives.
 
 ### Changed
 

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -284,7 +284,7 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
 
     #### Annotation evaluation queries
 
-    Filtering samples by annotation evaluation results from a specific [evaluation run](evaluation.md), can be realized via `AnnotationMetricQuery.confusion(...)` together with `AnnotationEvaluationMetricField(...)`. In the below example we filter for samples where `cat` got confused as a `dog` by the model, and the IOU is higher than 0.3.
+    Use `AnnotationMetricQuery` to filter samples by annotation-level results from a specific [evaluation run](evaluation.md). For matched ground-truth and prediction pairs, use `AnnotationMetricQuery.confusion(...)`, optionally together with `AnnotationEvaluationMetricField(...)`. The example below finds samples where `cat` got confused as a `dog` and the IoU is greater than 0.3.
 
     ```py
     from lightly_studio.core.dataset_query import (
@@ -300,6 +300,27 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
     )
 
     # Assign the expression to a query:
+    query.match(expr)
+    ```
+
+    To filter samples with unmatched predictions or missed ground truths, use `AnnotationMetricQuery.false_positive(...)` and `AnnotationMetricQuery.false_negative(...)`.
+
+    ```py
+    from lightly_studio.core.dataset_query import AnnotationMetricQuery
+
+    # Samples where the model predicted a dog that did not match any ground truth.
+    expr = AnnotationMetricQuery.false_positive(
+        run_name="run1",
+        prediction="dog",
+    )
+
+    # Samples where a ground-truth cat was not matched by any prediction.
+    expr = AnnotationMetricQuery.false_negative(
+        run_name="run1",
+        ground_truth="cat",
+    )
+
+    # Assign either expression to a query:
     query.match(expr)
     ```
 

--- a/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/search_and_filter.md
@@ -284,7 +284,11 @@ sample-level examples translate to [`VideoSampleField`](../api/dataset_query.md#
 
     #### Annotation evaluation queries
 
-    Use `AnnotationMetricQuery` to filter samples by annotation-level results from a specific [evaluation run](evaluation.md). For matched ground-truth and prediction pairs, use `AnnotationMetricQuery.confusion(...)`, optionally together with `AnnotationEvaluationMetricField(...)`. The example below finds samples where `cat` got confused as a `dog` and the IoU is greater than 0.3.
+    Use `AnnotationMetricQuery` to filter samples by annotation-level results from a specific
+    [evaluation run](evaluation.md). For matched ground-truth and prediction pairs, use
+    `AnnotationMetricQuery.confusion(...)`, optionally together with
+    `AnnotationEvaluationMetricField(...)`. The example below finds samples where `cat` got
+    confused as a `dog` and the IoU is greater than 0.3.
 
     ```py
     from lightly_studio.core.dataset_query import (

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
@@ -29,8 +29,8 @@ class AnnotationMetricQuery(MatchExpression):
     """Query samples by annotation-level evaluation results.
 
     This query matches samples that belong to an evaluation run and contain annotation
-    pairs in a selected confusion-matrix cell or false positives, optionally constrained by
-    persisted annotation metrics.
+    pairs in a selected confusion-matrix cell, false positives, or false negatives,
+    optionally constrained by persisted annotation metrics.
 
     Example:
         ```python

--- a/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/annotation_evaluation_query.py
@@ -29,8 +29,10 @@ class AnnotationMetricQuery(MatchExpression):
     """Query samples by annotation-level evaluation results.
 
     This query matches samples that belong to an evaluation run and contain annotation
-    pairs in a selected confusion-matrix cell, false positives, or false negatives,
-    optionally constrained by persisted annotation metrics.
+    pairs in a selected confusion-matrix cell, false positives, or false negatives.
+    Confusion-matrix matches can optionally be constrained by persisted
+    ``AnnotationEvaluationMetricField`` criteria. False-positive and false-negative
+    matches do not support metric constraints.
 
     Example:
         ```python
@@ -58,6 +60,8 @@ class AnnotationMetricQuery(MatchExpression):
         *criteria: AnnotationEvaluationMetricMatchExpression,
     ) -> AnnotationMetricQuery:
         """Match samples by confusion-matrix cell within an evaluation run.
+
+        Persisted ``AnnotationEvaluationMetricField`` criteria can constrain matches.
 
         Example:
             ```python
@@ -92,6 +96,8 @@ class AnnotationMetricQuery(MatchExpression):
     ) -> AnnotationMetricQuery:
         """Match samples with false-positive predictions within an evaluation run.
 
+        Metric constraints are not supported for false-positive matches.
+
         Example:
             ```python
             AnnotationMetricQuery.false_positive(
@@ -119,6 +125,8 @@ class AnnotationMetricQuery(MatchExpression):
         ground_truth: str,
     ) -> AnnotationMetricQuery:
         """Match samples with false-negative ground truths within an evaluation run.
+
+        Metric constraints are not supported for false-negative matches.
 
         Example:
             ```python


### PR DESCRIPTION
## What has changed and why?
Updating docs after `false_positive`/`false_negative` have been implemented.

## How has it been tested?
Rendered locally and checked manually.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Python dataset queries can now filter annotation evaluation results for false positives and false negatives.
  * Added support for identifying unmatched predictions and missed ground truths by evaluation run.
* **Documentation**
  * Expanded annotation evaluation query guidance, including clearer usage of evaluation-run/annotation-level queries and examples for confusion-matrix filtering, false positives, and false negatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->