### PR TITLE
Use `isPending` and `hasSelection` in TagsMenu inputs

### DIFF
--- a/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
@@ -7,11 +7,11 @@
         options: TagView[];
         hasSelection: boolean;
         busy: boolean;
-        showSelectionHint?: boolean;
         onSelect: (name: string) => void;
     }
 
-    let { options, hasSelection, busy, showSelectionHint = false, onSelect }: Props = $props();
+    let { options, hasSelection, busy, onSelect }: Props = $props();
+    const showSelectionHint = $derived(!hasSelection);
 
     let searchQuery = $state('');
     let showDropdown = $state(false);

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.svelte
@@ -5,12 +5,13 @@
 
     interface Props {
         options: TagView[];
+        hasSelection: boolean;
         busy: boolean;
         showSelectionHint?: boolean;
         onSelect: (name: string) => void;
     }
 
-    let { options, busy, showSelectionHint = false, onSelect }: Props = $props();
+    let { options, hasSelection, busy, showSelectionHint = false, onSelect }: Props = $props();
 
     let searchQuery = $state('');
     let showDropdown = $state(false);
@@ -28,7 +29,7 @@
     );
 
     function handleSelect(name: string) {
-        if (busy) {
+        if (busy || !hasSelection) {
             return;
         }
         onSelect(name);
@@ -83,7 +84,8 @@
             oninput={handleInput}
             onfocus={handleFocus}
             onblur={handleBlur}
-            disabled={busy}
+            isPending={busy}
+            disabled={!hasSelection}
         />
     </div>
 {/snippet}
@@ -108,7 +110,7 @@
                 <button
                     type="button"
                     class="flex w-full items-center px-2 py-1.5 text-xs hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
-                    disabled={busy}
+                    disabled={busy || !hasSelection}
                     value={tag.name}
                     onclick={handleOptionClick}
                 >
@@ -119,7 +121,7 @@
                 <button
                     type="button"
                     class="flex w-full items-center gap-1 px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
-                    disabled={busy}
+                    disabled={busy || !hasSelection}
                     onclick={handleCreateClick}
                 >
                     Create "{trimmedSearchQuery}"

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.test.ts
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.test.ts
@@ -27,6 +27,7 @@ describe('TagAssignInput', () => {
         render(TagAssignInput, {
             props: {
                 options,
+                hasSelection: true,
                 busy: false,
                 onSelect
             }
@@ -49,6 +50,7 @@ describe('TagAssignInput', () => {
         render(TagAssignInput, {
             props: {
                 options,
+                hasSelection: true,
                 busy: false,
                 onSelect
             }
@@ -68,6 +70,7 @@ describe('TagAssignInput', () => {
         render(TagAssignInput, {
             props: {
                 options,
+                hasSelection: true,
                 busy: false,
                 onSelect: vi.fn()
             }

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.test.ts
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagAssignInput.test.ts
@@ -3,34 +3,34 @@ import { describe, expect, it, vi } from 'vitest';
 import TagAssignInput from './TagAssignInput.svelte';
 import type { TagView } from '$lib/services/types';
 
-const options: TagView[] = [
-    {
-        tag_id: 'tag-1',
-        name: 'Vehicle',
-        kind: 'sample',
-        created_at: new Date('2024-01-01T00:00:00.000Z'),
-        updated_at: new Date('2024-01-01T00:00:00.000Z')
-    },
-    {
-        tag_id: 'tag-2',
-        name: 'Person',
-        kind: 'sample',
-        created_at: new Date('2024-01-02T00:00:00.000Z'),
-        updated_at: new Date('2024-01-02T00:00:00.000Z')
-    }
-];
+const defaultProps = {
+    options: [
+        {
+            tag_id: 'tag-1',
+            name: 'Vehicle',
+            kind: 'sample' as const,
+            created_at: new Date('2024-01-01T00:00:00.000Z'),
+            updated_at: new Date('2024-01-01T00:00:00.000Z')
+        },
+        {
+            tag_id: 'tag-2',
+            name: 'Person',
+            kind: 'sample' as const,
+            created_at: new Date('2024-01-02T00:00:00.000Z'),
+            updated_at: new Date('2024-01-02T00:00:00.000Z')
+        }
+    ] satisfies TagView[],
+    hasSelection: true,
+    busy: false,
+    onSelect: vi.fn()
+};
 
 describe('TagAssignInput', () => {
     it('filters options and selects an existing tag from the dropdown', async () => {
         const onSelect = vi.fn();
 
         render(TagAssignInput, {
-            props: {
-                options,
-                hasSelection: true,
-                busy: false,
-                onSelect
-            }
+            props: { ...defaultProps, onSelect }
         });
 
         const input = screen.getByPlaceholderText('Assign tag to selection');
@@ -48,12 +48,7 @@ describe('TagAssignInput', () => {
         const onSelect = vi.fn();
 
         render(TagAssignInput, {
-            props: {
-                options,
-                hasSelection: true,
-                busy: false,
-                onSelect
-            }
+            props: { ...defaultProps, onSelect }
         });
 
         const input = screen.getByPlaceholderText('Assign tag to selection');
@@ -68,12 +63,7 @@ describe('TagAssignInput', () => {
 
     it('clears the query and closes the dropdown on Escape', async () => {
         render(TagAssignInput, {
-            props: {
-                options,
-                hasSelection: true,
-                busy: false,
-                onSelect: vi.fn()
-            }
+            props: { ...defaultProps }
         });
 
         const input = screen.getByPlaceholderText('Assign tag to selection');

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagRenameInput.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagRenameInput.svelte
@@ -60,7 +60,7 @@
         class="h-8 text-xs"
         data-testid={`rename-tag-input-${tag.tag_id}`}
         placeholder="Tag name"
-        disabled={renamingTagId === tag.tag_id}
+        isPending={renamingTagId === tag.tag_id}
         onclick={(event: MouseEvent) => {
             event.stopPropagation();
         }}

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -226,7 +226,8 @@
 
         <TagAssignInput
             options={$tags}
-            busy={assignBusy || !hasSelection}
+            {hasSelection}
+            busy={assignBusy}
             showSelectionHint={!hasSelection}
             onSelect={handleAssign}
         />

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -224,12 +224,6 @@
             {/each}
         </div>
 
-        <TagAssignInput
-            options={$tags}
-            {hasSelection}
-            busy={assignBusy}
-            showSelectionHint={!hasSelection}
-            onSelect={handleAssign}
-        />
+        <TagAssignInput options={$tags} {hasSelection} busy={assignBusy} onSelect={handleAssign} />
     </div>
 </Segment>


### PR DESCRIPTION
## What has changed and why?

Separates two distinct disabled states in `TagAssignInput` and `TagRenameInput` that were previously conflated into a single `busy` / `disabled` prop:

- **Loading state** (`busy` / `renamingTagId`) now maps to `isPending` on the `Input` component, which shows a spinner without fully disabling the field.
- **No-selection state** (`hasSelection`) is now an explicit prop on `TagAssignInput` and drives `disabled` on the input and dropdown buttons.

Previously, `TagsMenu` passed `busy={assignBusy || !hasSelection}`, mixing a transient network state with a UI precondition into one prop. The two concerns are now cleanly separated.

## How has it been tested?

Unit tests + manual tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Tag assignment controls are now unavailable when no items are selected, reducing accidental interactions.
  - The tag assignment dropdown and “Create …” button are disabled when selection is missing or while an operation is in progress.
  - Assignment loading/pending state now reflects the real assignment activity.
  - Empty-selection guidance remains visible within the tags menu.
  - Tag renaming now shows a pending state while processing (instead of disabling the input).
- **Tests**
  - Refactored `TagAssignInput` tests to use shared props, including the new `hasSelection` value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->