### PR TITLE
Scopes the Annotation Classes panel counts to the annotation source

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import ColumnElement
 from sqlalchemy.orm import aliased
 from sqlmodel import Session, col, func, select
+from sqlmodel.sql.expression import Select
 
 from lightly_studio.database import db_array
 from lightly_studio.models.annotation.annotation_base import (
@@ -49,6 +51,12 @@ def count_image_annotations_by_collection(
     individually.  When ``count_mode`` is ``SAMPLES``, the count reflects the
     number of distinct parent samples that carry at least one matching annotation,
     so a sample with multiple annotations of the same label is counted only once.
+
+    When a subset of annotation source collections is selected (via the filter's
+    ``annotations_filter.collection_ids``), both the total and filtered counts are
+    restricted to those sources. Annotations from unselected sources are excluded
+    from the total as well, so the total never counts labels the current view does
+    not care about (e.g. viewing a single source shows "2 of 2", not "2 of 4").
     """
     # Resolve any embedding-plot region selection to concrete sample ids on the filter before the
     # query is built (the point-in-polygon test needs the session, which `apply` lacks).
@@ -69,6 +77,7 @@ def count_image_annotations_by_collection(
         collection_id=collection_id,
         annotation_type=annotation_type,
         count_mode=count_mode,
+        annotation_collection_ids=annotation_collection_ids,
     )
     current_counts = _get_current_counts(
         session=session,
@@ -91,11 +100,33 @@ def _build_count_expression(count_mode: AnnotationCountMode) -> ColumnElement[in
     return func.count(col(AnnotationBaseTable.sample_id))
 
 
+def _restrict_to_annotation_sources(
+    query: Select[tuple[Any, int]],
+    annotation_collection_ids: list[UUID],
+) -> Select[tuple[Any, int]]:
+    """Restrict the counted annotations to the given source collections.
+
+    The annotation's own sample (aliased to avoid clashing with the image sample
+    joined by the caller) carries its collection id.
+    """
+    annotation_sample = aliased(SampleTable)
+    return query.join(
+        annotation_sample,
+        col(annotation_sample.sample_id) == col(AnnotationBaseTable.sample_id),
+    ).where(
+        db_array.in_array(
+            column=col(annotation_sample.collection_id),
+            values=annotation_collection_ids,
+        )
+    )
+
+
 def _get_total_counts(
     session: Session,
     collection_id: UUID,
     annotation_type: AnnotationType | None = None,
     count_mode: AnnotationCountMode = AnnotationCountMode.OBJECTS,
+    annotation_collection_ids: list[UUID] | None = None,
 ) -> dict[str, int]:
     """Returns total annotation counts per label for the collection."""
     total_counts_query = (
@@ -122,6 +153,11 @@ def _get_total_counts(
     if annotation_type is not None:
         total_counts_query = total_counts_query.where(
             col(AnnotationBaseTable.annotation_type) == annotation_type
+        )
+
+    if annotation_collection_ids:
+        total_counts_query = _restrict_to_annotation_sources(
+            total_counts_query, annotation_collection_ids
         )
 
     total_counts_query = total_counts_query.group_by(
@@ -166,20 +202,9 @@ def _get_current_counts(  # noqa: PLR0913
             col(AnnotationBaseTable.annotation_type) == annotation_type
         )
 
-    # Restrict the counted annotations to the selected source collections. The
-    # annotation's own sample (aliased to avoid clashing with the image sample
-    # joined above) carries its collection id.
+    # Restrict the counted annotations to the selected source collections.
     if annotation_collection_ids:
-        annotation_sample = aliased(SampleTable)
-        filtered_query = filtered_query.join(
-            annotation_sample,
-            col(annotation_sample.sample_id) == col(AnnotationBaseTable.sample_id),
-        ).where(
-            db_array.in_array(
-                column=col(annotation_sample.collection_id),
-                values=annotation_collection_ids,
-            )
-        )
+        filtered_query = _restrict_to_annotation_sources(filtered_query, annotation_collection_ids)
 
     if image_filter is not None:
         filtered_query = image_filter.apply(filtered_query)

--- a/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
@@ -191,8 +191,9 @@ def test_count_image_annotations_by_collection_filters_by_annotation_source(
     )
     assert {label: current for label, current, _ in counts} == {"dog": 1, "cat": 1}
 
-    # Restricting to source A counts only its "dog"; totals stay full and "cat"
-    # drops to a current count of 0.
+    # Restricting to source A scopes both the current and total counts to that
+    # source: only "dog" is counted, and "cat" (which lives in source B) drops out
+    # of the results entirely rather than lingering with a zero current count.
     counts = image_resolver.count_image_annotations_by_collection(
         session=db_session,
         collection_id=collection_id,
@@ -203,8 +204,7 @@ def test_count_image_annotations_by_collection_filters_by_annotation_source(
         ),
     )
     counts_dict = {label: (current, total) for label, current, total in counts}
-    assert counts_dict["dog"] == (1, 1)
-    assert counts_dict["cat"] == (0, 1)
+    assert counts_dict == {"dog": (1, 1)}
 
     # Restricting to source B is the mirror image.
     counts = image_resolver.count_image_annotations_by_collection(
@@ -217,8 +217,68 @@ def test_count_image_annotations_by_collection_filters_by_annotation_source(
         ),
     )
     counts_dict = {label: (current, total) for label, current, total in counts}
-    assert counts_dict["dog"] == (0, 1)
-    assert counts_dict["cat"] == (1, 1)
+    assert counts_dict == {"cat": (1, 1)}
+
+
+def test_count_image_annotations_by_collection_total_excludes_other_sources(
+    db_session: Session,
+) -> None:
+    """A shared label's total is scoped to the selected source, not summed across all.
+
+    The same label lives on two images in source A and two images in source B.
+    Viewing a single source must report "2 of 2" for that label, not "2 of 4".
+    """
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    shared_label = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="shared"
+    )
+
+    def _annotate_images(count: int, source_name: str) -> UUID:
+        collection_ids = []
+        for index in range(count):
+            image = create_image(
+                session=db_session,
+                collection_id=collection_id,
+                file_path_abs=f"/path/to/{source_name}_{index}.png",
+            )
+            created = create_annotations(
+                session=db_session,
+                collection_id=collection_id,
+                annotations=[
+                    AnnotationDetails(
+                        sample_id=image.sample_id,
+                        annotation_label_id=shared_label.annotation_label_id,
+                    )
+                ],
+                collection_name=source_name,
+            )
+            collection_ids.append(created[0].annotation_collection_id)
+        # All annotations added under the same source share one collection id.
+        assert len(set(collection_ids)) == 1
+        return collection_ids[0]
+
+    source_a_collection_id = _annotate_images(count=2, source_name="source_a")
+    _annotate_images(count=2, source_name="source_b")
+
+    # Without a source filter the total sums both sources.
+    counts = image_resolver.count_image_annotations_by_collection(
+        session=db_session,
+        collection_id=collection_id,
+    )
+    assert {label: total for label, _, total in counts} == {"shared": 4}
+
+    # Restricting to source A scopes the total to that source: 2 of 2, not 2 of 4.
+    counts = image_resolver.count_image_annotations_by_collection(
+        session=db_session,
+        collection_id=collection_id,
+        image_filter=ImageFilter(
+            sample_filter=SampleFilter(
+                annotations_filter=AnnotationsFilter(collection_ids=[source_a_collection_id])
+            )
+        ),
+    )
+    assert {label: (current, total) for label, current, total in counts} == {"shared": (2, 2)}
 
 
 @pytest.fixture

--- a/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_collection.py
@@ -225,8 +225,8 @@ def test_count_image_annotations_by_collection_total_excludes_other_sources(
 ) -> None:
     """A shared label's total is scoped to the selected source, not summed across all.
 
-    The same label lives on two images in source A and two images in source B.
-    Viewing a single source must report "2 of 2" for that label, not "2 of 4".
+    The same label lives on one image in source A and one image in source B.
+    Viewing a single source must report "1 of 1" for that label, not "1 of 2".
     """
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
@@ -234,41 +234,49 @@ def test_count_image_annotations_by_collection_total_excludes_other_sources(
         session=db_session, root_collection_id=collection_id, label_name="shared"
     )
 
-    def _annotate_images(count: int, source_name: str) -> UUID:
-        collection_ids = []
-        for index in range(count):
-            image = create_image(
-                session=db_session,
-                collection_id=collection_id,
-                file_path_abs=f"/path/to/{source_name}_{index}.png",
-            )
-            created = create_annotations(
-                session=db_session,
-                collection_id=collection_id,
-                annotations=[
-                    AnnotationDetails(
-                        sample_id=image.sample_id,
-                        annotation_label_id=shared_label.annotation_label_id,
-                    )
-                ],
-                collection_name=source_name,
-            )
-            collection_ids.append(created[0].annotation_collection_id)
-        # All annotations added under the same source share one collection id.
-        assert len(set(collection_ids)) == 1
-        return collection_ids[0]
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/source_a.png",
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/source_b.png",
+    )
 
-    source_a_collection_id = _annotate_images(count=2, source_name="source_a")
-    _annotate_images(count=2, source_name="source_b")
+    source_a = create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=shared_label.annotation_label_id,
+            )
+        ],
+        collection_name="source_a",
+    )
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=shared_label.annotation_label_id,
+            )
+        ],
+        collection_name="source_b",
+    )
+    source_a_collection_id = source_a[0].annotation_collection_id
 
     # Without a source filter the total sums both sources.
     counts = image_resolver.count_image_annotations_by_collection(
         session=db_session,
         collection_id=collection_id,
     )
-    assert {label: total for label, _, total in counts} == {"shared": 4}
+    assert {label: total for label, _, total in counts} == {"shared": 2}
 
-    # Restricting to source A scopes the total to that source: 2 of 2, not 2 of 4.
+    # Restricting to source A scopes the total to that source: 1 of 1, not 1 of 2.
     counts = image_resolver.count_image_annotations_by_collection(
         session=db_session,
         collection_id=collection_id,
@@ -278,7 +286,7 @@ def test_count_image_annotations_by_collection_total_excludes_other_sources(
             )
         ),
     )
-    assert {label: (current, total) for label, current, total in counts} == {"shared": (2, 2)}
+    assert {label: (current, total) for label, current, total in counts} == {"shared": (1, 1)}
 
 
 @pytest.fixture

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsFilter/useAnnotationsFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsFilter/useAnnotationsFilter.test.ts
@@ -197,7 +197,7 @@ describe('useAnnotationsFilter', () => {
         expect(get(annotationFilterLabels)).toEqual({});
     });
 
-    it('pruneInvalidSelections removes selections whose label has zero current_count', () => {
+    it('pruneInvalidSelections keeps labels present in counts even at zero current_count', () => {
         selectedAnnotationFilterIds.set(new Set(['id-1', 'id-2']));
 
         const { setAnnotationCounts, pruneInvalidSelections } = useAnnotationsFilter({
@@ -210,13 +210,16 @@ describe('useAnnotationsFilter', () => {
         ]);
         pruneInvalidSelections();
 
-        // 'dog' (id-2) has a zero current_count and is toggled off; 'cat' stays.
-        expect(setSelectedAnnotationFilterIds).toHaveBeenCalledWith('id-2');
-        expect(setSelectedAnnotationFilterIds).not.toHaveBeenCalledWith('id-1');
-        expect(get(selectedAnnotationFilterIds)).toEqual(new Set(['id-1']));
+        // Both labels are present in the (source-scoped) counts, so neither is
+        // deselected: a class can't prune itself just because the active filter
+        // currently matches none of its rows.
+        expect(setSelectedAnnotationFilterIds).not.toHaveBeenCalled();
+        expect(get(selectedAnnotationFilterIds)).toEqual(new Set(['id-1', 'id-2']));
     });
 
     it('pruneInvalidSelections removes selections whose label is missing from counts', () => {
+        // Mirrors switching to an annotation source that does not contain 'dog':
+        // its label drops out of the source-scoped counts and gets deselected.
         selectedAnnotationFilterIds.set(new Set(['id-2']));
 
         const { setAnnotationCounts, pruneInvalidSelections } = useAnnotationsFilter({

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsFilter/useAnnotationsFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsFilter/useAnnotationsFilter.test.ts
@@ -197,6 +197,56 @@ describe('useAnnotationsFilter', () => {
         expect(get(annotationFilterLabels)).toEqual({});
     });
 
+    it('pruneInvalidSelections removes selections whose label has zero current_count', () => {
+        selectedAnnotationFilterIds.set(new Set(['id-1', 'id-2']));
+
+        const { setAnnotationCounts, pruneInvalidSelections } = useAnnotationsFilter({
+            annotationLabels
+        });
+
+        setAnnotationCounts([
+            { label_name: 'cat', total_count: 10, current_count: 5 },
+            { label_name: 'dog', total_count: 8, current_count: 0 }
+        ]);
+        pruneInvalidSelections();
+
+        // 'dog' (id-2) has a zero current_count and is toggled off; 'cat' stays.
+        expect(setSelectedAnnotationFilterIds).toHaveBeenCalledWith('id-2');
+        expect(setSelectedAnnotationFilterIds).not.toHaveBeenCalledWith('id-1');
+        expect(get(selectedAnnotationFilterIds)).toEqual(new Set(['id-1']));
+    });
+
+    it('pruneInvalidSelections removes selections whose label is missing from counts', () => {
+        selectedAnnotationFilterIds.set(new Set(['id-2']));
+
+        const { setAnnotationCounts, pruneInvalidSelections } = useAnnotationsFilter({
+            annotationLabels
+        });
+
+        setAnnotationCounts([{ label_name: 'cat', total_count: 10, current_count: 5 }]);
+        pruneInvalidSelections();
+
+        expect(setSelectedAnnotationFilterIds).toHaveBeenCalledWith('id-2');
+        expect(get(selectedAnnotationFilterIds)).toEqual(new Set());
+    });
+
+    it('pruneInvalidSelections keeps valid selections and is a no-op without counts', () => {
+        selectedAnnotationFilterIds.set(new Set(['id-1']));
+
+        const { setAnnotationCounts, pruneInvalidSelections } = useAnnotationsFilter({
+            annotationLabels
+        });
+
+        // No counts set yet: nothing should be toggled.
+        pruneInvalidSelections();
+        expect(setSelectedAnnotationFilterIds).not.toHaveBeenCalled();
+
+        setAnnotationCounts([{ label_name: 'cat', total_count: 10, current_count: 5 }]);
+        pruneInvalidSelections();
+        expect(setSelectedAnnotationFilterIds).not.toHaveBeenCalled();
+        expect(get(selectedAnnotationFilterIds)).toEqual(new Set(['id-1']));
+    });
+
     it('selectedAnnotationFilterNames returns selected label names', () => {
         selectedAnnotationFilterIds.set(new Set(['id-2']));
 

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsFilter/useAnnotationsFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsFilter/useAnnotationsFilter.ts
@@ -121,8 +121,6 @@ export function useAnnotationsFilter({
     // Drop selected annotation filters that are no longer valid: if a selected
     // label is absent from the counts, remove it from the selected set so the
     // active filter never refers to a hidden label.
-    // Called imperatively after counts update (see setAnnotationCounts consumers)
-    // rather than via a derived store, so the side effect runs deterministically.
     const pruneInvalidSelections = () => {
         const counts = get(annotationCountsStore);
         if (!counts) return;

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsFilter/useAnnotationsFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsFilter/useAnnotationsFilter.ts
@@ -118,6 +118,29 @@ export function useAnnotationsFilter({
         }
     );
 
+    // Drop selected annotation filters that are no longer valid: if a selected
+    // label is missing from the counts (or has a zero current_count) remove it
+    // from the selected set so the active filter never refers to a hidden row.
+    // Called imperatively after counts update (see setAnnotationCounts consumers)
+    // rather than via a derived store, so the side effect runs deterministically.
+    const pruneInvalidSelections = () => {
+        const counts = get(annotationCountsStore);
+        if (!counts) return;
+        const validNames = new Set(
+            counts.filter((c) => (c.current_count ?? 0) > 0).map((c) => c.label_name)
+        );
+        const idToName = new Map(
+            Object.entries(get(annotationFilterLabels)).map(([name, id]) => [id, name])
+        );
+        // Snapshot the ids before toggling, since toggling mutates the set.
+        Array.from(get(selectedAnnotationFilterIds)).forEach((selectedId) => {
+            const name = idToName.get(selectedId);
+            if (name && !validNames.has(name)) {
+                toggleSelectedAnnotationFilterId(selectedId);
+            }
+        });
+    };
+
     // Selected label names (reverse lookup)
     const selectedAnnotationFilterNames: Readable<string[]> = derived(
         [annotationFilterLabels, selectedAnnotationFilterIds],
@@ -159,6 +182,7 @@ export function useAnnotationsFilter({
         annotationFilterLabels,
         selectedAnnotationFilterNames,
         setAnnotationCounts,
+        pruneInvalidSelections,
         toggleAnnotationFilterSelection,
         toggleSelectedAnnotationFilterId,
         clearSelectedAnnotationFilterIds

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsFilter/useAnnotationsFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsFilter/useAnnotationsFilter.ts
@@ -119,16 +119,14 @@ export function useAnnotationsFilter({
     );
 
     // Drop selected annotation filters that are no longer valid: if a selected
-    // label is missing from the counts (or has a zero current_count) remove it
-    // from the selected set so the active filter never refers to a hidden row.
+    // label is absent from the counts, remove it from the selected set so the
+    // active filter never refers to a hidden label.
     // Called imperatively after counts update (see setAnnotationCounts consumers)
     // rather than via a derived store, so the side effect runs deterministically.
     const pruneInvalidSelections = () => {
         const counts = get(annotationCountsStore);
         if (!counts) return;
-        const validNames = new Set(
-            counts.filter((c) => (c.current_count ?? 0) > 0).map((c) => c.label_name)
-        );
+        const validNames = new Set(counts.map((c) => c.label_name));
         const idToName = new Map(
             Object.entries(get(annotationFilterLabels)).map(([name, id]) => [id, name])
         );

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -393,8 +393,9 @@
             setAnnotationCounts(
                 countsData as { label_name: string; total_count: number; current_count?: number }[]
             );
-            // Drop any selected label filters that no longer have matching rows in
-            // the fresh counts so the active filter never points at a hidden label.
+            // Drop selected label filters whose label is absent from the fresh,
+            // source-scoped counts (e.g. after switching to a source that doesn't
+            // contain the label) so the active filter never points at a hidden label.
             pruneInvalidSelections();
         }
     });

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -291,7 +291,8 @@
         annotationFilter: annotationFilterStore,
         annotationFilterRows,
         toggleAnnotationFilterSelection,
-        setAnnotationCounts
+        setAnnotationCounts,
+        pruneInvalidSelections
     } = useAnnotationsFilter({
         annotationLabels: annotationLabelsStore
     });
@@ -326,7 +327,8 @@
     const { selectedCollectionIds: selectedAnnotationSourceIds } = useAnnotationCollectionsFilter();
     const annotationFilterForCounts = $derived.by<AnnotationsFilter | undefined>(() => {
         const base = $annotationFilterStore;
-        const sourceIds = isAnnotations ? [] : $selectedAnnotationSourceIds;
+        const sourceIds =
+            isAnnotations || isAnnotationDetails ? [collectionId] : $selectedAnnotationSourceIds;
         if (sourceIds.length === 0) return base;
         return {
             ...(base ?? { filter_type: 'annotations' }),
@@ -391,6 +393,9 @@
             setAnnotationCounts(
                 countsData as { label_name: string; total_count: number; current_count?: number }[]
             );
+            // Drop any selected label filters that no longer have matching rows in
+            // the fresh counts so the active filter never points at a hidden label.
+            pruneInvalidSelections();
         }
     });
 


### PR DESCRIPTION
## What has changed and why?

Previously the class "total" count summed a label's annotations across *all* annotation
sources. So when viewing a single source, a class that also exists in another source showed
e.g. `2 of 4` even though only 2 of those annotations belong to the source you're looking at.
The current (filtered) count was already source-scoped, so the two numbers were inconsistent.

Annotation grid view now also scopes the count to the current collection.

Now both counts respect the selected source(s):
- **Backend** (`count_image_annotations_by_collection`): the annotation-source restriction
  (`annotations_filter.collection_ids`) is applied to the *total* count as well as the
  filtered count. The shared join was extracted into a `_restrict_to_annotation_sources`
  helper used by both queries. A label that exists only in unselected sources now drops out
  of the results entirely rather than lingering with a `0` count.
- **Frontend** (`+layout.svelte`): on the annotations / annotation-details routes, counts are
  now scoped to the active annotation collection (`[collectionId]`) instead of being left
  unscoped.
- **Frontend** (`useAnnotationsFilter`): added `pruneInvalidSelections()`, called after each
  counts refresh, which deselects any class filter whose label no longer has matching rows so
  the active filter can't point at a label that isn't shown.

## How has it been tested?

new tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Annotation counts and totals now respect only the selected annotation source(s), excluding unselected sources.
  * Label selections are automatically pruned when refreshed count data no longer includes them.
  * Annotation views compute counts using the correct collection scope, improving consistency when switching sources.
* **Tests**
  * Updated resolver tests to verify source-scoped totals and correct label filtering behavior.
  * Added unit tests for pruning invalid label selections in the annotations filter hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->