### PR TITLE
Add reusable parallelization utility (thread_imap_lazy)

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/add_images.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_images.py
@@ -84,6 +84,10 @@ def load_into_dataset_from_paths(
 
     report = FileOutcomeReport()
 
+    # TODO(Malte, 07/2026): Parallelize image indexing across images with
+    # parallelize.thread_imap_lazy (one task per image; workers and prefetch stay
+    # bounded) to overlap the per-image reads, especially for remote (e.g. S3) inputs.
+    # Keep DB writes on a single thread.
     for normalized_path in tqdm(
         normalized_paths,
         desc="Processing images",

--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -174,6 +174,11 @@ def load_into_collection_from_paths(  # noqa: PLR0913
         embedding_model_id=embedding_model_id,
     )
 
+    # TODO(Malte, 07/2026): Parallelize video indexing across videos with
+    # parallelize.thread_imap_lazy (one task per whole video, never split a video;
+    # workers and prefetch stay bounded) to overlap remote reads. Decode single-threaded
+    # per video and keep DB writes and embedding on a single thread, as neither the
+    # session nor the model is thread-safe.
     for video_path in tqdm(
         video_paths_list,
         desc="Loading frames from videos",

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -150,6 +150,10 @@ def _embed_dataset_batched(
     if context.max_batch_size <= 0:
         raise ValueError("max_batch_size must be positive.")
 
+    # TODO(Malte, 07/2026): Parallelize per-item preprocessing with
+    # parallelize.thread_imap_lazy (each item opens/decodes/preprocesses one image,
+    # independently), then group results with batching.batched for the batched forward
+    # pass. This overlaps CPU-bound preprocessing (and remote reads) with inference.
     # To avoid issues with db locking and multiprocessing we set the number of
     # workers to 0 (no multiprocessing). The DataLoader is still very useful for
     # batching and async prefetching of images.

--- a/lightly_studio/src/lightly_studio/utils/parallelize.py
+++ b/lightly_studio/src/lightly_studio/utils/parallelize.py
@@ -1,0 +1,129 @@
+"""Lazy, bounded parallel map over a thread pool.
+
+``thread_imap_lazy`` applies a function across a thread pool while consuming its input
+lazily: at most ``buffer_size`` items are read ahead of the caller and in flight at once.
+Read-ahead is bounded to the consumer, so it scales to very large or unbounded inputs and
+bounds any per-item resources (memory, temporary files) held by outstanding work.
+
+Threads (not processes) suit I/O-bound or GIL-releasing work (network downloads, disk
+reads, PyAV decode, torch/numpy): they overlap without the process spawn cost and input
+pickling of multiprocessing, which under the "spawn" start method (e.g. macOS) makes
+per-batch worker pools slower than a single thread.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections import deque
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from typing import TypeVar
+
+_T = TypeVar("_T")
+_R = TypeVar("_R")
+
+
+def thread_imap_lazy(
+    function: Callable[[_T], _R],
+    iterable: Iterable[_T],
+    max_workers: int,
+    buffer_size: int | None = None,
+) -> Iterator[_R]:
+    """Apply ``function`` across a thread pool, lazily and in input order.
+
+    A threaded analogue of ``map`` for I/O-bound or GIL-releasing work. Unlike
+    ``ThreadPoolExecutor.map``, the input is consumed lazily: at most ``buffer_size``
+    items are read ahead of the caller and in flight at once. A new item is read and
+    submitted only when the caller takes a result, so read-ahead stays bounded to the
+    consumer even when ``function`` is fast. This scales to very large or unbounded
+    inputs and bounds the per-item resources (memory, temporary files) held by
+    outstanding work.
+
+    Args:
+        function: Work applied to each item. Called concurrently from worker threads, so
+            it must be thread-safe with respect to any shared state it touches.
+        iterable: Items to process. Consumed lazily, one look-ahead window at a time.
+        max_workers: Number of worker threads. Must be at least 1.
+        buffer_size: Maximum items in flight (submitted but not yet yielded). Defaults to
+            ``max_workers``. Must be at least 1.
+
+    Yields:
+        ``function(item)`` for each item, in the order of ``iterable``.
+
+    Raises:
+        ValueError: If ``max_workers`` or ``buffer_size`` is less than 1.
+    """
+    buffer_size = _resolve_buffer_size(max_workers=max_workers, buffer_size=buffer_size)
+    items = iter(iterable)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # A FIFO queue of in-flight futures preserves input order on the way out.
+        pending: deque[Future[_R]] = deque(
+            executor.submit(function, item) for item in itertools.islice(items, buffer_size)
+        )
+        while pending:
+            # Re-raises the worker's exception here, in the caller, if it failed.
+            result = pending.popleft().result()
+            # Refill only now that the caller is taking a result, so read-ahead stays
+            # bounded to the consumer even when ``function`` is fast.
+            try:
+                next_item = next(items)
+            except StopIteration:
+                pass
+            else:
+                pending.append(executor.submit(function, next_item))
+            yield result
+
+
+def thread_imap_unordered_lazy(
+    function: Callable[[_T], _R],
+    iterable: Iterable[_T],
+    max_workers: int,
+    buffer_size: int | None = None,
+) -> Iterator[_R]:
+    """Apply ``function`` across a thread pool, lazily, yielding results as they complete.
+
+    Like :func:`thread_imap_lazy` but order is not preserved: a slow item does not hold up
+    faster ones behind it, which improves throughput when per-item durations vary (e.g.
+    downloading files of very different sizes). Prefer this when the caller does not depend
+    on input order. Read-ahead is bounded to the consumer exactly as in the ordered variant.
+
+    Args:
+        function: Work applied to each item. Called concurrently from worker threads, so
+            it must be thread-safe with respect to any shared state it touches.
+        iterable: Items to process. Consumed lazily, one look-ahead window at a time.
+        max_workers: Number of worker threads. Must be at least 1.
+        buffer_size: Maximum items in flight (submitted but not yet yielded). Defaults to
+            ``max_workers``. Must be at least 1.
+
+    Yields:
+        ``function(item)`` for each item, in completion order.
+
+    Raises:
+        ValueError: If ``max_workers`` or ``buffer_size`` is less than 1.
+    """
+    buffer_size = _resolve_buffer_size(max_workers=max_workers, buffer_size=buffer_size)
+    items = iter(iterable)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        pending: set[Future[_R]] = {
+            executor.submit(function, item) for item in itertools.islice(items, buffer_size)
+        }
+        while pending:
+            done, pending = wait(pending, return_when=FIRST_COMPLETED)
+            for future in done:
+                try:
+                    next_item = next(items)
+                except StopIteration:
+                    pass
+                else:
+                    pending.add(executor.submit(function, next_item))
+                yield future.result()
+
+
+def _resolve_buffer_size(max_workers: int, buffer_size: int | None) -> int:
+    """Validate the pool sizing and resolve a ``None`` buffer size to ``max_workers``."""
+    if max_workers < 1:
+        raise ValueError(f"max_workers must be at least 1, got {max_workers}.")
+    resolved = max_workers if buffer_size is None else buffer_size
+    if resolved < 1:
+        raise ValueError(f"buffer_size must be at least 1, got {resolved}.")
+    return resolved

--- a/lightly_studio/tests/utils/test_parallelize.py
+++ b/lightly_studio/tests/utils/test_parallelize.py
@@ -1,0 +1,111 @@
+import itertools
+import threading
+from collections.abc import Iterator
+
+import pytest
+
+from lightly_studio.utils import parallelize
+
+
+def test_thread_imap_lazy() -> None:
+    result = list(parallelize.thread_imap_lazy(lambda x: x * 2, range(10), max_workers=4))
+    assert result == [x * 2 for x in range(10)]
+
+
+def test_thread_imap_lazy__empty() -> None:
+    empty: list[int] = []
+    result = list(parallelize.thread_imap_lazy(lambda x: x, empty, max_workers=4))
+    assert result == []
+
+
+def test_thread_imap_lazy__preserves_order_despite_out_of_order_completion() -> None:
+    # Item 0 finishes only after item 1 has run, forcing completion order 1 then 0.
+    # The output must still be in input order.
+    item_1_done = threading.Event()
+
+    def func(x: int) -> int:
+        if x == 0:
+            item_1_done.wait(timeout=5)
+        else:
+            item_1_done.set()
+        return x
+
+    result = list(parallelize.thread_imap_lazy(func, [0, 1], max_workers=2, buffer_size=2))
+    assert result == [0, 1]
+
+
+def test_thread_imap_lazy__reads_ahead_bounded_by_buffer_size() -> None:
+    # Read-ahead must stay bounded to the consumer even for a fast function and an
+    # unbounded source: taking one result reads exactly one more item.
+    pulled = 0
+
+    def source() -> Iterator[int]:
+        nonlocal pulled
+        for i in itertools.count():
+            pulled += 1
+            yield i
+
+    buffer_size = 3
+    iterator = iter(
+        parallelize.thread_imap_lazy(lambda x: x, source(), max_workers=2, buffer_size=buffer_size)
+    )
+    assert next(iterator) == 0
+    # Initial fill reads buffer_size items; taking one result refills exactly one.
+    assert pulled == buffer_size + 1
+
+
+def test_thread_imap_lazy__reraises_function_error() -> None:
+    def func(x: int) -> int:
+        if x == 3:
+            raise ValueError("boom")
+        return x
+
+    yielded = []
+
+    def consume() -> None:
+        for result in parallelize.thread_imap_lazy(func, range(10), max_workers=2, buffer_size=2):
+            yielded.append(result)
+
+    with pytest.raises(ValueError, match="boom"):
+        consume()
+    assert yielded == [0, 1, 2]
+
+
+@pytest.mark.parametrize("max_workers", [0, -1])
+def test_thread_imap_lazy__invalid_max_workers(max_workers: int) -> None:
+    with pytest.raises(ValueError, match="max_workers must be at least 1"):
+        list(parallelize.thread_imap_lazy(lambda x: x, [1, 2], max_workers=max_workers))
+
+
+def test_thread_imap_lazy__invalid_buffer_size() -> None:
+    with pytest.raises(ValueError, match="buffer_size must be at least 1"):
+        list(parallelize.thread_imap_lazy(lambda x: x, [1, 2], max_workers=2, buffer_size=0))
+
+
+def test_thread_imap_unordered_lazy__yields_all_results() -> None:
+    results = parallelize.thread_imap_unordered_lazy(lambda x: x, range(20), max_workers=5)
+    assert sorted(results) == list(range(20))
+
+
+def test_thread_imap_unordered_lazy__reads_ahead_bounded_by_buffer_size() -> None:
+    pulled = 0
+
+    def source() -> Iterator[int]:
+        nonlocal pulled
+        for i in itertools.count():
+            pulled += 1
+            yield i
+
+    buffer_size = 3
+    iterator = iter(
+        parallelize.thread_imap_unordered_lazy(
+            lambda x: x, source(), max_workers=2, buffer_size=buffer_size
+        )
+    )
+    next(iterator)
+    assert pulled == buffer_size + 1
+
+
+def test_thread_imap_unordered_lazy__invalid_max_workers() -> None:
+    with pytest.raises(ValueError, match="max_workers must be at least 1"):
+        list(parallelize.thread_imap_unordered_lazy(lambda x: x, [1, 2], max_workers=0))


### PR DESCRIPTION
## What has changed and why?

Adds `thread_imap_lazy`. It allows to easily parallelise work releasing the GIL, e.g. downloads, decoding and PIL/numpy/torch operations. 

## How has it been tested?

unittests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)