### PR TITLE
Add video_resolver.get_sample_ids_by_stems

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/__init__.py
@@ -15,6 +15,7 @@ from lightly_studio.resolvers.video_resolver.get_sample_ids import (
     build_sample_ids_query,
     get_sample_ids,
 )
+from lightly_studio.resolvers.video_resolver.get_sample_ids_by_stems import get_sample_ids_by_stems
 from lightly_studio.resolvers.video_resolver.get_table_fields_bounds import (
     get_table_fields_bounds,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "get_by_id",
     "get_many_by_id",
     "get_sample_ids",
+    "get_sample_ids_by_stems",
     "get_table_fields_bounds",
     "get_view_by_id",
 ]

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_sample_ids_by_stems.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_sample_ids_by_stems.py
@@ -17,7 +17,7 @@ def get_sample_ids_by_stems(
 ) -> dict[str, UUID]:
     """Build a mapping from video identifier stems to sample IDs in a collection.
 
-    Each video is indexed by ``Path(file_name).stem`` and ``Path(file_path_abs).stem``.
+    Each video is indexed by ``Path(file_name).stem``.
     If the same stem maps to multiple videos, a ``ValueError`` is raised.
 
     Args:
@@ -28,21 +28,21 @@ def get_sample_ids_by_stems(
         A mapping from stem to sample_id.
     """
     query = (
-        select(VideoTable.file_name, VideoTable.file_path_abs, VideoTable.sample_id)
+        select(VideoTable.file_name, VideoTable.sample_id)
         .join(SampleTable)
         .where(col(SampleTable.collection_id) == collection_id)
     )
     videos = session.exec(query).all()
 
     stem_to_sample_id: dict[str, UUID] = {}
-    for file_name, file_path_abs, sample_id in videos:
-        for stem in {Path(file_name).stem, Path(file_path_abs).stem}:
-            existing = stem_to_sample_id.get(stem)
-            if existing is not None and existing != sample_id:
-                raise ValueError(
-                    f"Duplicate video stem '{stem}' in collection {collection_id}. "
-                    "Video identifiers must be unique."
-                )
-            stem_to_sample_id[stem] = sample_id
+    for file_name, sample_id in videos:
+        stem = Path(file_name).stem
+        existing = stem_to_sample_id.get(stem)
+        if existing is not None and existing != sample_id:
+            raise ValueError(
+                f"Duplicate video stem '{stem}' in collection {collection_id}. "
+                "Video identifiers must be unique."
+            )
+        stem_to_sample_id[stem] = sample_id
 
     return stem_to_sample_id

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_sample_ids_by_stems.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_sample_ids_by_stems.py
@@ -1,0 +1,48 @@
+"""Implementation of get_sample_ids_by_stems function for videos."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.video import VideoTable
+
+
+def get_sample_ids_by_stems(
+    session: Session,
+    collection_id: UUID,
+) -> dict[str, UUID]:
+    """Build a mapping from video identifier stems to sample IDs in a collection.
+
+    Each video is indexed by ``Path(file_name).stem`` and ``Path(file_path_abs).stem``.
+    If the same stem maps to multiple videos, a ``ValueError`` is raised.
+
+    Args:
+        session: The database session.
+        collection_id: The ID of the video collection to scope results to.
+
+    Returns:
+        A mapping from stem to sample_id.
+    """
+    query = (
+        select(VideoTable.file_name, VideoTable.file_path_abs, VideoTable.sample_id)
+        .join(SampleTable)
+        .where(col(SampleTable.collection_id) == collection_id)
+    )
+    videos = session.exec(query).all()
+
+    stem_to_sample_id: dict[str, UUID] = {}
+    for file_name, file_path_abs, sample_id in videos:
+        for stem in {Path(file_name).stem, Path(file_path_abs).stem}:
+            existing = stem_to_sample_id.get(stem)
+            if existing is not None and existing != sample_id:
+                raise ValueError(
+                    f"Duplicate video stem '{stem}' in collection {collection_id}. "
+                    "Video identifiers must be unique."
+                )
+            stem_to_sample_id[stem] = sample_id
+
+    return stem_to_sample_id

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_get_sample_ids_by_stems.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_get_sample_ids_by_stems.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.resolvers import video_resolver
+from tests.helpers_resolvers import create_collection
+from tests.resolvers.video.helpers import VideoStub, create_video
+
+
+def test_get_sample_ids_by_stems(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    other_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+
+    video = create_video(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/data/videos/v_action1.mp4"),
+    )
+    create_video(
+        session=db_session,
+        collection_id=other_collection.collection_id,
+        video=VideoStub(path="/data/videos/v_other.mp4"),
+    )
+
+    stem_to_sample_id = video_resolver.get_sample_ids_by_stems(
+        session=db_session,
+        collection_id=collection.collection_id,
+    )
+
+    # Only videos of the requested collection are returned, indexed by stem.
+    assert stem_to_sample_id == {"v_action1": video.sample_id}
+
+
+def test_get_sample_ids_by_stems__raises_on_duplicate_stem(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+
+    # Two videos with different paths but the same file name stem.
+    create_video(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/data/a/v_action1.mp4"),
+    )
+    create_video(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/data/b/v_action1.mp4"),
+    )
+
+    with pytest.raises(ValueError, match="Duplicate video stem 'v_action1'"):
+        video_resolver.get_sample_ids_by_stems(
+            session=db_session,
+            collection_id=collection.collection_id,
+        )


### PR DESCRIPTION
## What has changed and why?

First of 3 PRs splitting #1602 (import ActivityNet-style event annotations).

Adds `video_resolver.get_sample_ids_by_stems`, which builds a mapping from
video file-name/path stems to sample IDs within a collection (raising on
duplicate stems). This is the matching primitive used by the ActivityNet
importer to attach annotations to existing videos by identifier.

## How has it been tested?

New unit test covering collection scoping, stem indexing, and the
duplicate-stem `ValueError`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new video resolver that looks up sample identifiers by filename/path stem.
  * Supports scoping results to a specific collection.
  * Detects duplicate stems that map to different sample identifiers and reports an error.

* **Tests**
  * Added unit tests covering collection filtering, stem→sample-id mapping, and duplicate-stem error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->