### PR TITLE
Skip undecodable videos during indexing

### DIFF
--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -270,13 +270,23 @@ def _load_single_video(
                 embed_frames=context.embed_frames,
                 embedding_model_id=context.embedding_model_id,
             )
-            frame_sample_ids = _create_video_frame_samples(
-                context=extraction_context,
-                video_container=video_container,
-                video_channel=context.video_channel,
-                num_decode_threads=context.num_decode_threads,
-                target_fps=context.target_fps,
-            )
+            try:
+                frame_sample_ids = _create_video_frame_samples(
+                    context=extraction_context,
+                    video_container=video_container,
+                    video_channel=context.video_channel,
+                    num_decode_threads=context.num_decode_threads,
+                    target_fps=context.target_fps,
+                )
+            except (OSError, FFmpegError) as e:
+                # A frame that fails to decode mid-stream leaves the already-committed video row
+                # and any flushed frame batches behind. Remove them so a broken video leaves no
+                # rows, then translate the failure into a broken-file signal so the caller's
+                # report.track records it and the run continues instead of aborting.
+                video_resolver.delete_with_frames(
+                    session=context.session, video_sample_id=video_sample_ids[0]
+                )
+                raise BrokenInputFileError() from e
 
             return video_sample_ids[0], frame_sample_ids
         finally:

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/__init__.py
@@ -4,6 +4,7 @@ from lightly_studio.resolvers.video_resolver.count_video_frame_annotations_by_co
     count_video_frame_annotations_by_video_collection,
 )
 from lightly_studio.resolvers.video_resolver.create_many import create_many
+from lightly_studio.resolvers.video_resolver.delete_with_frames import delete_with_frames
 from lightly_studio.resolvers.video_resolver.get_adjacent_videos import get_adjacent_videos
 from lightly_studio.resolvers.video_resolver.get_all_by_collection_id import (
     get_all_by_collection_id,
@@ -24,6 +25,7 @@ __all__ = [
     "build_sample_ids_query",
     "count_video_frame_annotations_by_video_collection",
     "create_many",
+    "delete_with_frames",
     "get_adjacent_videos",
     "get_all_by_collection_id",
     "get_all_by_collection_id_with_frames",

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/delete_with_frames.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/delete_with_frames.py
@@ -1,0 +1,57 @@
+"""Implementation of a scoped delete for a single video and its frames."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session, col, delete, select
+
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.models.video import VideoFrameTable, VideoTable
+from lightly_studio.utils import batching
+
+
+def delete_with_frames(session: Session, video_sample_id: UUID) -> None:
+    """Delete a video and everything indexing created for it.
+
+    Removes the video's frame embeddings, its ``video_frame`` rows, the ``video`` row, and all the
+    ``sample`` rows for the video and its frames, in foreign-key-safe order (child -> parent; there
+    are no ``ON DELETE CASCADE`` foreign keys). Used to roll back a video that failed to decode
+    mid-stream, so a broken video leaves no rows behind. Only rows for the given video are touched.
+
+    Args:
+        session: The database session.
+        video_sample_id: The sample ID of the video to delete.
+    """
+    # Capture the frame sample IDs up front: the video_frame rows are deleted below, so their
+    # sample rows can no longer be selected via a subquery on VideoFrameTable afterwards.
+    frame_sample_ids = list(
+        session.exec(
+            select(VideoFrameTable.sample_id).where(
+                col(VideoFrameTable.parent_sample_id) == video_sample_id
+            )
+        ).all()
+    )
+    sample_ids = [*frame_sample_ids, video_sample_id]
+
+    # 1. Frame (and video) embeddings reference sample.sample_id.
+    for batch in batching.batched(items=sample_ids):
+        session.exec(
+            delete(SampleEmbeddingTable).where(col(SampleEmbeddingTable.sample_id).in_(batch))
+        )
+    # 2. video_frame rows reference both sample.sample_id and video.sample_id.
+    session.exec(
+        delete(VideoFrameTable).where(col(VideoFrameTable.parent_sample_id) == video_sample_id)
+    )
+    # DuckDB validates foreign keys against committed state, so child deletes must be committed
+    # before deleting their parent rows. PostgreSQL also supports these intermediate commits.
+    session.commit()
+    # 3. The video row references sample.sample_id.
+    session.exec(delete(VideoTable).where(col(VideoTable.sample_id) == video_sample_id))
+    session.commit()
+    # 4. The sample rows for the frames and the video itself.
+    for batch in batching.batched(items=sample_ids):
+        session.exec(delete(SampleTable).where(col(SampleTable.sample_id).in_(batch)))
+
+    session.commit()

--- a/lightly_studio/tests/core/video/test_add_videos.py
+++ b/lightly_studio/tests/core/video/test_add_videos.py
@@ -4,12 +4,14 @@ import os
 from argparse import ArgumentParser
 from pathlib import Path
 from unittest.mock import MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import fsspec
 import pytest
 from av import container
 from av.codec.context import ThreadType
+from av.container import InputContainer
+from av.error import InvalidDataError
 from labelformat.model.binary_mask_segmentation import BinaryMaskSegmentation
 from labelformat.model.bounding_box import BoundingBox, BoundingBoxFormat
 from labelformat.model.category import Category
@@ -32,7 +34,7 @@ from lightly_studio.core.video.add_videos import FrameExtractionContext
 from lightly_studio.dataset.embedding_generator import RandomEmbeddingGenerator
 from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
 from lightly_studio.models.collection import SampleType
-from lightly_studio.models.video import VideoCreate
+from lightly_studio.models.video import VideoCreate, VideoFrameCreate
 from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
@@ -159,6 +161,79 @@ def test_load_into_collection_from_paths__records_missing_broken_already_present
     assert "already_present=2" in caplog.text
     assert "missing=3" in caplog.text
     assert "broken=4" in caplog.text
+
+
+def test_load_into_collection_from_paths__mid_decode_failure_is_cleaned_up(
+    db_session: Session,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    good_path = create_video_file(output_path=tmp_path / "good.mp4", num_frames=2, fps=1)
+    broken_path = create_video_file(output_path=tmp_path / "broken.mp4", num_frames=2, fps=1)
+    _fail_after_frame_creation(mocker=mocker, failing_file_name=broken_path.name)
+
+    with caplog.at_level("INFO"):
+        video_sample_ids, _ = add_videos.load_into_collection_from_paths(
+            session=db_session,
+            collection_id=collection.collection_id,
+            video_paths=[str(broken_path), str(good_path)],
+        )
+
+    videos = video_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    ).samples
+    assert [video.file_name for video in videos] == [good_path.name]
+    assert video_sample_ids == [videos[0].sample_id]
+    assert "added=1" in caplog.text
+    assert "broken=1" in caplog.text
+
+
+def _fail_after_frame_creation(
+    mocker: MockerFixture,
+    failing_file_name: str,
+) -> None:
+    """Make one video fail after its frame rows have been committed."""
+    original_create = add_videos._create_video_frame_samples
+
+    def create_frames_then_maybe_fail(
+        context: FrameExtractionContext,
+        video_container: InputContainer,
+        video_channel: int,
+        num_decode_threads: int | None = None,
+        target_fps: float | None = None,
+    ) -> list[UUID]:
+        video = video_resolver.get_by_id(session=context.session, sample_id=context.video_sample_id)
+        assert video is not None
+        if video.file_name == failing_file_name:
+            video_frame_resolver.create_many(
+                session=context.session,
+                collection_id=context.collection_id,
+                samples=[
+                    VideoFrameCreate(
+                        frame_number=0,
+                        frame_timestamp_s=0.0,
+                        frame_timestamp_pts=0,
+                        parent_sample_id=context.video_sample_id,
+                    )
+                ],
+            )
+            raise InvalidDataError(1094995529, "Invalid data found while decoding a frame")
+
+        return original_create(
+            context=context,
+            video_container=video_container,
+            video_channel=video_channel,
+            num_decode_threads=num_decode_threads,
+            target_fps=target_fps,
+        )
+
+    mocker.patch.object(
+        add_videos,
+        "_create_video_frame_samples",
+        side_effect=create_frames_then_maybe_fail,
+    )
 
 
 def test__create_video_frame_samples(db_session: Session, tmp_path: Path) -> None:

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_delete_with_frames.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_delete_with_frames.py
@@ -1,0 +1,73 @@
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.models.video import VideoFrameTable, VideoTable
+from lightly_studio.resolvers import video_resolver
+from tests.helpers_resolvers import (
+    create_collection,
+    create_embedding_model,
+    create_sample_embedding,
+)
+from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
+
+
+def test_delete_with_frames(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    deleted_video = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="deleted.mp4", duration_s=2, fps=1),
+    )
+    retained_video = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="retained.mp4", duration_s=2, fps=1),
+    )
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=deleted_video.video_frames_collection_id,
+        embedding_dimension=2,
+    )
+    deleted_sample_ids = [deleted_video.video_sample_id, *deleted_video.frame_sample_ids]
+    retained_sample_ids = [retained_video.video_sample_id, *retained_video.frame_sample_ids]
+    for sample_id in [*deleted_video.frame_sample_ids, *retained_video.frame_sample_ids]:
+        create_sample_embedding(
+            session=db_session,
+            sample_id=sample_id,
+            embedding_model_id=embedding_model.embedding_model_id,
+            embedding=[1.0, 2.0],
+        )
+
+    video_resolver.delete_with_frames(
+        session=db_session, video_sample_id=deleted_video.video_sample_id
+    )
+
+    assert db_session.get(VideoTable, deleted_video.video_sample_id) is None
+    for frame_sample_id in deleted_video.frame_sample_ids:
+        assert db_session.get(VideoFrameTable, frame_sample_id) is None
+    for sample_id in deleted_sample_ids:
+        assert db_session.get(SampleTable, sample_id) is None
+    for frame_sample_id in deleted_video.frame_sample_ids:
+        assert (
+            db_session.get(
+                SampleEmbeddingTable,
+                (frame_sample_id, embedding_model.embedding_model_id),
+            )
+            is None
+        )
+
+    assert db_session.get(VideoTable, retained_video.video_sample_id) is not None
+    for frame_sample_id in retained_video.frame_sample_ids:
+        assert db_session.get(VideoFrameTable, frame_sample_id) is not None
+    for sample_id in retained_sample_ids:
+        assert db_session.get(SampleTable, sample_id) is not None
+    for frame_sample_id in retained_video.frame_sample_ids:
+        assert (
+            db_session.get(
+                SampleEmbeddingTable,
+                (frame_sample_id, embedding_model.embedding_model_id),
+            )
+            is not None
+        )


### PR DESCRIPTION
## What has changed and why?

Video indexing now treats mid-stream PyAV decode failures as broken input files instead of aborting the complete ingest run.
## How has it been tested?

unittests

Tested manually with `ls.VideoDataset.load_or_create("s3://igor-test-bucket-us/large-videos_input/")`, which used to fail.

With this PR:

```bash
(lightly-studio) malteebnerlightly@MacBook-Pro-3 lightly_studio % python /Users/malteebnerlightly/Documents/GitHub/lightly-studio/dataset_examples_studio/normal/example_large_video_dataset.py
2026-07-16 11:41:56,327 INFO: Deleted existing database file: large_video_dataset__s3.db
Discovering files: 15 files [00:03,  4.51 files/s]
2026-07-16 11:42:00,146 INFO: Found 15 videos in s3://igor-test-bucket-us/large-videos_input/.
2026-07-16 11:42:02,052 INFO: Using MobileCLIP embedding generator for images.
2026-07-16 11:42:02,860 INFO: Parsing tokenizer identifier. Schema: None, Identifier: ViT-B-16
2026-07-16 11:42:02,860 INFO: Attempting to load config from built-in: ViT-B-16
2026-07-16 11:42:02,860 INFO: Using default SimpleTokenizer.
Loading frames from videos:  20%|███▏ | 3/15 [00:39<02:39, 13.31s/ video]2026-07-16 11:42:58,534 ERROR: Invalid NAL unit size (52137 > 14190).
2026-07-16 11:42:58,534 ERROR: missing picture in access unit with size 14194
2026-07-16 11:42:58,534 ERROR: Invalid NAL unit size (52137 > 14190).
2026-07-16 11:42:58,534 ERROR: Error splitting the input into NAL units.
Loading frames from videos:  27%|██▎         | 4/15 [00:55<02:40, 14.62s/ video]2026-07-16 11:43:12,471 ERROR: Invalid NAL unit size (52137 > 14190).
2026-07-16 11:43:12,471 ERROR: missing picture in access unit with size 14194
2026-07-16 11:43:12,471 ERROR: Invalid NAL unit size (52137 > 14190).
2026-07-16 11:43:12,471 ERROR: Error splitting the input into NAL units.
Loading frames from videos:  33%|██▎               | 5/15 [01:09<02:23, 14.38s/ video]2026-07-16 11:43:32,962 ERROR: Invalid NAL unit size (52137 > 14190).
2026-07-16 11:43:32,962 ERROR: missing picture in access unit with size 14194
2026-07-16 11:43:32,962 ERROR: Invalid NAL unit size (52137 > 14190).
2026-07-16 11:43:32,962 ERROR: Error splitting the input into NAL units.
Loading frames from videos: 100%███████| 15/15 [02:26<00:00,  9.78s/ video]
2026-07-16 11:44:29,706 INFO: File outcomes: added=12, already_present=0, missing=0, broken=3.
2026-07-16 11:44:29,706 INFO: Example added paths: s3://igor-test-bucket-us/large-videos_input/Pexels Videos 2558580.mp4, s3://igor-test-bucket-us/large-videos_input/Pexels Videos 2558580_2.mp4, s3://igor-test-bucket-us/large-videos_input/Pexels Videos 2558580_w.mp4, s3://igor-test-bucket-us/large-videos_input/pexels-ben-collins-7342528.mp4, s3://igor-test-bucket-us/large-videos_input/pexels-ben-collins-7342528_2.mp4.
2026-07-16 11:44:29,706 INFO: Example broken paths: s3://igor-test-bucket-us/large-videos_input/hawaii_blue_water_4K.mp4, s3://igor-test-bucket-us/large-videos_input/hawaii_blue_water_4K_2.mp4, s3://igor-test-bucket-us/large-videos_input/hawaii_blue_water_4K_w.mp4.
2026-07-16 11:44:29,713 INFO: Using PerceptionEncoder embedding generator for videos.
Generating embeddings: 100%█████| 12/12 [00:00<00:00, 3737.13 embeddings/s]
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed or corrupted video imports are now rolled back cleanly, removing any partially created video and frame data.
  * Other videos and their associated data remain unaffected when one video fails during processing.

* **Tests**
  * Added coverage for mid-import video failures and verification that related records and embeddings are removed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->