### PR TITLE
introduce function to initialise histogram chart

### DIFF
--- a/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.test.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.test.ts
@@ -1,19 +1,34 @@
 import { describe, expect, it } from 'vitest';
+import * as echarts from 'echarts/core';
+import { CustomChart } from 'echarts/charts';
+import { GridComponent, TooltipComponent } from 'echarts/components';
+import { SVGRenderer } from 'echarts/renderers';
 import { buildHistogramOption, isBinInRange, renderHistogramBin } from './buildHistogramOption';
 import { normal, singleBin } from './fixtures';
 
+echarts.use([CustomChart, GridComponent, TooltipComponent, SVGRenderer]);
+
+// echarts measures label text through a canvas 2d context that jsdom doesn't
+// implement; stub the one method it needs so `setOption` stays quiet. Text
+// layout has no bearing on the data-space snapping assertion below.
+HTMLCanvasElement.prototype.getContext = (() => ({
+    measureText: (text: string) => ({ width: text.length * 6 })
+})) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
 const ACCENT = '#3bd99f';
 const DIMMED = '#4b5563';
+
+type Option = ReturnType<typeof buildHistogramOption>;
 
 interface BarDatum {
     value: [number, number];
     itemStyle: { color: string };
 }
 
-const getSeriesData = (option: ReturnType<typeof buildHistogramOption>): BarDatum[] => {
-    const series = option.series as { data: BarDatum[] }[];
-    return series[0].data;
-};
+const getBars = (option: Option): BarDatum[] => (option.series as { data: BarDatum[] }[])[0].data;
+const getColors = (option: Option): string[] => getBars(option).map((bar) => bar.itemStyle.color);
+const getTooltipFormatter = (option: Option): ((params: { dataIndex: number }[]) => string) =>
+    (option.tooltip as { formatter: (params: { dataIndex: number }[]) => string }).formatter;
 
 describe('isBinInRange', () => {
     it('includes bins fully inside the range', () => {
@@ -44,20 +59,22 @@ describe('isBinInRange', () => {
 });
 
 describe('buildHistogramOption', () => {
-    it('maps every bin count to a bar', () => {
-        const data = getSeriesData(buildHistogramOption(normal));
-        expect(data.map((bar) => bar.value)).toEqual(normal.counts.map((count, i) => [i, count]));
+    it('maps every bin count to a bar centered on its bin', () => {
+        // x is the bin center (index + 0.5) so the axis tooltip snaps to the bar
+        // under the cursor rather than to the next bin past a bar's midpoint.
+        const bars = getBars(buildHistogramOption(normal));
+        expect(bars.map((bar) => bar.value)).toEqual(
+            normal.counts.map((count, i) => [i + 0.5, count])
+        );
     });
 
     it('renders all bins in the accent color when no range is given', () => {
-        const data = getSeriesData(buildHistogramOption(normal));
-        expect(data.every((bar) => bar.itemStyle.color === ACCENT)).toBe(true);
+        expect(getColors(buildHistogramOption(normal)).every((c) => c === ACCENT)).toBe(true);
     });
 
     it('dims bins outside the selected range', () => {
         // Bins cover [0,5), [5,10) … [95,100]; range [20, 40] spans bins 4..7.
-        const data = getSeriesData(buildHistogramOption(normal, { min: 20, max: 40 }));
-        const colors = data.map((bar) => bar.itemStyle.color);
+        const colors = getColors(buildHistogramOption(normal, { min: 20, max: 40 }));
         expect(colors[3]).toBe(DIMMED); // [15,20) only touches min
         expect(colors[4]).toBe(ACCENT);
         expect(colors[5]).toBe(ACCENT);
@@ -67,40 +84,30 @@ describe('buildHistogramOption', () => {
 
     it('highlights exactly one bar when the range is a single bin', () => {
         // Range [10, 15] = bin 2 exactly.
-        const data = getSeriesData(buildHistogramOption(normal, { min: 10, max: 15 }));
-        const accented = data.filter((bar) => bar.itemStyle.color === ACCENT);
-        expect(accented).toHaveLength(1);
-        expect(data[2].itemStyle.color).toBe(ACCENT);
+        const colors = getColors(buildHistogramOption(normal, { min: 10, max: 15 }));
+        expect(colors.filter((c) => c === ACCENT)).toEqual([ACCENT]);
+        expect(colors[2]).toBe(ACCENT);
     });
 
     it('highlights everything when the range spans the full domain', () => {
-        const data = getSeriesData(buildHistogramOption(normal, { min: 0, max: 100 }));
-        expect(data.every((bar) => bar.itemStyle.color === ACCENT)).toBe(true);
+        expect(
+            getColors(buildHistogramOption(normal, { min: 0, max: 100 })).every((c) => c === ACCENT)
+        ).toBe(true);
     });
 
     it('handles the single-bin constant-value case', () => {
-        const data = getSeriesData(buildHistogramOption(singleBin, { min: 42, max: 42 }));
-        expect(data).toHaveLength(1);
-        expect(data[0].itemStyle.color).toBe(ACCENT);
+        expect(getColors(buildHistogramOption(singleBin, { min: 42, max: 42 }))).toEqual([ACCENT]);
     });
 
     it('formats the tooltip with bin interval, count and percentage', () => {
-        const option = buildHistogramOption(normal);
-        const tooltip = option.tooltip as {
-            formatter: (params: { dataIndex: number }[]) => string;
-        };
-        const html = tooltip.formatter([{ dataIndex: 9 }]);
+        const html = getTooltipFormatter(buildHistogramOption(normal))([{ dataIndex: 9 }]);
         expect(html).toContain('45');
         expect(html).toContain('50');
         expect(html).toContain('%');
     });
 
     it('returns an empty tooltip for an out-of-range data index', () => {
-        const option = buildHistogramOption(normal);
-        const tooltip = option.tooltip as {
-            formatter: (params: { dataIndex: number }[]) => string;
-        };
-        expect(tooltip.formatter([{ dataIndex: 999 }])).toBe('');
+        expect(getTooltipFormatter(buildHistogramOption(normal))([{ dataIndex: 999 }])).toBe('');
     });
 
     it('hides both axes by default (inline variant)', () => {
@@ -124,61 +131,72 @@ describe('buildHistogramOption', () => {
     });
 });
 
-describe('renderHistogramBin', () => {
-    // Fake render API: 3 bins over a 100px-wide grid (fractional 33.33px band).
-    // The x-axis is a value axis over bin indices, so `coord` maps index i to
-    // the bin's left edge; count 0 sits at y=50 and counts map to y = 50 - count.
-    const makeApi = (dataIndex: number, count: number) => ({
-        value: (dimension: number) => (dimension === 1 ? count : dataIndex),
-        coord: ([index, value]: [number, number]): [number, number] => [
-            index * (100 / 3),
-            50 - value
-        ],
-        size: (): [number, number] => [100 / 3, 0],
-        style: () => ({ fill: ACCENT })
-    });
+describe('axis tooltip snapping', () => {
+    // Exercises the real ECharts pointer resolution rather than just the
+    // encoding: for a value axis, axisTrigger.js resolves a hover with
+    // `series.indicesOfNearest(axisDim, dim, value, null)`, so we call the same
+    // API. The nearest data point to any x inside bin k must be bin k — which
+    // holds only because the data is centered (index + 0.5); a left-edge
+    // encoding would snap right-half hovers to the next bin.
+    it('resolves a hover anywhere in a bar to that bar, not its neighbor', () => {
+        const dom = document.createElement('div');
+        const chart = echarts.init(dom, null, { renderer: 'svg', width: 800, height: 300 });
+        chart.setOption(buildHistogramOption(normal));
 
-    it('snaps both bin edges to integer pixels', () => {
-        const rect = renderHistogramBin({ dataIndex: 1 }, makeApi(1, 10)) as {
-            shape: { x: number; width: number; y: number; height: number };
-        };
-        expect(Number.isInteger(rect.shape.x)).toBe(true);
-        expect(Number.isInteger(rect.shape.width)).toBe(true);
-        expect(Number.isInteger(rect.shape.y)).toBe(true);
-        expect(Number.isInteger(rect.shape.height)).toBe(true);
+        // getModel/getSeriesByIndex are internal, untyped echarts APIs.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const series = (chart as any).getModel().getSeriesByIndex(0);
+        // Sample near both edges of the first, a middle, and the last bin; the
+        // right-half values (x.7) are the ones a left-edge encoding misresolved.
+        for (const axisValue of [0.2, 0.7, 3.2, 3.7, 19.2, 19.7]) {
+            const [nearest] = series.indicesOfNearest('x', 'x', axisValue, null);
+            expect(nearest).toBe(Math.floor(axisValue));
+        }
+
+        chart.dispose();
+    });
+});
+
+describe('renderHistogramBin', () => {
+    interface Rect {
+        shape: { x: number; y: number; width: number; height: number };
+        style: { fill: string };
+    }
+
+    // Fake render API: `binCount` bins over a 100px-wide grid. The x-axis is a
+    // value axis over bin indices, so `coord` maps index i to the bin's left
+    // edge; count 0 sits at y=50 and counts map to y = 50 - count. value(0) is
+    // the bin center (index + 0.5), matching how `buildSeries` encodes the data.
+    const renderBin = (binIndex: number, count: number, binCount = 3): Rect => {
+        const band = 100 / binCount;
+        return renderHistogramBin(null, {
+            value: (dimension: number) => (dimension === 1 ? count : binIndex + 0.5),
+            coord: ([index, value]: [number, number]): [number, number] => [
+                index * band,
+                50 - value
+            ],
+            size: (): [number, number] => [band, 0],
+            visual: () => ACCENT
+        }) as unknown as Rect;
+    };
+
+    it('snaps every rect edge to an integer pixel', () => {
+        const { shape } = renderBin(1, 10);
+        expect(Object.values(shape).every(Number.isInteger)).toBe(true);
     });
 
     it('leaves a uniform 1px gap between adjacent bins', () => {
-        const first = renderHistogramBin({ dataIndex: 0 }, makeApi(0, 5)) as {
-            shape: { x: number; width: number };
-        };
-        const second = renderHistogramBin({ dataIndex: 1 }, makeApi(1, 8)) as {
-            shape: { x: number; width: number };
-        };
+        const first = renderBin(0, 5);
+        const second = renderBin(1, 8);
         expect(second.shape.x - (first.shape.x + first.shape.width)).toBe(1);
     });
 
     it('never collapses a bin below 1px width', () => {
         // 200 bins over 100px: the band is narrower than the 1px gap.
-        const narrowApi = (dataIndex: number, count: number) => ({
-            value: (dimension: number) => (dimension === 1 ? count : dataIndex),
-            coord: ([index, value]: [number, number]): [number, number] => [
-                index * (100 / 200),
-                50 - value
-            ],
-            size: (): [number, number] => [100 / 200, 0],
-            style: () => ({ fill: ACCENT })
-        });
-        const rect = renderHistogramBin({ dataIndex: 3 }, narrowApi(3, 5)) as {
-            shape: { width: number };
-        };
-        expect(rect.shape.width).toBeGreaterThanOrEqual(1);
+        expect(renderBin(3, 5, 200).shape.width).toBeGreaterThanOrEqual(1);
     });
 
     it('applies the item style from the data', () => {
-        const rect = renderHistogramBin({ dataIndex: 0 }, makeApi(0, 5)) as {
-            style: { fill: string };
-        };
-        expect(rect.style.fill).toBe(ACCENT);
+        expect(renderBin(0, 5).style.fill).toBe(ACCENT);
     });
 });

--- a/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.test.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import { buildHistogramOption, isBinInRange, renderHistogramBin } from './buildHistogramOption';
+import { normal, singleBin } from './fixtures';
+
+const ACCENT = '#3bd99f';
+const DIMMED = '#4b5563';
+
+interface BarDatum {
+    value: [number, number];
+    itemStyle: { color: string };
+}
+
+const getSeriesData = (option: ReturnType<typeof buildHistogramOption>): BarDatum[] => {
+    const series = option.series as { data: BarDatum[] }[];
+    return series[0].data;
+};
+
+describe('isBinInRange', () => {
+    it('includes bins fully inside the range', () => {
+        expect(isBinInRange(10, 15, { min: 0, max: 100 })).toBe(true);
+    });
+
+    it('includes bins partially overlapping the range on either side', () => {
+        expect(isBinInRange(0, 10, { min: 5, max: 100 })).toBe(true);
+        expect(isBinInRange(90, 100, { min: 0, max: 95 })).toBe(true);
+    });
+
+    it('excludes bins that merely touch the range boundary', () => {
+        // Bins are half-open [start, end): a shared edge is not an overlap, so
+        // selecting exactly one bin does not highlight its neighbors.
+        expect(isBinInRange(0, 5, { min: 5, max: 100 })).toBe(false);
+        expect(isBinInRange(95, 100, { min: 0, max: 95 })).toBe(false);
+    });
+
+    it('excludes bins entirely outside the range', () => {
+        expect(isBinInRange(0, 4, { min: 5, max: 100 })).toBe(false);
+        expect(isBinInRange(96, 100, { min: 0, max: 95 })).toBe(false);
+    });
+
+    it('compares zero-width bins inclusively', () => {
+        expect(isBinInRange(42, 42, { min: 42, max: 42 })).toBe(true);
+        expect(isBinInRange(42, 42, { min: 0, max: 10 })).toBe(false);
+    });
+});
+
+describe('buildHistogramOption', () => {
+    it('maps every bin count to a bar', () => {
+        const data = getSeriesData(buildHistogramOption(normal));
+        expect(data.map((bar) => bar.value)).toEqual(normal.counts.map((count, i) => [i, count]));
+    });
+
+    it('renders all bins in the accent color when no range is given', () => {
+        const data = getSeriesData(buildHistogramOption(normal));
+        expect(data.every((bar) => bar.itemStyle.color === ACCENT)).toBe(true);
+    });
+
+    it('dims bins outside the selected range', () => {
+        // Bins cover [0,5), [5,10) … [95,100]; range [20, 40] spans bins 4..7.
+        const data = getSeriesData(buildHistogramOption(normal, { min: 20, max: 40 }));
+        const colors = data.map((bar) => bar.itemStyle.color);
+        expect(colors[3]).toBe(DIMMED); // [15,20) only touches min
+        expect(colors[4]).toBe(ACCENT);
+        expect(colors[5]).toBe(ACCENT);
+        expect(colors[7]).toBe(ACCENT);
+        expect(colors[8]).toBe(DIMMED); // [40,45) only touches max
+    });
+
+    it('highlights exactly one bar when the range is a single bin', () => {
+        // Range [10, 15] = bin 2 exactly.
+        const data = getSeriesData(buildHistogramOption(normal, { min: 10, max: 15 }));
+        const accented = data.filter((bar) => bar.itemStyle.color === ACCENT);
+        expect(accented).toHaveLength(1);
+        expect(data[2].itemStyle.color).toBe(ACCENT);
+    });
+
+    it('highlights everything when the range spans the full domain', () => {
+        const data = getSeriesData(buildHistogramOption(normal, { min: 0, max: 100 }));
+        expect(data.every((bar) => bar.itemStyle.color === ACCENT)).toBe(true);
+    });
+
+    it('handles the single-bin constant-value case', () => {
+        const data = getSeriesData(buildHistogramOption(singleBin, { min: 42, max: 42 }));
+        expect(data).toHaveLength(1);
+        expect(data[0].itemStyle.color).toBe(ACCENT);
+    });
+
+    it('formats the tooltip with bin interval, count and percentage', () => {
+        const option = buildHistogramOption(normal);
+        const tooltip = option.tooltip as {
+            formatter: (params: { dataIndex: number }[]) => string;
+        };
+        const html = tooltip.formatter([{ dataIndex: 9 }]);
+        expect(html).toContain('45');
+        expect(html).toContain('50');
+        expect(html).toContain('%');
+    });
+
+    it('returns an empty tooltip for an out-of-range data index', () => {
+        const option = buildHistogramOption(normal);
+        const tooltip = option.tooltip as {
+            formatter: (params: { dataIndex: number }[]) => string;
+        };
+        expect(tooltip.formatter([{ dataIndex: 999 }])).toBe('');
+    });
+
+    it('hides both axes by default (inline variant)', () => {
+        const option = buildHistogramOption(normal);
+        expect((option.xAxis as { show: boolean }).show).toBe(false);
+        expect((option.yAxis as { show: boolean }).show).toBe(false);
+    });
+
+    it('shows axes with bin-edge values when showAxes is set', () => {
+        const option = buildHistogramOption(normal, undefined, { showAxes: true });
+        const xAxis = option.xAxis as {
+            show: boolean;
+            axisLabel: { formatter: (index: number) => string };
+        };
+        expect(xAxis.show).toBe(true);
+        expect((option.yAxis as { show: boolean }).show).toBe(true);
+        // Integer ticks land exactly on bin edges: 0 → domain min, N → max.
+        expect(xAxis.axisLabel.formatter(0)).toBe('0');
+        expect(xAxis.axisLabel.formatter(10)).toBe('50');
+        expect(xAxis.axisLabel.formatter(20)).toBe('100');
+    });
+});
+
+describe('renderHistogramBin', () => {
+    // Fake render API: 3 bins over a 100px-wide grid (fractional 33.33px band).
+    // The x-axis is a value axis over bin indices, so `coord` maps index i to
+    // the bin's left edge; count 0 sits at y=50 and counts map to y = 50 - count.
+    const makeApi = (dataIndex: number, count: number) => ({
+        value: (dimension: number) => (dimension === 1 ? count : dataIndex),
+        coord: ([index, value]: [number, number]): [number, number] => [
+            index * (100 / 3),
+            50 - value
+        ],
+        size: (): [number, number] => [100 / 3, 0],
+        style: () => ({ fill: ACCENT })
+    });
+
+    it('snaps both bin edges to integer pixels', () => {
+        const rect = renderHistogramBin({ dataIndex: 1 }, makeApi(1, 10)) as {
+            shape: { x: number; width: number; y: number; height: number };
+        };
+        expect(Number.isInteger(rect.shape.x)).toBe(true);
+        expect(Number.isInteger(rect.shape.width)).toBe(true);
+        expect(Number.isInteger(rect.shape.y)).toBe(true);
+        expect(Number.isInteger(rect.shape.height)).toBe(true);
+    });
+
+    it('leaves a uniform 1px gap between adjacent bins', () => {
+        const first = renderHistogramBin({ dataIndex: 0 }, makeApi(0, 5)) as {
+            shape: { x: number; width: number };
+        };
+        const second = renderHistogramBin({ dataIndex: 1 }, makeApi(1, 8)) as {
+            shape: { x: number; width: number };
+        };
+        expect(second.shape.x - (first.shape.x + first.shape.width)).toBe(1);
+    });
+
+    it('never collapses a bin below 1px width', () => {
+        // 200 bins over 100px: the band is narrower than the 1px gap.
+        const narrowApi = (dataIndex: number, count: number) => ({
+            value: (dimension: number) => (dimension === 1 ? count : dataIndex),
+            coord: ([index, value]: [number, number]): [number, number] => [
+                index * (100 / 200),
+                50 - value
+            ],
+            size: (): [number, number] => [100 / 200, 0],
+            style: () => ({ fill: ACCENT })
+        });
+        const rect = renderHistogramBin({ dataIndex: 3 }, narrowApi(3, 5)) as {
+            shape: { width: number };
+        };
+        expect(rect.shape.width).toBeGreaterThanOrEqual(1);
+    });
+
+    it('applies the item style from the data', () => {
+        const rect = renderHistogramBin({ dataIndex: 0 }, makeApi(0, 5)) as {
+            style: { fill: string };
+        };
+        expect(rect.style.fill).toBe(ACCENT);
+    });
+});

--- a/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.ts
@@ -27,21 +27,29 @@ export interface HistogramOptionOptions {
     showAxes?: boolean;
 }
 
+/** A single bar: the half-open value interval `[start, end)` and its count. */
 interface HistogramBin {
     start: number;
     end: number;
     count: number;
 }
 
+/** Inputs the x-axis needs to map integer bin indices back to domain values. */
 interface HistogramAxisOptions {
+    /** Number of bins; also the x-axis max (indices run `0..binCount`). */
     binCount: number;
+    /** Left edge of the first bin (domain minimum). */
     domainMin: number;
+    /** Right edge of the last bin (domain maximum). */
     domainMax: number;
+    /** Whether axis chrome is rendered (see `HistogramOptionOptions.showAxes`). */
     showAxes: boolean;
 }
 
+/** Inputs the bar series needs: the bins and the optional highlight range. */
 interface HistogramSeriesOptions {
     bins: HistogramBin[];
+    /** Selected value range; bins outside it render dimmed. Omit to highlight all. */
     range?: HistogramRange;
 }
 
@@ -59,16 +67,19 @@ export function isBinInRange(binStart: number, binEnd: number, range: HistogramR
     return binEnd > range.min && binStart < range.max;
 }
 
-// Minimal typings for the ECharts custom-series render callback (the full
-// types live in echarts' internal type surface, not in echarts/core).
-interface RenderItemParams {
-    dataIndex: number;
-}
+// Minimal typings for the ECharts custom-series render callback (the full types
+// live in echarts' internal type surface, not in echarts/core). ECharts calls
+// `renderItem(params, api)`; we ignore `params` and read everything — including
+// the bin center, which we encode as dimension 0 — through `api`.
 interface RenderItemApi {
+    /** Reads encoded dimension `d` of the current item (0 = bin center, 1 = count). */
     value: (dimension: number) => number;
+    /** Maps a data-space point `[index, value]` to pixel coordinates `[x, y]`. */
     coord: (point: [number, number]) => [number, number];
+    /** Maps a data-space span `[dx, dy]` to its pixel size `[width, height]`. */
     size: (span: [number, number]) => [number, number];
-    style: () => Record<string, unknown>;
+    /** Resolved visual for the current item; `'color'` returns its itemStyle fill. */
+    visual: (visualType: string) => string;
 }
 
 /**
@@ -78,14 +89,12 @@ interface RenderItemApi {
  * seams. Rounding both edges of every bin to integers makes the bar widths and
  * the gaps between them consistent regardless of chart width.
  *
- * The x-axis is a value axis over bin indices, so bin `i` spans `[i, i + 1]`
- * and `api.coord` returns its left edge.
+ * The x-axis is a value axis over bin indices. `api.value(0)` is the bin
+ * *center* `i + 0.5` (see `buildSeries`), so we step back half a band to the
+ * left edge `i`; bin `i` spans `[i, i + 1]` and `api.coord` maps it to pixels.
  */
-export function renderHistogramBin(
-    params: RenderItemParams,
-    api: RenderItemApi
-): Record<string, unknown> {
-    const index = params.dataIndex;
+export function renderHistogramBin(_params: unknown, api: RenderItemApi): Record<string, unknown> {
+    const index = api.value(0) - 0.5;
     const count = api.value(1);
     const [leftX, topY] = api.coord([index, count]);
     const [, baseY] = api.coord([index, 0]);
@@ -104,7 +113,7 @@ export function renderHistogramBin(
             width: Math.max(1, right - left),
             height: Math.round(baseY) - top
         },
-        style: api.style()
+        style: { fill: api.visual('color') }
     };
 }
 
@@ -139,6 +148,7 @@ export function buildHistogramOption(
     };
 }
 
+/** Pairs each count with its bin's edges (`counts[i]` spans `binEdges[i..i+1]`). */
 function buildBins(data: HistogramData): HistogramBin[] {
     return data.counts.map((count, index) => ({
         start: data.binEdges[index],
@@ -147,6 +157,7 @@ function buildBins(data: HistogramData): HistogramBin[] {
     }));
 }
 
+/** Tooltip showing the hovered bin's interval, count, and share of the total. */
 function buildTooltip(bins: HistogramBin[]): Record<string, unknown> {
     const totalCount = bins.reduce((sum, bin) => sum + bin.count, 0);
     return {
@@ -166,6 +177,7 @@ function buildTooltip(bins: HistogramBin[]): Record<string, unknown> {
     };
 }
 
+/** Plot padding: gutters for labels when axes show, flush to the edges when not. */
 function buildGrid(showAxes: boolean): Record<string, unknown> {
     // containLabel reserves gutters for labels; right padding avoids clipping.
     return showAxes
@@ -173,6 +185,10 @@ function buildGrid(showAxes: boolean): Record<string, unknown> {
         : { left: 0, right: 0, top: 2, bottom: 0 };
 }
 
+/**
+ * Value x-axis spanning `0..binCount`. Tick labels convert the integer bin
+ * index back to a domain value, so edges read as real numbers, not indices.
+ */
 function buildXAxis(options: HistogramAxisOptions): Record<string, unknown> {
     const indexToValue = (index: number): number =>
         options.domainMin + (index / options.binCount) * (options.domainMax - options.domainMin);
@@ -191,6 +207,7 @@ function buildXAxis(options: HistogramAxisOptions): Record<string, unknown> {
     };
 }
 
+/** Value y-axis for counts, with whole-number ticks. */
 function buildYAxis(showAxes: boolean): Record<string, unknown> {
     return {
         type: 'value',
@@ -202,6 +219,10 @@ function buildYAxis(showAxes: boolean): Record<string, unknown> {
     };
 }
 
+/**
+ * The custom bar series: one pixel-snapped rect per bin (see
+ * `renderHistogramBin`), each colored by whether it falls in the range.
+ */
 function buildSeries(options: HistogramSeriesOptions): Record<string, unknown>[] {
     return [
         {
@@ -209,7 +230,12 @@ function buildSeries(options: HistogramSeriesOptions): Record<string, unknown>[]
             renderItem: renderHistogramBin,
             encode: { x: 0, y: 1 },
             data: options.bins.map((bin, index) => ({
-                value: [index, bin.count],
+                // x is the bin *center* (index + 0.5), not the left edge, so the
+                // axis-trigger tooltip snaps the pointer to the bar the cursor is
+                // actually over. A left-edge point would snap to the next bin once
+                // the cursor passed a bar's midpoint. `renderHistogramBin` steps
+                // back half a band to recover the left edge for drawing.
+                value: [index + 0.5, bin.count],
                 itemStyle: {
                     color:
                         !options.range || isBinInRange(bin.start, bin.end, options.range)

--- a/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.ts
@@ -1,0 +1,222 @@
+import type { EChartsCoreOption } from 'echarts/core';
+import {
+    CHART_AXIS_LABEL,
+    CHART_LINE_COLOR,
+    formatFloat,
+    formatInteger,
+    formatPercent
+} from '$lib/utils';
+import type { HistogramData, HistogramRange } from './types';
+
+// Same accent as BarChart (the Lightly primary green, --color-lightly-primary).
+const BAR_COLOR = '#3bd99f';
+// Bins outside the selected range: dimmed but still legible against the panel.
+const BAR_COLOR_DIMMED = '#4b5563';
+
+// Gap between adjacent bins, in px. Carved out of each bin's right edge, so it
+// is exactly this wide everywhere (the edges are snapped to integer pixels).
+const BIN_GAP_PX = 1;
+
+export interface HistogramOptionOptions {
+    /**
+     * Renders numeric axes: bin-edge values along the x-axis and counts along
+     * the y-axis. Off by default for the inline filter-panel variant, where
+     * the range slider underneath provides the x-scale and axis gutters would
+     * break the bar ↔ slider alignment.
+     */
+    showAxes?: boolean;
+}
+
+interface HistogramBin {
+    start: number;
+    end: number;
+    count: number;
+}
+
+interface HistogramAxisOptions {
+    binCount: number;
+    domainMin: number;
+    domainMax: number;
+    showAxes: boolean;
+}
+
+interface HistogramSeriesOptions {
+    bins: HistogramBin[];
+    range?: HistogramRange;
+}
+
+/**
+ * A bin is highlighted when its interior overlaps the selected range. Bin `i`
+ * covers the half-open interval `[edges[i], edges[i + 1])`, so a range that
+ * merely touches a bin's edge does not select it — selecting exactly one bin
+ * highlights exactly one bar, not its neighbors.
+ */
+export function isBinInRange(binStart: number, binEnd: number, range: HistogramRange): boolean {
+    // Zero-width bin (constant-valued field): compare inclusively.
+    if (binStart === binEnd) {
+        return binStart >= range.min && binStart <= range.max;
+    }
+    return binEnd > range.min && binStart < range.max;
+}
+
+// Minimal typings for the ECharts custom-series render callback (the full
+// types live in echarts' internal type surface, not in echarts/core).
+interface RenderItemParams {
+    dataIndex: number;
+}
+interface RenderItemApi {
+    value: (dimension: number) => number;
+    coord: (point: [number, number]) => [number, number];
+    size: (span: [number, number]) => [number, number];
+    style: () => Record<string, unknown>;
+}
+
+/**
+ * Draws one bin as a pixel-snapped rect with a uniform 1px gap to its right
+ * neighbor. The built-in bar series computes fractional per-bar widths, and
+ * canvas antialiasing turns those fractional boundaries into uneven hairline
+ * seams. Rounding both edges of every bin to integers makes the bar widths and
+ * the gaps between them consistent regardless of chart width.
+ *
+ * The x-axis is a value axis over bin indices, so bin `i` spans `[i, i + 1]`
+ * and `api.coord` returns its left edge.
+ */
+export function renderHistogramBin(
+    params: RenderItemParams,
+    api: RenderItemApi
+): Record<string, unknown> {
+    const index = params.dataIndex;
+    const count = api.value(1);
+    const [leftX, topY] = api.coord([index, count]);
+    const [, baseY] = api.coord([index, 0]);
+    const [bandWidth] = api.size([1, 0]);
+
+    const left = Math.round(leftX);
+    const right = Math.round(leftX + bandWidth) - BIN_GAP_PX;
+    const top = Math.round(topY);
+
+    return {
+        type: 'rect',
+        shape: {
+            x: left,
+            y: top,
+            // Never collapse below 1px, however narrow the bins get.
+            width: Math.max(1, right - left),
+            height: Math.round(baseY) - top
+        },
+        style: api.style()
+    };
+}
+
+/**
+ * Builds the ECharts option for a histogram (pass to `setOption`). By default
+ * there is no axes chrome — the inline variant sits directly above a range
+ * slider that provides the x-scale — and bars span the full width edge to
+ * edge. Pass `showAxes: true` (distribution panel) to render bin-edge values
+ * on the x-axis and counts on the y-axis.
+ */
+export function buildHistogramOption(
+    data: HistogramData,
+    range?: HistogramRange,
+    options: HistogramOptionOptions = {}
+): EChartsCoreOption {
+    const bins = buildBins(data);
+    const showAxes = options.showAxes ?? false;
+    const axisOptions = {
+        binCount: data.counts.length,
+        domainMin: data.binEdges[0],
+        domainMax: data.binEdges[data.binEdges.length - 1],
+        showAxes
+    };
+
+    return {
+        backgroundColor: 'transparent',
+        tooltip: buildTooltip(bins),
+        grid: buildGrid(showAxes),
+        xAxis: buildXAxis(axisOptions),
+        yAxis: buildYAxis(showAxes),
+        series: buildSeries({ bins, range })
+    };
+}
+
+function buildBins(data: HistogramData): HistogramBin[] {
+    return data.counts.map((count, index) => ({
+        start: data.binEdges[index],
+        end: data.binEdges[index + 1],
+        count
+    }));
+}
+
+function buildTooltip(bins: HistogramBin[]): Record<string, unknown> {
+    const totalCount = bins.reduce((sum, bin) => sum + bin.count, 0);
+    return {
+        trigger: 'axis',
+        axisPointer: { type: 'line' },
+        // Let the tooltip escape the short inline canvas instead of being clipped.
+        confine: false,
+        formatter: (params: { dataIndex: number }[]) => {
+            const bin = bins[params[0]?.dataIndex];
+            if (!bin) return '';
+            const percent = totalCount > 0 ? ` (${formatPercent(bin.count / totalCount)})` : '';
+            return (
+                `<b>${formatFloat(bin.start)} – ${formatFloat(bin.end)}</b><br/>` +
+                `Count: <b>${formatInteger(bin.count)}</b>${percent}`
+            );
+        }
+    };
+}
+
+function buildGrid(showAxes: boolean): Record<string, unknown> {
+    // containLabel reserves gutters for labels; right padding avoids clipping.
+    return showAxes
+        ? { left: 4, right: 16, top: 8, bottom: 4, containLabel: true }
+        : { left: 0, right: 0, top: 2, bottom: 0 };
+}
+
+function buildXAxis(options: HistogramAxisOptions): Record<string, unknown> {
+    const indexToValue = (index: number): number =>
+        options.domainMin + (index / options.binCount) * (options.domainMax - options.domainMin);
+    return {
+        type: 'value',
+        min: 0,
+        max: options.binCount,
+        show: options.showAxes,
+        axisLabel: {
+            ...CHART_AXIS_LABEL,
+            formatter: (index: number) => formatFloat(indexToValue(index))
+        },
+        axisLine: { lineStyle: { color: CHART_LINE_COLOR } },
+        axisTick: { lineStyle: { color: CHART_LINE_COLOR } },
+        splitLine: { show: false }
+    };
+}
+
+function buildYAxis(showAxes: boolean): Record<string, unknown> {
+    return {
+        type: 'value',
+        show: showAxes,
+        // Counts are whole numbers; avoid fractional tick labels.
+        minInterval: 1,
+        axisLabel: CHART_AXIS_LABEL,
+        splitLine: { lineStyle: { color: CHART_LINE_COLOR } }
+    };
+}
+
+function buildSeries(options: HistogramSeriesOptions): Record<string, unknown>[] {
+    return [
+        {
+            type: 'custom',
+            renderItem: renderHistogramBin,
+            encode: { x: 0, y: 1 },
+            data: options.bins.map((bin, index) => ({
+                value: [index, bin.count],
+                itemStyle: {
+                    color:
+                        !options.range || isBinInRange(bin.start, bin.end, options.range)
+                            ? BAR_COLOR
+                            : BAR_COLOR_DIMMED
+                }
+            }))
+        }
+    ];
+}

--- a/lightly_studio_view/src/lib/components/Histogram/createHistogramChart.test.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/createHistogramChart.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ECharts } from 'echarts/core';
+import { pixelToBinIndex } from './createHistogramChart';
+
+// createHistogramChart.ts registers echarts modules at import time; stub them so
+// the module loads without pulling in the real (heavy) echarts runtime.
+vi.mock('echarts/core', () => ({ use: vi.fn() }));
+vi.mock('echarts/charts', () => ({ CustomChart: {} }));
+vi.mock('echarts/components', () => ({ GridComponent: {}, TooltipComponent: {} }));
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+
+// The x-axis is a value axis over bin indices; 10px per bin index mirrors the
+// component test's canvas geometry (20 bins over a 200px canvas).
+const makeChart = (): ECharts =>
+    ({
+        convertFromPixel: (_finder: unknown, offsetX: number) => offsetX / 10
+    }) as unknown as ECharts;
+
+describe('pixelToBinIndex', () => {
+    it('floors a fractional bin index to the containing bin', () => {
+        // offsetX 25 → 2.5 → bin 2.
+        expect(pixelToBinIndex(makeChart(), 25, 20)).toBe(2);
+    });
+
+    it('clamps offsets before the left edge to the first bin', () => {
+        expect(pixelToBinIndex(makeChart(), -50, 20)).toBe(0);
+    });
+
+    it('clamps offsets past the right edge to the last bin', () => {
+        expect(pixelToBinIndex(makeChart(), 9999, 20)).toBe(19);
+    });
+});

--- a/lightly_studio_view/src/lib/components/Histogram/createHistogramChart.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/createHistogramChart.ts
@@ -52,22 +52,34 @@ function setupDragListeners(
 ): () => void {
     const zr = chart.getZr();
     const toBinIndex = (offsetX: number) => pixelToBinIndex(chart, offsetX, options.getBinCount());
-    const handleMouseDown = (event: MouseOffsetEvent) =>
+
+    let dragging = false;
+
+    const handleMouseDown = (event: MouseOffsetEvent) => {
+        dragging = true;
         options.onDragStart(toBinIndex(event.offsetX));
-    const handleMouseMove = (event: MouseOffsetEvent) =>
+    };
+    const handleMouseMove = (event: MouseOffsetEvent) => {
+        if (!dragging) return;
         options.onDragMove(toBinIndex(event.offsetX));
+    };
     const handleWindowMouseMove = (event: MouseEvent) => {
+        if (!dragging) return;
         const offsetX = event.clientX - options.container.getBoundingClientRect().left;
         options.onDragMove(toBinIndex(offsetX));
+    };
+    const handleMouseUp = () => {
+        dragging = false;
+        options.onDragEnd();
     };
     zr.on('mousedown', handleMouseDown);
     zr.on('mousemove', handleMouseMove);
     window.addEventListener('mousemove', handleWindowMouseMove);
-    window.addEventListener('mouseup', options.onDragEnd);
+    window.addEventListener('mouseup', handleMouseUp);
 
     return () => {
         window.removeEventListener('mousemove', handleWindowMouseMove);
-        window.removeEventListener('mouseup', options.onDragEnd);
+        window.removeEventListener('mouseup', handleMouseUp);
     };
 }
 

--- a/lightly_studio_view/src/lib/components/Histogram/createHistogramChart.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/createHistogramChart.ts
@@ -1,0 +1,79 @@
+import * as echarts from 'echarts/core';
+import { CustomChart } from 'echarts/charts';
+import { GridComponent, TooltipComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+
+echarts.use([CustomChart, GridComponent, TooltipComponent, CanvasRenderer]);
+
+interface CreateHistogramChartOptions {
+    /** Element the chart mounts into; also observed for resizes. */
+    container: HTMLDivElement;
+    /** Current number of bins, read lazily so it tracks data changes. */
+    getBinCount: () => number;
+    /** Pointer pressed on the chart, over the given bin index. */
+    onDragStart: (binIndex: number) => void;
+    /** Pointer moved to the given bin index while a drag is in progress. */
+    onDragMove: (binIndex: number) => void;
+    /** Pointer released, ending the drag. */
+    onDragEnd: () => void;
+}
+
+interface HistogramChartSetup {
+    /** The initialized ECharts instance, for pushing options via `setOption`. */
+    chart: echarts.ECharts;
+    /** Tears down listeners, the resize observer, and the chart instance. */
+    destroy: () => void;
+}
+
+/** The subset of a zrender pointer event we read: the x offset within the canvas. */
+interface MouseOffsetEvent {
+    offsetX: number;
+}
+
+export function createHistogramChart(options: CreateHistogramChartOptions): HistogramChartSetup {
+    const chart = echarts.init(options.container, null, { renderer: 'canvas' });
+    const removeDragListeners = setupDragListeners(chart, options);
+    const resizeObserver = new ResizeObserver(() => chart.resize());
+    resizeObserver.observe(options.container);
+
+    return {
+        chart,
+        destroy: () => {
+            removeDragListeners();
+            resizeObserver.disconnect();
+            chart.dispose();
+        }
+    };
+}
+
+function setupDragListeners(
+    chart: echarts.ECharts,
+    options: CreateHistogramChartOptions
+): () => void {
+    const zr = chart.getZr();
+    const toBinIndex = (offsetX: number) => pixelToBinIndex(chart, offsetX, options.getBinCount());
+    const handleMouseDown = (event: MouseOffsetEvent) =>
+        options.onDragStart(toBinIndex(event.offsetX));
+    const handleMouseMove = (event: MouseOffsetEvent) =>
+        options.onDragMove(toBinIndex(event.offsetX));
+    const handleWindowMouseMove = (event: MouseEvent) => {
+        const offsetX = event.clientX - options.container.getBoundingClientRect().left;
+        options.onDragMove(toBinIndex(offsetX));
+    };
+    zr.on('mousedown', handleMouseDown);
+    zr.on('mousemove', handleMouseMove);
+    window.addEventListener('mousemove', handleWindowMouseMove);
+    window.addEventListener('mouseup', options.onDragEnd);
+
+    return () => {
+        window.removeEventListener('mousemove', handleWindowMouseMove);
+        window.removeEventListener('mouseup', options.onDragEnd);
+    };
+}
+
+export function pixelToBinIndex(chart: echarts.ECharts, offsetX: number, binCount: number): number {
+    // The x-axis is a value axis over bin indices, so the converted coordinate
+    // is a fractional bin index.
+    const index = Math.floor(chart.convertFromPixel({ xAxisIndex: 0 }, offsetX));
+    return Math.min(Math.max(index, 0), binCount - 1);
+}

--- a/lightly_studio_view/src/lib/components/Histogram/fixtures.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/fixtures.ts
@@ -1,0 +1,13 @@
+import type { HistogramData } from './types';
+
+/** Roughly normal distribution over [0, 100], 20 bins. */
+export const normal: HistogramData = {
+    binEdges: Array.from({ length: 21 }, (_, i) => i * 5),
+    counts: [1, 2, 4, 7, 12, 19, 28, 38, 46, 50, 50, 46, 38, 28, 19, 12, 7, 4, 2, 1]
+};
+
+/** All values identical — the backend collapses this to a single bin. */
+export const singleBin: HistogramData = {
+    binEdges: [42, 42],
+    counts: [3]
+};

--- a/lightly_studio_view/src/lib/components/Histogram/index.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/index.ts
@@ -1,0 +1,2 @@
+export { default as Histogram } from './Histogram.svelte';
+export type { HistogramData, HistogramRange } from './types';

--- a/lightly_studio_view/src/lib/components/Histogram/index.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/index.ts
@@ -1,2 +1,1 @@
-export { default as Histogram } from './Histogram.svelte';
 export type { HistogramData, HistogramRange } from './types';

--- a/lightly_studio_view/src/lib/components/Histogram/types.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Bin-based distribution of a numeric field.
+ *
+ * `binEdges` has length `counts.length + 1`; bin `i` covers the half-open
+ * interval `[binEdges[i], binEdges[i + 1])` (the last bin includes its right
+ * edge). Mirrors the backend `HistogramView` model.
+ */
+export interface HistogramData {
+    binEdges: number[];
+    counts: number[];
+}
+
+/** Inclusive value range used to highlight the selected bins. */
+export interface HistogramRange {
+    min: number;
+    max: number;
+}


### PR DESCRIPTION
## What has changed and why?

This PR introduces function to create histogram plot instance to attach it later within the component as part of the story to introduce [numeric metadata values representation](https://linear.app/lightly/issue/LIG-9579/view-numeric-metadata-distribution-2ed). This function will be used to initialise coming with follow-up visual Histogram component based on created options.


## How has it been tested?

It is accompanied by unit test and passing CI checks should be enough to count it as correct.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
