### PR TITLE
Add classification annotation grid item component

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { type AnnotationWithPayloadView } from '$lib/api/lightly_studio_local';
-    import { get } from 'svelte/store';
     import { useSettings } from '$lib/hooks';
     import SampleClassificationPills from '$lib/components/SampleClassificationPills/SampleClassificationPills.svelte';
     import { getThumbnailUrl, getSampleDimensions } from './getThumbnailData';
@@ -35,9 +34,6 @@
 
     const { gridViewThumbnailQualityStore } = useSettings();
 
-    let quality = $state(get(gridViewThumbnailQualityStore));
-    $effect(() => gridViewThumbnailQualityStore.subscribe((v) => (quality = v)));
-
     // Stable id captured at init — same pattern as AnnotationItem (avoids re-reading
     // the annotation prop during effect cleanup after the grid array shrinks).
     const annotationId = annotation.annotation.sample_id;
@@ -45,7 +41,7 @@
     const thumbnailUrl = $derived(
         getThumbnailUrl({
             annotation,
-            quality,
+            quality: $gridViewThumbnailQualityStore,
             containerWidth,
             containerHeight,
             cachedCollectionVersion

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
@@ -1,14 +1,9 @@
 <script lang="ts">
-    import {
-        SampleType,
-        type AnnotationWithPayloadView,
-        type ImageAnnotationView,
-        type VideoFrameAnnotationView
-    } from '$lib/api/lightly_studio_local';
+    import { type AnnotationWithPayloadView } from '$lib/api/lightly_studio_local';
     import { get } from 'svelte/store';
-    import { useSettings } from '$lib/hooks/useSettings';
+    import { useSettings } from '$lib/hooks';
     import SampleClassificationPills from '$lib/components/SampleClassificationPills/SampleClassificationPills.svelte';
-    import { getGridImageURL, getGridFrameURL, getGridThumbnailRequestSize } from '$lib/utils';
+    import { getThumbnailUrl, getSampleDimensions } from './getThumbnailData';
     import type { CropWindow } from '../AnnotationItem/renderCropObjectUrl';
 
     interface Props {
@@ -47,37 +42,17 @@
     // the annotation prop during effect cleanup after the grid array shrinks).
     const annotationId = annotation.annotation.sample_id;
 
-    const thumbnailUrl = $derived.by(() => {
-        const dpr = globalThis.window?.devicePixelRatio || 1;
-        const renderedWidth = getGridThumbnailRequestSize(containerWidth, dpr);
-        const renderedHeight = getGridThumbnailRequestSize(containerHeight, dpr);
-        if (annotation.parent_sample_type === SampleType.IMAGE) {
-            const image = annotation.parent_sample_data as ImageAnnotationView;
-            return getGridImageURL({
-                sampleId: image.sample_id,
-                quality,
-                renderedWidth,
-                renderedHeight,
-                cacheBuster: cachedCollectionVersion
-            });
-        }
-        const frame = annotation.parent_sample_data as VideoFrameAnnotationView;
-        return getGridFrameURL({
-            sampleId: frame.sample_id,
+    const thumbnailUrl = $derived(
+        getThumbnailUrl({
+            annotation,
             quality,
-            renderedWidth,
-            renderedHeight
-        });
-    });
+            containerWidth,
+            containerHeight,
+            cachedCollectionVersion
+        })
+    );
 
-    const sampleDimensions = $derived.by(() => {
-        if (annotation.parent_sample_type === SampleType.IMAGE) {
-            const image = annotation.parent_sample_data as ImageAnnotationView;
-            return { width: image.width, height: image.height };
-        }
-        const frame = annotation.parent_sample_data as VideoFrameAnnotationView;
-        return { width: frame.video.width, height: frame.video.height };
-    });
+    const sampleDimensions = $derived(getSampleDimensions(annotation));
 
     // Emit a full-image CropWindow so classification tiles participate in drag-to-search.
     // windowX/Y=0 covers the entire sample — there is no bounding box to crop for classification.

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+    import {
+        SampleType,
+        type AnnotationWithPayloadView,
+        type ImageAnnotationView,
+        type VideoFrameAnnotationView
+    } from '$lib/api/lightly_studio_local';
+    import { get } from 'svelte/store';
+    import { useSettings } from '$lib/hooks/useSettings';
+    import SampleClassificationPills from '$lib/components/SampleClassificationPills/SampleClassificationPills.svelte';
+    import { getGridImageURL, getGridFrameURL, getGridThumbnailRequestSize } from '$lib/utils';
+    import type { CropWindow } from '../AnnotationItem/renderCropObjectUrl';
+
+    interface Props {
+        /** The classification annotation with its parent sample data. */
+        annotation: AnnotationWithPayloadView;
+        /** Width of the grid container tile in pixels. */
+        containerWidth: number;
+        /** Height of the grid container tile in pixels. */
+        containerHeight: number;
+        /** Whether text labels are visible globally. */
+        showLabel: boolean;
+        /** Whether this tile is currently selected. */
+        selected?: boolean;
+        /** Collection version cache-buster (same as AnnotationImageGridItem). */
+        cachedCollectionVersion?: string;
+        /** Reports full-image crop geometry for drag-to-search (same contract as AnnotationItem). */
+        onCropWindowChange?: (annotationId: string, window: CropWindow | null) => void;
+    }
+
+    let {
+        annotation,
+        containerWidth,
+        containerHeight,
+        showLabel,
+        selected = false,
+        cachedCollectionVersion = '',
+        onCropWindowChange
+    }: Props = $props();
+
+    const { gridViewThumbnailQualityStore } = useSettings();
+
+    let quality = $state(get(gridViewThumbnailQualityStore));
+    $effect(() => gridViewThumbnailQualityStore.subscribe((v) => (quality = v)));
+
+    // Stable id captured at init — same pattern as AnnotationItem (avoids re-reading
+    // the annotation prop during effect cleanup after the grid array shrinks).
+    const annotationId = annotation.annotation.sample_id;
+
+    const thumbnailUrl = $derived.by(() => {
+        const dpr = globalThis.window?.devicePixelRatio || 1;
+        const renderedWidth = getGridThumbnailRequestSize(containerWidth, dpr);
+        const renderedHeight = getGridThumbnailRequestSize(containerHeight, dpr);
+        if (annotation.parent_sample_type === SampleType.IMAGE) {
+            const image = annotation.parent_sample_data as ImageAnnotationView;
+            return getGridImageURL({
+                sampleId: image.sample_id,
+                quality,
+                renderedWidth,
+                renderedHeight,
+                cacheBuster: cachedCollectionVersion
+            });
+        }
+        const frame = annotation.parent_sample_data as VideoFrameAnnotationView;
+        return getGridFrameURL({
+            sampleId: frame.sample_id,
+            quality,
+            renderedWidth,
+            renderedHeight
+        });
+    });
+
+    const sampleDimensions = $derived.by(() => {
+        if (annotation.parent_sample_type === SampleType.IMAGE) {
+            const image = annotation.parent_sample_data as ImageAnnotationView;
+            return { width: image.width, height: image.height };
+        }
+        const frame = annotation.parent_sample_data as VideoFrameAnnotationView;
+        return { width: frame.video.width, height: frame.video.height };
+    });
+
+    // Emit a full-image CropWindow so classification tiles participate in drag-to-search.
+    // windowX/Y=0 covers the entire sample — there is no bounding box to crop for classification.
+    $effect(() => {
+        if (!thumbnailUrl) return;
+        onCropWindowChange?.(annotationId, {
+            sourceUrl: thumbnailUrl,
+            sampleWidth: sampleDimensions.width,
+            sampleHeight: sampleDimensions.height,
+            windowWidth: sampleDimensions.width,
+            windowHeight: sampleDimensions.height,
+            windowX: 0,
+            windowY: 0
+        });
+        return () => onCropWindowChange?.(annotationId, null);
+    });
+</script>
+
+<div
+    class="relative overflow-hidden rounded-lg bg-black"
+    class:grid-item-selected={selected}
+    aria-selected={selected}
+    style="width: {containerWidth}px; height: {containerHeight}px; background-image: url('{thumbnailUrl}'); background-size: cover; background-position: center;"
+>
+    {#if showLabel}
+        <!-- One tile shows exactly one label — [annotation.annotation] wraps a single classification. -->
+        <SampleClassificationPills sample={{ annotations: [annotation.annotation] }} />
+    {/if}
+</div>

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.test.ts
@@ -26,33 +26,43 @@ vi.mock('$lib/utils', async (importOriginal) => {
     };
 });
 
+function buildAnnotation(
+    overrides: Partial<AnnotationWithPayloadView> = {}
+): AnnotationWithPayloadView {
+    return {
+        parent_sample_type: SampleType.IMAGE,
+        annotation: {
+            sample_id: 'ann-1',
+            annotation_type: AnnotationType.CLASSIFICATION,
+            annotation_label: { annotation_label_name: 'cat' },
+            annotation_collection_id: 'col-1',
+            parent_sample_id: 'img-1'
+        } as unknown as AnnotationView,
+        parent_sample_data: {
+            sample_id: 'img-1',
+            width: 800,
+            height: 600
+        } as unknown as ImageAnnotationView,
+        ...overrides
+    };
+}
+
+const defaultProps = {
+    containerWidth: 200,
+    containerHeight: 150,
+    showLabel: true,
+    cachedCollectionVersion: 'v1'
+};
+
+function renderItem(annotation: AnnotationWithPayloadView, props: Record<string, unknown> = {}) {
+    return render(AnnotationClassificationGridItem, {
+        props: { annotation, ...defaultProps, ...props }
+    });
+}
+
 describe('AnnotationClassificationGridItem', () => {
     it('renders thumbnail div and SampleClassificationPills for an image annotation', async () => {
-        const annotation = {
-            parent_sample_type: SampleType.IMAGE,
-            annotation: {
-                sample_id: 'ann-1',
-                annotation_type: AnnotationType.CLASSIFICATION,
-                annotation_label: { annotation_label_name: 'cat' },
-                annotation_collection_id: 'col-1',
-                parent_sample_id: 'img-1'
-            } as unknown as AnnotationView,
-            parent_sample_data: {
-                sample_id: 'img-1',
-                width: 800,
-                height: 600
-            } as unknown as ImageAnnotationView
-        } satisfies AnnotationWithPayloadView;
-
-        const { container } = render(AnnotationClassificationGridItem, {
-            props: {
-                annotation,
-                containerWidth: 200,
-                containerHeight: 150,
-                showLabel: true,
-                cachedCollectionVersion: 'v1'
-            }
-        });
+        const { container } = renderItem(buildAnnotation());
 
         await tick();
 
@@ -63,29 +73,14 @@ describe('AnnotationClassificationGridItem', () => {
     });
 
     it('renders thumbnail using frame URL for a video frame annotation', async () => {
-        const annotation = {
+        const annotation = buildAnnotation({
             parent_sample_type: SampleType.VIDEO_FRAME,
-            annotation: {
-                sample_id: 'ann-2',
-                annotation_type: AnnotationType.CLASSIFICATION,
-                annotation_label: { annotation_label_name: 'dog' },
-                annotation_collection_id: 'col-1',
-                parent_sample_id: 'frame-1'
-            } as unknown as AnnotationView,
             parent_sample_data: {
                 sample_id: 'frame-1',
                 video: { width: 1920, height: 1080, file_path_abs: '/video.mp4' }
             } as unknown as VideoFrameAnnotationView
-        } satisfies AnnotationWithPayloadView;
-
-        const { container } = render(AnnotationClassificationGridItem, {
-            props: {
-                annotation,
-                containerWidth: 200,
-                containerHeight: 150,
-                showLabel: true
-            }
         });
+        const { container } = renderItem(annotation);
 
         await tick();
 
@@ -94,131 +89,45 @@ describe('AnnotationClassificationGridItem', () => {
     });
 
     it('applies grid-item-selected class when selected is true', () => {
-        const annotation = {
-            parent_sample_type: SampleType.IMAGE,
-            annotation: {
-                sample_id: 'ann-3',
-                annotation_type: AnnotationType.CLASSIFICATION,
-                annotation_label: { annotation_label_name: 'cat' },
-                annotation_collection_id: 'col-1',
-                parent_sample_id: 'img-3'
-            } as unknown as AnnotationView,
-            parent_sample_data: {
-                sample_id: 'img-3',
-                width: 800,
-                height: 600
-            } as unknown as ImageAnnotationView
-        } satisfies AnnotationWithPayloadView;
-
-        const { container } = render(AnnotationClassificationGridItem, {
-            props: {
-                annotation,
-                containerWidth: 200,
-                containerHeight: 150,
-                showLabel: true,
-                selected: true
-            }
-        });
+        const { container } = renderItem(buildAnnotation(), { selected: true });
 
         expect(container.firstElementChild).toHaveAttribute('aria-selected', 'true');
     });
 
     it('hides SampleClassificationPills when showLabel is false', () => {
-        const annotation = {
-            parent_sample_type: SampleType.IMAGE,
-            annotation: {
-                sample_id: 'ann-4',
-                annotation_type: AnnotationType.CLASSIFICATION,
-                annotation_label: { annotation_label_name: 'cat' },
-                annotation_collection_id: 'col-1',
-                parent_sample_id: 'img-4'
-            } as unknown as AnnotationView,
-            parent_sample_data: {
-                sample_id: 'img-4',
-                width: 800,
-                height: 600
-            } as unknown as ImageAnnotationView
-        } satisfies AnnotationWithPayloadView;
-
-        render(AnnotationClassificationGridItem, {
-            props: {
-                annotation,
-                containerWidth: 200,
-                containerHeight: 150,
-                showLabel: false
-            }
-        });
+        renderItem(buildAnnotation(), { showLabel: false });
 
         expect(screen.queryByTestId('mock-classification-pills')).not.toBeInTheDocument();
     });
 
     it('passes only the single annotation to SampleClassificationPills', async () => {
-        const annotation = {
-            parent_sample_type: SampleType.IMAGE,
-            annotation: {
-                sample_id: 'ann-5',
-                annotation_type: AnnotationType.CLASSIFICATION,
-                annotation_label: { annotation_label_name: 'cat' },
-                annotation_collection_id: 'col-1',
-                parent_sample_id: 'img-5'
-            } as unknown as AnnotationView,
-            parent_sample_data: {
-                sample_id: 'img-5',
-                width: 800,
-                height: 600
-            } as unknown as ImageAnnotationView
-        } satisfies AnnotationWithPayloadView;
-
-        render(AnnotationClassificationGridItem, {
-            props: {
-                annotation,
-                containerWidth: 200,
-                containerHeight: 150,
-                showLabel: true
-            }
-        });
+        renderItem(buildAnnotation());
 
         await tick();
 
         const pills = screen.getByTestId('mock-classification-pills');
         // Exactly one annotation is passed — not all sibling labels for the parent sample.
         expect(pills).toHaveAttribute('data-annotation-count', '1');
-        expect(pills).toHaveAttribute('data-annotation-id', 'ann-5');
+        expect(pills).toHaveAttribute('data-annotation-id', 'ann-1');
     });
 
     it('calls onCropWindowChange with a full-image CropWindow (windowX/Y=0) once URL is available', async () => {
         const onCropWindowChange = vi.fn();
-        const annotation = {
-            parent_sample_type: SampleType.IMAGE,
-            annotation: {
-                sample_id: 'ann-6',
-                annotation_type: AnnotationType.CLASSIFICATION,
-                annotation_label: { annotation_label_name: 'cat' },
-                annotation_collection_id: 'col-1',
-                parent_sample_id: 'img-6'
-            } as unknown as AnnotationView,
+        const annotation = buildAnnotation({
             parent_sample_data: {
-                sample_id: 'img-6',
+                sample_id: 'img-1',
                 width: 1024,
                 height: 768
             } as unknown as ImageAnnotationView
-        } satisfies AnnotationWithPayloadView;
-
-        render(AnnotationClassificationGridItem, {
-            props: {
-                annotation,
-                containerWidth: 200,
-                containerHeight: 150,
-                showLabel: true,
-                onCropWindowChange
-            }
         });
+
+        renderItem(annotation, { onCropWindowChange });
 
         await tick();
 
         expect(onCropWindowChange).toHaveBeenCalledOnce();
         const [annotationId, cropWindow] = onCropWindowChange.mock.calls[0];
-        expect(annotationId).toBe('ann-6');
+        expect(annotationId).toBe('ann-1');
         expect(cropWindow.windowX).toBe(0);
         expect(cropWindow.windowY).toBe(0);
         expect(cropWindow.windowWidth).toBe(1024);
@@ -229,40 +138,15 @@ describe('AnnotationClassificationGridItem', () => {
 
     it('calls onCropWindowChange with null on unmount', async () => {
         const onCropWindowChange = vi.fn();
-        const annotation = {
-            parent_sample_type: SampleType.IMAGE,
-            annotation: {
-                sample_id: 'ann-7',
-                annotation_type: AnnotationType.CLASSIFICATION,
-                annotation_label: { annotation_label_name: 'cat' },
-                annotation_collection_id: 'col-1',
-                parent_sample_id: 'img-7'
-            } as unknown as AnnotationView,
-            parent_sample_data: {
-                sample_id: 'img-7',
-                width: 1024,
-                height: 768
-            } as unknown as ImageAnnotationView
-        } satisfies AnnotationWithPayloadView;
 
-        const { unmount } = render(AnnotationClassificationGridItem, {
-            props: {
-                annotation,
-                containerWidth: 200,
-                containerHeight: 150,
-                showLabel: true,
-                onCropWindowChange
-            }
-        });
+        const { unmount } = renderItem(buildAnnotation(), { onCropWindowChange });
 
         await tick();
-
         unmount();
-
         await tick();
 
         const lastCall = onCropWindowChange.mock.calls.at(-1);
-        expect(lastCall?.[0]).toBe('ann-7');
+        expect(lastCall?.[0]).toBe('ann-1');
         expect(lastCall?.[1]).toBeNull();
     });
 });

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import '@testing-library/jest-dom';
+import { tick } from 'svelte';
+import {
+    SampleType,
+    AnnotationType,
+    type AnnotationWithPayloadView,
+    type ImageAnnotationView,
+    type VideoFrameAnnotationView,
+    type AnnotationView
+} from '$lib/api/lightly_studio_local';
+import AnnotationClassificationGridItem from './AnnotationClassificationGridItem.svelte';
+
+vi.mock('$lib/components/SampleClassificationPills/SampleClassificationPills.svelte', async () => {
+    const module = await import('./SampleClassificationPills.mock.svelte');
+    return { default: module.default };
+});
+
+vi.mock('$lib/utils', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('$lib/utils')>();
+    return {
+        ...actual,
+        getGridImageURL: ({ sampleId }: { sampleId: string }) => `http://images/sample/${sampleId}`,
+        getGridFrameURL: ({ sampleId }: { sampleId: string }) => `http://frames/media/${sampleId}`
+    };
+});
+
+describe('AnnotationClassificationGridItem', () => {
+    it('renders thumbnail div and SampleClassificationPills for an image annotation', async () => {
+        const annotation = {
+            parent_sample_type: SampleType.IMAGE,
+            annotation: {
+                sample_id: 'ann-1',
+                annotation_type: AnnotationType.CLASSIFICATION,
+                annotation_label: { annotation_label_name: 'cat' },
+                annotation_collection_id: 'col-1',
+                parent_sample_id: 'img-1'
+            } as unknown as AnnotationView,
+            parent_sample_data: {
+                sample_id: 'img-1',
+                width: 800,
+                height: 600
+            } as unknown as ImageAnnotationView
+        } satisfies AnnotationWithPayloadView;
+
+        const { container } = render(AnnotationClassificationGridItem, {
+            props: {
+                annotation,
+                containerWidth: 200,
+                containerHeight: 150,
+                showLabel: true,
+                cachedCollectionVersion: 'v1'
+            }
+        });
+
+        await tick();
+
+        const thumbnail = container.firstElementChild as HTMLElement;
+        expect(thumbnail).toBeInTheDocument();
+        expect(thumbnail.style.backgroundImage).toContain('img-1');
+        expect(screen.getByTestId('mock-classification-pills')).toBeInTheDocument();
+    });
+
+    it('renders thumbnail using frame URL for a video frame annotation', async () => {
+        const annotation = {
+            parent_sample_type: SampleType.VIDEO_FRAME,
+            annotation: {
+                sample_id: 'ann-2',
+                annotation_type: AnnotationType.CLASSIFICATION,
+                annotation_label: { annotation_label_name: 'dog' },
+                annotation_collection_id: 'col-1',
+                parent_sample_id: 'frame-1'
+            } as unknown as AnnotationView,
+            parent_sample_data: {
+                sample_id: 'frame-1',
+                video: { width: 1920, height: 1080, file_path_abs: '/video.mp4' }
+            } as unknown as VideoFrameAnnotationView
+        } satisfies AnnotationWithPayloadView;
+
+        const { container } = render(AnnotationClassificationGridItem, {
+            props: {
+                annotation,
+                containerWidth: 200,
+                containerHeight: 150,
+                showLabel: true
+            }
+        });
+
+        await tick();
+
+        const thumbnail = container.firstElementChild as HTMLElement;
+        expect(thumbnail.style.backgroundImage).toContain('frames/media/frame-1');
+    });
+
+    it('applies grid-item-selected class when selected is true', () => {
+        const annotation = {
+            parent_sample_type: SampleType.IMAGE,
+            annotation: {
+                sample_id: 'ann-3',
+                annotation_type: AnnotationType.CLASSIFICATION,
+                annotation_label: { annotation_label_name: 'cat' },
+                annotation_collection_id: 'col-1',
+                parent_sample_id: 'img-3'
+            } as unknown as AnnotationView,
+            parent_sample_data: {
+                sample_id: 'img-3',
+                width: 800,
+                height: 600
+            } as unknown as ImageAnnotationView
+        } satisfies AnnotationWithPayloadView;
+
+        const { container } = render(AnnotationClassificationGridItem, {
+            props: {
+                annotation,
+                containerWidth: 200,
+                containerHeight: 150,
+                showLabel: true,
+                selected: true
+            }
+        });
+
+        expect(container.firstElementChild).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('hides SampleClassificationPills when showLabel is false', () => {
+        const annotation = {
+            parent_sample_type: SampleType.IMAGE,
+            annotation: {
+                sample_id: 'ann-4',
+                annotation_type: AnnotationType.CLASSIFICATION,
+                annotation_label: { annotation_label_name: 'cat' },
+                annotation_collection_id: 'col-1',
+                parent_sample_id: 'img-4'
+            } as unknown as AnnotationView,
+            parent_sample_data: {
+                sample_id: 'img-4',
+                width: 800,
+                height: 600
+            } as unknown as ImageAnnotationView
+        } satisfies AnnotationWithPayloadView;
+
+        render(AnnotationClassificationGridItem, {
+            props: {
+                annotation,
+                containerWidth: 200,
+                containerHeight: 150,
+                showLabel: false
+            }
+        });
+
+        expect(screen.queryByTestId('mock-classification-pills')).not.toBeInTheDocument();
+    });
+
+    it('passes only the single annotation to SampleClassificationPills', async () => {
+        const annotation = {
+            parent_sample_type: SampleType.IMAGE,
+            annotation: {
+                sample_id: 'ann-5',
+                annotation_type: AnnotationType.CLASSIFICATION,
+                annotation_label: { annotation_label_name: 'cat' },
+                annotation_collection_id: 'col-1',
+                parent_sample_id: 'img-5'
+            } as unknown as AnnotationView,
+            parent_sample_data: {
+                sample_id: 'img-5',
+                width: 800,
+                height: 600
+            } as unknown as ImageAnnotationView
+        } satisfies AnnotationWithPayloadView;
+
+        render(AnnotationClassificationGridItem, {
+            props: {
+                annotation,
+                containerWidth: 200,
+                containerHeight: 150,
+                showLabel: true
+            }
+        });
+
+        await tick();
+
+        const pills = screen.getByTestId('mock-classification-pills');
+        // Exactly one annotation is passed — not all sibling labels for the parent sample.
+        expect(pills).toHaveAttribute('data-annotation-count', '1');
+        expect(pills).toHaveAttribute('data-annotation-id', 'ann-5');
+    });
+
+    it('calls onCropWindowChange with a full-image CropWindow (windowX/Y=0) once URL is available', async () => {
+        const onCropWindowChange = vi.fn();
+        const annotation = {
+            parent_sample_type: SampleType.IMAGE,
+            annotation: {
+                sample_id: 'ann-6',
+                annotation_type: AnnotationType.CLASSIFICATION,
+                annotation_label: { annotation_label_name: 'cat' },
+                annotation_collection_id: 'col-1',
+                parent_sample_id: 'img-6'
+            } as unknown as AnnotationView,
+            parent_sample_data: {
+                sample_id: 'img-6',
+                width: 1024,
+                height: 768
+            } as unknown as ImageAnnotationView
+        } satisfies AnnotationWithPayloadView;
+
+        render(AnnotationClassificationGridItem, {
+            props: {
+                annotation,
+                containerWidth: 200,
+                containerHeight: 150,
+                showLabel: true,
+                onCropWindowChange
+            }
+        });
+
+        await tick();
+
+        expect(onCropWindowChange).toHaveBeenCalledOnce();
+        const [annotationId, cropWindow] = onCropWindowChange.mock.calls[0];
+        expect(annotationId).toBe('ann-6');
+        expect(cropWindow.windowX).toBe(0);
+        expect(cropWindow.windowY).toBe(0);
+        expect(cropWindow.windowWidth).toBe(1024);
+        expect(cropWindow.windowHeight).toBe(768);
+        expect(cropWindow.sampleWidth).toBe(1024);
+        expect(cropWindow.sampleHeight).toBe(768);
+    });
+
+    it('calls onCropWindowChange with null on unmount', async () => {
+        const onCropWindowChange = vi.fn();
+        const annotation = {
+            parent_sample_type: SampleType.IMAGE,
+            annotation: {
+                sample_id: 'ann-7',
+                annotation_type: AnnotationType.CLASSIFICATION,
+                annotation_label: { annotation_label_name: 'cat' },
+                annotation_collection_id: 'col-1',
+                parent_sample_id: 'img-7'
+            } as unknown as AnnotationView,
+            parent_sample_data: {
+                sample_id: 'img-7',
+                width: 1024,
+                height: 768
+            } as unknown as ImageAnnotationView
+        } satisfies AnnotationWithPayloadView;
+
+        const { unmount } = render(AnnotationClassificationGridItem, {
+            props: {
+                annotation,
+                containerWidth: 200,
+                containerHeight: 150,
+                showLabel: true,
+                onCropWindowChange
+            }
+        });
+
+        await tick();
+
+        unmount();
+
+        await tick();
+
+        const lastCall = onCropWindowChange.mock.calls.at(-1);
+        expect(lastCall?.[0]).toBe('ann-7');
+        expect(lastCall?.[1]).toBeNull();
+    });
+});

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/SampleClassificationPills.mock.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/SampleClassificationPills.mock.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+    import type { AnnotationView } from '$lib/api/lightly_studio_local';
+
+    interface Props {
+        sample: { annotations: AnnotationView[] };
+    }
+
+    let { sample }: Props = $props();
+</script>
+
+<div
+    data-testid="mock-classification-pills"
+    data-annotation-count={sample.annotations.length}
+    data-annotation-id={sample.annotations[0]?.sample_id}
+></div>

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/getThumbnailData.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/getThumbnailData.ts
@@ -1,0 +1,73 @@
+import {
+    SampleType,
+    type AnnotationWithPayloadView,
+    type ImageAnnotationView,
+    type VideoFrameAnnotationView
+} from '$lib/api/lightly_studio_local';
+import {
+    getGridImageURL,
+    getGridFrameURL,
+    getGridThumbnailRequestSize,
+    type GridThumbnailQuality
+} from '$lib/utils';
+
+type GetThumbnailUrlParams = {
+    annotation: AnnotationWithPayloadView;
+    quality: GridThumbnailQuality;
+    containerWidth: number;
+    containerHeight: number;
+    cachedCollectionVersion: string;
+};
+
+/**
+ * Returns the thumbnail URL for a classification annotation's parent sample.
+ *
+ * Dispatches to the image or video-frame URL helper based on `parent_sample_type`,
+ * scaling the requested resolution to the rendered container size × device pixel ratio.
+ */
+export function getThumbnailUrl({
+    annotation,
+    quality,
+    containerWidth,
+    containerHeight,
+    cachedCollectionVersion
+}: GetThumbnailUrlParams): string {
+    const dpr = globalThis.window?.devicePixelRatio || 1;
+    const renderedWidth = getGridThumbnailRequestSize(containerWidth, dpr);
+    const renderedHeight = getGridThumbnailRequestSize(containerHeight, dpr);
+    if (annotation.parent_sample_type === SampleType.IMAGE) {
+        const image = annotation.parent_sample_data as ImageAnnotationView;
+        return getGridImageURL({
+            sampleId: image.sample_id,
+            quality,
+            renderedWidth,
+            renderedHeight,
+            cacheBuster: cachedCollectionVersion
+        });
+    }
+    const frame = annotation.parent_sample_data as VideoFrameAnnotationView;
+    return getGridFrameURL({
+        sampleId: frame.sample_id,
+        quality,
+        renderedWidth,
+        renderedHeight
+    });
+}
+
+/**
+ * Returns the original pixel dimensions of the parent sample.
+ *
+ * For images this is the stored image size; for video frames it is the video
+ * resolution. Used to express the full-image CropWindow in original coordinates.
+ */
+export function getSampleDimensions(annotation: AnnotationWithPayloadView): {
+    width: number;
+    height: number;
+} {
+    if (annotation.parent_sample_type === SampleType.IMAGE) {
+        const image = annotation.parent_sample_data as ImageAnnotationView;
+        return { width: image.width, height: image.height };
+    }
+    const frame = annotation.parent_sample_data as VideoFrameAnnotationView;
+    return { width: frame.video.width, height: frame.video.height };
+}

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGridItem/AnnotationClassificationGridItem.mock.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGridItem/AnnotationClassificationGridItem.mock.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import type { AnnotationWithPayloadView } from '$lib/api/lightly_studio_local';
+
+    interface Props {
+        annotation: AnnotationWithPayloadView;
+        selected?: boolean;
+    }
+
+    let { annotation, selected = false }: Props = $props();
+</script>
+
+<div
+    data-testid="mock-classification-grid-item"
+    data-annotation-id={annotation.annotation.sample_id}
+    data-selected={selected}
+></div>

--- a/lightly_studio_view/src/lib/utils/index.ts
+++ b/lightly_studio_view/src/lib/utils/index.ts
@@ -17,7 +17,8 @@ export { getImageURL as getImageURLById } from './getImageURL';
 export {
     getGridFrameURL,
     getGridImageURL,
-    getGridThumbnailRequestSize
+    getGridThumbnailRequestSize,
+    type GridThumbnailQuality
 } from './getGridThumbnailURL/getGridThumbnailURL';
 export { getVideoURLById } from './getVideoURLById/getVideoURLById';
 export { getURL } from './getURL/getURL';


### PR DESCRIPTION
## What has changed and why?

This PR adds `AnnotationClassificationGridItem` for classification annotations whose parent sample is an image or video frame. The component renders its thumbnail with the existing grid image and frame URL helpers, reuses `SampleClassificationPills` for label display.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added classification tiles to annotation grids with thumbnail previews, selection state, and optional classification labels.
  * Classification tiles now support drag-to-search across the full sample.
  * Added support for image and video-frame thumbnails.

* **Tests**
  * Added coverage for rendering, selection, labels, thumbnail paths, and drag-to-search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->