### PR TITLE
Fast Track: bind verdicts to PR base state

### DIFF
--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -4,13 +4,8 @@ name: Fast Track Guardrails
 # an artifact for the bot. NOT a required status check — else would block every non-fast-track PR.
 on:
   pull_request:
-    # labeled/unlabeled so toggling the opt-out label re-evaluates.
-    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
-
-# Judge only the latest push per PR ref.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    # Re-evaluate when the opt-out label or comparison base changes.
+    types: [opened, edited, ready_for_review, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -19,7 +14,13 @@ permissions:
 jobs:
   guardrails:
     name: Fast Track Guardrails
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'edited' || github.event.changes.base != null)
+    # Job-level concurrency prevents an unrelated skipped edit from cancelling this job.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   guardrails:
     name: Fast Track Guardrails
+    # Skip drafts. `edited` fires on any PR edit (title, body, base), so restrict it
+    # to base retargets — those change the diff and warrant a re-judge; other edits don't.
     if: >-
       github.event.pull_request.draft == false &&
       (github.event.action != 'edited' || github.event.changes.base != null)

--- a/fast_track/src/guardrails/author-opt-out.test.ts
+++ b/fast_track/src/guardrails/author-opt-out.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildOptOutVerdict, OPT_OUT_LABEL } from './author-opt-out';
+
+const routing = {
+    prNumber: 7,
+    headSha: 'abc',
+    baseRef: 'main',
+    baseSha: 'base123'
+};
+
+describe('buildOptOutVerdict', () => {
+    it('returns no override without the opt-out label', () => {
+        expect(buildOptOutVerdict([], routing)).toBeUndefined();
+    });
+
+    it('returns an opt-out verdict bound to the PR and head', () => {
+        expect(buildOptOutVerdict([OPT_OUT_LABEL], routing)).toEqual({
+            verdict: 'opt_out',
+            guardrails: [],
+            pr_number: 7,
+            head_sha: 'abc',
+            base_ref: 'main',
+            base_sha: 'base123',
+            reason: `Author requested human review with the \`${OPT_OUT_LABEL}\` label.`
+        });
+    });
+});

--- a/fast_track/src/guardrails/author-opt-out.ts
+++ b/fast_track/src/guardrails/author-opt-out.ts
@@ -1,5 +1,4 @@
-import type { Verdict } from '../shared/verdict';
-import type { VerdictRouting } from './build-verdict';
+import type { Verdict, VerdictRouting } from '../shared/verdict';
 
 export const OPT_OUT_LABEL = 'needs-human-review';
 

--- a/fast_track/src/guardrails/author-opt-out.ts
+++ b/fast_track/src/guardrails/author-opt-out.ts
@@ -1,6 +1,6 @@
 import type { Verdict, VerdictRouting } from '../shared/verdict';
 
-export const OPT_OUT_LABEL = 'needs-human-review';
+export const OPT_OUT_LABEL = 'no-fast-track';
 
 /** Return an override verdict when the PR author requested human review. */
 export function buildOptOutVerdict(labels: string[], routing: VerdictRouting): Verdict | undefined {

--- a/fast_track/src/guardrails/author-opt-out.ts
+++ b/fast_track/src/guardrails/author-opt-out.ts
@@ -1,0 +1,18 @@
+import type { Verdict } from '../shared/verdict';
+import type { VerdictRouting } from './build-verdict';
+
+export const OPT_OUT_LABEL = 'needs-human-review';
+
+/** Return an override verdict when the PR author requested human review. */
+export function buildOptOutVerdict(labels: string[], routing: VerdictRouting): Verdict | undefined {
+    if (!labels.includes(OPT_OUT_LABEL)) return undefined;
+    return {
+        verdict: 'opt_out',
+        guardrails: [],
+        pr_number: routing.prNumber,
+        head_sha: routing.headSha,
+        base_ref: routing.baseRef,
+        base_sha: routing.baseSha,
+        reason: `Author requested human review with the \`${OPT_OUT_LABEL}\` label.`
+    };
+}

--- a/fast_track/src/guardrails/build-verdict.test.ts
+++ b/fast_track/src/guardrails/build-verdict.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from 'vitest';
 import type { RunResult } from './run-guardrails';
 import { buildVerdict } from './build-verdict';
 
-const routing = { prNumber: 42, headSha: 'deadbeef' };
+const routing = {
+    prNumber: 42,
+    headSha: 'deadbeef',
+    baseRef: 'main',
+    baseSha: 'base123'
+};
 
 describe('buildVerdict', () => {
     it('carries the status, breakdown, and routing on a pass — no reason', () => {
@@ -16,7 +21,9 @@ describe('buildVerdict', () => {
             verdict: 'pass',
             guardrails: [{ name: 'dummy', status: 'pass', summary: 'ok' }],
             pr_number: 42,
-            head_sha: 'deadbeef'
+            head_sha: 'deadbeef',
+            base_ref: 'main',
+            base_sha: 'base123'
         });
     });
 

--- a/fast_track/src/guardrails/build-verdict.ts
+++ b/fast_track/src/guardrails/build-verdict.ts
@@ -5,19 +5,23 @@ import type { RunResult } from './run-guardrails';
 export interface VerdictRouting {
     prNumber: number;
     headSha: string;
+    baseRef: string;
+    baseSha: string;
 }
 
 /**
  * Wrap a {@link RunResult} into the wire {@link Verdict}, adding the routing
  * fields and a {@link reason} for the PR comment on a non-pass. `opt_out` is
- * never produced here — it's an author-label override the bot applies (design §2.3).
+ * produced separately by `buildOptOutVerdict`.
  */
 export function buildVerdict(run: RunResult, routing: VerdictRouting): Verdict {
     const verdict: Verdict = {
         verdict: run.status,
         guardrails: run.guardrails,
         pr_number: routing.prNumber,
-        head_sha: routing.headSha
+        head_sha: routing.headSha,
+        base_ref: routing.baseRef,
+        base_sha: routing.baseSha
     };
     if (run.status !== 'pass') {
         verdict.reason = buildReason(run.guardrails);

--- a/fast_track/src/guardrails/build-verdict.ts
+++ b/fast_track/src/guardrails/build-verdict.ts
@@ -1,13 +1,5 @@
-import type { GuardrailResult, Verdict } from '../shared/verdict';
+import type { GuardrailResult, Verdict, VerdictRouting } from '../shared/verdict';
 import type { RunResult } from './run-guardrails';
-
-/** UNTRUSTED: written in PR context, re-derived by the bot against the trusted commit (design §3). */
-export interface VerdictRouting {
-    prNumber: number;
-    headSha: string;
-    baseRef: string;
-    baseSha: string;
-}
 
 /**
  * Wrap a {@link RunResult} into the wire {@link Verdict}, adding the routing

--- a/fast_track/src/guardrails/build-verdict.ts
+++ b/fast_track/src/guardrails/build-verdict.ts
@@ -3,8 +3,7 @@ import type { RunResult } from './run-guardrails';
 
 /**
  * Wrap a {@link RunResult} into the wire {@link Verdict}, adding the routing
- * fields and a {@link reason} for the PR comment on a non-pass. `opt_out` is
- * produced separately by `buildOptOutVerdict`.
+ * fields and a {@link reason} for the PR comment on a non-pass.
  */
 export function buildVerdict(run: RunResult, routing: VerdictRouting): Verdict {
     const verdict: Verdict = {

--- a/fast_track/src/guardrails/ci.ts
+++ b/fast_track/src/guardrails/ci.ts
@@ -3,8 +3,10 @@ import { fileURLToPath } from 'node:url';
 
 import { context, getOctokit } from '@actions/github';
 
-import { ApiGuardrailContext } from './context/api-context';
+import type { Verdict } from '../shared/verdict';
+import { buildOptOutVerdict } from './author-opt-out';
 import { buildVerdict } from './build-verdict';
+import { ApiGuardrailContext } from './context/api-context';
 import { guardrails, selectGuardrails } from './registry';
 import { runGuardrails } from './run-guardrails';
 
@@ -18,7 +20,8 @@ const VERDICT_PATH = 'verdict.json';
 interface PullRequestEvent {
     number: number;
     head: { sha: string };
-    base: { ref: string };
+    base: { ref: string; sha: string };
+    labels: Array<{ name?: string }>;
 }
 
 function readPullRequest(): PullRequestEvent {
@@ -35,11 +38,23 @@ async function main(env: NodeJS.ProcessEnv): Promise<void> {
     if (token === undefined || token === '') throw new Error('GITHUB_TOKEN is not set.');
 
     const pr = readPullRequest();
-    const octokit = getOctokit(token);
+    const routing = {
+        prNumber: pr.number,
+        headSha: pr.head.sha,
+        baseRef: pr.base.ref,
+        baseSha: pr.base.sha
+    };
+    const labels = pr.labels.flatMap((label) => (label.name === undefined ? [] : [label.name]));
+    const optOutVerdict = buildOptOutVerdict(labels, routing);
+
+    if (optOutVerdict !== undefined) {
+        await writeVerdict(optOutVerdict);
+        return;
+    }
 
     // Base ref from the event, so stacked / non-main bases diff correctly.
     const guardrailContext = new ApiGuardrailContext({
-        octokit,
+        octokit: getOctokit(token),
         owner: context.repo.owner,
         repo: context.repo.repo,
         prNumber: pr.number,
@@ -49,8 +64,12 @@ async function main(env: NodeJS.ProcessEnv): Promise<void> {
     // hasPrContext: true — unlike the local CLI, pr-only guardrails run here.
     const selected = selectGuardrails(guardrails, { hasPrContext: true });
     const run = await runGuardrails(guardrailContext, selected);
-    const verdict = buildVerdict(run, { prNumber: pr.number, headSha: pr.head.sha });
+    const verdict = buildVerdict(run, routing);
 
+    await writeVerdict(verdict);
+}
+
+async function writeVerdict(verdict: Verdict): Promise<void> {
     await writeFile(VERDICT_PATH, `${JSON.stringify(verdict, null, 2)}\n`);
     console.log(
         `Verdict: ${verdict.verdict} (${verdict.guardrails.length} guardrail(s)) → ${VERDICT_PATH}`

--- a/fast_track/src/guardrails/ci.ts
+++ b/fast_track/src/guardrails/ci.ts
@@ -21,7 +21,7 @@ interface PullRequestEvent {
     number: number;
     head: { sha: string };
     base: { ref: string; sha: string };
-    labels: Array<{ name?: string }>;
+    labels: Array<{ name: string }>;
 }
 
 function readPullRequest(): PullRequestEvent {
@@ -41,7 +41,7 @@ function parsePrContext(pr: PullRequestEvent): { routing: VerdictRouting; labels
             baseRef: pr.base.ref,
             baseSha: pr.base.sha
         },
-        labels: pr.labels.flatMap((label) => (label.name === undefined ? [] : [label.name]))
+        labels: pr.labels.map((label) => label.name)
     };
 }
 

--- a/fast_track/src/guardrails/ci.ts
+++ b/fast_track/src/guardrails/ci.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import { context, getOctokit } from '@actions/github';
 
-import type { Verdict } from '../shared/verdict';
+import type { Verdict, VerdictRouting } from '../shared/verdict';
 import { buildOptOutVerdict } from './author-opt-out';
 import { buildVerdict } from './build-verdict';
 import { ApiGuardrailContext } from './context/api-context';
@@ -32,19 +32,25 @@ function readPullRequest(): PullRequestEvent {
     return pr as PullRequestEvent;
 }
 
+/** Map the PR event to the routing the verdict is bound to and its label names. */
+function parsePrContext(pr: PullRequestEvent): { routing: VerdictRouting; labels: string[] } {
+    return {
+        routing: {
+            prNumber: pr.number,
+            headSha: pr.head.sha,
+            baseRef: pr.base.ref,
+            baseSha: pr.base.sha
+        },
+        labels: pr.labels.flatMap((label) => (label.name === undefined ? [] : [label.name]))
+    };
+}
+
 async function main(env: NodeJS.ProcessEnv): Promise<void> {
     // Via env, not core.getInput: a `run:` step has no `with:` to feed it.
     const token = env.GITHUB_TOKEN;
     if (token === undefined || token === '') throw new Error('GITHUB_TOKEN is not set.');
 
-    const pr = readPullRequest();
-    const routing = {
-        prNumber: pr.number,
-        headSha: pr.head.sha,
-        baseRef: pr.base.ref,
-        baseSha: pr.base.sha
-    };
-    const labels = pr.labels.flatMap((label) => (label.name === undefined ? [] : [label.name]));
+    const { routing, labels } = parsePrContext(readPullRequest());
     const optOutVerdict = buildOptOutVerdict(labels, routing);
 
     if (optOutVerdict !== undefined) {
@@ -57,8 +63,8 @@ async function main(env: NodeJS.ProcessEnv): Promise<void> {
         octokit: getOctokit(token),
         owner: context.repo.owner,
         repo: context.repo.repo,
-        prNumber: pr.number,
-        baseRef: pr.base.ref
+        prNumber: routing.prNumber,
+        baseRef: routing.baseRef
     });
 
     // hasPrContext: true — unlike the local CLI, pr-only guardrails run here.

--- a/fast_track/src/shared/verdict.ts
+++ b/fast_track/src/shared/verdict.ts
@@ -22,6 +22,10 @@ export interface Verdict {
     pr_number: number;
     /** Untrusted routing: PR-context code writes it, the Bot re-derives and cross-checks. */
     head_sha: string;
+    /** Untrusted routing: binds the verdict to the base branch used for judging. */
+    base_ref: string;
+    /** Untrusted routing: binds the verdict to the exact base revision used for judging. */
+    base_sha: string;
     /** Shown in the PR comment on a non-pass verdict. */
     reason?: string;
 }

--- a/fast_track/src/shared/verdict.ts
+++ b/fast_track/src/shared/verdict.ts
@@ -29,3 +29,16 @@ export interface Verdict {
     /** Shown in the PR comment on a non-pass verdict. */
     reason?: string;
 }
+
+/**
+ * The camelCase routing inputs the verdict builders map onto the snake_case wire
+ * fields above. Shared by every builder, so it lives here rather than being owned
+ * by one builder module. UNTRUSTED: written in PR context, re-derived by the Bot
+ * against the trusted commit (design §3).
+ */
+export interface VerdictRouting {
+    prNumber: number;
+    headSha: string;
+    baseRef: string;
+    baseSha: string;
+}


### PR DESCRIPTION
## What has changed and why?
This change describes exactly which PR comparison was judged, no just which PR head commit.

A branch containing a commit could have been rebased, thus its SHA digest might have changed.

Also im[lements the opt-out mechanism with `no-fast-track` label.

## How has it been tested?

Added tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for opting out of automated guardrail checks using the `no-fast-track` label.
  * Opted-out pull requests now receive an `opt_out` verdict with opt-out guidance and a reason referencing the label.
* **Bug Fixes**
  * Verdicts now include the evaluated base branch name and exact base revision for improved traceability.
* **CI / Reliability**
  * Guardrail re-evaluation now runs for edited pull requests only when the comparison base changes, and avoids unrelated edits canceling in-progress runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->