### PR TITLE
Fast Track: derive current internal PR targets

### DIFF
--- a/fast_track/src/bot/derive-target.test.ts
+++ b/fast_track/src/bot/derive-target.test.ts
@@ -43,21 +43,28 @@ function derive(pullRequests: unknown[]) {
 
 describe('deriveTarget', () => {
     it('returns the internal open PR bound to the trusted head', async () => {
-        await expect(derive([pullRequest()])).resolves.toEqual({
+        const pr = pullRequest({
+            number: 7,
+            base: { ref: 'release', sha: 'base456', repo: { id: 1 } },
+            labels: [{ name: 'fast-track' }]
+        });
+        await expect(derive([pr])).resolves.toEqual({
             prNumber: 7,
             headSha: HEAD_SHA,
-            baseRef: 'main',
-            baseSha: 'base123',
-            labels: []
+            baseRef: 'release',
+            baseSha: 'base456',
+            labels: ['fast-track']
         });
     });
 
     it('refuses to guess when multiple internal PRs share the trusted head', async () => {
-        await expect(derive([pullRequest(), pullRequest({ number: 8 })])).resolves.toBeNull();
+        await expect(
+            derive([pullRequest({ number: 7 }), pullRequest({ number: 8 })])
+        ).resolves.toBeNull();
     });
 
     it('walks every page so a second candidate cannot hide behind pagination', async () => {
-        const octokit = fakeOctokit([pullRequest(), pullRequest({ number: 8 })]);
+        const octokit = fakeOctokit([pullRequest({ number: 7 }), pullRequest({ number: 8 })]);
         await expect(
             deriveTarget({
                 octokit,
@@ -105,10 +112,23 @@ describe('refreshTarget', () => {
     };
 
     it('reloads the current base and labels', async () => {
-        const octokit = fakeOctokit([], pullRequest({ labels: [{ name: 'bug' }] }));
+        // target starts on main/base123; the freshly fetched PR has been retargeted
+        // and relabelled, and refreshTarget must return the current values.
+        const current = pullRequest({
+            number: 7,
+            base: { ref: 'release', sha: 'base456', repo: { id: 1 } },
+            labels: [{ name: 'bug' }]
+        });
+        const octokit = fakeOctokit([], current);
         await expect(
             refreshTarget({ octokit, owner: 'lightly-ai', repo: 'lightly-studio', target })
-        ).resolves.toEqual({ ...target, labels: ['bug'] });
+        ).resolves.toEqual({
+            prNumber: 7,
+            headSha: HEAD_SHA,
+            baseRef: 'release',
+            baseSha: 'base456',
+            labels: ['bug']
+        });
     });
 
     it('rejects a target whose head changed before mutation', async () => {

--- a/fast_track/src/bot/derive-target.test.ts
+++ b/fast_track/src/bot/derive-target.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Octokit } from '../guardrails/context/types';
+import { deriveTarget, refreshTarget, type BotTarget } from './derive-target';
+
+const HEAD_SHA = 'abc123';
+
+function pullRequest(overrides: Record<string, unknown> = {}) {
+    return {
+        number: 7,
+        state: 'open',
+        draft: false,
+        labels: [],
+        head: { sha: HEAD_SHA, repo: { id: 1, fork: false } },
+        base: { ref: 'main', sha: 'base123', repo: { id: 1 } },
+        ...overrides
+    };
+}
+
+/**
+ * A fake Octokit whose `paginate` returns `pullRequests` (as the real one does
+ * after walking every page). `listPullRequestsAssociatedWithCommit` is a
+ * sentinel so a test can assert we hand *that* endpoint to `paginate`.
+ */
+function fakeOctokit(pullRequests: unknown[], current = pullRequest()): Octokit {
+    return {
+        paginate: vi.fn().mockResolvedValue(pullRequests),
+        rest: {
+            repos: { listPullRequestsAssociatedWithCommit: 'assoc-endpoint' },
+            pulls: { get: vi.fn().mockResolvedValue({ data: current }) }
+        }
+    } as unknown as Octokit;
+}
+
+function derive(pullRequests: unknown[]) {
+    return deriveTarget({
+        octokit: fakeOctokit(pullRequests),
+        owner: 'lightly-ai',
+        repo: 'lightly-studio',
+        trustedHeadSha: HEAD_SHA
+    });
+}
+
+describe('deriveTarget', () => {
+    it('returns the internal open PR bound to the trusted head', async () => {
+        await expect(derive([pullRequest()])).resolves.toEqual({
+            prNumber: 7,
+            headSha: HEAD_SHA,
+            baseRef: 'main',
+            baseSha: 'base123',
+            labels: []
+        });
+    });
+
+    it('refuses to guess when multiple internal PRs share the trusted head', async () => {
+        await expect(derive([pullRequest(), pullRequest({ number: 8 })])).resolves.toBeNull();
+    });
+
+    it('walks every page so a second candidate cannot hide behind pagination', async () => {
+        const octokit = fakeOctokit([pullRequest(), pullRequest({ number: 8 })]);
+        await expect(
+            deriveTarget({
+                octokit,
+                owner: 'lightly-ai',
+                repo: 'lightly-studio',
+                trustedHeadSha: HEAD_SHA
+            })
+        ).resolves.toBeNull();
+        expect(octokit.paginate).toHaveBeenCalledWith('assoc-endpoint', {
+            owner: 'lightly-ai',
+            repo: 'lightly-studio',
+            commit_sha: HEAD_SHA,
+            per_page: 100
+        });
+    });
+
+    it('ignores superseded, closed, and draft PRs', async () => {
+        await expect(
+            derive([pullRequest({ head: { sha: 'newer', repo: { id: 1, fork: false } } })])
+        ).resolves.toBeNull();
+        await expect(derive([pullRequest({ state: 'closed' })])).resolves.toBeNull();
+        await expect(derive([pullRequest({ draft: true })])).resolves.toBeNull();
+    });
+
+    it('refuses cross-repository, explicit, and deleted forks', async () => {
+        const crossRepo = pullRequest({ head: { sha: HEAD_SHA, repo: { id: 2, fork: false } } });
+        const explicitFork = pullRequest({
+            head: { sha: HEAD_SHA, repo: { id: 1, fork: true } }
+        });
+        const deletedFork = pullRequest({ head: { sha: HEAD_SHA, repo: null } });
+
+        await expect(derive([crossRepo])).resolves.toBeNull();
+        await expect(derive([explicitFork])).resolves.toBeNull();
+        await expect(derive([deletedFork])).resolves.toBeNull();
+    });
+});
+
+describe('refreshTarget', () => {
+    const target: BotTarget = {
+        prNumber: 7,
+        headSha: HEAD_SHA,
+        baseRef: 'main',
+        baseSha: 'base123',
+        labels: []
+    };
+
+    it('reloads the current base and labels', async () => {
+        const octokit = fakeOctokit([], pullRequest({ labels: [{ name: 'bug' }] }));
+        await expect(
+            refreshTarget({ octokit, owner: 'lightly-ai', repo: 'lightly-studio', target })
+        ).resolves.toEqual({ ...target, labels: ['bug'] });
+    });
+
+    it('rejects a target whose head changed before mutation', async () => {
+        const current = pullRequest({ head: { sha: 'newer', repo: { id: 1, fork: false } } });
+        const octokit = fakeOctokit([], current);
+        await expect(
+            refreshTarget({ octokit, owner: 'lightly-ai', repo: 'lightly-studio', target })
+        ).resolves.toBeNull();
+    });
+});

--- a/fast_track/src/bot/derive-target.ts
+++ b/fast_track/src/bot/derive-target.ts
@@ -1,0 +1,98 @@
+import type { Octokit } from '../guardrails/context/types';
+
+/** `listPullRequestsAssociatedWithCommit` caps per_page at 100. */
+const PER_PAGE = 100;
+
+export interface BotTarget {
+    prNumber: number;
+    headSha: string;
+    baseRef: string;
+    baseSha: string;
+    labels: string[];
+}
+
+interface DeriveTargetParams {
+    octokit: Octokit;
+    owner: string;
+    repo: string;
+    trustedHeadSha: string;
+}
+
+/**
+ * Find the pull request that the workflow_run head SHA belongs to, using
+ * GitHub as the source of truth. Returns the matching PR, or null when there
+ * is no safe target: no open PR at that exact head SHA, a draft, a fork, or
+ * more than one candidate.
+ */
+export async function deriveTarget(params: DeriveTargetParams): Promise<BotTarget | null> {
+    const { octokit, owner, repo, trustedHeadSha } = params;
+    // Walk every page: the "exactly one candidate" check below is a security
+    // invariant, so it must see all associated PRs, not just the first page.
+    const pullRequests = await octokit.paginate(
+        octokit.rest.repos.listPullRequestsAssociatedWithCommit,
+        { owner, repo, commit_sha: trustedHeadSha, per_page: PER_PAGE }
+    );
+
+    const eligiblePullRequests = pullRequests.filter(
+        (candidate) =>
+            candidate.state === 'open' &&
+            !candidate.draft &&
+            candidate.head.sha === trustedHeadSha &&
+            !isFork(candidate)
+    );
+    if (eligiblePullRequests.length !== 1) return null;
+    const [pullRequest] = eligiblePullRequests;
+    if (pullRequest === undefined) return null;
+
+    return toTarget(pullRequest);
+}
+
+/** Reload mutable PR state before the bot writes an approval or comment. */
+export async function refreshTarget(
+    params: Omit<DeriveTargetParams, 'trustedHeadSha'> & { target: BotTarget }
+): Promise<BotTarget | null> {
+    const { data: pullRequest } = await params.octokit.rest.pulls.get({
+        owner: params.owner,
+        repo: params.repo,
+        pull_number: params.target.prNumber
+    });
+    if (
+        pullRequest.state !== 'open' ||
+        pullRequest.draft ||
+        pullRequest.head.sha !== params.target.headSha ||
+        isFork(pullRequest)
+    ) {
+        return null;
+    }
+    return toTarget(pullRequest);
+}
+
+function toTarget(pullRequest: {
+    number: number;
+    head: { sha: string };
+    base: { ref: string; sha: string };
+    labels: Array<{ name?: string }>;
+}): BotTarget {
+    return {
+        prNumber: pullRequest.number,
+        headSha: pullRequest.head.sha,
+        baseRef: pullRequest.base.ref,
+        baseSha: pullRequest.base.sha,
+        labels: pullRequest.labels.flatMap((label) =>
+            label.name === undefined ? [] : [label.name]
+        )
+    };
+}
+
+function isFork(pullRequest: {
+    head: { repo: { fork?: boolean; id?: number } | null };
+    base: { repo: { id?: number } };
+}): boolean {
+    const headRepo = pullRequest.head.repo;
+    return (
+        headRepo === null ||
+        headRepo.fork === true ||
+        headRepo.id === undefined ||
+        headRepo.id !== pullRequest.base.repo.id
+    );
+}


### PR DESCRIPTION
## What has changed and why?

Second PR in the Fast Track bot series (follows #1681). Adds the bot's targeting layer: given the trusted `workflow_run` head SHA, resolve which pull request the verdict actually applies to, rather than trusting artifact-supplied routing.

`deriveTarget` accepts a PR only when exactly one open, non-draft, same-repository PR matches the head SHA; stale, draft, closed, fork, and ambiguous targets fail closed as a clean no-op. `refreshTarget` re-reads mutable PR state right before a write to close the check-then-act race window.

This is pure additive code under `src/bot/` and is not yet wired into any workflow — later PRs in the series consume it.

## How has it been tested?

`make -C fast_track static-checks` and `make -C fast_track test` both pass (16 files, 143 tests, including the new targeting suite).

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated, safety-checked pull request targeting for workflow runs, deriving a valid target from the trusted commit.
  * Ensures the chosen pull request is open, non-draft, matches the expected commit, and is not an invalid/forked source.
  * Refreshes target information at processing time and invalidates targets if the pull request no longer matches expectations.

* **Tests**
  * Added Vitest coverage for target derivation and refresh behavior, including pagination, labels, and rejection of superseded/closed/draft or mismatched targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->