### PR TITLE
Fast Track: manage bot approval reviews

### DIFF
--- a/fast_track/src/bot/review.test.ts
+++ b/fast_track/src/bot/review.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Octokit } from '../guardrails/context/types';
+import { approve, dismissApproval } from './review';
+
+const BOT_LOGIN = 'fast-track-bot[bot]';
+const HEAD_SHA = 'abc123';
+
+interface FakeReview {
+    id: number;
+    login: string;
+    state: string;
+    commitId: string;
+}
+
+function fakeOctokit(reviews: FakeReview[]) {
+    const listReviews = Symbol('listReviews');
+    const createReview = vi.fn().mockResolvedValue({});
+    const dismissReview = vi.fn().mockResolvedValue({});
+    const octokit = {
+        paginate: vi.fn().mockResolvedValue(
+            reviews.map((review) => ({
+                id: review.id,
+                user: { login: review.login },
+                state: review.state,
+                commit_id: review.commitId
+            }))
+        ),
+        rest: { pulls: { listReviews, createReview, dismissReview } }
+    } as unknown as Octokit;
+    return { octokit, createReview, dismissReview };
+}
+
+function params(octokit: Octokit) {
+    return {
+        octokit,
+        owner: 'lightly-ai',
+        repo: 'lightly-studio',
+        prNumber: 7,
+        headSha: HEAD_SHA,
+        botLogin: BOT_LOGIN
+    };
+}
+
+describe('approve', () => {
+    it('creates the first approval', async () => {
+        const fake = fakeOctokit([]);
+        await expect(approve(params(fake.octokit))).resolves.toBe('approved');
+        expect(fake.createReview).toHaveBeenCalledWith(
+            expect.objectContaining({ commit_id: HEAD_SHA, event: 'APPROVE' })
+        );
+    });
+
+    it('does nothing when the bot already approved the validated head', async () => {
+        const fake = fakeOctokit([
+            { id: 1, login: BOT_LOGIN, state: 'APPROVED', commitId: HEAD_SHA }
+        ]);
+        await expect(approve(params(fake.octokit))).resolves.toBe('noop');
+        expect(fake.createReview).not.toHaveBeenCalled();
+        expect(fake.dismissReview).not.toHaveBeenCalled();
+    });
+
+    it('refreshes an approval and dismisses the superseded one', async () => {
+        const fake = fakeOctokit([{ id: 1, login: BOT_LOGIN, state: 'APPROVED', commitId: 'old' }]);
+        await expect(approve(params(fake.octokit))).resolves.toBe('approved');
+        expect(fake.createReview).toHaveBeenCalledOnce();
+        expect(fake.dismissReview).toHaveBeenCalledWith(expect.objectContaining({ review_id: 1 }));
+    });
+
+    it('keeps only one approval when duplicate approvals exist for the current head', async () => {
+        const fake = fakeOctokit([
+            { id: 1, login: BOT_LOGIN, state: 'APPROVED', commitId: HEAD_SHA },
+            { id: 2, login: BOT_LOGIN, state: 'APPROVED', commitId: HEAD_SHA }
+        ]);
+        await expect(approve(params(fake.octokit))).resolves.toBe('noop');
+        expect(fake.createReview).not.toHaveBeenCalled();
+        expect(fake.dismissReview).toHaveBeenCalledOnce();
+    });
+});
+
+describe('dismissApproval', () => {
+    it('dismisses only the bot approval', async () => {
+        const fake = fakeOctokit([
+            { id: 1, login: BOT_LOGIN, state: 'APPROVED', commitId: HEAD_SHA },
+            { id: 2, login: 'human', state: 'APPROVED', commitId: HEAD_SHA },
+            { id: 3, login: BOT_LOGIN, state: 'COMMENTED', commitId: HEAD_SHA }
+        ]);
+        await expect(dismissApproval(params(fake.octokit))).resolves.toBe(1);
+        expect(fake.dismissReview).toHaveBeenCalledOnce();
+        expect(fake.dismissReview).toHaveBeenCalledWith(expect.objectContaining({ review_id: 1 }));
+    });
+});

--- a/fast_track/src/bot/review.test.ts
+++ b/fast_track/src/bot/review.test.ts
@@ -31,7 +31,7 @@ function fakeOctokit(reviews: FakeReview[]) {
     return { octokit, createReview, dismissReview };
 }
 
-function params(octokit: Octokit) {
+function buildReviewParams(octokit: Octokit) {
     return {
         octokit,
         owner: 'lightly-ai',
@@ -45,7 +45,7 @@ function params(octokit: Octokit) {
 describe('approve', () => {
     it('creates the first approval', async () => {
         const fake = fakeOctokit([]);
-        await expect(approve(params(fake.octokit))).resolves.toBe('approved');
+        await expect(approve(buildReviewParams(fake.octokit))).resolves.toBe('approved');
         expect(fake.createReview).toHaveBeenCalledWith(
             expect.objectContaining({ commit_id: HEAD_SHA, event: 'APPROVE' })
         );
@@ -55,14 +55,14 @@ describe('approve', () => {
         const fake = fakeOctokit([
             { id: 1, login: BOT_LOGIN, state: 'APPROVED', commitId: HEAD_SHA }
         ]);
-        await expect(approve(params(fake.octokit))).resolves.toBe('noop');
+        await expect(approve(buildReviewParams(fake.octokit))).resolves.toBe('noop');
         expect(fake.createReview).not.toHaveBeenCalled();
         expect(fake.dismissReview).not.toHaveBeenCalled();
     });
 
     it('refreshes an approval and dismisses the superseded one', async () => {
         const fake = fakeOctokit([{ id: 1, login: BOT_LOGIN, state: 'APPROVED', commitId: 'old' }]);
-        await expect(approve(params(fake.octokit))).resolves.toBe('approved');
+        await expect(approve(buildReviewParams(fake.octokit))).resolves.toBe('approved');
         expect(fake.createReview).toHaveBeenCalledOnce();
         expect(fake.dismissReview).toHaveBeenCalledWith(expect.objectContaining({ review_id: 1 }));
     });
@@ -72,7 +72,7 @@ describe('approve', () => {
             { id: 1, login: BOT_LOGIN, state: 'APPROVED', commitId: HEAD_SHA },
             { id: 2, login: BOT_LOGIN, state: 'APPROVED', commitId: HEAD_SHA }
         ]);
-        await expect(approve(params(fake.octokit))).resolves.toBe('noop');
+        await expect(approve(buildReviewParams(fake.octokit))).resolves.toBe('noop');
         expect(fake.createReview).not.toHaveBeenCalled();
         expect(fake.dismissReview).toHaveBeenCalledOnce();
     });
@@ -85,7 +85,7 @@ describe('dismissApproval', () => {
             { id: 2, login: 'human', state: 'APPROVED', commitId: HEAD_SHA },
             { id: 3, login: BOT_LOGIN, state: 'COMMENTED', commitId: HEAD_SHA }
         ]);
-        await expect(dismissApproval(params(fake.octokit))).resolves.toBe(1);
+        await expect(dismissApproval(buildReviewParams(fake.octokit))).resolves.toBe(1);
         expect(fake.dismissReview).toHaveBeenCalledOnce();
         expect(fake.dismissReview).toHaveBeenCalledWith(expect.objectContaining({ review_id: 1 }));
     });

--- a/fast_track/src/bot/review.ts
+++ b/fast_track/src/bot/review.ts
@@ -1,0 +1,73 @@
+import type { Octokit } from '../guardrails/context/types';
+
+const DISMISS_MESSAGE = 'Fast Track checks no longer pass; dismissing the bot approval.';
+const SUPERSEDED_MESSAGE = 'Superseded by a newer Fast Track approval.';
+
+interface ReviewParams {
+    octokit: Octokit;
+    owner: string;
+    repo: string;
+    prNumber: number;
+    botLogin: string;
+}
+
+interface ApproveParams extends ReviewParams {
+    headSha: string;
+}
+
+/** Keep exactly one active bot approval, bound to the validated head. */
+export async function approve(params: ApproveParams): Promise<'approved' | 'noop'> {
+    const reviews = await listBotApprovals(params);
+    const current = reviews.find((review) => review.commit_id === params.headSha);
+
+    if (current === undefined) {
+        await params.octokit.rest.pulls.createReview({
+            owner: params.owner,
+            repo: params.repo,
+            pull_number: params.prNumber,
+            commit_id: params.headSha,
+            event: 'APPROVE'
+        });
+    }
+
+    await dismissReviews(
+        params,
+        reviews.filter((review) => review !== current),
+        SUPERSEDED_MESSAGE
+    );
+    return current === undefined ? 'approved' : 'noop';
+}
+
+/** Dismiss only the App's active approvals, never a human review. */
+export async function dismissApproval(params: ReviewParams): Promise<number> {
+    const reviews = await listBotApprovals(params);
+    await dismissReviews(params, reviews, DISMISS_MESSAGE);
+    return reviews.length;
+}
+
+async function listBotApprovals(params: ReviewParams) {
+    const reviews = await params.octokit.paginate(params.octokit.rest.pulls.listReviews, {
+        owner: params.owner,
+        repo: params.repo,
+        pull_number: params.prNumber
+    });
+    return reviews.filter(
+        (review) => review.user?.login === params.botLogin && review.state === 'APPROVED'
+    );
+}
+
+async function dismissReviews(
+    params: ReviewParams,
+    reviews: Awaited<ReturnType<typeof listBotApprovals>>,
+    message: string
+): Promise<void> {
+    for (const review of reviews) {
+        await params.octokit.rest.pulls.dismissReview({
+            owner: params.owner,
+            repo: params.repo,
+            pull_number: params.prNumber,
+            review_id: review.id,
+            message
+        });
+    }
+}


### PR DESCRIPTION
## What has changed and why?

Part of the Fast Track Bot (LIG-10099), shipped as a series of small PRs.

This PR adds the review-management module (`fast_track/src/bot/review.ts`) that lets the bot manage its own approval on a pull request idempotently:

- **`approve`** keeps exactly one active bot approval, bound to the validated head SHA. If an approval for the current head already exists it is a no-op; otherwise it creates one. Any older bot approvals for other commits are dismissed as superseded.
- **`dismissApproval`** dismisses only the App's own active approvals when Fast Track checks no longer pass.
- Both operations only ever touch reviews authored by the bot login and in the `APPROVED` state, so human reviews and comments are never modified.

This module is standalone: it imports only `Octokit` from the guardrails context types and is consumed by later PRs (the fail-closed orchestrator).

## How has it been tested?

- `make -C fast_track static-checks`
- `make -C fast_track test` — all tests pass, including the new `src/bot/review.test.ts` covering approve/no-op/supersede and bot-only dismissal.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bot-managed pull request approval handling.
  * The bot now creates exactly one active approval per pull request head SHA and refreshes it when superseded.
  * If an approval already exists for the current validated head, the bot performs no changes.
  * Added the ability to dismiss only the bot’s active approvals when they’re no longer valid.

* **Tests**
  * Added automated test coverage for approving, reusing, refreshing, and deduplicating bot approvals.
  * Added tests confirming dismissal targets only bot approval reviews (not human or other bot reviews).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->