### PR TITLE
Fast Track: maintain one status comment

### DIFF
--- a/fast_track/src/bot/comment.test.ts
+++ b/fast_track/src/bot/comment.test.ts
@@ -96,4 +96,14 @@ describe('upsertComment', () => {
         await expect(upsert(fake.octokit)).resolves.toBe('noop');
         expect(fake.updateComment).not.toHaveBeenCalled();
     });
+
+    it('ignores comments from other authors and unmarked bot comments', async () => {
+        const fake = fakeOctokit([
+            { id: 1, login: 'a-human', body: `${MARKER}\nlooks like ours but is not` },
+            { id: 2, login: BOT_LOGIN, body: 'an unmarked bot comment' }
+        ]);
+        await expect(upsert(fake.octokit)).resolves.toBe('created');
+        expect(fake.createComment).toHaveBeenCalled();
+        expect(fake.updateComment).not.toHaveBeenCalled();
+    });
 });

--- a/fast_track/src/bot/comment.test.ts
+++ b/fast_track/src/bot/comment.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Octokit } from '../guardrails/context/types';
+import type { Verdict } from '../shared/verdict';
+import { renderComment, upsertComment } from './comment';
+
+const BOT_LOGIN = 'fast-track-bot[bot]';
+const HEAD_SHA = 'abc1234def';
+const MARKER = '<!-- fast-track-bot -->';
+
+function verdict(overrides: Partial<Verdict> = {}): Verdict {
+    return {
+        verdict: 'pass',
+        guardrails: [{ name: 'dummy', status: 'pass', summary: 'ok' }],
+        pr_number: 7,
+        head_sha: HEAD_SHA,
+        base_ref: 'main',
+        base_sha: 'base123',
+        ...overrides
+    };
+}
+
+describe('renderComment', () => {
+    it('renders pass, fail, and opt-out states', () => {
+        expect(renderComment(verdict(), HEAD_SHA)).toContain('✅ Fast Track');
+        expect(renderComment(verdict({ verdict: 'fail', reason: 'failed' }), HEAD_SHA)).toContain(
+            '❌ Fast Track: checks did not pass\n\nfailed'
+        );
+        expect(
+            renderComment(
+                verdict({ verdict: 'opt_out', reason: 'Author opted out.', guardrails: [] }),
+                HEAD_SHA
+            )
+        ).toContain('⏭️ Fast Track skipped');
+    });
+
+    it('renders guardrails safely in a Markdown table', () => {
+        const body = renderComment(
+            verdict({
+                guardrails: [{ name: 'lint|check', status: 'fail', summary: 'one\ntwo|three' }]
+            }),
+            HEAD_SHA
+        );
+        expect(body).toContain('| lint\\|check | ❌ | one two\\|three |');
+        expect(body).toContain('<sub>Reflects `abc1234`.</sub>');
+    });
+});
+
+function fakeOctokit(comments: Array<{ id: number; login: string; body: string }>) {
+    const listComments = Symbol('listComments');
+    const createComment = vi.fn().mockResolvedValue({});
+    const updateComment = vi.fn().mockResolvedValue({});
+    const octokit = {
+        paginate: vi.fn().mockResolvedValue(
+            comments.map((comment) => ({
+                id: comment.id,
+                user: { login: comment.login },
+                body: comment.body
+            }))
+        ),
+        rest: { issues: { listComments, createComment, updateComment } }
+    } as unknown as Octokit;
+    return { octokit, createComment, updateComment };
+}
+
+function upsert(octokit: Octokit) {
+    return upsertComment({
+        octokit,
+        owner: 'lightly-ai',
+        repo: 'lightly-studio',
+        prNumber: 7,
+        botLogin: BOT_LOGIN,
+        body: 'new status'
+    });
+}
+
+describe('upsertComment', () => {
+    it('creates the first marked comment', async () => {
+        const fake = fakeOctokit([]);
+        await expect(upsert(fake.octokit)).resolves.toBe('created');
+        expect(fake.createComment).toHaveBeenCalledWith(
+            expect.objectContaining({ body: `${MARKER}\nnew status` })
+        );
+    });
+
+    it('updates the existing marked bot comment', async () => {
+        const fake = fakeOctokit([{ id: 3, login: BOT_LOGIN, body: `${MARKER}\nold status` }]);
+        await expect(upsert(fake.octokit)).resolves.toBe('updated');
+        expect(fake.updateComment).toHaveBeenCalledWith(
+            expect.objectContaining({ comment_id: 3, body: `${MARKER}\nnew status` })
+        );
+    });
+
+    it('does not edit an identical comment', async () => {
+        const fake = fakeOctokit([{ id: 3, login: BOT_LOGIN, body: `${MARKER}\nnew status` }]);
+        await expect(upsert(fake.octokit)).resolves.toBe('noop');
+        expect(fake.updateComment).not.toHaveBeenCalled();
+    });
+});

--- a/fast_track/src/bot/comment.ts
+++ b/fast_track/src/bot/comment.ts
@@ -40,11 +40,10 @@ export function renderComment(verdict: Verdict, headSha: string): string {
     return lines.join('\n');
 }
 
-/** Create or edit the App's marked comment, leaving all other comments alone. */
-export async function upsertComment(
+/** Find the App's existing marked comment, or `undefined` if it has none yet. */
+async function findBotComment(
     params: UpsertCommentParams
-): Promise<'created' | 'updated' | 'noop'> {
-    const fullBody = `${COMMENT_MARKER}\n${params.body}`;
+): Promise<{ id: number; body: string } | undefined> {
     const comments = await params.octokit.paginate(params.octokit.rest.issues.listComments, {
         owner: params.owner,
         repo: params.repo,
@@ -55,6 +54,15 @@ export async function upsertComment(
             comment.user?.login === params.botLogin &&
             (comment.body ?? '').startsWith(COMMENT_MARKER)
     );
+    return existing === undefined ? undefined : { id: existing.id, body: existing.body ?? '' };
+}
+
+/** Create or edit the App's marked comment, leaving all other comments alone. */
+export async function upsertComment(
+    params: UpsertCommentParams
+): Promise<'created' | 'updated' | 'noop'> {
+    const fullBody = `${COMMENT_MARKER}\n${params.body}`;
+    const existing = await findBotComment(params);
 
     if (existing === undefined) {
         await params.octokit.rest.issues.createComment({

--- a/fast_track/src/bot/comment.ts
+++ b/fast_track/src/bot/comment.ts
@@ -42,7 +42,7 @@ export function renderComment(verdict: Verdict, headSha: string): string {
 
 /** Find the App's existing marked comment, or `undefined` if it has none yet. */
 async function findBotComment(
-    params: UpsertCommentParams
+    params: Pick<UpsertCommentParams, 'octokit' | 'owner' | 'repo' | 'prNumber' | 'botLogin'>
 ): Promise<{ id: number; body: string } | undefined> {
     const comments = await params.octokit.paginate(params.octokit.rest.issues.listComments, {
         owner: params.owner,

--- a/fast_track/src/bot/comment.ts
+++ b/fast_track/src/bot/comment.ts
@@ -1,0 +1,81 @@
+import type { Octokit } from '../guardrails/context/types';
+import type { Verdict } from '../shared/verdict';
+
+const COMMENT_MARKER = '<!-- fast-track-bot -->';
+const HEADLINES: Record<Verdict['verdict'], string> = {
+    pass: '✅ Fast Track: all required checks passed — auto-approved.',
+    fail: '❌ Fast Track: checks did not pass',
+    opt_out: '⏭️ Fast Track skipped — deferring to human review'
+};
+
+interface UpsertCommentParams {
+    octokit: Octokit;
+    owner: string;
+    repo: string;
+    prNumber: number;
+    botLogin: string;
+    body: string;
+}
+
+/** Render the human-visible part of the bot's single status comment. */
+export function renderComment(verdict: Verdict, headSha: string): string {
+    const lines = [`### ${HEADLINES[verdict.verdict]}`];
+    if (verdict.verdict !== 'pass' && verdict.reason !== undefined) {
+        lines.push('', verdict.reason);
+    }
+
+    if (verdict.guardrails.length === 0) {
+        lines.push('', '_No guardrails were run._');
+    } else {
+        lines.push('', '| Guardrail | Result | Message |', '|---|---|---|');
+        for (const guardrail of verdict.guardrails) {
+            const icon = guardrail.status === 'pass' ? '✅' : '❌';
+            lines.push(
+                `| ${escapeCell(guardrail.name)} | ${icon} | ${escapeCell(guardrail.summary)} |`
+            );
+        }
+    }
+
+    lines.push('', `<sub>Reflects \`${headSha.slice(0, 7)}\`.</sub>`);
+    return lines.join('\n');
+}
+
+/** Create or edit the App's marked comment, leaving all other comments alone. */
+export async function upsertComment(
+    params: UpsertCommentParams
+): Promise<'created' | 'updated' | 'noop'> {
+    const fullBody = `${COMMENT_MARKER}\n${params.body}`;
+    const comments = await params.octokit.paginate(params.octokit.rest.issues.listComments, {
+        owner: params.owner,
+        repo: params.repo,
+        issue_number: params.prNumber
+    });
+    const existing = comments.find(
+        (comment) =>
+            comment.user?.login === params.botLogin &&
+            (comment.body ?? '').startsWith(COMMENT_MARKER)
+    );
+
+    if (existing === undefined) {
+        await params.octokit.rest.issues.createComment({
+            owner: params.owner,
+            repo: params.repo,
+            issue_number: params.prNumber,
+            body: fullBody
+        });
+        return 'created';
+    }
+    if (existing.body === fullBody) return 'noop';
+
+    await params.octokit.rest.issues.updateComment({
+        owner: params.owner,
+        repo: params.repo,
+        comment_id: existing.id,
+        body: fullBody
+    });
+    return 'updated';
+}
+
+function escapeCell(value: string): string {
+    return value.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+}


### PR DESCRIPTION
## What has changed and why?

Adds the Fast Track bot's status-comment layer: a single, bot-owned PR comment that reports the current guardrail verdict.

- `renderComment` builds the human-visible body — a headline for `pass`/`fail`/`opt_out`, an optional reason for non-pass verdicts, a per-guardrail results table, and a footer noting the reflected head SHA.
- `upsertComment` maintains exactly one comment: it finds the App's existing comment via a hidden marker plus author login, creates it if absent, and otherwise updates it — skipping the write entirely (`noop`) when the rendered body is unchanged. Comments authored by anyone else are never touched.

This is one step of the Fast Track bot (LIG-10099); it has no runtime effect until the orchestrator and workflow wire it up in later PRs.

## How has it been tested?

`make -C fast_track static-checks` and `make -C fast_track test` both pass. New unit tests in `comment.test.ts` cover rendering per verdict state and the create/update/noop upsert paths.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated status comments for each run, including pass/fail/skipped outcomes.
  * Displays guardrail results in a safe, readable Markdown table (or a “no guardrails ran” message).
  * Includes a short commit SHA reference in the comment for quick traceability.
  * Creates the bot comment when missing and updates it only when the content changes (avoiding duplicates).
* **Tests**
  * Added test coverage for rendering (including failure reasons and skipped markers) and for create/update/no-op upsert behavior, including ignoring unrelated comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->