### PR TITLE
Add getThumbnailData for AnnotationClassificationGridItem

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/getThumbnailData.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/getThumbnailData.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+    SampleType,
+    type AnnotationWithPayloadView,
+    type ImageAnnotationView,
+    type VideoFrameAnnotationView
+} from '$lib/api/lightly_studio_local';
+
+import { getThumbnailUrl, getSampleDimensions } from './getThumbnailData';
+
+vi.mock('$env/static/public', () => ({
+    PUBLIC_SAMPLES_URL: 'https://example.com/images',
+    PUBLIC_VIDEOS_FRAMES_MEDIA_URL: 'https://example.com/frames'
+}));
+
+const imageAnnotation: AnnotationWithPayloadView = {
+    parent_sample_type: SampleType.IMAGE,
+    annotation: {} as AnnotationWithPayloadView['annotation'],
+    parent_sample_data: {
+        sample_id: 'img-1',
+        file_path_abs: '/path/to/img.jpg',
+        width: 1920,
+        height: 1080,
+        sample: {} as ImageAnnotationView['sample']
+    } as ImageAnnotationView
+};
+
+const videoFrameAnnotation: AnnotationWithPayloadView = {
+    parent_sample_type: SampleType.VIDEO_FRAME,
+    annotation: {} as AnnotationWithPayloadView['annotation'],
+    parent_sample_data: {
+        sample_id: 'frame-1',
+        video: {
+            width: 1280,
+            height: 720,
+            file_path_abs: '/path/to/video.mp4'
+        }
+    } as VideoFrameAnnotationView
+};
+
+describe('getThumbnailUrl', () => {
+    test('returns image URL for image annotation', () => {
+        const url = getThumbnailUrl({
+            annotation: imageAnnotation,
+            quality: 'raw',
+            containerWidth: 200,
+            containerHeight: 150,
+            cachedCollectionVersion: 'v1'
+        });
+        expect(url).toBe('https://example.com/images/sample/img-1?v=v1');
+    });
+
+    test('returns video frame URL for video frame annotation', () => {
+        const url = getThumbnailUrl({
+            annotation: videoFrameAnnotation,
+            quality: 'raw',
+            containerWidth: 200,
+            containerHeight: 150,
+            cachedCollectionVersion: 'v1'
+        });
+        expect(url).toBe('https://example.com/frames/frame-1');
+    });
+
+    test('includes quality params for high quality image', () => {
+        vi.stubGlobal('window', { devicePixelRatio: 1 });
+        const url = getThumbnailUrl({
+            annotation: imageAnnotation,
+            quality: 'high',
+            containerWidth: 200,
+            containerHeight: 150,
+            cachedCollectionVersion: 'v2'
+        });
+        expect(url).toBe(
+            'https://example.com/images/sample/img-1?v=v2&quality=high&max_width=200&max_height=150'
+        );
+        vi.unstubAllGlobals();
+    });
+
+    test('includes quality params for high quality video frame', () => {
+        vi.stubGlobal('window', { devicePixelRatio: 1 });
+        const url = getThumbnailUrl({
+            annotation: videoFrameAnnotation,
+            quality: 'high',
+            containerWidth: 200,
+            containerHeight: 150,
+            cachedCollectionVersion: 'v2'
+        });
+        expect(url).toBe(
+            'https://example.com/frames/frame-1?quality=high&max_width=200&max_height=150'
+        );
+        vi.unstubAllGlobals();
+    });
+});
+
+describe('getSampleDimensions', () => {
+    test('returns image dimensions for image annotation', () => {
+        expect(getSampleDimensions(imageAnnotation)).toEqual({ width: 1920, height: 1080 });
+    });
+
+    test('returns video dimensions for video frame annotation', () => {
+        expect(getSampleDimensions(videoFrameAnnotation)).toEqual({ width: 1280, height: 720 });
+    });
+});

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/getThumbnailData.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/getThumbnailData.ts
@@ -1,0 +1,59 @@
+import {
+    SampleType,
+    type AnnotationWithPayloadView,
+    type ImageAnnotationView,
+    type VideoFrameAnnotationView
+} from '$lib/api/lightly_studio_local';
+import { getGridImageURL, getGridFrameURL, getGridThumbnailRequestSize } from '$lib/utils';
+
+type GridThumbnailQuality = Parameters<typeof getGridImageURL>[0]['quality'];
+
+type GetThumbnailUrlParams = {
+    annotation: AnnotationWithPayloadView;
+    quality: GridThumbnailQuality;
+    containerWidth: number;
+    containerHeight: number;
+    cachedCollectionVersion: string;
+};
+
+export function getThumbnailUrl({
+    annotation,
+    quality,
+    containerWidth,
+    containerHeight,
+    cachedCollectionVersion
+}: GetThumbnailUrlParams): string {
+    const dpr = globalThis.window?.devicePixelRatio || 1;
+    const renderedWidth = getGridThumbnailRequestSize(containerWidth, dpr);
+    const renderedHeight = getGridThumbnailRequestSize(containerHeight, dpr);
+    if (annotation.parent_sample_type === SampleType.IMAGE) {
+        const image = annotation.parent_sample_data as ImageAnnotationView;
+        return getGridImageURL({
+            sampleId: image.sample_id,
+            quality,
+            renderedWidth,
+            renderedHeight,
+            cacheBuster: cachedCollectionVersion
+        });
+    }
+    const frame = annotation.parent_sample_data as VideoFrameAnnotationView;
+    return getGridFrameURL({
+        sampleId: frame.sample_id,
+        quality,
+        renderedWidth,
+        renderedHeight
+    });
+}
+
+// CropWindow is expressed in original sample coordinates
+export function getSampleDimensions(annotation: AnnotationWithPayloadView): {
+    width: number;
+    height: number;
+} {
+    if (annotation.parent_sample_type === SampleType.IMAGE) {
+        const image = annotation.parent_sample_data as ImageAnnotationView;
+        return { width: image.width, height: image.height };
+    }
+    const frame = annotation.parent_sample_data as VideoFrameAnnotationView;
+    return { width: frame.video.width, height: frame.video.height };
+}

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/getThumbnailData.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/getThumbnailData.ts
@@ -1,6 +1,5 @@
 import {
     SampleType,
-    type AnnotationWithPayloadView,
     type ImageAnnotationView,
     type VideoFrameAnnotationView
 } from '$lib/api/lightly_studio_local';
@@ -8,13 +7,48 @@ import { getGridImageURL, getGridFrameURL, getGridThumbnailRequestSize } from '$
 
 type GridThumbnailQuality = Parameters<typeof getGridImageURL>[0]['quality'];
 
+interface AnnotationSampleData {
+    parent_sample_type: string;
+    parent_sample_data: ImageAnnotationView | VideoFrameAnnotationView;
+}
+
 type GetThumbnailUrlParams = {
-    annotation: AnnotationWithPayloadView;
+    annotation: AnnotationSampleData;
     quality: GridThumbnailQuality;
     containerWidth: number;
     containerHeight: number;
     cachedCollectionVersion: string;
 };
+
+interface SampleDimensions {
+    width: number;
+    height: number;
+}
+
+function getImageThumbnailUrl(
+    image: ImageAnnotationView,
+    quality: GridThumbnailQuality,
+    renderedWidth: number,
+    renderedHeight: number,
+    cachedCollectionVersion: string
+): string {
+    return getGridImageURL({
+        sampleId: image.sample_id,
+        quality,
+        renderedWidth,
+        renderedHeight,
+        cacheBuster: cachedCollectionVersion
+    });
+}
+
+function getFrameThumbnailUrl(
+    frame: VideoFrameAnnotationView,
+    quality: GridThumbnailQuality,
+    renderedWidth: number,
+    renderedHeight: number
+): string {
+    return getGridFrameURL({ sampleId: frame.sample_id, quality, renderedWidth, renderedHeight });
+}
 
 export function getThumbnailUrl({
     annotation,
@@ -27,29 +61,24 @@ export function getThumbnailUrl({
     const renderedWidth = getGridThumbnailRequestSize(containerWidth, dpr);
     const renderedHeight = getGridThumbnailRequestSize(containerHeight, dpr);
     if (annotation.parent_sample_type === SampleType.IMAGE) {
-        const image = annotation.parent_sample_data as ImageAnnotationView;
-        return getGridImageURL({
-            sampleId: image.sample_id,
+        return getImageThumbnailUrl(
+            annotation.parent_sample_data as ImageAnnotationView,
             quality,
             renderedWidth,
             renderedHeight,
-            cacheBuster: cachedCollectionVersion
-        });
+            cachedCollectionVersion
+        );
     }
-    const frame = annotation.parent_sample_data as VideoFrameAnnotationView;
-    return getGridFrameURL({
-        sampleId: frame.sample_id,
+    return getFrameThumbnailUrl(
+        annotation.parent_sample_data as VideoFrameAnnotationView,
         quality,
         renderedWidth,
         renderedHeight
-    });
+    );
 }
 
 // CropWindow is expressed in original sample coordinates
-export function getSampleDimensions(annotation: AnnotationWithPayloadView): {
-    width: number;
-    height: number;
-} {
+export function getSampleDimensions(annotation: AnnotationSampleData): SampleDimensions {
     if (annotation.parent_sample_type === SampleType.IMAGE) {
         const image = annotation.parent_sample_data as ImageAnnotationView;
         return { width: image.width, height: image.height };


### PR DESCRIPTION
## What has changed and why?

Stacks on lightly-ai/lightly-studio#1680, which introduced `AnnotationClassificationGridItem` and extracted thumbnail URL and sample dimension logic into a standalone `getThumbnailData.ts` module.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added thumbnail URL generation for image and video-frame annotations in the annotation grid.
  * Implemented high-quality, DPR-aware thumbnail sizing (width/height query parameters).
  * Added retrieval of original sample dimensions for annotations.
* **Tests**
  * Added automated tests validating thumbnail URL construction (including cache-busting and quality parameters) and correct dimension extraction for both image and video-frame annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->