### PR TITLE
Fast Track: apply verdicts fail closed

### DIFF
--- a/fast_track/src/bot/run-bot.test.ts
+++ b/fast_track/src/bot/run-bot.test.ts
@@ -36,6 +36,7 @@ interface FakeOptions {
     existingApproval?: boolean;
     currentPullRequests?: unknown[];
     associatedPullRequests?: unknown[];
+    failPostApprovalRefresh?: boolean;
 }
 
 function fakeOctokit(options: FakeOptions = {}) {
@@ -76,9 +77,13 @@ function fakeOctokit(options: FakeOptions = {}) {
             },
             pulls: {
                 get: vi.fn().mockImplementation(async () => {
-                    const value =
-                        currentPullRequests[Math.min(getCall, currentPullRequests.length - 1)];
+                    const call = getCall;
                     getCall += 1;
+                    if (options.failPostApprovalRefresh && call === 1) {
+                        throw new Error('transient GitHub API failure');
+                    }
+                    const value =
+                        currentPullRequests[Math.min(call, currentPullRequests.length - 1)];
                     return { data: value };
                 }),
                 listReviews,
@@ -145,6 +150,14 @@ describe('runBot', () => {
             head: { sha: 'newer', repo: { id: 1, fork: false } }
         });
         const execution = run(verdict(), { currentPullRequests: [pullRequest(), newer] });
+        await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
+        expect(execution.createReview).toHaveBeenCalledOnce();
+        expect(execution.dismissReview).toHaveBeenCalledOnce();
+        expect(execution.createComment).not.toHaveBeenCalled();
+    });
+
+    it('dismisses the approval if the post-approval refresh fails', async () => {
+        const execution = run(verdict(), { failPostApprovalRefresh: true });
         await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
         expect(execution.createReview).toHaveBeenCalledOnce();
         expect(execution.dismissReview).toHaveBeenCalledOnce();

--- a/fast_track/src/bot/run-bot.test.ts
+++ b/fast_track/src/bot/run-bot.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Octokit } from '../guardrails/context/types';
+import { OPT_OUT_LABEL } from '../guardrails/author-opt-out';
+import type { Verdict } from '../shared/verdict';
+import { runBot } from './run-bot';
+
+const HEAD_SHA = 'abc123';
+const BOT_LOGIN = 'fast-track-bot[bot]';
+
+function verdict(overrides: Partial<Verdict> = {}): Verdict {
+    return {
+        verdict: 'pass',
+        guardrails: [{ name: 'dummy', status: 'pass', summary: 'ok' }],
+        pr_number: 7,
+        head_sha: HEAD_SHA,
+        base_ref: 'main',
+        base_sha: 'base123',
+        ...overrides
+    };
+}
+
+function pullRequest(overrides: Record<string, unknown> = {}) {
+    return {
+        number: 7,
+        state: 'open',
+        draft: false,
+        labels: [],
+        head: { sha: HEAD_SHA, repo: { id: 1, fork: false } },
+        base: { ref: 'main', sha: 'base123', repo: { id: 1 } },
+        ...overrides
+    };
+}
+
+interface FakeOptions {
+    existingApproval?: boolean;
+    currentPullRequests?: unknown[];
+    associatedPullRequests?: unknown[];
+}
+
+function fakeOctokit(options: FakeOptions = {}) {
+    const listReviews = Symbol('listReviews');
+    const listComments = Symbol('listComments');
+    const listAssociated = Symbol('listAssociated');
+    const reviews = options.existingApproval
+        ? [{ id: 1, user: { login: BOT_LOGIN }, state: 'APPROVED', commit_id: HEAD_SHA }]
+        : [];
+    const currentPullRequests = options.currentPullRequests ?? [pullRequest()];
+    const associatedPullRequests = options.associatedPullRequests ?? [pullRequest()];
+    let getCall = 0;
+
+    const createReview = vi.fn().mockImplementation(async () => {
+        reviews.push({
+            id: reviews.length + 1,
+            user: { login: BOT_LOGIN },
+            state: 'APPROVED',
+            commit_id: HEAD_SHA
+        });
+    });
+    const dismissReview = vi.fn().mockImplementation(async ({ review_id }) => {
+        const review = reviews.find((candidate) => candidate.id === review_id);
+        if (review !== undefined) review.state = 'DISMISSED';
+    });
+    const createComment = vi.fn().mockResolvedValue({});
+    const octokit = {
+        paginate: vi.fn().mockImplementation(async (route: symbol) => {
+            if (route === listReviews)
+                return reviews.filter((review) => review.state === 'APPROVED');
+            if (route === listComments) return [];
+            if (route === listAssociated) return associatedPullRequests;
+            return [];
+        }),
+        rest: {
+            repos: {
+                listPullRequestsAssociatedWithCommit: listAssociated
+            },
+            pulls: {
+                get: vi.fn().mockImplementation(async () => {
+                    const value =
+                        currentPullRequests[Math.min(getCall, currentPullRequests.length - 1)];
+                    getCall += 1;
+                    return { data: value };
+                }),
+                listReviews,
+                createReview,
+                dismissReview
+            },
+            issues: {
+                listComments,
+                createComment,
+                updateComment: vi.fn().mockResolvedValue({})
+            }
+        }
+    } as unknown as Octokit;
+    return { octokit, createReview, dismissReview, createComment };
+}
+
+function run(value: unknown, options: FakeOptions & { guardrailsSucceeded?: boolean } = {}) {
+    const fake = fakeOctokit(options);
+    return {
+        result: runBot({
+            octokit: fake.octokit,
+            owner: 'lightly-ai',
+            repo: 'lightly-studio',
+            trustedHeadSha: HEAD_SHA,
+            botLogin: BOT_LOGIN,
+            guardrailsSucceeded: options.guardrailsSucceeded ?? true,
+            requiredGuardrailNames: ['dummy'],
+            verdict: value
+        }),
+        ...fake
+    };
+}
+
+describe('runBot', () => {
+    it('approves and comments on a current pass', async () => {
+        const execution = run(verdict());
+        await expect(execution.result).resolves.toEqual({ status: 'approved', prNumber: 7 });
+        expect(execution.createReview).toHaveBeenCalledOnce();
+        expect(execution.createComment).toHaveBeenCalledOnce();
+    });
+
+    it('dismisses an existing approval on a failure verdict', async () => {
+        const execution = run(verdict({ verdict: 'fail', reason: 'Human review required.' }), {
+            existingApproval: true
+        });
+        await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
+        expect(execution.dismissReview).toHaveBeenCalledOnce();
+        expect(execution.createComment).toHaveBeenCalledOnce();
+    });
+
+    it('uses the current opt-out label instead of a stale pass artifact', async () => {
+        const current = pullRequest({ labels: [{ name: OPT_OUT_LABEL }] });
+        const execution = run(verdict(), {
+            existingApproval: true,
+            currentPullRequests: [current]
+        });
+        await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
+        expect(execution.createReview).not.toHaveBeenCalled();
+        expect(execution.dismissReview).toHaveBeenCalledOnce();
+    });
+
+    it('revokes a pass approval if the head changes during the run', async () => {
+        const newer = pullRequest({
+            head: { sha: 'newer', repo: { id: 1, fork: false } }
+        });
+        const execution = run(verdict(), { currentPullRequests: [pullRequest(), newer] });
+        await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
+        expect(execution.createReview).toHaveBeenCalledOnce();
+        expect(execution.dismissReview).toHaveBeenCalledOnce();
+        expect(execution.createComment).not.toHaveBeenCalled();
+    });
+
+    it('skips when no eligible PR matches the trusted head', async () => {
+        const execution = run(verdict(), { associatedPullRequests: [] });
+        await expect(execution.result).resolves.toEqual({
+            status: 'skipped',
+            reason: 'No eligible PR matched the trusted workflow run.'
+        });
+        expect(execution.createReview).not.toHaveBeenCalled();
+        expect(execution.dismissReview).not.toHaveBeenCalled();
+    });
+});

--- a/fast_track/src/bot/run-bot.test.ts
+++ b/fast_track/src/bot/run-bot.test.ts
@@ -32,11 +32,15 @@ function pullRequest(overrides: Record<string, unknown> = {}) {
     };
 }
 
+type PullRead = { pr?: unknown; throws?: boolean };
+
 interface FakeOptions {
     existingApproval?: boolean;
-    currentPullRequests?: unknown[];
     associatedPullRequests?: unknown[];
-    failPostApprovalRefresh?: boolean;
+    // pulls.get fires twice: reloading the target before approving, then
+    // re-checking it afterward. Each read returns a PR or throws.
+    reloadBeforeApprove?: PullRead;
+    recheckAfterApprove?: PullRead;
 }
 
 function fakeOctokit(options: FakeOptions = {}) {
@@ -46,8 +50,11 @@ function fakeOctokit(options: FakeOptions = {}) {
     const reviews = options.existingApproval
         ? [{ id: 1, user: { login: BOT_LOGIN }, state: 'APPROVED', commit_id: HEAD_SHA }]
         : [];
-    const currentPullRequests = options.currentPullRequests ?? [pullRequest()];
     const associatedPullRequests = options.associatedPullRequests ?? [pullRequest()];
+    const pullReads: PullRead[] = [
+        options.reloadBeforeApprove ?? { pr: pullRequest() },
+        options.recheckAfterApprove ?? { pr: pullRequest() }
+    ];
     let getCall = 0;
 
     const createReview = vi.fn().mockImplementation(async () => {
@@ -77,14 +84,10 @@ function fakeOctokit(options: FakeOptions = {}) {
             },
             pulls: {
                 get: vi.fn().mockImplementation(async () => {
-                    const call = getCall;
+                    const read = pullReads[Math.min(getCall, pullReads.length - 1)] ?? {};
                     getCall += 1;
-                    if (options.failPostApprovalRefresh && call === 1) {
-                        throw new Error('transient GitHub API failure');
-                    }
-                    const value =
-                        currentPullRequests[Math.min(call, currentPullRequests.length - 1)];
-                    return { data: value };
+                    if (read.throws === true) throw new Error('transient GitHub API failure');
+                    return { data: read.pr };
                 }),
                 listReviews,
                 createReview,
@@ -138,7 +141,7 @@ describe('runBot', () => {
         const current = pullRequest({ labels: [{ name: OPT_OUT_LABEL }] });
         const execution = run(verdict(), {
             existingApproval: true,
-            currentPullRequests: [current]
+            reloadBeforeApprove: { pr: current }
         });
         await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
         expect(execution.createReview).not.toHaveBeenCalled();
@@ -149,7 +152,7 @@ describe('runBot', () => {
         const newer = pullRequest({
             head: { sha: 'newer', repo: { id: 1, fork: false } }
         });
-        const execution = run(verdict(), { currentPullRequests: [pullRequest(), newer] });
+        const execution = run(verdict(), { recheckAfterApprove: { pr: newer } });
         await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
         expect(execution.createReview).toHaveBeenCalledOnce();
         expect(execution.dismissReview).toHaveBeenCalledOnce();
@@ -157,7 +160,7 @@ describe('runBot', () => {
     });
 
     it('dismisses the approval if the post-approval refresh fails', async () => {
-        const execution = run(verdict(), { failPostApprovalRefresh: true });
+        const execution = run(verdict(), { recheckAfterApprove: { throws: true } });
         await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
         expect(execution.createReview).toHaveBeenCalledOnce();
         expect(execution.dismissReview).toHaveBeenCalledOnce();

--- a/fast_track/src/bot/run-bot.test.ts
+++ b/fast_track/src/bot/run-bot.test.ts
@@ -37,8 +37,8 @@ type PullRead = { pr?: unknown; throws?: boolean };
 interface FakeOptions {
     existingApproval?: boolean;
     associatedPullRequests?: unknown[];
-    // pulls.get fires twice: reloading the target before approving, then
-    // re-checking it afterward. Each read returns a PR or throws.
+    // pulls.get gets called twice: once to reload the target before the approval,
+    // then once to re-check it afterwards. Configure the return values here.
     reloadBeforeApprove?: PullRead;
     recheckAfterApprove?: PullRead;
 }

--- a/fast_track/src/bot/run-bot.ts
+++ b/fast_track/src/bot/run-bot.ts
@@ -1,0 +1,83 @@
+import type { Octokit } from '../guardrails/context/types';
+import type { Verdict } from '../shared/verdict';
+import { renderComment, upsertComment } from './comment';
+import { deriveTarget, refreshTarget, type BotTarget } from './derive-target';
+import { approve, dismissApproval } from './review';
+import { effectiveVerdict, verdictMatchesTarget } from './verdict-policy';
+
+interface RunBotParams {
+    octokit: Octokit;
+    owner: string;
+    repo: string;
+    trustedHeadSha: string;
+    botLogin: string;
+    guardrailsSucceeded: boolean;
+    requiredGuardrailNames: readonly string[];
+    verdict: unknown;
+}
+
+export type BotResult =
+    { status: 'approved' | 'dismissed'; prNumber: number } | { status: 'skipped'; reason: string };
+
+type BotActionParams = Parameters<typeof dismissApproval>[0];
+
+/** Apply a current pass verdict, revoking the bot approval for every other outcome. */
+export async function runBot(params: RunBotParams): Promise<BotResult> {
+    const target = await currentTarget(params);
+    if (target === null) {
+        return { status: 'skipped', reason: 'No eligible PR matched the trusted workflow run.' };
+    }
+
+    const verdict = effectiveVerdict(params, target);
+    const actionParams: BotActionParams = {
+        octokit: params.octokit,
+        owner: params.owner,
+        repo: params.repo,
+        prNumber: target.prNumber,
+        botLogin: params.botLogin
+    };
+    return verdict.verdict === 'pass'
+        ? applyPass(params, target, verdict, actionParams)
+        : applyFailure(target, verdict, actionParams);
+}
+
+async function currentTarget(params: RunBotParams): Promise<BotTarget | null> {
+    const derivedTarget = await deriveTarget(params);
+    if (derivedTarget === null) return null;
+    return refreshTarget({ ...params, target: derivedTarget });
+}
+
+async function applyPass(
+    params: RunBotParams,
+    target: BotTarget,
+    verdict: Verdict,
+    actionParams: BotActionParams
+): Promise<BotResult> {
+    await approve({ ...actionParams, headSha: target.headSha });
+    const finalTarget = await refreshTarget({ ...params, target });
+    if (finalTarget === null || !verdictMatchesTarget(verdict, finalTarget)) {
+        await dismissApproval(actionParams);
+        return { status: 'dismissed', prNumber: target.prNumber };
+    }
+
+    await updateStatusComment(verdict, finalTarget.headSha, actionParams);
+    return { status: 'approved', prNumber: finalTarget.prNumber };
+}
+
+async function applyFailure(
+    target: BotTarget,
+    verdict: Verdict,
+    actionParams: BotActionParams
+): Promise<BotResult> {
+    await dismissApproval(actionParams);
+    await updateStatusComment(verdict, target.headSha, actionParams);
+    return { status: 'dismissed', prNumber: target.prNumber };
+}
+
+async function updateStatusComment(
+    verdict: Verdict,
+    headSha: string,
+    params: Omit<Parameters<typeof upsertComment>[0], 'body'>
+): Promise<void> {
+    await upsertComment({ ...params, body: renderComment(verdict, headSha) });
+}

--- a/fast_track/src/bot/run-bot.ts
+++ b/fast_track/src/bot/run-bot.ts
@@ -47,6 +47,21 @@ async function currentTarget(params: RunBotParams): Promise<BotTarget | null> {
     return refreshTarget({ ...params, target: derivedTarget });
 }
 
+/**
+ * Reload the target, treating a failed reload as "no longer verifiable" so the
+ * caller fails closed. A throw here would otherwise skip the post-approval
+ * rollback and leave an unverified approval active.
+ */
+async function refreshOrNull(
+    params: Parameters<typeof refreshTarget>[0]
+): Promise<BotTarget | null> {
+    try {
+        return await refreshTarget(params);
+    } catch {
+        return null;
+    }
+}
+
 async function applyPass(
     params: RunBotParams,
     target: BotTarget,
@@ -54,7 +69,7 @@ async function applyPass(
     actionParams: BotActionParams
 ): Promise<BotResult> {
     await approve({ ...actionParams, headSha: target.headSha });
-    const finalTarget = await refreshTarget({ ...params, target });
+    const finalTarget = await refreshOrNull({ ...params, target });
     if (finalTarget === null || !verdictMatchesTarget(verdict, finalTarget)) {
         await dismissApproval(actionParams);
         return { status: 'dismissed', prNumber: target.prNumber };

--- a/fast_track/src/bot/run-bot.ts
+++ b/fast_track/src/bot/run-bot.ts
@@ -57,7 +57,11 @@ async function refreshOrNull(
 ): Promise<BotTarget | null> {
     try {
         return await refreshTarget(params);
-    } catch {
+    } catch (error) {
+        console.warn(
+            'Fast Track: target refresh failed; treating the target as unverifiable.',
+            error
+        );
         return null;
     }
 }


### PR DESCRIPTION
## What has changed and why?

Adds the Fast Track bot orchestrator (`run-bot.ts`): derive the trusted PR target from GitHub state, resolve the effective verdict via `verdict-policy`, and either approve a current pass or dismiss the bot approval for every other outcome. The pass path re-checks the target after approving and dismisses if the PR changed during the write.

Stacked on the verdict-policy PR (#1690), which is now based on `main`. Retarget this PR to `main` once #1690 merges.

## How has it been tested?

`make -C fast_track static-checks` and `make -C fast_track test` pass. `run-bot.test.ts` covers approve+comment on a pass, dismissal on a failure verdict, the current-opt-out-label override, the head-changed-during-run race, and the no-eligible-target skip. Verdict-decision edge cases live in `verdict-policy.test.ts` (#1690).

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated bot handling for eligible pull requests based on evaluation verdicts.
  * Approves passing pull requests and updates their status comments.
  * Dismisses approvals for non-passing verdicts, including cases where the PR is opted out.
  * Skips processing when no eligible pull request matches.
* **Bug Fixes**
  * Prevents stale approvals by rechecking the PR state after approval and dismissing if it no longer matches.
  * Dismisses approvals when post-approval refresh/recheck fails or returns no matching target.
* **Tests**
  * Added a comprehensive test suite covering approval, dismissal, skipping, and refresh edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->