### PR TITLE
Fast Track: extract verdict policy

### DIFF
--- a/fast_track/src/bot/verdict-policy.test.ts
+++ b/fast_track/src/bot/verdict-policy.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import { OPT_OUT_LABEL } from '../guardrails/author-opt-out';
+import type { Verdict } from '../shared/verdict';
+import type { BotTarget } from './derive-target';
+import { effectiveVerdict, verdictMatchesTarget } from './verdict-policy';
+
+// Object mothers: a happy-path target and pass verdict. Each test overrides only
+// the field it is about, so the meaningful delta stays visible in the test body.
+function target(overrides: Partial<BotTarget> = {}): BotTarget {
+    return {
+        prNumber: 7,
+        headSha: 'abc123',
+        baseRef: 'main',
+        baseSha: 'base123',
+        labels: [],
+        ...overrides
+    };
+}
+
+function passVerdict(overrides: Partial<Verdict> = {}): Verdict {
+    return {
+        verdict: 'pass',
+        guardrails: [{ name: 'dummy', status: 'pass', summary: 'ok' }],
+        pr_number: 7,
+        head_sha: 'abc123',
+        base_ref: 'main',
+        base_sha: 'base123',
+        ...overrides
+    };
+}
+
+describe('effectiveVerdict', () => {
+    it('returns the artifact verdict when a current pass matches the target', () => {
+        const artifact = passVerdict();
+
+        const result = effectiveVerdict(
+            { guardrailsSucceeded: true, requiredGuardrailNames: ['dummy'], verdict: artifact },
+            target()
+        );
+
+        expect(result).toEqual(artifact);
+    });
+
+    it('passes when only an optional (non-required) guardrail failed', () => {
+        const artifact = passVerdict({
+            guardrails: [
+                { name: 'dummy', status: 'pass', summary: 'ok' },
+                { name: 'advisory', status: 'fail', summary: 'consider simplifying' }
+            ]
+        });
+
+        const result = effectiveVerdict(
+            { guardrailsSucceeded: true, requiredGuardrailNames: ['dummy'], verdict: artifact },
+            target()
+        );
+
+        expect(result.verdict).toBe('pass');
+    });
+
+    it('opts out when the target carries the opt-out label, ignoring a passing artifact', () => {
+        const result = effectiveVerdict(
+            {
+                guardrailsSucceeded: true,
+                requiredGuardrailNames: ['dummy'],
+                verdict: passVerdict()
+            },
+            target({ labels: [OPT_OUT_LABEL] })
+        );
+
+        expect(result.verdict).toBe('opt_out');
+    });
+
+    it('fails when the guardrail workflow did not complete', () => {
+        const result = effectiveVerdict(
+            { guardrailsSucceeded: false, requiredGuardrailNames: ['dummy'], verdict: undefined },
+            target()
+        );
+
+        expect(result.verdict).toBe('fail');
+    });
+
+    it('fails a structurally invalid verdict artifact', () => {
+        const malformed = { verdict: 'pass' };
+
+        const result = effectiveVerdict(
+            { guardrailsSucceeded: true, requiredGuardrailNames: ['dummy'], verdict: malformed },
+            target()
+        );
+
+        expect(result.verdict).toBe('fail');
+    });
+
+    it('fails a pass that is missing a required guardrail', () => {
+        const artifact = passVerdict({ guardrails: [] });
+
+        const result = effectiveVerdict(
+            { guardrailsSucceeded: true, requiredGuardrailNames: ['dummy'], verdict: artifact },
+            target()
+        );
+
+        expect(result.verdict).toBe('fail');
+    });
+
+    it('fails a pass whose required guardrail did not pass', () => {
+        const artifact = passVerdict({
+            guardrails: [{ name: 'dummy', status: 'fail', summary: 'failed' }]
+        });
+
+        const result = effectiveVerdict(
+            { guardrailsSucceeded: true, requiredGuardrailNames: ['dummy'], verdict: artifact },
+            target()
+        );
+
+        expect(result.verdict).toBe('fail');
+    });
+
+    it('fails an opt-out artifact when the target is not labelled (stale or spoofed)', () => {
+        const artifact = passVerdict({
+            verdict: 'opt_out',
+            guardrails: [],
+            reason: 'Author requested human review.'
+        });
+
+        const result = effectiveVerdict(
+            { guardrailsSucceeded: true, requiredGuardrailNames: ['dummy'], verdict: artifact },
+            target()
+        );
+
+        expect(result.verdict).toBe('fail');
+    });
+
+    it('fails a verdict bound to an earlier base revision', () => {
+        const result = effectiveVerdict(
+            {
+                guardrailsSucceeded: true,
+                requiredGuardrailNames: ['dummy'],
+                verdict: passVerdict()
+            },
+            target({ baseRef: 'release', baseSha: 'newbase' })
+        );
+
+        expect(result.verdict).toBe('fail');
+    });
+});
+
+describe('verdictMatchesTarget', () => {
+    it('accepts a verdict aligned with its target', () => {
+        expect(verdictMatchesTarget(passVerdict(), target())).toBe(true);
+    });
+
+    it('rejects a verdict whose PR number differs', () => {
+        expect(verdictMatchesTarget(passVerdict({ pr_number: 8 }), target())).toBe(false);
+    });
+
+    it('rejects a verdict whose head SHA differs', () => {
+        expect(verdictMatchesTarget(passVerdict(), target({ headSha: 'newer' }))).toBe(false);
+    });
+
+    it('rejects a verdict whose base ref differs', () => {
+        expect(verdictMatchesTarget(passVerdict(), target({ baseRef: 'release' }))).toBe(false);
+    });
+
+    it('rejects a verdict whose base SHA differs', () => {
+        expect(verdictMatchesTarget(passVerdict(), target({ baseSha: 'newbase' }))).toBe(false);
+    });
+
+    it('rejects a verdict when the target is opted out', () => {
+        expect(verdictMatchesTarget(passVerdict(), target({ labels: [OPT_OUT_LABEL] }))).toBe(
+            false
+        );
+    });
+});

--- a/fast_track/src/bot/verdict-policy.ts
+++ b/fast_track/src/bot/verdict-policy.ts
@@ -1,0 +1,78 @@
+import { OPT_OUT_LABEL } from '../guardrails/author-opt-out';
+import type { Verdict } from '../shared/verdict';
+import type { BotTarget } from './derive-target';
+import { isVerdict } from './verdict-schema';
+
+/** The subset of run inputs the verdict decision depends on. */
+export interface VerdictInput {
+    guardrailsSucceeded: boolean;
+    requiredGuardrailNames: readonly string[];
+    verdict: unknown;
+}
+
+/** Resolve the outcome to apply: the artifact verdict when trustworthy, else a
+ *  synthesized opt-out/failure. Fail-closed — unexpected input never passes. */
+export function effectiveVerdict(input: VerdictInput, target: BotTarget): Verdict {
+    const { verdict, guardrailsSucceeded, requiredGuardrailNames } = input;
+
+    if (target.labels.includes(OPT_OUT_LABEL)) {
+        const reason = `Human review requested with the \`${OPT_OUT_LABEL}\` label.`;
+        return failureVerdict('opt_out', target, reason);
+    }
+    if (!guardrailsSucceeded) {
+        return failureVerdict(
+            'fail',
+            target,
+            'The guardrail workflow did not complete successfully.'
+        );
+    }
+    if (!isVerdict(verdict)) {
+        return failureVerdict(
+            'fail',
+            target,
+            'The guardrail workflow produced an invalid verdict.'
+        );
+    }
+    if (verdict.verdict === 'pass' && !hasRequiredPasses(verdict, requiredGuardrailNames)) {
+        return failureVerdict('fail', target, 'A required guardrail did not pass.');
+    }
+    if (!verdictMatchesTarget(verdict, target)) {
+        return failureVerdict('fail', target, 'The guardrail verdict no longer matches this PR.');
+    }
+    return verdict;
+}
+
+/** Whether the verdict is still bound to the current PR target and not opted out. */
+export function verdictMatchesTarget(verdict: Verdict, target: BotTarget): boolean {
+    return (
+        verdict.pr_number === target.prNumber &&
+        verdict.head_sha === target.headSha &&
+        verdict.base_ref === target.baseRef &&
+        verdict.base_sha === target.baseSha &&
+        !target.labels.includes(OPT_OUT_LABEL)
+    );
+}
+
+function failureVerdict(status: 'fail' | 'opt_out', target: BotTarget, reason: string): Verdict {
+    return {
+        verdict: status,
+        guardrails: [],
+        pr_number: target.prNumber,
+        head_sha: target.headSha,
+        base_ref: target.baseRef,
+        base_sha: target.baseSha,
+        reason
+    };
+}
+
+/** Policy check: every required guardrail is present and passing. */
+function hasRequiredPasses(verdict: Verdict, requiredGuardrailNames: readonly string[]): boolean {
+    return (
+        requiredGuardrailNames.length > 0 &&
+        requiredGuardrailNames.every((name) =>
+            verdict.guardrails.some(
+                (guardrail) => guardrail.name === name && guardrail.status === 'pass'
+            )
+        )
+    );
+}

--- a/fast_track/src/bot/verdict-policy.ts
+++ b/fast_track/src/bot/verdict-policy.ts
@@ -65,7 +65,8 @@ function failureVerdict(status: 'fail' | 'opt_out', target: BotTarget, reason: s
     };
 }
 
-/** Policy check: every required guardrail is present and passing. */
+/** Policy check: every required guardrail is present and passing. Fail-closed —
+ *  an empty required set is treated as missing configuration, never as a pass. */
 function hasRequiredPasses(verdict: Verdict, requiredGuardrailNames: readonly string[]): boolean {
     return (
         requiredGuardrailNames.length > 0 &&

--- a/fast_track/src/bot/verdict-schema.test.ts
+++ b/fast_track/src/bot/verdict-schema.test.ts
@@ -48,6 +48,8 @@ describe('isVerdict', () => {
         ],
         ['a non-integer pr_number', { ...artifact(), pr_number: 1.5 }],
         ['a non-string head_sha', { ...artifact(), head_sha: 123 }],
+        ['a non-string base_ref', { ...artifact(), base_ref: 123 }],
+        ['a non-string base_sha', { ...artifact(), base_sha: 123 }],
         ['a non-string reason', { ...artifact(), reason: 42 }]
     ])('rejects %s', (_description, value) => {
         expect(isVerdict(value)).toBe(false);

--- a/fast_track/src/bot/verdict-schema.test.ts
+++ b/fast_track/src/bot/verdict-schema.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Verdict } from '../shared/verdict';
+import { isVerdict } from './verdict-schema';
+
+// Canonical well-formed pass artifact. Tests override its fields.
+function artifact(): Verdict {
+    return {
+        verdict: 'pass',
+        guardrails: [{ name: 'dummy', status: 'pass', summary: 'ok' }],
+        pr_number: 7,
+        head_sha: 'abc123',
+        base_ref: 'main',
+        base_sha: 'base123'
+    };
+}
+
+describe('isVerdict', () => {
+    it('accepts a well-formed pass verdict', () => {
+        expect(isVerdict(artifact())).toBe(true);
+    });
+
+    it('accepts a well-formed fail verdict', () => {
+        expect(isVerdict({ ...artifact(), verdict: 'fail', reason: 'a guardrail failed' })).toBe(
+            true
+        );
+    });
+
+    // Rejection cases.
+    it.each<[string, unknown]>([
+        ['a non-object', undefined],
+        [
+            'an opt_out status (synthesized from the live label, never parsed)',
+            { ...artifact(), verdict: 'opt_out' }
+        ],
+        ['a non-string status', { ...artifact(), verdict: ['pass'] }],
+        ['a missing guardrails array', { ...artifact(), guardrails: undefined }],
+        ['a malformed guardrail entry', { ...artifact(), guardrails: [{ name: 'dummy' }] }],
+        [
+            'duplicate guardrail names',
+            {
+                ...artifact(),
+                guardrails: [
+                    { name: 'dummy', status: 'pass', summary: 'ok' },
+                    { name: 'dummy', status: 'fail', summary: 'again' }
+                ]
+            }
+        ],
+        ['a non-integer pr_number', { ...artifact(), pr_number: 1.5 }],
+        ['a non-string head_sha', { ...artifact(), head_sha: 123 }],
+        ['a non-string reason', { ...artifact(), reason: 42 }]
+    ])('rejects %s', (_description, value) => {
+        expect(isVerdict(value)).toBe(false);
+    });
+});

--- a/fast_track/src/bot/verdict-schema.ts
+++ b/fast_track/src/bot/verdict-schema.ts
@@ -31,5 +31,5 @@ function isGuardrailResult(value: unknown): value is GuardrailResult {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null;
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/fast_track/src/bot/verdict-schema.ts
+++ b/fast_track/src/bot/verdict-schema.ts
@@ -1,0 +1,35 @@
+import type { GuardrailResult, Verdict } from '../shared/verdict';
+
+/**
+ * Structural guard for an untrusted JSON artifact. `opt_out` is intentionally rejected:
+ * it is synthesized from the live PR label, never trusted from the artifact.
+ */
+export function isVerdict(value: unknown): value is Verdict {
+    if (!isRecord(value)) return false;
+    if (value.verdict !== 'pass' && value.verdict !== 'fail') return false;
+    if (!Array.isArray(value.guardrails) || !value.guardrails.every(isGuardrailResult)) {
+        return false;
+    }
+    const names = value.guardrails.map((guardrail) => guardrail.name);
+    if (new Set(names).size !== names.length) return false;
+    return (
+        Number.isInteger(value.pr_number) &&
+        typeof value.head_sha === 'string' &&
+        typeof value.base_ref === 'string' &&
+        typeof value.base_sha === 'string' &&
+        (value.reason === undefined || typeof value.reason === 'string')
+    );
+}
+
+function isGuardrailResult(value: unknown): value is GuardrailResult {
+    if (!isRecord(value)) return false;
+    return (
+        typeof value.name === 'string' &&
+        (value.status === 'pass' || value.status === 'fail') &&
+        typeof value.summary === 'string'
+    );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}


### PR DESCRIPTION
## What has changed and why?

Extracts the pure verdict decision out of the Fast Track bot orchestrator into `verdict-policy.ts`: `effectiveVerdict` (opt-out label, artifact schema validation, base-revision drift) and `verdictMatchesTarget`, plus the verdict schema guards. No Octokit dependency, so it is unit-tested directly with plain objects — no HTTP fake.

Split out of the orchestrator PR so the branchy decision logic reviews on its own. Based on `main` — D1c (#1686) is merged.

## How has it been tested?

`make -C fast_track static-checks` and `make -C fast_track test` pass. New `verdict-policy.test.ts` covers pass, opt-out, invalid/missing/spoofed/empty/inconsistent verdicts, a crashed workflow, base-revision drift, and every `verdictMatchesTarget` mismatch.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added fail-closed verdict policy that validates verdict artifacts and PR/commit binding before accepting outcomes.
  - Added automatic pass/fail/opt-out decisioning based on guardrail success, required guardrails, artifact schema, and opt-out labeling.

- **Bug Fixes**
  - Prevents accepting malformed, stale, or mismatched verdicts by enforcing strict runtime validation.

- **Tests**
  - Added new Vitest suites covering verdict schema validation and policy decision behavior across valid, invalid, spoofed, and opt-out cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->