### PR TITLE
Tolerate broken files per-item in image embedding

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -11,6 +11,7 @@ import numpy as np
 from numpy.typing import NDArray
 from PIL import Image
 
+from lightly_studio.dataset.image_embedding import ImageEmbeddingResult
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 
 
@@ -65,7 +66,9 @@ class ImageEmbeddingGenerator(EmbeddingGenerator, Protocol):
     for creating embeddings.
     """
 
-    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> NDArray[np.float32]:
+    def embed_images(
+        self, filepaths: list[str], show_progress: bool = True
+    ) -> ImageEmbeddingResult:
         """Generate embeddings for multiple image samples.
 
         TODO(Michal, 04/2025): Use DatasetLoader as input instead.
@@ -75,8 +78,8 @@ class ImageEmbeddingGenerator(EmbeddingGenerator, Protocol):
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            A numpy array representing the generated embeddings
-            in the same order as the input file paths.
+            An ``ImageEmbeddingResult`` with embeddings for the readable files, in the same
+            order as the corresponding input file paths.
         """
         ...
 
@@ -164,10 +167,13 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         """Generate a random embedding for a text sample."""
         return [random.random() for _ in range(self._dimension)]
 
-    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> NDArray[np.float32]:
+    def embed_images(
+        self, filepaths: list[str], show_progress: bool = True
+    ) -> ImageEmbeddingResult:
         """Generate random embeddings for multiple image samples."""
         _ = show_progress  # Not used for random embeddings.
-        return np.random.rand(len(filepaths), self._dimension).astype(np.float32)
+        embeddings = np.random.rand(len(filepaths), self._dimension).astype(np.float32)
+        return ImageEmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(filepaths))))
 
     def embed_image_crops(
         self, image_crops: list[ImageCrop], show_progress: bool = True

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -238,13 +238,14 @@ class EmbeddingManager:
         filepaths = [sample_id_to_filepath[sample_id] for sample_id in sample_ids]
 
         # Generate embeddings for the samples.
-        embeddings = model.embed_images(filepaths=filepaths)
+        result = model.embed_images(filepaths=filepaths)
+        kept_sample_ids = [sample_ids[index] for index in result.kept_indices]
 
         _store_embeddings(
             session=session,
             model_id=model_id,
-            sample_ids=sample_ids,
-            embeddings=embeddings,
+            sample_ids=kept_sample_ids,
+            embeddings=result.embeddings,
         )
 
     def embed_annotations(
@@ -335,11 +336,11 @@ class EmbeddingManager:
         model = self._get_image_model(model_id)
 
         # Generate embedding for the image without progress bar.
-        embeddings = model.embed_images(filepaths=[filepath], show_progress=False)
+        result = model.embed_images(filepaths=[filepath], show_progress=False)
 
         # Return the single embedding as a list of floats.
-        result: list[float] = embeddings[0].tolist()
-        return result
+        embedding: list[float] = result.embeddings[0].tolist()
+        return embedding
 
     def embed_videos(
         self,

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -9,7 +9,7 @@ crop-specific path lives in ``image_crop_embedding.py`` and reuses the same
 from __future__ import annotations
 
 import os
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import TypeVar
 
@@ -17,9 +17,10 @@ import fsspec
 import numpy as np
 import torch
 from numpy.typing import NDArray
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from tqdm import tqdm
 
+from lightly_studio.core.file_outcome_report import FileOutcome, FileOutcomeReport
 from lightly_studio.utils import batching, parallelize
 
 _ItemT = TypeVar("_ItemT")
@@ -52,12 +53,31 @@ class _EmbeddingProgress:
     unit: str
 
 
+@dataclass(frozen=True)
+class ImageEmbeddingResult:
+    """Embeddings for the image files that could be read, plus which inputs they cover.
+
+    Broken files (unreadable/undecodable) are skipped rather than aborting the whole
+    run, so ``embeddings`` may hold fewer rows than the input file list. ``kept_indices``
+    maps each row back to its position in the input list, in input order, letting callers
+    realign any parallel per-file data (e.g. sample IDs) with the embeddings.
+
+    Attributes:
+        embeddings: Float32 array of shape ``(len(kept_indices), embedding_dimension)``.
+        kept_indices: Indices into the input file list of the files that were embedded,
+            in input order.
+    """
+
+    embeddings: NDArray[np.float32]
+    kept_indices: list[int]
+
+
 def embed_image_files_batched(
     filepaths: list[str],
     context: EmbeddingContext,
     show_progress: bool,
-) -> NDArray[np.float32]:
-    """Embed image files in batches, preserving input order.
+) -> ImageEmbeddingResult:
+    """Embed image files in batches, preserving input order and skipping broken files.
 
     Args:
         filepaths: Paths of the images to embed.
@@ -65,21 +85,40 @@ def embed_image_files_batched(
         show_progress: Whether to show a tqdm progress bar.
 
     Returns:
-        Float32 array of shape ``(len(filepaths), embedding_dimension)``.
+        An ``ImageEmbeddingResult`` whose embeddings cover only the readable files, with
+        ``kept_indices`` mapping each row back to its input position.
+
+    Raises:
+        AllInputFilesFailedError: If at least one file was attempted and every attempted
+            file was broken (i.e. no file could be read and embedded).
+        ValueError: If ``context.max_batch_size`` is not positive.
     """
 
-    def load_and_preprocess(filepath: str) -> torch.Tensor:
-        with fsspec.open(filepath, "rb") as file:
-            image = Image.open(file).convert("RGB")
-            return context.preprocess(image)
+    def load_and_preprocess(filepath: str) -> torch.Tensor | None:
+        try:
+            with fsspec.open(filepath, "rb") as file:
+                image = Image.open(file).convert("RGB")
+        except (OSError, UnidentifiedImageError):
+            return None
+        return context.preprocess(image)
 
-    return _embed_items_batched(
+    embeddings, kept_indices = _embed_items_batched(
         items=filepaths,
         preprocess_item=load_and_preprocess,
         context=context,
         show_progress=show_progress,
         progress=_EmbeddingProgress(desc="Generating embeddings", unit=" images"),
     )
+
+    kept = set(kept_indices)
+    report = FileOutcomeReport()
+    for index, filepath in enumerate(filepaths):
+        outcome = FileOutcome.ADDED if index in kept else FileOutcome.BROKEN
+        report.record(path=filepath, outcome=outcome)
+    report.raise_if_all_failed()
+    report.log_summary()
+
+    return ImageEmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
 
 
 def embed_pil_images_batched(
@@ -97,33 +136,40 @@ def embed_pil_images_batched(
     Returns:
         Float32 array of shape ``(len(images), embedding_dimension)``.
     """
-    return _embed_items_batched(
+    embeddings, _ = _embed_items_batched(
         items=images,
         preprocess_item=context.preprocess,
         context=context,
         show_progress=show_progress,
         progress=_EmbeddingProgress(desc="Generating frame embeddings", unit=" frames"),
     )
+    return embeddings
 
 
 def _embed_items_batched(
     items: Sequence[_ItemT],
-    preprocess_item: Callable[[_ItemT], torch.Tensor],
+    preprocess_item: Callable[[_ItemT], torch.Tensor | None],
     context: EmbeddingContext,
     show_progress: bool,
     progress: _EmbeddingProgress,
-) -> NDArray[np.float32]:
+) -> tuple[NDArray[np.float32], list[int]]:
     """Preprocess items on a thread pool and embed them in batches, preserving order.
 
     ``preprocess_item`` (per-item PIL decode/resize/normalize, plus remote reads for file
     inputs) runs on a bounded thread pool, overlapping that CPU-bound work with GPU/MPS
-    inference. Inference (``encode_batch``) runs only here on the calling thread, so the
-    model is never touched concurrently; ``thread_imap_lazy`` preserves input order and
-    caps the items in flight, keeping embeddings aligned to ``items`` and memory bounded.
+    inference. It returns ``None`` for an item that should be skipped (e.g. an unreadable
+    file); such items are dropped before batching. Inference (``encode_batch``) runs only here on
+    the calling thread, so the model is never touched concurrently; ``thread_imap_lazy`` preserves
+    input order and caps the items in flight, keeping embeddings aligned to ``items`` and memory
+    bounded.
+
+    Returns:
+        The embeddings for the kept items and their indices into ``items``, both in input
+        order.
     """
     total_items = len(items)
     if not total_items:
-        return np.empty((0, context.embedding_dimension), dtype=np.float32)
+        return np.empty((0, context.embedding_dimension), dtype=np.float32), []
 
     if context.max_batch_size <= 0:
         raise ValueError("max_batch_size must be positive.")
@@ -136,13 +182,29 @@ def _embed_items_batched(
         # while memory stays bounded to a small multiple of the batch size.
         buffer_size=2 * context.max_batch_size,
     )
-    return _encode_preprocessed_batches(
-        preprocessed_tensors=preprocessed_tensors,
+    # Drop skipped items before batching
+    kept_indices: list[int] = []
+    kept_tensors = _keep_non_none(preprocessed_tensors, kept_indices=kept_indices)
+    embeddings = _encode_preprocessed_batches(
+        preprocessed_tensors=kept_tensors,
+        # Upper bound: the array is truncated to the number of items actually embedded.
         total_items=total_items,
         context=context,
         show_progress=show_progress,
         progress=progress,
     )
+    return embeddings[: len(kept_indices)], kept_indices
+
+
+def _keep_non_none(
+    tensors: Iterable[torch.Tensor | None],
+    kept_indices: list[int],
+) -> Iterator[torch.Tensor]:
+    """Yield the non-``None`` tensors, appending each kept tensor's input index in order."""
+    for index, tensor in enumerate(tensors):
+        if tensor is not None:
+            kept_indices.append(index)
+            yield tensor
 
 
 def _encode_preprocessed_batches(

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -185,9 +185,7 @@ def _embed_items_batched(
     )
     # Drop skipped items before batching, recording which input indices survive.
     kept_indices: list[int] = []
-    kept_tensors_iter = _keep_non_none(
-        tensors=preprocessed_tensors, out_kept_indices=kept_indices
-    )
+    kept_tensors_iter = _keep_non_none(tensors=preprocessed_tensors, out_kept_indices=kept_indices)
     embeddings = _encode_preprocessed_batches(
         preprocessed_tensors=kept_tensors_iter,
         max_items=total_items,

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -102,7 +102,7 @@ def embed_image_files_batched(
             return None
         return context.preprocess(image)
 
-    embeddings, kept_indices = _embed_items_batched(
+    result = _embed_items_batched(
         items=filepaths,
         preprocess_item=load_and_preprocess,
         context=context,
@@ -110,15 +110,15 @@ def embed_image_files_batched(
         progress=_EmbeddingProgress(desc="Generating embeddings", unit=" images"),
     )
 
-    kept = set(kept_indices)
+    kept_indices_set = set(result.kept_indices)
     report = FileOutcomeReport()
     for index, filepath in enumerate(filepaths):
-        outcome = FileOutcome.ADDED if index in kept else FileOutcome.BROKEN
+        outcome = FileOutcome.ADDED if index in kept_indices_set else FileOutcome.BROKEN
         report.record(path=filepath, outcome=outcome)
     report.raise_if_all_failed()
     report.log_summary()
 
-    return ImageEmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
+    return result
 
 
 def embed_pil_images_batched(
@@ -136,14 +136,14 @@ def embed_pil_images_batched(
     Returns:
         Float32 array of shape ``(len(images), embedding_dimension)``.
     """
-    embeddings, _ = _embed_items_batched(
+    result = _embed_items_batched(
         items=images,
         preprocess_item=context.preprocess,
         context=context,
         show_progress=show_progress,
         progress=_EmbeddingProgress(desc="Generating frame embeddings", unit=" frames"),
     )
-    return embeddings
+    return result.embeddings
 
 
 def _embed_items_batched(
@@ -152,7 +152,7 @@ def _embed_items_batched(
     context: EmbeddingContext,
     show_progress: bool,
     progress: _EmbeddingProgress,
-) -> tuple[NDArray[np.float32], list[int]]:
+) -> ImageEmbeddingResult:
     """Preprocess items on a thread pool and embed them in batches, preserving order.
 
     ``preprocess_item`` (per-item PIL decode/resize/normalize, plus remote reads for file
@@ -164,12 +164,13 @@ def _embed_items_batched(
     bounded.
 
     Returns:
-        The embeddings for the kept items and their indices into ``items``, both in input
-        order.
+        An ``ImageEmbeddingResult`` whose embeddings cover the kept items and whose
+        ``kept_indices`` map each row back to its index into ``items``, both in input order.
     """
     total_items = len(items)
     if not total_items:
-        return np.empty((0, context.embedding_dimension), dtype=np.float32), []
+        empty = np.empty((0, context.embedding_dimension), dtype=np.float32)
+        return ImageEmbeddingResult(embeddings=empty, kept_indices=[])
 
     if context.max_batch_size <= 0:
         raise ValueError("max_batch_size must be positive.")
@@ -182,44 +183,57 @@ def _embed_items_batched(
         # while memory stays bounded to a small multiple of the batch size.
         buffer_size=2 * context.max_batch_size,
     )
-    # Drop skipped items before batching
+    # Drop skipped items before batching, recording which input indices survive.
     kept_indices: list[int] = []
-    kept_tensors = _keep_non_none(preprocessed_tensors, kept_indices=kept_indices)
+    kept_tensors_iter = _keep_non_none(
+        tensors=preprocessed_tensors, out_kept_indices=kept_indices
+    )
     embeddings = _encode_preprocessed_batches(
-        preprocessed_tensors=kept_tensors,
-        # Upper bound: the array is truncated to the number of items actually embedded.
-        total_items=total_items,
+        preprocessed_tensors=kept_tensors_iter,
+        max_items=total_items,
         context=context,
         show_progress=show_progress,
         progress=progress,
     )
-    return embeddings[: len(kept_indices)], kept_indices
+    return ImageEmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
 
 
 def _keep_non_none(
     tensors: Iterable[torch.Tensor | None],
-    kept_indices: list[int],
+    out_kept_indices: list[int],
 ) -> Iterator[torch.Tensor]:
-    """Yield the non-``None`` tensors, appending each kept tensor's input index in order."""
+    """Yield the non-``None`` tensors, recording their input indices as they are consumed.
+
+    Args:
+        tensors: The preprocessed tensor stream, with ``None`` marking a skipped item.
+        out_kept_indices: Output list, mutated in place. As the returned iterator is
+            consumed, the input index of each yielded (non-``None``) tensor is appended, in
+            input order. It is empty until iteration starts and complete once the iterator is
+            exhausted, so callers must finish consuming before reading it.
+    """
     for index, tensor in enumerate(tensors):
         if tensor is not None:
-            kept_indices.append(index)
+            out_kept_indices.append(index)
             yield tensor
 
 
 def _encode_preprocessed_batches(
     preprocessed_tensors: Iterable[torch.Tensor],
-    total_items: int,
+    max_items: int,
     context: EmbeddingContext,
     show_progress: bool,
     progress: _EmbeddingProgress,
 ) -> NDArray[np.float32]:
-    """Stack the preprocessed tensor stream into batches and run inference, preserving order."""
-    embeddings = np.empty((total_items, context.embedding_dimension), dtype=np.float32)
+    """Stack the preprocessed tensor stream into batches and run inference, preserving order.
+
+    ``max_items`` is an upper bound on the number of embeddings (the input count before any
+    skips); the returned array is truncated to the number of tensors actually encoded.
+    """
+    embeddings = np.empty((max_items, context.embedding_dimension), dtype=np.float32)
     position = 0
     with (
         tqdm(
-            total=total_items,
+            total=max_items,
             desc=progress.desc,
             unit=progress.unit,
             disable=not show_progress,
@@ -234,7 +248,8 @@ def _encode_preprocessed_batches(
             position += batch_size
             progress_bar.update(batch_size)
 
-    return embeddings
+    # Truncate to the number of tensors actually encoded (``max_items`` was an upper bound).
+    return embeddings[:position]
 
 
 def _preprocess_workers() -> int:

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -16,7 +16,7 @@ from lightly_studio.vendor import mobileclip
 
 from . import file_utils, image_crop_embedding, image_embedding
 from .embedding_generator import ImageCrop, ImageEmbeddingGenerator
-from .image_embedding import EmbeddingContext
+from .image_embedding import EmbeddingContext, ImageEmbeddingResult
 
 MODEL_NAME = "mobileclip_s0"
 MOBILECLIP_DOWNLOAD_URL = (
@@ -84,7 +84,9 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
         return embedding_list
 
-    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> NDArray[np.float32]:
+    def embed_images(
+        self, filepaths: list[str], show_progress: bool = True
+    ) -> ImageEmbeddingResult:
         """Embed images with MobileCLIP.
 
         Args:
@@ -92,8 +94,8 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            A numpy array representing the generated embeddings
-            in the same order as the input file paths.
+            An ``ImageEmbeddingResult`` with embeddings for the readable files, in the same
+            order as the corresponding input file paths.
         """
         return image_embedding.embed_image_files_batched(
             filepaths=filepaths,

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -21,7 +21,7 @@ from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transfor
 
 from . import file_utils, image_crop_embedding, image_embedding
 from .embedding_generator import ImageCrop, ImageEmbeddingGenerator, VideoEmbeddingGenerator
-from .image_embedding import EmbeddingContext
+from .image_embedding import EmbeddingContext, ImageEmbeddingResult
 
 MODEL_NAME = "PE-Core-T16-384"
 DEFAULT_VIDEO_CHANNEL = 0
@@ -162,7 +162,9 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
         return embedding_list
 
-    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> NDArray[np.float32]:
+    def embed_images(
+        self, filepaths: list[str], show_progress: bool = True
+    ) -> ImageEmbeddingResult:
         """Embed images with Perception Encoder.
 
         Args:
@@ -170,8 +172,8 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            A numpy array representing the generated embeddings
-            in the same order as the input file paths.
+            An ``ImageEmbeddingResult`` with embeddings for the readable files, in the same
+            order as the corresponding input file paths.
         """
         return image_embedding.embed_image_files_batched(
             filepaths=filepaths,

--- a/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
@@ -24,7 +24,7 @@ import lightly_studio as ls
 from lightly_studio.database import db_manager
 from lightly_studio.dataset import file_utils, image_crop_embedding, image_embedding
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
-from lightly_studio.dataset.image_embedding import EmbeddingContext
+from lightly_studio.dataset.image_embedding import EmbeddingContext, ImageEmbeddingResult
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor import mobileclip
 
@@ -86,8 +86,10 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
             embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
         return embedding_list
 
-    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> NDArray[np.float32]:
-        """Embed a batch of images, returning one row per input path."""
+    def embed_images(
+        self, filepaths: list[str], show_progress: bool = True
+    ) -> ImageEmbeddingResult:
+        """Embed a batch of images, returning one row per readable input path."""
         return image_embedding.embed_image_files_batched(
             filepaths=filepaths,
             context=self._embedding_context(),

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -21,6 +21,7 @@ from lightly_studio.dataset.embedding_manager import (
     EmbeddingManager,
     TextEmbedQuery,
 )
+from lightly_studio.dataset.image_embedding import ImageEmbeddingResult
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
@@ -101,7 +102,7 @@ def test_register_multiple_models(
 
         def embed_images(
             self, filepaths: list[str], show_progress: bool = True
-        ) -> NDArray[np.float32]:
+        ) -> ImageEmbeddingResult:
             raise NotImplementedError()
 
         def embed_image_crops(
@@ -628,9 +629,12 @@ def test_set_default_embedding_model_falls_back_to_env_for_unregistered_slot(
 
         def embed_images(
             self, filepaths: list[str], show_progress: bool = True
-        ) -> NDArray[np.float32]:
+        ) -> ImageEmbeddingResult:
             _ = show_progress
-            return np.zeros((len(filepaths), 3), dtype=np.float32)
+            return ImageEmbeddingResult(
+                embeddings=np.zeros((len(filepaths), 3), dtype=np.float32),
+                kept_indices=list(range(len(filepaths))),
+            )
 
         def embed_image_crops(
             self, image_crops: list[ImageCrop], show_progress: bool = True

--- a/lightly_studio/tests/dataset/test_image_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_embedding.py
@@ -19,7 +19,7 @@ def test_embed_image_files_batched__empty_input_returns_empty_array() -> None:
             max_batch_size=2,
             device=torch.device("cpu"),
             preprocess=lambda image: torch.tensor([float(image.size[0])]),
-            encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
+            encode_batch=lambda images_tensor: images_tensor.cpu().numpy(),
         ),
         show_progress=False,
     )
@@ -32,7 +32,7 @@ def test_embed_image_files_batched__preserves_input_order(tmp_path: Path) -> Non
     # Each image has a distinct width, and preprocess encodes an image as its
     # width, so the embeddings must come back in input order across batches.
     widths = [5, 6, 7]
-    filepaths = _write_images(tmp_path, widths)
+    filepaths = _write_images(tmp_path=tmp_path, widths=widths)
 
     result = image_embedding.embed_image_files_batched(
         filepaths=filepaths,
@@ -60,7 +60,7 @@ def test_embed_image_files_batched__preserves_order_despite_out_of_order_preproc
     # image only, so the test stays fast and still passes (in order) when preprocessing
     # happens to run single-threaded.
     widths = [5, 6, 7, 8]
-    filepaths = _write_images(tmp_path, widths)
+    filepaths = _write_images(tmp_path=tmp_path, widths=widths)
 
     def preprocess(image: Image.Image) -> torch.Tensor:
         if image.size[0] == widths[0]:
@@ -86,12 +86,19 @@ def test_embed_image_files_batched__skips_broken_files(tmp_path: Path) -> None:
     # Broken files are skipped per-item: the embeddings cover only the readable files and
     # kept_indices maps each row back to its input position, so callers stay in sync.
     widths = [5, 6, 7, 8]
-    filepaths = _write_images(tmp_path, widths)
+    valid_filepaths = _write_images(tmp_path=tmp_path, widths=widths)
     broken = tmp_path / "broken.png"
     broken.write_bytes(b"not a valid image")
     missing = tmp_path / "missing.png"
     # Interleave broken/missing files with readable ones at positions 1 and 3.
-    filepaths = [filepaths[0], str(broken), filepaths[1], str(missing), filepaths[2], filepaths[3]]
+    filepaths = [
+        valid_filepaths[0],
+        str(broken),
+        valid_filepaths[1],
+        str(missing),
+        valid_filepaths[2],
+        valid_filepaths[3],
+    ]
 
     result = image_embedding.embed_image_files_batched(
         filepaths=filepaths,

--- a/lightly_studio/tests/dataset/test_image_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_embedding.py
@@ -6,37 +6,35 @@ import pytest
 import torch
 from PIL import Image
 
+from lightly_studio.core.file_outcome_report import AllInputFilesFailedError
 from lightly_studio.dataset import image_embedding
 from lightly_studio.dataset.image_embedding import EmbeddingContext
 
 
 def test_embed_image_files_batched__empty_input_returns_empty_array() -> None:
-    embeddings = image_embedding.embed_image_files_batched(
+    result = image_embedding.embed_image_files_batched(
         filepaths=[],
         context=EmbeddingContext(
             embedding_dimension=4,
             max_batch_size=2,
             device=torch.device("cpu"),
             preprocess=lambda image: torch.tensor([float(image.size[0])]),
-            encode_batch=lambda images_tensor: images_tensor.cpu().numpy(),
+            encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
         ),
         show_progress=False,
     )
 
-    assert embeddings.shape == (0, 4)
+    assert result.embeddings.shape == (0, 4)
+    assert result.kept_indices == []
 
 
 def test_embed_image_files_batched__preserves_input_order(tmp_path: Path) -> None:
     # Each image has a distinct width, and preprocess encodes an image as its
     # width, so the embeddings must come back in input order across batches.
     widths = [5, 6, 7]
-    filepaths = []
-    for index, width in enumerate(widths):
-        path = tmp_path / f"image_{index}.png"
-        Image.new("RGB", (width, 10), color=(255, 0, 0)).save(path)
-        filepaths.append(str(path))
+    filepaths = _write_images(tmp_path, widths)
 
-    embeddings = image_embedding.embed_image_files_batched(
+    result = image_embedding.embed_image_files_batched(
         filepaths=filepaths,
         context=EmbeddingContext(
             embedding_dimension=1,
@@ -48,8 +46,9 @@ def test_embed_image_files_batched__preserves_input_order(tmp_path: Path) -> Non
         show_progress=False,
     )
 
-    assert embeddings.shape == (3, 1)
-    assert embeddings[:, 0].tolist() == [float(width) for width in widths]
+    assert result.embeddings.shape == (3, 1)
+    assert result.kept_indices == [0, 1, 2]
+    assert result.embeddings[:, 0].tolist() == [float(width) for width in widths]
 
 
 def test_embed_image_files_batched__preserves_order_despite_out_of_order_preprocess(
@@ -61,18 +60,14 @@ def test_embed_image_files_batched__preserves_order_despite_out_of_order_preproc
     # image only, so the test stays fast and still passes (in order) when preprocessing
     # happens to run single-threaded.
     widths = [5, 6, 7, 8]
-    filepaths = []
-    for index, width in enumerate(widths):
-        path = tmp_path / f"image_{index}.png"
-        Image.new("RGB", (width, 10), color=(255, 0, 0)).save(path)
-        filepaths.append(str(path))
+    filepaths = _write_images(tmp_path, widths)
 
     def preprocess(image: Image.Image) -> torch.Tensor:
         if image.size[0] == widths[0]:
             time.sleep(0.1)
         return torch.tensor([float(image.size[0])])
 
-    embeddings = image_embedding.embed_image_files_batched(
+    result = image_embedding.embed_image_files_batched(
         filepaths=filepaths,
         context=EmbeddingContext(
             embedding_dimension=1,
@@ -84,7 +79,55 @@ def test_embed_image_files_batched__preserves_order_despite_out_of_order_preproc
         show_progress=False,
     )
 
-    assert embeddings[:, 0].tolist() == [float(width) for width in widths]
+    assert result.embeddings[:, 0].tolist() == [float(width) for width in widths]
+
+
+def test_embed_image_files_batched__skips_broken_files(tmp_path: Path) -> None:
+    # Broken files are skipped per-item: the embeddings cover only the readable files and
+    # kept_indices maps each row back to its input position, so callers stay in sync.
+    widths = [5, 6, 7, 8]
+    filepaths = _write_images(tmp_path, widths)
+    broken = tmp_path / "broken.png"
+    broken.write_bytes(b"not a valid image")
+    missing = tmp_path / "missing.png"
+    # Interleave broken/missing files with readable ones at positions 1 and 3.
+    filepaths = [filepaths[0], str(broken), filepaths[1], str(missing), filepaths[2], filepaths[3]]
+
+    result = image_embedding.embed_image_files_batched(
+        filepaths=filepaths,
+        context=EmbeddingContext(
+            embedding_dimension=1,
+            max_batch_size=2,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
+        ),
+        show_progress=False,
+    )
+
+    assert result.kept_indices == [0, 2, 4, 5]
+    assert result.embeddings[:, 0].tolist() == [float(width) for width in widths]
+
+
+def test_embed_image_files_batched__raises_when_all_files_broken(tmp_path: Path) -> None:
+    broken_paths = []
+    for index in range(3):
+        path = tmp_path / f"broken_{index}.png"
+        path.write_bytes(b"not a valid image")
+        broken_paths.append(str(path))
+
+    with pytest.raises(AllInputFilesFailedError):
+        image_embedding.embed_image_files_batched(
+            filepaths=broken_paths,
+            context=EmbeddingContext(
+                embedding_dimension=1,
+                max_batch_size=2,
+                device=torch.device("cpu"),
+                preprocess=lambda image: torch.tensor([float(image.size[0])]),
+                encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
+            ),
+            show_progress=False,
+        )
 
 
 def test_embed_image_files_batched__propagates_preprocess_error(tmp_path: Path) -> None:
@@ -145,3 +188,13 @@ def test_embed_pil_images_batched__preserves_input_order() -> None:
 
     assert embeddings.shape == (3, 1)
     assert embeddings[:, 0].tolist() == [float(width) for width in widths]
+
+
+def _write_images(tmp_path: Path, widths: list[int]) -> list[str]:
+    """Write one RGB image per width and return their file paths, in order."""
+    filepaths = []
+    for index, width in enumerate(widths):
+        path = tmp_path / f"image_{index}.png"
+        Image.new("RGB", (width, 10), color=(255, 0, 0)).save(path)
+        filepaths.append(str(path))
+    return filepaths

--- a/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
@@ -43,7 +43,7 @@ class TestMobileCLIPEmbeddingGenerator:
     def test_embed_images(self) -> None:
         mobileclip = MobileCLIPEmbeddingGenerator()
         cat_image_path = FIXTURES_DIR / "cat.jpg"
-        embeddings = mobileclip.embed_images([str(cat_image_path)])
+        embeddings = mobileclip.embed_images([str(cat_image_path)]).embeddings
 
         assert len(embeddings) == 1
         cat_embedding = embeddings[0]
@@ -71,7 +71,7 @@ class TestMobileCLIPEmbeddingGenerator:
 
         full_crop = ImageCrop(filepath=str(cat_image_path), x=0, y=0, width=width, height=height)
         crop_embeddings = mobileclip.embed_image_crops([full_crop])
-        image_embeddings = mobileclip.embed_images([str(cat_image_path)])
+        image_embeddings = mobileclip.embed_images([str(cat_image_path)]).embeddings
 
         assert crop_embeddings.shape == (1, 512)
         # A crop covering the entire image is preprocessed and encoded identically
@@ -91,7 +91,7 @@ class TestMobileCLIPEmbeddingGenerator:
             cat_pil_image = image.convert("RGB")
 
         pil_embeddings = mobileclip.embed_pil_images([cat_pil_image])
-        image_embeddings = mobileclip.embed_images([str(cat_image_path)])
+        image_embeddings = mobileclip.embed_images([str(cat_image_path)]).embeddings
 
         assert pil_embeddings.shape == (1, 512)
         # An in-memory PIL image is preprocessed and encoded identically to the same
@@ -119,7 +119,7 @@ class TestMobileCLIPEmbeddingGenerator:
 
         # Embed image.
         cat_image_path = FIXTURES_DIR / "cat.jpg"
-        cat_image_emb = torch.tensor(mobileclip.embed_images([str(cat_image_path)])[0])
+        cat_image_emb = torch.tensor(mobileclip.embed_images([str(cat_image_path)]).embeddings[0])
         cat_image_emb /= cat_image_emb.norm(dim=-1, keepdim=True)
 
         # Compute softmax similarity as in ml-mobileclip repo example.

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -45,7 +45,7 @@ class TestPerceptionEncoderEmbeddingGenerator:
     def test_embed_images(self) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
         cat_image_path = FIXTURES_DIR / "cat.jpg"
-        embeddings = perception_encoder.embed_images([str(cat_image_path)])
+        embeddings = perception_encoder.embed_images([str(cat_image_path)]).embeddings
 
         assert len(embeddings) == 1
         cat_embedding = embeddings[0]
@@ -73,7 +73,7 @@ class TestPerceptionEncoderEmbeddingGenerator:
 
         full_crop = ImageCrop(filepath=str(cat_image_path), x=0, y=0, width=width, height=height)
         crop_embeddings = perception_encoder.embed_image_crops([full_crop])
-        image_embeddings = perception_encoder.embed_images([str(cat_image_path)])
+        image_embeddings = perception_encoder.embed_images([str(cat_image_path)]).embeddings
 
         assert crop_embeddings.shape == (1, 512)
         # A crop covering the entire image is preprocessed and encoded identically
@@ -93,7 +93,7 @@ class TestPerceptionEncoderEmbeddingGenerator:
             cat_pil_image = image.convert("RGB")
 
         pil_embeddings = perception_encoder.embed_pil_images([cat_pil_image])
-        image_embeddings = perception_encoder.embed_images([str(cat_image_path)])
+        image_embeddings = perception_encoder.embed_images([str(cat_image_path)]).embeddings
 
         assert pil_embeddings.shape == (1, 512)
         # An in-memory PIL image is preprocessed and encoded identically to the same
@@ -139,7 +139,9 @@ class TestPerceptionEncoderEmbeddingGenerator:
 
         # Embed image.
         cat_image_path = FIXTURES_DIR / "cat.jpg"
-        cat_image_emb = torch.tensor(perception_encoder.embed_images([str(cat_image_path)])[0])
+        cat_image_emb = torch.tensor(
+            perception_encoder.embed_images([str(cat_image_path)]).embeddings[0]
+        )
         cat_image_emb /= cat_image_emb.norm(dim=-1, keepdim=True)
 
         # Compute softmax similarity as in perception_encoder repo example.


### PR DESCRIPTION
## Summary

Route the image-embedding file-loading path through the centralized `FileOutcomeReport` so an unreadable/undecodable file is **skipped per-item** instead of aborting the whole embedding run.

- `embed_image_files_batched` catches `(OSError, UnidentifiedImageError)` per file, drops the item **before batching** (so batches stay full-sized and no empty batch reaches `torch.stack`), and returns an `ImageEmbeddingResult` carrying `kept_indices` so callers can realign parallel per-file data. Outcomes are recorded in a `FileOutcomeReport`; when every attempted file is broken it raises `AllInputFilesFailedError`.
- `ImageEmbeddingResult` is propagated through the `ImageEmbeddingGenerator` protocol and its implementations (mobileclip, perception_encoder, `RandomEmbeddingGenerator`, custom-model example).
- `embedding_manager.embed_images` filters `sample_ids` by `kept_indices` before storing, keeping sample IDs and embeddings in sync. `compute_image_embedding` relies on the all-failed raise for a single broken file.

The in-memory PIL path (`embed_pil_images_batched`) never skips and keeps its 1:1 array return.

## Scope

This covers the **full-image embedding path only** (the originally-reported unhandled file open). The crop path (`image_crop_embedding.py`) is not included here.

## Testing

- `make static-checks` — ruff + format clean; mypy clean on all touched files (pre-existing unrelated `s3fs` stub errors aside).
- Added tests: mixed good/broken/missing files with `kept_indices` assertions, all-broken raises, single-image broken; updated existing tests for the new return type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image embedding outputs now include both the generated embeddings and the positions of successfully processed files.
  * Unreadable or invalid images are skipped while valid images continue processing.
  * If all supplied images fail, a clear error is raised.
* **Updates**
  * MobileCLIP, perception-encoder, and custom embedding generators now return the structured embedding result.
  * Dataset embedding storage now preserves correct sample-to-embedding associations when files are skipped.
* **Tests**
  * Updated the embedding-related test suite to validate the new result format and broken-file behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->