### PR TITLE
[LIG-10245] Add grouped sample-tag counts query hook

### DIFF
--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -48,3 +48,4 @@ export {
     useImageAnnotationCounts,
     useImageAnnotationCountsQueryKey
 } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
+export { useImageAnnotationCountsBySampleTags } from '$lib/hooks/useImageAnnotationCountsBySampleTags/useImageAnnotationCountsBySampleTags.svelte';

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -69,3 +69,4 @@ export {
     type OperatorParameterColumn,
     type OperatorParameterType
 } from '$lib/hooks/useOperators';
+export { useImageAnnotationCountsBySampleTags } from '$lib/hooks/useImageAnnotationCountsBySampleTags/useImageAnnotationCountsBySampleTags.svelte';

--- a/lightly_studio_view/src/lib/hooks/useImageAnnotationCountsBySampleTags/useImageAnnotationCountsBySampleTags.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageAnnotationCountsBySampleTags/useImageAnnotationCountsBySampleTags.svelte.ts
@@ -1,0 +1,74 @@
+import { createQuery } from '@tanstack/svelte-query';
+import type {
+    AnnotationCountMode,
+    AnnotationType,
+    ImageFilter,
+    SampleTagAnnotationCountsView
+} from '$lib/api/lightly_studio_local';
+import {
+    countImageAnnotationsBySampleTagsOptions,
+    countImageAnnotationsBySampleTagsQueryKey
+} from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import { countImageAnnotationsBySampleTags } from '$lib/api/lightly_studio_local/sdk.gen';
+import { useImageAnnotationCountsQueryKey } from '../useImageAnnotationCounts/useImageAnnotationCounts';
+
+interface GroupedAnnotationCountsParams {
+    collectionId: string;
+    sampleTagIds: string[];
+    filter?: ImageFilter;
+    annotationType?: AnnotationType;
+    countMode?: AnnotationCountMode;
+}
+
+export function buildImageAnnotationCountsBySampleTagsRequest({
+    collectionId,
+    sampleTagIds,
+    filter,
+    annotationType,
+    countMode
+}: GroupedAnnotationCountsParams) {
+    return {
+        path: { collection_id: collectionId },
+        body: {
+            sample_tag_ids: sampleTagIds,
+            ...(filter ? { filter } : {}),
+            ...(annotationType ? { annotation_type: annotationType } : {}),
+            ...(countMode ? { count_mode: countMode } : {})
+        }
+    };
+}
+
+export function buildImageAnnotationCountsBySampleTagsQueryKey(
+    params: GroupedAnnotationCountsParams
+): ReturnType<typeof countImageAnnotationsBySampleTagsQueryKey> {
+    return [
+        ...useImageAnnotationCountsQueryKey,
+        'by-sample-tags',
+        buildImageAnnotationCountsBySampleTagsRequest(params)
+    ] as unknown as ReturnType<typeof countImageAnnotationsBySampleTagsQueryKey>;
+}
+
+export const useImageAnnotationCountsBySampleTags = (
+    getParams: () => GroupedAnnotationCountsParams & { enabled?: boolean }
+) => {
+    return createQuery(() => {
+        const { enabled, ...params } = getParams();
+        const requestOptions = buildImageAnnotationCountsBySampleTagsRequest(params);
+
+        return {
+            ...countImageAnnotationsBySampleTagsOptions(requestOptions),
+            queryKey: buildImageAnnotationCountsBySampleTagsQueryKey(params),
+            queryFn: async ({ signal }: { signal: AbortSignal }) => {
+                const { data } = await countImageAnnotationsBySampleTags({
+                    ...requestOptions,
+                    signal,
+                    throwOnError: true
+                });
+                return data;
+            },
+            enabled: (enabled ?? true) && params.sampleTagIds.length > 0,
+            placeholderData: (previousData: SampleTagAnnotationCountsView[] | undefined) =>
+                previousData
+        };
+    });
+};


### PR DESCRIPTION
## Summary

- add a typed TanStack Query hook for the grouped sample-tag annotation-count endpoint
- build requests from collection ID, ordered sample tag IDs, the complete image filter, annotation type, and count mode
- keep grouped queries under the existing annotation-count cache-key prefix so annotation mutations invalidate both views
- disable grouped fetching for empty tag selections
- preserve previous grouped data during reactive key transitions and forward request cancellation
- export the hook through the public hooks barrel

## Why

The distribution panel needs one reactive request per annotation-type view, not one request per selected tag. Keeping every request dimension in the key prevents stale results when filters, count mode, annotation type, or tag order changes.

This is split from LIG-10239 to keep the query/cache behavior independently reviewable and below the requested 150-line threshold.

## Stack

- Base: LIG-10238 backend grouped endpoint (#1692)
- This PR: generated-client query integration
- Next: LIG-10239 local sample-tag selection and distribution wiring

## Testing

Generate the local API client from the stacked backend schema, then run frontend checks:

```bash
cd lightly_studio
.venv/bin/python src/lightly_studio/export_schema.py
cd ../lightly_studio_view
npm run generate-api-client
make static-checks
```

Validated locally with Node 24.13.1: Prettier, ESLint, TypeScript, and Svelte diagnostics all pass.

Focused query-key/request tests are added in the dedicated LIG-10241 coverage stack.

## Linear

[LIG-10245](https://linear.app/lightly/issue/LIG-10245/frontend-grouped-sample-tag-counts-query-hook)