### PR TITLE
LIG-10239 Wire sample-tag distribution comparison

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -1,6 +1,9 @@
 import type { CategoryCount } from '$lib/components/BarChart';
 import type { ClassSetSelection } from '$lib/components/ClassSetConfig';
-import { type AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
+import type {
+    AnnotationCountMode,
+    SampleTagAnnotationCountsView
+} from '$lib/api/lightly_studio_local/types.gen';
 import type { HistogramData, HistogramRange } from '$lib/components/Histogram';
 
 export type DistributionSortOption = 'count' | 'name';
@@ -25,6 +28,8 @@ export interface DistributionSourceGroup {
     label: string;
     /** Category counts rendered as a bar chart. Mutually exclusive with `histogram`. */
     data?: CategoryCount[];
+    /** Counts grouped by the sample tags selected for comparison. */
+    comparisonData?: SampleTagAnnotationCountsView[];
     /** Numeric bin distribution rendered as a histogram. Mutually exclusive with `data`. */
     histogram?: HistogramData;
     /**
@@ -44,6 +49,8 @@ export interface DistributionSource {
     label: string;
     /** Counts for a simple source. Mutually exclusive with `groups` and `histogram`. */
     data?: CategoryCount[];
+    /** Counts grouped by the sample tags selected for comparison. */
+    comparisonData?: SampleTagAnnotationCountsView[];
     /** Numeric bin distribution rendered as a histogram. Mutually exclusive with `data`. */
     histogram?: HistogramData;
     /**

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -1,6 +1,9 @@
 import type { CategoryCount } from '$lib/components/BarChart';
 import type { ClassSetSelection } from '$lib/components/ClassSetConfig';
-import { type AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
+import type {
+    AnnotationCountMode,
+    SampleTagAnnotationCountsView
+} from '$lib/api/lightly_studio_local/types.gen';
 import type { HistogramData, HistogramRange } from '$lib/components/Histogram';
 import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
 import type { CategoricalMetadataValue } from '$lib/services/types';
@@ -57,6 +60,8 @@ export interface DistributionSourceGroup {
     label: string;
     /** Category counts rendered as a bar chart. Mutually exclusive with `histogram`. */
     data?: CategoryCount[];
+    /** Counts grouped by the sample tags selected for comparison. */
+    comparisonData?: SampleTagAnnotationCountsView[];
     /** Numeric bin distribution rendered as a histogram. Mutually exclusive with `data`. */
     histogram?: HistogramData;
     /**
@@ -91,6 +96,8 @@ export interface DistributionSource {
     label: string;
     /** Counts for a simple source. Mutually exclusive with `groups` and `histogram`. */
     data?: CategoryCount[];
+    /** Counts grouped by the sample tags selected for comparison. */
+    comparisonData?: SampleTagAnnotationCountsView[];
     /** Numeric bin distribution rendered as a histogram. Mutually exclusive with `data`. */
     histogram?: HistogramData;
     /**

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -72,8 +72,10 @@
     import {
         useSelectionSummary,
         useImageAnnotationCounts,
+        useImageAnnotationCountsBySampleTags,
         useImageAnnotationCountsQueryKey,
-        useNumericMetadataDistribution
+        useNumericMetadataDistribution,
+        useTags
     } from '$lib/hooks';
     import { useSelectAll } from '$lib/hooks/useSelectAll/useSelectAll';
     import { isInputElement } from '$lib/utils';
@@ -454,6 +456,20 @@
 
     // Global count mode for the distribution panel (applies to all sources).
     let distributionCountMode = $state<AnnotationCountMode>(AnnotationCountMode.OBJECTS);
+    let distributionSampleTagIds = $state<string[]>([]);
+    const { tags: distributionSampleTags } = $derived(
+        useTags({ collection_id: datasetId, kind: ['sample'] })
+    );
+    const distributionSampleTagItems = $derived(
+        $distributionSampleTags.map((tag) => ({ value: tag.tag_id, label: tag.name }))
+    );
+    $effect(() => {
+        const validIds = new Set($distributionSampleTags.map((tag) => tag.tag_id));
+        const validSelection = distributionSampleTagIds.filter((id) => validIds.has(id));
+        if (validSelection.length !== distributionSampleTagIds.length) {
+            distributionSampleTagIds = validSelection;
+        }
+    });
 
     // Only create the per-type queries while the panel is open so we don't fetch
     // extra count queries on every collection view.
@@ -494,6 +510,27 @@
         enabled: distributionPanelVisible
     }));
 
+    const groupedCountsParams = (annotationType?: AnnotationType) => ({
+        collectionId: datasetId,
+        sampleTagIds: distributionSampleTagIds,
+        filter: imageAnnotationCountsFilter,
+        countMode: distributionCountMode,
+        annotationType,
+        enabled: distributionPanelVisible
+    });
+    const distributionAllTagQuery = useImageAnnotationCountsBySampleTags(() =>
+        groupedCountsParams()
+    );
+    const distributionClassificationTagQuery = useImageAnnotationCountsBySampleTags(() =>
+        groupedCountsParams(AnnotationType.CLASSIFICATION)
+    );
+    const distributionObjectDetectionTagQuery = useImageAnnotationCountsBySampleTags(() =>
+        groupedCountsParams(AnnotationType.OBJECT_DETECTION)
+    );
+    const distributionSegmentationTagQuery = useImageAnnotationCountsBySampleTags(() =>
+        groupedCountsParams(AnnotationType.SEGMENTATION_MASK)
+    );
+
     // The panel's sources are the distribution *types* (class labels,
     // metadata, …); the subset within a type (annotation type, metadata key)
     // is the source's group, picked in a second, contextual dropdown.
@@ -528,40 +565,55 @@
             distributionAllQuery.data !== undefined
                 ? toCategoryCounts(distributionAllQuery.data)
                 : classDistributionCounts;
-        const allTypesGroup = { id: 'all', label: 'All types', data: allDistributionData };
+        const allTypesGroup = {
+            id: 'all',
+            label: 'All types',
+            data: allDistributionData,
+            comparisonData: distributionAllTagQuery.data
+        };
 
         const perType: {
             id: AnnotationType;
             label: string;
             query: ReturnType<typeof useImageAnnotationCounts>;
+            comparisonQuery: ReturnType<typeof useImageAnnotationCountsBySampleTags>;
         }[] = [
             {
                 id: AnnotationType.CLASSIFICATION,
                 label: 'Classification',
-                query: distributionClassificationQuery
+                query: distributionClassificationQuery,
+                comparisonQuery: distributionClassificationTagQuery
             },
             {
                 id: AnnotationType.OBJECT_DETECTION,
                 label: 'Object detection',
-                query: distributionObjectDetectionQuery
+                query: distributionObjectDetectionQuery,
+                comparisonQuery: distributionObjectDetectionTagQuery
             },
             {
                 id: AnnotationType.SEGMENTATION_MASK,
                 label: 'Segmentation',
-                query: distributionSegmentationQuery
+                query: distributionSegmentationQuery,
+                comparisonQuery: distributionSegmentationTagQuery
             }
         ];
         const typeGroups = perType
-            .map(({ id, label, query }) => ({
+            .map(({ id, label, query, comparisonQuery }) => ({
                 id,
                 label,
-                data: toCategoryCounts(query.data)
+                data: toCategoryCounts(query.data),
+                comparisonData: comparisonQuery.data
             }))
             // Skip types with no matches in the current view so the picker stays clean.
             .filter((group) => group.data.length > 0);
         // With zero or one populated type, "All types" would just duplicate it —
         // drop the group picker entirely.
-        if (typeGroups.length <= 1) return { ...base, data: allDistributionData };
+        if (typeGroups.length <= 1)
+            return {
+                ...base,
+                data: allDistributionData,
+                comparisonData: distributionAllTagQuery.data
+            };
         return { ...base, groups: [allTypesGroup, ...typeGroups] };
     });
 
@@ -815,6 +867,10 @@
                                     {histogramBinCount}
                                     onHistogramBinCountChange={(binCount) =>
                                         (histogramBinCount = binCount)}
+                                    comparisonTagItems={distributionSampleTagItems}
+                                    selectedComparisonTagIds={distributionSampleTagIds}
+                                    onComparisonTagIdsChange={(ids) =>
+                                        (distributionSampleTagIds = ids)}
                                 />
                             {/await}
                         {/if}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -73,10 +73,12 @@
     import {
         useSelectionSummary,
         useImageAnnotationCounts,
+        useImageAnnotationCountsBySampleTags,
         useImageAnnotationCountsQueryKey,
         useNumericMetadataDistribution,
         usePostHog,
-        useCategoricalMetadataDistribution
+        useCategoricalMetadataDistribution,
+        useTags
     } from '$lib/hooks';
     import { useSelectAll } from '$lib/hooks/useSelectAll/useSelectAll';
     import { isInputElement } from '$lib/utils';
@@ -494,6 +496,20 @@
 
     // Global count mode for the distribution panel (applies to all sources).
     let distributionCountMode = $state<AnnotationCountMode>(AnnotationCountMode.OBJECTS);
+    let distributionSampleTagIds = $state<string[]>([]);
+    const { tags: distributionSampleTags } = $derived(
+        useTags({ collection_id: datasetId, kind: ['sample'] })
+    );
+    const distributionSampleTagItems = $derived(
+        $distributionSampleTags.map((tag) => ({ value: tag.tag_id, label: tag.name }))
+    );
+    $effect(() => {
+        const validIds = new Set($distributionSampleTags.map((tag) => tag.tag_id));
+        const validSelection = distributionSampleTagIds.filter((id) => validIds.has(id));
+        if (validSelection.length !== distributionSampleTagIds.length) {
+            distributionSampleTagIds = validSelection;
+        }
+    });
 
     // Only create the per-type queries while the panel is open so we don't fetch
     // extra count queries on every collection view.
@@ -534,6 +550,27 @@
         enabled: distributionPanelVisible
     }));
 
+    const groupedCountsParams = (annotationType?: AnnotationType) => ({
+        collectionId: datasetId,
+        sampleTagIds: distributionSampleTagIds,
+        filter: imageAnnotationCountsFilter,
+        countMode: distributionCountMode,
+        annotationType,
+        enabled: distributionPanelVisible
+    });
+    const distributionAllTagQuery = useImageAnnotationCountsBySampleTags(() =>
+        groupedCountsParams()
+    );
+    const distributionClassificationTagQuery = useImageAnnotationCountsBySampleTags(() =>
+        groupedCountsParams(AnnotationType.CLASSIFICATION)
+    );
+    const distributionObjectDetectionTagQuery = useImageAnnotationCountsBySampleTags(() =>
+        groupedCountsParams(AnnotationType.OBJECT_DETECTION)
+    );
+    const distributionSegmentationTagQuery = useImageAnnotationCountsBySampleTags(() =>
+        groupedCountsParams(AnnotationType.SEGMENTATION_MASK)
+    );
+
     // The panel's sources are the distribution *types* (class labels,
     // metadata, …); the subset within a type (annotation type, metadata key)
     // is the source's group, picked in a second, contextual dropdown.
@@ -568,40 +605,55 @@
             distributionAllQuery.data !== undefined
                 ? toCategoryCounts(distributionAllQuery.data)
                 : classDistributionCounts;
-        const allTypesGroup = { id: 'all', label: 'All types', data: allDistributionData };
+        const allTypesGroup = {
+            id: 'all',
+            label: 'All types',
+            data: allDistributionData,
+            comparisonData: distributionAllTagQuery.data
+        };
 
         const perType: {
             id: AnnotationType;
             label: string;
             query: ReturnType<typeof useImageAnnotationCounts>;
+            comparisonQuery: ReturnType<typeof useImageAnnotationCountsBySampleTags>;
         }[] = [
             {
                 id: AnnotationType.CLASSIFICATION,
                 label: 'Classification',
-                query: distributionClassificationQuery
+                query: distributionClassificationQuery,
+                comparisonQuery: distributionClassificationTagQuery
             },
             {
                 id: AnnotationType.OBJECT_DETECTION,
                 label: 'Object detection',
-                query: distributionObjectDetectionQuery
+                query: distributionObjectDetectionQuery,
+                comparisonQuery: distributionObjectDetectionTagQuery
             },
             {
                 id: AnnotationType.SEGMENTATION_MASK,
                 label: 'Segmentation',
-                query: distributionSegmentationQuery
+                query: distributionSegmentationQuery,
+                comparisonQuery: distributionSegmentationTagQuery
             }
         ];
         const typeGroups = perType
-            .map(({ id, label, query }) => ({
+            .map(({ id, label, query, comparisonQuery }) => ({
                 id,
                 label,
-                data: toCategoryCounts(query.data)
+                data: toCategoryCounts(query.data),
+                comparisonData: comparisonQuery.data
             }))
             // Skip types with no matches in the current view so the picker stays clean.
             .filter((group) => group.data.length > 0);
         // With zero or one populated type, "All types" would just duplicate it —
         // drop the group picker entirely.
-        if (typeGroups.length <= 1) return { ...base, data: allDistributionData };
+        if (typeGroups.length <= 1)
+            return {
+                ...base,
+                data: allDistributionData,
+                comparisonData: distributionAllTagQuery.data
+            };
         return { ...base, groups: [allTypesGroup, ...typeGroups] };
     });
 
@@ -937,6 +989,10 @@
                                             {histogramBinCount}
                                             onHistogramBinCountChange={(binCount) =>
                                                 (histogramBinCount = binCount)}
+                                            comparisonTagItems={distributionSampleTagItems}
+                                            selectedComparisonTagIds={distributionSampleTagIds}
+                                            onComparisonTagIdsChange={(ids) =>
+                                                (distributionSampleTagIds = ids)}
                                         />
                                     {/key}
                                 {/await}


### PR DESCRIPTION
## Summary

- load sample tags for the active image dataset without reusing the grid's selected-tag state
- keep a local, ordered comparison selection and prune IDs that are no longer available
- issue grouped class-count requests for All types, Classification, Object detection, and Segmentation
- apply the complete active image filter and current annotation count mode to every grouped request
- attach grouped responses to the matching distribution source/group for chart rendering

## Stack

- Base: #1694 (LIG-10246 comparison selector)
- Previous: #1693 (LIG-10245 grouped query hook)
- Backend: #1692 (LIG-10238 grouped counts endpoint)
- This PR: [LIG-10239](https://linear.app/lightly/issue/LIG-10239/frontend-sample-tag-comparison-selection-and-query-wiring)
- Follow-up: LIG-10240 renders the attached comparison data as grouped chart series

## Testing instructions

1. Check out this branch with the preceding stacked PRs.
2. Generate the local API client if it is not already present:
   ```bash
   cd lightly_studio_view
   npm run generate-api-client
   ```
3. Run:
   ```bash
   make static-checks
   ```
4. Open an image collection with sample tags and the Distribution panel.
5. Select multiple tags in **Compare by** and verify grouped count requests are sent for the current All types / annotation-type scopes.
6. Toggle filters and count mode, then verify the grouped requests update while the dataset grid's active tag filter remains unchanged.
7. Clear the comparison selection and verify grouped requests are disabled and the overall distribution remains available.

## Validation

- `make static-checks` (Node 24.13.1): passed