### PR TITLE
Fast Track: make bot PR state validation safer

### DIFF
--- a/fast_track/src/bot/run-bot.test.ts
+++ b/fast_track/src/bot/run-bot.test.ts
@@ -33,14 +33,34 @@ function pullRequest(overrides: Record<string, unknown> = {}) {
 }
 
 type PullRead = { pr?: unknown; throws?: boolean };
+type AssociatedRead = { prs?: unknown[]; throws?: boolean };
+
+/**
+ * Fake one API endpoint that is called several times during a run. Give it the
+ * responses in call order; it hands back the next one each call, and keeps
+ * returning the last one after that. A response marked `{ throws: true }` makes
+ * that call fail instead, standing in for a GitHub API error.
+ */
+function sequentialReads<T extends { throws?: boolean }>(reads: T[]): () => T {
+    let call = 0;
+    return () => {
+        const read = reads[Math.min(call, reads.length - 1)] ?? ({} as T);
+        call += 1;
+        if (read.throws === true) throw new Error('transient GitHub API failure');
+        return read;
+    };
+}
 
 interface FakeOptions {
     existingApproval?: boolean;
+    // deriveTarget looks up the PRs associated with the head commit. It runs once
+    // to find the target, then again only after an approval, to confirm exactly
+    // one eligible PR still points at that commit. Set each call's response here;
+    // the second defaults to repeating the first.
     associatedPullRequests?: unknown[];
-    // pulls.get gets called twice: once to reload the target before the approval,
-    // then once to re-check it afterwards. Configure the return values here.
+    reDeriveAfterApprove?: AssociatedRead;
+    // pulls.get runs once, to reload mutable PR state before the approval.
     reloadBeforeApprove?: PullRead;
-    recheckAfterApprove?: PullRead;
 }
 
 function fakeOctokit(options: FakeOptions = {}) {
@@ -51,11 +71,13 @@ function fakeOctokit(options: FakeOptions = {}) {
         ? [{ id: 1, user: { login: BOT_LOGIN }, state: 'APPROVED', commit_id: HEAD_SHA }]
         : [];
     const associatedPullRequests = options.associatedPullRequests ?? [pullRequest()];
-    const pullReads: PullRead[] = [
-        options.reloadBeforeApprove ?? { pr: pullRequest() },
-        options.recheckAfterApprove ?? { pr: pullRequest() }
-    ];
-    let getCall = 0;
+    const nextAssociated = sequentialReads<AssociatedRead>([
+        { prs: associatedPullRequests },
+        options.reDeriveAfterApprove ?? { prs: associatedPullRequests }
+    ]);
+    const nextPull = sequentialReads<PullRead>([
+        options.reloadBeforeApprove ?? { pr: pullRequest() }
+    ]);
 
     const createReview = vi.fn().mockImplementation(async () => {
         reviews.push({
@@ -75,7 +97,7 @@ function fakeOctokit(options: FakeOptions = {}) {
             if (route === listReviews)
                 return reviews.filter((review) => review.state === 'APPROVED');
             if (route === listComments) return [];
-            if (route === listAssociated) return associatedPullRequests;
+            if (route === listAssociated) return nextAssociated().prs ?? [];
             return [];
         }),
         rest: {
@@ -83,12 +105,7 @@ function fakeOctokit(options: FakeOptions = {}) {
                 listPullRequestsAssociatedWithCommit: listAssociated
             },
             pulls: {
-                get: vi.fn().mockImplementation(async () => {
-                    const read = pullReads[Math.min(getCall, pullReads.length - 1)] ?? {};
-                    getCall += 1;
-                    if (read.throws === true) throw new Error('transient GitHub API failure');
-                    return { data: read.pr };
-                }),
+                get: vi.fn().mockImplementation(async () => ({ data: nextPull().pr })),
                 listReviews,
                 createReview,
                 dismissReview
@@ -152,17 +169,50 @@ describe('runBot', () => {
         const newer = pullRequest({
             head: { sha: 'newer', repo: { id: 1, fork: false } }
         });
-        const execution = run(verdict(), { recheckAfterApprove: { pr: newer } });
+        const execution = run(verdict(), { reDeriveAfterApprove: { prs: [newer] } });
         await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
         expect(execution.createReview).toHaveBeenCalledOnce();
         expect(execution.dismissReview).toHaveBeenCalledOnce();
         expect(execution.createComment).not.toHaveBeenCalled();
     });
 
-    it('dismisses the approval if the post-approval refresh fails', async () => {
-        const execution = run(verdict(), { recheckAfterApprove: { throws: true } });
+    it('revokes a pass approval if a second PR now shares the head', async () => {
+        const other = pullRequest({ number: 8 });
+        const execution = run(verdict(), {
+            reDeriveAfterApprove: { prs: [pullRequest(), other] }
+        });
         await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
         expect(execution.createReview).toHaveBeenCalledOnce();
+        expect(execution.dismissReview).toHaveBeenCalledOnce();
+        expect(execution.createComment).not.toHaveBeenCalled();
+    });
+
+    it('dismisses the approval if the post-approval re-derive fails', async () => {
+        const execution = run(verdict(), { reDeriveAfterApprove: { throws: true } });
+        await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
+        expect(execution.createReview).toHaveBeenCalledOnce();
+        expect(execution.dismissReview).toHaveBeenCalledOnce();
+        expect(execution.createComment).not.toHaveBeenCalled();
+    });
+
+    it('dismisses an existing approval if the target is lost before approving', async () => {
+        const execution = run(verdict(), {
+            existingApproval: true,
+            reloadBeforeApprove: { pr: pullRequest({ state: 'closed' }) }
+        });
+        await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
+        expect(execution.createReview).not.toHaveBeenCalled();
+        expect(execution.dismissReview).toHaveBeenCalledOnce();
+        expect(execution.createComment).not.toHaveBeenCalled();
+    });
+
+    it('dismisses an existing approval if the pre-approval reload throws', async () => {
+        const execution = run(verdict(), {
+            existingApproval: true,
+            reloadBeforeApprove: { throws: true }
+        });
+        await expect(execution.result).resolves.toEqual({ status: 'dismissed', prNumber: 7 });
+        expect(execution.createReview).not.toHaveBeenCalled();
         expect(execution.dismissReview).toHaveBeenCalledOnce();
         expect(execution.createComment).not.toHaveBeenCalled();
     });

--- a/fast_track/src/bot/run-bot.ts
+++ b/fast_track/src/bot/run-bot.ts
@@ -21,45 +21,66 @@ export type BotResult =
 
 type BotActionParams = Parameters<typeof dismissApproval>[0];
 
+/** A verified target ready to act on, or the finished result to return when
+ *  there is nothing to act on (no PR) or the target could not be verified. */
+type VerifyOutcome = { target: BotTarget; actionParams: BotActionParams } | { done: BotResult };
+
 /** Apply a current pass verdict, revoking the bot approval for every other outcome. */
 export async function runBot(params: RunBotParams): Promise<BotResult> {
-    const target = await currentTarget(params);
-    if (target === null) {
-        return { status: 'skipped', reason: 'No eligible PR matched the trusted workflow run.' };
-    }
+    const outcome = await verifyTarget(params);
+    if ('done' in outcome) return outcome.done;
 
+    const { target, actionParams } = outcome;
     const verdict = effectiveVerdict(params, target);
-    const actionParams: BotActionParams = {
-        octokit: params.octokit,
-        owner: params.owner,
-        repo: params.repo,
-        prNumber: target.prNumber,
-        botLogin: params.botLogin
-    };
     return verdict.verdict === 'pass'
         ? applyPass(params, target, verdict, actionParams)
         : applyFailure(target, verdict, actionParams);
 }
 
-async function currentTarget(params: RunBotParams): Promise<BotTarget | null> {
+/**
+ * Find the target and reload its mutable state before any write. If there is no
+ * PR, skip. If the target is no longer verifiable, fail closed: dismiss any
+ * existing approval bound to this PR rather than skip, which would leave a stale
+ * approval active.
+ */
+async function verifyTarget(params: RunBotParams): Promise<VerifyOutcome> {
     const derivedTarget = await deriveTarget(params);
-    if (derivedTarget === null) return null;
-    return refreshTarget({ ...params, target: derivedTarget });
+    if (derivedTarget === null) {
+        return {
+            done: { status: 'skipped', reason: 'No eligible PR matched the trusted workflow run.' }
+        };
+    }
+
+    const actionParams = toActionParams(params, derivedTarget.prNumber);
+    const target = await targetOrNull(() => refreshTarget({ ...params, target: derivedTarget }));
+    if (target === null) {
+        await dismissApproval(actionParams);
+        return { done: { status: 'dismissed', prNumber: derivedTarget.prNumber } };
+    }
+    return { target, actionParams };
+}
+
+function toActionParams(params: RunBotParams, prNumber: number): BotActionParams {
+    return {
+        octokit: params.octokit,
+        owner: params.owner,
+        repo: params.repo,
+        prNumber,
+        botLogin: params.botLogin
+    };
 }
 
 /**
- * Reload the target, treating a failed reload as "no longer verifiable" so the
- * caller fails closed. A throw here would otherwise skip the post-approval
- * rollback and leave an unverified approval active.
+ * Resolve a target, treating a thrown error as "no longer verifiable" so the
+ * caller fails closed. A throw would otherwise skip the pre-approval dismissal
+ * or the post-approval rollback and leave an unverified approval active.
  */
-async function refreshOrNull(
-    params: Parameters<typeof refreshTarget>[0]
-): Promise<BotTarget | null> {
+async function targetOrNull(resolve: () => Promise<BotTarget | null>): Promise<BotTarget | null> {
     try {
-        return await refreshTarget(params);
+        return await resolve();
     } catch (error) {
         console.warn(
-            'Fast Track: target refresh failed; treating the target as unverifiable.',
+            'Fast Track: target check failed; treating the target as unverifiable.',
             error
         );
         return null;
@@ -73,7 +94,9 @@ async function applyPass(
     actionParams: BotActionParams
 ): Promise<BotResult> {
     await approve({ ...actionParams, headSha: target.headSha });
-    const finalTarget = await refreshOrNull({ ...params, target });
+    // Re-derive rather than reload: the re-check must re-run the "exactly one
+    // eligible PR at this head" invariant, not just reload the single known PR.
+    const finalTarget = await targetOrNull(() => deriveTarget(params));
     if (finalTarget === null || !verdictMatchesTarget(verdict, finalTarget)) {
         await dismissApproval(actionParams);
         return { status: 'dismissed', prNumber: target.prNumber };


### PR DESCRIPTION
## What has changed and why?

The Fast Track bot automatically approves a PR when all guardrails pass. It checks the PR twice — right before it approves, and again right after — to make sure nothing changed underneath it. This PR makes both checks safer. Both changes are in `run-bot.ts`.

**1. The check after approving now catches a second PR pointing at the same commit.**

The bot only approves when exactly one open PR points at the commit it tested. After it approves, it confirms this is still true. The old check only reloaded the *one* PR it already knew about, so it could miss a *second* PR that had meanwhile started pointing at the same commit — an ambiguous situation the bot should back out of. It now redoes the full "find exactly one PR for this commit" search, so it notices the second PR and removes its approval.

**2. If the PR disappears right before approving, the bot now removes its old approval instead of quietly quitting.**

Just before approving, the bot reloads the PR to confirm it's still open, not a draft, and unchanged. If it finds the PR is gone/changed (or the reload itself errors), the bot used to just stop — but if it had approved this PR on an earlier run, that stale approval was left in place. It now removes its earlier approval in this case.

Both checks treat an unexpected error as "can't confirm it's safe," so they remove the approval rather than leave one that couldn't be verified.

Follows D1e (apply verdicts fail closed, #1689), now merged; this PR is based on `main`.

## How has it been tested?

`make -C fast_track static-checks` and `make -C fast_track test` pass (21 files, 189 tests). Added `run-bot.test.ts` cases: after approving, both a changed head commit and a second PR at the same commit lead to the approval being removed; an error during the check after approving removes the approval; and if the PR is lost (or the reload errors) just before approving, an earlier approval is removed rather than left in place.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot approval handling when a pull request’s eligibility changes mid-run (including approval revocation when the head changes).
  * Dismisses existing approvals when the target can’t be reliably verified, including cases where verification/reload fails.
  * Re-derives and revalidates the eligible pull request before completing approval actions to avoid stale or incorrect approvals.
* **Tests**
  * Expanded and updated scenarios for re-derivation behavior, revoked approvals, and transient verification failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
