### PR TITLE
LIG-10252 Show groups for a single distribution source

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -230,24 +230,28 @@
             />
         {/if}
     </div>
-    {#if hasSourceSelector}
+    {#if hasSourceSelector || groupItems.length > 0}
         <!-- Fixed-width labels + flex-1 triggers keep both selects the same
              width, filling the panel row. -->
         <div class="mt-2 flex flex-col gap-2" data-testid="dataset-distribution-source">
-            <div class="flex items-center gap-2">
-                <span class="w-[100px] shrink-0 text-xs text-muted-foreground">Distribution</span>
-                <Select
-                    items={sourceItems}
-                    value={activeSource.id}
-                    size="xs"
-                    class="min-w-0 flex-1"
-                    testId="dataset-distribution-source-select"
-                    onValueChange={(value) => {
-                        selectedSourceId = value;
-                        selectedGroupId = undefined;
-                    }}
-                />
-            </div>
+            {#if hasSourceSelector}
+                <div class="flex items-center gap-2">
+                    <span class="w-[100px] shrink-0 text-xs text-muted-foreground"
+                        >Distribution</span
+                    >
+                    <Select
+                        items={sourceItems}
+                        value={activeSource.id}
+                        size="xs"
+                        class="min-w-0 flex-1"
+                        testId="dataset-distribution-source-select"
+                        onValueChange={(value) => {
+                            selectedSourceId = value;
+                            selectedGroupId = undefined;
+                        }}
+                    />
+                </div>
+            {/if}
 
             {#if groupItems.length > 0}
                 <div class="flex items-center gap-2">

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -319,24 +319,28 @@
             />
         {/if}
     </div>
-    {#if hasSourceSelector}
+    {#if hasSourceSelector || groupItems.length > 0}
         <!-- Fixed-width labels + flex-1 triggers keep both selects the same
              width, filling the panel row. -->
         <div class="mt-2 flex flex-col gap-2" data-testid="dataset-distribution-source">
-            <div class="flex items-center gap-2">
-                <span class="w-[100px] shrink-0 text-xs text-muted-foreground">Distribution</span>
-                <Select
-                    items={sourceItems}
-                    value={activeSource.id}
-                    size="xs"
-                    class="min-w-0 flex-1"
-                    testId="dataset-distribution-source-select"
-                    onValueChange={(value) => {
-                        selectedSourceId = value;
-                        selectedGroupId = undefined;
-                    }}
-                />
-            </div>
+            {#if hasSourceSelector}
+                <div class="flex items-center gap-2">
+                    <span class="w-[100px] shrink-0 text-xs text-muted-foreground"
+                        >Distribution</span
+                    >
+                    <Select
+                        items={sourceItems}
+                        value={activeSource.id}
+                        size="xs"
+                        class="min-w-0 flex-1"
+                        testId="dataset-distribution-source-select"
+                        onValueChange={(value) => {
+                            selectedSourceId = value;
+                            selectedGroupId = undefined;
+                        }}
+                    />
+                </div>
+            {/if}
 
             {#if groupItems.length > 0}
                 <div class="flex items-center gap-2">

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -422,6 +422,26 @@ describe('DatasetDistributionPanel', () => {
         expect(onHistogramRangeSelect).toHaveBeenCalledWith('confidence', { min: 0.5, max: 1 });
     });
 
+    it('shows a group selector when the only source has multiple groups', () => {
+        render(DatasetDistributionPanel, {
+            props: {
+                sources: [
+                    {
+                        id: 'classes',
+                        label: 'Annotation classes',
+                        groups: [
+                            { id: 'all', label: 'All types', data: balanced },
+                            { id: 'classification', label: 'Classification', data: balanced }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        expect(screen.queryByTestId('dataset-distribution-source-select')).not.toBeInTheDocument();
+        expect(screen.getByTestId('dataset-distribution-group-select')).toBeInTheDocument();
+    });
+
     const histogramSources: DistributionSource[] = [
         {
             id: 'metadata',

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -698,6 +698,26 @@ describe('DatasetDistributionPanel', () => {
         expect(onHistogramRangeSelect).toHaveBeenCalledWith('confidence', { min: 0.5, max: 1 });
     });
 
+    it('shows a group selector when the only source has multiple groups', () => {
+        render(DatasetDistributionPanel, {
+            props: {
+                sources: [
+                    {
+                        id: 'classes',
+                        label: 'Annotation classes',
+                        groups: [
+                            { id: 'all', label: 'All types', data: balanced },
+                            { id: 'classification', label: 'Classification', data: balanced }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        expect(screen.queryByTestId('dataset-distribution-source-select')).not.toBeInTheDocument();
+        expect(screen.getByTestId('dataset-distribution-group-select')).toBeInTheDocument();
+    });
+
     const histogramSources: DistributionSource[] = [
         {
             id: 'metadata',


### PR DESCRIPTION
## Summary

- render the contextual distribution-group selector even when only one top-level source exists
- keep the top-level source selector hidden for a single source
- add a regression test for a single Annotation classes source with multiple annotation-type groups

## Stack

- Base: #1700 (LIG-10250 grouped BarChart coverage)
- This PR: [LIG-10252](https://linear.app/lightly/issue/LIG-10252/frontend-show-distribution-group-selector-for-a-single-source)
- Follow-up: LIG-10249 covers comparison selection and group integration

This edge case was found while exercising LIG-10249: without numeric metadata, the existing wrapper hid the annotation-type selector together with the source selector.

## Testing instructions

```bash
cd lightly_studio_view
make static-checks
npm run test:unit -- --run \
  src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
```

Then open a dataset without numeric metadata and verify Annotation type is selectable while the Distribution source selector remains hidden.

## Validation

- focused DatasetDistributionPanel suite: 29 tests passed