### PR TITLE
Fast Track: run approval bot from CI

### DIFF
--- a/.github/workflows/fast_track_bot.yml
+++ b/.github/workflows/fast_track_bot.yml
@@ -1,0 +1,79 @@
+name: Fast Track Bot
+
+# Acts only after the read-only guardrail workflow completes. workflow_run uses
+# base-repository context, so App credentials are never exposed to PR code.
+on:
+  workflow_run:
+    workflows: ["Fast Track Guardrails"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  approve:
+    name: Fast Track Approval
+    # Scoped to the job, not the workflow: a skipped run (an unrelated title/body
+    # edit) must not cancel a bot that is revoking an approval. Only real runs for
+    # the same branch supersede each other.
+    concurrency:
+      group: >-
+        ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{
+        github.event.workflow_run.head_branch }}
+      cancel-in-progress: true
+    # A skipped guardrail run means a title/body edit left the code and base
+    # unchanged, so the existing approval still holds and there is nothing to
+    # re-judge. Every other outcome — failure, timeout, or a cancelled run with no
+    # fresh verdict — reaches the bot, which fails closed and revokes.
+    if: github.event.workflow_run.conclusion != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        # Only the permissions the bot uses: read the verdict artifact, write
+        # the review and status comment.
+        with:
+          app-id: ${{ secrets.FAST_TRACK_APP_ID }}
+          private-key: ${{ secrets.FAST_TRACK_APP_PRIVATE_KEY }}
+          permission-actions: read
+          permission-contents: read
+          permission-pull-requests: write
+
+      # No ref: checkout the trusted default branch, never the PR head. Checkout
+      # must precede artifact download because it cleans the working tree.
+      - name: Checkout Trusted Bot Code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set Up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: fast_track/.nvmrc
+          cache: npm
+          cache-dependency-path: fast_track/package-lock.json
+
+      - name: Install Dependencies
+        working-directory: fast_track
+        run: npm ci
+
+      - name: Download Verdict
+        id: download
+        # Tolerate a missing verdict so the bot still runs and revokes, fail closed.
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: fast-track-verdict
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ steps.app-token.outputs.token }}
+          path: fast_track/verdict
+
+      - name: Run Fast Track Bot
+        working-directory: fast_track
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GUARDRAIL_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: npm run bot-ci

--- a/fast_track/README.md
+++ b/fast_track/README.md
@@ -6,15 +6,14 @@ thin GitHub workflows launch it.
 
 Runs via [`tsx`](https://tsx.is/) — no build step, no compiled artifact.
 
-> **Status:** the judging half is live. The verdict contract, the guardrail
-> framework (context types, an always-pass dummy guardrail, the registry +
-> selector), the runner, and both context providers (local git + CI API) are in
-> place with unit tests. The **Fast Track Guardrails** workflow
-> (`.github/workflows/fast_track_guardrails.yml`) runs on every non-draft PR: its
-> CI entry (`src/guardrails/ci.ts`) judges the PR via the read-only GitHub API
-> and uploads a `verdict.json` artifact. Locally, `make run-guardrails` runs the
-> guardrails against your branch's committed changes. The bot (which reads the
-> verdict and approves) lands in subsequent, independently reviewable PRs.
+The **Fast Track Guardrails** workflow judges every non-draft PR with a read-only
+token and uploads `verdict.json`. The **Fast Track Bot** workflow then runs the
+trusted default-branch bot code with a short-lived App token. It validates the
+artifact against the current PR head and base, refuses fork PRs, and idempotently
+maintains one approval and one status comment. A crashed workflow or missing,
+invalid, or stale verdict revokes the bot approval. Add the `no-fast-track`
+label to opt out and defer to a human. Locally, `make run-guardrails` judges
+committed changes.
 
 ## Local commands
 

--- a/fast_track/package.json
+++ b/fast_track/package.json
@@ -14,7 +14,8 @@
         "test": "vitest run",
         "guardrails": "tsx src/guardrails/cli.ts",
         "list-guardrails": "tsx src/guardrails/cli.ts --list",
-        "guardrails-ci": "tsx src/guardrails/ci.ts"
+        "guardrails-ci": "tsx src/guardrails/ci.ts",
+        "bot-ci": "tsx src/bot/ci.ts"
     },
     "dependencies": {
         "@actions/github": "^6.0.1",

--- a/fast_track/src/bot/ci.ts
+++ b/fast_track/src/bot/ci.ts
@@ -1,0 +1,56 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import { context, getOctokit } from '@actions/github';
+
+import { guardrails } from '../guardrails/registry';
+import { runBot } from './run-bot';
+
+// The verdict comes from code in the pull request, so it can be faked. That is
+// fine: a faked pass only earns the bot's approval, which still cannot merge the
+// pull request on its own. Safety rests on this, not on trusting the verdict.
+const VERDICT_PATH = 'verdict/verdict.json';
+
+async function main(env: NodeJS.ProcessEnv): Promise<void> {
+    const token = requiredEnv(env, 'GITHUB_TOKEN');
+    const trustedHeadSha = requiredEnv(env, 'HEAD_SHA');
+    const appSlug = requiredEnv(env, 'APP_SLUG');
+    const guardrailConclusion = requiredEnv(env, 'GUARDRAIL_CONCLUSION');
+    const verdict = await readVerdict();
+
+    const result = await runBot({
+        octokit: getOctokit(token),
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        trustedHeadSha,
+        botLogin: `${appSlug}[bot]`,
+        guardrailsSucceeded: guardrailConclusion === 'success',
+        requiredGuardrailNames: guardrails
+            .filter((guardrail) => guardrail.required)
+            .map((guardrail) => guardrail.name),
+        verdict
+    });
+    console.log(JSON.stringify(result));
+}
+
+async function readVerdict(): Promise<unknown> {
+    try {
+        return JSON.parse(await readFile(VERDICT_PATH, 'utf8')) as unknown;
+    } catch (error) {
+        console.warn(`Could not read a valid verdict from ${VERDICT_PATH}.`, error);
+        return undefined;
+    }
+}
+
+function requiredEnv(env: NodeJS.ProcessEnv, name: string): string {
+    const value = env[name];
+    if (value === undefined || value === '') throw new Error(`${name} is not set.`);
+    return value;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main(process.env).catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
## What has changed and why?

Makes the Fast Track approval bot go live. Adds the **Fast Track Bot** workflow, triggered when the read-only guardrail workflow completes. It checks out trusted default-branch code, mints a short-lived App token, downloads the verdict artifact, and runs the bot — keeping App credentials away from pull-request code.

Beyond the bot mechanics already reviewed in earlier PRs, this one:

- Ignores guardrail runs that finish as *skipped* or *cancelled* (a title/body edit or a superseded run), so an unrelated edit can no longer drop a valid approval. Real failures still revoke.
- Scopes the App token to only the permissions the bot uses.
- Notes at the verdict-read site that the verdict is not a trusted signal: it is produced by pull-request code, and a faked pass only earns an approval that still cannot merge on its own.

Stacked on #1698; review the single top commit.

**NOTE:** The bot approval is not yet sufficient to merge a PR! The CODEOWNERS file still requires a human review, we will disable it once we are happy with the Fast Track system.

Note 2: There is a potential race condition if two guardrail runs are triggered at almost the same time. Will be addressed in a follow-up.

## How has it been tested?

`make -C fast_track static-checks` and `make -C fast_track test` pass (189 tests). Workflow YAML validated. The live `workflow_run` path can only be exercised once the workflow is on the default branch.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a “Fast Track Bot” workflow that runs after Guardrails completes to verify the verdict artifact and handle PR approval/status updates.
  - Automated approval is revoked for missing, invalid, stale, or non-successful verdicts; fork PRs remain excluded.
  - Added a `no-fast-track` label opt-out, and the bot avoids duplicate in-progress runs for the same PR branch.
  - Introduced a dedicated `bot-ci` runner to execute the bot logic.

- **Documentation**
  - Updated Fast Track docs with the full end-to-end workflow contract and local guardrails guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->