### PR TITLE
Extract EmbeddingResult to a shared, path-agnostic module

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.typing import NDArray
 from PIL import Image
 
-from lightly_studio.dataset.image_embedding import ImageEmbeddingResult
+from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 
 
@@ -66,9 +66,7 @@ class ImageEmbeddingGenerator(EmbeddingGenerator, Protocol):
     for creating embeddings.
     """
 
-    def embed_images(
-        self, filepaths: list[str], show_progress: bool = True
-    ) -> ImageEmbeddingResult:
+    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> EmbeddingResult:
         """Generate embeddings for multiple image samples.
 
         TODO(Michal, 04/2025): Use DatasetLoader as input instead.
@@ -78,7 +76,7 @@ class ImageEmbeddingGenerator(EmbeddingGenerator, Protocol):
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            An ``ImageEmbeddingResult`` with embeddings for the readable files, in the same
+            An ``EmbeddingResult`` with embeddings for the readable files, in the same
             order as the corresponding input file paths.
         """
         ...
@@ -167,13 +165,11 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         """Generate a random embedding for a text sample."""
         return [random.random() for _ in range(self._dimension)]
 
-    def embed_images(
-        self, filepaths: list[str], show_progress: bool = True
-    ) -> ImageEmbeddingResult:
+    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> EmbeddingResult:
         """Generate random embeddings for multiple image samples."""
         _ = show_progress  # Not used for random embeddings.
         embeddings = np.random.rand(len(filepaths), self._dimension).astype(np.float32)
-        return ImageEmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(filepaths))))
+        return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(filepaths))))
 
     def embed_image_crops(
         self, image_crops: list[ImageCrop], show_progress: bool = True

--- a/lightly_studio/src/lightly_studio/dataset/embedding_result.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_result.py
@@ -1,0 +1,32 @@
+"""Result type shared by the batched embedding paths.
+
+Holds :class:`EmbeddingResult`, the model-agnostic return type used across the
+image, image-crop, and video embedding paths. It lives in its own module so any
+embedding path can depend on it without pulling in a path-specific module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class EmbeddingResult:
+    """Embeddings for the inputs that could be read, plus which inputs they cover.
+
+    Broken inputs (unreadable/undecodable files) are skipped rather than aborting the
+    whole run, so ``embeddings`` may hold fewer rows than the input list. ``kept_indices``
+    maps each row back to its position in the input list, in input order, letting callers
+    realign any parallel per-input data (e.g. sample IDs) with the embeddings.
+
+    Attributes:
+        embeddings: Float32 array of shape ``(len(kept_indices), embedding_dimension)``.
+        kept_indices: Indices into the input list of the inputs that were embedded,
+            in input order.
+    """
+
+    embeddings: NDArray[np.float32]
+    kept_indices: list[int]

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -21,6 +21,7 @@ from PIL import Image, UnidentifiedImageError
 from tqdm import tqdm
 
 from lightly_studio.core.file_outcome_report import FileOutcome, FileOutcomeReport
+from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.utils import batching, parallelize
 
 _ItemT = TypeVar("_ItemT")
@@ -53,30 +54,11 @@ class _EmbeddingProgress:
     unit: str
 
 
-@dataclass(frozen=True)
-class ImageEmbeddingResult:
-    """Embeddings for the image files that could be read, plus which inputs they cover.
-
-    Broken files (unreadable/undecodable) are skipped rather than aborting the whole
-    run, so ``embeddings`` may hold fewer rows than the input file list. ``kept_indices``
-    maps each row back to its position in the input list, in input order, letting callers
-    realign any parallel per-file data (e.g. sample IDs) with the embeddings.
-
-    Attributes:
-        embeddings: Float32 array of shape ``(len(kept_indices), embedding_dimension)``.
-        kept_indices: Indices into the input file list of the files that were embedded,
-            in input order.
-    """
-
-    embeddings: NDArray[np.float32]
-    kept_indices: list[int]
-
-
 def embed_image_files_batched(
     filepaths: list[str],
     context: EmbeddingContext,
     show_progress: bool,
-) -> ImageEmbeddingResult:
+) -> EmbeddingResult:
     """Embed image files in batches, preserving input order and skipping broken files.
 
     Args:
@@ -85,7 +67,7 @@ def embed_image_files_batched(
         show_progress: Whether to show a tqdm progress bar.
 
     Returns:
-        An ``ImageEmbeddingResult`` whose embeddings cover only the readable files, with
+        An ``EmbeddingResult`` whose embeddings cover only the readable files, with
         ``kept_indices`` mapping each row back to its input position.
 
     Raises:
@@ -152,7 +134,7 @@ def _embed_items_batched(
     context: EmbeddingContext,
     show_progress: bool,
     progress: _EmbeddingProgress,
-) -> ImageEmbeddingResult:
+) -> EmbeddingResult:
     """Preprocess items on a thread pool and embed them in batches, preserving order.
 
     ``preprocess_item`` (per-item PIL decode/resize/normalize, plus remote reads for file
@@ -164,13 +146,13 @@ def _embed_items_batched(
     bounded.
 
     Returns:
-        An ``ImageEmbeddingResult`` whose embeddings cover the kept items and whose
+        An ``EmbeddingResult`` whose embeddings cover the kept items and whose
         ``kept_indices`` map each row back to its index into ``items``, both in input order.
     """
     total_items = len(items)
     if not total_items:
         empty = np.empty((0, context.embedding_dimension), dtype=np.float32)
-        return ImageEmbeddingResult(embeddings=empty, kept_indices=[])
+        return EmbeddingResult(embeddings=empty, kept_indices=[])
 
     if context.max_batch_size <= 0:
         raise ValueError("max_batch_size must be positive.")
@@ -193,7 +175,7 @@ def _embed_items_batched(
         show_progress=show_progress,
         progress=progress,
     )
-    return ImageEmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
+    return EmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
 
 
 def _keep_non_none(

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -16,7 +16,8 @@ from lightly_studio.vendor import mobileclip
 
 from . import file_utils, image_crop_embedding, image_embedding
 from .embedding_generator import ImageCrop, ImageEmbeddingGenerator
-from .image_embedding import EmbeddingContext, ImageEmbeddingResult
+from .embedding_result import EmbeddingResult
+from .image_embedding import EmbeddingContext
 
 MODEL_NAME = "mobileclip_s0"
 MOBILECLIP_DOWNLOAD_URL = (
@@ -84,9 +85,7 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
         return embedding_list
 
-    def embed_images(
-        self, filepaths: list[str], show_progress: bool = True
-    ) -> ImageEmbeddingResult:
+    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> EmbeddingResult:
         """Embed images with MobileCLIP.
 
         Args:
@@ -94,7 +93,7 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            An ``ImageEmbeddingResult`` with embeddings for the readable files, in the same
+            An ``EmbeddingResult`` with embeddings for the readable files, in the same
             order as the corresponding input file paths.
         """
         return image_embedding.embed_image_files_batched(

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -21,7 +21,8 @@ from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transfor
 
 from . import file_utils, image_crop_embedding, image_embedding
 from .embedding_generator import ImageCrop, ImageEmbeddingGenerator, VideoEmbeddingGenerator
-from .image_embedding import EmbeddingContext, ImageEmbeddingResult
+from .embedding_result import EmbeddingResult
+from .image_embedding import EmbeddingContext
 
 MODEL_NAME = "PE-Core-T16-384"
 DEFAULT_VIDEO_CHANNEL = 0
@@ -162,9 +163,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
         return embedding_list
 
-    def embed_images(
-        self, filepaths: list[str], show_progress: bool = True
-    ) -> ImageEmbeddingResult:
+    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> EmbeddingResult:
         """Embed images with Perception Encoder.
 
         Args:
@@ -172,7 +171,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             show_progress: Whether to show a progress bar during embedding.
 
         Returns:
-            An ``ImageEmbeddingResult`` with embeddings for the readable files, in the same
+            An ``EmbeddingResult`` with embeddings for the readable files, in the same
             order as the corresponding input file paths.
         """
         return image_embedding.embed_image_files_batched(

--- a/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
@@ -23,8 +23,9 @@ from PIL import Image
 import lightly_studio as ls
 from lightly_studio.database import db_manager
 from lightly_studio.dataset import file_utils, image_crop_embedding, image_embedding
+from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
-from lightly_studio.dataset.image_embedding import EmbeddingContext, ImageEmbeddingResult
+from lightly_studio.dataset.image_embedding import EmbeddingContext
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor import mobileclip
 
@@ -86,9 +87,7 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
             embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
         return embedding_list
 
-    def embed_images(
-        self, filepaths: list[str], show_progress: bool = True
-    ) -> ImageEmbeddingResult:
+    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> EmbeddingResult:
         """Embed a batch of images, returning one row per readable input path."""
         return image_embedding.embed_image_files_batched(
             filepaths=filepaths,

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -21,7 +21,7 @@ from lightly_studio.dataset.embedding_manager import (
     EmbeddingManager,
     TextEmbedQuery,
 )
-from lightly_studio.dataset.image_embedding import ImageEmbeddingResult
+from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
@@ -100,9 +100,7 @@ def test_register_multiple_models(
         def embed_text(self, text: str) -> list[float]:
             raise NotImplementedError()
 
-        def embed_images(
-            self, filepaths: list[str], show_progress: bool = True
-        ) -> ImageEmbeddingResult:
+        def embed_images(self, filepaths: list[str], show_progress: bool = True) -> EmbeddingResult:
             raise NotImplementedError()
 
         def embed_image_crops(
@@ -627,11 +625,9 @@ def test_set_default_embedding_model_falls_back_to_env_for_unregistered_slot(
             _ = text
             return [0.1, 0.2, 0.3]
 
-        def embed_images(
-            self, filepaths: list[str], show_progress: bool = True
-        ) -> ImageEmbeddingResult:
+        def embed_images(self, filepaths: list[str], show_progress: bool = True) -> EmbeddingResult:
             _ = show_progress
-            return ImageEmbeddingResult(
+            return EmbeddingResult(
                 embeddings=np.zeros((len(filepaths), 3), dtype=np.float32),
                 kept_indices=list(range(len(filepaths))),
             )


### PR DESCRIPTION
## Summary

Prefactor sliced out of #1706. Pure rename/move — **no behavior change**.

- Rename `ImageEmbeddingResult` → `EmbeddingResult` and move it out of `image_embedding.py` into its own dependency-free module `dataset/embedding_result.py`.
- The type carries `embeddings` + `kept_indices` and is not image-specific. Giving it a neutral home lets the image, image-crop, and (future) video embedding paths reuse it without importing a path-specific module.
- Only the **image** embedding path is touched here. The crop path still returns `NDArray` on `main` and adopts `EmbeddingResult` in the stacked crop PR (#1706).

## Stacking

#1706 (crop broken-file handling) will be rebased to stack on top of this PR.

## Testing

- `make static-checks` — ruff + format + mypy clean.
- `pytest tests/dataset/{test_embedding_manager,test_mobileclip_embedding_generator,test_perception_encoder_embedding_generator,test_embedding_generator}.py` — 46 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized embedding results across image, crop, and video workflows.
  * Embedding outputs now consistently include generated vectors and the source-item indices they correspond to.
  * Existing embedding behavior and filtering of unreadable inputs remain unchanged.
* **Examples & Tests**
  * Updated custom embedding examples and validation coverage to use the standardized result format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->