### PR TITLE
Fix: truncate text overflow for tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Long tags shown in the left side menu are truncated.
+
 ### Security
 
 ## \[1.0.3\] - 2026-07-10

--- a/lightly_studio_view/src/lib/components/Form/Checkbox/Checkbox.svelte
+++ b/lightly_studio_view/src/lib/components/Form/Checkbox/Checkbox.svelte
@@ -20,8 +20,8 @@
     } = $props();
 </script>
 
-<div class="flex flex-col gap-2">
-    <div class="flex gap-2">
+<div class="flex min-w-0 flex-col gap-2">
+    <div class="flex min-w-0 gap-2">
         <Checkbox
             id={name}
             aria-labelledby={`${name}-label`}
@@ -32,8 +32,9 @@
         <Label
             id={`${name}-label`}
             for={name}
-            class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            class="min-w-0 flex-1 truncate text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
             data-testid="tags-menu-label"
+            title={label}
         >
             {label}
         </Label>


### PR DESCRIPTION
## What has changed and why?

Before
<img width="498" height="347" alt="image" src="https://github.com/user-attachments/assets/952fa44c-44b9-448b-b887-7efd5337fe02" />

or 

<img width="332" height="124" alt="image" src="https://github.com/user-attachments/assets/7c51f69a-ce75-45ba-abfd-064ca75b514e" />



After
<img width="507" height="344" alt="image" src="https://github.com/user-attachments/assets/e5892927-925a-4042-bde1-ebc52628ffb5" />

If you hover long enough we also show the title (so users still see the full tag name):
<img width="478" height="347" alt="image" src="https://github.com/user-attachments/assets/a6e4c77d-49d3-4baa-a79d-50aa3062db8b" />


## How has it been tested?

- Manual in the GUI as this is only as HTML class change

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [X] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long tags in the left-side menu are now truncated instead of overflowing.
  * Checkbox labels now fit more reliably within their available space and display full text on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->