### PR TITLE
Fast Track: shared Octokit type module

### DIFF
--- a/fast_track/src/bot/comment.test.ts
+++ b/fast_track/src/bot/comment.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { Octokit } from '../guardrails/context/types';
+import type { Octokit } from '../shared/octokit';
 import type { Verdict } from '../shared/verdict';
 import { renderComment, upsertComment } from './comment';
 

--- a/fast_track/src/bot/comment.ts
+++ b/fast_track/src/bot/comment.ts
@@ -1,4 +1,4 @@
-import type { Octokit } from '../guardrails/context/types';
+import type { Octokit } from '../shared/octokit';
 import type { Verdict } from '../shared/verdict';
 
 const COMMENT_MARKER = '<!-- fast-track-bot -->';

--- a/fast_track/src/bot/derive-target.test.ts
+++ b/fast_track/src/bot/derive-target.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { Octokit } from '../guardrails/context/types';
+import type { Octokit } from '../shared/octokit';
 import { deriveTarget, refreshTarget, type BotTarget } from './derive-target';
 
 const HEAD_SHA = 'abc123';

--- a/fast_track/src/bot/derive-target.ts
+++ b/fast_track/src/bot/derive-target.ts
@@ -1,4 +1,4 @@
-import type { Octokit } from '../guardrails/context/types';
+import type { Octokit } from '../shared/octokit';
 
 /** `listPullRequestsAssociatedWithCommit` caps per_page at 100. */
 const PER_PAGE = 100;

--- a/fast_track/src/bot/review.test.ts
+++ b/fast_track/src/bot/review.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { Octokit } from '../guardrails/context/types';
+import type { Octokit } from '../shared/octokit';
 import { approve, dismissApproval } from './review';
 
 const BOT_LOGIN = 'fast-track-bot[bot]';

--- a/fast_track/src/bot/review.ts
+++ b/fast_track/src/bot/review.ts
@@ -1,4 +1,4 @@
-import type { Octokit } from '../guardrails/context/types';
+import type { Octokit } from '../shared/octokit';
 
 const DISMISS_MESSAGE = 'Fast Track checks no longer pass; dismissing the bot approval.';
 const SUPERSEDED_MESSAGE = 'Superseded by a newer Fast Track approval.';

--- a/fast_track/src/bot/run-bot.test.ts
+++ b/fast_track/src/bot/run-bot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { Octokit } from '../guardrails/context/types';
+import type { Octokit } from '../shared/octokit';
 import { OPT_OUT_LABEL } from '../guardrails/author-opt-out';
 import type { Verdict } from '../shared/verdict';
 import { runBot } from './run-bot';

--- a/fast_track/src/bot/run-bot.ts
+++ b/fast_track/src/bot/run-bot.ts
@@ -1,4 +1,4 @@
-import type { Octokit } from '../guardrails/context/types';
+import type { Octokit } from '../shared/octokit';
 import type { Verdict } from '../shared/verdict';
 import { renderComment, upsertComment } from './comment';
 import { deriveTarget, refreshTarget, type BotTarget } from './derive-target';

--- a/fast_track/src/guardrails/context/api-context.test.ts
+++ b/fast_track/src/guardrails/context/api-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Octokit } from './api-context';
+import type { Octokit } from '../../shared/octokit';
 import { ApiGuardrailContext, toChangedFile } from './api-context';
 
 /** A `pulls.listFiles` entry, with the extra fields the mapper ignores. */

--- a/fast_track/src/guardrails/context/api-context.ts
+++ b/fast_track/src/guardrails/context/api-context.ts
@@ -1,6 +1,5 @@
-import type { ChangedFile, FileStatus, GuardrailContext, Octokit } from './types';
-
-export type { Octokit };
+import type { Octokit } from '../../shared/octokit';
+import type { ChangedFile, FileStatus, GuardrailContext } from './types';
 
 /** `pulls.listFiles` caps per_page at 100. */
 const PER_PAGE = 100;

--- a/fast_track/src/guardrails/context/types.ts
+++ b/fast_track/src/guardrails/context/types.ts
@@ -1,14 +1,7 @@
-import type { GitHub } from '@actions/github/lib/utils';
-
+import type { Octokit } from '../../shared/octokit';
 import type { GuardrailResult } from '../../shared/verdict';
 
 export type FileStatus = 'added' | 'deleted' | 'modified' | 'renamed' | 'copied';
-
-/**
- * A hydrated Octokit client. Type-only import — erases at runtime so the local
- * git path never loads `@actions/github`.
- */
-export type Octokit = InstanceType<typeof GitHub>;
 
 export interface ChangedFile {
     path: string;

--- a/fast_track/src/shared/octokit.ts
+++ b/fast_track/src/shared/octokit.ts
@@ -1,0 +1,10 @@
+import type { GitHub } from '@actions/github/lib/utils';
+
+/**
+ * A hydrated Octokit client, shared by the bot and the guardrails. Type-only
+ * import — it erases at runtime, so referencing `Octokit` never pulls
+ * `@actions/github` into a bundle. This keeps the guardrails' local git path
+ * (which has no Actions runtime) free of the dependency; the bot always loads
+ * it in CI regardless.
+ */
+export type Octokit = InstanceType<typeof GitHub>;


### PR DESCRIPTION
## What has changed and why?

Move the `Octokit` type definition to a shared location (`src/shared/octokit.ts`) so the bot and guardrails both import it from one source.

## How has it been tested?

`make -C fast_track static-checks && make -C fast_track test` — green.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized the Octokit type definition for consistent use across bot and guardrail components.
  * No changes to runtime behavior or public functionality.

* **Tests**
  * Updated type references in automated tests while preserving existing test logic and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->