### PR TITLE
Dim unselected categorical bars when a selection is active

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -9,10 +9,10 @@ import {
 } from '$lib/utils';
 import type { CategoryCount } from './';
 
-// Single accent color (the Lightly primary green, --color-lightly-primary #3bd99f):
-// per-class colors carry no meaning in a count distribution.
+// Same accent as Histogram (the Lightly primary green, --color-lightly-primary #3bd99f).
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
-const SELECTED_BORDER_COLOR = 'rgba(255,255,255,0.95)';
+// Bars not in the active selection render dimmed, matching the histogram behaviour.
+const BAR_COLOR_DIMMED = '#4b5563';
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
 export type BarChartOrientation = 'vertical' | 'horizontal';
@@ -41,6 +41,9 @@ export function buildEchartsOption(
     const isHorizontal = orientation === 'horizontal';
 
     const labels = data.map((item) => item.label);
+    // When any category is actively selected, dim the rest — mirrors the range
+    // highlighting in the numeric Histogram where out-of-range bins go grey.
+    const hasAnySelected = data.some((item) => item.selected === true);
 
     const categoryAxis = {
         type: 'category' as const,
@@ -92,13 +95,12 @@ export function buildEchartsOption(
                 type: 'bar',
                 data: data.map((item) => {
                     if (item.selected == null && item.selectable == null) return item.count;
+                    const isDimmed = hasAnySelected && !item.selected;
                     return {
                         value: item.count,
                         itemStyle: {
-                            color: BAR_COLOR,
-                            opacity: item.selectable === false ? 0.45 : 1,
-                            borderColor: item.selected ? SELECTED_BORDER_COLOR : 'transparent',
-                            borderWidth: item.selected ? 3 : 0
+                            color: isDimmed ? BAR_COLOR_DIMMED : BAR_COLOR,
+                            opacity: item.selectable === false ? 0.45 : 1
                         }
                     };
                 }),


### PR DESCRIPTION
## Summary

- Adds `BAR_COLOR_DIMMED` (`#4b5563`) to `buildEchartsOption` — the same grey used by the numeric `Histogram` for out-of-range bins.
- When any categorical value is selected, bars that are not selected render in grey instead of staying green.
- Removes the white selected-bar border; the green/grey colour contrast communicates selection without it.

Part of a stack — `p2` and `p3` build on top of this.

## Test plan

- [ ] Select a categorical metadata value from the distribution panel — unselected bars turn grey, selected bar stays green.
- [ ] Deselect all values — all bars return to green.
- [ ] `buildEchartsOption` unit tests pass (`npm run test:unit -- --run`).
- [ ] Static checks pass (`npm run static-checks`).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)