### PR TITLE
Show full-count background bars when sidebar filters reduce categorical distributions

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -41,22 +41,55 @@ describe('buildEchartsOption', () => {
         expect(horizontal.xAxis.minInterval).toBe(1);
     });
 
-    it('adds selected and disabled treatments without changing typed category identity', () => {
+    it('dims unselected bars green when a selection is active; disabled bars keep reduced opacity', () => {
         const option = buildEchartsOption([
-            { id: 'selected', label: 'Missing', count: 3, selected: true, selectable: true },
+            { id: 'sel', label: 'Missing', count: 3, selected: true, selectable: true },
             { id: 'other', label: 'Other', count: 2, selected: false, selectable: false }
         ]) as {
             series: [{ data: { value: number; itemStyle: Record<string, unknown> }[] }];
         };
 
+        // Selected bar: accent green, full opacity.
         expect(option.series[0].data[0]).toMatchObject({
             value: 3,
-            itemStyle: { borderWidth: 3, opacity: 1 }
+            itemStyle: { color: 'rgba(59,217,159,0.85)', opacity: 1 }
         });
+        // Non-selected + non-selectable: dimmed colour and reduced opacity.
         expect(option.series[0].data[1]).toMatchObject({
             value: 2,
-            itemStyle: { borderWidth: 0, opacity: 0.45 }
+            itemStyle: { color: '#4b5563', opacity: 0.45 }
         });
+    });
+
+    it('overlays a filtered foreground bar on a grey full-count background when filteredCount differs', () => {
+        const option = buildEchartsOption([
+            { label: 'dog', count: 100, filteredCount: 60 },
+            { label: 'cat', count: 50, filteredCount: 50 }
+        ]) as {
+            series: [
+                { type: string; data: { value: number }[] },
+                { type: string; data: { value: number }[]; barGap: string }
+            ];
+        };
+
+        // Two series rendered when filter is active.
+        expect(option.series).toHaveLength(2);
+        // Background series: always full count.
+        expect(option.series[0].data[0].value).toBe(100);
+        expect(option.series[0].data[1].value).toBe(50);
+        // Foreground series: filtered count; uses barGap '-100%' to overlay.
+        expect(option.series[1].data[0]).toMatchObject({ value: 60 });
+        expect(option.series[1].data[1]).toMatchObject({ value: 50 });
+        expect(option.series[1].barGap).toBe('-100%');
+    });
+
+    it('renders a single series and no background when all filteredCounts match full counts', () => {
+        const option = buildEchartsOption([
+            { label: 'dog', count: 100, filteredCount: 100 },
+            { label: 'cat', count: 50, filteredCount: 50 }
+        ]) as { series: unknown[] };
+
+        expect(option.series).toHaveLength(1);
     });
 
     it('accepts compact top padding without changing the default grid', () => {

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -13,6 +13,9 @@ import type { CategoryCount } from './';
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
 // Bars not in the active selection render dimmed, matching the histogram behaviour.
 const BAR_COLOR_DIMMED = '#4b5563';
+// Full-dataset context bars drawn behind the filtered foreground bars.
+// Matches CHART_LINE_COLOR so background bars blend with the chart grid lines.
+const BAR_COLOR_BACKGROUND = '#374151';
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
 export type BarChartOrientation = 'vertical' | 'horizontal';
@@ -44,6 +47,12 @@ export function buildEchartsOption(
     // When any category is actively selected, dim the rest — mirrors the range
     // highlighting in the numeric Histogram where out-of-range bins go grey.
     const hasAnySelected = data.some((item) => item.selected === true);
+    // Render a grey background bar at the full count when sidebar filters reduce
+    // some bars below their unfiltered height. This keeps the original distribution
+    // visible as context while the foreground bar communicates the filtered portion.
+    const hasActiveFilter = data.some(
+        (item) => item.filteredCount !== undefined && item.filteredCount !== item.count
+    );
 
     const categoryAxis = {
         type: 'category' as const,
@@ -75,39 +84,87 @@ export function buildEchartsOption(
         splitLine: { lineStyle: { color: CHART_LINE_COLOR } }
     };
 
+    // Tooltip shows "Total / In filter" when a filter is active and actually
+    // reduces the hovered bar; otherwise shows the single "Count" line.
+    const formatter = (params: { name: string; value: number }[]) => {
+        if (params.length >= 2) {
+            const totalValue = params[0].value; // background series = full count
+            const filteredValue = params[1].value; // foreground series = filtered count
+            if (totalValue !== filteredValue) {
+                const totalPct =
+                    totalCount > 0 ? ` (${formatPercent(totalValue / totalCount)})` : '';
+                const filteredPct =
+                    totalCount > 0 ? ` (${formatPercent(filteredValue / totalCount)})` : '';
+                return `<b>${params[0].name}</b><br/>Total: <b>${totalValue}</b>${totalPct}<br/>In filter: <b>${filteredValue}</b>${filteredPct}`;
+            }
+        }
+        const [{ name, value }] = params;
+        const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
+        return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
+    };
+
+    // Foreground bar: coloured at the filtered count (or full count when no filter).
+    const foregroundData = data.map((item) => {
+        // Simple items with no selection/filter state can be returned as raw numbers,
+        // which ECharts renders without per-item itemStyle overhead.
+        if (item.selected == null && item.selectable == null && item.filteredCount == null) {
+            return item.count;
+        }
+        const foregroundCount =
+            hasActiveFilter && item.filteredCount !== undefined ? item.filteredCount : item.count;
+        const isDimmed = hasAnySelected && !item.selected;
+        return {
+            value: foregroundCount,
+            itemStyle: {
+                color: isDimmed ? BAR_COLOR_DIMMED : BAR_COLOR,
+                opacity: item.selectable === false ? 0.45 : 1
+            }
+        };
+    });
+
+    const foregroundSeries = {
+        type: 'bar',
+        data: foregroundData,
+        itemStyle: { color: BAR_COLOR },
+        barCategoryGap: '25%',
+        // Overlay on top of the background series (barGap: '-100%' makes the bar
+        // occupy the same slot as the preceding series instead of shifting right).
+        ...(hasActiveFilter ? { barGap: '-100%' } : {}),
+        emphasis: CHART_EMPHASIS
+    };
+
+    // Background series: full (unfiltered) count, always grey — only rendered
+    // when the filter is active and at least one bar is visibly reduced.
+    const backgroundSeries = hasActiveFilter
+        ? {
+              type: 'bar',
+              data: data.map((item) => ({
+                  value: item.count,
+                  itemStyle: {
+                      color: BAR_COLOR_BACKGROUND,
+                      opacity: item.selectable === false ? 0.45 : 1
+                  }
+              })),
+              barCategoryGap: '25%',
+              // Suppress hover highlight on the background so emphasis styling
+              // (colour change, scale) only fires on the foreground bars.
+              emphasis: { disabled: true }
+          }
+        : null;
+
+    const series = hasActiveFilter ? [backgroundSeries, foregroundSeries] : [foregroundSeries];
+
     return {
         backgroundColor: 'transparent',
         tooltip: {
             trigger: 'axis',
             axisPointer: { type: 'shadow' },
-            formatter: (params: { name: string; value: number }[]) => {
-                const [{ name, value }] = params;
-                const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
-                return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
-            }
+            formatter
         },
         grid: { left: 8, right: 8, top: gridTopPx, bottom: 8, containLabel: true },
         // Swap which axis holds the categories so bars grow rightward when horizontal.
         xAxis: isHorizontal ? valueAxis : categoryAxis,
         yAxis: isHorizontal ? categoryAxis : valueAxis,
-        series: [
-            {
-                type: 'bar',
-                data: data.map((item) => {
-                    if (item.selected == null && item.selectable == null) return item.count;
-                    const isDimmed = hasAnySelected && !item.selected;
-                    return {
-                        value: item.count,
-                        itemStyle: {
-                            color: isDimmed ? BAR_COLOR_DIMMED : BAR_COLOR,
-                            opacity: item.selectable === false ? 0.45 : 1
-                        }
-                    };
-                }),
-                itemStyle: { color: BAR_COLOR },
-                barCategoryGap: '25%',
-                emphasis: CHART_EMPHASIS
-            }
-        ]
+        series
     };
 }

--- a/lightly_studio_view/src/lib/components/BarChart/types.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/types.ts
@@ -4,6 +4,13 @@ export interface CategoryCount {
     id?: string;
     label: string;
     count: number;
+    /**
+     * Count after the active sidebar filters are applied. When set, a grey
+     * background bar shows the full `count` while a coloured foreground bar
+     * shows this filtered portion, giving a stable distribution context.
+     * Omit (or set equal to `count`) when no filter is active.
+     */
+    filteredCount?: number;
     /** Whether the category is active in a controlled selection. */
     selected?: boolean;
     /** Whether clicking the bar can change selection. */

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -123,16 +123,30 @@
     const activeHistogram = $derived(activeGroup?.histogram ?? activeSource.histogram ?? null);
     const activeCategorical = $derived(activeGroup?.categorical ?? null);
     const categoricalData = $derived<CategoryCount[]>(
-        (activeCategorical?.buckets ?? []).map((bucket) => ({
-            id: bucket.id,
-            label: bucket.label,
-            count: bucket.count,
-            selectable: bucket.kind !== 'other',
-            pinned: bucket.kind !== 'value',
-            selected:
-                bucket.kind !== 'other' &&
-                activeCategorical?.selectedValues.some((value) => Object.is(value, bucket.value))
-        }))
+        (activeCategorical?.buckets ?? []).map((bucket) => {
+            // When filteredBuckets is defined (query has returned) look up the
+            // filtered count for this bucket. Absent = 0 (filter removed it entirely).
+            const filteredBucket = activeCategorical?.filteredBuckets?.find(
+                (fb) => fb.id === bucket.id
+            );
+            const filteredCount =
+                activeCategorical?.filteredBuckets !== undefined
+                    ? (filteredBucket?.count ?? 0)
+                    : undefined;
+            return {
+                id: bucket.id,
+                label: bucket.label,
+                count: bucket.count,
+                filteredCount,
+                selectable: bucket.kind !== 'other',
+                pinned: bucket.kind !== 'value',
+                selected:
+                    bucket.kind !== 'other' &&
+                    activeCategorical?.selectedValues.some((value) =>
+                        Object.is(value, bucket.value)
+                    )
+            };
+        })
     );
     const displayedData = $derived(activeCategorical ? categoricalData : activeData);
     const configurationItems = $derived(

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -267,12 +267,13 @@ describe('DatasetDistributionPanel', () => {
 
         const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
             yAxis: { data: string[] };
-            series: [{ data: { itemStyle: { borderWidth: number } }[] }];
+            series: [{ data: { itemStyle: { color: string } }[] }];
             grid: { top: number };
         };
         expect(option.yAxis.data).toEqual(['Missing', 'Missing', 'Other']);
         expect(option.grid.top).toBe(4);
-        expect(option.series[0].data[0].itemStyle.borderWidth).toBe(3);
+        // 'Missing' (value) is selected → accent green; the others are dimmed grey.
+        expect(option.series[0].data[0].itemStyle.color).toBe('rgba(59,217,159,0.85)');
 
         echartsMock.getClickHandler()?.({ dataIndex: 1 });
         expect(onCategoricalValueToggle).toHaveBeenCalledWith('city', null);

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -42,6 +42,14 @@ export interface DistributionSourceGroup {
     /** Controlled categorical distribution and selection state. */
     categorical?: {
         buckets: CategoricalMetadataBucket[];
+        /**
+         * Buckets from the same query with all sidebar filters applied.
+         * When provided, each bar shows a grey background at the full `count`
+         * with a coloured foreground at the filtered count, giving context for
+         * how active filters affect the distribution.
+         * Omit (undefined) while the filtered query is still loading.
+         */
+        filteredBuckets?: CategoricalMetadataBucket[];
         selectedValues: CategoricalMetadataValue[];
         loading?: boolean;
         error?: string;

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -615,6 +615,20 @@
     }));
     const categoricalMetadataDistributions = $derived(categoricalMetadataQuery.data ?? {});
 
+    // Second categorical query with the full sidebar filter applied.  Its counts
+    // are passed as `filteredBuckets` so each bar can show a grey background at
+    // the unfiltered height with a coloured foreground at the filtered height.
+    const categoricalMetadataFilteredQuery = useCategoricalMetadataDistribution(() => ({
+        collectionId,
+        filter: imageAnnotationCountsFilter,
+        enabled: distributionPanelVisible
+    }));
+    // Keep undefined (not {}) while loading so DatasetDistributionPanel defers
+    // rendering the background bars until the filtered data is ready.
+    const categoricalMetadataFilteredDistributions = $derived(
+        categoricalMetadataFilteredQuery.data
+    );
+
     const metadataDistributionSource = $derived.by<DistributionSource | null>(() => {
         const numericKeys = Object.keys(metadataDistributions);
         const categoricalKeys = ($metadataInfo ?? [])
@@ -639,6 +653,9 @@
                     label: key,
                     categorical: {
                         buckets: categoricalMetadataDistributions[key] ?? [],
+                        // undefined until the filtered query has returned so the
+                        // distribution panel waits before showing background bars.
+                        filteredBuckets: categoricalMetadataFilteredDistributions?.[key],
                         selectedValues: $categoricalMetadataValues[key] ?? [],
                         loading: categoricalMetadataQuery.isFetching,
                         error: categoricalMetadataQuery.error?.message


### PR DESCRIPTION
## Summary

After `p2` categorical bar heights are always the full-dataset count. But if a non-categorical sidebar filter (annotation class, image dimensions) is active, the bars give no visual feedback about which categories are most or least affected by that filter.

This PR adds a second ECharts series that overlays a filtered-count foreground on the existing full-count background:

- **Background series** (dark grey `#374151`): always drawn at the full unfiltered count — stable height.
- **Foreground series** (green/grey per `p1`): drawn at the filtered count using `barGap: '-100%'` to overlay exactly.
- Tooltip upgrades to **"Total / In filter"** for bars where the filter actually reduces the count; unchanged for unaffected bars.
- A second `useCategoricalMetadataDistribution` query with the full `imageAnnotationCountsFilter` provides the filtered counts as `filteredBuckets`.
- When no filter is active both queries return identical counts → `hasActiveFilter = false` → single series rendered, visually identical to the pre-filter state.

**Stack:** `p1` → `p2` → **`p3`**

## Test plan

- [ ] Apply an annotation-class or dimension filter — grey background bars appear at full height, coloured foreground bars shrink to the filtered portion.
- [ ] Remove the filter — background bars disappear, single-series rendering returns.
- [ ] Hover a bar whose filter count differs from its full count — tooltip shows "Total / In filter".
- [ ] Hover an unaffected bar — tooltip shows "Count" as before.
- [ ] All 2 128 unit tests pass (`npm run test:unit -- --run`).
- [ ] Static checks pass (`npm run static-checks`).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)