### PR TITLE
Fast Track: ignore superseded guardrail runs

### DIFF
--- a/.github/workflows/fast_track_bot.yml
+++ b/.github/workflows/fast_track_bot.yml
@@ -74,6 +74,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           GUARDRAIL_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          # Identify the triggering guardrail run so the bot can skip when a newer
+          # run for the same head has already acted (out-of-order workflow_run
+          # delivery). run_attempt covers re-runs, which keep the run number.
+          # Reads use the token's existing actions:read grant.
+          GUARDRAIL_WORKFLOW_ID: ${{ github.event.workflow_run.workflow_id }}
+          GUARDRAIL_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          GUARDRAIL_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         run: npm run bot-ci

--- a/fast_track/src/bot/ci.ts
+++ b/fast_track/src/bot/ci.ts
@@ -14,8 +14,12 @@ const VERDICT_PATH = 'verdict/verdict.json';
 async function main(env: NodeJS.ProcessEnv): Promise<void> {
     const token = requiredEnv(env, 'GITHUB_TOKEN');
     const trustedHeadSha = requiredEnv(env, 'HEAD_SHA');
+    const headBranch = requiredEnv(env, 'HEAD_BRANCH');
     const appSlug = requiredEnv(env, 'APP_SLUG');
     const guardrailConclusion = requiredEnv(env, 'GUARDRAIL_CONCLUSION');
+    const guardrailWorkflowId = requiredIntEnv(env, 'GUARDRAIL_WORKFLOW_ID');
+    const guardrailRunNumber = requiredIntEnv(env, 'GUARDRAIL_RUN_NUMBER');
+    const guardrailRunAttempt = requiredIntEnv(env, 'GUARDRAIL_RUN_ATTEMPT');
     const verdict = await readVerdict();
 
     const result = await runBot({
@@ -23,11 +27,15 @@ async function main(env: NodeJS.ProcessEnv): Promise<void> {
         owner: context.repo.owner,
         repo: context.repo.repo,
         trustedHeadSha,
+        headBranch,
         botLogin: `${appSlug}[bot]`,
         guardrailsSucceeded: guardrailConclusion === 'success',
         requiredGuardrailNames: guardrails
             .filter((guardrail) => guardrail.required)
             .map((guardrail) => guardrail.name),
+        guardrailWorkflowId,
+        guardrailRunNumber,
+        guardrailRunAttempt,
         verdict
     });
     console.log(JSON.stringify(result));
@@ -46,6 +54,13 @@ function requiredEnv(env: NodeJS.ProcessEnv, name: string): string {
     const value = env[name];
     if (value === undefined || value === '') throw new Error(`${name} is not set.`);
     return value;
+}
+
+function requiredIntEnv(env: NodeJS.ProcessEnv, name: string): number {
+    const value = requiredEnv(env, name);
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed)) throw new Error(`${name} is not an integer: ${value}`);
+    return parsed;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/fast_track/src/bot/latest-run.test.ts
+++ b/fast_track/src/bot/latest-run.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Octokit } from '../shared/octokit';
+import { isSupersededRun } from './latest-run';
+
+const HEAD_SHA = 'abc123';
+const HEAD_BRANCH = 'feature';
+const WORKFLOW_ID = 42;
+const RUN_NUMBER = 10;
+const RUN_ATTEMPT = 1;
+
+function workflowRun(overrides: Record<string, unknown> = {}) {
+    return {
+        run_number: 11,
+        run_attempt: 1,
+        status: 'completed',
+        conclusion: 'success',
+        ...overrides
+    };
+}
+
+/**
+ * A fake Octokit whose `paginate` returns `runs` (as the real one does after
+ * walking every page). `listWorkflowRuns` is a sentinel so a test can assert we
+ * hand *that* endpoint to `paginate`. Pass `{ throws: true }` to fail the read.
+ */
+function fakeOctokit(runs: unknown[] | { throws: true }): Octokit {
+    return {
+        paginate: vi.fn().mockImplementation(async () => {
+            if (!Array.isArray(runs)) throw new Error('transient GitHub API failure');
+            return runs;
+        }),
+        rest: { actions: { listWorkflowRuns: 'runs-endpoint' } }
+    } as unknown as Octokit;
+}
+
+function check(runs: unknown[] | { throws: true }) {
+    return isSupersededRun({
+        octokit: fakeOctokit(runs),
+        owner: 'lightly-ai',
+        repo: 'lightly-studio',
+        headSha: HEAD_SHA,
+        headBranch: HEAD_BRANCH,
+        workflowId: WORKFLOW_ID,
+        runNumber: RUN_NUMBER,
+        runAttempt: RUN_ATTEMPT
+    });
+}
+
+describe('isSupersededRun', () => {
+    it('is superseded by a newer run that reached a real conclusion', async () => {
+        await expect(check([workflowRun({ run_number: 11, conclusion: 'success' })])).resolves.toBe(
+            true
+        );
+        // A cancelled newer run also supersedes: only a skipped run is excluded.
+        await expect(
+            check([workflowRun({ run_number: 11, conclusion: 'cancelled' })])
+        ).resolves.toBe(true);
+    });
+
+    it('is not superseded by a newer run that only skipped', async () => {
+        // A title/body edit produces a skipped run carrying no judgment;
+        // suppressing this run on it would leave a passing PR unapproved.
+        await expect(check([workflowRun({ run_number: 11, conclusion: 'skipped' })])).resolves.toBe(
+            false
+        );
+    });
+
+    it('is not superseded by a newer run still in progress', async () => {
+        await expect(
+            check([workflowRun({ run_number: 11, status: 'in_progress', conclusion: null })])
+        ).resolves.toBe(false);
+    });
+
+    it('is not superseded by older or equal runs', async () => {
+        await expect(
+            check([workflowRun({ run_number: 10, run_attempt: 1 }), workflowRun({ run_number: 9 })])
+        ).resolves.toBe(false);
+    });
+
+    it('is superseded by a later attempt of the same run', async () => {
+        // A later attempt of the same run supersedes an earlier one.
+        await expect(
+            check([workflowRun({ run_number: RUN_NUMBER, run_attempt: 2 })])
+        ).resolves.toBe(true);
+    });
+
+    it('queries the guardrail workflow at the trusted head and branch, every page', async () => {
+        const octokit = fakeOctokit([]);
+        await isSupersededRun({
+            octokit,
+            owner: 'lightly-ai',
+            repo: 'lightly-studio',
+            headSha: HEAD_SHA,
+            headBranch: HEAD_BRANCH,
+            workflowId: WORKFLOW_ID,
+            runNumber: RUN_NUMBER,
+            runAttempt: RUN_ATTEMPT
+        });
+        expect(octokit.paginate).toHaveBeenCalledWith('runs-endpoint', {
+            owner: 'lightly-ai',
+            repo: 'lightly-studio',
+            workflow_id: WORKFLOW_ID,
+            head_sha: HEAD_SHA,
+            branch: HEAD_BRANCH,
+            per_page: 100
+        });
+    });
+
+    it('proceeds (not superseded) when the run listing fails', async () => {
+        // Fail-closed: skipping on error would drop a genuine dismissal.
+        await expect(check({ throws: true })).resolves.toBe(false);
+    });
+});

--- a/fast_track/src/bot/latest-run.test.ts
+++ b/fast_track/src/bot/latest-run.test.ts
@@ -6,8 +6,6 @@ import { isSupersededRun } from './latest-run';
 const HEAD_SHA = 'abc123';
 const HEAD_BRANCH = 'feature';
 const WORKFLOW_ID = 42;
-const RUN_NUMBER = 10;
-const RUN_ATTEMPT = 1;
 
 function workflowRun(overrides: Record<string, unknown> = {}) {
     return {
@@ -34,7 +32,11 @@ function fakeOctokit(runs: unknown[] | { throws: true }): Octokit {
     } as unknown as Octokit;
 }
 
-function check(runs: unknown[] | { throws: true }) {
+/** Run the check as if triggered by `triggeringRun`, against the listed `runs`. */
+function check(
+    triggeringRun: { runNumber: number; runAttempt?: number },
+    runs: unknown[] | { throws: true }
+) {
     return isSupersededRun({
         octokit: fakeOctokit(runs),
         owner: 'lightly-ai',
@@ -42,46 +44,53 @@ function check(runs: unknown[] | { throws: true }) {
         headSha: HEAD_SHA,
         headBranch: HEAD_BRANCH,
         workflowId: WORKFLOW_ID,
-        runNumber: RUN_NUMBER,
-        runAttempt: RUN_ATTEMPT
+        runNumber: triggeringRun.runNumber,
+        runAttempt: triggeringRun.runAttempt ?? 1
     });
 }
 
 describe('isSupersededRun', () => {
     it('is superseded by a newer run that reached a real conclusion', async () => {
-        await expect(check([workflowRun({ run_number: 11, conclusion: 'success' })])).resolves.toBe(
-            true
-        );
+        await expect(
+            check({ runNumber: 10 }, [workflowRun({ run_number: 11, conclusion: 'success' })])
+        ).resolves.toBe(true);
         // A cancelled newer run also supersedes: only a skipped run is excluded.
         await expect(
-            check([workflowRun({ run_number: 11, conclusion: 'cancelled' })])
+            check({ runNumber: 10 }, [workflowRun({ run_number: 11, conclusion: 'cancelled' })])
         ).resolves.toBe(true);
     });
 
     it('is not superseded by a newer run that only skipped', async () => {
         // A title/body edit produces a skipped run carrying no judgment;
         // suppressing this run on it would leave a passing PR unapproved.
-        await expect(check([workflowRun({ run_number: 11, conclusion: 'skipped' })])).resolves.toBe(
-            false
-        );
+        await expect(
+            check({ runNumber: 10 }, [workflowRun({ run_number: 11, conclusion: 'skipped' })])
+        ).resolves.toBe(false);
     });
 
     it('is not superseded by a newer run still in progress', async () => {
         await expect(
-            check([workflowRun({ run_number: 11, status: 'in_progress', conclusion: null })])
+            check({ runNumber: 10 }, [
+                workflowRun({ run_number: 11, status: 'in_progress', conclusion: null })
+            ])
         ).resolves.toBe(false);
     });
 
     it('is not superseded by older or equal runs', async () => {
         await expect(
-            check([workflowRun({ run_number: 10, run_attempt: 1 }), workflowRun({ run_number: 9 })])
+            check({ runNumber: 10 }, [
+                workflowRun({ run_number: 10, run_attempt: 1 }),
+                workflowRun({ run_number: 9 })
+            ])
         ).resolves.toBe(false);
     });
 
     it('is superseded by a later attempt of the same run', async () => {
         // A later attempt of the same run supersedes an earlier one.
         await expect(
-            check([workflowRun({ run_number: RUN_NUMBER, run_attempt: 2 })])
+            check({ runNumber: 10, runAttempt: 1 }, [
+                workflowRun({ run_number: 10, run_attempt: 2 })
+            ])
         ).resolves.toBe(true);
     });
 
@@ -94,8 +103,8 @@ describe('isSupersededRun', () => {
             headSha: HEAD_SHA,
             headBranch: HEAD_BRANCH,
             workflowId: WORKFLOW_ID,
-            runNumber: RUN_NUMBER,
-            runAttempt: RUN_ATTEMPT
+            runNumber: 10,
+            runAttempt: 1
         });
         expect(octokit.paginate).toHaveBeenCalledWith('runs-endpoint', {
             owner: 'lightly-ai',
@@ -109,6 +118,6 @@ describe('isSupersededRun', () => {
 
     it('proceeds (not superseded) when the run listing fails', async () => {
         // Fail-closed: skipping on error would drop a genuine dismissal.
-        await expect(check({ throws: true })).resolves.toBe(false);
+        await expect(check({ runNumber: 10 }, { throws: true })).resolves.toBe(false);
     });
 });

--- a/fast_track/src/bot/latest-run.ts
+++ b/fast_track/src/bot/latest-run.ts
@@ -50,12 +50,7 @@ export async function isSupersededRun(params: SupersededRunParams): Promise<bool
             branch: headBranch,
             per_page: PER_PAGE
         });
-        return runs.some(
-            (run) =>
-                isNewerRun(run, runNumber, runAttempt) &&
-                run.status === 'completed' &&
-                run.conclusion !== 'skipped'
-        );
+        return runs.some((run) => isNewerRun(run, runNumber, runAttempt) && hasRealConclusion(run));
     } catch (error) {
         console.warn('Fast Track: could not check for superseding runs; proceeding.', error);
         return false;
@@ -71,4 +66,10 @@ function isNewerRun(
 ): boolean {
     if (run.run_number !== runNumber) return run.run_number > runNumber;
     return (run.run_attempt ?? 1) > runAttempt;
+}
+
+/** A run carries a verdict worth acting on when it completed with a conclusion
+ *  other than `skipped` (a title/body edit skips guardrails with no judgment). */
+function hasRealConclusion(run: { status?: string | null; conclusion?: string | null }): boolean {
+    return run.status === 'completed' && run.conclusion !== 'skipped';
 }

--- a/fast_track/src/bot/latest-run.ts
+++ b/fast_track/src/bot/latest-run.ts
@@ -1,0 +1,74 @@
+import type { Octokit } from '../shared/octokit';
+
+/** `listWorkflowRuns` caps per_page at 100. */
+const PER_PAGE = 100;
+
+export interface SupersededRunParams {
+    octokit: Octokit;
+    owner: string;
+    repo: string;
+    /** The head SHA the triggering guardrail run judged. */
+    headSha: string;
+    /** The head branch the triggering run ran on. Two branches can share a head
+     *  SHA, so the comparison is scoped to this branch to ignore unrelated runs. */
+    headBranch: string;
+    /**
+     * The guardrail workflow whose runs are compared. `run_number` only
+     * increases within one workflow, so the comparison is scoped to it.
+     */
+    workflowId: number;
+    /** `run_number` of the guardrail run that triggered this bot execution. */
+    runNumber: number;
+    /** `run_attempt` of the triggering run. A re-run keeps `run_number` and
+     *  bumps this, so recency compares the (run_number, run_attempt) pair. */
+    runAttempt: number;
+}
+
+/**
+ * Whether a newer guardrail run for the same head has already reached a real
+ * conclusion, which makes the triggering run stale.
+ *
+ * `workflow_run` events can arrive out of order, so a late event from a
+ * cancelled early run can reach the bot after a newer run has already approved.
+ * The two runs share a head, so only run recency can tell them apart; a stale
+ * run must skip rather than dismiss the newer run's fresh approval.
+ *
+ * Only a `completed`, non-`skipped` run supersedes: a `skipped` run (from a
+ * title/body edit) carries no judgment, so treating it as superseding would
+ * leave a passing PR unapproved. A read error returns `false` so the bot still
+ * runs, since skipping would drop a genuine dismissal.
+ */
+export async function isSupersededRun(params: SupersededRunParams): Promise<boolean> {
+    const { octokit, owner, repo, headSha, headBranch, workflowId, runNumber, runAttempt } = params;
+    try {
+        // Walk every page: a superseding run could sit on any of them.
+        const runs = await octokit.paginate(octokit.rest.actions.listWorkflowRuns, {
+            owner,
+            repo,
+            workflow_id: workflowId,
+            head_sha: headSha,
+            branch: headBranch,
+            per_page: PER_PAGE
+        });
+        return runs.some(
+            (run) =>
+                isNewerRun(run, runNumber, runAttempt) &&
+                run.status === 'completed' &&
+                run.conclusion !== 'skipped'
+        );
+    } catch (error) {
+        console.warn('Fast Track: could not check for superseding runs; proceeding.', error);
+        return false;
+    }
+}
+
+/** Recency order on the (run_number, run_attempt) pair. The run listing reports
+ *  each run at its latest attempt, so a re-run supersedes its earlier attempts. */
+function isNewerRun(
+    run: { run_number: number; run_attempt?: number },
+    runNumber: number,
+    runAttempt: number
+): boolean {
+    if (run.run_number !== runNumber) return run.run_number > runNumber;
+    return (run.run_attempt ?? 1) > runAttempt;
+}

--- a/fast_track/src/bot/run-bot.test.ts
+++ b/fast_track/src/bot/run-bot.test.ts
@@ -7,6 +7,8 @@ import { runBot } from './run-bot';
 
 const HEAD_SHA = 'abc123';
 const BOT_LOGIN = 'fast-track-bot[bot]';
+const WORKFLOW_ID = 42;
+const RUN_NUMBER = 10;
 
 function verdict(overrides: Partial<Verdict> = {}): Verdict {
     return {
@@ -61,12 +63,22 @@ interface FakeOptions {
     reDeriveAfterApprove?: AssociatedRead;
     // pulls.get runs once, to reload mutable PR state before the approval.
     reloadBeforeApprove?: PullRead;
+    // Runs returned by listWorkflowRuns for the trusted head. A run with a higher
+    // run_number that completed with a real (non-skipped) conclusion supersedes
+    // this one. Defaults to none, so nothing supersedes.
+    workflowRuns?: unknown[];
+}
+
+function workflowRun(overrides: Record<string, unknown> = {}) {
+    return { run_number: 11, status: 'completed', conclusion: 'success', ...overrides };
 }
 
 function fakeOctokit(options: FakeOptions = {}) {
     const listReviews = Symbol('listReviews');
     const listComments = Symbol('listComments');
     const listAssociated = Symbol('listAssociated');
+    const listWorkflowRuns = Symbol('listWorkflowRuns');
+    const workflowRuns = options.workflowRuns ?? [];
     const reviews = options.existingApproval
         ? [{ id: 1, user: { login: BOT_LOGIN }, state: 'APPROVED', commit_id: HEAD_SHA }]
         : [];
@@ -98,9 +110,13 @@ function fakeOctokit(options: FakeOptions = {}) {
                 return reviews.filter((review) => review.state === 'APPROVED');
             if (route === listComments) return [];
             if (route === listAssociated) return nextAssociated().prs ?? [];
+            if (route === listWorkflowRuns) return workflowRuns;
             return [];
         }),
         rest: {
+            actions: {
+                listWorkflowRuns
+            },
             repos: {
                 listPullRequestsAssociatedWithCommit: listAssociated
             },
@@ -120,7 +136,10 @@ function fakeOctokit(options: FakeOptions = {}) {
     return { octokit, createReview, dismissReview, createComment };
 }
 
-function run(value: unknown, options: FakeOptions & { guardrailsSucceeded?: boolean } = {}) {
+function run(
+    value: unknown,
+    options: FakeOptions & { guardrailsSucceeded?: boolean; guardrailRunNumber?: number } = {}
+) {
     const fake = fakeOctokit(options);
     return {
         result: runBot({
@@ -128,9 +147,13 @@ function run(value: unknown, options: FakeOptions & { guardrailsSucceeded?: bool
             owner: 'lightly-ai',
             repo: 'lightly-studio',
             trustedHeadSha: HEAD_SHA,
+            headBranch: 'feature',
             botLogin: BOT_LOGIN,
             guardrailsSucceeded: options.guardrailsSucceeded ?? true,
             requiredGuardrailNames: ['dummy'],
+            guardrailWorkflowId: WORKFLOW_ID,
+            guardrailRunNumber: options.guardrailRunNumber ?? RUN_NUMBER,
+            guardrailRunAttempt: 1,
             verdict: value
         }),
         ...fake
@@ -225,5 +248,30 @@ describe('runBot', () => {
         });
         expect(execution.createReview).not.toHaveBeenCalled();
         expect(execution.dismissReview).not.toHaveBeenCalled();
+    });
+
+    it('skips without touching an approval when a newer run superseded it', async () => {
+        // The late event from a stale run must not dismiss the newer run's
+        // approval, so it bails before any read or write.
+        const execution = run(verdict({ verdict: 'fail', reason: 'stale' }), {
+            existingApproval: true,
+            workflowRuns: [workflowRun({ run_number: 11 })]
+        });
+        await expect(execution.result).resolves.toEqual({
+            status: 'skipped',
+            reason: 'A newer guardrail run for this head superseded it.'
+        });
+        expect(execution.createReview).not.toHaveBeenCalled();
+        expect(execution.dismissReview).not.toHaveBeenCalled();
+    });
+
+    it('still acts when the only newer run merely skipped', async () => {
+        // A title/body edit skips guardrails and carries no judgment, so it must
+        // not suppress this passing run.
+        const execution = run(verdict(), {
+            workflowRuns: [workflowRun({ run_number: 11, conclusion: 'skipped' })]
+        });
+        await expect(execution.result).resolves.toEqual({ status: 'approved', prNumber: 7 });
+        expect(execution.createReview).toHaveBeenCalledOnce();
     });
 });

--- a/fast_track/src/bot/run-bot.test.ts
+++ b/fast_track/src/bot/run-bot.test.ts
@@ -255,6 +255,7 @@ describe('runBot', () => {
         // approval, so it bails before any read or write.
         const execution = run(verdict({ verdict: 'fail', reason: 'stale' }), {
             existingApproval: true,
+            guardrailRunNumber: 10,
             workflowRuns: [workflowRun({ run_number: 11 })]
         });
         await expect(execution.result).resolves.toEqual({
@@ -269,6 +270,7 @@ describe('runBot', () => {
         // A title/body edit skips guardrails and carries no judgment, so it must
         // not suppress this passing run.
         const execution = run(verdict(), {
+            guardrailRunNumber: 10,
             workflowRuns: [workflowRun({ run_number: 11, conclusion: 'skipped' })]
         });
         await expect(execution.result).resolves.toEqual({ status: 'approved', prNumber: 7 });

--- a/fast_track/src/bot/run-bot.ts
+++ b/fast_track/src/bot/run-bot.ts
@@ -2,6 +2,7 @@ import type { Octokit } from '../shared/octokit';
 import type { Verdict } from '../shared/verdict';
 import { renderComment, upsertComment } from './comment';
 import { deriveTarget, refreshTarget, type BotTarget } from './derive-target';
+import { isSupersededRun } from './latest-run';
 import { approve, dismissApproval } from './review';
 import { effectiveVerdict, verdictMatchesTarget } from './verdict-policy';
 
@@ -10,9 +11,17 @@ interface RunBotParams {
     owner: string;
     repo: string;
     trustedHeadSha: string;
+    /** Head branch of the triggering run, to scope the recency check. */
+    headBranch: string;
     botLogin: string;
     guardrailsSucceeded: boolean;
     requiredGuardrailNames: readonly string[];
+    /** The guardrail workflow that triggered this run, for the recency check. */
+    guardrailWorkflowId: number;
+    /** `run_number` of the triggering guardrail run, for the recency check. */
+    guardrailRunNumber: number;
+    /** `run_attempt` of the triggering guardrail run, for the recency check. */
+    guardrailRunAttempt: number;
     verdict: unknown;
 }
 
@@ -27,6 +36,12 @@ type VerifyOutcome = { target: BotTarget; actionParams: BotActionParams } | { do
 
 /** Apply a current pass verdict, revoking the bot approval for every other outcome. */
 export async function runBot(params: RunBotParams): Promise<BotResult> {
+    // Check first, before any read or write: a stale run must not dismiss the
+    // approval a newer run for this head just created.
+    if (await isSupersededRun(toSupersededParams(params))) {
+        return { status: 'skipped', reason: 'A newer guardrail run for this head superseded it.' };
+    }
+
     const outcome = await verifyTarget(params);
     if ('done' in outcome) return outcome.done;
 
@@ -58,6 +73,19 @@ async function verifyTarget(params: RunBotParams): Promise<VerifyOutcome> {
         return { done: { status: 'dismissed', prNumber: derivedTarget.prNumber } };
     }
     return { target, actionParams };
+}
+
+function toSupersededParams(params: RunBotParams): Parameters<typeof isSupersededRun>[0] {
+    return {
+        octokit: params.octokit,
+        owner: params.owner,
+        repo: params.repo,
+        headSha: params.trustedHeadSha,
+        headBranch: params.headBranch,
+        workflowId: params.guardrailWorkflowId,
+        runNumber: params.guardrailRunNumber,
+        runAttempt: params.guardrailRunAttempt
+    };
 }
 
 function toActionParams(params: RunBotParams, prNumber: number): BotActionParams {

--- a/fast_track/src/bot/run-bot.ts
+++ b/fast_track/src/bot/run-bot.ts
@@ -39,10 +39,9 @@ export async function runBot(params: RunBotParams): Promise<BotResult> {
     // Check first, before any read or write: a stale run must not dismiss the
     // approval a newer run for this head just created.
     //
-    // Residual race: the bot's concurrency group cancels by event arrival order,
-    // not run recency, so a late stale delivery can cancel a newer bot that had
-    // not yet written its action and then skip here, leaving that action undone.
-    // Not closable in this layer; the durable fix is the concurrency model.
+    // This cannot fully close the race: the concurrency group cancels by event
+    // arrival, not run recency, so a stale delivery can still cancel a newer bot
+    // mid-action, then skip here. Fully closing it is a concurrency-config change.
     if (await isSupersededRun(toSupersededParams(params))) {
         return { status: 'skipped', reason: 'A newer guardrail run for this head superseded it.' };
     }

--- a/fast_track/src/bot/run-bot.ts
+++ b/fast_track/src/bot/run-bot.ts
@@ -2,7 +2,7 @@ import type { Octokit } from '../shared/octokit';
 import type { Verdict } from '../shared/verdict';
 import { renderComment, upsertComment } from './comment';
 import { deriveTarget, refreshTarget, type BotTarget } from './derive-target';
-import { isSupersededRun } from './latest-run';
+import { isSupersededRun, type SupersededRunParams } from './latest-run';
 import { approve, dismissApproval } from './review';
 import { effectiveVerdict, verdictMatchesTarget } from './verdict-policy';
 
@@ -75,7 +75,7 @@ async function verifyTarget(params: RunBotParams): Promise<VerifyOutcome> {
     return { target, actionParams };
 }
 
-function toSupersededParams(params: RunBotParams): Parameters<typeof isSupersededRun>[0] {
+function toSupersededParams(params: RunBotParams): SupersededRunParams {
     return {
         octokit: params.octokit,
         owner: params.owner,

--- a/fast_track/src/bot/run-bot.ts
+++ b/fast_track/src/bot/run-bot.ts
@@ -38,6 +38,11 @@ type VerifyOutcome = { target: BotTarget; actionParams: BotActionParams } | { do
 export async function runBot(params: RunBotParams): Promise<BotResult> {
     // Check first, before any read or write: a stale run must not dismiss the
     // approval a newer run for this head just created.
+    //
+    // Residual race: the bot's concurrency group cancels by event arrival order,
+    // not run recency, so a late stale delivery can cancel a newer bot that had
+    // not yet written its action and then skip here, leaving that action undone.
+    // Not closable in this layer; the durable fix is the concurrency model.
     if (await isSupersededRun(toSupersededParams(params))) {
         return { status: 'skipped', reason: 'A newer guardrail run for this head superseded it.' };
     }


### PR DESCRIPTION
## What has changed and why?

`workflow_run` events are not delivered in order. Two rapid label changes on one head produce two guardrail runs there; the first is cancelled and the second approves. If the cancelled run's event arrives late, its bot execution dismisses the approval the newer run just created. Head SHA, the concurrency group, and the conclusion filter cannot tell two runs at the same head apart — only run recency can.

This adds `isSupersededRun`: the bot skips when a newer guardrail run for the same head has already reached a real conclusion. A `skipped` newer run is excluded on purpose, so a title/body edit cannot suppress a passing run. The bot workflow passes the triggering run's workflow id and run number; the token's existing `actions: read` grant covers the lookup, so no permission change.

## How has it been tested?

`make -C fast_track static-checks` and `make -C fast_track test` pass (199 tests). New unit tests cover the recency rule (real conclusion supersedes, `skipped`/in-progress/older runs do not, read errors proceed) and the bot skipping without touching an approval.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fast Track now detects when a guardrail run is superseded by a newer head-specific execution and skips outdated runs to prevent duplicate actions.
  * CI now passes additional guardrail run identifiers to the bot.
* **Bug Fixes**
  * Correctly applies recency rules using run number and attempt, treating newer completed (non-skipped) runs as superseding.
  * If listing workflow runs fails, the bot safely proceeds.
* **Tests**
  * Added test coverage for supersedence decisions and for bot skip/approval behavior under newer run scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->