### PR TITLE
Add ApiKeyTable DB schema and migration

### DIFF
--- a/lightly_studio/src/lightly_studio/api/db_tables.py
+++ b/lightly_studio/src/lightly_studio/api/db_tables.py
@@ -52,3 +52,6 @@ from lightly_studio.models.evaluation_sample_metric import (
 from lightly_studio.models.temporal_span import (
     TemporalSpanTable,  # noqa: F401, required for SQLModel to work properly
 )
+from lightly_studio.models.api_key import (
+    ApiKeyTable,  # noqa: F401, required for SQLModel to work properly
+)

--- a/lightly_studio/src/lightly_studio/migrations/versions/1784000000_b1c2d3e4f5a6_add_api_key_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1784000000_b1c2d3e4f5a6_add_api_key_table.py
@@ -1,0 +1,53 @@
+"""add-api-key-table.
+
+Revision ID: b1c2d3e4f5a6
+Revises: c3d4e5f6a7b8
+Create Date: 2026-07-22 14:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, Sequence[str], None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "api_key",
+        sa.Column("api_key_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("key_hash", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum("ACTIVE", "REVOKED", name="apikeystatus"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("api_key_id"),
+    )
+    op.create_index("ix_api_key_key_hash", "api_key", ["key_hash"], unique=True)
+    op.create_index("ix_api_key_user_id", "api_key", ["user_id"], unique=False)
+    op.create_index("ix_api_key_created_at", "api_key", ["created_at"], unique=False)
+    op.create_index("ix_api_key_status", "api_key", ["status"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_api_key_status", table_name="api_key")
+    op.drop_index("ix_api_key_created_at", table_name="api_key")
+    op.drop_index("ix_api_key_user_id", table_name="api_key")
+    op.drop_index("ix_api_key_key_hash", table_name="api_key")
+    op.drop_table("api_key")
+    sa.Enum(name="apikeystatus").drop(op.get_bind(), checkfirst=False)

--- a/lightly_studio/src/lightly_studio/models/api_key.py
+++ b/lightly_studio/src/lightly_studio/models/api_key.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from uuid import UUID, uuid4
+from uuid import UUID
 
+import pydantic
 from sqlalchemy import Column, DateTime
 from sqlmodel import Field, SQLModel
 
@@ -29,6 +31,16 @@ class ApiKeyCreate(ApiKeyBase):
 
     expires_at: datetime | None = Field(default=None)
 
+    @pydantic.field_validator("expires_at")
+    @classmethod
+    def _normalize_expires_at(cls, value: datetime | None) -> datetime | None:
+        """Reject naive datetimes and normalize aware datetimes to UTC."""
+        if value is None:
+            return None
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("expires_at must include timezone information")
+        return value.astimezone(timezone.utc)
+
 
 class ApiKeyView(ApiKeyBase):
     """Model used when viewing API key information."""
@@ -51,7 +63,7 @@ class ApiKeyTable(ApiKeyBase, table=True):
 
     __tablename__ = "api_key"
 
-    api_key_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    api_key_id: UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     key_hash: str = Field(index=True, unique=True, description="SHA-256 hash of secret key")
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/lightly_studio/src/lightly_studio/models/api_key.py
+++ b/lightly_studio/src/lightly_studio/models/api_key.py
@@ -1,0 +1,68 @@
+"""This module defines the ApiKey model for database-backed API key authentication."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from uuid import UUID, uuid4
+
+from sqlalchemy import Column, DateTime
+from sqlmodel import Field, SQLModel
+
+
+class ApiKeyStatus(str, Enum):
+    """Status of an API key."""
+
+    ACTIVE = "active"
+    REVOKED = "revoked"
+
+
+class ApiKeyBase(SQLModel):
+    """Base class for ApiKey model."""
+
+    name: str = Field(description="Name or description for the API key")
+    user_id: int = Field(index=True, description="ID of the user that owns this API key")
+
+
+class ApiKeyCreate(ApiKeyBase):
+    """Model used when creating an API key."""
+
+    expires_at: datetime | None = Field(default=None)
+
+
+class ApiKeyView(ApiKeyBase):
+    """Model used when viewing API key information."""
+
+    api_key_id: UUID
+    created_at: datetime
+    expires_at: datetime | None = None
+    last_used_at: datetime | None = None
+    status: ApiKeyStatus
+
+
+class ApiKeyCreateResponse(ApiKeyView):
+    """Model returned when an API key is created (includes raw secret key)."""
+
+    key: str
+
+
+class ApiKeyTable(ApiKeyBase, table=True):
+    """This class defines the ApiKey model table in the database."""
+
+    __tablename__ = "api_key"
+
+    api_key_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    key_hash: str = Field(index=True, unique=True, description="SHA-256 hash of secret key")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), index=True, nullable=False),
+    )
+    expires_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    last_used_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    status: ApiKeyStatus = Field(default=ApiKeyStatus.ACTIVE, index=True)

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -13,7 +13,8 @@ _HANDLED_TABLES_COUNT = 24
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)
 # - two_dim_embeddings (cached projections, regenerated as needed)
-_EXCLUDED_TABLES_COUNT = 2
+# - api_key (application-level)
+_EXCLUDED_TABLES_COUNT = 3
 
 _TOTAL_TABLES_COUNT = _HANDLED_TABLES_COUNT + _EXCLUDED_TABLES_COUNT
 

--- a/lightly_studio/tests/models/test_api_key.py
+++ b/lightly_studio/tests/models/test_api_key.py
@@ -1,9 +1,36 @@
 """Tests for API key models."""
 
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
 from sqlalchemy import DateTime, Enum, Integer, UniqueConstraint
 from sqlmodel import SQLModel
 
-from lightly_studio.models.api_key import ApiKeyTable
+from lightly_studio.models.api_key import ApiKeyCreate, ApiKeyTable
+
+
+class TestApiKeyCreate:
+    """Tests for the API key creation model."""
+
+    def test_expires_at__none(self) -> None:
+        api_key = ApiKeyCreate(name="Automation key", user_id=42)
+
+        assert api_key.expires_at is None
+
+    def test_expires_at__naive(self) -> None:
+        expires_at = datetime(2027, 1, 1, tzinfo=timezone.utc).replace(tzinfo=None)
+
+        with pytest.raises(ValidationError, match="must include timezone information"):
+            ApiKeyCreate(name="Automation key", user_id=42, expires_at=expires_at)
+
+    def test_expires_at__aware(self) -> None:
+        expires_at = datetime(2027, 1, 1, 2, tzinfo=timezone(timedelta(hours=2)))
+
+        api_key = ApiKeyCreate(name="Automation key", user_id=42, expires_at=expires_at)
+
+        assert api_key.expires_at == datetime(2027, 1, 1, tzinfo=timezone.utc)
+        assert api_key.expires_at.tzinfo is timezone.utc
 
 
 def test_api_key_table_column_types() -> None:

--- a/lightly_studio/tests/models/test_api_key.py
+++ b/lightly_studio/tests/models/test_api_key.py
@@ -1,0 +1,32 @@
+"""Tests for API key models."""
+
+from sqlalchemy import DateTime, Enum, Integer, UniqueConstraint
+from sqlmodel import SQLModel
+
+from lightly_studio.models.api_key import ApiKeyTable
+
+
+def test_api_key_table_column_types() -> None:
+    """Columns use the types expected by the PostgreSQL migration."""
+    table = SQLModel.metadata.tables[ApiKeyTable.__tablename__]
+
+    assert isinstance(table.c.user_id.type, Integer)
+
+    status_type = table.c.status.type
+    assert isinstance(status_type, Enum)
+    assert status_type.enums == ["ACTIVE", "REVOKED"]
+
+    for column_name in ("created_at", "expires_at", "last_used_at"):
+        date_type = table.c[column_name].type
+        assert isinstance(date_type, DateTime)
+        assert date_type.timezone
+
+
+def test_api_key_hash_has_one_unique_index() -> None:
+    """The key hash is enforced by one unique index."""
+    table = SQLModel.metadata.tables[ApiKeyTable.__tablename__]
+
+    key_hash_indexes = [index for index in table.indexes if index.columns.keys() == ["key_hash"]]
+    assert len(key_hash_indexes) == 1
+    assert key_hash_indexes[0].unique
+    assert not any(isinstance(constraint, UniqueConstraint) for constraint in table.constraints)


### PR DESCRIPTION
## What has changed and why?
We want to allow API key login for the self hosted version.

## How has it been tested?
Added tests, also a followup commit in a WIP branch locally.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced database-backed API key management, including ownership, expiration handling, last-used tracking, and active/revoked status.
  * Added API key models for creation, viewing, and returning the newly generated secret.
  * Created a new `api_key` database table with indexes for efficient lookup, including uniqueness on the stored key hash.
* **Tests**
  * Added tests covering `expires_at` validation (timezone-aware normalization to UTC) and allowed `None`.
  * Added schema/index checks for correct column types and unique index behavior on the stored key hash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->