### PR TITLE
BE: categorical metadata value-counts API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,7 @@ Exceptions from the guidelines:
 - We allow direct function imports from `tests.helpers_resolvers`, `tests.resolvers.video.helpers`, and `tests.resolvers.evaluation_sample_metric_resolver.helpers` in Python
 
 
+
+## AI Team Workflow
+
+For feature work, act as `lead`: read `docs/`, select the needed roles from `.agents/`, create or update a feature specification with a wireframe and decision rationale, implement only the agreed scope, then request independent validation from `quality-engineer`.

--- a/docs/features/lig-9584-categorical-metadata-value-counts.md
+++ b/docs/features/lig-9584-categorical-metadata-value-counts.md
@@ -1,0 +1,237 @@
+# Feature: Categorical Metadata Value Counts
+
+**Status:** Implemented  
+**Linear:** [LIG-9584](https://linear.app/lightly/issue/LIG-9584/backend-categorical-metadata-value-counts-endpoint-5-sp)  
+**Downstream consumer:** [LIG-9585](https://linear.app/lightly/issue/LIG-9585/frontend-categorical-metadata-bar-chart-filter-ui-8-sp)
+
+## Problem and Target User
+
+ML engineers need to understand how categorical metadata such as `city`, `camera_id`, or
+`production_line` is distributed across a dataset. Today the backend exposes metadata schemas and
+numeric histograms, but it cannot aggregate categorical values. The frontend therefore cannot show
+categorical imbalance, reveal missing ingestion data, or populate a categorical filter.
+
+The immediate user of this feature is the frontend engineer building the distribution panel. The
+end user is an ML engineer checking whether production data is balanced and complete before
+training or evaluating a model.
+
+The endpoint must keep high-cardinality fields usable: return the 20 most frequent non-null values,
+aggregate the remaining non-null values, and count missing values separately.
+
+## Proposed User Flow
+
+1. The dataset distribution panel requests categorical value counts for a collection, optionally
+   passing the same active sample filters used by the grid.
+2. The backend discovers categorical fields from the collection's merged metadata schema.
+3. For each categorical field, the backend applies the active filters except filters on that field
+   itself, then groups non-null values and counts missing samples.
+4. The backend returns up to 20 concrete values, an `other_count`, and a `missing_count` for each
+   field.
+5. The frontend labels the semantic aggregate fields as **Other** and **Missing**, renders the
+   distribution, and can use concrete values in its filter control.
+
+## Wireframe
+
+This is a backend-only feature. The wireframe describes the API and data flow rather than a screen.
+
+```text
++--------------------------------------------------------------------------------+
+| POST /collections/{collection_id}/metadata/value-counts                        |
+|--------------------------------------------------------------------------------|
+| Request                                                                        |
+| {                                                                              |
+|   "filters": <ImageFilter, optional>                                           |
+| }                                                                              |
++--------------------------------------+-----------------------------------------+
+                                       |
+                                       v
++--------------------------------------------------------------------------------+
+| Resolve categorical schema fields (string, boolean)                            |
+| For each field:                                                                |
+|   1. remove that field's own metadata filter                                   |
+|   2. apply all remaining sample filters                                        |
+|   3. GROUP BY extracted JSON value + COUNT                                     |
+|   4. keep top 20; sum remainder; count absent/null separately                  |
++--------------------------------------+-----------------------------------------+
+                                       |
+                                       v
++--------------------------------------------------------------------------------+
+| 200 OK                                                                         |
+| {                                                                              |
+|   "city": {                                                                   |
+|     "value_counts": [                                                         |
+|       { "value": "Zurich", "count": 120 },                                  |
+|       { "value": "Berlin", "count": 64 }                                    |
+|     ],                                                                         |
+|     "other_count": 17,                                                        |
+|     "missing_count": 3                                                        |
+|   }                                                                            |
+| }                                                                              |
++--------------------------------------------------------------------------------+
+```
+
+### Meaningful response states
+
+```text
+No categorical fields            Field exists; no matching samples
+{}                               {
+                                   "city": {
+                                     "value_counts": [],
+                                     "other_count": 0,
+                                     "missing_count": 0
+                                   }
+                                 }
+
+All matching samples missing     More than 20 concrete values
+{                                {
+  "city": {                       "camera_id": {
+    "value_counts": [],              "value_counts": [<20 entries>],
+    "other_count": 0,                "other_count": 481,
+    "missing_count": 42               "missing_count": 7
+  }                                  }
+}                                  }
+                                 }
+```
+
+## Content and Interaction
+
+### Proposed contract
+
+- Use `POST /collections/{collection_id}/metadata/value-counts` so callers can provide the same
+  structured `ImageFilter` used by the existing numeric histogram endpoint.
+- The request body is optional. No body means counts for the full collection.
+- Return a mapping keyed by metadata field name, matching the existing
+  `/metadata/histograms` response convention.
+- Each field maps to:
+  - `value_counts`: up to 20 `{value, count}` entries for concrete non-null values;
+  - `other_count`: the sum of concrete values outside the top 20;
+  - `missing_count`: samples where the key is absent or resolves to JSON null.
+- `value` preserves the categorical scalar type (`string` or `boolean`). `count`, `other_count`,
+  and `missing_count` are non-negative integers.
+- `value_counts` is ordered by descending count. Equal counts use a deterministic ascending value
+  order so responses and charts do not move arbitrarily between requests.
+- Top 20 applies only to concrete non-null values. **Other** and **Missing** are additional semantic
+  buckets, so a field can produce at most 22 displayed bars.
+- `other_count` and `missing_count` are always present, including when zero. The frontend may omit
+  zero-height bars from presentation.
+
+### Contract-facing content semantics
+
+- **Missing** means the field is absent from the sample, the sample has no metadata row, or the
+  extracted JSON value is null. It does not mean an empty string, `false`, or the literal string
+  `"Missing"`.
+- **Other** means the sum of all concrete non-null values ranked below the top 20. It is not the
+  literal string `"Other"` and it does not include missing samples.
+- **Missing** and **Other** are presentation labels derived from `missing_count` and `other_count`.
+  They must not be serialized as ordinary `value` entries; a user may legitimately store the
+  strings `"Missing"` or `"Other"`.
+- Every matching sample contributes exactly once per field. For each response field:
+  `sum(value_counts[].count) + other_count + missing_count` equals the number of samples after
+  applicable filters.
+- The field's own metadata filter is excluded while other active filters remain applied. This
+  faceted-search behavior preserves alternative values while the user edits that field and mirrors
+  numeric metadata histograms.
+
+### Validation
+
+- `collection_id` follows the existing metadata endpoint convention; a syntactically valid unknown
+  collection returns an empty mapping.
+- Only scalar categorical schema types are returned. Numeric, list, dict, and complex metadata
+  fields are omitted rather than partially coerced.
+- The top-value limit is fixed at 20 for this scope; the endpoint does not expose a caller-supplied
+  limit.
+
+## States
+
+- **Loading:** The endpoint is a single synchronous HTTP request with no partial/streaming response.
+  The downstream frontend owns loading feedback and may keep prior data visible while refetching.
+- **Empty:** Return `200 {}` when the collection has no categorical fields. Keep known categorical
+  field keys in the response with zero counts when filters match no samples.
+- **Error:** Use existing collection/API error handling for an invalid or inaccessible collection.
+  Database/query failures fail the request as a whole; do not return silently partial field data.
+- **Success:** Return `200` with the field mapping. A field with only missing values has empty
+  `value_counts`, `other_count: 0`, and its full sample total in `missing_count`.
+
+## Responsive and Accessibility Requirements
+
+- Responsive layout does not apply to this backend-only endpoint.
+- The response exposes bucket meaning structurally so clients do not have to infer semantics from
+  English labels, color, position, or capitalization.
+- Counts remain machine-readable integers. The downstream UI is responsible for localized labels,
+  accessible bar names, and non-color-only distinction of Missing and Other.
+
+## Decision Rationale
+
+- **Mirror the numeric histogram endpoint:** A POST request with optional `ImageFilter`, a response
+  keyed by field, and own-field filter exclusion gives the frontend one consistent distribution
+  model.
+- **Return all categorical fields in one request:** The distribution panel can switch fields without
+  issuing a new request, while the server still limits every high-cardinality result.
+- **Separate aggregate counts from concrete values:** Structural `other_count` and `missing_count`
+  avoid collisions with real user values named `"Other"` or `"Missing"` and make filtering intent
+  unambiguous.
+- **Count missing against all collection samples:** An inner join would hide samples with no metadata
+  row and under-report precisely the ingestion failures this feature is intended to reveal.
+- **Use a fixed top 20:** It satisfies the agreed usability/performance bound and avoids adding a
+  tuning control without a demonstrated consumer need.
+- **Order by frequency with deterministic ties:** Most important categories appear first and API
+  snapshots remain stable.
+- **Keep aggregation in SQL:** GROUP BY and COUNT avoid loading per-sample metadata into Python and
+  follow the existing resolver/database boundary for both DuckDB and PostgreSQL.
+
+## Acceptance Criteria
+
+- [x] A collection-level endpoint returns value counts for every scalar categorical metadata field.
+- [x] Unfiltered requests count the full collection; requests with `ImageFilter` count matching
+      samples.
+- [x] For each field, its own metadata filter is excluded while all other active filters apply.
+- [x] A field with 20 or fewer distinct non-null values returns every value with `other_count: 0`.
+- [x] A field with more than 20 distinct non-null values returns exactly the 20 most frequent values
+      and the sum of all remaining values in `other_count`.
+- [x] Top-value ties have a deterministic order and no sample is counted twice or dropped.
+- [x] `missing_count` includes samples with an absent key, explicit JSON null, and no metadata row.
+- [x] Empty strings, `false`, and literal `"Missing"`/`"Other"` values remain concrete values rather
+      than being merged into semantic buckets.
+- [x] Empty collections or collections without categorical metadata return `200 {}`.
+- [x] Known categorical fields remain present with zero counts when active filters match no samples.
+- [x] Numeric and complex metadata fields are not returned by this endpoint.
+- [x] The response models are represented in generated OpenAPI output.
+- [x] Resolver and route tests cover low cardinality, high cardinality, missing values, filtering,
+      own-field filter exclusion, empty results, deterministic ties, and collection isolation.
+- [x] The aggregation works on the supported DuckDB and PostgreSQL JSON extraction paths.
+
+## Non-goals
+
+- Building the bar chart, categorical selector, or checkbox/multi-select UI (LIG-9585).
+- Adding or changing categorical metadata filter operators.
+- Making the Other bucket selectable; it aggregates multiple values and cannot identify a single
+  filter predicate.
+- Adding pagination, search, arbitrary top-N configuration, or returning the full high-cardinality
+  tail.
+- Aggregating list, dict, GPS, datetime, or other complex metadata types.
+- Changing numeric histogram behavior or the existing metadata info endpoint.
+- Persisting precomputed counts or adding a database migration.
+
+## Assumptions and Open Questions
+
+### Assumptions
+
+- Categorical metadata means scalar `string` and `boolean` schema types. Integers and floats remain
+  numeric even when they happen to have few unique values.
+- Top 20 is recomputed from the samples remaining after applicable filters rather than fixed to the
+  collection's unfiltered top 20; this makes the response represent the active dataset view.
+- Missing is based on the total sample population after applicable filters, not only samples that
+  already have a metadata row.
+- Returning every categorical field in one request is acceptable at expected metadata-field counts,
+  consistent with the all-fields numeric histogram endpoint.
+
+### Open questions
+
+- The downstream story requires **Missing** to be filterable, but the current equality filter does
+  not define an explicit absent/null operator. Confirm whether LIG-9585 will add that filter contract
+  or whether a separate backend follow-up is required; it is not part of this counts endpoint.
+- Should boolean metadata be presented through this categorical flow in LIG-9585? This spec includes
+  it because it is a scalar finite category, but the Linear examples mention strings only.
+- If querying all categorical fields proves expensive for collections with many metadata keys,
+  should a later optimization add an optional field selector? It is deliberately omitted from the
+  initial contract.

--- a/lightly_studio/e2e-tests/index_distribution.py
+++ b/lightly_studio/e2e-tests/index_distribution.py
@@ -132,8 +132,9 @@ def _sample_metadata(rng: random.Random) -> Mapping[str, Any]:
         "reviewed": rng.choices([True, False], [0.3, 0.7])[0],
         "camera_id": rng.choices(CAMERA_IDS, CAMERA_WEIGHTS)[0],
     }
+    split_missing_probability = 0.2
     # ~20 % of images have no split — exercises the "Missing" bucket.
-    if rng.random() >= 0.2:
+    if rng.random() >= split_missing_probability:
         metadata["split"] = rng.choices(DATASET_SPLITS, SPLIT_WEIGHTS)[0]
     return metadata
 

--- a/lightly_studio/e2e-tests/index_distribution.py
+++ b/lightly_studio/e2e-tests/index_distribution.py
@@ -7,9 +7,9 @@ seeded (all default to true):
 - ``ADD_OBJECT_DETECTIONS`` a few weighted detection boxes per image
 - ``ADD_SEGMENTATIONS``     one or two weighted segmentation masks per image
 - ``ADD_METADATA``          numeric metadata fields with distinct distribution
-  shapes (bell, flat, skewed, discrete, constant) plus a string field —
-  rendered as histograms in the panel's "Metadata" distribution and above the
-  range sliders in the metadata filter panel
+  shapes (bell, flat, skewed, discrete, constant) plus several categorical
+  fields (string, boolean, many-valued, partially-missing) — rendered as
+  histograms / bar charts in the panel's "Metadata" distribution
 
 Examples::
 
@@ -71,6 +71,20 @@ SEGMENTATION_CLASSES = ["road", "sky", "building", "vegetation", "sidewalk"]
 SEGMENTATION_WEIGHTS = [0.3, 0.25, 0.2, 0.15, 0.1]
 
 LOCATIONS = ["city", "rural", "mountain", "coastal", "desert"]
+LOCATION_WEIGHTS = [0.35, 0.25, 0.20, 0.12, 0.08]
+
+# Skewed weather distribution: sunny dominates, snowy is rare.
+WEATHER_CONDITIONS = ["sunny", "partly_cloudy", "overcast", "rainy", "foggy", "snowy"]
+WEATHER_WEIGHTS = [0.40, 0.25, 0.15, 0.10, 0.07, 0.03]
+
+# Common ML split assignment; ~20 % of samples intentionally left unassigned
+# so the "Missing" bucket appears in the categorical distribution panel.
+DATASET_SPLITS = ["train", "val", "test"]
+SPLIT_WEIGHTS = [0.70, 0.20, 0.10]
+
+# 25 camera IDs: exercises the top-20 "Other" bucket in value-counts.
+CAMERA_IDS = [f"CAM_{i:02d}" for i in range(1, 26)]
+CAMERA_WEIGHTS = [max(1, 26 - i) for i in range(1, 26)]  # CAM_01 most frequent
 
 
 def _box(
@@ -93,16 +107,35 @@ def _rectangle_mask(
 
 
 def _sample_metadata(rng: random.Random) -> Mapping[str, Any]:
-    """Return one sample's metadata, each key with a distinct distribution."""
-    return {
+    """Return one sample's metadata with numeric and categorical fields.
+
+    Numeric fields cover distinct distribution shapes (bell, flat, skewed,
+    discrete, constant).  Categorical fields exercise:
+    - weighted strings with few values  (location, weather)
+    - a boolean field                   (reviewed)
+    - a many-valued string field that   (camera_id — 25 values triggers the
+      overflows the top-20 limit          "Other" bucket in value-counts)
+    - a field present on only ~80 % of  (split — triggers the "Missing" bucket)
+      samples
+    """
+    metadata: dict[str, Any] = {
+        # Numeric fields
         "confidence": min(1.0, max(0.0, rng.gauss(0.75, 0.12))),
         "brightness": rng.uniform(0.0, 255.0),
         "object_size": rng.lognormvariate(3.0, 0.8),
         "temperature": rng.randint(10, 40),
         "num_defects": rng.choices([0, 1, 2, 3, 5, 8], [50, 25, 12, 7, 4, 2])[0],
         "sensor_gain": 1.0,
-        "location": rng.choice(LOCATIONS),
+        # Categorical fields
+        "location": rng.choices(LOCATIONS, LOCATION_WEIGHTS)[0],
+        "weather": rng.choices(WEATHER_CONDITIONS, WEATHER_WEIGHTS)[0],
+        "reviewed": rng.choices([True, False], [0.3, 0.7])[0],
+        "camera_id": rng.choices(CAMERA_IDS, CAMERA_WEIGHTS)[0],
     }
+    # ~20 % of images have no split — exercises the "Missing" bucket.
+    if rng.random() >= 0.2:
+        metadata["split"] = rng.choices(DATASET_SPLITS, SPLIT_WEIGHTS)[0]
+    return metadata
 
 
 def main() -> None:
@@ -171,7 +204,7 @@ def main() -> None:
             ("classifications", ADD_CLASSIFICATIONS),
             ("object detections", ADD_OBJECT_DETECTIONS),
             ("segmentation masks", ADD_SEGMENTATIONS),
-            ("numeric metadata", ADD_METADATA),
+            ("metadata", ADD_METADATA),
         ]
         if enabled
     ]

--- a/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
@@ -14,9 +14,16 @@ from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.errors import TagNotFoundError
 from lightly_studio.metadata import compute_similarity, compute_typicality
 from lightly_studio.models.collection import CollectionTable
-from lightly_studio.models.metadata import HistogramView, MetadataInfoView
+from lightly_studio.models.metadata import (
+    HistogramView,
+    MetadataInfoView,
+    MetadataValueCountsView,
+)
 from lightly_studio.resolvers import embedding_model_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.resolvers.metadata_resolver.sample import (
+    categorical_value_counts as metadata_value_counts_resolver,
+)
 from lightly_studio.resolvers.metadata_resolver.sample import (
     get_metadata_info as metadata_info_resolver,
 )
@@ -82,6 +89,26 @@ def get_metadata_histograms(
         collection_id=collection_id,
         filters=request.filters if request else None,
         bin_count=request.bin_count if request else _DEFAULT_BIN_COUNT,
+    )
+
+
+class MetadataValueCountsRequest(BaseModel):
+    """Request body for computing filtered categorical value counts."""
+
+    filters: ImageFilter | None = Field(None, description="Filter parameters for samples")
+
+
+@metadata_router.post("/metadata/value-counts", response_model=dict[str, MetadataValueCountsView])
+def get_metadata_value_counts(
+    session: SessionDep,
+    collection_id: Annotated[UUID, Path(title="collection Id")],
+    request: MetadataValueCountsRequest | None = None,
+) -> dict[str, MetadataValueCountsView]:
+    """Compute categorical metadata value counts under optional sample filters."""
+    return metadata_value_counts_resolver.get_metadata_value_counts(
+        session=session,
+        collection_id=collection_id,
+        filters=request.filters if request else None,
     )
 
 

--- a/lightly_studio/src/lightly_studio/database/db_json.py
+++ b/lightly_studio/src/lightly_studio/database/db_json.py
@@ -70,6 +70,22 @@ class json_extract(GenericFunction[Any]):  # noqa: N801
         super().__init__(column)
 
 
+class json_extract_string(GenericFunction[str]):  # noqa: N801
+    """Extract a top-level JSON scalar as plain text.
+
+    The key is bound rather than interpolated into SQL. It is treated literally,
+    so dots and quotes in metadata keys do not become path syntax.
+    """
+
+    inherit_cache = False
+    type = Text()
+
+    def __init__(self, column: Any, field: str) -> None:
+        """Initialize with a JSON column and top-level field name."""
+        field_parameter = sqlalchemy.literal(field, type_=_JsonTopLevelKeyType())
+        super().__init__(column, field_parameter)
+
+
 @compiles(json_extract)
 def _compile_json_extract_unsupported(
     element: json_extract, compiler: SQLCompiler, **kw: Any
@@ -104,6 +120,49 @@ def _compile_json_extract_postgresql(
     return _build_pg_json_accessor(
         column=col_sql, field=element.field, cast_to_float=element.cast_to_float
     )
+
+
+@compiles(json_extract_string)
+def _compile_json_extract_string_unsupported(
+    element: json_extract_string, compiler: SQLCompiler, **kw: Any
+) -> str:
+    """Raise for unsupported dialects."""
+    raise NotImplementedError(
+        f"Unsupported dialect: {compiler.dialect.name}."
+        " Only 'postgresql' and 'duckdb' are supported."
+    )
+
+
+@compiles(json_extract_string, "duckdb")
+def _compile_json_extract_string_duckdb(
+    element: json_extract_string, compiler: SQLCompiler, **kw: Any
+) -> str:
+    """Extract a JSON scalar as plain text on DuckDB."""
+    column, field = element.clauses
+    return f"json_extract_string({compiler.process(column, **kw)}, {compiler.process(field, **kw)})"
+
+
+@compiles(json_extract_string, "postgresql")
+def _compile_json_extract_string_postgresql(
+    element: json_extract_string, compiler: SQLCompiler, **kw: Any
+) -> str:
+    """Extract a JSON scalar as plain text on PostgreSQL."""
+    column, field = element.clauses
+    return f"{compiler.process(column, **kw)}->>{compiler.process(field, **kw)}"
+
+
+class _JsonTopLevelKeyType(TypeDecorator[str]):
+    """Bind a literal top-level JSON key for each supported database."""
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value: str | None, dialect: Dialect) -> str | None:
+        """Convert DuckDB keys to JSON Pointer and leave PostgreSQL keys raw."""
+        if value is None or dialect.name != "duckdb":
+            return value
+        escaped = value.replace("~", "~0").replace("/", "~1")
+        return f"/{escaped}"
 
 
 class _JsonStringType(TypeDecorator[str]):

--- a/lightly_studio/src/lightly_studio/models/metadata.py
+++ b/lightly_studio/src/lightly_studio/models/metadata.py
@@ -208,6 +208,21 @@ class HistogramView(BaseModel):
     counts: list[int] = Field(description="Value count per bin")
 
 
+class MetadataValueCountView(BaseModel):
+    """Count for one concrete categorical metadata value."""
+
+    value: str | bool = Field(description="Categorical metadata value")
+    count: int = Field(description="Number of samples with this value", ge=0)
+
+
+class MetadataValueCountsView(BaseModel):
+    """Top values and aggregate counts for a categorical metadata field."""
+
+    value_counts: list[MetadataValueCountView] = Field(description="Top concrete values")
+    other_count: int = Field(description="Count outside the top values", ge=0)
+    missing_count: int = Field(description="Count of absent or null values", ge=0)
+
+
 class MetadataInfoView(BaseModel):
     """Metadata info response model for API endpoints."""
 

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
@@ -1,0 +1,156 @@
+"""Resolver for categorical sample metadata value counts."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import func
+from sqlalchemy.sql.elements import ColumnElement
+from sqlmodel import Session, col, select
+
+from lightly_studio.database import db_json
+from lightly_studio.models.metadata import (
+    MetadataValueCountsView,
+    MetadataValueCountView,
+    SampleMetadataTable,
+)
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers.metadata_resolver.sample import (
+    get_metadata_info as metadata_info_resolver,
+)
+
+if TYPE_CHECKING:
+    from lightly_studio.resolvers.image_filter import ImageFilter
+
+_CATEGORICAL_TYPES = ("string", "boolean")
+_TOP_VALUE_COUNT = 20
+
+
+def get_metadata_value_counts(
+    session: Session,
+    collection_id: UUID,
+    filters: ImageFilter | None = None,
+) -> dict[str, MetadataValueCountsView]:
+    """Count categorical metadata values for a collection.
+
+    Each field's own metadata filter is excluded while all other filters apply.
+    Results contain the 20 most frequent concrete values, with the remaining
+    concrete and missing values counted separately.
+
+    Args:
+        session: The database session.
+        collection_id: The collection whose sample metadata is aggregated.
+        filters: Optional image filters restricting the counted samples.
+
+    Returns:
+        A mapping from categorical metadata keys to their value counts.
+    """
+    schema = metadata_info_resolver._get_merged_schema(  # noqa: SLF001
+        session=session, collection_id=collection_id
+    )
+    result: dict[str, MetadataValueCountsView] = {}
+    for key, metadata_type in schema.items():
+        if metadata_type not in _CATEGORICAL_TYPES:
+            continue
+        field_filters = metadata_info_resolver._without_metadata_key_filter(  # noqa: SLF001
+            filters=filters, metadata_key=key
+        )
+        result[key] = _get_field_value_counts(
+            session=session,
+            collection_id=collection_id,
+            metadata_key=key,
+            metadata_type=metadata_type,
+            filters=field_filters,
+        )
+    return result
+
+
+def _get_field_value_counts(
+    session: Session,
+    collection_id: UUID,
+    metadata_key: str,
+    metadata_type: str,
+    filters: ImageFilter | None,
+) -> MetadataValueCountsView:
+    value_expr = db_json.json_extract_string(column=SampleMetadataTable.data, field=metadata_key)
+    total_count, concrete_count = _get_total_and_concrete_counts(
+        session=session,
+        collection_id=collection_id,
+        value_expr=value_expr,
+        filters=filters,
+    )
+    rows = _get_top_value_counts(
+        session=session,
+        collection_id=collection_id,
+        value_expr=value_expr,
+        filters=filters,
+    )
+    value_counts = [
+        MetadataValueCountView(
+            value=_parse_value(value=value, metadata_type=metadata_type), count=int(count)
+        )
+        for value, count in rows
+    ]
+    top_count = sum(value_count.count for value_count in value_counts)
+    return MetadataValueCountsView(
+        value_counts=value_counts,
+        other_count=concrete_count - top_count,
+        missing_count=total_count - concrete_count,
+    )
+
+
+def _get_total_and_concrete_counts(
+    session: Session,
+    collection_id: UUID,
+    value_expr: ColumnElement[str],
+    filters: ImageFilter | None,
+) -> tuple[int, int]:
+    query = (
+        select(func.count(), func.count(value_expr))
+        .select_from(SampleTable)
+        .join(
+            SampleMetadataTable,
+            col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
+            isouter=True,
+        )
+        .where(SampleTable.collection_id == collection_id)
+    )
+    query = metadata_info_resolver._apply_image_filters(  # noqa: SLF001
+        query=query, collection_id=collection_id, filters=filters
+    )
+    total_count, concrete_count = session.execute(query).one()
+    return int(total_count), int(concrete_count)
+
+
+def _get_top_value_counts(
+    session: Session,
+    collection_id: UUID,
+    value_expr: ColumnElement[str],
+    filters: ImageFilter | None,
+) -> list[tuple[str, int]]:
+    count_expr = func.count().label("value_count")
+    query = (
+        select(value_expr, count_expr)
+        .select_from(SampleTable)
+        .join(
+            SampleMetadataTable,
+            col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
+            isouter=True,
+        )
+        .where(SampleTable.collection_id == collection_id)
+        .where(value_expr.isnot(None))
+        .group_by(value_expr)
+        .order_by(count_expr.desc(), value_expr.asc())
+        .limit(_TOP_VALUE_COUNT)
+    )
+    query = metadata_info_resolver._apply_image_filters(  # noqa: SLF001
+        query=query, collection_id=collection_id, filters=filters
+    )
+    return [(str(value), int(count)) for value, count in session.execute(query).all()]
+
+
+def _parse_value(value: str, metadata_type: str) -> str | bool:
+    if metadata_type == "boolean":
+        return value.lower() == "true"
+    return value

--- a/lightly_studio/src/lightly_studio/type_definitions.py
+++ b/lightly_studio/src/lightly_studio/type_definitions.py
@@ -29,6 +29,8 @@ QueryType = TypeVar(
     Select[tuple[VideoTable, VideoFrameTable]],
     SelectOfScalar[VideoFrameTable],
     Select[tuple[Any, int]],
+    Select[tuple[int, int]],
+    Select[tuple[str, int]],
     Select[tuple[UUID, int]],
     Select[tuple[AnnotationBaseTable, Any]],
     Select[tuple[ImageTable, Any]],

--- a/lightly_studio/tests/api/routes/api/test_metadata.py
+++ b/lightly_studio/tests/api/routes/api/test_metadata.py
@@ -8,7 +8,12 @@ from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK
-from lightly_studio.models.metadata import HistogramView, MetadataInfoView
+from lightly_studio.models.metadata import (
+    HistogramView,
+    MetadataInfoView,
+    MetadataValueCountsView,
+    MetadataValueCountView,
+)
 from lightly_studio.resolvers import image_resolver, metadata_resolver, tag_resolver
 from tests.helpers_resolvers import (
     create_collection,
@@ -73,6 +78,70 @@ def test_get_metadata_info__empty_response(test_client: TestClient, mocker: Mock
     assert response.status_code == HTTP_STATUS_OK
     data = response.json()
     assert data == []
+
+
+def test_get_metadata_value_counts(test_client: TestClient, mocker: MockerFixture) -> None:
+    collection_id = uuid4()
+    resolver = mocker.patch(
+        "lightly_studio.api.routes.api.metadata."
+        "metadata_value_counts_resolver.get_metadata_value_counts",
+        return_value={
+            "city": MetadataValueCountsView(
+                value_counts=[MetadataValueCountView(value="Zurich", count=2)],
+                other_count=1,
+                missing_count=3,
+            )
+        },
+    )
+    filters = {
+        "sample_filter": {"metadata_filters": [{"key": "country", "op": "==", "value": "CH"}]}
+    }
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/metadata/value-counts",
+        json={"filters": filters},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {
+        "city": {
+            "value_counts": [{"value": "Zurich", "count": 2}],
+            "other_count": 1,
+            "missing_count": 3,
+        }
+    }
+    called_filters = resolver.call_args.kwargs["filters"]
+    assert called_filters.model_dump(exclude_none=True) == {
+        "filter_type": "image",
+        "sample_filter": {
+            "filter_type": "sample",
+            "metadata_filters": [{"key": "country", "op": "==", "value": "CH"}],
+        },
+    }
+
+
+def test_get_metadata_value_counts__optional_body(
+    test_client: TestClient, mocker: MockerFixture
+) -> None:
+    collection_id = uuid4()
+    resolver = mocker.patch(
+        "lightly_studio.api.routes.api.metadata."
+        "metadata_value_counts_resolver.get_metadata_value_counts",
+        return_value={},
+    )
+
+    response = test_client.post(f"/api/collections/{collection_id}/metadata/value-counts")
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {}
+    assert resolver.call_args.kwargs["filters"] is None
+
+
+def test_metadata_value_counts__openapi_models(test_client: TestClient) -> None:
+    openapi = test_client.get("/openapi.json").json()
+    schemas = openapi["components"]["schemas"]
+    assert "MetadataValueCountView" in schemas
+    assert "MetadataValueCountsView" in schemas
 
 
 # TODO(Mihnea, 10/2025): Also add tests with passing `embedding_model_name` and/or `metadata_name`

--- a/lightly_studio/tests/database/test_db_json.py
+++ b/lightly_studio/tests/database/test_db_json.py
@@ -118,6 +118,53 @@ def test_json_extract__sqlite_raises() -> None:
         expr.compile(dialect=sqlite.dialect())
 
 
+def test_json_extract_string__duckdb() -> None:
+    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field="location")
+    result = expr.compile(dialect=Dialect())
+    assert str(result) == "json_extract_string(data, %(param_1)s)"
+    assert result.params == {"param_1": "location"}
+
+
+def test_json_extract_string__postgresql() -> None:
+    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field="location")
+    result = expr.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
+    assert str(result) == "data->>%(param_1)s"
+    assert result.params == {"param_1": "location"}
+
+
+@pytest.mark.parametrize("field", ["site.name", "owner's site"])
+def test_json_extract_string__special_key_is_bound(field: str) -> None:
+    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field=field)
+    duckdb_result = expr.compile(dialect=Dialect())
+    postgres_result = expr.compile(
+        dialect=postgresql.dialect()  # type: ignore[no-untyped-call]
+    )
+
+    assert str(duckdb_result) == "json_extract_string(data, %(param_1)s)"
+    assert duckdb_result.params == {"param_1": field}
+    assert str(postgres_result) == "data->>%(param_1)s"
+    assert postgres_result.params == {"param_1": field}
+
+
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    [
+        ("site.name", "/site.name"),
+        ("owner's site", "/owner's site"),
+        ("path/to~site", "/path~1to~0site"),
+    ],
+)
+def test_json_top_level_key_type__duckdb_path(field: str, expected: str) -> None:
+    type_ = db_json._JsonTopLevelKeyType()
+    assert type_.process_bind_param(value=field, dialect=Dialect()) == expected
+
+
+def test_json_extract_string__sqlite_raises() -> None:
+    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field="location")
+    with pytest.raises(NotImplementedError, match="Unsupported dialect: sqlite"):
+        expr.compile(dialect=sqlite.dialect())
+
+
 def test_json_literal__duckdb_string_value() -> None:
     """String values are JSON-encoded for DuckDB."""
     lit = db_json.json_literal("hello")

--- a/lightly_studio/tests/metadata/test_get_metadata_value_counts.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_value_counts.py
@@ -1,0 +1,176 @@
+"""Tests for categorical metadata value counts."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlmodel import Session
+
+from lightly_studio.models.metadata import SampleMetadataTable
+from lightly_studio.resolvers.image_filter import FilterDimensions, ImageFilter
+from lightly_studio.resolvers.metadata_resolver.metadata_filter import MetadataFilter
+from lightly_studio.resolvers.metadata_resolver.sample import categorical_value_counts
+from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
+from tests.helpers_resolvers import create_collection, create_image
+
+
+def test_get_metadata_value_counts__categorical_values_and_missing(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    _create_sample(db_session, collection_id, {"city": "Zurich", "active": True, "score": 1})
+    _create_sample(db_session, collection_id, {"city": "Zurich", "active": False})
+    _create_sample(db_session, collection_id, {"city": "", "active": False})
+    _create_sample(db_session, collection_id, {"city": "Missing", "active": True})
+    _create_sample(db_session, collection_id, {"city": "Other", "active": True})
+    _create_explicit_null_sample(db_session=db_session, collection_id=collection_id)
+    create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/no-metadata.png",
+    )
+
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session, collection_id=collection_id
+    )
+
+    assert set(counts) == {"city", "active"}
+    assert [(entry.value, entry.count) for entry in counts["city"].value_counts] == [
+        ("Zurich", 2),
+        ("", 1),
+        ("Missing", 1),
+        ("Other", 1),
+    ]
+    assert counts["city"].other_count == 0
+    assert counts["city"].missing_count == 2
+    assert [(entry.value, entry.count) for entry in counts["active"].value_counts] == [
+        (True, 3),
+        (False, 2),
+    ]
+    assert counts["active"].missing_count == 2
+
+
+def test_get_metadata_value_counts__top_twenty_and_collection_isolation(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    for index in range(21):
+        _create_sample(db_session, collection.collection_id, {"category": f"value-{index:02d}"})
+    _create_sample(db_session, collection.collection_id, {"category": "value-20"})
+
+    other_collection = create_collection(session=db_session)
+    for _ in range(3):
+        _create_sample(db_session, other_collection.collection_id, {"category": "value-00"})
+
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session, collection_id=collection.collection_id
+    )["category"]
+
+    assert len(counts.value_counts) == 20
+    assert (counts.value_counts[0].value, counts.value_counts[0].count) == ("value-20", 2)
+    assert [entry.value for entry in counts.value_counts[1:]] == [
+        f"value-{index:02d}" for index in range(19)
+    ]
+    assert counts.other_count == 1
+    assert counts.missing_count == 0
+
+
+def test_get_metadata_value_counts__filters_and_own_key_exclusion(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    _create_sample(db_session, collection.collection_id, {"city": "A", "group": "x"})
+    _create_sample(db_session, collection.collection_id, {"city": "B", "group": "x"})
+    _create_sample(db_session, collection.collection_id, {"city": "B", "group": "y"})
+    filters = ImageFilter(
+        sample_filter=SampleFilter(
+            metadata_filters=[
+                MetadataFilter(key="city", op="==", value="A"),
+                MetadataFilter(key="group", op="==", value="x"),
+            ]
+        )
+    )
+
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session,
+        collection_id=collection.collection_id,
+        filters=filters,
+    )
+
+    assert [(entry.value, entry.count) for entry in counts["city"].value_counts] == [
+        ("A", 1),
+        ("B", 1),
+    ]
+    assert [(entry.value, entry.count) for entry in counts["group"].value_counts] == [("x", 1)]
+
+
+def test_get_metadata_value_counts__known_fields_with_no_matches(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    _create_sample(db_session, collection.collection_id, {"city": "A"})
+
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session,
+        collection_id=collection.collection_id,
+        filters=ImageFilter(width=FilterDimensions(min=10_000)),
+    )
+
+    assert counts["city"].value_counts == []
+    assert counts["city"].other_count == 0
+    assert counts["city"].missing_count == 0
+
+
+def test_get_metadata_value_counts__unknown_collection_is_empty(db_session: Session) -> None:
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session, collection_id=uuid4()
+    )
+    assert counts == {}
+
+
+def test_get_metadata_value_counts__literal_top_level_keys(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    _create_sample(
+        db_session,
+        collection.collection_id,
+        {"site.name": "Zurich", "owner's site": "primary"},
+    )
+
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert counts["site.name"].value_counts[0].value == "Zurich"
+    assert counts["owner's site"].value_counts[0].value == "primary"
+
+
+def _create_sample(
+    db_session: Session,
+    collection_id: UUID,
+    metadata: dict[str, Any],
+) -> None:
+    image = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs=f"/path/to/{uuid4()}.png",
+    )
+    for key, value in metadata.items():
+        image.sample[key] = value
+
+
+def _create_explicit_null_sample(db_session: Session, collection_id: UUID) -> None:
+    image = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/explicit-null.png",
+    )
+    db_session.add(
+        SampleMetadataTable(
+            sample_id=image.sample_id,
+            data={"city": None},
+            metadata_schema={"city": "string"},
+        )
+    )
+    db_session.commit()


### PR DESCRIPTION
## Summary

Introduces the backend foundation for categorical metadata distributions.

- New `GET /metadata/value_counts` API endpoint that returns value frequencies for all categorical metadata fields per collection
- `categorical_value_counts.py` resolver: queries the JSON metadata store, collects the top-N values per field, and groups the rest into an `__other__` bucket; also emits a `__missing__` bucket when samples have no value for the field
- DB helper for extracting distinct values from the JSON column
- E2E seeding script extended with four categorical fields (`location`, `weather`, `reviewed`, `camera_id`, `split`) to exercise weighted strings, booleans, many-valued strings (triggers the "Other" bucket), and partial coverage (triggers the "Missing" bucket)

## Test plan

- [ ] `make static-checks` passes
- [ ] `make test-ci` passes (new unit tests in `tests/metadata/test_get_metadata_value_counts.py` and `tests/database/test_db_json.py`)
- [ ] Manual: run `make start-e2e-distribution` and verify the endpoint returns counts for the seeded fields

Part of LIG-9585.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint for categorical metadata value counts.
  - Reports the top 20 values for each categorical field, plus “other” and missing totals.
  - Supports optional filters while excluding the field being aggregated from its own filter.
  - Handles string and boolean metadata, missing values, deterministic ordering, and literal field names.

- **Documentation**
  - Added the feature specification and AI team workflow guidance.

- **Tests**
  - Added coverage for API responses, filtering, database compatibility, missing values, and collection isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->