### PR TITLE
BE: add 'in' operator to MetadataFilter for categorical filtering

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
@@ -3,7 +3,9 @@
 import operator
 from typing import Any, Callable, Literal, Protocol, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+from pydantic_core import PydanticCustomError
+from sqlalchemy import or_
 from sqlalchemy.sql.elements import ColumnElement
 
 from lightly_studio.database import db_json
@@ -14,7 +16,8 @@ T = TypeVar("T", bound=BaseModel)
 M = TypeVar("M", bound="HasMetadata")
 
 # Valid operators for metadata filtering
-MetadataOperator = Literal[">", "<", "==", ">=", "<=", "!="]
+MetadataComparisonOperator = Literal[">", "<", "==", ">=", "<=", "!="]
+MetadataOperator = Literal[">", "<", "==", ">=", "<=", "!=", "in"]
 
 
 class HasMetadata(Protocol):
@@ -30,6 +33,24 @@ class MetadataFilter(BaseModel):
     key: str
     op: MetadataOperator
     value: Any
+
+    @model_validator(mode="after")
+    def validate_in_value(self) -> "MetadataFilter":  # noqa: N804
+        """Validate the categorical values accepted by the ``in`` operator."""
+        if self.op != "in":
+            return self
+        if not isinstance(self.value, list) or not self.value:
+            raise PydanticCustomError(
+                "metadata_in_value", "'in' metadata filters require a non-empty array."
+            )
+        concrete_types = {type(value) for value in self.value if value is not None}
+        if not concrete_types.issubset({str, bool}) or len(concrete_types) > 1:
+            raise PydanticCustomError(
+                "metadata_in_value",
+                "'in' metadata filter values must be homogeneous strings or booleans, "
+                "optionally including null.",
+            )
+        return self
 
 
 # Ignore PLW1641 because `==` and `!=` create filters here, so this class does
@@ -66,7 +87,9 @@ class Metadata:  # noqa: PLW1641
         return MetadataFilter(key=self.key, op="!=", value=value)
 
 
-_OP_MAP: dict[MetadataOperator, Callable[[ColumnElement[Any], Any], ColumnElement[bool]]] = {
+_OP_MAP: dict[
+    MetadataComparisonOperator, Callable[[ColumnElement[Any], Any], ColumnElement[bool]]
+] = {
     ">": operator.gt,
     "<": operator.lt,
     "==": operator.eq,
@@ -116,13 +139,21 @@ def apply_metadata_filters(
     if not metadata_filters:
         return query
 
-    # Apply the filters using JSON extraction
+    match_missing = any(
+        meta_filter.op == "in" and None in meta_filter.value for meta_filter in metadata_filters
+    )
     query = query.join(
         metadata_model,
         metadata_join_condition,
+        isouter=match_missing,
     )
 
     for meta_filter in metadata_filters:
+        if meta_filter.op == "in":
+            query = query.where(
+                _build_in_condition(metadata_model=metadata_model, metadata_filter=meta_filter)
+            )
+            continue
         extract_expr = db_json.json_extract(
             column=metadata_model.data,
             field=meta_filter.key,
@@ -133,3 +164,23 @@ def apply_metadata_filters(
         query = query.where(condition)
 
     return query
+
+
+def _build_in_condition(
+    metadata_model: type[M], metadata_filter: MetadataFilter
+) -> ColumnElement[bool]:
+    """Build an OR predicate for a validated categorical ``in`` filter."""
+    extract_expr = db_json.json_extract_string(
+        column=metadata_model.data, field=metadata_filter.key
+    )
+    values = [
+        str(value).lower() if isinstance(value, bool) else value
+        for value in metadata_filter.value
+        if value is not None
+    ]
+    conditions: list[ColumnElement[bool]] = []
+    if values:
+        conditions.append(extract_expr.in_(values))
+    if None in metadata_filter.value:
+        conditions.append(extract_expr.is_(None))
+    return or_(*conditions)

--- a/lightly_studio/tests/api/routes/api/test_metadata.py
+++ b/lightly_studio/tests/api/routes/api/test_metadata.py
@@ -144,6 +144,20 @@ def test_metadata_value_counts__openapi_models(test_client: TestClient) -> None:
     assert "MetadataValueCountsView" in schemas
 
 
+def test_metadata_filter__invalid_in_value_returns_422(test_client: TestClient) -> None:
+    collection_id = uuid4()
+    response = test_client.post(
+        f"/api/collections/{collection_id}/metadata/value-counts",
+        json={
+            "filters": {
+                "sample_filter": {"metadata_filters": [{"key": "city", "op": "in", "value": []}]}
+            }
+        },
+    )
+
+    assert response.status_code == 422
+
+
 # TODO(Mihnea, 10/2025): Also add tests with passing `embedding_model_name` and/or `metadata_name`
 #  in the body.
 def test_compute_typicality_metadata(test_client: TestClient, db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/metadata_resolvers/sample/test_sample_metadata_filtering.py
+++ b/lightly_studio/tests/resolvers/metadata_resolvers/sample/test_sample_metadata_filtering.py
@@ -5,6 +5,7 @@ from sqlmodel import Session
 from lightly_studio.resolvers import sample_resolver
 from lightly_studio.resolvers.metadata_resolver.metadata_filter import (
     Metadata,
+    MetadataFilter,
 )
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import (
@@ -106,3 +107,104 @@ def test_metadata_multiple_filters(db_session: Session) -> None:
     ).samples
     assert len(samples) == 1
     assert samples[0].sample_id == sample2.sample_id
+
+
+def test_metadata_in_filter__concrete_values_and_other_keys(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    first = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/first.png",
+    ).sample
+    second = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/second.png",
+    ).sample
+    third = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/third.png",
+    ).sample
+    first["city"] = "Zurich"
+    first["reviewed"] = True
+    second["city"] = "Berlin"
+    second["reviewed"] = False
+    third["city"] = "Paris"
+    third["reviewed"] = True
+
+    filters = SampleFilter(
+        metadata_filters=[
+            MetadataFilter(key="city", op="in", value=["Zurich", "Berlin"]),
+            MetadataFilter(key="reviewed", op="in", value=[True]),
+        ]
+    )
+    samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    assert [sample.sample_id for sample in samples] == [first.sample_id]
+
+
+def test_metadata_in_filter__missing(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    concrete = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/concrete.png",
+    ).sample
+    other_metadata = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/other-metadata.png",
+    ).sample
+    no_metadata = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/no-metadata.png",
+    ).sample
+    concrete["city"] = "Zurich"
+    other_metadata["country"] = "CH"
+
+    filters = SampleFilter(metadata_filters=[MetadataFilter(key="city", op="in", value=[None])])
+    samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    assert {sample.sample_id for sample in samples} == {
+        other_metadata.sample_id,
+        no_metadata.sample_id,
+    }
+
+
+def test_metadata_in_filter__concrete_and_missing_special_key(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    concrete = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/concrete.png",
+    ).sample
+    missing = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/missing.png",
+    ).sample
+    excluded = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/excluded.png",
+    ).sample
+    concrete["city.name's"] = "Zurich"
+    excluded["city.name's"] = "Paris"
+
+    filters = SampleFilter(
+        metadata_filters=[MetadataFilter(key="city.name's", op="in", value=["Zurich", None])]
+    )
+    samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    assert {sample.sample_id for sample in samples} == {
+        concrete.sample_id,
+        missing.sample_id,
+    }

--- a/lightly_studio/tests/resolvers/metadata_resolvers/test_metadata_filter.py
+++ b/lightly_studio/tests/resolvers/metadata_resolvers/test_metadata_filter.py
@@ -38,7 +38,7 @@ def test_apply_metadata_filters__postgres_missing_and_special_key() -> None:
         metadata_join_condition=col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
     )
 
-    compiled = query.compile(dialect=postgresql.dialect())
+    compiled = query.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
     sql = str(compiled).lower()
     assert "left outer join" in sql
     assert "->>" in sql

--- a/lightly_studio/tests/resolvers/metadata_resolvers/test_metadata_filter.py
+++ b/lightly_studio/tests/resolvers/metadata_resolvers/test_metadata_filter.py
@@ -1,0 +1,47 @@
+"""Tests for generic metadata filters."""
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.dialects import postgresql
+from sqlmodel import col, select
+
+from lightly_studio.models.metadata import SampleMetadataTable
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers.metadata_resolver import metadata_filter
+from lightly_studio.resolvers.metadata_resolver.metadata_filter import MetadataFilter
+
+
+@pytest.mark.parametrize(
+    "value",
+    [[], ["Zurich", True], [1, 2], [None, 1]],
+)
+def test_metadata_filter__invalid_in_value(value: list[object]) -> None:
+    with pytest.raises(ValidationError):
+        MetadataFilter(key="city", op="in", value=value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [["Zurich", "Berlin"], [True, False], ["Zurich", None], [None]],
+)
+def test_metadata_filter__valid_in_value(value: list[object]) -> None:
+    metadata_filter = MetadataFilter(key="city", op="in", value=value)
+
+    assert metadata_filter.value == value
+
+
+def test_apply_metadata_filters__postgres_missing_and_special_key() -> None:
+    query = metadata_filter.apply_metadata_filters(
+        select(SampleTable),
+        [MetadataFilter(key="city.name's", op="in", value=["Zurich", None])],
+        metadata_model=SampleMetadataTable,
+        metadata_join_condition=col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
+    )
+
+    compiled = query.compile(dialect=postgresql.dialect())
+    sql = str(compiled).lower()
+    assert "left outer join" in sql
+    assert "->>" in sql
+    assert " in " in sql
+    assert " is null" in sql
+    assert "city.name's" in compiled.params.values()


### PR DESCRIPTION
## Summary

Stacked on p1.

- Adds an `in` operator to `MetadataFilter` that accepts a list of `str | bool | None` values
- Builds an `OR` predicate for non-null values using a standard SQL `IN` clause
- When `None` is in the list, uses a `LEFT OUTER JOIN` so that samples with no metadata entry for the field are also included
- Validates that the list is non-empty and that all values share the same type (prevents mixing strings with booleans or numbers)

## Test plan

- [ ] `make static-checks` passes
- [ ] New unit tests in `tests/resolvers/metadata_resolvers/test_metadata_filter.py` and `tests/api/routes/api/test_metadata.py`
- [ ] `tests/sample/test_sample_metadata_filtering.py` covers round-trip filtering with null and non-null values

Part of LIG-9585.