### PR TITLE
FE: data layer for categorical metadata filtering

### DIFF
--- a/lightly_studio_view/src/lib/components/Images/Images.svelte
+++ b/lightly_studio_view/src/lib/components/Images/Images.svelte
@@ -45,7 +45,7 @@
     });
 
     const { dimensionsValues: dimensions } = useDimensions();
-    const { metadataValues } = useMetadataFilters(collection_id);
+    const { metadataValues, categoricalMetadataValues } = useMetadataFilters(collection_id);
 
     const {
         getCollectionVersion,
@@ -67,6 +67,7 @@
             dimensions: $dimensions ?? undefined
         },
         metadata_values: $metadataValues,
+        categorical_metadata_values: $categoricalMetadataValues,
         text_embedding: $textEmbedding?.embedding
     });
 
@@ -141,6 +142,7 @@
             `${$dimensions?.min_width}-${$dimensions?.max_width}`,
             `${$dimensions?.min_height}-${$dimensions?.max_height}`,
             JSON.stringify($metadataValues),
+            JSON.stringify($categoricalMetadataValues),
             $textEmbedding?.queryText || '',
             confusionCell ? JSON.stringify(confusionCell) : '',
             JSON.stringify($imageSortBy)

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -8,6 +8,7 @@ export { useTags } from '$lib/hooks/useTags/useTags';
 export { useVideoFramesBounds } from '$lib/hooks/useVideoFramesBounds/useVideoFramesBounds';
 export { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 export { useNumericMetadataDistribution } from '$lib/hooks/useNumericMetadataDistribution/useNumericMetadataDistribution';
+export { useCategoricalMetadataDistribution } from '$lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution';
 export { useFramesFilter } from '$lib/hooks/useFramesFilter/useFramesFilter';
 export { useCaptions } from '$lib/hooks/useCaptions/useCaptions';
 export { useRemoveTagFromSample } from '$lib/hooks/useRemoveTagFromSample/useRemoveTagFromSample';

--- a/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { MetadataValueCountsView } from '$lib/api/lightly_studio_local';
+import {
+    getCategoricalMetadataDistributionRequestOptions,
+    selectCategoricalDistributions
+} from './useCategoricalMetadataDistribution';
+
+describe('selectCategoricalDistributions', () => {
+    it('preserves typed values and keeps semantic buckets distinct from labels', () => {
+        const response: Record<string, MetadataValueCountsView> = {
+            city: {
+                value_counts: [
+                    { value: 'Missing', count: 4 },
+                    { value: true, count: 2 }
+                ],
+                missing_count: 3,
+                other_count: 1
+            }
+        };
+
+        expect(selectCategoricalDistributions(response).city).toEqual([
+            {
+                id: '["value","string","Missing"]',
+                kind: 'value',
+                value: 'Missing',
+                label: 'Missing (value)',
+                count: 4
+            },
+            {
+                id: '["value","boolean",true]',
+                kind: 'value',
+                value: true,
+                label: 'true',
+                count: 2
+            },
+            {
+                id: '["missing"]',
+                kind: 'missing',
+                value: null,
+                label: 'Missing (no value)',
+                count: 3
+            },
+            { id: '["other"]', kind: 'other', label: 'Other', count: 1 }
+        ]);
+    });
+
+    it('omits zero semantic buckets and maps an absent response to an empty record', () => {
+        expect(
+            selectCategoricalDistributions({
+                city: { value_counts: [], missing_count: 0, other_count: 0 }
+            })
+        ).toEqual({ city: [] });
+        expect(selectCategoricalDistributions(undefined)).toEqual({});
+    });
+});
+
+describe('getCategoricalMetadataDistributionRequestOptions', () => {
+    it('forwards the active image filter', () => {
+        expect(
+            getCategoricalMetadataDistributionRequestOptions({
+                collectionId: 'collection-id',
+                filter: { width: { min: 100 } }
+            })
+        ).toEqual({
+            path: { collection_id: 'collection-id' },
+            body: { filters: { width: { min: 100 } } }
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.ts
+++ b/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.ts
@@ -1,0 +1,99 @@
+import { createQuery } from '@tanstack/svelte-query';
+import type { ImageFilter, MetadataValueCountsView } from '$lib/api/lightly_studio_local';
+import { getMetadataValueCountsOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import { getMetadataValueCounts } from '$lib/api/lightly_studio_local/sdk.gen';
+
+export type CategoricalMetadataBucket =
+    | {
+          id: string;
+          kind: 'value';
+          value: string | boolean;
+          label: string;
+          count: number;
+      }
+    | { id: string; kind: 'missing'; value: null; label: string; count: number }
+    | { id: string; kind: 'other'; label: string; count: number };
+
+const valueBucketId = (value: string | boolean): string =>
+    JSON.stringify(['value', typeof value, value]);
+
+export const selectCategoricalDistributions = (
+    response: Record<string, MetadataValueCountsView> | undefined
+): Record<string, CategoricalMetadataBucket[]> =>
+    Object.fromEntries(
+        Object.entries(response ?? {}).map(([key, counts]) => {
+            const hasLiteralMissing = counts.value_counts.some(({ value }) => value === 'Missing');
+            const hasLiteralOther = counts.value_counts.some(({ value }) => value === 'Other');
+            const buckets: CategoricalMetadataBucket[] = counts.value_counts.map(
+                ({ value, count }) => ({
+                    id: valueBucketId(value),
+                    kind: 'value',
+                    value,
+                    label:
+                        value === 'Missing' && counts.missing_count > 0
+                            ? 'Missing (value)'
+                            : value === 'Other' && counts.other_count > 0
+                              ? 'Other (value)'
+                              : String(value),
+                    count
+                })
+            );
+            if (counts.missing_count > 0) {
+                buckets.push({
+                    id: JSON.stringify(['missing']),
+                    kind: 'missing',
+                    value: null,
+                    label: hasLiteralMissing ? 'Missing (no value)' : 'Missing',
+                    count: counts.missing_count
+                });
+            }
+            if (counts.other_count > 0) {
+                buckets.push({
+                    id: JSON.stringify(['other']),
+                    kind: 'other',
+                    label: hasLiteralOther ? 'Other (aggregated)' : 'Other',
+                    count: counts.other_count
+                });
+            }
+            return [key, buckets];
+        })
+    );
+
+export interface CategoricalMetadataDistributionOptions {
+    collectionId: string;
+    filter?: ImageFilter;
+}
+
+export const getCategoricalMetadataDistributionRequestOptions = ({
+    collectionId,
+    filter
+}: CategoricalMetadataDistributionOptions) => ({
+    path: { collection_id: collectionId },
+    ...(filter ? { body: { filters: filter } } : {})
+});
+
+export const useCategoricalMetadataDistribution = (
+    getOptions: () => CategoricalMetadataDistributionOptions & { enabled?: boolean }
+) =>
+    createQuery(() => {
+        const { collectionId, filter, enabled = true } = getOptions();
+        const requestOptions = getCategoricalMetadataDistributionRequestOptions({
+            collectionId,
+            filter
+        });
+        return {
+            ...getMetadataValueCountsOptions(requestOptions),
+            enabled,
+            select: selectCategoricalDistributions,
+            placeholderData: (previous: Record<string, MetadataValueCountsView> | undefined) =>
+                previous,
+            queryFn: async ({ signal }: { signal: AbortSignal }) => {
+                const { data } = await getMetadataValueCounts({
+                    ...requestOptions,
+                    signal,
+                    throwOnError: true
+                });
+                return data;
+            }
+        };
+    });

--- a/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.test.ts
@@ -78,4 +78,21 @@ describe('getFrameFilter', () => {
             frame_number: {}
         });
     });
+
+    it('adds categorical metadata filters', async () => {
+        const { createMetadataFilters } = await import('../useMetadataFilters/useMetadataFilters');
+        vi.mocked(createMetadataFilters).mockReturnValueOnce([
+            { key: 'city', value: ['Zurich', null], op: 'in' }
+        ]);
+
+        const filter = getFrameFilter({
+            collection_id: 'coll-1',
+            filters: { categorical_metadata_values: { city: ['Zurich', null] } }
+        });
+
+        expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+        expect(filter?.sample_filter?.metadata_filters).toEqual([
+            { key: 'city', value: ['Zurich', null], op: 'in' }
+        ]);
+    });
 });

--- a/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.ts
@@ -5,7 +5,7 @@ import type {
     VideoFrameFilter,
     VideoFrameFieldsBoundsView
 } from '$lib/api/lightly_studio_local/types.gen';
-type MetadataValues = Record<string, { min: number; max: number }>;
+import type { CategoricalMetadataValues, MetadataValues } from '$lib/services/types';
 
 export type VideoFrameFilterParams = {
     collection_id: string;
@@ -14,6 +14,7 @@ export type VideoFrameFilterParams = {
         annotation_label_ids?: string[];
         sample_ids?: string[];
         metadata_values?: MetadataValues;
+        categorical_metadata_values?: CategoricalMetadataValues;
     };
     frame_bounds?: VideoFrameFieldsBoundsView | null;
     video_id?: string | null;
@@ -60,8 +61,11 @@ export const getFrameFilter = (params: VideoFrameFilterParams | null): VideoFram
         sampleFilter.tag_ids = tagIds;
     }
 
-    if (params.filters?.metadata_values) {
-        const metadataFilters = createMetadataFilters(params.filters.metadata_values);
+    if (params.filters?.metadata_values || params.filters?.categorical_metadata_values) {
+        const metadataFilters = createMetadataFilters(
+            params.filters.metadata_values ?? {},
+            params.filters.categorical_metadata_values
+        );
         if (metadataFilters.length > 0) {
             sampleFilter.metadata_filters = metadataFilters;
         }

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
@@ -7,6 +7,7 @@ import { useSessionStorage } from './useSessionStorage/useSessionStorage';
 import type { MetadataInfo } from '$lib/services/types';
 import type { MetadataBounds } from '$lib/services/types';
 import type { MetadataValues } from '$lib/services/types';
+import type { CategoricalMetadataValues } from '$lib/services/types';
 import { useReversibleActions } from './useReversibleActions';
 import type { CollectionView, SampleType, TagByFilterBody } from '$lib/api/lightly_studio_local';
 import type { Point } from 'embedding-atlas/svelte';
@@ -59,6 +60,10 @@ const filterPanelCollapsed = useSessionStorage<boolean>(
 // Metadata stores
 const metadataBounds = useSessionStorage<MetadataBounds>('lightlyStudio_metadata_bounds', {});
 const metadataValues = useSessionStorage<MetadataValues>('lightlyStudio_metadata_values', {});
+const categoricalMetadataValues = useSessionStorage<CategoricalMetadataValues>(
+    'lightlyStudio_categorical_metadata_values',
+    {}
+);
 const metadataInfo = useSessionStorage<MetadataInfo[]>('lightlyStudio_metadata_info', []);
 
 // Store the most recently selected annotation label.
@@ -137,6 +142,9 @@ export const useGlobalStorage = () => {
     // Metadata update methods
     const updateMetadataValues = (values: MetadataValues) => {
         metadataValues.set(values);
+    };
+    const updateCategoricalMetadataValues = (values: CategoricalMetadataValues) => {
+        categoricalMetadataValues.set(values);
     };
     const updateMetadataBounds = (bounds: MetadataBounds) => {
         metadataBounds.set(bounds);
@@ -234,8 +242,10 @@ export const useGlobalStorage = () => {
         // Metadata stores
         metadataBounds,
         metadataValues,
+        categoricalMetadataValues,
         metadataInfo,
         updateMetadataValues,
+        updateCategoricalMetadataValues,
         updateMetadataBounds,
         updateMetadataInfo,
         filteredFramesCount,

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
@@ -3,6 +3,7 @@ import { get } from 'svelte/store';
 import { useImageFilters } from './useImageFilters';
 import type { QueryExpr, SortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
 import { SortDirection } from '$lib/api/lightly_studio_local/types.gen';
+import { createMetadataFilters } from '../useMetadataFilters/useMetadataFilters';
 
 const queryExpr = {
     match_expr: {
@@ -67,6 +68,22 @@ describe('useImageFilters', () => {
             updateQueryExpr(undefined);
             expect(get(imageFilter)?.sample_filter?.query_expr).toBeUndefined();
         });
+    });
+
+    it('forwards numeric and categorical metadata state into the shared image filter', () => {
+        vi.mocked(createMetadataFilters).mockReturnValueOnce([
+            { key: 'city', op: 'in', value: ['Zurich', null] }
+        ]);
+        const { imageFilter, updateFilterParams } = useImageFilters();
+        updateFilterParams({
+            ...normalFilterParams,
+            metadata_values: {},
+            categorical_metadata_values: { city: ['Zurich', null] }
+        });
+
+        const metadataFilters = get(imageFilter)?.sample_filter?.metadata_filters;
+        expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+        expect(metadataFilters).toEqual([{ key: 'city', op: 'in', value: ['Zurich', null] }]);
     });
 
     describe('updateConfusionCell', () => {

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -103,8 +103,11 @@ const imageFilter = derived(
             sampleFilter.confusion_cell = confusionCell;
         }
 
-        if ($filterParams.metadata_values) {
-            const metadataFilters = createMetadataFilters($filterParams.metadata_values);
+        if ($filterParams.metadata_values || $filterParams.categorical_metadata_values) {
+            const metadataFilters = createMetadataFilters(
+                $filterParams.metadata_values ?? {},
+                $filterParams.categorical_metadata_values
+            );
             if (metadataFilters.length > 0) {
                 sampleFilter.metadata_filters = metadataFilters;
             }

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.test.ts
@@ -199,5 +199,19 @@ describe('buildRequestBody', () => {
                 metadataFilterFixture
             ]);
         });
+
+        it('applies categorical metadata values via createMetadataFilters', () => {
+            const result = buildRequestBody(
+                {
+                    collection_id: 'col-1',
+                    mode: 'normal',
+                    categorical_metadata_values: { city: ['Zurich', null] }
+                },
+                0
+            );
+            expect(result.filters?.sample_filter?.metadata_filters).toEqual([
+                metadataFilterFixture
+            ]);
+        });
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
@@ -14,9 +14,13 @@ const buildBaseBody = (params: ImagesInfiniteParams, pageParam: number): ReadIma
     filters: {
         sample_filter: {
             query_expr: params.query_expr ?? undefined,
-            metadata_filters: params.metadata_values
-                ? createMetadataFilters(params.metadata_values)
-                : undefined
+            metadata_filters:
+                params.metadata_values || params.categorical_metadata_values
+                    ? createMetadataFilters(
+                          params.metadata_values ?? {},
+                          params.categorical_metadata_values
+                      )
+                    : undefined
         }
     }
 });

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
@@ -93,6 +93,19 @@ describe('createImagesInfiniteOptions', () => {
             });
             expect(options1.queryKey).not.toEqual(options2.queryKey);
         });
+
+        it('includes typed categorical selections in the query key', () => {
+            const categoricalMetadataValues = { city: ['Zurich', null] };
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                categorical_metadata_values: categoricalMetadataValues
+            });
+
+            expect(options.queryKey[4]).toMatchObject({
+                categorical_metadata_values: categoricalMetadataValues
+            });
+        });
     });
 
     describe('enabled', () => {

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.ts
@@ -15,6 +15,7 @@ export const createImagesInfiniteOptions = (params: ImagesInfiniteParams) => {
         params.mode === 'normal' ? params.filters : params.classifierSamples,
         {
             metadata_values: params.metadata_values,
+            categorical_metadata_values: params.categorical_metadata_values,
             text_embedding: params.text_embedding,
             query_expr: params.query_expr
         },

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -8,6 +8,7 @@ import type {
 } from '$lib/api/lightly_studio_local';
 import type { DimensionBounds } from '$lib/services/loadDimensionBounds';
 import type { MetadataValues } from '$lib/services/types';
+import type { CategoricalMetadataValues } from '$lib/services/types';
 
 export interface ClassifierSamples {
     positiveSampleIds: string[];
@@ -25,6 +26,7 @@ export type ImagesInfiniteParams = {
     sort_by?: ReadImagesRequest['sort_by'];
     text_embedding?: ReadImagesRequest['text_embedding'];
     metadata_values?: MetadataValues;
+    categorical_metadata_values?: CategoricalMetadataValues;
 } & (
     | { mode: 'normal'; filters?: NormalModeFilters }
     | { mode: 'classifier'; classifierSamples?: ClassifierSamples }
@@ -37,6 +39,7 @@ export type SamplesQueryKey = readonly [
     NormalModeFilters | ClassifierSamples | undefined,
     {
         metadata_values?: MetadataValues;
+        categorical_metadata_values?: CategoricalMetadataValues;
         text_embedding?: ReadImagesRequest['text_embedding'];
         query_expr?: QueryExpr;
     },

--- a/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.test.ts
@@ -83,6 +83,18 @@ describe('createMetadataFilters', () => {
         expect(filters).toHaveLength(0);
     });
 
+    it('combines numeric ranges with one OR predicate per non-empty categorical key', () => {
+        const filters = createMetadataFilters(
+            { temperature: { min: 20, max: 100 } },
+            { city: ['Zurich', 'Berlin', null], ignored: [] }
+        );
+
+        expect(filters).toEqual([
+            { key: 'temperature', value: 20, op: '>=' },
+            { key: 'city', value: ['Zurich', 'Berlin', null], op: 'in' }
+        ]);
+    });
+
     it('should only create min filter when min is not at bound', () => {
         const metadataValues: MetadataValues = {
             temperature: { min: 20, max: 100 } // Only min is not at bound

--- a/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.ts
@@ -3,6 +3,7 @@ import type { MetadataInfoView, MetadataFilter } from '$lib/api/lightly_studio_l
 import { get, writable } from 'svelte/store';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 import { validate as validateUUID } from 'uuid';
+import type { CategoricalMetadataValues } from '$lib/services/types';
 type MetadataBounds = Record<string, { min: number; max: number }>;
 type MetadataValues = Record<string, { min: number; max: number }>;
 
@@ -16,6 +17,8 @@ const loadInitialMetadataInfo = async (collection_id: string) => {
         return;
     }
     lastCollectionId.set(collection_id);
+    const storage = useGlobalStorage();
+    storage.updateCategoricalMetadataValues({});
 
     const { data: metadataInfoData } = await getMetadataInfo({
         path: {
@@ -26,7 +29,7 @@ const loadInitialMetadataInfo = async (collection_id: string) => {
     if (!metadataInfoData) {
         return;
     }
-    const { updateMetadataBounds, updateMetadataValues, updateMetadataInfo } = useGlobalStorage();
+    const { updateMetadataBounds, updateMetadataValues, updateMetadataInfo } = storage;
 
     // Extract numerical metadata for bounds and values
     const bounds: MetadataBounds = {};
@@ -46,7 +49,10 @@ const loadInitialMetadataInfo = async (collection_id: string) => {
     updateMetadataInfo(metadataInfoData);
 };
 
-export const createMetadataFilters = (metadataValues: MetadataValues): MetadataFilter[] => {
+export const createMetadataFilters = (
+    metadataValues: MetadataValues,
+    categoricalMetadataValues: CategoricalMetadataValues = {}
+): MetadataFilter[] => {
     const filters: MetadataFilter[] = [];
     const { metadataBounds } = useGlobalStorage();
 
@@ -76,6 +82,11 @@ export const createMetadataFilters = (metadataValues: MetadataValues): MetadataF
             }
         }
     }
+    for (const [key, values] of Object.entries(categoricalMetadataValues)) {
+        if (values.length > 0) {
+            filters.push({ key, value: values, op: 'in' });
+        }
+    }
     return filters;
 };
 
@@ -88,7 +99,9 @@ export const useMetadataFilters = (collection_id?: string) => {
         metadataBounds,
         metadataValues,
         metadataInfo,
+        categoricalMetadataValues,
         updateMetadataValues,
+        updateCategoricalMetadataValues,
         updateMetadataBounds,
         updateMetadataInfo
     } = useGlobalStorage();
@@ -97,7 +110,9 @@ export const useMetadataFilters = (collection_id?: string) => {
         metadataBounds,
         metadataValues,
         metadataInfo,
+        categoricalMetadataValues,
         updateMetadataValues,
+        updateCategoricalMetadataValues,
         updateMetadataBounds,
         updateMetadataInfo,
         createMetadataFilters

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
@@ -131,6 +131,24 @@ describe('useVideoFilters', () => {
                 { key: 'temp', value: 10, op: '>=' }
             ]);
         });
+
+        it('includes categorical metadata selections in the sample filter', async () => {
+            const { createMetadataFilters } =
+                await import('../useMetadataFilters/useMetadataFilters');
+            vi.mocked(createMetadataFilters).mockReturnValueOnce([
+                { key: 'city', value: ['Zurich', null], op: 'in' }
+            ]);
+            const { videoFilter, updateFilterParams } = useVideoFilters();
+
+            updateFilterParams({
+                collection_id: 'coll-1',
+                filters: { categorical_metadata_values: { city: ['Zurich', null] } }
+            });
+
+            const metadataFilters = get(videoFilter)?.sample_filter?.metadata_filters;
+            expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+            expect(metadataFilters).toEqual([{ key: 'city', value: ['Zurich', null], op: 'in' }]);
+        });
     });
 
     describe('updateSampleIds', () => {

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
@@ -6,7 +6,7 @@ import type {
     VideoFilter,
     VideoFieldsBoundsView
 } from '$lib/api/lightly_studio_local/types.gen';
-type MetadataValues = Record<string, { min: number; max: number }>;
+import type { CategoricalMetadataValues, MetadataValues } from '$lib/services/types';
 
 export type VideoFilterParams = {
     collection_id: string;
@@ -15,6 +15,7 @@ export type VideoFilterParams = {
         annotation_frames_label_ids?: string[];
         sample_ids?: string[];
         metadata_values?: MetadataValues;
+        categorical_metadata_values?: CategoricalMetadataValues;
     };
     video_bounds?: VideoFieldsBoundsView | null;
 };
@@ -69,8 +70,14 @@ export const buildVideoFilter = ($filterParams: VideoFilterParams | null): Video
         sampleFilter.tag_ids = tagIds;
     }
 
-    if ($filterParams.filters?.metadata_values) {
-        const metadataFilters = createMetadataFilters($filterParams.filters.metadata_values);
+    if (
+        $filterParams.filters?.metadata_values ||
+        $filterParams.filters?.categorical_metadata_values
+    ) {
+        const metadataFilters = createMetadataFilters(
+            $filterParams.filters.metadata_values ?? {},
+            $filterParams.filters.categorical_metadata_values
+        );
         if (metadataFilters.length > 0) {
             sampleFilter.metadata_filters = metadataFilters;
         }

--- a/lightly_studio_view/src/lib/services/types.ts
+++ b/lightly_studio_view/src/lib/services/types.ts
@@ -87,3 +87,5 @@ export type SideEffectHook<T, I = unknown> = (params: I) => SideEffectHookResult
 export type MetadataInfo = MetadataInfoView;
 export type MetadataBounds = Record<string, { min: number; max: number }>;
 export type MetadataValues = Record<string, { min: number; max: number }>;
+export type CategoricalMetadataValue = string | boolean | null;
+export type CategoricalMetadataValues = Record<string, CategoricalMetadataValue[]>;


### PR DESCRIPTION
## Summary

Stacked on p2. Pure data layer — no UI changes.

- **`CategoricalMetadataValues` type** (`services/types.ts`): maps field name → set of selected values (including the sentinel `__missing__` string)
- **Global session-storage slot** (`useGlobalStorage.ts`): persists categorical selections across page navigation
- **`useCategoricalMetadataDistribution` hook**: calls the new value-counts endpoint, disambiguates literal `"Missing"`/`"Other"` strings from the sentinel buckets, and returns typed `CategoricalMetadataBucket[]` arrays per field
- **`createMetadataFilters`** extended: converts the selected values map into one `in` filter per non-empty field; also clears the store when the collection changes
- **Filter hooks** (`useImageFilters`, `useVideoFilters`, `useFramesFilter`, `useImagesInfinite`): all accept the optional `categorical_metadata_values` parameter and forward it to the filter builder

## Test plan

- [ ] `make static-checks` (frontend) passes
- [ ] `npm run test:unit` passes (new tests in all four hooks and in the distribution hook)

Part of LIG-9585.