### PR TITLE
FE: BarChart selection visuals and MetadataCategoricalFilter component

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
+++ b/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
@@ -89,7 +89,7 @@
         instance.on('click', (params: { dataIndex?: number }) => {
             if (typeof params.dataIndex !== 'number') return;
             const item = data[params.dataIndex];
-            if (item) onBarClick?.(item);
+            if (item && item.selectable !== false) onBarClick?.(item);
         });
         const resizeObserver = new ResizeObserver(() => instance.resize());
         resizeObserver.observe(container);

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -41,6 +41,24 @@ describe('buildEchartsOption', () => {
         expect(horizontal.xAxis.minInterval).toBe(1);
     });
 
+    it('adds selected and disabled treatments without changing typed category identity', () => {
+        const option = buildEchartsOption([
+            { id: 'selected', label: 'Missing', count: 3, selected: true, selectable: true },
+            { id: 'other', label: 'Other', count: 2, selected: false, selectable: false }
+        ]) as {
+            series: [{ data: { value: number; itemStyle: Record<string, unknown> }[] }];
+        };
+
+        expect(option.series[0].data[0]).toMatchObject({
+            value: 3,
+            itemStyle: { borderWidth: 3, opacity: 1 }
+        });
+        expect(option.series[0].data[1]).toMatchObject({
+            value: 2,
+            itemStyle: { borderWidth: 0, opacity: 0.45 }
+        });
+    });
+
     const getFormatter = (option: unknown) =>
         (
             option as {

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -12,6 +12,7 @@ import type { CategoryCount } from './';
 // Single accent color (the Lightly primary green, --color-lightly-primary #3bd99f):
 // per-class colors carry no meaning in a count distribution.
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
+const SELECTED_BORDER_COLOR = 'rgba(255,255,255,0.95)';
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
 export type BarChartOrientation = 'vertical' | 'horizontal';
@@ -86,7 +87,18 @@ export function buildEchartsOption(
         series: [
             {
                 type: 'bar',
-                data: data.map((item) => item.count),
+                data: data.map((item) => {
+                    if (item.selected == null && item.selectable == null) return item.count;
+                    return {
+                        value: item.count,
+                        itemStyle: {
+                            color: BAR_COLOR,
+                            opacity: item.selectable === false ? 0.45 : 1,
+                            borderColor: item.selected ? SELECTED_BORDER_COLOR : 'transparent',
+                            borderWidth: item.selected ? 3 : 0
+                        }
+                    };
+                }),
                 itemStyle: { color: BAR_COLOR },
                 barCategoryGap: '25%',
                 emphasis: CHART_EMPHASIS

--- a/lightly_studio_view/src/lib/components/BarChart/types.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/types.ts
@@ -1,5 +1,11 @@
 /** A single category (e.g. a class name) with its count. */
 export interface CategoryCount {
+    /** Stable identity when multiple bars share the same display label. */
+    id?: string;
     label: string;
     count: number;
+    /** Whether the category is active in a controlled selection. */
+    selected?: boolean;
+    /** Whether clicking the bar can change selection. */
+    selectable?: boolean;
 }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+    import { ChevronsUpDown } from '@lucide/svelte';
+    import * as Popover from '$lib/components/ui/popover';
+    import { Button } from '$lib/components/ui/button';
+    import { Checkbox } from '$lib/components/ui/checkbox';
+    import { Input } from '$lib/components/ui/input';
+    import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution';
+    import type { CategoricalMetadataValue } from '$lib/services/types';
+
+    interface Props {
+        buckets: CategoricalMetadataBucket[];
+        selectedValues: CategoricalMetadataValue[];
+        loading?: boolean;
+        onToggle: (value: CategoricalMetadataValue) => void;
+        onClear: () => void;
+    }
+
+    const { buckets, selectedValues, loading = false, onToggle, onClear }: Props = $props();
+    let search = $state('');
+    type SelectableBucket = Exclude<CategoricalMetadataBucket, { kind: 'other' }>;
+    type FilterOption = { bucket: SelectableBucket; retained: boolean };
+
+    const returnedSelectable = $derived(
+        buckets.filter((bucket): bucket is SelectableBucket => bucket.kind !== 'other')
+    );
+    const options = $derived.by<FilterOption[]>(() => {
+        const returned: FilterOption[] = returnedSelectable.map((bucket) => ({
+            bucket,
+            retained: false
+        }));
+        const retained: FilterOption[] = selectedValues
+            .filter((value) => !returnedSelectable.some((bucket) => Object.is(bucket.value, value)))
+            .map((value) => ({
+                bucket:
+                    value === null
+                        ? {
+                              id: JSON.stringify(['missing']),
+                              kind: 'missing',
+                              value: null,
+                              label: 'Missing',
+                              count: 0
+                          }
+                        : {
+                              id: JSON.stringify(['retained', typeof value, value]),
+                              kind: 'value',
+                              value,
+                              label: String(value),
+                              count: 0
+                          },
+                retained: true
+            }));
+        return [...returned, ...retained];
+    });
+    const optionLabel = (option: FilterOption): string => {
+        const hasMissing = options.some(({ bucket }) => bucket.kind === 'missing');
+        const hasOtherAggregate = buckets.some((bucket) => bucket.kind === 'other');
+        if (
+            option.bucket.kind === 'missing' &&
+            options.some(({ bucket }) => bucket.value === 'Missing')
+        ) {
+            return 'Missing (no value)';
+        }
+        if (option.bucket.kind === 'value' && option.bucket.value === 'Missing' && hasMissing) {
+            return 'Missing (value)';
+        }
+        if (
+            option.bucket.kind === 'value' &&
+            option.bucket.value === 'Other' &&
+            hasOtherAggregate
+        ) {
+            return 'Other (value)';
+        }
+        return option.bucket.label;
+    };
+    const visible = $derived(
+        options.filter((option) => optionLabel(option).toLowerCase().includes(search.toLowerCase()))
+    );
+    const showSearch = $derived(buckets.filter((bucket) => bucket.kind === 'value').length > 5);
+    const summary = $derived(
+        selectedValues.length === 0
+            ? 'All values'
+            : selectedValues.length === 1
+              ? optionLabel(
+                    options.find(({ bucket }) => Object.is(bucket.value, selectedValues[0]))!
+                )
+              : `${selectedValues.length} selected`
+    );
+    const isSelected = (value: CategoricalMetadataValue) =>
+        selectedValues.some((selected) => Object.is(selected, value));
+    const checkboxLabel = (option: FilterOption) =>
+        `${
+            option.bucket.kind === 'missing'
+                ? 'Select missing metadata'
+                : `Select value ${optionLabel(option)}`
+        }, ${option.retained ? 'count unavailable' : `${option.bucket.count} samples`}`;
+</script>
+
+<div class="mt-2 flex items-center gap-2" data-testid="metadata-categorical-filter">
+    <span class="w-[100px] shrink-0 text-xs text-muted-foreground">Values</span>
+    <Popover.Root onOpenChange={(open) => !open && (search = '')}>
+        <Popover.Trigger>
+            {#snippet child({ props })}
+                <Button
+                    {...props}
+                    variant="outline"
+                    size="sm"
+                    class="min-w-0 flex-1 justify-between max-sm:min-h-11"
+                    disabled={loading && buckets.length === 0}
+                    aria-label="Select metadata values"
+                    data-testid="metadata-categorical-filter-trigger"
+                >
+                    <span class="truncate">{loading ? 'Loading…' : summary}</span>
+                    <ChevronsUpDown class="opacity-50" />
+                </Button>
+            {/snippet}
+        </Popover.Trigger>
+        <Popover.Content class="w-[min(320px,calc(100vw-2rem))] p-2" align="end">
+            {#if showSearch}
+                <Input
+                    bind:value={search}
+                    placeholder="Search values…"
+                    aria-label="Search values"
+                    class="max-sm:min-h-11"
+                />
+            {/if}
+            <div class="mt-2 max-h-56 space-y-1 overflow-y-auto">
+                {#each visible as option (option.bucket.id)}
+                    <label
+                        class="flex min-h-8 cursor-pointer items-center gap-2 rounded px-2 text-sm hover:bg-accent max-sm:min-h-11"
+                    >
+                        <Checkbox
+                            checked={isSelected(option.bucket.value)}
+                            onCheckedChange={() => onToggle(option.bucket.value)}
+                            aria-label={checkboxLabel(option)}
+                        />
+                        <span class="min-w-0 flex-1 truncate" title={optionLabel(option)}
+                            >{optionLabel(option)}</span
+                        >
+                        <span class="text-muted-foreground"
+                            >{option.retained ? 'Not in top 20' : option.bucket.count}</span
+                        >
+                    </label>
+                {/each}
+                {#if visible.length === 0}<p class="p-2 text-sm text-muted-foreground">
+                        No values found.
+                    </p>{/if}
+                {#if buckets.some((bucket) => bucket.kind === 'other')}
+                    <p class="p-2 text-xs text-muted-foreground">
+                        Other is an aggregate and cannot be selected.
+                    </p>
+                {/if}
+            </div>
+            {#if selectedValues.length > 0}
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    class="mt-2 w-full max-sm:min-h-11"
+                    onclick={onClear}>Clear</Button
+                >
+            {/if}
+        </Popover.Content>
+    </Popover.Root>
+</div>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.test.ts
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import MetadataCategoricalFilter from './MetadataCategoricalFilter.svelte';
+import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution';
+
+const buckets: CategoricalMetadataBucket[] = [
+    {
+        id: 'literal-missing',
+        kind: 'value',
+        value: 'Missing',
+        label: 'Missing',
+        count: 4
+    },
+    { id: 'missing', kind: 'missing', value: null, label: 'Missing', count: 3 },
+    { id: 'other', kind: 'other', label: 'Other', count: 2 }
+];
+
+describe('MetadataCategoricalFilter', () => {
+    it('keeps literal Missing and semantic Missing distinct and disables Other', async () => {
+        const onToggle = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: { buckets, selectedValues: ['Missing'], onToggle, onClear: vi.fn() }
+        });
+
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        const literal = screen.getByRole('checkbox', {
+            name: 'Select value Missing (value), 4 samples'
+        });
+        const missing = screen.getByRole('checkbox', {
+            name: 'Select missing metadata, 3 samples'
+        });
+        expect(literal).toBeChecked();
+        expect(missing).not.toBeChecked();
+        expect(screen.getByText('Other is an aggregate and cannot be selected.')).toBeVisible();
+        expect(screen.queryByRole('checkbox', { name: /Other/ })).not.toBeInTheDocument();
+
+        await fireEvent.click(missing);
+        expect(onToggle).toHaveBeenCalledWith(null);
+    });
+
+    it('searches values and clears the controlled selection', async () => {
+        const searchableBuckets: CategoricalMetadataBucket[] = [
+            ...buckets,
+            ...Array.from({ length: 5 }, (_, index) => ({
+                id: `value-${index}`,
+                kind: 'value' as const,
+                value: `value-${index}`,
+                label: `value-${index}`,
+                count: index + 1
+            }))
+        ];
+        const onClear = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: {
+                buckets: searchableBuckets,
+                selectedValues: [null],
+                onToggle: vi.fn(),
+                onClear
+            }
+        });
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        await fireEvent.input(screen.getByLabelText('Search values'), {
+            target: { value: 'not present' }
+        });
+        expect(screen.getByText('No values found.')).toBeVisible();
+        await fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+        expect(onClear).toHaveBeenCalledOnce();
+    });
+
+    it('keeps a selected value removable when it is absent from the latest response', async () => {
+        const onToggle = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: { buckets: [], selectedValues: ['stale'], onToggle, onClear: vi.fn() }
+        });
+
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        expect(screen.queryByLabelText('Search values')).not.toBeInTheDocument();
+        expect(screen.getByText('Not in top 20')).toBeVisible();
+        await fireEvent.click(
+            screen.getByRole('checkbox', {
+                name: 'Select value stale, count unavailable'
+            })
+        );
+        expect(onToggle).toHaveBeenCalledWith('stale');
+    });
+
+    it('disambiguates a retained literal Other from the aggregate bucket', async () => {
+        const onToggle = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: { buckets, selectedValues: ['Other'], onToggle, onClear: vi.fn() }
+        });
+
+        expect(screen.getByTestId('metadata-categorical-filter-trigger')).toHaveTextContent(
+            'Other (value)'
+        );
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        expect(screen.getAllByText('Other (value)')).toHaveLength(2);
+        expect(screen.getByText('Other is an aggregate and cannot be selected.')).toBeVisible();
+        await fireEvent.click(
+            screen.getByRole('checkbox', {
+                name: 'Select value Other (value), count unavailable'
+            })
+        );
+        expect(onToggle).toHaveBeenCalledWith('Other');
+    });
+
+    it('shows search only above five returned concrete values', async () => {
+        const fiveConcrete: CategoricalMetadataBucket[] = [
+            ...Array.from({ length: 5 }, (_, index) => ({
+                id: `value-${index}`,
+                kind: 'value' as const,
+                value: `value-${index}`,
+                label: `value-${index}`,
+                count: index + 1
+            })),
+            { id: 'missing', kind: 'missing', value: null, label: 'Missing', count: 3 },
+            { id: 'other', kind: 'other', label: 'Other', count: 2 }
+        ];
+        render(MetadataCategoricalFilter, {
+            props: {
+                buckets: fiveConcrete,
+                selectedValues: ['retained'],
+                onToggle: vi.fn(),
+                onClear: vi.fn()
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        expect(screen.queryByLabelText('Search values')).not.toBeInTheDocument();
+        expect(screen.getByText('Not in top 20')).toBeVisible();
+    });
+});


### PR DESCRIPTION
## Summary

Stacked on p3.

**BarChart visual states** (`buildEchartsOption.ts`, `types.ts`):
- `CategoryCount` gains optional `selected` and `selectable` boolean fields
- Selected bars render with a bright white border; unselectable bars are dimmed to 45% opacity
- Clicks on `selectable=false` bars are suppressed so the host component only receives intentional selections

**`MetadataCategoricalFilter` component** (new):
- Checkbox list for selecting categorical metadata values
- First-class "Missing" entry (maps to the `__missing__` sentinel) so users can filter for samples with no value for the field
- "Clear" action resets the selection for the field
- Fully unit-tested (`MetadataCategoricalFilter.test.ts`, 132 lines of coverage)

## Test plan

- [ ] `make static-checks` (frontend) passes
- [ ] `npm run test:unit` passes

Part of LIG-9585.