### PR TITLE
FE: integrate categorical distributions into distribution panel and pages

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -18,6 +18,8 @@
         type DistributionSourceGroup
     } from './types';
     import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
+    import MetadataCategoricalFilter from './MetadataCategoricalFilter.svelte';
+    import type { CategoricalMetadataValue } from '$lib/services/types';
 
     interface Props {
         /**
@@ -59,6 +61,12 @@
         histogramBinCount?: number;
         /** Called when the user picks a new histogram bin count. */
         onHistogramBinCountChange?: (binCount: number) => void;
+        /** Called when a concrete categorical value or Missing is toggled. */
+        onCategoricalValueToggle?: (groupId: string, value: CategoricalMetadataValue) => void;
+        /** Removes every categorical value selected for the given group. */
+        onCategoricalValuesClear?: (groupId: string) => void;
+        /** Retries a failed categorical distribution request. */
+        onCategoricalRetry?: () => void;
     }
 
     const {
@@ -72,7 +80,10 @@
         initialCountMode = AnnotationCountMode.OBJECTS,
         onHistogramRangeSelect,
         histogramBinCount = 20,
-        onHistogramBinCountChange
+        onHistogramBinCountChange,
+        onCategoricalValueToggle,
+        onCategoricalValuesClear,
+        onCategoricalRetry
     }: Props = $props();
 
     // Normalise to a source list so the rest of the panel has one code path.
@@ -85,7 +96,7 @@
     let selectedGroupId = $state<string | undefined>(undefined);
 
     const groupHasContent = (group: DistributionSourceGroup): boolean =>
-        (group.data?.length ?? 0) > 0 || group.histogram != null;
+        (group.data?.length ?? 0) > 0 || group.histogram != null || group.categorical != null;
 
     const sourceHasContent = (source: DistributionSource): boolean =>
         (source.data?.length ?? 0) > 0 ||
@@ -109,6 +120,19 @@
     // A group/source carrying bins renders as a histogram instead of a bar
     // chart; the categorical controls (sort, top-N, orientation) don't apply.
     const activeHistogram = $derived(activeGroup?.histogram ?? activeSource.histogram ?? null);
+    const activeCategorical = $derived(activeGroup?.categorical ?? null);
+    const categoricalData = $derived<CategoryCount[]>(
+        (activeCategorical?.buckets ?? []).map((bucket) => ({
+            id: bucket.id,
+            label: bucket.label,
+            count: bucket.count,
+            selectable: bucket.kind !== 'other',
+            selected:
+                bucket.kind !== 'other' &&
+                activeCategorical?.selectedValues.some((value) => Object.is(value, bucket.value))
+        }))
+    );
+    const displayedData = $derived(activeCategorical ? categoricalData : activeData);
     const activeHistogramRange = $derived(activeGroup?.selectedRange ?? activeSource.selectedRange);
     const handleHistogramRangeSelect = (range: HistogramRange) => {
         const groupId = activeGroup?.id ?? activeSource.id;
@@ -153,8 +177,16 @@
         (activeSource.groups ?? []).map((group) => ({ value: group.id, label: group.label }))
     );
 
-    const visible = $derived(selectVisibleCounts(activeData, config));
-    const totalCount = $derived(activeData.reduce((sum, item) => sum + item.count, 0));
+    const visible = $derived(
+        activeCategorical ? displayedData : selectVisibleCounts(displayedData, config)
+    );
+    const totalCount = $derived(displayedData.reduce((sum, item) => sum + item.count, 0));
+
+    const handleCategoricalBarClick = (item: CategoryCount) => {
+        const bucket = activeCategorical?.buckets.find((candidate) => candidate.id === item.id);
+        if (!bucket || bucket.kind === 'other' || !activeGroup) return;
+        onCategoricalValueToggle?.(activeGroup.id, bucket.value);
+    };
 
     function applyConfig(next: DistributionConfig) {
         if (next.countMode !== config.countMode) {
@@ -163,6 +195,10 @@
         config = next;
     }
 </script>
+
+{#snippet categoricalEmptyState()}
+    <span>No matching samples for this metadata field.</span>
+{/snippet}
 
 <div
     class="flex h-full min-w-0 flex-1 flex-col rounded-[1vw] bg-card p-4"
@@ -259,6 +295,34 @@
                 />
             </div>
         </div>
+    {:else if activeCategorical && activeGroup}
+        <MetadataCategoricalFilter
+            buckets={activeCategorical.buckets}
+            selectedValues={activeCategorical.selectedValues}
+            loading={activeCategorical.loading}
+            onToggle={(value) => onCategoricalValueToggle?.(activeGroup.id, value)}
+            onClear={() => onCategoricalValuesClear?.(activeGroup.id)}
+        />
+        {#if activeCategorical.loading && activeCategorical.buckets.length > 0}
+            <p class="mt-1 text-xs text-muted-foreground" role="status">Updating values…</p>
+        {/if}
+        {#if activeCategorical.error && activeCategorical.buckets.length > 0}
+            <div
+                class="mt-1 flex items-center justify-between gap-2 text-xs text-destructive"
+                role="alert"
+            >
+                <span>Could not update metadata distribution.</span>
+                {#if onCategoricalRetry}
+                    <button
+                        class="underline max-sm:min-h-11"
+                        type="button"
+                        onclick={onCategoricalRetry}
+                    >
+                        Retry
+                    </button>
+                {/if}
+            </div>
+        {/if}
     {:else if activeData.length > 0}
         <PanelHeader
             {config}
@@ -289,32 +353,69 @@
                 showAxes
                 onRangeSelect={onHistogramRangeSelect ? handleHistogramRangeSelect : undefined}
             />
+        {:else if activeCategorical?.loading && activeCategorical.buckets.length === 0}
+            <div class="p-8 text-center text-sm text-muted-foreground" role="status">
+                Loading metadata distribution…
+            </div>
+        {:else if activeCategorical?.error && activeCategorical.buckets.length === 0}
+            <div class="space-y-2 p-8 text-center text-sm" role="alert">
+                <p class="text-destructive">Could not load metadata distribution.</p>
+                {#if onCategoricalRetry}
+                    <Button
+                        variant="secondary"
+                        buttonProps={{
+                            size: 'sm',
+                            class: 'max-sm:min-h-11',
+                            onclick: onCategoricalRetry,
+                            'data-testid': 'metadata-categorical-retry'
+                        }}>Retry</Button
+                    >
+                {/if}
+            </div>
         {:else}
+            {#if activeCategorical}
+                <ul class="sr-only" aria-label="Categorical metadata value counts">
+                    {#each activeCategorical.buckets as bucket (bucket.id)}
+                        <li>
+                            {bucket.label}: {bucket.count} samples{bucket.kind === 'other'
+                                ? ', aggregated and not selectable'
+                                : activeCategorical.selectedValues.some((value) =>
+                                        Object.is(value, bucket.value)
+                                    )
+                                  ? ', selected'
+                                  : ''}
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
             <BarChart
                 data={visible}
-                orientation={config.orientation}
+                orientation={activeCategorical ? 'horizontal' : config.orientation}
                 maxHeightPx={chartHeight || undefined}
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
-                {onBarClick}
+                onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
+                emptyState={activeCategorical ? categoricalEmptyState : undefined}
             />
         {/if}
     </div>
 </div>
-<DistributionConfigDialog
-    bind:open={configDialogOpen}
-    allClasses={activeData.map((item) => item.label)}
-    {config}
-    onApply={applyConfig}
-/>
-<ExpandDialog
-    bind:open={expandOpen}
-    data={activeData}
-    {config}
-    {valueNoun}
-    onConfigChange={applyConfig}
-    {onBarClick}
-/>
+{#if !activeCategorical}
+    <DistributionConfigDialog
+        bind:open={configDialogOpen}
+        allClasses={activeData.map((item) => item.label)}
+        {config}
+        onApply={applyConfig}
+    />
+    <ExpandDialog
+        bind:open={expandOpen}
+        data={activeData}
+        {config}
+        {valueNoun}
+        onConfigChange={applyConfig}
+        {onBarClick}
+    />
+{/if}
 {#if activeHistogram}
     <HistogramExpandDialog
         bind:open={histogramExpandOpen}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -8,11 +8,14 @@ import { AnnotationCountMode, AnnotationType } from '$lib/api/lightly_studio_loc
 
 const echartsMock = vi.hoisted(() => {
     const zrHandlers: Record<string, (event: { offsetX: number; offsetY: number }) => void> = {};
+    let clickHandler: ((params: { dataIndex?: number }) => void) | undefined;
     const instance = {
         setOption: vi.fn(),
         resize: vi.fn(),
         dispose: vi.fn(),
-        on: vi.fn(),
+        on: vi.fn((event: string, handler: (params: { dataIndex?: number }) => void) => {
+            if (event === 'click') clickHandler = handler;
+        }),
         // 2 bins across a 200px-wide canvas → 100px per bin index.
         convertFromPixel: vi.fn((_finder: unknown, offsetX: number) => offsetX / 100),
         getZr: () => ({
@@ -22,7 +25,12 @@ const echartsMock = vi.hoisted(() => {
             off: vi.fn()
         })
     };
-    return { init: vi.fn(() => instance), instance, zrHandlers };
+    return {
+        init: vi.fn(() => instance),
+        instance,
+        zrHandlers,
+        getClickHandler: () => clickHandler
+    };
 });
 
 vi.mock('echarts/core', () => ({
@@ -216,6 +224,120 @@ describe('DatasetDistributionPanel', () => {
         expect(screen.getByTestId('histogram')).toBeInTheDocument();
         expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
             '100 samples · 2 bins · 0–1'
+        );
+    });
+
+    it('preserves categorical endpoint order and toggles typed buckets but not Other', () => {
+        const onCategoricalValueToggle = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: ['Missing'],
+                            buckets: [
+                                {
+                                    id: 'literal',
+                                    kind: 'value',
+                                    value: 'Missing',
+                                    label: 'Missing',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 3
+                                },
+                                { id: 'other', kind: 'other', label: 'Other', count: 2 }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources, onCategoricalValueToggle } });
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+            series: [{ data: { itemStyle: { borderWidth: number } }[] }];
+        };
+        expect(option.yAxis.data).toEqual(['Missing', 'Missing', 'Other']);
+        expect(option.series[0].data[0].itemStyle.borderWidth).toBe(3);
+
+        echartsMock.getClickHandler()?.({ dataIndex: 1 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledWith('city', null);
+        echartsMock.getClickHandler()?.({ dataIndex: 2 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledOnce();
+    });
+
+    it('shows categorical loading and retryable error states', async () => {
+        const onCategoricalRetry = vi.fn();
+        const source = (state: { loading?: boolean; error?: string }): DistributionSource[] => [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: { buckets: [], selectedValues: ['Zurich'], ...state }
+                    }
+                ]
+            }
+        ];
+        const view = render(DatasetDistributionPanel, {
+            props: { sources: source({ loading: true }), onCategoricalRetry }
+        });
+        expect(screen.getByRole('status')).toHaveTextContent('Loading metadata distribution');
+
+        await view.rerender({
+            sources: source({ error: 'network failure' }),
+            onCategoricalRetry
+        });
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not load metadata distribution');
+        await fireEvent.click(screen.getByTestId('metadata-categorical-retry'));
+        expect(onCategoricalRetry).toHaveBeenCalledOnce();
+    });
+
+    it('keeps stale categorical bars visible after a refetch error', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                }
+                            ],
+                            selectedValues: [],
+                            error: 'network failure'
+                        }
+                    }
+                ]
+            }
+        ];
+
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not update');
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+        expect(screen.getByLabelText('Categorical metadata value counts')).toHaveTextContent(
+            'Zurich: 4 samples'
         );
     });
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -2,6 +2,8 @@ import type { CategoryCount } from '$lib/components/BarChart';
 import type { ClassSetSelection } from '$lib/components/ClassSetConfig';
 import { type AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 import type { HistogramData, HistogramRange } from '$lib/components/Histogram';
+import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution';
+import type { CategoricalMetadataValue } from '$lib/services/types';
 
 export type DistributionSortOption = 'count' | 'name';
 
@@ -32,6 +34,13 @@ export interface DistributionSourceGroup {
      * metadata filter). Bins outside it render dimmed.
      */
     selectedRange?: HistogramRange;
+    /** Controlled categorical distribution and selection state. */
+    categorical?: {
+        buckets: CategoricalMetadataBucket[];
+        selectedValues: CategoricalMetadataValue[];
+        loading?: boolean;
+        error?: string;
+    };
 }
 
 /**

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.svelte
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.svelte
@@ -28,10 +28,14 @@
                 >
                     {#snippet subtitle()}
                         <div class="truncate text-xs text-muted-foreground">
-                            {hook.formatValue(chip.key, chip.range.min)} – {hook.formatValue(
-                                chip.key,
-                                chip.range.max
-                            )}
+                            {#if chip.kind === 'categorical'}
+                                {hook.formatCategoricalValues(chip.values)}
+                            {:else if chip.range}
+                                {hook.formatValue(chip.key, chip.range.min)} – {hook.formatValue(
+                                    chip.key,
+                                    chip.range.max
+                                )}
+                            {/if}
                         </div>
                     {/snippet}
                 </FilterChip>

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.test.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.test.ts
@@ -9,6 +9,16 @@ describe('MetadataFilterChips', () => {
     beforeEach(() => {
         storage.updateMetadataBounds({});
         storage.updateMetadataValues({});
+        storage.updateCategoricalMetadataValues({});
+    });
+
+    it('distinguishes literal values from semantic Missing in a chip', () => {
+        storage.updateCategoricalMetadataValues({ city: ['Missing', null, 'Other'] });
+        render(MetadataFilterChips);
+
+        expect(screen.getByTestId('metadata-filter-chip-city')).toHaveTextContent(
+            'Missing (value), Missing (no value), Other (value)'
+        );
     });
 
     it('renders nothing when no filter is narrowed', () => {

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.svelte.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.svelte.ts
@@ -1,6 +1,7 @@
 import { fromStore } from 'svelte/store';
 import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import { formatFloat, formatInteger } from '$lib/utils';
+import type { CategoricalMetadataValue } from '$lib/services/types';
 
 type Range = { min: number; max: number };
 type BoundsMap = Record<string, Range>;
@@ -8,17 +9,26 @@ type BoundsMap = Record<string, Range>;
 export interface MetadataFilterChip {
     key: string;
     active: boolean;
-    range: Range;
+    kind: 'numeric' | 'categorical';
+    range?: Range;
+    values?: CategoricalMetadataValue[];
 }
 
 export function useMetadataFilterChips(collectionId: string | undefined) {
-    const { metadataBounds, metadataValues, updateMetadataValues } =
-        useMetadataFilters(collectionId);
+    const {
+        metadataBounds,
+        metadataValues,
+        categoricalMetadataValues,
+        updateMetadataValues,
+        updateCategoricalMetadataValues
+    } = useMetadataFilters(collectionId);
 
     const boundsStore = fromStore(metadataBounds);
     const valuesStore = fromStore(metadataValues);
+    const categoricalStore = fromStore(categoricalMetadataValues);
 
     let lastRanges = $state<BoundsMap>({});
+    let lastCategoricalValues = $state<Record<string, CategoricalMetadataValue[]>>({});
 
     const isNarrowed = (key: string): boolean => {
         const bound = boundsStore.current[key];
@@ -38,6 +48,19 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
         }
     });
 
+    $effect(() => {
+        for (const [key, values] of Object.entries(categoricalStore.current)) {
+            if (values.length === 0) continue;
+            const previous = lastCategoricalValues[key] ?? [];
+            const unchanged =
+                previous.length === values.length &&
+                previous.every((value, index) => Object.is(value, values[index]));
+            if (!unchanged) {
+                lastCategoricalValues = { ...lastCategoricalValues, [key]: [...values] };
+            }
+        }
+    });
+
     // One chip per key that is narrowed now or has a remembered range: active
     // chips show the current range, disabled ones the remembered range.
     const chips = $derived.by<MetadataFilterChip[]>(() => {
@@ -45,16 +68,32 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
             ...Object.keys(lastRanges),
             ...Object.keys(valuesStore.current).filter(isNarrowed)
         ]);
-        return [...keys]
+        const numericChips = [...keys]
             .filter((key) => boundsStore.current[key])
             .map((key) => {
                 const active = isNarrowed(key);
                 const range: Range | undefined = active
                     ? valuesStore.current[key]
                     : lastRanges[key];
-                return { key, active, range };
+                return range ? { key, active, range, kind: 'numeric' as const } : null;
             })
-            .filter((chip): chip is MetadataFilterChip => !!chip.range);
+            .filter((chip): chip is NonNullable<typeof chip> => chip !== null);
+        const categoricalKeys = new Set([
+            ...Object.keys(lastCategoricalValues),
+            ...Object.entries(categoricalStore.current)
+                .filter(([, values]) => values.length > 0)
+                .map(([key]) => key)
+        ]);
+        const categoricalChips: MetadataFilterChip[] = [...categoricalKeys].map((key) => {
+            const current = categoricalStore.current[key] ?? [];
+            return {
+                key,
+                active: current.length > 0,
+                kind: 'categorical',
+                values: current.length > 0 ? current : lastCategoricalValues[key]
+            };
+        });
+        return [...numericChips, ...categoricalChips];
     });
 
     const setRange = (key: string, range: Range) => {
@@ -62,6 +101,13 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
     };
 
     const handleToggle = (key: string, checked: boolean | 'indeterminate') => {
+        if (lastCategoricalValues[key]) {
+            updateCategoricalMetadataValues({
+                ...categoricalStore.current,
+                [key]: checked ? lastCategoricalValues[key] : []
+            });
+            return;
+        }
         const bound = boundsStore.current[key];
         if (!bound) return;
         if (checked && lastRanges[key]) {
@@ -72,6 +118,15 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
     };
 
     const handleClear = (key: string) => {
+        if (lastCategoricalValues[key]) {
+            const next = { ...categoricalStore.current };
+            delete next[key];
+            updateCategoricalMetadataValues(next);
+            lastCategoricalValues = Object.fromEntries(
+                Object.entries(lastCategoricalValues).filter(([valueKey]) => valueKey !== key)
+            );
+            return;
+        }
         const bound = boundsStore.current[key];
         if (bound) setRange(key, { min: bound.min, max: bound.max });
         lastRanges = Object.fromEntries(
@@ -85,12 +140,26 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
         return isInteger ? formatInteger(value) : formatFloat(value);
     };
 
+    const formatCategoricalValues = (values: CategoricalMetadataValue[] = []): string => {
+        const hasMissingValue = values.includes('Missing');
+        const hasNoValue = values.includes(null);
+        return values
+            .map((value) => {
+                if (value === null) return hasMissingValue ? 'Missing (no value)' : 'Missing';
+                if (value === 'Missing' && hasNoValue) return 'Missing (value)';
+                if (value === 'Other') return 'Other (value)';
+                return String(value);
+            })
+            .join(', ');
+    };
+
     return {
         get chips() {
             return chips;
         },
         handleToggle,
         handleClear,
-        formatValue
+        formatValue,
+        formatCategoricalValues
     };
 }

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.test.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.test.ts
@@ -21,6 +21,7 @@ describe('useMetadataFilterChips', () => {
     beforeEach(() => {
         storage.updateMetadataBounds({});
         storage.updateMetadataValues({});
+        storage.updateCategoricalMetadataValues({});
     });
 
     it('provides a chip only for narrowed filters, not for full-range ones', () => {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -73,7 +73,8 @@
         useSelectionSummary,
         useImageAnnotationCounts,
         useImageAnnotationCountsQueryKey,
-        useNumericMetadataDistribution
+        useNumericMetadataDistribution,
+        useCategoricalMetadataDistribution
     } from '$lib/hooks';
     import { useSelectAll } from '$lib/hooks/useSelectAll/useSelectAll';
     import { isInputElement } from '$lib/utils';
@@ -286,9 +287,14 @@
             : 'Search samples by description or image'
     );
 
-    const { metadataValues, metadataBounds, updateMetadataValues } = $derived.by(() =>
-        useMetadataFilters(collectionId)
-    );
+    const {
+        metadataValues,
+        metadataBounds,
+        metadataInfo,
+        categoricalMetadataValues,
+        updateMetadataValues,
+        updateCategoricalMetadataValues
+    } = $derived.by(() => useMetadataFilters(collectionId));
     const { dimensionsValues } = useDimensions(collectionIdStore);
 
     const annotationLabelsQuery = useAnnotationLabels(() => ({
@@ -309,7 +315,9 @@
     });
 
     const metadataFilters = $derived(
-        metadataValues ? createMetadataFilters($metadataValues) : undefined
+        metadataValues
+            ? createMetadataFilters($metadataValues, $categoricalMetadataValues)
+            : undefined
     );
     const { videoFramesBoundsValues } = useVideoFramesBounds();
     const { videoBoundsValues } = useVideoBounds();
@@ -583,21 +591,43 @@
     // selectDistributions internally via the TanStack Query `select` option.
     const metadataDistributions = $derived(metadataHistogramsQuery.data ?? {});
 
+    const categoricalMetadataQuery = useCategoricalMetadataDistribution(() => ({
+        collectionId,
+        filter: imageAnnotationCountsFilter,
+        enabled: distributionPanelVisible
+    }));
+    const categoricalMetadataDistributions = $derived(categoricalMetadataQuery.data ?? {});
+
     const metadataDistributionSource = $derived.by<DistributionSource | null>(() => {
-        const keys = Object.keys(metadataDistributions);
-        if (keys.length === 0) return null;
+        const numericKeys = Object.keys(metadataDistributions);
+        const categoricalKeys = ($metadataInfo ?? [])
+            .filter((info) => info.type === 'string' || info.type === 'boolean')
+            .map((info) => info.name);
+        if (numericKeys.length === 0 && categoricalKeys.length === 0) return null;
         return {
             id: 'metadata',
             label: 'Metadata',
             groupLabel: 'Metadata key',
             valueNoun: 'samples',
-            groups: keys.map((key) => ({
-                id: key,
-                label: key,
-                histogram: metadataDistributions[key],
-                // Highlight the active filter range; bins outside it dim.
-                selectedRange: $metadataValues[key]
-            }))
+            groups: [
+                ...numericKeys.map((key) => ({
+                    id: key,
+                    label: key,
+                    histogram: metadataDistributions[key],
+                    // Highlight the active filter range; bins outside it dim.
+                    selectedRange: $metadataValues[key]
+                })),
+                ...categoricalKeys.map((key) => ({
+                    id: key,
+                    label: key,
+                    categorical: {
+                        buckets: categoricalMetadataDistributions[key] ?? [],
+                        selectedValues: $categoricalMetadataValues[key] ?? [],
+                        loading: categoricalMetadataQuery.isFetching,
+                        error: categoricalMetadataQuery.error?.message
+                    }
+                }))
+            ]
         };
     });
 
@@ -623,6 +653,24 @@
                 ? { min: bound.min, max: bound.max }
                 : { min: clampedMin, max: clampedMax }
         });
+    };
+
+    const handleCategoricalValueToggle = (metadataKey: string, value: string | boolean | null) => {
+        const selected = $categoricalMetadataValues[metadataKey] ?? [];
+        const exists = selected.some((candidate) => Object.is(candidate, value));
+        const next = exists
+            ? selected.filter((candidate) => !Object.is(candidate, value))
+            : [...selected, value];
+        updateCategoricalMetadataValues({
+            ...$categoricalMetadataValues,
+            [metadataKey]: next
+        });
+    };
+
+    const clearCategoricalValues = (metadataKey: string) => {
+        const next = { ...$categoricalMetadataValues };
+        delete next[metadataKey];
+        updateCategoricalMetadataValues(next);
     };
 
     const distributionSources = $derived<DistributionSource[]>(
@@ -812,6 +860,9 @@
                                         distributionCountMode = mode;
                                     }}
                                     onHistogramRangeSelect={handleDistributionHistogramRangeSelect}
+                                    onCategoricalValueToggle={handleCategoricalValueToggle}
+                                    onCategoricalValuesClear={clearCategoricalValues}
+                                    onCategoricalRetry={() => categoricalMetadataQuery.refetch()}
                                     {histogramBinCount}
                                     onHistogramBinCountChange={(binCount) =>
                                         (histogramBinCount = binCount)}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
@@ -22,7 +22,9 @@
 
     const collectionId = $derived(page.params.collection_id);
 
-    const { metadataValues } = $derived(useMetadataFilters(collectionId));
+    const { metadataValues, categoricalMetadataValues } = $derived(
+        useMetadataFilters(collectionId)
+    );
     const { videoFramesBoundsValues } = $derived(useVideoFramesBounds(collectionId));
 
     const { selectedAnnotationFilterIdsArray: selectedAnnotationFilterIds } =
@@ -41,7 +43,8 @@
                 ? $selectedAnnotationFilterIds
                 : undefined,
             tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined,
-            metadata_values: $metadataValues
+            metadata_values: $metadataValues,
+            categorical_metadata_values: $categoricalMetadataValues
         },
         frame_bounds: $videoFramesBoundsValues
     });

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
@@ -26,7 +26,7 @@
         })
     );
 
-    const { metadataValues } = useMetadataFilters();
+    const { metadataValues, categoricalMetadataValues } = useMetadataFilters();
     const { selectedAnnotationFilterIdsArray: selectedAnnotationsFilterIds } =
         useSelectedAnnotationsFilter();
     const { videoBoundsValues } = $derived.by(() => useVideoBounds(collectionId));
@@ -42,7 +42,8 @@
                 ? $selectedAnnotationsFilterIds
                 : undefined,
             tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined,
-            metadata_values: $metadataValues
+            metadata_values: $metadataValues,
+            categorical_metadata_values: $categoricalMetadataValues
         },
         video_bounds: $videoBoundsValues
     });


### PR DESCRIPTION
## Summary

Stacked on p4. First PR that produces visible UI changes.

**`DatasetDistributionPanel`**: adds a `categorical` slot to `DistributionSourceGroup`; for each field with categorical data the panel renders a `MetadataCategoricalFilter` above a horizontal `BarChart` with loading/error/retry states.

**`MetadataFilterChips`**: `useMetadataFilterChips` now tracks categorical selections and produces chips with a disambiguated label format — literal `"Missing"` and `"Other"` values are quoted to distinguish them from the sentinel buckets.

**Collection layout and video pages**: the layout fetches categorical distributions (via `useCategoricalMetadataDistribution`), exposes `toggleCategoricalValue` / `clearCategoricalField` handlers to `DatasetDistributionPanel`, and passes `categoricalMetadataValues` into the shared `metadataFilters`. The frames and videos pages forward the same values to their filter hooks.

## Test plan

- [ ] `make static-checks` (frontend) passes
- [ ] `npm run test:unit` passes (new tests for `DatasetDistributionPanel` and `useMetadataFilterChips`)
- [ ] Manual: open a collection with categorical metadata, see bar charts in the distribution panel, click a bar to filter, verify chips appear and filters apply

Part of LIG-9585.