### PR TITLE
FE: categorical distribution configuration and expanded view

### DIFF
--- a/docs/features/lig-9585-categorical-metadata-distribution-filter.md
+++ b/docs/features/lig-9585-categorical-metadata-distribution-filter.md
@@ -1,0 +1,215 @@
+# Feature: Categorical Metadata Distribution and Filter
+
+**Status:** Implemented; QA ready
+
+**Linear:** [LIG-9585](https://linear.app/lightly/issue/LIG-9585/frontend-categorical-metadata-bar-chart-filter-ui-8-sp)
+
+**Depends on:** [LIG-9584](https://linear.app/lightly/issue/LIG-9584/backend-categorical-metadata-value-counts-endpoint-5-sp)
+
+## Problem and Target User
+
+ML engineers can inspect numeric metadata distributions, but categorical fields such as `city`,
+`camera_id`, or a boolean flag are absent from the distribution panel and cannot be filtered there.
+They need to spot imbalance and missing metadata, then narrow the grid without leaving the plot.
+
+## Proposed User Flow
+
+1. Open the existing dataset distribution panel and select **Metadata**.
+2. Use the existing **Metadata key** selector to choose a numeric or categorical field.
+3. Numeric fields continue to show the current histogram. Categorical fields show a horizontal bar
+   chart and a compact searchable value selector.
+4. Select one or more concrete values or **Missing**. The grid and all distributions update using
+   the shared active filter; alternatives for the edited field remain visible through faceting.
+5. Deselect every value (or use **Clear**) to remove that field's categorical filter.
+
+## Wireframes
+
+### Loaded categorical field
+
+```text
++--------------------------------------------------+
+| Distribution                                  [x]|
+| Distribution  [ Metadata                 v ]     |
+| Metadata key  [ city                     v ]     |
+|                                                  |
+| Values        [ 2 selected · Search values  v ]  |
+|                                                  |
+| Zurich    |████████████████████| 120             |
+| Berlin    |██████████          |  64             |
+| Missing   |██                  |   8             |
+| Other     |█                   |   4  (display)   |
++--------------------------------------------------+
+
+Values popover
++--------------------------------------+
+| Search values…                       |
+| [x] Zurich                       120 |
+| [x] Berlin                        64 |
+| [ ] Missing                        8 |
+|     Other is an aggregate and cannot |
+|     be selected                        |
+| [Clear]                              |
++--------------------------------------+
+```
+
+The bars for selected concrete values and Missing have a non-colour-only selected treatment.
+Clicking a selectable bar toggles the same selection as its checkbox. Other is not interactive.
+
+### Loading, empty, and error
+
+```text
+Loading/refetch                 No categorical fields
++---------------------------+  +---------------------------+
+| Values [Loading…]         |  | No categorical metadata   |
+| Previous bars stay visible|  | is available.             |
++---------------------------+  +---------------------------+
+
+Selected field has no matches  Request failed
++---------------------------+  +---------------------------+
+| No matching samples for   |  | Could not load metadata   |
+| this metadata field.      |  | distribution. [Retry]     |
++---------------------------+  +---------------------------+
+```
+
+## Content and Interaction
+
+- String and boolean fields use categorical bars; integer and float fields keep using histograms.
+- Concrete values are ordered by the endpoint (frequency with deterministic ties). **Missing** and
+  non-zero **Other** are appended as semantic buckets.
+- Values retain typed identity (`string`, `boolean`, or `null`) independently from display labels.
+  Literal strings `"Missing"` and `"Other"` therefore remain ordinary selectable values.
+- **Missing** means absent key, JSON null, or no metadata row and is represented internally by
+  `null`. **Other** is display-only because its members are not returned by the endpoint.
+- Multiple values for one key use OR semantics. Filters for different keys and all other active
+  filters use AND semantics.
+- Selected values remain available in the selector while refetching. A field's own categorical
+  filter is excluded only from that field's count query, matching the numeric faceting behavior.
+- Empty selection means no categorical filter for the field. The UI never sends an empty `in`
+  predicate.
+- The selector summary reads **All values**, the selected value for one item, or **N selected**.
+- Categorical fields expose the existing distribution settings and expanded-chart actions. Settings
+  support top-N, manual value selection, and count/value sorting; they are stored per metadata key.
+  The categorical chart remains horizontal and omits **Count by** because the endpoint counts
+  samples. Missing and Other remain visible in top-N mode; manual mode is explicitly user-selected.
+- For five or fewer concrete values, show direct checkboxes without search. Longer lists add search
+  inside the same compact popover; search only narrows returned options and never changes the grid.
+- Retain selected values when they are absent from the latest top-20 response so users can still
+  deselect them, and summarize active categorical fields in the existing metadata-filter chip area.
+
+## States
+
+- **Loading:** Disable selection until initial data arrives. During later refetches, retain previous
+  bars and selections and show a subtle busy indicator.
+- **Empty:** If no categorical fields exist, omit categorical groups. If a known selected field has
+  no matches, show the field-level empty message rather than an empty chart.
+- **Error:** Keep the panel and selectors usable, show a concise error with Retry, and do not clear
+  active selections.
+- **Success:** Show the chart and value selector. Omit zero-count Missing and Other bars.
+
+## Responsive and Accessibility Requirements
+
+- Keep controls full-width and stacked in the side panel; the value popover must not exceed the
+  viewport and its list scrolls independently.
+- Every selectable value is keyboard reachable and toggleable with Enter or Space. Escape closes
+  the popover and returns focus to its trigger.
+- Expose checkbox state, counts, chart labels, selected state, loading state, and disabled Other
+  semantics to assistive technology. Do not communicate selection through colour alone.
+- Long field/value labels truncate visually but remain available through accessible names/tooltips.
+- Touch targets are at least 32 px in the desktop side panel and 44 px in narrow/touch layouts.
+
+## Decision Rationale
+
+- **Reuse the existing source and field selectors:** numeric and categorical metadata are two
+  renderings of the same concept, so adding another navigation layer would be needless ceremony.
+- **Horizontal bars:** categorical labels remain readable and the existing `BarChart` can be reused.
+- **Compact searchable multi-select:** checkboxes are fast for common low-cardinality fields while
+  search keeps the top-20 list manageable.
+- **Explicit Missing; display-only Other:** Missing maps to a precise predicate; Other does not.
+- **Live faceted counts:** the chart continues to explain the current grid without hiding alternative
+  values for the field being edited.
+- **Follow FiftyOne's useful behavior, not its layout:** FiftyOne supports categorical histograms,
+  current-view updates, low-cardinality checkboxes, and search for longer value lists. Lightly keeps
+  those interaction principles inside its existing distribution panel rather than adding a second
+  full filter sidebar.
+
+## Acceptance Criteria
+
+- [ ] The Metadata source lists numeric, string, and boolean fields in the existing field selector.
+- [ ] Numeric fields still render the existing histogram and range filter behavior.
+- [ ] Categorical fields render endpoint-ordered horizontal bars with counts.
+- [ ] Categorical fields provide a horizontal expanded view and value-specific configuration for
+      top-N, manual selection, and count/value sorting without exposing Count by or orientation.
+- [ ] Concrete string/boolean values and Missing can be selected by checkbox and bar click.
+- [ ] Multiple values for one field filter with OR; filters across fields remain AND.
+- [ ] Literal `"Missing"`/`"Other"` values do not collide with semantic buckets.
+- [ ] Other is visible when non-zero, clearly non-selectable, and never produces a filter.
+- [ ] Grid requests, query keys, filter hashes, counts, and distribution requests use the same
+      categorical selection state and update when it changes.
+- [ ] A categorical field's own predicate is excluded from its returned counts.
+- [ ] Empty selection removes that field's predicate; selections reset on collection change.
+- [ ] Active categorical filters appear in metadata-filter chips and stale selected values remain
+      removable when absent from the latest response.
+- [ ] Loading/refetch, empty, and error states preserve active filters and provide clear feedback.
+- [ ] Keyboard, focus, screen-reader, and responsive requirements are covered by tests or manual QA.
+
+## Architecture Contract
+
+### Backend filter extension
+
+- Extend `MetadataOperator` with `in`.
+- A categorical field is encoded as one predicate, for example:
+
+```json
+{ "key": "city", "op": "in", "value": ["Zurich", "Berlin", null] }
+```
+
+- Array members are OR-ed. `null` matches absent keys, explicit JSON null, and samples without a
+  metadata row. Different filter objects retain existing AND semantics.
+- Concrete members must be homogeneous strings or homogeneous booleans; an optional null may be
+  mixed in. Reject empty arrays and unsupported/mixed values with HTTP 422.
+- Use literal top-level JSON-key extraction and an outer metadata join whenever null is requested.
+  Existing comparison operators and nested-field behavior remain unchanged.
+- The value-count response is unchanged; its resolver already removes all own-key predicates.
+
+### Frontend ownership and data flow
+
+- Shared metadata filter storage owns `Record<string, (string | boolean | null)[]>` categorical
+  selections and resets it when the collection changes.
+- Filter creation combines numeric range predicates with one non-empty categorical `in` predicate
+  per key. The combined predicates drive grid requests and every distribution/count request, and
+  categorical state is included in query keys/filter hashes.
+- `useCategoricalMetadataDistribution.ts` parallels the numeric hook, calls
+  `POST /metadata/value-counts`, forwards the reactive `ImageFilter`, maps semantic buckets without
+  label-based identity, and keeps prior data during refetch.
+- Metadata source groups use a discriminated categorical payload, mutually exclusive with `data`
+  and `histogram`. The panel emits `(groupId, typedValue)` when a concrete/Missing bucket toggles.
+- `MetadataCategoricalFilter.svelte` owns only the value popover and categorical presentation; the
+  shared store remains the source of truth.
+
+### Verification surfaces
+
+- Backend validation/query tests: string/boolean OR, null-only, concrete plus null, AND across keys,
+  dotted/apostrophe keys, no metadata row, empty/mixed-array rejection, DuckDB and PostgreSQL paths.
+- Frontend unit/component tests: response mapping, request forwarding, filter construction/reset,
+  request/query-key propagation, bar/checkbox toggling, Missing versus literal `"Missing"`, disabled
+  Other, loading/empty/error, and selected styling.
+- Regenerate OpenAPI and the frontend client, then run backend and frontend static checks plus focused
+  test suites.
+
+## Non-goals
+
+- Selecting or expanding the aggregated Other bucket.
+- Returning/searching the full high-cardinality tail or adding server-side value search.
+- Moving categorical filters into the existing left filter panel or adding a new permanent sidebar.
+- Changing numeric histogram behavior, class distribution configuration, or count modes.
+- Persisting distributions or adding a database migration.
+
+## Assumptions and Open Questions
+
+- Boolean metadata follows the categorical path.
+- The endpoint's fixed top 20 is sufficient for this first UI; selected top values remain present
+  because own-field filters are excluded.
+- The small `in` extension is part of LIG-9585 because Missing and multi-select cannot meet the
+  ticket's acceptance criteria with scalar comparison operators.
+- Open question for later work: if users need values hidden in Other, add a dedicated value-search
+  endpoint rather than pretending an aggregate bucket identifies its members.

--- a/lightly_studio_view/src/lib/components/BarChart/types.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/types.ts
@@ -8,4 +8,6 @@ export interface CategoryCount {
     selected?: boolean;
     /** Whether clicking the bar can change selection. */
     selectable?: boolean;
+    /** Keeps semantic buckets visible when a top-N view is applied. */
+    pinned?: boolean;
 }

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.svelte
@@ -13,6 +13,8 @@
         open: boolean;
         /** Every class label available; bounds top-N and populates the manual selector. */
         allClasses: string[];
+        /** Stable values and labels for manual selection. */
+        items?: SelectItem[];
         /** The currently applied selection. Copied into a draft each time the dialog opens. */
         selection: ClassSetSelection;
         /** Sort options for the top-N tab (host-specific ranking criteria). */
@@ -23,6 +25,8 @@
         testIdPrefix: string;
         /** Shows an "All" quick action next to the number input. */
         showAllButton?: boolean;
+        /** Singular/plural labels for the configured chart items. */
+        itemNounPlural?: string;
         /** Extra controls rendered below the tabs (e.g. coloring options). */
         extraSections?: Snippet;
         /** Invoked with the new selection when the user clicks Apply. The dialog then closes itself. */
@@ -32,16 +36,18 @@
     let {
         open = $bindable(),
         allClasses,
+        items,
         selection,
         sortItems,
         description,
         testIdPrefix,
         showAllButton = false,
+        itemNounPlural = 'classes',
         extraSections,
         onApply
     }: Props = $props();
 
-    const maxN = $derived(allClasses.length);
+    const maxN = $derived(items?.length ?? allClasses.length);
 
     const toDraft = (): ClassSetSelection => ({
         mode: selection.mode,
@@ -73,7 +79,7 @@
 <Dialog.Root bind:open>
     <Dialog.Content class="max-w-[420px]">
         <Dialog.Header>
-            <Dialog.Title>Configure classes</Dialog.Title>
+            <Dialog.Title>Configure {itemNounPlural}</Dialog.Title>
             <Dialog.Description>{description}</Dialog.Description>
         </Dialog.Header>
         <Tabs.Root bind:value={draft.mode}>
@@ -84,7 +90,7 @@
             <Tabs.Content value="topN">
                 <div class="space-y-3 pt-2">
                     <label class="flex items-center justify-between gap-2 text-sm">
-                        Number of classes
+                        Number of {itemNounPlural}
                         <span class="flex items-center gap-1">
                             <Input
                                 type="number"
@@ -124,6 +130,9 @@
                 <ManualClassSelector
                     bind:selected={draft.manualClasses}
                     {allClasses}
+                    {items}
+                    {itemNounPlural}
+                    itemNoun={itemNounPlural === 'classes' ? 'class' : 'value'}
                     searchTestId={`${testIdPrefix}-search`}
                 />
             </Tabs.Content>

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.test.ts
@@ -54,6 +54,13 @@ describe('ClassSetConfigDialog', () => {
         expect(input).toHaveAttribute('max', '30');
     });
 
+    it('uses custom item nouns', () => {
+        renderDialog({ itemNounPlural: 'values' });
+
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.getByText('Number of values')).toBeInTheDocument();
+    });
+
     it('shows the label of the current sort option on the trigger', () => {
         renderDialog({ selection: { ...baseSelection, sortBy: 'name' } });
 

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
@@ -4,35 +4,52 @@
     import * as Command from '$lib/components/ui/command';
     import { cn } from '$lib/utils';
 
+    type ManualSelectionItem = { value: string; label: string };
+
     interface Props {
         /** Currently selected class labels. Bindable — mutated on toggle / Select all / Clear. */
         selected: string[];
         /** Full list of class labels to choose from, in the order they should be displayed. */
         allClasses: string[];
+        /** Optional stable values and display labels; labels need not be unique. */
+        items?: ManualSelectionItem[];
+        itemNoun?: string;
+        itemNounPlural?: string;
         /** test-id for the search input; lets each host keep its own id scheme. */
         searchTestId?: string;
     }
 
-    let { selected = $bindable(), allClasses, searchTestId }: Props = $props();
+    let {
+        selected = $bindable(),
+        allClasses,
+        items,
+        itemNoun = 'class',
+        itemNounPlural = 'classes',
+        searchTestId
+    }: Props = $props();
 
-    const toggle = (className: string) => {
-        selected = selected.includes(className)
-            ? selected.filter((c) => c !== className)
-            : [...selected, className];
+    const resolvedItems = $derived(
+        items ?? allClasses.map((className) => ({ value: className, label: className }))
+    );
+
+    const toggle = (value: string) => {
+        selected = selected.includes(value)
+            ? selected.filter((selectedValue) => selectedValue !== value)
+            : [...selected, value];
     };
 </script>
 
 <div class="pt-2">
     <div class="mb-1 flex items-center justify-between">
         <span class="text-xs text-muted-foreground">
-            {selected.length} of {allClasses.length} selected
+            {selected.length} of {resolvedItems.length} selected
         </span>
         <div class="flex gap-1">
             <Button
                 variant="ghost"
                 size="sm"
                 class="h-6 px-2 text-xs"
-                onclick={() => (selected = [...allClasses])}
+                onclick={() => (selected = resolvedItems.map((item) => item.value))}
             >
                 Select all
             </Button>
@@ -47,13 +64,17 @@
         </div>
     </div>
     <Command.Root class="rounded-md border">
-        <Command.Input placeholder="Search classes..." data-testid={searchTestId} />
+        <Command.Input placeholder="Search {itemNounPlural}..." data-testid={searchTestId} />
         <Command.List class="max-h-[220px] dark:[color-scheme:dark]">
-            <Command.Empty>No class found.</Command.Empty>
-            {#each allClasses as className (className)}
-                <Command.Item value={className} onSelect={() => toggle(className)}>
-                    <CheckIcon class={cn(!selected.includes(className) && 'text-transparent')} />
-                    <span class="min-w-0 flex-1 truncate">{className}</span>
+            <Command.Empty>No {itemNoun} found.</Command.Empty>
+            {#each resolvedItems as item (item.value)}
+                <Command.Item
+                    value={item.value}
+                    keywords={[item.label]}
+                    onSelect={() => toggle(item.value)}
+                >
+                    <CheckIcon class={cn(!selected.includes(item.value) && 'text-transparent')} />
+                    <span class="min-w-0 flex-1 truncate">{item.label}</span>
                 </Command.Item>
             {/each}
         </Command.List>

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
@@ -40,4 +40,24 @@ describe('ManualClassSelector', () => {
 
         expect(screen.getByTestId('my-search')).toBeInTheDocument();
     });
+
+    it('uses stable values for duplicate labels and custom copy', async () => {
+        render(ManualClassSelector, {
+            props: {
+                selected: [],
+                allClasses: ['Missing', 'Missing'],
+                items: [
+                    { value: 'literal-missing', label: 'Missing' },
+                    { value: 'semantic-missing', label: 'Missing' }
+                ],
+                itemNoun: 'value',
+                itemNounPlural: 'values'
+            }
+        });
+
+        expect(screen.getByPlaceholderText('Search values...')).toBeInTheDocument();
+        expect(screen.getAllByText('Missing')).toHaveLength(2);
+        await fireEvent.click(screen.getAllByText('Missing')[0]);
+        await waitFor(() => expect(screen.getByText('1 of 2 selected')).toBeInTheDocument());
+    });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -12,6 +12,7 @@
     import PanelHeader from './PanelHeader/PanelHeader.svelte';
     import { selectVisibleCounts } from './selectVisibleCounts';
     import {
+        CATEGORICAL_DISTRIBUTION_SORT_LABELS,
         HISTOGRAM_BIN_COUNT_ITEMS,
         type DistributionConfig,
         type DistributionSource,
@@ -127,12 +128,16 @@
             label: bucket.label,
             count: bucket.count,
             selectable: bucket.kind !== 'other',
+            pinned: bucket.kind !== 'value',
             selected:
                 bucket.kind !== 'other' &&
                 activeCategorical?.selectedValues.some((value) => Object.is(value, bucket.value))
         }))
     );
     const displayedData = $derived(activeCategorical ? categoricalData : activeData);
+    const configurationItems = $derived(
+        displayedData.map((item) => ({ value: item.id ?? item.label, label: item.label }))
+    );
     const activeHistogramRange = $derived(activeGroup?.selectedRange ?? activeSource.selectedRange);
     const handleHistogramRangeSelect = (range: HistogramRange) => {
         const groupId = activeGroup?.id ?? activeSource.id;
@@ -154,6 +159,23 @@
         orientation: 'horizontal',
         countMode: initialCountMode
     });
+    const defaultCategoricalConfig: DistributionConfig = {
+        mode: 'topN',
+        n: 1,
+        sortBy: 'count',
+        manualClasses: [],
+        orientation: 'horizontal',
+        countMode: AnnotationCountMode.SAMPLES
+    };
+    let categoricalConfigs = $state<Record<string, DistributionConfig>>({});
+    const categoricalConfig = $derived<DistributionConfig>(
+        activeGroup
+            ? (categoricalConfigs[activeGroup.id] ?? {
+                  ...defaultCategoricalConfig,
+                  n: Math.max(categoricalData.length, 1)
+              })
+            : defaultCategoricalConfig
+    );
     let configDialogOpen = $state(false);
     let expandOpen = $state(false);
     let histogramExpandOpen = $state(false);
@@ -177,9 +199,10 @@
         (activeSource.groups ?? []).map((group) => ({ value: group.id, label: group.label }))
     );
 
-    const visible = $derived(
-        activeCategorical ? displayedData : selectVisibleCounts(displayedData, config)
+    const activeViewConfig = $derived<DistributionConfig>(
+        activeCategorical ? categoricalConfig : config
     );
+    const visible = $derived(selectVisibleCounts(displayedData, activeViewConfig));
     const totalCount = $derived(displayedData.reduce((sum, item) => sum + item.count, 0));
 
     const handleCategoricalBarClick = (item: CategoryCount) => {
@@ -188,7 +211,23 @@
         onCategoricalValueToggle?.(activeGroup.id, bucket.value);
     };
 
+    const setCategoricalConfig = (next: DistributionConfig) => {
+        if (!activeGroup) return;
+        categoricalConfigs = {
+            ...categoricalConfigs,
+            [activeGroup.id]: {
+                ...next,
+                orientation: 'horizontal',
+                countMode: AnnotationCountMode.SAMPLES
+            }
+        };
+    };
+
     function applyConfig(next: DistributionConfig) {
+        if (activeCategorical) {
+            setCategoricalConfig(next);
+            return;
+        }
         if (next.countMode !== config.countMode) {
             onCountModeChange?.(next.countMode ?? AnnotationCountMode.OBJECTS);
         }
@@ -323,6 +362,26 @@
                 {/if}
             </div>
         {/if}
+        {#if categoricalData.length > 0}
+            <PanelHeader
+                config={categoricalConfig}
+                classCount={categoricalData.length}
+                visibleClassCount={visible.length}
+                {totalCount}
+                {valueNoun}
+                categoryNoun="value"
+                categoryNounPlural="values"
+                sortLabels={CATEGORICAL_DISTRIBUTION_SORT_LABELS}
+                onConfigure={() => (configDialogOpen = true)}
+                onShowAll={() =>
+                    setCategoricalConfig({
+                        ...categoricalConfig,
+                        mode: 'topN',
+                        n: categoricalData.length
+                    })}
+                onExpand={() => (expandOpen = true)}
+            />
+        {/if}
     {:else if activeData.length > 0}
         <PanelHeader
             {config}
@@ -390,7 +449,7 @@
             {/if}
             <BarChart
                 data={visible}
-                orientation={activeCategorical ? 'horizontal' : config.orientation}
+                orientation={activeViewConfig.orientation}
                 maxHeightPx={chartHeight || undefined}
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
@@ -400,20 +459,29 @@
         {/if}
     </div>
 </div>
-{#if !activeCategorical}
+{#if !activeHistogram}
     <DistributionConfigDialog
         bind:open={configDialogOpen}
-        allClasses={activeData.map((item) => item.label)}
-        {config}
+        allClasses={displayedData.map((item) => item.label)}
+        items={configurationItems}
+        config={activeViewConfig}
+        showCountMode={!activeCategorical}
+        itemNounPlural={activeCategorical ? 'values' : 'classes'}
+        sortLabels={activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
         onApply={applyConfig}
     />
     <ExpandDialog
         bind:open={expandOpen}
-        data={activeData}
-        {config}
+        data={displayedData}
+        config={activeViewConfig}
         {valueNoun}
+        categoryNoun={activeCategorical ? 'value' : 'class'}
+        categoryNounPlural={activeCategorical ? 'values' : 'classes'}
+        sortLabels={activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
+        showCountMode={!activeCategorical}
+        fixedOrientation={activeCategorical ? 'horizontal' : undefined}
         onConfigChange={applyConfig}
-        {onBarClick}
+        onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
     />
 {/if}
 {#if activeHistogram}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -276,6 +276,107 @@ describe('DatasetDistributionPanel', () => {
         expect(onCategoricalValueToggle).toHaveBeenCalledOnce();
     });
 
+    it('configures and expands categorical values while keeping bars horizontal', async () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                valueNoun: 'samples',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 1
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        expect(screen.getByText(/2 values · sorted by count · 5 samples/)).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('dataset-distribution-toggle-orientation')
+        ).not.toBeInTheDocument();
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+        await fireEvent.click(screen.getByText('Cancel'));
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-expand'));
+        expect(screen.getByTestId('dataset-distribution-expanded-configure')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('dataset-distribution-expanded-toggle-orientation')
+        ).not.toBeInTheDocument();
+    });
+
+    it('manually configures colliding categorical labels by stable bucket id', async () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'status',
+                        label: 'status',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'literal-missing',
+                                    kind: 'value',
+                                    value: 'Missing',
+                                    label: 'Missing',
+                                    count: 4
+                                },
+                                {
+                                    id: 'semantic-missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 3
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        await fireEvent.click(screen.getByRole('tab', { name: 'Manual' }));
+        const missingOptions = screen.getAllByText('Missing');
+        expect(missingOptions).toHaveLength(2);
+        await fireEvent.click(missingOptions[1]);
+        await fireEvent.click(screen.getByTestId('distribution-config-apply'));
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+            series: [{ data: { value: number }[] }];
+        };
+        expect(option.yAxis.data).toEqual(['Missing']);
+        expect(option.series[0].data[0].value).toBe(3);
+    });
+
     it('shows categorical loading and retryable error states', async () => {
         const onCategoricalRetry = vi.fn();
         const source = (state: { loading?: boolean; error?: string }): DistributionSource[] => [

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.svelte
@@ -13,19 +13,37 @@
         open: boolean;
         /** Every class label available, used to bound top-N and populate the manual selector. */
         allClasses: string[];
+        /** Stable values and display labels for manual selection. */
+        items?: SelectItem[];
         /** The currently applied config. */
         config: DistributionConfig;
         /** Whether to show the Count by selector (default true). */
         showCountMode?: boolean;
+        /** Singular/plural labels used by categorical distributions. */
+        itemNounPlural?: string;
+        /** Labels for the available sort modes. */
+        sortLabels?: Record<DistributionSortOption, string>;
         /** Invoked with the new config when the user clicks Apply. */
         onApply: (config: DistributionConfig) => void;
     }
 
-    let { open = $bindable(), allClasses, config, showCountMode = true, onApply }: Props = $props();
+    let {
+        open = $bindable(),
+        allClasses,
+        items,
+        config,
+        showCountMode = true,
+        itemNounPlural = 'classes',
+        sortLabels = DISTRIBUTION_SORT_LABELS,
+        onApply
+    }: Props = $props();
 
-    const sortItems: SelectItem[] = (
-        Object.keys(DISTRIBUTION_SORT_LABELS) as DistributionSortOption[]
-    ).map((value) => ({ value, label: DISTRIBUTION_SORT_LABELS[value] }));
+    const sortItems = $derived<SelectItem[]>(
+        (Object.keys(sortLabels) as DistributionSortOption[]).map((value) => ({
+            value,
+            label: sortLabels[value]
+        }))
+    );
 
     const countModeItems: SelectItem[] = [
         { value: AnnotationCountMode.OBJECTS, label: 'Objects' },
@@ -43,11 +61,13 @@
 <ClassSetConfigDialog
     bind:open
     {allClasses}
+    {items}
     selection={config}
     {sortItems}
-    description="Choose which classes the distribution chart shows."
+    description="Choose which {itemNounPlural} the distribution chart shows."
     testIdPrefix="distribution-config"
     showAllButton
+    {itemNounPlural}
     onApply={(selection) =>
         onApply({ ...config, ...selection, countMode: draftCountMode } as DistributionConfig)}
 >

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.test.ts
@@ -45,6 +45,25 @@ describe('DistributionConfigDialog', () => {
         expect(screen.getByTestId('distribution-config-top-n')).toHaveValue(5);
     });
 
+    it('uses metadata value wording and hides count mode when configured', () => {
+        renderDialog({ itemNounPlural: 'values', showCountMode: false });
+
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.getByText('Number of values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+    });
+
+    it('uses value wording in the manual selector', async () => {
+        renderDialog({ itemNounPlural: 'values', showCountMode: false });
+
+        await fireEvent.click(screen.getByRole('tab', { name: 'Manual' }));
+        expect(screen.getByPlaceholderText('Search values...')).toBeInTheDocument();
+        await fireEvent.input(screen.getByPlaceholderText('Search values...'), {
+            target: { value: 'not present' }
+        });
+        expect(screen.getByText('No value found.')).toBeInTheDocument();
+    });
+
     it('does not render its content while closed', () => {
         renderDialog({ open: false });
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
@@ -4,7 +4,12 @@
     import DistributionConfigDialog from '../DistributionConfigDialog/DistributionConfigDialog.svelte';
     import PanelHeader from '../PanelHeader/PanelHeader.svelte';
     import { selectVisibleCounts } from '../selectVisibleCounts';
-    import type { DistributionConfig } from '../types';
+    import type {
+        DistributionConfig,
+        DistributionOrientation,
+        DistributionSortOption
+    } from '../types';
+    import { DISTRIBUTION_SORT_LABELS } from '../types';
 
     interface Props {
         /** Two-way bound flag controlling dialog visibility. */
@@ -15,6 +20,12 @@
         config: DistributionConfig;
         /** Noun for the header summary (e.g. 'annotations', 'samples'). */
         valueNoun?: string;
+        categoryNoun?: string;
+        categoryNounPlural?: string;
+        sortLabels?: Record<DistributionSortOption, string>;
+        showCountMode?: boolean;
+        /** Keeps categorical metadata horizontal while reusing the expanded chart. */
+        fixedOrientation?: DistributionOrientation;
         /** Invoked when the user applies a new config from the expanded view. */
         onConfigChange: (config: DistributionConfig) => void;
         onBarClick?: (item: CategoryCount) => void;
@@ -25,6 +36,11 @@
         data,
         config,
         valueNoun = 'annotations',
+        categoryNoun = 'class',
+        categoryNounPlural = 'classes',
+        sortLabels = DISTRIBUTION_SORT_LABELS,
+        showCountMode = true,
+        fixedOrientation,
         onConfigChange,
         onBarClick
     }: Props = $props();
@@ -37,13 +53,19 @@
 
     const visible = $derived(selectVisibleCounts(data, config));
     const totalCount = $derived(data.reduce((sum, item) => sum + item.count, 0));
+    const orientation = $derived(fixedOrientation ?? config.orientation);
+    const configurationItems = $derived(
+        data.map((item) => ({ value: item.id ?? item.label, label: item.label }))
+    );
 </script>
 
 <Dialog.Root bind:open>
     <Dialog.Content class="flex h-[92vh] max-w-[94vw] flex-col sm:max-w-[94vw]">
         <Dialog.Header>
             <Dialog.Title>Distribution</Dialog.Title>
-            <Dialog.Description>Hover a bar for the full class name and count</Dialog.Description>
+            <Dialog.Description>
+                Hover a bar for the full {categoryNoun} name and count
+            </Dialog.Description>
         </Dialog.Header>
         <PanelHeader
             {config}
@@ -51,13 +73,19 @@
             visibleClassCount={visible.length}
             {totalCount}
             {valueNoun}
+            {categoryNoun}
+            {categoryNounPlural}
+            {sortLabels}
             onConfigure={() => (configDialogOpen = true)}
             onShowAll={() => onConfigChange({ ...config, mode: 'topN', n: data.length })}
-            onToggleOrientation={() =>
-                onConfigChange({
-                    ...config,
-                    orientation: config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
-                })}
+            onToggleOrientation={fixedOrientation
+                ? undefined
+                : () =>
+                      onConfigChange({
+                          ...config,
+                          orientation:
+                              config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
+                      })}
             testIdPrefix="dataset-distribution-expanded"
         />
         <div
@@ -66,7 +94,7 @@
         >
             <BarChart
                 data={visible}
-                orientation={config.orientation}
+                {orientation}
                 maxHeightPx={chartHeight || undefined}
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
@@ -79,6 +107,10 @@
 <DistributionConfigDialog
     bind:open={configDialogOpen}
     allClasses={data.map((item) => item.label)}
+    items={configurationItems}
     {config}
+    {showCountMode}
+    itemNounPlural={categoryNounPlural}
+    {sortLabels}
     onApply={onConfigChange}
 />

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.test.ts
@@ -96,4 +96,27 @@ describe('ExpandDialog', () => {
 
         expect(onConfigChange).toHaveBeenCalledWith({ ...config, orientation: 'horizontal' });
     });
+
+    it('keeps categorical values horizontal and exposes value configuration', async () => {
+        renderDialog({
+            fixedOrientation: 'horizontal',
+            categoryNoun: 'value',
+            categoryNounPlural: 'values',
+            showCountMode: false,
+            sortLabels: { count: 'Count', name: 'Value' }
+        });
+
+        expect(screen.getByText(/values · sorted by count/)).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('dataset-distribution-expanded-toggle-orientation')
+        ).not.toBeInTheDocument();
+        await fireEvent.click(screen.getByTestId('dataset-distribution-expanded-configure'));
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+        };
+        expect(option.yAxis.data).toBeDefined();
+    });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
@@ -19,6 +19,11 @@
         totalCount?: number;
         /** Noun for the total count summary (e.g. 'annotations', 'samples'). */
         valueNoun?: string;
+        /** Singular/plural labels for the distributed categories. */
+        categoryNoun?: string;
+        categoryNounPlural?: string;
+        /** Labels for the active sort mode. */
+        sortLabels?: Record<keyof typeof DISTRIBUTION_SORT_LABELS, string>;
         /** Opens the view-config dialog (top-N and sort order). */
         onConfigure: () => void;
         /** Quick action showing all classes; rendered only while a subset is visible. */
@@ -37,6 +42,9 @@
         visibleClassCount,
         totalCount,
         valueNoun = 'annotations',
+        categoryNoun = 'class',
+        categoryNounPlural = 'classes',
+        sortLabels = DISTRIBUTION_SORT_LABELS,
         onConfigure,
         onShowAll,
         onToggleOrientation,
@@ -49,12 +57,13 @@
     <div class="mb-2 flex-1 text-xs text-muted-foreground">
         {#if visibleClassCount < classCount}
             {config.mode === 'manual' ? 'Showing' : 'Top'}
-            {visibleClassCount} of {classCount} classes
+            {visibleClassCount} of {classCount}
+            {categoryNounPlural}
         {:else}
             {classCount}
-            {classCount === 1 ? 'class' : 'classes'}
+            {classCount === 1 ? categoryNoun : categoryNounPlural}
         {/if}
-        · sorted by {DISTRIBUTION_SORT_LABELS[config.sortBy].toLowerCase()}
+        · sorted by {sortLabels[config.sortBy].toLowerCase()}
         {#if totalCount !== undefined}
             · {totalCount.toLocaleString('en-US')}
             {valueNoun}
@@ -89,7 +98,7 @@
     <Button
         variant="ghost"
         icon={SettingsIcon}
-        ariaLabel="Configure distribution classes"
+        ariaLabel="Configure distribution {categoryNounPlural}"
         buttonProps={{
             size: 'sm',
             class: 'h-8 gap-1',

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
@@ -44,6 +44,21 @@ describe('PanelHeader', () => {
         expect(screen.getByText(/491 samples/)).toBeInTheDocument();
     });
 
+    it('uses custom category wording and sort labels', () => {
+        render(PanelHeader, {
+            props: {
+                ...defaultProps,
+                categoryNoun: 'value',
+                categoryNounPlural: 'values',
+                sortLabels: { count: 'Count', name: 'Value' },
+                config: { ...config, sortBy: 'name' }
+            }
+        });
+
+        expect(screen.getByText(/5 values · sorted by value/)).toBeInTheDocument();
+        expect(screen.getByLabelText('Configure distribution values')).toBeInTheDocument();
+    });
+
     it('shows the "Show all" action only for a visible subset and forwards clicks', async () => {
         const onShowAll = vi.fn();
         render(PanelHeader, {

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.test.ts
@@ -49,6 +49,23 @@ describe('selectVisibleCounts', () => {
         expect(visible.map((item) => item.label)).toEqual(['dog', 'car']);
     });
 
+    it('uses stable ids for manual selections when labels collide', () => {
+        const visible = selectVisibleCounts(
+            [
+                { id: 'literal-missing', label: 'Missing', count: 2 },
+                { id: 'semantic-missing', label: 'Missing', count: 1 }
+            ],
+            {
+                mode: 'manual',
+                n: 1,
+                sortBy: 'count',
+                manualClasses: ['semantic-missing']
+            }
+        );
+
+        expect(visible.map((item) => item.id)).toEqual(['semantic-missing']);
+    });
+
     it('returns nothing when the manual selection is empty', () => {
         const visible = selectVisibleCounts(data, {
             mode: 'manual',
@@ -57,5 +74,18 @@ describe('selectVisibleCounts', () => {
             manualClasses: []
         });
         expect(visible).toEqual([]);
+    });
+
+    it('keeps pinned semantic buckets within a top-N limit', () => {
+        const visible = selectVisibleCounts(
+            [
+                ...data,
+                { label: 'Missing', count: 1, pinned: true },
+                { label: 'Other', count: 2, pinned: true }
+            ],
+            { mode: 'topN', n: 3, sortBy: 'count', manualClasses: [] }
+        );
+
+        expect(visible.map((item) => item.label)).toEqual(['person', 'Other', 'Missing']);
     });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.ts
@@ -16,7 +16,16 @@ export function selectVisibleCounts(
             : a.label.localeCompare(b.label)
     );
     if (config.mode === 'manual') {
-        return sorted.filter((item) => config.manualClasses.includes(item.label));
+        return sorted.filter((item) => config.manualClasses.includes(item.id ?? item.label));
     }
-    return sorted.slice(0, Math.max(config.n, 1));
+    const limit = Math.max(config.n, 1);
+    const pinned = sorted.filter((item) => item.pinned);
+    if (pinned.length === 0) return sorted.slice(0, limit);
+
+    const remainingSlots = Math.max(limit - pinned.length, 0);
+    const selected = new Set([
+        ...pinned,
+        ...sorted.filter((item) => !item.pinned).slice(0, remainingSlots)
+    ]);
+    return sorted.filter((item) => selected.has(item));
 }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -12,6 +12,11 @@ export const DISTRIBUTION_SORT_LABELS: Record<DistributionSortOption, string> = 
     name: 'Class name'
 };
 
+export const CATEGORICAL_DISTRIBUTION_SORT_LABELS: Record<DistributionSortOption, string> = {
+    count: 'Count',
+    name: 'Value'
+};
+
 /** Bar layout for the distribution chart. */
 export type DistributionOrientation = 'vertical' | 'horizontal';
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -852,21 +852,24 @@
                             <QueryEditorPanel onClose={() => setActivePanel('none')} />
                         {:else if distributionPanelVisible}
                             {#await import('$lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte') then { default: DatasetDistributionPanel }}
-                                <DatasetDistributionPanel
-                                    sources={distributionSources}
-                                    initialCountMode={distributionCountMode}
-                                    onClose={() => setActivePanel('none')}
-                                    onCountModeChange={(mode) => {
-                                        distributionCountMode = mode;
-                                    }}
-                                    onHistogramRangeSelect={handleDistributionHistogramRangeSelect}
-                                    onCategoricalValueToggle={handleCategoricalValueToggle}
-                                    onCategoricalValuesClear={clearCategoricalValues}
-                                    onCategoricalRetry={() => categoricalMetadataQuery.refetch()}
-                                    {histogramBinCount}
-                                    onHistogramBinCountChange={(binCount) =>
-                                        (histogramBinCount = binCount)}
-                                />
+                                {#key collectionId}
+                                    <DatasetDistributionPanel
+                                        sources={distributionSources}
+                                        initialCountMode={distributionCountMode}
+                                        onClose={() => setActivePanel('none')}
+                                        onCountModeChange={(mode) => {
+                                            distributionCountMode = mode;
+                                        }}
+                                        onHistogramRangeSelect={handleDistributionHistogramRangeSelect}
+                                        onCategoricalValueToggle={handleCategoricalValueToggle}
+                                        onCategoricalValuesClear={clearCategoricalValues}
+                                        onCategoricalRetry={() =>
+                                            categoricalMetadataQuery.refetch()}
+                                        {histogramBinCount}
+                                        onHistogramBinCountChange={(binCount) =>
+                                            (histogramBinCount = binCount)}
+                                    />
+                                {/key}
                             {/await}
                         {/if}
                     </Pane>


### PR DESCRIPTION
## Summary

Stacked on p5.

**Configuration dialog** (`DistributionConfigDialog`): extended to support `itemNounPlural` and `showCountMode` props so it can be reused for categorical values (renders "Configure values / Number of values" wording instead of the annotation-class default).

**`ManualClassSelector`**: generic item noun props propagated through so the manual selection mode shows "Search values…" / "No value found." for categorical fields.

**`BarChart` types**: adds `orientation` to `BarChartConfig` so config state can persist the user's chosen direction.

**`DatasetDistributionPanel` config + expanded view**:
- Each categorical group gets its own `DistributionConfigDialog` (top-N, sort order, manual value selection)
- `ExpandDialog` renders the full categorical bar chart at a larger size
- `selectVisibleCounts` helper limits displayed bars to the configured top-N

**Feature documentation** (`docs/features/lig-9585-categorical-metadata-distribution-filter.md`): full spec covering the distribution panel, filter interaction, bucket edge cases, and visual states.

## Test plan

- [ ] `make static-checks` (frontend) passes
- [ ] `npm run test:unit` passes (new tests in `ClassSetConfigDialog`, `DistributionConfigDialog`, `ExpandDialog`, `DatasetDistributionPanel`, and `selectVisibleCounts`)
- [ ] Manual: click the gear icon on a categorical bar chart, change top-N, verify the chart updates; click expand, verify the full chart opens

Part of LIG-9585.