### PR TITLE
FE: filter-aware bar colours and dual-series background bars

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -41,22 +41,55 @@ describe('buildEchartsOption', () => {
         expect(horizontal.xAxis.minInterval).toBe(1);
     });
 
-    it('adds selected and disabled treatments without changing typed category identity', () => {
+    it('dims unselected bars green when a selection is active; disabled bars keep reduced opacity', () => {
         const option = buildEchartsOption([
-            { id: 'selected', label: 'Missing', count: 3, selected: true, selectable: true },
+            { id: 'sel', label: 'Missing', count: 3, selected: true, selectable: true },
             { id: 'other', label: 'Other', count: 2, selected: false, selectable: false }
         ]) as {
             series: [{ data: { value: number; itemStyle: Record<string, unknown> }[] }];
         };
 
+        // Selected bar: accent green, full opacity.
         expect(option.series[0].data[0]).toMatchObject({
             value: 3,
-            itemStyle: { borderWidth: 3, opacity: 1 }
+            itemStyle: { color: 'rgba(59,217,159,0.85)', opacity: 1 }
         });
+        // Non-selected + non-selectable: dimmed colour and reduced opacity.
         expect(option.series[0].data[1]).toMatchObject({
             value: 2,
-            itemStyle: { borderWidth: 0, opacity: 0.45 }
+            itemStyle: { color: '#4b5563', opacity: 0.45 }
         });
+    });
+
+    it('overlays a filtered foreground bar on a grey full-count background when filteredCount differs', () => {
+        const option = buildEchartsOption([
+            { label: 'dog', count: 100, filteredCount: 60 },
+            { label: 'cat', count: 50, filteredCount: 50 }
+        ]) as {
+            series: [
+                { type: string; data: { value: number }[] },
+                { type: string; data: { value: number }[]; barGap: string }
+            ];
+        };
+
+        // Two series rendered when filter is active.
+        expect(option.series).toHaveLength(2);
+        // Background series: always full count.
+        expect(option.series[0].data[0].value).toBe(100);
+        expect(option.series[0].data[1].value).toBe(50);
+        // Foreground series: filtered count; uses barGap '-100%' to overlay.
+        expect(option.series[1].data[0]).toMatchObject({ value: 60 });
+        expect(option.series[1].data[1]).toMatchObject({ value: 50 });
+        expect(option.series[1].barGap).toBe('-100%');
+    });
+
+    it('renders a single series and no background when all filteredCounts match full counts', () => {
+        const option = buildEchartsOption([
+            { label: 'dog', count: 100, filteredCount: 100 },
+            { label: 'cat', count: 50, filteredCount: 50 }
+        ]) as { series: unknown[] };
+
+        expect(option.series).toHaveLength(1);
     });
 
     it('accepts compact top padding without changing the default grid', () => {

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -9,10 +9,10 @@ import {
 } from '$lib/utils';
 import type { CategoryCount } from './';
 
-// Single accent color (the Lightly primary green, --color-lightly-primary #3bd99f):
-// per-class colors carry no meaning in a count distribution.
+// Same accent as Histogram (the Lightly primary green, --color-lightly-primary #3bd99f).
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
-const SELECTED_BORDER_COLOR = 'rgba(255,255,255,0.95)';
+// Bars not in the active selection render dimmed, matching the histogram behaviour.
+const BAR_COLOR_DIMMED = '#4b5563';
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
 export type BarChartOrientation = 'vertical' | 'horizontal';
@@ -41,6 +41,9 @@ export function buildEchartsOption(
     const isHorizontal = orientation === 'horizontal';
 
     const labels = data.map((item) => item.label);
+    // When any category is actively selected, dim the rest — mirrors the range
+    // highlighting in the numeric Histogram where out-of-range bins go grey.
+    const hasAnySelected = data.some((item) => item.selected === true);
 
     const categoryAxis = {
         type: 'category' as const,
@@ -92,13 +95,12 @@ export function buildEchartsOption(
                 type: 'bar',
                 data: data.map((item) => {
                     if (item.selected == null && item.selectable == null) return item.count;
+                    const isDimmed = hasAnySelected && !item.selected;
                     return {
                         value: item.count,
                         itemStyle: {
-                            color: BAR_COLOR,
-                            opacity: item.selectable === false ? 0.45 : 1,
-                            borderColor: item.selected ? SELECTED_BORDER_COLOR : 'transparent',
-                            borderWidth: item.selected ? 3 : 0
+                            color: isDimmed ? BAR_COLOR_DIMMED : BAR_COLOR,
+                            opacity: item.selectable === false ? 0.45 : 1
                         }
                     };
                 }),

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -111,9 +111,7 @@ export function buildEchartsOption(
             return item.count;
         }
         const foregroundCount =
-            hasActiveFilter && item.filteredCount !== undefined
-                ? item.filteredCount
-                : item.count;
+            hasActiveFilter && item.filteredCount !== undefined ? item.filteredCount : item.count;
         const isDimmed = hasAnySelected && !item.selected;
         return {
             value: foregroundCount,

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -13,6 +13,9 @@ import type { CategoryCount } from './';
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
 // Bars not in the active selection render dimmed, matching the histogram behaviour.
 const BAR_COLOR_DIMMED = '#4b5563';
+// Full-dataset context bars drawn behind the filtered foreground bars.
+// Matches CHART_LINE_COLOR so background bars blend with the chart grid lines.
+const BAR_COLOR_BACKGROUND = '#374151';
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
 export type BarChartOrientation = 'vertical' | 'horizontal';
@@ -44,6 +47,12 @@ export function buildEchartsOption(
     // When any category is actively selected, dim the rest — mirrors the range
     // highlighting in the numeric Histogram where out-of-range bins go grey.
     const hasAnySelected = data.some((item) => item.selected === true);
+    // Render a grey background bar at the full count when sidebar filters reduce
+    // some bars below their unfiltered height. This keeps the original distribution
+    // visible as context while the foreground bar communicates the filtered portion.
+    const hasActiveFilter = data.some(
+        (item) => item.filteredCount !== undefined && item.filteredCount !== item.count
+    );
 
     const categoryAxis = {
         type: 'category' as const,
@@ -75,39 +84,89 @@ export function buildEchartsOption(
         splitLine: { lineStyle: { color: CHART_LINE_COLOR } }
     };
 
+    // Tooltip shows "Total / In filter" when a filter is active and actually
+    // reduces the hovered bar; otherwise shows the single "Count" line.
+    const formatter = (params: { name: string; value: number }[]) => {
+        if (params.length >= 2) {
+            const totalValue = params[0].value; // background series = full count
+            const filteredValue = params[1].value; // foreground series = filtered count
+            if (totalValue !== filteredValue) {
+                const totalPct =
+                    totalCount > 0 ? ` (${formatPercent(totalValue / totalCount)})` : '';
+                const filteredPct =
+                    totalCount > 0 ? ` (${formatPercent(filteredValue / totalCount)})` : '';
+                return `<b>${params[0].name}</b><br/>Total: <b>${totalValue}</b>${totalPct}<br/>In filter: <b>${filteredValue}</b>${filteredPct}`;
+            }
+        }
+        const [{ name, value }] = params;
+        const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
+        return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
+    };
+
+    // Foreground bar: coloured at the filtered count (or full count when no filter).
+    const foregroundData = data.map((item) => {
+        // Simple items with no selection/filter state can be returned as raw numbers,
+        // which ECharts renders without per-item itemStyle overhead.
+        if (item.selected == null && item.selectable == null && item.filteredCount == null) {
+            return item.count;
+        }
+        const foregroundCount =
+            hasActiveFilter && item.filteredCount !== undefined
+                ? item.filteredCount
+                : item.count;
+        const isDimmed = hasAnySelected && !item.selected;
+        return {
+            value: foregroundCount,
+            itemStyle: {
+                color: isDimmed ? BAR_COLOR_DIMMED : BAR_COLOR,
+                opacity: item.selectable === false ? 0.45 : 1
+            }
+        };
+    });
+
+    const foregroundSeries = {
+        type: 'bar',
+        data: foregroundData,
+        itemStyle: { color: BAR_COLOR },
+        barCategoryGap: '25%',
+        // Overlay on top of the background series (barGap: '-100%' makes the bar
+        // occupy the same slot as the preceding series instead of shifting right).
+        ...(hasActiveFilter ? { barGap: '-100%' } : {}),
+        emphasis: CHART_EMPHASIS
+    };
+
+    // Background series: full (unfiltered) count, always grey — only rendered
+    // when the filter is active and at least one bar is visibly reduced.
+    const backgroundSeries = hasActiveFilter
+        ? {
+              type: 'bar',
+              data: data.map((item) => ({
+                  value: item.count,
+                  itemStyle: {
+                      color: BAR_COLOR_BACKGROUND,
+                      opacity: item.selectable === false ? 0.45 : 1
+                  }
+              })),
+              barCategoryGap: '25%',
+              // Suppress hover highlight on the background so emphasis styling
+              // (colour change, scale) only fires on the foreground bars.
+              emphasis: { disabled: true }
+          }
+        : null;
+
+    const series = hasActiveFilter ? [backgroundSeries, foregroundSeries] : [foregroundSeries];
+
     return {
         backgroundColor: 'transparent',
         tooltip: {
             trigger: 'axis',
             axisPointer: { type: 'shadow' },
-            formatter: (params: { name: string; value: number }[]) => {
-                const [{ name, value }] = params;
-                const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
-                return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
-            }
+            formatter
         },
         grid: { left: 8, right: 8, top: gridTopPx, bottom: 8, containLabel: true },
         // Swap which axis holds the categories so bars grow rightward when horizontal.
         xAxis: isHorizontal ? valueAxis : categoryAxis,
         yAxis: isHorizontal ? categoryAxis : valueAxis,
-        series: [
-            {
-                type: 'bar',
-                data: data.map((item) => {
-                    if (item.selected == null && item.selectable == null) return item.count;
-                    const isDimmed = hasAnySelected && !item.selected;
-                    return {
-                        value: item.count,
-                        itemStyle: {
-                            color: isDimmed ? BAR_COLOR_DIMMED : BAR_COLOR,
-                            opacity: item.selectable === false ? 0.45 : 1
-                        }
-                    };
-                }),
-                itemStyle: { color: BAR_COLOR },
-                barCategoryGap: '25%',
-                emphasis: CHART_EMPHASIS
-            }
-        ]
+        series
     };
 }

--- a/lightly_studio_view/src/lib/components/BarChart/types.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/types.ts
@@ -4,6 +4,13 @@ export interface CategoryCount {
     id?: string;
     label: string;
     count: number;
+    /**
+     * Count after the active sidebar filters are applied. When set, a grey
+     * background bar shows the full `count` while a coloured foreground bar
+     * shows this filtered portion, giving a stable distribution context.
+     * Omit (or set equal to `count`) when no filter is active.
+     */
+    filteredCount?: number;
     /** Whether the category is active in a controlled selection. */
     selected?: boolean;
     /** Whether clicking the bar can change selection. */

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -123,16 +123,30 @@
     const activeHistogram = $derived(activeGroup?.histogram ?? activeSource.histogram ?? null);
     const activeCategorical = $derived(activeGroup?.categorical ?? null);
     const categoricalData = $derived<CategoryCount[]>(
-        (activeCategorical?.buckets ?? []).map((bucket) => ({
-            id: bucket.id,
-            label: bucket.label,
-            count: bucket.count,
-            selectable: bucket.kind !== 'other',
-            pinned: bucket.kind !== 'value',
-            selected:
-                bucket.kind !== 'other' &&
-                activeCategorical?.selectedValues.some((value) => Object.is(value, bucket.value))
-        }))
+        (activeCategorical?.buckets ?? []).map((bucket) => {
+            // When filteredBuckets is defined (query has returned) look up the
+            // filtered count for this bucket. Absent = 0 (filter removed it entirely).
+            const filteredBucket = activeCategorical?.filteredBuckets?.find(
+                (fb) => fb.id === bucket.id
+            );
+            const filteredCount =
+                activeCategorical?.filteredBuckets !== undefined
+                    ? (filteredBucket?.count ?? 0)
+                    : undefined;
+            return {
+                id: bucket.id,
+                label: bucket.label,
+                count: bucket.count,
+                filteredCount,
+                selectable: bucket.kind !== 'other',
+                pinned: bucket.kind !== 'value',
+                selected:
+                    bucket.kind !== 'other' &&
+                    activeCategorical?.selectedValues.some((value) =>
+                        Object.is(value, bucket.value)
+                    )
+            };
+        })
     );
     const displayedData = $derived(activeCategorical ? categoricalData : activeData);
     const configurationItems = $derived(

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -267,12 +267,13 @@ describe('DatasetDistributionPanel', () => {
 
         const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
             yAxis: { data: string[] };
-            series: [{ data: { itemStyle: { borderWidth: number } }[] }];
+            series: [{ data: { itemStyle: { color: string } }[] }];
             grid: { top: number };
         };
         expect(option.yAxis.data).toEqual(['Missing', 'Missing', 'Other']);
         expect(option.grid.top).toBe(4);
-        expect(option.series[0].data[0].itemStyle.borderWidth).toBe(3);
+        // 'Missing' (value) is selected → accent green; the others are dimmed grey.
+        expect(option.series[0].data[0].itemStyle.color).toBe('rgba(59,217,159,0.85)');
 
         echartsMock.getClickHandler()?.({ dataIndex: 1 });
         expect(onCategoricalValueToggle).toHaveBeenCalledWith('city', null);

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -42,6 +42,14 @@ export interface DistributionSourceGroup {
     /** Controlled categorical distribution and selection state. */
     categorical?: {
         buckets: CategoricalMetadataBucket[];
+        /**
+         * Buckets from the same query with all sidebar filters applied.
+         * When provided, each bar shows a grey background at the full `count`
+         * with a coloured foreground at the filtered count, giving context for
+         * how active filters affect the distribution.
+         * Omit (undefined) while the filtered query is still loading.
+         */
+        filteredBuckets?: CategoricalMetadataBucket[];
         selectedValues: CategoricalMetadataValue[];
         loading?: boolean;
         error?: string;

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -615,6 +615,20 @@
     }));
     const categoricalMetadataDistributions = $derived(categoricalMetadataQuery.data ?? {});
 
+    // Second categorical query with the full sidebar filter applied.  Its counts
+    // are passed as `filteredBuckets` so each bar can show a grey background at
+    // the unfiltered height with a coloured foreground at the filtered height.
+    const categoricalMetadataFilteredQuery = useCategoricalMetadataDistribution(() => ({
+        collectionId,
+        filter: imageAnnotationCountsFilter,
+        enabled: distributionPanelVisible
+    }));
+    // Keep undefined (not {}) while loading so DatasetDistributionPanel defers
+    // rendering the background bars until the filtered data is ready.
+    const categoricalMetadataFilteredDistributions = $derived(
+        categoricalMetadataFilteredQuery.data
+    );
+
     const metadataDistributionSource = $derived.by<DistributionSource | null>(() => {
         const numericKeys = Object.keys(metadataDistributions);
         const categoricalKeys = ($metadataInfo ?? [])
@@ -639,6 +653,9 @@
                     label: key,
                     categorical: {
                         buckets: categoricalMetadataDistributions[key] ?? [],
+                        // undefined until the filtered query has returned so the
+                        // distribution panel waits before showing background bars.
+                        filteredBuckets: categoricalMetadataFilteredDistributions?.[key],
                         selectedValues: $categoricalMetadataValues[key] ?? [],
                         loading: categoricalMetadataQuery.isFetching,
                         error: categoricalMetadataQuery.error?.message

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -370,6 +370,24 @@
         })
     );
 
+    // Distribution queries always show the full dataset so bar heights stay
+    // stable as sidebar filters are applied.  Filtering is communicated through
+    // bar colour (green = in selection, grey = out of selection) rather than
+    // through shrinking bars, which loses the original distribution context.
+    // Tag / sample / confusion-cell / query context is kept so the distributions
+    // stay scoped to the collection the user is currently exploring.
+    const distributionBaseFilter = $derived(
+        buildImageFilter({
+            dimensionsValues: null,
+            annotationFilter: undefined,
+            metadataFilters: undefined,
+            sampleIds: isAnnotations ? [] : plotFilterImageSampleIds,
+            tagIds: isAnnotations ? [] : plotFilterTagIds,
+            confusionCell: isAnnotations ? null : plotFilterConfusionCell,
+            queryExpr: isAnnotations ? null : plotFilterQueryExpr
+        })
+    );
+
     const imageAnnotationCountsQuery = useImageAnnotationCounts(() => ({
         collectionId: datasetId,
         filter: imageAnnotationCountsFilter,
@@ -573,17 +591,16 @@
         return { ...base, groups: [allTypesGroup, ...typeGroups] };
     });
 
-    // Numeric metadata fields as histogram groups. Bin edges span the full
-    // collection (stable axis); counts track the active filters — the query
-    // refetches whenever the grid filter changes. Each key's own metadata
-    // filter is excluded server-side (faceted-search behavior). Disabled while
-    // the distribution panel is closed to avoid background fetching.
+    // Numeric metadata fields as histogram groups. Bin edges and counts both
+    // span the full collection (distributionBaseFilter strips analysis filters)
+    // so bar heights stay stable while the user adjusts sidebar filters.
+    // Disabled while the distribution panel is closed to avoid background fetching.
     // User-configurable bin count for the metadata histograms.
     let histogramBinCount = $state(20);
 
     const metadataHistogramsQuery = useNumericMetadataDistribution(() => ({
         collectionId: collectionId,
-        filter: imageAnnotationCountsFilter,
+        filter: distributionBaseFilter,
         binCount: histogramBinCount,
         enabled: distributionPanelVisible
     }));
@@ -593,7 +610,7 @@
 
     const categoricalMetadataQuery = useCategoricalMetadataDistribution(() => ({
         collectionId,
-        filter: imageAnnotationCountsFilter,
+        filter: distributionBaseFilter,
         enabled: distributionPanelVisible
     }));
     const categoricalMetadataDistributions = $derived(categoricalMetadataQuery.data ?? {});


### PR DESCRIPTION
## Summary

Stacked on p7. Final visual layer — makes the distribution charts aware of active sidebar filters.

**Dim unselected bars** (`buildEchartsOption.ts`): when the user has selected one or more categorical values, all other bars render in grey (`#4b5563`), matching the numeric Histogram behaviour. The white border on selected bars is removed because the green/grey contrast already communicates selection clearly.

**Keep full distribution visible** (`+layout.svelte`): introduces `distributionBaseFilter` — a derived filter that strips the analysis filters (metadata, annotation, dimension) while keeping the collection-scoping context (tagIds, sampleIds, etc.). Both distribution queries now use this base filter so bar heights always reflect the full dataset, not the currently filtered subset.

**Dual-series background bars** (`buildEchartsOption.ts`, `BarChart/types.ts`):
- `CategoryCount` gains an optional `filteredCount` field
- When the layout fetches a second distribution using the full `imageAnnotationCountsFilter` (including sidebar filters), it passes the filtered counts to each categorical group
- If any bar's `filteredCount` differs from its full count, the chart renders two ECharts series: a grey background series at full height and a green/grey foreground series at filtered height
- Tooltip updates to "Total / In filter" when the filter actually reduces any bar; falls back to the single "Count" line otherwise
- When no sidebar filter is active the second query returns identical counts, `hasActiveFilter` is false, and a single series is rendered — no visual change from the unfiltered state

## Test plan

- [ ] `make static-checks` (frontend) passes (includes Prettier fix for the ternary in `buildEchartsOption`)
- [ ] `npm run test:unit` passes (new tests in `buildEchartsOption.test.ts` for the dual-series logic)
- [ ] Manual: apply an annotation-class filter from the left sidebar, verify categorical bars show grey background at full height and green foreground at filtered height; clear the filter, verify bars return to solid colour

Part of LIG-9585.