### PR TITLE
Improve Fast Track bot comment

### DIFF
--- a/.github/workflows/fast_track_bot.yml
+++ b/.github/workflows/fast_track_bot.yml
@@ -76,4 +76,5 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           GUARDRAIL_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          GUARDRAIL_RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: npm run bot-ci

--- a/fast_track/src/bot/ci.ts
+++ b/fast_track/src/bot/ci.ts
@@ -28,7 +28,9 @@ async function main(env: NodeJS.ProcessEnv): Promise<void> {
         requiredGuardrailNames: guardrails
             .filter((guardrail) => guardrail.required)
             .map((guardrail) => guardrail.name),
-        verdict
+        verdict,
+        // Trusted, from the workflow_run event — the run where the guardrails ran.
+        runUrl: env.GUARDRAIL_RUN_URL
     });
     console.log(JSON.stringify(result));
 }

--- a/fast_track/src/bot/comment.test.ts
+++ b/fast_track/src/bot/comment.test.ts
@@ -22,16 +22,41 @@ function verdict(overrides: Partial<Verdict> = {}): Verdict {
 
 describe('renderComment', () => {
     it('renders pass, fail, and opt-out states', () => {
-        expect(renderComment(verdict(), HEAD_SHA)).toContain('✅ Fast Track');
+        expect(renderComment(verdict(), HEAD_SHA)).toContain('✅&nbsp; Fast Track');
         expect(renderComment(verdict({ verdict: 'fail', reason: 'failed' }), HEAD_SHA)).toContain(
-            '❌ Fast Track: checks did not pass\n\nfailed'
+            '❌&nbsp; Fast Track: checks did not pass'
         );
         expect(
             renderComment(
                 verdict({ verdict: 'opt_out', reason: 'Author opted out.', guardrails: [] }),
                 HEAD_SHA
             )
-        ).toContain('⏭️ Fast Track skipped');
+        ).toContain('⏭️&nbsp; Fast Track skipped');
+    });
+
+    it('keeps the fail reason out of the header but surfaces the opt-out reason', () => {
+        expect(
+            renderComment(verdict({ verdict: 'fail', reason: 'lint failed' }), HEAD_SHA)
+        ).not.toContain('lint failed');
+        expect(
+            renderComment(
+                verdict({ verdict: 'opt_out', reason: 'Author opted out.', guardrails: [] }),
+                HEAD_SHA
+            )
+        ).toContain('Author opted out.');
+    });
+
+    it('links the guardrail run when a URL is given', () => {
+        const url = 'https://github.com/lightly-ai/lightly-studio/actions/runs/123';
+        expect(renderComment(verdict(), HEAD_SHA, url)).toContain(`(${url})`);
+        expect(renderComment(verdict(), HEAD_SHA)).not.toContain('View the guardrail run');
+    });
+
+    it('always includes the local-repro hint', () => {
+        expect(renderComment(verdict(), HEAD_SHA)).toContain('make run-guardrails');
+        expect(renderComment(verdict({ verdict: 'fail', reason: 'x' }), HEAD_SHA)).toContain(
+            'make run-guardrails'
+        );
     });
 
     it('renders guardrails safely in a Markdown table', () => {

--- a/fast_track/src/bot/comment.ts
+++ b/fast_track/src/bot/comment.ts
@@ -3,9 +3,9 @@ import type { Verdict } from '../shared/verdict';
 
 const COMMENT_MARKER = '<!-- fast-track-bot -->';
 const HEADLINES: Record<Verdict['verdict'], string> = {
-    pass: '✅ Fast Track: all required checks passed — auto-approved.',
-    fail: '❌ Fast Track: checks did not pass',
-    opt_out: '⏭️ Fast Track skipped — deferring to human review'
+    pass: '✅&nbsp; Fast Track: all required checks passed — auto-approved.',
+    fail: '❌&nbsp; Fast Track: checks did not pass',
+    opt_out: '⏭️&nbsp; Fast Track skipped — deferring to human review'
 };
 
 interface UpsertCommentParams {
@@ -18,9 +18,9 @@ interface UpsertCommentParams {
 }
 
 /** Render the human-visible part of the bot's single status comment. */
-export function renderComment(verdict: Verdict, headSha: string): string {
+export function renderComment(verdict: Verdict, headSha: string, runUrl?: string): string {
     const lines = [`### ${HEADLINES[verdict.verdict]}`];
-    if (verdict.verdict !== 'pass' && verdict.reason !== undefined) {
+    if (verdict.verdict === 'opt_out' && verdict.reason !== undefined) {
         lines.push('', verdict.reason);
     }
 
@@ -35,6 +35,16 @@ export function renderComment(verdict: Verdict, headSha: string): string {
             );
         }
     }
+
+    if (runUrl !== undefined) {
+        lines.push('', `[View the guardrail run](${runUrl})`);
+    }
+
+    lines.push(
+        '',
+        'To run the guardrails locally, from `fast_track/` run `make install` once, then ' +
+            '`make run-guardrails` (or `GUARDRAILS=<name1>,<name2> make run-guardrails` for some guardrails).'
+    );
 
     lines.push('', `<sub>Reflects \`${headSha.slice(0, 7)}\`.</sub>`);
     return lines.join('\n');

--- a/fast_track/src/bot/run-bot.ts
+++ b/fast_track/src/bot/run-bot.ts
@@ -14,6 +14,8 @@ interface RunBotParams {
     guardrailsSucceeded: boolean;
     requiredGuardrailNames: readonly string[];
     verdict: unknown;
+    /** URL of the guardrail run that produced the verdict, linked in the comment. */
+    runUrl?: string;
 }
 
 export type BotResult =
@@ -34,7 +36,7 @@ export async function runBot(params: RunBotParams): Promise<BotResult> {
     const verdict = effectiveVerdict(params, target);
     return verdict.verdict === 'pass'
         ? applyPass(params, target, verdict, actionParams)
-        : applyFailure(target, verdict, actionParams);
+        : applyFailure(params, target, verdict, actionParams);
 }
 
 /**
@@ -102,24 +104,26 @@ async function applyPass(
         return { status: 'dismissed', prNumber: target.prNumber };
     }
 
-    await updateStatusComment(verdict, finalTarget.headSha, actionParams);
+    await updateStatusComment(verdict, finalTarget.headSha, params.runUrl, actionParams);
     return { status: 'approved', prNumber: finalTarget.prNumber };
 }
 
 async function applyFailure(
+    params: RunBotParams,
     target: BotTarget,
     verdict: Verdict,
     actionParams: BotActionParams
 ): Promise<BotResult> {
     await dismissApproval(actionParams);
-    await updateStatusComment(verdict, target.headSha, actionParams);
+    await updateStatusComment(verdict, target.headSha, params.runUrl, actionParams);
     return { status: 'dismissed', prNumber: target.prNumber };
 }
 
 async function updateStatusComment(
     verdict: Verdict,
     headSha: string,
+    runUrl: string | undefined,
     params: Omit<Parameters<typeof upsertComment>[0], 'body'>
 ): Promise<void> {
-    await upsertComment({ ...params, body: renderComment(verdict, headSha) });
+    await upsertComment({ ...params, body: renderComment(verdict, headSha, runUrl) });
 }


### PR DESCRIPTION
## What has changed and why?

Makes the Fast Track bot's PR comment more useful:

- Links the guardrail CI run that produced the verdict.
- Adds a hint (shown for every verdict) on how to run the guardrails locally via `make`.
- Drops the failure reason from the header, since it just repeats the failing guardrail's row in the table.

## How has it been tested?

`make static-checks` and `make test` in `fast_track/`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)