### PR TITLE
Analytics: Track Dataset Exploration workflow events in PostHog

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -5,6 +5,7 @@
     type SearchImage = { name: string; previewUrl: string };
 
     interface Props {
+        collectionId: string;
         canSelectAll: boolean;
         isSelectionActive: boolean;
         isImages: boolean;
@@ -23,6 +24,7 @@
     }
 
     const {
+        collectionId,
         canSelectAll,
         isSelectionActive,
         isImages,
@@ -54,7 +56,7 @@
     {/snippet}
     {#snippet auxControls()}
         {#if isImages}
-            <OrderBy datasetId={collectionDatasetId} />
+            <OrderBy {collectionId} datasetId={collectionDatasetId} />
         {/if}
     {/snippet}
     {#if hasMediaWithEmbeddings}

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -39,6 +39,7 @@ vi.mock('$lib/hooks/useFileDrop/useFileDrop', () => ({
 import DatasetGridHeader from './DatasetGridHeader.svelte';
 
 const defaultProps = {
+    collectionId: 'col1',
     canSelectAll: false,
     isSelectionActive: false,
     isImages: false,

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { SortDirection } from '$lib/api/lightly_studio_local';
     import { useOrderBy } from '$lib/hooks/useOrderBy/useOrderBy';
-    import { useGlobalStorage } from '$lib/hooks';
+    import { useGlobalStorage, usePostHog } from '$lib/hooks';
     import { Select, type SelectItem } from '$lib/components/Select';
     import { Button } from '$lib/components/ui/button';
     import { Tooltip } from '$lib/components/ui/tooltip';
@@ -15,6 +15,7 @@
     const { collectionId, datasetId }: Props = $props();
 
     const { textEmbedding } = useGlobalStorage();
+    const { trackEvent } = usePostHog();
     const isSimilaritySearchActive = $derived(!!$textEmbedding);
 
     const {
@@ -70,6 +71,9 @@
             triggerLabel={$selectedLabel ?? undefined}
             allowDeselect
             onValueChange={handleValueChange}
+            onOpenChange={(open) => {
+                if (open) trackEvent('sort_by_opened', { collection_id: collectionId });
+            }}
             disabled={isSimilaritySearchActive}
             placeholder="Sort by"
             size="xs"

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
@@ -8,10 +8,11 @@
     import { ArrowDown, ArrowUp } from '@lucide/svelte';
 
     interface Props {
+        collectionId: string;
         datasetId: string;
     }
 
-    const { datasetId }: Props = $props();
+    const { collectionId, datasetId }: Props = $props();
 
     const { textEmbedding } = useGlobalStorage();
     const isSimilaritySearchActive = $derived(!!$textEmbedding);
@@ -24,7 +25,7 @@
         handleFieldClick,
         toggleDirection,
         dispose
-    } = useOrderBy({ datasetId });
+    } = useOrderBy({ collectionId, datasetId });
 
     $effect(() => {
         return () => dispose();

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
@@ -25,7 +25,7 @@
         handleFieldClick,
         toggleDirection,
         dispose
-    } = useOrderBy({ collectionId, datasetId });
+    } = useOrderBy({ collectionId: () => collectionId, datasetId });
 
     $effect(() => {
         return () => dispose();

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.test.ts
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.test.ts
@@ -58,13 +58,13 @@ describe('OrderBy', () => {
     });
 
     it('shows placeholder text when no field is selected', () => {
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).toHaveTextContent('Sort by');
     });
 
     it('shows a tooltip on hover over the sort trigger', async () => {
         const user = userEvent.setup();
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.hover(screen.getByTestId('sort-by-trigger'));
 
@@ -80,12 +80,12 @@ describe('OrderBy', () => {
                 is_numeric: false
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).toHaveTextContent('file name');
     });
 
     it('direction button is disabled when no field is selected', () => {
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-direction-button')).toBeDisabled();
     });
 
@@ -98,7 +98,7 @@ describe('OrderBy', () => {
                 is_numeric: false
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-direction-button')).not.toBeDisabled();
     });
 
@@ -112,7 +112,7 @@ describe('OrderBy', () => {
                 is_numeric: false
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.hover(screen.getByTestId('sort-direction-button'));
 
@@ -129,7 +129,7 @@ describe('OrderBy', () => {
                 is_numeric: false
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.hover(screen.getByTestId('sort-direction-button'));
 
@@ -138,7 +138,7 @@ describe('OrderBy', () => {
 
     it('selects a field and calls updateSortBy with asc direction by default', async () => {
         const user = userEvent.setup();
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-file_name'));
@@ -163,7 +163,7 @@ describe('OrderBy', () => {
                 is_numeric: false
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-file_name'));
@@ -181,7 +181,7 @@ describe('OrderBy', () => {
                 is_numeric: false
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-width'));
@@ -205,7 +205,7 @@ describe('OrderBy', () => {
                 is_numeric: false
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await fireEvent.click(screen.getByTestId('sort-direction-button'));
 
@@ -228,7 +228,7 @@ describe('OrderBy', () => {
                 is_numeric: false
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await fireEvent.click(screen.getByTestId('sort-direction-button'));
 
@@ -243,7 +243,7 @@ describe('OrderBy', () => {
     });
 
     it('does not call updateSortBy when direction button is clicked with no field selected', async () => {
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await fireEvent.click(screen.getByTestId('sort-direction-button'));
 
@@ -252,7 +252,7 @@ describe('OrderBy', () => {
 
     it('lists all sort fields in the dropdown', async () => {
         const user = userEvent.setup();
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
 
@@ -271,7 +271,7 @@ describe('OrderBy', () => {
             { name: 'label', type: 'string' },
             { name: 'active', type: 'boolean' }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
 
@@ -290,7 +290,7 @@ describe('OrderBy', () => {
             { name: 'nested', type: 'dict' },
             { name: 'score', type: 'float' }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
 
@@ -302,7 +302,7 @@ describe('OrderBy', () => {
     it('selects a numeric metadata field with is_numeric true', async () => {
         const user = userEvent.setup();
         mocks.metadataInfoValue = [{ name: 'score', type: 'float' }];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-score'));
@@ -320,7 +320,7 @@ describe('OrderBy', () => {
     it('selects a string metadata field with is_numeric false', async () => {
         const user = userEvent.setup();
         mocks.metadataInfoValue = [{ name: 'category', type: 'string' }];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-category'));
@@ -345,7 +345,7 @@ describe('OrderBy', () => {
                 is_numeric: true
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).toHaveTextContent('metadata.brightness');
     });
 
@@ -359,7 +359,7 @@ describe('OrderBy', () => {
                 is_numeric: true
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await fireEvent.click(screen.getByTestId('sort-direction-button'));
 
@@ -384,7 +384,7 @@ describe('OrderBy', () => {
                 ]
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
 
@@ -400,7 +400,7 @@ describe('OrderBy', () => {
                 metrics: [{ metric_name: 'precision', min_value: 0, max_value: 1 }]
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-run1-precision'));
@@ -431,7 +431,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-run1-precision'));
@@ -448,13 +448,13 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).toHaveTextContent('run1.precision');
     });
 
     it('disables the sort select when text embedding is active', () => {
         mocks.textEmbeddingValue = { embedding: [0.1, 0.2], queryText: 'dogs' };
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).toBeDisabled();
     });
 
@@ -468,13 +468,13 @@ describe('OrderBy', () => {
                 is_numeric: false
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-direction-button')).toBeDisabled();
     });
 
     it('enables the sort select when text embedding is inactive', () => {
         mocks.textEmbeddingValue = undefined;
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).not.toBeDisabled();
     });
 
@@ -487,7 +487,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { datasetId: 'ds1' } });
+        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await fireEvent.click(screen.getByTestId('sort-direction-button'));
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
@@ -3,6 +3,7 @@
     import { Select, SelectMenuItem } from '$lib/components/Select';
     import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
     import { usePlotColorByType } from './usePlotColorByType/usePlotColorByType';
+    import { usePostHog } from '$lib/hooks/usePostHog';
 
     interface Props {
         collectionId: string;
@@ -24,6 +25,7 @@
     const { metadataInfo } = useMetadataFilters(collectionId);
     const { selectedColorByType, setSelectedColorByType, clearSelectedColorByType } =
         usePlotColorByType(collectionId);
+    const { trackEvent } = usePostHog();
 
     const colorableFields = $derived(
         ($metadataInfo ?? []).filter((field) => supportedTypes.has(field.type))
@@ -75,6 +77,10 @@
         if (value === '' || value === NO_COLOR_BY) {
             clearSelectedColorByType();
             onSelectedKeyChange(null);
+            trackEvent('embedding_color_by_changed', {
+                collection_id: collectionId,
+                color_by_type: null
+            });
             return;
         }
 
@@ -84,12 +90,24 @@
         if (option.type === 'tags') {
             setSelectedColorByType('tags');
             onSelectedKeyChange(null);
+            trackEvent('embedding_color_by_changed', {
+                collection_id: collectionId,
+                color_by_type: 'tag'
+            });
         } else if (option.type === 'annotation_label') {
             setSelectedColorByType('annotation_label');
             onSelectedKeyChange(null);
+            trackEvent('embedding_color_by_changed', {
+                collection_id: collectionId,
+                color_by_type: 'annotation_label'
+            });
         } else {
             setSelectedColorByType('metadata');
             onSelectedKeyChange(option.fieldName);
+            trackEvent('embedding_color_by_changed', {
+                collection_id: collectionId,
+                color_by_type: 'metadata_field'
+            });
         }
     };
 </script>

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
@@ -3,7 +3,7 @@
     import { Select, SelectMenuItem } from '$lib/components/Select';
     import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
     import { usePlotColorByType } from './usePlotColorByType/usePlotColorByType';
-    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { usePostHog } from '$lib/hooks';
 
     interface Props {
         collectionId: string;

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
@@ -73,6 +73,14 @@
         return 'Color by';
     });
 
+    const handleOpenChange = (open: boolean) => {
+        if (!open) return;
+        trackEvent('color_by_opened', {
+            collection_id: collectionId,
+            current_color_by: $selectedColorByType
+        });
+    };
+
     const handleValueChange = (value: string) => {
         if (value === '' || value === NO_COLOR_BY) {
             clearSelectedColorByType();
@@ -92,7 +100,7 @@
             onSelectedKeyChange(null);
             trackEvent('embedding_color_by_changed', {
                 collection_id: collectionId,
-                color_by_type: 'tag'
+                color_by_type: 'tags'
             });
         } else if (option.type === 'annotation_label') {
             setSelectedColorByType('annotation_label');
@@ -106,7 +114,7 @@
             onSelectedKeyChange(option.fieldName);
             trackEvent('embedding_color_by_changed', {
                 collection_id: collectionId,
-                color_by_type: 'metadata_field'
+                color_by_type: 'metadata'
             });
         }
     };
@@ -118,6 +126,7 @@
     value={selectValue}
     allowDeselect
     onValueChange={handleValueChange}
+    onOpenChange={handleOpenChange}
     size="xs"
     class="w-48"
     testId="plot-color-by-button"

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
@@ -95,28 +95,17 @@
         const option = colorByOptions[Number(value)];
         if (!option) return;
 
-        if (option.type === 'tags') {
-            setSelectedColorByType('tags');
-            onSelectedKeyChange(null);
-            trackEvent('embedding_color_by_changed', {
-                collection_id: collectionId,
-                color_by_type: 'tags'
-            });
-        } else if (option.type === 'annotation_label') {
-            setSelectedColorByType('annotation_label');
-            onSelectedKeyChange(null);
-            trackEvent('embedding_color_by_changed', {
-                collection_id: collectionId,
-                color_by_type: 'annotation_label'
-            });
-        } else {
+        if (option.type === 'metadata') {
             setSelectedColorByType('metadata');
             onSelectedKeyChange(option.fieldName);
-            trackEvent('embedding_color_by_changed', {
-                collection_id: collectionId,
-                color_by_type: 'metadata'
-            });
+        } else {
+            setSelectedColorByType(option.type);
+            onSelectedKeyChange(null);
         }
+        trackEvent('embedding_color_by_changed', {
+            collection_id: collectionId,
+            color_by_type: option.type
+        });
     };
 </script>
 

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
-    import Button from '$lib/components/ui/button/button.svelte';
+    import { Button } from '$lib/components/ui/button';
     import {
         EmbeddingView,
         type Point,
@@ -36,7 +36,7 @@
     import { usePlotColorBy } from './usePlotColorBy/usePlotColorBy';
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
     import { useSelectedAnnotationsFilter } from '$lib/hooks/useAnnotationsFilter/useAnnotationsFilter';
-    import { writable } from 'svelte/store';
+    import { writable, get } from 'svelte/store';
     import { usePostHog } from '$lib/hooks';
 
     let { collectionId }: { collectionId: string } = $props();
@@ -146,7 +146,10 @@
         toggleCategoryVisibility,
         focusCategoryVisibility,
         resetCategoryVisibility
-    } = useCategoryVisibility();
+    } = useCategoryVisibility({
+        getCollectionId: () => collectionId,
+        getColorByType: () => get(selectedColorByType)
+    });
 
     // The backend re-ranks color slots per request, so a stale toggle would hide the wrong slot;
     // reset hidden categories on every legend change. EXCLUDED keeps its meaning, so it always
@@ -392,7 +395,14 @@
             pendingSelectionType = null;
             return;
         }
-        pendingSelectionType = isRectangleSelection(selection) ? 'rectangle' : 'lasso';
+        const nextType = isRectangleSelection(selection) ? 'rectangle' : 'lasso';
+        if (pendingSelectionType === null) {
+            trackEvent('embedding_selection_started', {
+                collection_id: collectionId,
+                selection_type: nextType
+            });
+        }
+        pendingSelectionType = nextType;
         const normalizedSelection = isRectangleSelection(selection)
             ? getPolygonFromRectangle(selection)
             : selection;

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -37,8 +37,10 @@
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
     import { useSelectedAnnotationsFilter } from '$lib/hooks/useAnnotationsFilter/useAnnotationsFilter';
     import { writable } from 'svelte/store';
+    import { usePostHog } from '$lib/hooks/usePostHog';
 
     let { collectionId }: { collectionId: string } = $props();
+    const { trackEvent } = usePostHog();
     const { setShowEmbeddingPlot, getRangeSelection, setRangeSelectionForCollection } =
         useGlobalStorage();
     const rangeSelection = getRangeSelection(collectionId);
@@ -253,8 +255,16 @@
                 }
             } else if (!isEqual($selectedSampleIds, currentSampleIds)) {
                 videoFilters.updateSampleIds($selectedSampleIds);
+                if (pendingSelectionType) {
+                    trackEvent('embedding_selection_made', {
+                        collection_id: collectionId,
+                        selection_type: pendingSelectionType,
+                        selected_count: selectedCount
+                    });
+                }
             }
             setRangeSelection(null);
+            pendingSelectionType = null;
             return;
         }
 
@@ -262,8 +272,16 @@
             clearRegion();
         } else {
             commitRegion(polygon, selectedCount);
+            if (pendingSelectionType) {
+                trackEvent('embedding_selection_made', {
+                    collection_id: collectionId,
+                    selection_type: pendingSelectionType,
+                    selected_count: selectedCount
+                });
+            }
         }
         setRangeSelection(null);
+        pendingSelectionType = null;
     };
 
     let plotContainer: HTMLDivElement | null = $state(null);
@@ -325,6 +343,8 @@
         return selection !== null && !Array.isArray(selection);
     };
 
+    let pendingSelectionType = $state<'lasso' | 'rectangle' | null>(null);
+
     const getPolygonFromRectangle = (rect: Rectangle) => {
         return [
             { x: rect.xMin, y: rect.yMin },
@@ -369,8 +389,10 @@
         // we clear selection
         if (!selection && $rangeSelection) {
             clearSelection();
+            pendingSelectionType = null;
             return;
         }
+        pendingSelectionType = isRectangleSelection(selection) ? 'rectangle' : 'lasso';
         const normalizedSelection = isRectangleSelection(selection)
             ? getPolygonFromRectangle(selection)
             : selection;

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -37,7 +37,7 @@
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
     import { useSelectedAnnotationsFilter } from '$lib/hooks/useAnnotationsFilter/useAnnotationsFilter';
     import { writable } from 'svelte/store';
-    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { usePostHog } from '$lib/hooks';
 
     let { collectionId }: { collectionId: string } = $props();
     const { trackEvent } = usePostHog();

--- a/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.test.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.test.ts
@@ -4,7 +4,10 @@ import { useCategoryVisibility } from './useCategoryVisibility';
 
 describe('useCategoryVisibility', () => {
     it('toggles hidden categories', () => {
-        const { hiddenCategories, toggleCategoryVisibility } = useCategoryVisibility();
+        const { hiddenCategories, toggleCategoryVisibility } = useCategoryVisibility({
+            getCollectionId: () => 'col_1',
+            getColorByType: () => null
+        });
 
         toggleCategoryVisibility(2);
         expect(get(hiddenCategories)).toEqual(new Set([2]));
@@ -14,7 +17,10 @@ describe('useCategoryVisibility', () => {
     });
 
     it('focuses one category and restores all categories on a second focus', () => {
-        const { hiddenCategories, focusCategoryVisibility } = useCategoryVisibility();
+        const { hiddenCategories, focusCategoryVisibility } = useCategoryVisibility({
+            getCollectionId: () => 'col_1',
+            getColorByType: () => null
+        });
         const categories = [2, 3, 4];
 
         focusCategoryVisibility(categories, 3);
@@ -26,7 +32,7 @@ describe('useCategoryVisibility', () => {
 
     it('preserves a hidden reserved row through both isolate branches', () => {
         const { hiddenCategories, toggleCategoryVisibility, focusCategoryVisibility } =
-            useCategoryVisibility();
+            useCategoryVisibility({ getCollectionId: () => 'col_1', getColorByType: () => null });
         // Colored isolate universe; reserved row 1 lives outside it.
         const categories = [3, 4, 5];
 
@@ -43,7 +49,7 @@ describe('useCategoryVisibility', () => {
 
     it('resets hidden categories', () => {
         const { hiddenCategories, resetCategoryVisibility, toggleCategoryVisibility } =
-            useCategoryVisibility();
+            useCategoryVisibility({ getCollectionId: () => 'col_1', getColorByType: () => null });
 
         toggleCategoryVisibility(4);
         resetCategoryVisibility();
@@ -53,7 +59,7 @@ describe('useCategoryVisibility', () => {
 
     it('preserves requested reserved rows on reset while clearing remapped color slots', () => {
         const { hiddenCategories, resetCategoryVisibility, toggleCategoryVisibility } =
-            useCategoryVisibility();
+            useCategoryVisibility({ getCollectionId: () => 'col_1', getColorByType: () => null });
 
         toggleCategoryVisibility(1); // reserved row, stable by index
         toggleCategoryVisibility(4); // color slot, remapped on refresh

--- a/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.ts
+++ b/lightly_studio_view/src/lib/components/PlotPanel/useCategoryVisibility/useCategoryVisibility.ts
@@ -1,4 +1,11 @@
-import { writable, type Readable } from 'svelte/store';
+import { writable, get, type Readable } from 'svelte/store';
+import { usePostHog } from '$lib/hooks';
+import type { PlotColorByType } from '../PlotColorByPopover/usePlotColorByType/usePlotColorByType';
+
+interface UseCategoryVisibilityParams {
+    getCollectionId: () => string;
+    getColorByType: () => PlotColorByType | null;
+}
 
 interface UseCategoryVisibilityReturn {
     hiddenCategories: Readable<Set<number>>;
@@ -10,7 +17,11 @@ interface UseCategoryVisibilityReturn {
 /**
  * Tracks hidden plot categories and exposes focused visibility helpers for the PlotPanel.
  */
-export const useCategoryVisibility = (): UseCategoryVisibilityReturn => {
+export const useCategoryVisibility = ({
+    getCollectionId,
+    getColorByType
+}: UseCategoryVisibilityParams): UseCategoryVisibilityReturn => {
+    const { trackEvent } = usePostHog();
     const hiddenCategories = writable(new Set<number>());
 
     const getToggledHiddenCategories = (
@@ -53,12 +64,22 @@ export const useCategoryVisibility = (): UseCategoryVisibilityReturn => {
     };
 
     const toggleCategoryVisibility = (category: number) => {
+        const action = get(hiddenCategories).has(category) ? 'show' : 'hide';
+        trackEvent('legend_category_toggled', {
+            collection_id: getCollectionId(),
+            color_by_type: getColorByType(),
+            action
+        });
         hiddenCategories.update((currentHiddenCategories) =>
             getToggledHiddenCategories(currentHiddenCategories, category)
         );
     };
 
     const focusCategoryVisibility = (categories: number[], category: number) => {
+        trackEvent('legend_category_isolated', {
+            collection_id: getCollectionId(),
+            color_by_type: getColorByType()
+        });
         hiddenCategories.update((currentHiddenCategories) =>
             getFocusedHiddenCategories(currentHiddenCategories, categories, category)
         );

--- a/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.svelte
+++ b/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.svelte
@@ -1,22 +1,29 @@
 <script lang="ts">
     import { cn } from '$lib/utils/shadcn';
     import { useGlobalStorage } from '$lib/hooks';
+    import { usePostHog } from '$lib/hooks/usePostHog';
     import { ChartColumn, ChartNetwork, Gauge, SearchCode } from '@lucide/svelte';
     import { Tooltip } from '$lib/components/ui/tooltip';
 
     type PanelType = Parameters<ReturnType<typeof useGlobalStorage>['setActivePanel']>[0];
 
     interface Props {
+        collectionId: string;
         isImages: boolean;
         hasMediaWithEmbeddings: boolean;
         supportsEvaluation: boolean;
     }
-    const { isImages, hasMediaWithEmbeddings, supportsEvaluation }: Props = $props();
+    const { collectionId, isImages, hasMediaWithEmbeddings, supportsEvaluation }: Props = $props();
 
     const { activePanel, setActivePanel } = useGlobalStorage();
+    const { trackEvent } = usePostHog();
 
     function toggle(panel: PanelType) {
-        setActivePanel($activePanel === panel ? 'none' : panel);
+        const nextPanel = $activePanel === panel ? 'none' : panel;
+        setActivePanel(nextPanel);
+        if (nextPanel !== 'none') {
+            trackEvent('tool_panel_opened', { collection_id: collectionId, panel_type: nextPanel });
+        }
     }
 </script>
 

--- a/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.svelte
+++ b/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { cn } from '$lib/utils/shadcn';
     import { useGlobalStorage } from '$lib/hooks';
-    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { usePostHog } from '$lib/hooks';
     import { ChartColumn, ChartNetwork, Gauge, SearchCode } from '@lucide/svelte';
     import { Tooltip } from '$lib/components/ui/tooltip';
 

--- a/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.svelte
+++ b/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
     import { cn } from '$lib/utils/shadcn';
-    import { useGlobalStorage } from '$lib/hooks';
-    import { usePostHog } from '$lib/hooks';
     import { ChartColumn, ChartNetwork, Gauge, SearchCode } from '@lucide/svelte';
     import { Tooltip } from '$lib/components/ui/tooltip';
-
-    type PanelType = Parameters<ReturnType<typeof useGlobalStorage>['setActivePanel']>[0];
+    import { useSidePanelTabs } from './useSidePanelTabs';
 
     interface Props {
         collectionId: string;
@@ -15,16 +12,7 @@
     }
     const { collectionId, isImages, hasMediaWithEmbeddings, supportsEvaluation }: Props = $props();
 
-    const { activePanel, setActivePanel } = useGlobalStorage();
-    const { trackEvent } = usePostHog();
-
-    function toggle(panel: PanelType) {
-        const nextPanel = $activePanel === panel ? 'none' : panel;
-        setActivePanel(nextPanel);
-        if (nextPanel !== 'none') {
-            trackEvent('tool_panel_opened', { collection_id: collectionId, panel_type: nextPanel });
-        }
-    }
+    const { activePanel, toggle } = useSidePanelTabs({ collectionId });
 </script>
 
 <div class="flex w-14 flex-col gap-2 rounded-xl bg-card p-1.5">
@@ -45,7 +33,7 @@
                 data-testid="side-panel-tabs-embed"
                 aria-label="Embeddings"
                 aria-pressed={$activePanel === 'embeddingPlot'}
-                onclick={() => toggle('embeddingPlot')}
+                onclick={() => toggle($activePanel, 'embeddingPlot')}
             >
                 <ChartNetwork class="size-4" />
                 <span>Embed</span>
@@ -69,7 +57,7 @@
                 data-testid="side-panel-tabs-query"
                 aria-label="Query"
                 aria-pressed={$activePanel === 'queryEditor'}
-                onclick={() => toggle('queryEditor')}
+                onclick={() => toggle($activePanel, 'queryEditor')}
             >
                 <SearchCode class="size-4" />
                 <span>Query</span>
@@ -93,7 +81,7 @@
                 data-testid="side-panel-tabs-eval"
                 aria-label="Evaluation"
                 aria-pressed={$activePanel === 'evaluationRuns'}
-                onclick={() => toggle('evaluationRuns')}
+                onclick={() => toggle($activePanel, 'evaluationRuns')}
             >
                 <Gauge class="size-4" />
                 <span>Eval</span>
@@ -117,7 +105,7 @@
                 data-testid="side-panel-tabs-distribution"
                 aria-label="Distribution"
                 aria-pressed={$activePanel === 'distribution'}
-                onclick={() => toggle('distribution')}
+                onclick={() => toggle($activePanel, 'distribution')}
             >
                 <ChartColumn class="size-4" />
                 <span>Distr</span>

--- a/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.test.ts
+++ b/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.test.ts
@@ -23,46 +23,81 @@ describe('SidePanelTabs', () => {
 
     it('renders the Query button only when isImages is true', () => {
         const { unmount } = render(SidePanelTabs, {
-            props: { isImages: true, hasMediaWithEmbeddings: false, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: true,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: false
+            }
         });
         expect(screen.getByTestId('side-panel-tabs-query')).toBeInTheDocument();
         unmount();
 
         render(SidePanelTabs, {
-            props: { isImages: false, hasMediaWithEmbeddings: false, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: false,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: false
+            }
         });
         expect(screen.queryByTestId('side-panel-tabs-query')).not.toBeInTheDocument();
     });
 
     it('renders the Embed button only when hasMediaWithEmbeddings is true', () => {
         const { unmount } = render(SidePanelTabs, {
-            props: { isImages: false, hasMediaWithEmbeddings: true, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: false,
+                hasMediaWithEmbeddings: true,
+                supportsEvaluation: false
+            }
         });
         expect(screen.getByTestId('side-panel-tabs-embed')).toBeInTheDocument();
         unmount();
 
         render(SidePanelTabs, {
-            props: { isImages: false, hasMediaWithEmbeddings: false, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: false,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: false
+            }
         });
         expect(screen.queryByTestId('side-panel-tabs-embed')).not.toBeInTheDocument();
     });
 
     it('renders the Eval button only when supportsEvaluation is true', () => {
         const { unmount } = render(SidePanelTabs, {
-            props: { isImages: true, hasMediaWithEmbeddings: false, supportsEvaluation: true }
+            props: {
+                collectionId: 'col1',
+                isImages: true,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: true
+            }
         });
         expect(screen.getByTestId('side-panel-tabs-eval')).toBeInTheDocument();
         unmount();
 
         render(SidePanelTabs, {
-            props: { isImages: true, hasMediaWithEmbeddings: false, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: true,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: false
+            }
         });
         expect(screen.queryByTestId('side-panel-tabs-eval')).not.toBeInTheDocument();
     });
 
     it('calls setActivePanel with queryEditor when Query button is clicked', async () => {
         render(SidePanelTabs, {
-            props: { isImages: true, hasMediaWithEmbeddings: false, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: true,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: false
+            }
         });
 
         await fireEvent.click(screen.getByTestId('side-panel-tabs-query'));
@@ -72,7 +107,12 @@ describe('SidePanelTabs', () => {
     it('calls setActivePanel with none when the active Query button is clicked again', async () => {
         activePanel.set('queryEditor');
         render(SidePanelTabs, {
-            props: { isImages: true, hasMediaWithEmbeddings: false, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: true,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: false
+            }
         });
 
         await fireEvent.click(screen.getByTestId('side-panel-tabs-query'));
@@ -81,7 +121,12 @@ describe('SidePanelTabs', () => {
 
     it('calls setActivePanel with embeddingPlot when Embed button is clicked', async () => {
         render(SidePanelTabs, {
-            props: { isImages: false, hasMediaWithEmbeddings: true, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: false,
+                hasMediaWithEmbeddings: true,
+                supportsEvaluation: false
+            }
         });
 
         await fireEvent.click(screen.getByTestId('side-panel-tabs-embed'));
@@ -90,20 +135,35 @@ describe('SidePanelTabs', () => {
 
     it('renders the Distribution button only when isImages is true', () => {
         const { unmount } = render(SidePanelTabs, {
-            props: { isImages: true, hasMediaWithEmbeddings: false, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: true,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: false
+            }
         });
         expect(screen.getByTestId('side-panel-tabs-distribution')).toBeInTheDocument();
         unmount();
 
         render(SidePanelTabs, {
-            props: { isImages: false, hasMediaWithEmbeddings: false, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: false,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: false
+            }
         });
         expect(screen.queryByTestId('side-panel-tabs-distribution')).not.toBeInTheDocument();
     });
 
     it('calls setActivePanel with distribution when the Distribution button is clicked', async () => {
         render(SidePanelTabs, {
-            props: { isImages: true, hasMediaWithEmbeddings: false, supportsEvaluation: false }
+            props: {
+                collectionId: 'col1',
+                isImages: true,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: false
+            }
         });
 
         await fireEvent.click(screen.getByTestId('side-panel-tabs-distribution'));
@@ -112,7 +172,12 @@ describe('SidePanelTabs', () => {
 
     it('calls setActivePanel with evaluationRuns when Eval button is clicked', async () => {
         render(SidePanelTabs, {
-            props: { isImages: true, hasMediaWithEmbeddings: false, supportsEvaluation: true }
+            props: {
+                collectionId: 'col1',
+                isImages: true,
+                hasMediaWithEmbeddings: false,
+                supportsEvaluation: true
+            }
         });
 
         await fireEvent.click(screen.getByTestId('side-panel-tabs-eval'));
@@ -122,7 +187,12 @@ describe('SidePanelTabs', () => {
     it('marks the active panel button with aria-pressed', async () => {
         activePanel.set('embeddingPlot');
         render(SidePanelTabs, {
-            props: { isImages: true, hasMediaWithEmbeddings: true, supportsEvaluation: true }
+            props: {
+                collectionId: 'col1',
+                isImages: true,
+                hasMediaWithEmbeddings: true,
+                supportsEvaluation: true
+            }
         });
 
         expect(screen.getByTestId('side-panel-tabs-embed')).toHaveAttribute('aria-pressed', 'true');

--- a/lightly_studio_view/src/lib/components/SidePanelTabs/useSidePanelTabs.ts
+++ b/lightly_studio_view/src/lib/components/SidePanelTabs/useSidePanelTabs.ts
@@ -1,0 +1,22 @@
+import { useGlobalStorage, usePostHog } from '$lib/hooks';
+
+type PanelType = Parameters<ReturnType<typeof useGlobalStorage>['setActivePanel']>[0];
+
+interface UseSidePanelTabsParams {
+    collectionId: string;
+}
+
+export function useSidePanelTabs({ collectionId }: UseSidePanelTabsParams) {
+    const { activePanel, setActivePanel } = useGlobalStorage();
+    const { trackEvent } = usePostHog();
+
+    function toggle(activePanel: PanelType | 'none', panel: PanelType) {
+        const nextPanel = activePanel === panel ? 'none' : panel;
+        setActivePanel(nextPanel);
+        if (nextPanel !== 'none') {
+            trackEvent('tool_panel_opened', { collection_id: collectionId, panel_type: nextPanel });
+        }
+    }
+
+    return { activePanel, toggle };
+}

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -44,6 +44,7 @@ export { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDi
 export { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
 export { useSettings } from '$lib/hooks/useSettings';
 export { usePostHog } from '$lib/hooks/usePostHog';
+export { useTrackSampleInspected } from '$lib/hooks/useTrackSampleInspected';
 export { useAnnotationClassVisibility } from '$lib/hooks/useAnnotationClassVisibility/useAnnotationClassVisibility';
 export {
     useImageAnnotationCounts,

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -43,6 +43,7 @@ export { useSubmitCombinationSelection } from '$lib/hooks/useSubmitCombinationSe
 export { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
 export { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
 export { useSettings } from '$lib/hooks/useSettings';
+export { usePostHog } from '$lib/hooks/usePostHog';
 export { useAnnotationClassVisibility } from '$lib/hooks/useAnnotationClassVisibility/useAnnotationClassVisibility';
 export {
     useImageAnnotationCounts,

--- a/lightly_studio_view/src/lib/hooks/useImageUpload/useImageUpload.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageUpload/useImageUpload.test.ts
@@ -88,7 +88,8 @@ describe('useImageUpload', () => {
         expect(get(upload.previewUrl)).toBe('blob:preview-url');
         expect(onSuccess).toHaveBeenCalledWith({
             fileName: 'image.png',
-            embedding: [1, 2, 3]
+            embedding: [1, 2, 3],
+            collectionId: 'collection-id'
         });
         expect(onError).not.toHaveBeenCalled();
     });

--- a/lightly_studio_view/src/lib/hooks/useImageUpload/useImageUpload.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageUpload/useImageUpload.ts
@@ -5,6 +5,7 @@ import { get, readonly, writable, type Readable } from 'svelte/store';
 type UploadSuccessResult = {
     fileName: string;
     embedding: number[];
+    collectionId: string;
 };
 
 type UseImageUploadParams = {
@@ -108,7 +109,7 @@ export function useImageUpload({
             });
 
             setPreview(file.name, URL.createObjectURL(file));
-            onSuccess({ fileName: file.name, embedding });
+            onSuccess({ fileName: file.name, embedding, collectionId });
         } catch (error: unknown) {
             clear();
             const message = error instanceof Error ? error.message : 'Failed to upload image';

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.test.ts
@@ -32,7 +32,7 @@ describe('useOrderBy', () => {
 
     describe('selectedDirection', () => {
         it('returns ASC when no sort is active', () => {
-            const { selectedDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { selectedDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
             expect(get(selectedDirection)).toBe(SortDirection.ASC);
         });
 
@@ -45,14 +45,14 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { selectedDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { selectedDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
             expect(get(selectedDirection)).toBe(SortDirection.DESC);
         });
     });
 
     describe('selectedLabel', () => {
         it('returns null when no sort is active', () => {
-            const { selectedLabel } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
             expect(get(selectedLabel)).toBeNull();
         });
 
@@ -65,7 +65,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
             expect(get(selectedLabel)).toBe('file name');
         });
 
@@ -87,7 +87,7 @@ describe('useOrderBy', () => {
                     is_numeric: true
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
             expect(get(selectedLabel)).toBe('metadata.brightness');
         });
 
@@ -109,14 +109,14 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
             expect(get(selectedLabel)).toBe('run1.precision');
         });
     });
 
     describe('isFieldSelected', () => {
         it('returns false for any field when no sort is active', () => {
-            const { isFieldSelected } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
             const check = get(isFieldSelected);
 
             expect(check({ source: 'image', value: 'file_name', label: 'file name' })).toBe(false);
@@ -131,7 +131,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { isFieldSelected } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
             const check = get(isFieldSelected);
 
             expect(check({ source: 'image', value: 'width', label: 'width' })).toBe(true);
@@ -147,7 +147,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { isFieldSelected } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
             const check = get(isFieldSelected);
 
             expect(
@@ -169,7 +169,7 @@ describe('useOrderBy', () => {
         });
 
         it('updates reactively when imageSortBy changes', () => {
-            const { isFieldSelected } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
             const field = { source: 'image' as const, value: 'width', label: 'width' };
 
             expect(get(isFieldSelected)(field)).toBe(false);
@@ -189,7 +189,7 @@ describe('useOrderBy', () => {
 
     describe('handleFieldClick', () => {
         it('selects an image field with ASC direction by default', () => {
-            const { handleFieldClick } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
 
             handleFieldClick({ source: 'image', value: 'file_name', label: 'file name' });
 
@@ -212,7 +212,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { handleFieldClick } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
 
             handleFieldClick({ source: 'image', value: 'file_name', label: 'file name' });
 
@@ -228,7 +228,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { handleFieldClick } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
 
             handleFieldClick({ source: 'image', value: 'width', label: 'width' });
 
@@ -243,7 +243,7 @@ describe('useOrderBy', () => {
         });
 
         it('sets is_numeric true for numeric metadata fields', () => {
-            const { handleFieldClick } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
 
             handleFieldClick({
                 source: 'metadata',
@@ -263,7 +263,7 @@ describe('useOrderBy', () => {
         });
 
         it('selects an evaluation metric field', () => {
-            const { handleFieldClick } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
 
             handleFieldClick({
                 source: 'evaluation_metric',
@@ -285,7 +285,7 @@ describe('useOrderBy', () => {
 
     describe('toggleDirection', () => {
         it('does nothing when no sort is active', () => {
-            const { toggleDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
 
             toggleDirection();
 
@@ -301,7 +301,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { toggleDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
 
             toggleDirection();
             expect(updateSortBy).toHaveBeenCalledWith([
@@ -341,7 +341,7 @@ describe('useOrderBy', () => {
                     is_numeric: true
                 }
             ]);
-            const { toggleDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
 
             toggleDirection();
 
@@ -364,7 +364,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { toggleDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
 
             toggleDirection();
 

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.test.ts
@@ -32,7 +32,7 @@ describe('useOrderBy', () => {
 
     describe('selectedDirection', () => {
         it('returns ASC when no sort is active', () => {
-            const { selectedDirection } = useOrderBy({ datasetId: 'ds1' });
+            const { selectedDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
             expect(get(selectedDirection)).toBe(SortDirection.ASC);
         });
 
@@ -45,14 +45,14 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { selectedDirection } = useOrderBy({ datasetId: 'ds1' });
+            const { selectedDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
             expect(get(selectedDirection)).toBe(SortDirection.DESC);
         });
     });
 
     describe('selectedLabel', () => {
         it('returns null when no sort is active', () => {
-            const { selectedLabel } = useOrderBy({ datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
             expect(get(selectedLabel)).toBeNull();
         });
 
@@ -65,7 +65,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
             expect(get(selectedLabel)).toBe('file name');
         });
 
@@ -87,7 +87,7 @@ describe('useOrderBy', () => {
                     is_numeric: true
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
             expect(get(selectedLabel)).toBe('metadata.brightness');
         });
 
@@ -109,14 +109,14 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
             expect(get(selectedLabel)).toBe('run1.precision');
         });
     });
 
     describe('isFieldSelected', () => {
         it('returns false for any field when no sort is active', () => {
-            const { isFieldSelected } = useOrderBy({ datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
             const check = get(isFieldSelected);
 
             expect(check({ source: 'image', value: 'file_name', label: 'file name' })).toBe(false);
@@ -131,7 +131,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { isFieldSelected } = useOrderBy({ datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
             const check = get(isFieldSelected);
 
             expect(check({ source: 'image', value: 'width', label: 'width' })).toBe(true);
@@ -147,7 +147,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { isFieldSelected } = useOrderBy({ datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
             const check = get(isFieldSelected);
 
             expect(
@@ -169,7 +169,7 @@ describe('useOrderBy', () => {
         });
 
         it('updates reactively when imageSortBy changes', () => {
-            const { isFieldSelected } = useOrderBy({ datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
             const field = { source: 'image' as const, value: 'width', label: 'width' };
 
             expect(get(isFieldSelected)(field)).toBe(false);
@@ -189,7 +189,7 @@ describe('useOrderBy', () => {
 
     describe('handleFieldClick', () => {
         it('selects an image field with ASC direction by default', () => {
-            const { handleFieldClick } = useOrderBy({ datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
 
             handleFieldClick({ source: 'image', value: 'file_name', label: 'file name' });
 
@@ -212,7 +212,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { handleFieldClick } = useOrderBy({ datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
 
             handleFieldClick({ source: 'image', value: 'file_name', label: 'file name' });
 
@@ -228,7 +228,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { handleFieldClick } = useOrderBy({ datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
 
             handleFieldClick({ source: 'image', value: 'width', label: 'width' });
 
@@ -243,7 +243,7 @@ describe('useOrderBy', () => {
         });
 
         it('sets is_numeric true for numeric metadata fields', () => {
-            const { handleFieldClick } = useOrderBy({ datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
 
             handleFieldClick({
                 source: 'metadata',
@@ -263,7 +263,7 @@ describe('useOrderBy', () => {
         });
 
         it('selects an evaluation metric field', () => {
-            const { handleFieldClick } = useOrderBy({ datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
 
             handleFieldClick({
                 source: 'evaluation_metric',
@@ -285,7 +285,7 @@ describe('useOrderBy', () => {
 
     describe('toggleDirection', () => {
         it('does nothing when no sort is active', () => {
-            const { toggleDirection } = useOrderBy({ datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
 
             toggleDirection();
 
@@ -301,7 +301,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { toggleDirection } = useOrderBy({ datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
 
             toggleDirection();
             expect(updateSortBy).toHaveBeenCalledWith([
@@ -341,7 +341,7 @@ describe('useOrderBy', () => {
                     is_numeric: true
                 }
             ]);
-            const { toggleDirection } = useOrderBy({ datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
 
             toggleDirection();
 
@@ -364,7 +364,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { toggleDirection } = useOrderBy({ datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({ collectionId: 'col1', datasetId: 'ds1' });
 
             toggleDirection();
 

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.test.ts
@@ -32,7 +32,10 @@ describe('useOrderBy', () => {
 
     describe('selectedDirection', () => {
         it('returns ASC when no sort is active', () => {
-            const { selectedDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { selectedDirection } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
             expect(get(selectedDirection)).toBe(SortDirection.ASC);
         });
 
@@ -45,7 +48,10 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { selectedDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { selectedDirection } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
             expect(get(selectedDirection)).toBe(SortDirection.DESC);
         });
     });
@@ -116,7 +122,10 @@ describe('useOrderBy', () => {
 
     describe('isFieldSelected', () => {
         it('returns false for any field when no sort is active', () => {
-            const { isFieldSelected } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
             const check = get(isFieldSelected);
 
             expect(check({ source: 'image', value: 'file_name', label: 'file name' })).toBe(false);
@@ -131,7 +140,10 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { isFieldSelected } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
             const check = get(isFieldSelected);
 
             expect(check({ source: 'image', value: 'width', label: 'width' })).toBe(true);
@@ -147,7 +159,10 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { isFieldSelected } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
             const check = get(isFieldSelected);
 
             expect(
@@ -169,7 +184,10 @@ describe('useOrderBy', () => {
         });
 
         it('updates reactively when imageSortBy changes', () => {
-            const { isFieldSelected } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { isFieldSelected } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
             const field = { source: 'image' as const, value: 'width', label: 'width' };
 
             expect(get(isFieldSelected)(field)).toBe(false);
@@ -189,7 +207,10 @@ describe('useOrderBy', () => {
 
     describe('handleFieldClick', () => {
         it('selects an image field with ASC direction by default', () => {
-            const { handleFieldClick } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
 
             handleFieldClick({ source: 'image', value: 'file_name', label: 'file name' });
 
@@ -212,7 +233,10 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { handleFieldClick } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
 
             handleFieldClick({ source: 'image', value: 'file_name', label: 'file name' });
 
@@ -228,7 +252,10 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { handleFieldClick } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
 
             handleFieldClick({ source: 'image', value: 'width', label: 'width' });
 
@@ -243,7 +270,10 @@ describe('useOrderBy', () => {
         });
 
         it('sets is_numeric true for numeric metadata fields', () => {
-            const { handleFieldClick } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
 
             handleFieldClick({
                 source: 'metadata',
@@ -263,7 +293,10 @@ describe('useOrderBy', () => {
         });
 
         it('selects an evaluation metric field', () => {
-            const { handleFieldClick } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { handleFieldClick } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
 
             handleFieldClick({
                 source: 'evaluation_metric',
@@ -285,7 +318,10 @@ describe('useOrderBy', () => {
 
     describe('toggleDirection', () => {
         it('does nothing when no sort is active', () => {
-            const { toggleDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
 
             toggleDirection();
 
@@ -301,7 +337,10 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { toggleDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
 
             toggleDirection();
             expect(updateSortBy).toHaveBeenCalledWith([
@@ -341,7 +380,10 @@ describe('useOrderBy', () => {
                     is_numeric: true
                 }
             ]);
-            const { toggleDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
 
             toggleDirection();
 
@@ -364,7 +406,10 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { toggleDirection } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { toggleDirection } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: 'ds1'
+            });
 
             toggleDirection();
 

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
@@ -122,7 +122,12 @@ export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOr
                   };
         updateSortBy([next]);
         const { sort_source, field_name } = sortExprAnalytics(next);
-        trackEvent('grid_sorted', { collection_id: collectionId(), sort_source, field_name, direction });
+        trackEvent('grid_sorted', {
+            collection_id: collectionId(),
+            sort_source,
+            field_name,
+            direction
+        });
     }
 
     function toggleDirection() {
@@ -133,7 +138,12 @@ export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOr
         const next: SortExpr = { ...current, direction };
         updateSortBy([next]);
         const { sort_source, field_name } = sortExprAnalytics(next);
-        trackEvent('grid_sorted', { collection_id: collectionId(), sort_source, field_name, direction });
+        trackEvent('grid_sorted', {
+            collection_id: collectionId(),
+            sort_source,
+            field_name,
+            direction
+        });
     }
 
     return {

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
@@ -11,7 +11,7 @@ import {
 import type { SortExpr } from '$lib/hooks/useImagesInfinite/types';
 
 interface UseOrderByParams {
-    collectionId: string;
+    collectionId: () => string;
     datasetId: string;
 }
 
@@ -106,7 +106,7 @@ export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOr
                 }
             ]);
             trackEvent('grid_sorted', {
-                collection_id: collectionId,
+                collection_id: collectionId(),
                 sort_source: 'evaluation_metric',
                 field_name: `${field.evaluation_run_name}.${field.metric_name}`,
                 direction: get(selectedDirection)
@@ -121,7 +121,7 @@ export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOr
                 }
             ]);
             trackEvent('grid_sorted', {
-                collection_id: collectionId,
+                collection_id: collectionId(),
                 sort_source: sortSource(field),
                 field_name: field.value,
                 direction: get(selectedDirection)
@@ -154,7 +154,7 @@ export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOr
             ]);
         }
         trackEvent('grid_sorted', {
-            collection_id: collectionId,
+            collection_id: collectionId(),
             sort_source:
                 current.source === 'evaluation_metric'
                     ? 'evaluation_metric'

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
@@ -1,7 +1,7 @@
 import { derived, get, type Readable } from 'svelte/store';
 import { SortDirection } from '$lib/api/lightly_studio_local';
 import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
-import { usePostHog } from '$lib/hooks/usePostHog';
+import { usePostHog } from '$lib/hooks';
 import {
     formatEvaluationMetricLabel,
     useSortFields,

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
@@ -42,10 +42,17 @@ function checkIsFieldSelected(field: SortField, current: SortExpr | undefined): 
     );
 }
 
-function sortSource(field: SortField): string {
-    if (field.source === 'evaluation_metric') return 'evaluation_metric';
-    if (field.source === 'metadata') return 'metadata_field';
-    return 'image_field';
+function sortExprAnalytics(expr: SortExpr): { sort_source: string; field_name: string } {
+    if (expr.source === 'evaluation_metric') {
+        return {
+            sort_source: 'evaluation_metric',
+            field_name: `${expr.evaluation_run_name}.${expr.metric_name}`
+        };
+    }
+    return {
+        sort_source: expr.source === 'metadata' ? 'metadata_field' : 'image_field',
+        field_name: expr.field_name
+    };
 }
 
 export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOrderByReturn {
@@ -96,77 +103,37 @@ export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOr
         const current = get(imageSortBy)?.[0];
         if (checkIsFieldSelected(field, current)) {
             updateSortBy(null);
-        } else if (field.source === 'evaluation_metric') {
-            updateSortBy([
-                {
-                    source: 'evaluation_metric',
-                    evaluation_run_name: field.evaluation_run_name,
-                    metric_name: field.metric_name,
-                    direction: get(selectedDirection)
-                }
-            ]);
-            trackEvent('grid_sorted', {
-                collection_id: collectionId(),
-                sort_source: 'evaluation_metric',
-                field_name: `${field.evaluation_run_name}.${field.metric_name}`,
-                direction: get(selectedDirection)
-            });
-        } else {
-            updateSortBy([
-                {
-                    source: field.source,
-                    field_name: field.value,
-                    direction: get(selectedDirection),
-                    is_numeric: field.is_numeric ?? false
-                }
-            ]);
-            trackEvent('grid_sorted', {
-                collection_id: collectionId(),
-                sort_source: sortSource(field),
-                field_name: field.value,
-                direction: get(selectedDirection)
-            });
+            return;
         }
+        const direction = get(selectedDirection);
+        const next: SortExpr =
+            field.source === 'evaluation_metric'
+                ? {
+                      source: 'evaluation_metric',
+                      evaluation_run_name: field.evaluation_run_name,
+                      metric_name: field.metric_name,
+                      direction
+                  }
+                : {
+                      source: field.source,
+                      field_name: field.value,
+                      direction,
+                      is_numeric: field.is_numeric ?? false
+                  };
+        updateSortBy([next]);
+        const { sort_source, field_name } = sortExprAnalytics(next);
+        trackEvent('grid_sorted', { collection_id: collectionId(), sort_source, field_name, direction });
     }
 
     function toggleDirection() {
         const current = get(imageSortBy)?.[0];
         if (!current) return;
-        const next =
+        const direction =
             get(selectedDirection) === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC;
-        if (current.source === 'evaluation_metric') {
-            updateSortBy([
-                {
-                    source: 'evaluation_metric',
-                    evaluation_run_name: current.evaluation_run_name,
-                    metric_name: current.metric_name,
-                    direction: next
-                }
-            ]);
-        } else {
-            updateSortBy([
-                {
-                    source: current.source,
-                    field_name: current.field_name,
-                    direction: next,
-                    is_numeric: current.is_numeric
-                }
-            ]);
-        }
-        trackEvent('grid_sorted', {
-            collection_id: collectionId(),
-            sort_source:
-                current.source === 'evaluation_metric'
-                    ? 'evaluation_metric'
-                    : current.source === 'metadata'
-                      ? 'metadata_field'
-                      : 'image_field',
-            field_name:
-                current.source === 'evaluation_metric'
-                    ? `${current.evaluation_run_name}.${current.metric_name}`
-                    : current.field_name,
-            direction: next
-        });
+        const next: SortExpr = { ...current, direction };
+        updateSortBy([next]);
+        const { sort_source, field_name } = sortExprAnalytics(next);
+        trackEvent('grid_sorted', { collection_id: collectionId(), sort_source, field_name, direction });
     }
 
     return {

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
@@ -1,6 +1,7 @@
 import { derived, get, type Readable } from 'svelte/store';
 import { SortDirection } from '$lib/api/lightly_studio_local';
 import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
+import { usePostHog } from '$lib/hooks/usePostHog';
 import {
     formatEvaluationMetricLabel,
     useSortFields,
@@ -10,6 +11,7 @@ import {
 import type { SortExpr } from '$lib/hooks/useImagesInfinite/types';
 
 interface UseOrderByParams {
+    collectionId: string;
     datasetId: string;
 }
 
@@ -40,9 +42,16 @@ function checkIsFieldSelected(field: SortField, current: SortExpr | undefined): 
     );
 }
 
-export function useOrderBy({ datasetId }: UseOrderByParams): UseOrderByReturn {
+function sortSource(field: SortField): string {
+    if (field.source === 'evaluation_metric') return 'evaluation_metric';
+    if (field.source === 'metadata') return 'metadata_field';
+    return 'image_field';
+}
+
+export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOrderByReturn {
     const { imageSortBy, updateSortBy } = useImageFilters();
     const { allSortFields, dispose } = useSortFields({ datasetId });
+    const { trackEvent } = usePostHog();
 
     const selectedDirection = derived(
         imageSortBy,
@@ -96,6 +105,12 @@ export function useOrderBy({ datasetId }: UseOrderByParams): UseOrderByReturn {
                     direction: get(selectedDirection)
                 }
             ]);
+            trackEvent('grid_sorted', {
+                collection_id: collectionId,
+                sort_source: 'evaluation_metric',
+                field_name: `${field.evaluation_run_name}.${field.metric_name}`,
+                direction: get(selectedDirection)
+            });
         } else {
             updateSortBy([
                 {
@@ -105,6 +120,12 @@ export function useOrderBy({ datasetId }: UseOrderByParams): UseOrderByReturn {
                     is_numeric: field.is_numeric ?? false
                 }
             ]);
+            trackEvent('grid_sorted', {
+                collection_id: collectionId,
+                sort_source: sortSource(field),
+                field_name: field.value,
+                direction: get(selectedDirection)
+            });
         }
     }
 
@@ -132,6 +153,20 @@ export function useOrderBy({ datasetId }: UseOrderByParams): UseOrderByReturn {
                 }
             ]);
         }
+        trackEvent('grid_sorted', {
+            collection_id: collectionId,
+            sort_source:
+                current.source === 'evaluation_metric'
+                    ? 'evaluation_metric'
+                    : current.source === 'metadata'
+                      ? 'metadata_field'
+                      : 'image_field',
+            field_name:
+                current.source === 'evaluation_metric'
+                    ? `${current.evaluation_run_name}.${current.metric_name}`
+                    : current.field_name,
+            direction: next
+        });
     }
 
     return {

--- a/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
+++ b/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
@@ -1,7 +1,7 @@
 import { useImageUpload } from '$lib/hooks/useImageUpload/useImageUpload';
 import { useTextEmbedding } from '$lib/hooks/useTextEmbedding/useTextEmbedding';
 import type { TextEmbedding } from '$lib/hooks/useGlobalStorage';
-import { usePostHog } from '$lib/hooks/usePostHog';
+import { usePostHog } from '$lib/hooks';
 import { toast } from 'svelte-sonner';
 import { derived, readonly, type Readable, type Writable } from 'svelte/store';
 

--- a/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
+++ b/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
@@ -55,10 +55,10 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
     const upload = useImageUpload({
         getCollectionId,
         onError,
-        onSuccess: ({ fileName, embedding: vector }) => {
+        onSuccess: ({ fileName, embedding: vector, collectionId }) => {
             embedding.set({ queryText: fileName, embedding: vector });
             trackEvent('search_executed', {
-                collection_id: getCollectionId(),
+                collection_id: collectionId,
                 search_type: 'image'
             });
         }
@@ -67,10 +67,10 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
     const text = useTextEmbedding({
         getCollectionId,
         onError,
-        onSuccess: ({ queryText, embedding: vector }) => {
+        onSuccess: ({ queryText, embedding: vector, collectionId }) => {
             embedding.set({ queryText, embedding: vector });
             trackEvent('search_executed', {
-                collection_id: getCollectionId(),
+                collection_id: collectionId,
                 search_type: 'text',
                 query_length: queryText.length
             });

--- a/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
+++ b/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
@@ -105,8 +105,7 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
     const setImage = async (file: File) => {
         trackEvent('search_initiated', {
             collection_id: getCollectionId(),
-            search_type: 'image',
-            file_name: file.name
+            search_type: 'image'
         });
         await upload.upload(file);
     };

--- a/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
+++ b/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
@@ -91,11 +91,23 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
         upload.clear();
         if (!input.trim()) {
             embedding.set(undefined);
+        } else {
+            trackEvent('search_initiated', {
+                collection_id: getCollectionId(),
+                search_type: 'text',
+                query_text: input,
+                query_length: input.length
+            });
         }
         await text.embed(input);
     };
 
     const setImage = async (file: File) => {
+        trackEvent('search_initiated', {
+            collection_id: getCollectionId(),
+            search_type: 'image',
+            file_name: file.name
+        });
         await upload.upload(file);
     };
 
@@ -115,6 +127,10 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
             upload.setPreview(imagePreview.name, imagePreview.previewUrl, true);
         }
         embedding.set({ queryText, embedding: vector });
+        trackEvent('search_initiated', {
+            collection_id: getCollectionId(),
+            search_type: 'annotation_crop'
+        });
         trackEvent('search_executed', {
             collection_id: getCollectionId(),
             search_type: 'annotation_crop'

--- a/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
+++ b/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
@@ -1,6 +1,7 @@
 import { useImageUpload } from '$lib/hooks/useImageUpload/useImageUpload';
 import { useTextEmbedding } from '$lib/hooks/useTextEmbedding/useTextEmbedding';
 import type { TextEmbedding } from '$lib/hooks/useGlobalStorage';
+import { usePostHog } from '$lib/hooks/usePostHog';
 import { toast } from 'svelte-sonner';
 import { derived, readonly, type Readable, type Writable } from 'svelte/store';
 
@@ -45,6 +46,8 @@ interface Return {
 }
 
 export function useSearchEmbedding({ getCollectionId, embedding }: Params): Return {
+    const { trackEvent } = usePostHog();
+
     const onError = (message: string) => {
         toast.error('Error', { description: message });
     };
@@ -54,6 +57,10 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
         onError,
         onSuccess: ({ fileName, embedding: vector }) => {
             embedding.set({ queryText: fileName, embedding: vector });
+            trackEvent('search_executed', {
+                collection_id: getCollectionId(),
+                search_type: 'image'
+            });
         }
     });
 
@@ -62,6 +69,11 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
         onError,
         onSuccess: ({ queryText, embedding: vector }) => {
             embedding.set({ queryText, embedding: vector });
+            trackEvent('search_executed', {
+                collection_id: getCollectionId(),
+                search_type: 'text',
+                query_length: queryText.length
+            });
         }
     });
 
@@ -103,6 +115,10 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
             upload.setPreview(imagePreview.name, imagePreview.previewUrl, true);
         }
         embedding.set({ queryText, embedding: vector });
+        trackEvent('search_executed', {
+            collection_id: getCollectionId(),
+            search_type: 'annotation_crop'
+        });
     };
 
     const clear = () => {

--- a/lightly_studio_view/src/lib/hooks/useTextEmbedding/useTextEmbedding.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useTextEmbedding/useTextEmbedding.test.ts
@@ -32,7 +32,8 @@ describe('useTextEmbedding', () => {
         });
         expect(onSuccess).toHaveBeenCalledWith({
             queryText: 'a yellow excavator',
-            embedding: [1, 2, 3]
+            embedding: [1, 2, 3],
+            collectionId: 'collection-id'
         });
     });
 
@@ -110,7 +111,11 @@ describe('useTextEmbedding', () => {
 
         resolveSecond({ data: [2], error: undefined });
         await second;
-        expect(onSuccess).toHaveBeenLastCalledWith({ queryText: 'second', embedding: [2] });
+        expect(onSuccess).toHaveBeenLastCalledWith({
+            queryText: 'second',
+            embedding: [2],
+            collectionId: 'collection-id'
+        });
 
         resolveFirst({ data: [1], error: undefined });
         await first;

--- a/lightly_studio_view/src/lib/hooks/useTextEmbedding/useTextEmbedding.ts
+++ b/lightly_studio_view/src/lib/hooks/useTextEmbedding/useTextEmbedding.ts
@@ -4,6 +4,7 @@ import { writable, type Writable } from 'svelte/store';
 type EmbedSuccessResult = {
     queryText: string;
     embedding: number[];
+    collectionId: string;
 };
 
 type UseTextEmbeddingParams = {
@@ -37,11 +38,12 @@ export function useTextEmbedding({
         const trimmed = text.trim();
         if (!trimmed) return;
 
+        const collectionId = getCollectionId();
         pendingRequests += 1;
         isEmbedding.set(true);
         try {
             const { data, error } = await embedText({
-                path: { collection_id: getCollectionId() },
+                path: { collection_id: collectionId },
                 query: { query_text: trimmed, embedding_model_id: null }
             });
             if (requestId !== latestRequestId) return;
@@ -50,7 +52,7 @@ export function useTextEmbedding({
                 throw new Error(String(errObj.error ?? errObj.message ?? 'Failed to embed text'));
             }
             if (!data) throw new Error('Failed to embed text');
-            onSuccess({ queryText: trimmed, embedding: data });
+            onSuccess({ queryText: trimmed, embedding: data, collectionId });
         } catch (err) {
             if (requestId !== latestRequestId) return;
             const message = err instanceof Error ? err.message : 'Failed to embed text';

--- a/lightly_studio_view/src/lib/hooks/useTrackSampleInspected.ts
+++ b/lightly_studio_view/src/lib/hooks/useTrackSampleInspected.ts
@@ -1,0 +1,19 @@
+import { afterNavigate } from '$app/navigation';
+import { usePostHog } from '$lib/hooks/usePostHog';
+
+type SampleType = 'image' | 'video' | 'video_frame';
+
+export const useTrackSampleInspected = (
+    collectionId: () => string,
+    sampleType: SampleType,
+    isGridRoute: (routeId: string | null) => boolean
+) => {
+    const { trackEvent } = usePostHog();
+    afterNavigate((nav) => {
+        trackEvent('sample_inspected', {
+            collection_id: collectionId(),
+            sample_type: sampleType,
+            opened_from: isGridRoute(nav.from?.route.id ?? null) ? 'grid' : 'direct_url'
+        });
+    });
+};

--- a/lightly_studio_view/src/routes/+layout.svelte
+++ b/lightly_studio_view/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { browser } from '$app/environment';
     import { useSettings } from '$lib/hooks/useSettings';
-    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { usePostHog } from '$lib/hooks';
     import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
     import { onMount } from 'svelte';
     import '../app.css';

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -84,7 +84,7 @@
     import { useSearchEmbedding } from '$lib/hooks/useSearchEmbedding/useSearchEmbedding';
     import { useEvaluationRuns } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
     import { clearAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
-    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { usePostHog } from '$lib/hooks';
     const { data, children } = $props();
     const {
         collection,

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -226,10 +226,7 @@
         }
     }
 
-    afterNavigate((navigation) => {
-        const collectionBasePath = `/datasets/${page.params.dataset_id}/${page.params.collection_type}/${page.params.collection_id}`;
-        if (navigation.from?.url.pathname.startsWith(collectionBasePath)) return;
-
+    afterNavigate(() => {
         trackEvent('collection_opened', {
             dataset_id: collection.dataset_id,
             collection_id: collection.collection_id,

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -226,7 +226,10 @@
         }
     }
 
-    afterNavigate(() => {
+    afterNavigate((navigation) => {
+        const collectionBasePath = `/datasets/${page.params.dataset_id}/${page.params.collection_type}/${page.params.collection_id}`;
+        if (navigation.from?.url.pathname.startsWith(collectionBasePath)) return;
+
         trackEvent('collection_opened', {
             dataset_id: collection.dataset_id,
             collection_id: collection.collection_id,

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -18,6 +18,7 @@
     import Separator from '$lib/components/ui/separator/separator.svelte';
     import { GripVertical, PanelLeftClose, SlidersHorizontal } from '@lucide/svelte';
     import { onDestroy, onMount } from 'svelte';
+    import { afterNavigate } from '$app/navigation';
     import { toStore } from 'svelte/store';
     import { Header } from '$lib/components';
     import MenuDialogHost from '$lib/components/Header/MenuDialogHost.svelte';
@@ -83,6 +84,7 @@
     import { useSearchEmbedding } from '$lib/hooks/useSearchEmbedding/useSearchEmbedding';
     import { useEvaluationRuns } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
     import { clearAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
+    import { usePostHog } from '$lib/hooks/usePostHog';
     const { data, children } = $props();
     const {
         collection,
@@ -112,6 +114,8 @@
         // captures a store reference that never goes stale.
         textEmbedding
     } = useGlobalStorage();
+
+    const { trackEvent } = usePostHog();
 
     const evaluationRunsQuery = useEvaluationRuns(() => ({ datasetId: collection.dataset_id }));
     const evaluationRuns = $derived(evaluationRunsQuery.data ?? []);
@@ -221,6 +225,15 @@
             search.onError(message);
         }
     }
+
+    afterNavigate(() => {
+        trackEvent('collection_opened', {
+            dataset_id: collection.dataset_id,
+            collection_id: collection.collection_id,
+            collection_type: `${collection.sample_type}s`,
+            sample_count: collection.total_sample_count
+        });
+    });
 
     // Setup event handlers for keyboard shortcuts
     onMount(() => {
@@ -729,6 +742,7 @@
                         {/if}
                         <div class="min-w-0 flex-1">
                             <DatasetGridHeader
+                                {collectionId}
                                 {canSelectAll}
                                 isSelectionActive={$selectedCount > 0}
                                 {isImages}
@@ -829,7 +843,12 @@
                 </div>
             {/if}
             {#if isCollectionGrid && (isImages || hasMediaWithEmbeddings)}
-                <SidePanelTabs {isImages} {hasMediaWithEmbeddings} {supportsEvaluation} />
+                <SidePanelTabs
+                    {collectionId}
+                    {isImages}
+                    {hasMediaWithEmbeddings}
+                    {supportsEvaluation}
+                />
             {/if}
             {#if hasEmbeddings}
                 {#await import('$lib/components/FewShotClassifier/CreateClassifierDialog.svelte') then { default: CreateClassifierDialog }}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/[sample_id]/+page.svelte
@@ -13,6 +13,7 @@
     import ViewVideoButton from '$lib/components/ViewVideoButton/ViewVideoButton.svelte';
     import FrameDetailsNavigation from '$lib/components/FrameDetailsNavigation/FrameDetailsNavigation.svelte';
     import { usePostHog } from '$lib/hooks/usePostHog';
+    import { isVideoFramesRoute } from '$lib/routes';
 
     const { data }: { data: PageData } = $props();
     const { collection_id, sampleId } = $derived(data);
@@ -22,7 +23,7 @@
         trackEvent('sample_inspected', {
             collection_id,
             sample_type: 'video_frame',
-            opened_from: nav.from !== null ? 'grid' : 'direct_url'
+            opened_from: isVideoFramesRoute(nav.from?.route.id ?? null) ? 'grid' : 'direct_url'
         });
     });
     const { refetch, videoFrame } = useFrame(() => sampleId);

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/[sample_id]/+page.svelte
@@ -2,7 +2,7 @@
     import { PUBLIC_VIDEOS_FRAMES_MEDIA_URL } from '$env/static/public';
     import type { PageData } from './$types';
     import { type SampleView } from '$lib/api/lightly_studio_local';
-    import { goto, afterNavigate } from '$app/navigation';
+    import { goto } from '$app/navigation';
     import { routeHelpers } from '$lib/routes';
     import FrameDetailsBreadcrumb from '$lib/components/FrameDetailsBreadcrumb/FrameDetailsBreadcrumb.svelte';
     import { useFrame } from '$lib/hooks/useFrame/useFrame';
@@ -12,20 +12,13 @@
     import { page } from '$app/state';
     import ViewVideoButton from '$lib/components/ViewVideoButton/ViewVideoButton.svelte';
     import FrameDetailsNavigation from '$lib/components/FrameDetailsNavigation/FrameDetailsNavigation.svelte';
-    import { usePostHog } from '$lib/hooks';
+    import { useTrackSampleInspected } from '$lib/hooks';
     import { isVideoFramesRoute } from '$lib/routes';
 
     const { data }: { data: PageData } = $props();
     const { collection_id, sampleId } = $derived(data);
 
-    const { trackEvent } = usePostHog();
-    afterNavigate((nav) => {
-        trackEvent('sample_inspected', {
-            collection_id,
-            sample_type: 'video_frame',
-            opened_from: isVideoFramesRoute(nav.from?.route.id ?? null) ? 'grid' : 'direct_url'
-        });
-    });
+    useTrackSampleInspected(() => collection_id, 'video_frame', isVideoFramesRoute);
     const { refetch, videoFrame } = useFrame(() => sampleId);
 
     const sample = $derived(videoFrame.data);

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/[sample_id]/+page.svelte
@@ -2,7 +2,7 @@
     import { PUBLIC_VIDEOS_FRAMES_MEDIA_URL } from '$env/static/public';
     import type { PageData } from './$types';
     import { type SampleView } from '$lib/api/lightly_studio_local';
-    import { goto } from '$app/navigation';
+    import { goto, afterNavigate } from '$app/navigation';
     import { routeHelpers } from '$lib/routes';
     import FrameDetailsBreadcrumb from '$lib/components/FrameDetailsBreadcrumb/FrameDetailsBreadcrumb.svelte';
     import { useFrame } from '$lib/hooks/useFrame/useFrame';
@@ -12,9 +12,19 @@
     import { page } from '$app/state';
     import ViewVideoButton from '$lib/components/ViewVideoButton/ViewVideoButton.svelte';
     import FrameDetailsNavigation from '$lib/components/FrameDetailsNavigation/FrameDetailsNavigation.svelte';
+    import { usePostHog } from '$lib/hooks/usePostHog';
 
     const { data }: { data: PageData } = $props();
     const { collection_id, sampleId } = $derived(data);
+
+    const { trackEvent } = usePostHog();
+    afterNavigate((nav) => {
+        trackEvent('sample_inspected', {
+            collection_id,
+            sample_type: 'video_frame',
+            opened_from: nav.from !== null ? 'grid' : 'direct_url'
+        });
+    });
     const { refetch, videoFrame } = useFrame(() => sampleId);
 
     const sample = $derived(videoFrame.data);

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/[sample_id]/+page.svelte
@@ -12,7 +12,7 @@
     import { page } from '$app/state';
     import ViewVideoButton from '$lib/components/ViewVideoButton/ViewVideoButton.svelte';
     import FrameDetailsNavigation from '$lib/components/FrameDetailsNavigation/FrameDetailsNavigation.svelte';
-    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { usePostHog } from '$lib/hooks';
     import { isVideoFramesRoute } from '$lib/routes';
 
     const { data }: { data: PageData } = $props();

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
@@ -6,6 +6,7 @@
     import GroupsComponentsMenu from '$lib/components/GroupsComponentsMenu/GroupsComponentsMenu.svelte';
     import LayoutCard from '$lib/components/LayoutCard/LayoutCard.svelte';
     import { usePostHog } from '$lib/hooks/usePostHog';
+    import { isImagesRoute } from '$lib/routes';
 
     const { children } = $props();
 
@@ -22,7 +23,7 @@
         trackEvent('sample_inspected', {
             collection_id: collectionId,
             sample_type: collectionType,
-            opened_from: nav.from !== null ? 'grid' : 'direct_url'
+            opened_from: isImagesRoute(nav.from?.route.id ?? null) ? 'grid' : 'direct_url'
         });
     });
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
     import { page } from '$app/state';
+    import { afterNavigate } from '$app/navigation';
     import { createSampleDetailsToolbarContext } from '$lib/contexts/SampleDetailsToolbar.svelte';
     import { ImageDetails } from '$lib/components';
     import GroupsComponentsMenu from '$lib/components/GroupsComponentsMenu/GroupsComponentsMenu.svelte';
     import LayoutCard from '$lib/components/LayoutCard/LayoutCard.svelte';
+    import { usePostHog } from '$lib/hooks/usePostHog';
 
     const { children } = $props();
 
@@ -14,6 +16,15 @@
     const collectionType = $derived(page.params.collection_type);
     const collection = page.data.collection;
     const collectionId = $derived(page.params.collection_id!);
+
+    const { trackEvent } = usePostHog();
+    afterNavigate((nav) => {
+        trackEvent('sample_inspected', {
+            collection_id: collectionId,
+            sample_type: collectionType,
+            opened_from: nav.from !== null ? 'grid' : 'direct_url'
+        });
+    });
 
     const groupId = $derived.by(() => {
         return page.url.searchParams.get('group_id') ?? undefined;

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
@@ -5,7 +5,7 @@
     import { ImageDetails } from '$lib/components';
     import GroupsComponentsMenu from '$lib/components/GroupsComponentsMenu/GroupsComponentsMenu.svelte';
     import LayoutCard from '$lib/components/LayoutCard/LayoutCard.svelte';
-    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { usePostHog } from '$lib/hooks';
     import { isImagesRoute } from '$lib/routes';
 
     const { children } = $props();

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import { page } from '$app/state';
-    import { afterNavigate } from '$app/navigation';
     import { createSampleDetailsToolbarContext } from '$lib/contexts/SampleDetailsToolbar.svelte';
     import { ImageDetails } from '$lib/components';
     import GroupsComponentsMenu from '$lib/components/GroupsComponentsMenu/GroupsComponentsMenu.svelte';
     import LayoutCard from '$lib/components/LayoutCard/LayoutCard.svelte';
-    import { usePostHog } from '$lib/hooks';
+    import { useTrackSampleInspected } from '$lib/hooks';
     import { isImagesRoute } from '$lib/routes';
 
     const { children } = $props();
@@ -18,14 +17,7 @@
     const collection = page.data.collection;
     const collectionId = $derived(page.params.collection_id!);
 
-    const { trackEvent } = usePostHog();
-    afterNavigate((nav) => {
-        trackEvent('sample_inspected', {
-            collection_id: collectionId,
-            sample_type: 'image',
-            opened_from: isImagesRoute(nav.from?.route.id ?? null) ? 'grid' : 'direct_url'
-        });
-    });
+    useTrackSampleInspected(() => collectionId, 'image', isImagesRoute);
 
     const groupId = $derived.by(() => {
         return page.url.searchParams.get('group_id') ?? undefined;

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
@@ -22,7 +22,7 @@
     afterNavigate((nav) => {
         trackEvent('sample_inspected', {
             collection_id: collectionId,
-            sample_type: collectionType,
+            sample_type: 'image',
             opened_from: isImagesRoute(nav.from?.route.id ?? null) ? 'grid' : 'direct_url'
         });
     });

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
@@ -10,8 +10,19 @@
         Separator
     } from '$lib/components';
     import VideoDetailsBreadcrumb from '$lib/components/VideoDetailsBreadcrumb/VideoDetailsBreadcrumb.svelte';
+    import { afterNavigate } from '$app/navigation';
+    import { usePostHog } from '$lib/hooks/usePostHog';
 
     const { data }: { data: PageData } = $props();
+
+    const { trackEvent } = usePostHog();
+    afterNavigate((nav) => {
+        trackEvent('sample_inspected', {
+            collection_id: data.params.collection_id,
+            sample_type: 'video',
+            opened_from: nav.from !== null ? 'grid' : 'direct_url'
+        });
+    });
     const { data: video, isLoading, loadById, error, refetch } = useVideo();
     $effect(() => {
         loadById(data.params.sample_id);

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
@@ -10,20 +10,12 @@
         Separator
     } from '$lib/components';
     import VideoDetailsBreadcrumb from '$lib/components/VideoDetailsBreadcrumb/VideoDetailsBreadcrumb.svelte';
-    import { afterNavigate } from '$app/navigation';
-    import { usePostHog } from '$lib/hooks';
+    import { useTrackSampleInspected } from '$lib/hooks';
     import { isVideosRoute } from '$lib/routes';
 
     const { data }: { data: PageData } = $props();
 
-    const { trackEvent } = usePostHog();
-    afterNavigate((nav) => {
-        trackEvent('sample_inspected', {
-            collection_id: data.params.collection_id,
-            sample_type: 'video',
-            opened_from: isVideosRoute(nav.from?.route.id ?? null) ? 'grid' : 'direct_url'
-        });
-    });
+    useTrackSampleInspected(() => data.params.collection_id, 'video', isVideosRoute);
     const { data: video, isLoading, loadById, error, refetch } = useVideo();
     $effect(() => {
         loadById(data.params.sample_id);

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
@@ -11,7 +11,7 @@
     } from '$lib/components';
     import VideoDetailsBreadcrumb from '$lib/components/VideoDetailsBreadcrumb/VideoDetailsBreadcrumb.svelte';
     import { afterNavigate } from '$app/navigation';
-    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { usePostHog } from '$lib/hooks';
     import { isVideosRoute } from '$lib/routes';
 
     const { data }: { data: PageData } = $props();

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
@@ -12,6 +12,7 @@
     import VideoDetailsBreadcrumb from '$lib/components/VideoDetailsBreadcrumb/VideoDetailsBreadcrumb.svelte';
     import { afterNavigate } from '$app/navigation';
     import { usePostHog } from '$lib/hooks/usePostHog';
+    import { isVideosRoute } from '$lib/routes';
 
     const { data }: { data: PageData } = $props();
 
@@ -20,7 +21,7 @@
         trackEvent('sample_inspected', {
             collection_id: data.params.collection_id,
             sample_type: 'video',
-            opened_from: nav.from !== null ? 'grid' : 'direct_url'
+            opened_from: isVideosRoute(nav.from?.route.id ?? null) ? 'grid' : 'direct_url'
         });
     });
     const { data: video, isLoading, loadById, error, refetch } = useVideo();

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/page.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/page.test.ts
@@ -10,7 +10,8 @@ import type { LayoutLoadResult } from '../../+layout';
 
 vi.mock('$lib/hooks', () => ({
     useVideo: vi.fn(),
-    useCollectionWithChildren: vi.fn()
+    useCollectionWithChildren: vi.fn(),
+    useTrackSampleInspected: vi.fn()
 }));
 
 // Track which components were rendered


### PR DESCRIPTION
## What has changed and why?

Instruments 13 PostHog events that cover the **Dataset Exploration** workflow.

- `collection_opened` - fires on every collection navigation
- `search_executed` - fires on text, image, and annotation-crop search success
- `tool_panel_opened` - fires when any side panel transitions from closed to open
- `embedding_color_by_changed` - fires on every color-by change, including clear (`null`)
- `embedding_selection_made` - fires after a lasso or rectangle selection is committed
- `grid_sorted` - fires on field click and direction toggle; skips the default sort
- `sample_inspected` - fires on mount; derives `opened_from` from navigation referrer
- `sort_by_opened` - fires when the user opens the Sort By dropdown; captures `collection_id`
- `color_by_opened` - fires when the user opens the Color By popover; captures `collection_id` and `current_color_by`
- `embedding_selection_started` - fires when the user begins a lasso or rectangle selection on the embedding plot; captures `collection_id` and `selection_type` (`rectangle` or `lasso`)
- `search_initiated` - fires when the user triggers a similarity search; captures `collection_id` and `search_type` (`text`, `image`, or `annotation_crop`); text searches additionally capture `query_text` and `query_length`, image searches additionally capture `file_name`
- `legend_category_toggled` - fires when the user clicks a legend category to show or hide it; captures `collection_id`, `color_by_type`, and `action` (`show` or `hide`)
- `legend_category_isolated` - fires when the user alt-clicks a legend category to isolate it; captures `collection_id` and `color_by_type`

Image or video filter is not included in this PR.

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Analytics**
  - Added PostHog tracking for collection openings during navigation and for “sample inspected” across image/video/frame routes (including where the user came from).
  - Expanded analytics for embedding/search initiation & completion, color-by popover open/changes, side-panel tool openings, selection started/committed, legend category visibility toggles/isolation, and sort interactions (now collection-aware, including sort source/field/direction).
- **Improvements**
  - Sorting and related controls are now consistently scoped to the active collection/dataset context across the grid header, order-by control, side panel tabs, and dataset routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->