### PR TITLE
FE: extend DatasetDistributionPanel to render categorical distributions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,7 @@ Exceptions from the guidelines:
 - We allow direct function imports from `tests.helpers_resolvers`, `tests.resolvers.video.helpers`, and `tests.resolvers.evaluation_sample_metric_resolver.helpers` in Python
 
 
+
+## AI Team Workflow
+
+For feature work, act as `lead`: read `docs/`, select the needed roles from `.agents/`, create or update a feature specification with a wireframe and decision rationale, implement only the agreed scope, then request independent validation from `quality-engineer`.

--- a/docs/features/lig-9584-categorical-metadata-value-counts.md
+++ b/docs/features/lig-9584-categorical-metadata-value-counts.md
@@ -1,0 +1,237 @@
+# Feature: Categorical Metadata Value Counts
+
+**Status:** Implemented  
+**Linear:** [LIG-9584](https://linear.app/lightly/issue/LIG-9584/backend-categorical-metadata-value-counts-endpoint-5-sp)  
+**Downstream consumer:** [LIG-9585](https://linear.app/lightly/issue/LIG-9585/frontend-categorical-metadata-bar-chart-filter-ui-8-sp)
+
+## Problem and Target User
+
+ML engineers need to understand how categorical metadata such as `city`, `camera_id`, or
+`production_line` is distributed across a dataset. Today the backend exposes metadata schemas and
+numeric histograms, but it cannot aggregate categorical values. The frontend therefore cannot show
+categorical imbalance, reveal missing ingestion data, or populate a categorical filter.
+
+The immediate user of this feature is the frontend engineer building the distribution panel. The
+end user is an ML engineer checking whether production data is balanced and complete before
+training or evaluating a model.
+
+The endpoint must keep high-cardinality fields usable: return the 20 most frequent non-null values,
+aggregate the remaining non-null values, and count missing values separately.
+
+## Proposed User Flow
+
+1. The dataset distribution panel requests categorical value counts for a collection, optionally
+   passing the same active sample filters used by the grid.
+2. The backend discovers categorical fields from the collection's merged metadata schema.
+3. For each categorical field, the backend applies the active filters except filters on that field
+   itself, then groups non-null values and counts missing samples.
+4. The backend returns up to 20 concrete values, an `other_count`, and a `missing_count` for each
+   field.
+5. The frontend labels the semantic aggregate fields as **Other** and **Missing**, renders the
+   distribution, and can use concrete values in its filter control.
+
+## Wireframe
+
+This is a backend-only feature. The wireframe describes the API and data flow rather than a screen.
+
+```text
++--------------------------------------------------------------------------------+
+| POST /collections/{collection_id}/metadata/value-counts                        |
+|--------------------------------------------------------------------------------|
+| Request                                                                        |
+| {                                                                              |
+|   "filters": <ImageFilter, optional>                                           |
+| }                                                                              |
++--------------------------------------+-----------------------------------------+
+                                       |
+                                       v
++--------------------------------------------------------------------------------+
+| Resolve categorical schema fields (string, boolean)                            |
+| For each field:                                                                |
+|   1. remove that field's own metadata filter                                   |
+|   2. apply all remaining sample filters                                        |
+|   3. GROUP BY extracted JSON value + COUNT                                     |
+|   4. keep top 20; sum remainder; count absent/null separately                  |
++--------------------------------------+-----------------------------------------+
+                                       |
+                                       v
++--------------------------------------------------------------------------------+
+| 200 OK                                                                         |
+| {                                                                              |
+|   "city": {                                                                   |
+|     "value_counts": [                                                         |
+|       { "value": "Zurich", "count": 120 },                                  |
+|       { "value": "Berlin", "count": 64 }                                    |
+|     ],                                                                         |
+|     "other_count": 17,                                                        |
+|     "missing_count": 3                                                        |
+|   }                                                                            |
+| }                                                                              |
++--------------------------------------------------------------------------------+
+```
+
+### Meaningful response states
+
+```text
+No categorical fields            Field exists; no matching samples
+{}                               {
+                                   "city": {
+                                     "value_counts": [],
+                                     "other_count": 0,
+                                     "missing_count": 0
+                                   }
+                                 }
+
+All matching samples missing     More than 20 concrete values
+{                                {
+  "city": {                       "camera_id": {
+    "value_counts": [],              "value_counts": [<20 entries>],
+    "other_count": 0,                "other_count": 481,
+    "missing_count": 42               "missing_count": 7
+  }                                  }
+}                                  }
+                                 }
+```
+
+## Content and Interaction
+
+### Proposed contract
+
+- Use `POST /collections/{collection_id}/metadata/value-counts` so callers can provide the same
+  structured `ImageFilter` used by the existing numeric histogram endpoint.
+- The request body is optional. No body means counts for the full collection.
+- Return a mapping keyed by metadata field name, matching the existing
+  `/metadata/histograms` response convention.
+- Each field maps to:
+  - `value_counts`: up to 20 `{value, count}` entries for concrete non-null values;
+  - `other_count`: the sum of concrete values outside the top 20;
+  - `missing_count`: samples where the key is absent or resolves to JSON null.
+- `value` preserves the categorical scalar type (`string` or `boolean`). `count`, `other_count`,
+  and `missing_count` are non-negative integers.
+- `value_counts` is ordered by descending count. Equal counts use a deterministic ascending value
+  order so responses and charts do not move arbitrarily between requests.
+- Top 20 applies only to concrete non-null values. **Other** and **Missing** are additional semantic
+  buckets, so a field can produce at most 22 displayed bars.
+- `other_count` and `missing_count` are always present, including when zero. The frontend may omit
+  zero-height bars from presentation.
+
+### Contract-facing content semantics
+
+- **Missing** means the field is absent from the sample, the sample has no metadata row, or the
+  extracted JSON value is null. It does not mean an empty string, `false`, or the literal string
+  `"Missing"`.
+- **Other** means the sum of all concrete non-null values ranked below the top 20. It is not the
+  literal string `"Other"` and it does not include missing samples.
+- **Missing** and **Other** are presentation labels derived from `missing_count` and `other_count`.
+  They must not be serialized as ordinary `value` entries; a user may legitimately store the
+  strings `"Missing"` or `"Other"`.
+- Every matching sample contributes exactly once per field. For each response field:
+  `sum(value_counts[].count) + other_count + missing_count` equals the number of samples after
+  applicable filters.
+- The field's own metadata filter is excluded while other active filters remain applied. This
+  faceted-search behavior preserves alternative values while the user edits that field and mirrors
+  numeric metadata histograms.
+
+### Validation
+
+- `collection_id` follows the existing metadata endpoint convention; a syntactically valid unknown
+  collection returns an empty mapping.
+- Only scalar categorical schema types are returned. Numeric, list, dict, and complex metadata
+  fields are omitted rather than partially coerced.
+- The top-value limit is fixed at 20 for this scope; the endpoint does not expose a caller-supplied
+  limit.
+
+## States
+
+- **Loading:** The endpoint is a single synchronous HTTP request with no partial/streaming response.
+  The downstream frontend owns loading feedback and may keep prior data visible while refetching.
+- **Empty:** Return `200 {}` when the collection has no categorical fields. Keep known categorical
+  field keys in the response with zero counts when filters match no samples.
+- **Error:** Use existing collection/API error handling for an invalid or inaccessible collection.
+  Database/query failures fail the request as a whole; do not return silently partial field data.
+- **Success:** Return `200` with the field mapping. A field with only missing values has empty
+  `value_counts`, `other_count: 0`, and its full sample total in `missing_count`.
+
+## Responsive and Accessibility Requirements
+
+- Responsive layout does not apply to this backend-only endpoint.
+- The response exposes bucket meaning structurally so clients do not have to infer semantics from
+  English labels, color, position, or capitalization.
+- Counts remain machine-readable integers. The downstream UI is responsible for localized labels,
+  accessible bar names, and non-color-only distinction of Missing and Other.
+
+## Decision Rationale
+
+- **Mirror the numeric histogram endpoint:** A POST request with optional `ImageFilter`, a response
+  keyed by field, and own-field filter exclusion gives the frontend one consistent distribution
+  model.
+- **Return all categorical fields in one request:** The distribution panel can switch fields without
+  issuing a new request, while the server still limits every high-cardinality result.
+- **Separate aggregate counts from concrete values:** Structural `other_count` and `missing_count`
+  avoid collisions with real user values named `"Other"` or `"Missing"` and make filtering intent
+  unambiguous.
+- **Count missing against all collection samples:** An inner join would hide samples with no metadata
+  row and under-report precisely the ingestion failures this feature is intended to reveal.
+- **Use a fixed top 20:** It satisfies the agreed usability/performance bound and avoids adding a
+  tuning control without a demonstrated consumer need.
+- **Order by frequency with deterministic ties:** Most important categories appear first and API
+  snapshots remain stable.
+- **Keep aggregation in SQL:** GROUP BY and COUNT avoid loading per-sample metadata into Python and
+  follow the existing resolver/database boundary for both DuckDB and PostgreSQL.
+
+## Acceptance Criteria
+
+- [x] A collection-level endpoint returns value counts for every scalar categorical metadata field.
+- [x] Unfiltered requests count the full collection; requests with `ImageFilter` count matching
+      samples.
+- [x] For each field, its own metadata filter is excluded while all other active filters apply.
+- [x] A field with 20 or fewer distinct non-null values returns every value with `other_count: 0`.
+- [x] A field with more than 20 distinct non-null values returns exactly the 20 most frequent values
+      and the sum of all remaining values in `other_count`.
+- [x] Top-value ties have a deterministic order and no sample is counted twice or dropped.
+- [x] `missing_count` includes samples with an absent key, explicit JSON null, and no metadata row.
+- [x] Empty strings, `false`, and literal `"Missing"`/`"Other"` values remain concrete values rather
+      than being merged into semantic buckets.
+- [x] Empty collections or collections without categorical metadata return `200 {}`.
+- [x] Known categorical fields remain present with zero counts when active filters match no samples.
+- [x] Numeric and complex metadata fields are not returned by this endpoint.
+- [x] The response models are represented in generated OpenAPI output.
+- [x] Resolver and route tests cover low cardinality, high cardinality, missing values, filtering,
+      own-field filter exclusion, empty results, deterministic ties, and collection isolation.
+- [x] The aggregation works on the supported DuckDB and PostgreSQL JSON extraction paths.
+
+## Non-goals
+
+- Building the bar chart, categorical selector, or checkbox/multi-select UI (LIG-9585).
+- Adding or changing categorical metadata filter operators.
+- Making the Other bucket selectable; it aggregates multiple values and cannot identify a single
+  filter predicate.
+- Adding pagination, search, arbitrary top-N configuration, or returning the full high-cardinality
+  tail.
+- Aggregating list, dict, GPS, datetime, or other complex metadata types.
+- Changing numeric histogram behavior or the existing metadata info endpoint.
+- Persisting precomputed counts or adding a database migration.
+
+## Assumptions and Open Questions
+
+### Assumptions
+
+- Categorical metadata means scalar `string` and `boolean` schema types. Integers and floats remain
+  numeric even when they happen to have few unique values.
+- Top 20 is recomputed from the samples remaining after applicable filters rather than fixed to the
+  collection's unfiltered top 20; this makes the response represent the active dataset view.
+- Missing is based on the total sample population after applicable filters, not only samples that
+  already have a metadata row.
+- Returning every categorical field in one request is acceptable at expected metadata-field counts,
+  consistent with the all-fields numeric histogram endpoint.
+
+### Open questions
+
+- The downstream story requires **Missing** to be filterable, but the current equality filter does
+  not define an explicit absent/null operator. Confirm whether LIG-9585 will add that filter contract
+  or whether a separate backend follow-up is required; it is not part of this counts endpoint.
+- Should boolean metadata be presented through this categorical flow in LIG-9585? This spec includes
+  it because it is a scalar finite category, but the Linear examples mention strings only.
+- If querying all categorical fields proves expensive for collections with many metadata keys,
+  should a later optimization add an optional field selector? It is deliberately omitted from the
+  initial contract.

--- a/lightly_studio/e2e-tests/index_distribution.py
+++ b/lightly_studio/e2e-tests/index_distribution.py
@@ -132,8 +132,9 @@ def _sample_metadata(rng: random.Random) -> Mapping[str, Any]:
         "reviewed": rng.choices([True, False], [0.3, 0.7])[0],
         "camera_id": rng.choices(CAMERA_IDS, CAMERA_WEIGHTS)[0],
     }
+    split_missing_probability = 0.2
     # ~20 % of images have no split — exercises the "Missing" bucket.
-    if rng.random() >= 0.2:
+    if rng.random() >= split_missing_probability:
         metadata["split"] = rng.choices(DATASET_SPLITS, SPLIT_WEIGHTS)[0]
     return metadata
 

--- a/lightly_studio/e2e-tests/index_distribution.py
+++ b/lightly_studio/e2e-tests/index_distribution.py
@@ -7,9 +7,9 @@ seeded (all default to true):
 - ``ADD_OBJECT_DETECTIONS`` a few weighted detection boxes per image
 - ``ADD_SEGMENTATIONS``     one or two weighted segmentation masks per image
 - ``ADD_METADATA``          numeric metadata fields with distinct distribution
-  shapes (bell, flat, skewed, discrete, constant) plus a string field —
-  rendered as histograms in the panel's "Metadata" distribution and above the
-  range sliders in the metadata filter panel
+  shapes (bell, flat, skewed, discrete, constant) plus several categorical
+  fields (string, boolean, many-valued, partially-missing) — rendered as
+  histograms / bar charts in the panel's "Metadata" distribution
 
 Examples::
 
@@ -71,6 +71,20 @@ SEGMENTATION_CLASSES = ["road", "sky", "building", "vegetation", "sidewalk"]
 SEGMENTATION_WEIGHTS = [0.3, 0.25, 0.2, 0.15, 0.1]
 
 LOCATIONS = ["city", "rural", "mountain", "coastal", "desert"]
+LOCATION_WEIGHTS = [0.35, 0.25, 0.20, 0.12, 0.08]
+
+# Skewed weather distribution: sunny dominates, snowy is rare.
+WEATHER_CONDITIONS = ["sunny", "partly_cloudy", "overcast", "rainy", "foggy", "snowy"]
+WEATHER_WEIGHTS = [0.40, 0.25, 0.15, 0.10, 0.07, 0.03]
+
+# Common ML split assignment; ~20 % of samples intentionally left unassigned
+# so the "Missing" bucket appears in the categorical distribution panel.
+DATASET_SPLITS = ["train", "val", "test"]
+SPLIT_WEIGHTS = [0.70, 0.20, 0.10]
+
+# 25 camera IDs: exercises the top-20 "Other" bucket in value-counts.
+CAMERA_IDS = [f"CAM_{i:02d}" for i in range(1, 26)]
+CAMERA_WEIGHTS = [max(1, 26 - i) for i in range(1, 26)]  # CAM_01 most frequent
 
 
 def _box(
@@ -93,16 +107,35 @@ def _rectangle_mask(
 
 
 def _sample_metadata(rng: random.Random) -> Mapping[str, Any]:
-    """Return one sample's metadata, each key with a distinct distribution."""
-    return {
+    """Return one sample's metadata with numeric and categorical fields.
+
+    Numeric fields cover distinct distribution shapes (bell, flat, skewed,
+    discrete, constant).  Categorical fields exercise:
+    - weighted strings with few values  (location, weather)
+    - a boolean field                   (reviewed)
+    - a many-valued string field that   (camera_id — 25 values triggers the
+      overflows the top-20 limit          "Other" bucket in value-counts)
+    - a field present on only ~80 % of  (split — triggers the "Missing" bucket)
+      samples
+    """
+    metadata: dict[str, Any] = {
+        # Numeric fields
         "confidence": min(1.0, max(0.0, rng.gauss(0.75, 0.12))),
         "brightness": rng.uniform(0.0, 255.0),
         "object_size": rng.lognormvariate(3.0, 0.8),
         "temperature": rng.randint(10, 40),
         "num_defects": rng.choices([0, 1, 2, 3, 5, 8], [50, 25, 12, 7, 4, 2])[0],
         "sensor_gain": 1.0,
-        "location": rng.choice(LOCATIONS),
+        # Categorical fields
+        "location": rng.choices(LOCATIONS, LOCATION_WEIGHTS)[0],
+        "weather": rng.choices(WEATHER_CONDITIONS, WEATHER_WEIGHTS)[0],
+        "reviewed": rng.choices([True, False], [0.3, 0.7])[0],
+        "camera_id": rng.choices(CAMERA_IDS, CAMERA_WEIGHTS)[0],
     }
+    # ~20 % of images have no split — exercises the "Missing" bucket.
+    if rng.random() >= 0.2:
+        metadata["split"] = rng.choices(DATASET_SPLITS, SPLIT_WEIGHTS)[0]
+    return metadata
 
 
 def main() -> None:
@@ -171,7 +204,7 @@ def main() -> None:
             ("classifications", ADD_CLASSIFICATIONS),
             ("object detections", ADD_OBJECT_DETECTIONS),
             ("segmentation masks", ADD_SEGMENTATIONS),
-            ("numeric metadata", ADD_METADATA),
+            ("metadata", ADD_METADATA),
         ]
         if enabled
     ]

--- a/lightly_studio/e2e-tests/index_distribution.py
+++ b/lightly_studio/e2e-tests/index_distribution.py
@@ -77,10 +77,14 @@ LOCATION_WEIGHTS = [0.35, 0.25, 0.20, 0.12, 0.08]
 WEATHER_CONDITIONS = ["sunny", "partly_cloudy", "overcast", "rainy", "foggy", "snowy"]
 WEATHER_WEIGHTS = [0.40, 0.25, 0.15, 0.10, 0.07, 0.03]
 
+REVIEWED_VALUES = [True, False]
+REVIEWED_WEIGHTS = [0.3, 0.7]
+
 # Common ML split assignment; ~20 % of samples intentionally left unassigned
 # so the "Missing" bucket appears in the categorical distribution panel.
 DATASET_SPLITS = ["train", "val", "test"]
 SPLIT_WEIGHTS = [0.70, 0.20, 0.10]
+SPLIT_MISSING_PROBABILITY = 0.2
 
 # 25 camera IDs: exercises the top-20 "Other" bucket in value-counts.
 CAMERA_IDS = [f"CAM_{i:02d}" for i in range(1, 26)]
@@ -113,10 +117,8 @@ def _sample_metadata(rng: random.Random) -> Mapping[str, Any]:
     discrete, constant).  Categorical fields exercise:
     - weighted strings with few values  (location, weather)
     - a boolean field                   (reviewed)
-    - a many-valued string field that   (camera_id — 25 values triggers the
-      overflows the top-20 limit          "Other" bucket in value-counts)
-    - a field present on only ~80 % of  (split — triggers the "Missing" bucket)
-      samples
+    - camera_id has 25 values, which triggers the "Other" bucket in value counts
+    - split is present on only ~80 % of samples, which triggers the "Missing" bucket
     """
     metadata: dict[str, Any] = {
         # Numeric fields
@@ -129,12 +131,11 @@ def _sample_metadata(rng: random.Random) -> Mapping[str, Any]:
         # Categorical fields
         "location": rng.choices(LOCATIONS, LOCATION_WEIGHTS)[0],
         "weather": rng.choices(WEATHER_CONDITIONS, WEATHER_WEIGHTS)[0],
-        "reviewed": rng.choices([True, False], [0.3, 0.7])[0],
+        "reviewed": rng.choices(REVIEWED_VALUES, REVIEWED_WEIGHTS)[0],
         "camera_id": rng.choices(CAMERA_IDS, CAMERA_WEIGHTS)[0],
     }
-    split_missing_probability = 0.2
     # ~20 % of images have no split — exercises the "Missing" bucket.
-    if rng.random() >= split_missing_probability:
+    if rng.random() >= SPLIT_MISSING_PROBABILITY:
         metadata["split"] = rng.choices(DATASET_SPLITS, SPLIT_WEIGHTS)[0]
     return metadata
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/metadata.py
@@ -14,9 +14,16 @@ from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.errors import TagNotFoundError
 from lightly_studio.metadata import compute_similarity, compute_typicality
 from lightly_studio.models.collection import CollectionTable
-from lightly_studio.models.metadata import HistogramView, MetadataInfoView
+from lightly_studio.models.metadata import (
+    HistogramView,
+    MetadataInfoView,
+    MetadataValueCountsView,
+)
 from lightly_studio.resolvers import embedding_model_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.resolvers.metadata_resolver.sample import (
+    categorical_value_counts as metadata_value_counts_resolver,
+)
 from lightly_studio.resolvers.metadata_resolver.sample import (
     get_metadata_info as metadata_info_resolver,
 )
@@ -82,6 +89,26 @@ def get_metadata_histograms(
         collection_id=collection_id,
         filters=request.filters if request else None,
         bin_count=request.bin_count if request else _DEFAULT_BIN_COUNT,
+    )
+
+
+class MetadataValueCountsRequest(BaseModel):
+    """Request body for computing filtered categorical value counts."""
+
+    filters: ImageFilter | None = Field(None, description="Filter parameters for samples")
+
+
+@metadata_router.post("/metadata/value-counts", response_model=dict[str, MetadataValueCountsView])
+def get_metadata_value_counts(
+    session: SessionDep,
+    collection_id: Annotated[UUID, Path(title="collection Id")],
+    request: MetadataValueCountsRequest | None = None,
+) -> dict[str, MetadataValueCountsView]:
+    """Compute categorical metadata value counts under optional sample filters."""
+    return metadata_value_counts_resolver.get_metadata_value_counts(
+        session=session,
+        collection_id=collection_id,
+        filters=request.filters if request else None,
     )
 
 

--- a/lightly_studio/src/lightly_studio/database/db_json.py
+++ b/lightly_studio/src/lightly_studio/database/db_json.py
@@ -70,6 +70,22 @@ class json_extract(GenericFunction[Any]):  # noqa: N801
         super().__init__(column)
 
 
+class json_extract_string(GenericFunction[str]):  # noqa: N801
+    """Extract a top-level JSON scalar as plain text.
+
+    The key is bound rather than interpolated into SQL. It is treated literally,
+    so dots and quotes in metadata keys do not become path syntax.
+    """
+
+    inherit_cache = False
+    type = Text()
+
+    def __init__(self, column: Any, field: str) -> None:
+        """Initialize with a JSON column and top-level field name."""
+        field_parameter = sqlalchemy.literal(field, type_=_JsonTopLevelKeyType())
+        super().__init__(column, field_parameter)
+
+
 @compiles(json_extract)
 def _compile_json_extract_unsupported(
     element: json_extract, compiler: SQLCompiler, **kw: Any
@@ -104,6 +120,49 @@ def _compile_json_extract_postgresql(
     return _build_pg_json_accessor(
         column=col_sql, field=element.field, cast_to_float=element.cast_to_float
     )
+
+
+@compiles(json_extract_string)
+def _compile_json_extract_string_unsupported(
+    element: json_extract_string, compiler: SQLCompiler, **kw: Any
+) -> str:
+    """Raise for unsupported dialects."""
+    raise NotImplementedError(
+        f"Unsupported dialect: {compiler.dialect.name}."
+        " Only 'postgresql' and 'duckdb' are supported."
+    )
+
+
+@compiles(json_extract_string, "duckdb")
+def _compile_json_extract_string_duckdb(
+    element: json_extract_string, compiler: SQLCompiler, **kw: Any
+) -> str:
+    """Extract a JSON scalar as plain text on DuckDB."""
+    column, field = element.clauses
+    return f"json_extract_string({compiler.process(column, **kw)}, {compiler.process(field, **kw)})"
+
+
+@compiles(json_extract_string, "postgresql")
+def _compile_json_extract_string_postgresql(
+    element: json_extract_string, compiler: SQLCompiler, **kw: Any
+) -> str:
+    """Extract a JSON scalar as plain text on PostgreSQL."""
+    column, field = element.clauses
+    return f"{compiler.process(column, **kw)}->>{compiler.process(field, **kw)}"
+
+
+class _JsonTopLevelKeyType(TypeDecorator[str]):
+    """Bind a literal top-level JSON key for each supported database."""
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value: str | None, dialect: Dialect) -> str | None:
+        """Convert DuckDB keys to JSON Pointer and leave PostgreSQL keys raw."""
+        if value is None or dialect.name != "duckdb":
+            return value
+        escaped = value.replace("~", "~0").replace("/", "~1")
+        return f"/{escaped}"
 
 
 class _JsonStringType(TypeDecorator[str]):

--- a/lightly_studio/src/lightly_studio/models/metadata.py
+++ b/lightly_studio/src/lightly_studio/models/metadata.py
@@ -208,6 +208,21 @@ class HistogramView(BaseModel):
     counts: list[int] = Field(description="Value count per bin")
 
 
+class MetadataValueCountView(BaseModel):
+    """Count for one concrete categorical metadata value."""
+
+    value: str | bool = Field(description="Categorical metadata value")
+    count: int = Field(description="Number of samples with this value", ge=0)
+
+
+class MetadataValueCountsView(BaseModel):
+    """Top values and aggregate counts for a categorical metadata field."""
+
+    value_counts: list[MetadataValueCountView] = Field(description="Top concrete values")
+    other_count: int = Field(description="Count outside the top values", ge=0)
+    missing_count: int = Field(description="Count of absent or null values", ge=0)
+
+
 class MetadataInfoView(BaseModel):
     """Metadata info response model for API endpoints."""
 

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
@@ -3,7 +3,9 @@
 import operator
 from typing import Any, Callable, Literal, Protocol, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+from pydantic_core import PydanticCustomError
+from sqlalchemy import or_
 from sqlalchemy.sql.elements import ColumnElement
 
 from lightly_studio.database import db_json
@@ -14,7 +16,8 @@ T = TypeVar("T", bound=BaseModel)
 M = TypeVar("M", bound="HasMetadata")
 
 # Valid operators for metadata filtering
-MetadataOperator = Literal[">", "<", "==", ">=", "<=", "!="]
+MetadataComparisonOperator = Literal[">", "<", "==", ">=", "<=", "!="]
+MetadataOperator = Literal[">", "<", "==", ">=", "<=", "!=", "in"]
 
 
 class HasMetadata(Protocol):
@@ -30,6 +33,24 @@ class MetadataFilter(BaseModel):
     key: str
     op: MetadataOperator
     value: Any
+
+    @model_validator(mode="after")
+    def validate_in_value(self) -> "MetadataFilter":  # noqa: N804
+        """Validate the categorical values accepted by the ``in`` operator."""
+        if self.op != "in":
+            return self
+        if not isinstance(self.value, list) or not self.value:
+            raise PydanticCustomError(
+                "metadata_in_value", "'in' metadata filters require a non-empty array."
+            )
+        concrete_types = {type(value) for value in self.value if value is not None}
+        if not concrete_types.issubset({str, bool}) or len(concrete_types) > 1:
+            raise PydanticCustomError(
+                "metadata_in_value",
+                "'in' metadata filter values must be homogeneous strings or booleans, "
+                "optionally including null.",
+            )
+        return self
 
 
 # Ignore PLW1641 because `==` and `!=` create filters here, so this class does
@@ -66,7 +87,9 @@ class Metadata:  # noqa: PLW1641
         return MetadataFilter(key=self.key, op="!=", value=value)
 
 
-_OP_MAP: dict[MetadataOperator, Callable[[ColumnElement[Any], Any], ColumnElement[bool]]] = {
+_OP_MAP: dict[
+    MetadataComparisonOperator, Callable[[ColumnElement[Any], Any], ColumnElement[bool]]
+] = {
     ">": operator.gt,
     "<": operator.lt,
     "==": operator.eq,
@@ -116,13 +139,21 @@ def apply_metadata_filters(
     if not metadata_filters:
         return query
 
-    # Apply the filters using JSON extraction
+    match_missing = any(
+        meta_filter.op == "in" and None in meta_filter.value for meta_filter in metadata_filters
+    )
     query = query.join(
         metadata_model,
         metadata_join_condition,
+        isouter=match_missing,
     )
 
     for meta_filter in metadata_filters:
+        if meta_filter.op == "in":
+            query = query.where(
+                _build_in_condition(metadata_model=metadata_model, metadata_filter=meta_filter)
+            )
+            continue
         extract_expr = db_json.json_extract(
             column=metadata_model.data,
             field=meta_filter.key,
@@ -133,3 +164,23 @@ def apply_metadata_filters(
         query = query.where(condition)
 
     return query
+
+
+def _build_in_condition(
+    metadata_model: type[M], metadata_filter: MetadataFilter
+) -> ColumnElement[bool]:
+    """Build an OR predicate for a validated categorical ``in`` filter."""
+    extract_expr = db_json.json_extract_string(
+        column=metadata_model.data, field=metadata_filter.key
+    )
+    values = [
+        str(value).lower() if isinstance(value, bool) else value
+        for value in metadata_filter.value
+        if value is not None
+    ]
+    conditions: list[ColumnElement[bool]] = []
+    if values:
+        conditions.append(extract_expr.in_(values))
+    if None in metadata_filter.value:
+        conditions.append(extract_expr.is_(None))
+    return or_(*conditions)

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
@@ -1,0 +1,152 @@
+"""Resolver for categorical sample metadata value counts."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import func
+from sqlalchemy.sql.elements import ColumnElement
+from sqlmodel import Session, col, select
+
+from lightly_studio.database import db_json
+from lightly_studio.models.metadata import (
+    MetadataValueCountsView,
+    MetadataValueCountView,
+    SampleMetadataTable,
+)
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers.metadata_resolver.sample import metadata_helpers
+
+if TYPE_CHECKING:
+    from lightly_studio.resolvers.image_filter import ImageFilter
+
+_CATEGORICAL_TYPES = ("string", "boolean")
+_TOP_VALUE_COUNT = 20
+
+
+def get_metadata_value_counts(
+    session: Session,
+    collection_id: UUID,
+    filters: ImageFilter | None = None,
+) -> dict[str, MetadataValueCountsView]:
+    """Count categorical metadata values for a collection.
+
+    Each field's own metadata filter is excluded while all other filters apply.
+    Results contain the 20 most frequent concrete values, with the remaining
+    concrete and missing values counted separately.
+
+    Args:
+        session: The database session.
+        collection_id: The collection whose sample metadata is aggregated.
+        filters: Optional image filters restricting the counted samples.
+
+    Returns:
+        A mapping from categorical metadata keys to their value counts.
+    """
+    schema = metadata_helpers.get_merged_schema(session=session, collection_id=collection_id)
+    result: dict[str, MetadataValueCountsView] = {}
+    for key, metadata_type in schema.items():
+        if metadata_type not in _CATEGORICAL_TYPES:
+            continue
+        field_filters = metadata_helpers.without_metadata_key_filter(
+            filters=filters, metadata_key=key
+        )
+        result[key] = _get_field_value_counts(
+            session=session,
+            collection_id=collection_id,
+            metadata_key=key,
+            metadata_type=metadata_type,
+            filters=field_filters,
+        )
+    return result
+
+
+def _get_field_value_counts(
+    session: Session,
+    collection_id: UUID,
+    metadata_key: str,
+    metadata_type: str,
+    filters: ImageFilter | None,
+) -> MetadataValueCountsView:
+    value_expr = db_json.json_extract_string(column=SampleMetadataTable.data, field=metadata_key)
+    total_count, concrete_count = _get_total_and_concrete_counts(
+        session=session,
+        collection_id=collection_id,
+        value_expr=value_expr,
+        filters=filters,
+    )
+    rows = _get_top_value_counts(
+        session=session,
+        collection_id=collection_id,
+        value_expr=value_expr,
+        filters=filters,
+    )
+    value_counts = [
+        MetadataValueCountView(
+            value=_parse_value(value=value, metadata_type=metadata_type), count=int(count)
+        )
+        for value, count in rows
+    ]
+    top_count = sum(value_count.count for value_count in value_counts)
+    return MetadataValueCountsView(
+        value_counts=value_counts,
+        other_count=concrete_count - top_count,
+        missing_count=total_count - concrete_count,
+    )
+
+
+def _get_total_and_concrete_counts(
+    session: Session,
+    collection_id: UUID,
+    value_expr: ColumnElement[str],
+    filters: ImageFilter | None,
+) -> tuple[int, int]:
+    query = (
+        select(func.count(), func.count(value_expr))
+        .select_from(SampleTable)
+        .join(
+            SampleMetadataTable,
+            col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
+            isouter=True,
+        )
+        .where(SampleTable.collection_id == collection_id)
+    )
+    query = metadata_helpers.apply_image_filters(
+        query=query, collection_id=collection_id, filters=filters
+    )
+    total_count, concrete_count = session.execute(query).one()
+    return int(total_count), int(concrete_count)
+
+
+def _get_top_value_counts(
+    session: Session,
+    collection_id: UUID,
+    value_expr: ColumnElement[str],
+    filters: ImageFilter | None,
+) -> list[tuple[str, int]]:
+    count_expr = func.count().label("value_count")
+    query = (
+        select(value_expr, count_expr)
+        .select_from(SampleTable)
+        .join(
+            SampleMetadataTable,
+            col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
+            isouter=True,
+        )
+        .where(SampleTable.collection_id == collection_id)
+        .where(value_expr.isnot(None))
+        .group_by(value_expr)
+        .order_by(count_expr.desc(), value_expr.asc())
+        .limit(_TOP_VALUE_COUNT)
+    )
+    query = metadata_helpers.apply_image_filters(
+        query=query, collection_id=collection_id, filters=filters
+    )
+    return [(str(value), int(count)) for value, count in session.execute(query).all()]
+
+
+def _parse_value(value: str, metadata_type: str) -> str | bool:
+    if metadata_type == "boolean":
+        return value.lower() == "true"
+    return value

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
@@ -9,17 +9,16 @@ from sqlalchemy import Integer, cast, func
 from sqlmodel import Session, col, select
 
 from lightly_studio.database import db_json
-from lightly_studio.models.image import ImageTable
 from lightly_studio.models.metadata import (
     HistogramView,
     MetadataInfoView,
     SampleMetadataTable,
 )
 from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers.metadata_resolver.sample import metadata_helpers
 
 if TYPE_CHECKING:
     from lightly_studio.resolvers.image_filter import ImageFilter
-    from lightly_studio.type_definitions import QueryType
 
 # Number of bins used for numeric metadata histograms.
 _HISTOGRAM_BIN_COUNT = 20
@@ -44,7 +43,7 @@ def get_all_metadata_keys_and_schema(
         List of metadata info objects with 'name', 'type', and, for numerical
         types, 'min', 'max', and 'histogram'.
     """
-    merged = _get_merged_schema(session=session, collection_id=collection_id)
+    merged = metadata_helpers.get_merged_schema(session=session, collection_id=collection_id)
 
     result = []
     for key, metadata_type in merged.items():
@@ -95,7 +94,7 @@ def get_metadata_histograms(
     Returns:
         Mapping of metadata key to its histogram.
     """
-    merged = _get_merged_schema(session=session, collection_id=collection_id)
+    merged = metadata_helpers.get_merged_schema(session=session, collection_id=collection_id)
 
     histograms: dict[str, HistogramView] = {}
     for key, metadata_type in merged.items():
@@ -111,70 +110,10 @@ def get_metadata_histograms(
             collection_id=collection_id,
             metadata_key=key,
             stats=stats,
-            filters=_without_metadata_key_filter(filters=filters, metadata_key=key),
+            filters=metadata_helpers.without_metadata_key_filter(filters=filters, metadata_key=key),
             bin_count=bin_count,
         )
     return histograms
-
-
-def _get_merged_schema(session: Session, collection_id: UUID) -> dict[str, str]:
-    """Merge the metadata schemas of all samples in the collection."""
-    rows = session.exec(
-        select(SampleMetadataTable.metadata_schema)
-        .select_from(SampleTable)
-        .join(
-            SampleMetadataTable,
-            col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
-        )
-        .where(SampleTable.collection_id == collection_id)
-    ).all()
-    merged: dict[str, str] = {}
-    for schema_dict in rows:
-        merged.update(schema_dict)
-    return merged
-
-
-def _without_metadata_key_filter(
-    filters: ImageFilter | None, metadata_key: str
-) -> ImageFilter | None:
-    """Return a copy of ``filters`` without the metadata filters for ``metadata_key``."""
-    if (
-        filters is None
-        or filters.sample_filter is None
-        or not filters.sample_filter.metadata_filters
-    ):
-        return filters
-    updated = filters.model_copy(deep=True)
-    # Narrowed above via ``filters``; the deep copy preserves both.
-    assert updated.sample_filter is not None
-    assert updated.sample_filter.metadata_filters is not None
-    updated.sample_filter.metadata_filters = [
-        metadata_filter
-        for metadata_filter in updated.sample_filter.metadata_filters
-        if metadata_filter.key != metadata_key
-    ]
-    return updated
-
-
-def _apply_image_filters(
-    query: QueryType,
-    collection_id: UUID,
-    filters: ImageFilter | None,
-) -> QueryType:
-    """Restrict ``query`` to the samples matching ``filters``.
-
-    The filters are applied to an image sample-ids subquery (dimension filters
-    reference ``ImageTable``), which the metadata query then joins via ``IN``.
-    """
-    if filters is None:
-        return query
-    filtered_sample_ids = (
-        select(ImageTable.sample_id)
-        .join(ImageTable.sample)
-        .where(SampleTable.collection_id == collection_id)
-    )
-    filtered_sample_ids = filters.apply(filtered_sample_ids)
-    return query.where(col(SampleTable.sample_id).in_(filtered_sample_ids))
 
 
 def _get_metadata_min_max_count(
@@ -294,7 +233,9 @@ def _compute_histogram(  # noqa: PLR0913
         )
         .group_by(bucket_expr)
     )
-    query = _apply_image_filters(query=query, collection_id=collection_id, filters=filters)
+    query = metadata_helpers.apply_image_filters(
+        query=query, collection_id=collection_id, filters=filters
+    )
 
     counts_by_bucket = {int(bucket): int(count) for bucket, count in session.exec(query).all()}
     counts = [counts_by_bucket.get(i, 0) for i in range(bin_count)]
@@ -328,5 +269,7 @@ def _count_metadata_values(
             json_not_null_expr,
         )
     )
-    query = _apply_image_filters(query=query, collection_id=collection_id, filters=filters)
+    query = metadata_helpers.apply_image_filters(
+        query=query, collection_id=collection_id, filters=filters
+    )
     return int(session.exec(query).one())

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/metadata_helpers.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/metadata_helpers.py
@@ -1,0 +1,72 @@
+"""Shared helpers for metadata sample resolvers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+
+from lightly_studio.models.image import ImageTable
+from lightly_studio.models.metadata import SampleMetadataTable
+from lightly_studio.models.sample import SampleTable
+
+if TYPE_CHECKING:
+    from lightly_studio.resolvers.image_filter import ImageFilter
+    from lightly_studio.type_definitions import QueryType
+
+
+def get_merged_schema(session: Session, collection_id: UUID) -> dict[str, str]:
+    """Merge the metadata schemas of all samples in a collection."""
+    rows = session.exec(
+        select(SampleMetadataTable.metadata_schema)
+        .select_from(SampleTable)
+        .join(
+            SampleMetadataTable,
+            col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
+        )
+        .where(SampleTable.collection_id == collection_id)
+    ).all()
+    merged: dict[str, str] = {}
+    for schema_dict in rows:
+        merged.update(schema_dict)
+    return merged
+
+
+def without_metadata_key_filter(
+    filters: ImageFilter | None, metadata_key: str
+) -> ImageFilter | None:
+    """Return a copy of ``filters`` without the metadata filters for ``metadata_key``."""
+    if (
+        filters is None
+        or filters.sample_filter is None
+        or not filters.sample_filter.metadata_filters
+    ):
+        return filters
+    updated = filters.model_copy(deep=True)
+    # Narrowed above via ``filters``; the deep copy preserves both.
+    assert updated.sample_filter is not None
+    assert updated.sample_filter.metadata_filters is not None
+    updated.sample_filter.metadata_filters = [
+        metadata_filter
+        for metadata_filter in updated.sample_filter.metadata_filters
+        if metadata_filter.key != metadata_key
+    ]
+    return updated
+
+
+def apply_image_filters(
+    query: QueryType,
+    collection_id: UUID,
+    filters: ImageFilter | None,
+) -> QueryType:
+    """Restrict a query to samples matching ``filters``."""
+    if filters is None:
+        return query
+    filtered_sample_ids = (
+        select(ImageTable.sample_id)
+        .join(ImageTable.sample)
+        .where(SampleTable.collection_id == collection_id)
+    )
+    filtered_sample_ids = filters.apply(filtered_sample_ids)
+    return query.where(col(SampleTable.sample_id).in_(filtered_sample_ids))

--- a/lightly_studio/src/lightly_studio/type_definitions.py
+++ b/lightly_studio/src/lightly_studio/type_definitions.py
@@ -29,6 +29,8 @@ QueryType = TypeVar(
     Select[tuple[VideoTable, VideoFrameTable]],
     SelectOfScalar[VideoFrameTable],
     Select[tuple[Any, int]],
+    Select[tuple[int, int]],
+    Select[tuple[str, int]],
     Select[tuple[UUID, int]],
     Select[tuple[AnnotationBaseTable, Any]],
     Select[tuple[ImageTable, Any]],

--- a/lightly_studio/tests/api/routes/api/test_metadata.py
+++ b/lightly_studio/tests/api/routes/api/test_metadata.py
@@ -144,6 +144,20 @@ def test_metadata_value_counts__openapi_models(test_client: TestClient) -> None:
     assert "MetadataValueCountsView" in schemas
 
 
+def test_metadata_filter__invalid_in_value_returns_422(test_client: TestClient) -> None:
+    collection_id = uuid4()
+    response = test_client.post(
+        f"/api/collections/{collection_id}/metadata/value-counts",
+        json={
+            "filters": {
+                "sample_filter": {"metadata_filters": [{"key": "city", "op": "in", "value": []}]}
+            }
+        },
+    )
+
+    assert response.status_code == 422
+
+
 # TODO(Mihnea, 10/2025): Also add tests with passing `embedding_model_name` and/or `metadata_name`
 #  in the body.
 def test_compute_typicality_metadata(test_client: TestClient, db_session: Session) -> None:

--- a/lightly_studio/tests/api/routes/api/test_metadata.py
+++ b/lightly_studio/tests/api/routes/api/test_metadata.py
@@ -8,7 +8,12 @@ from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK
-from lightly_studio.models.metadata import HistogramView, MetadataInfoView
+from lightly_studio.models.metadata import (
+    HistogramView,
+    MetadataInfoView,
+    MetadataValueCountsView,
+    MetadataValueCountView,
+)
 from lightly_studio.resolvers import image_resolver, metadata_resolver, tag_resolver
 from tests.helpers_resolvers import (
     create_collection,
@@ -73,6 +78,70 @@ def test_get_metadata_info__empty_response(test_client: TestClient, mocker: Mock
     assert response.status_code == HTTP_STATUS_OK
     data = response.json()
     assert data == []
+
+
+def test_get_metadata_value_counts(test_client: TestClient, mocker: MockerFixture) -> None:
+    collection_id = uuid4()
+    resolver = mocker.patch(
+        "lightly_studio.api.routes.api.metadata."
+        "metadata_value_counts_resolver.get_metadata_value_counts",
+        return_value={
+            "city": MetadataValueCountsView(
+                value_counts=[MetadataValueCountView(value="Zurich", count=2)],
+                other_count=1,
+                missing_count=3,
+            )
+        },
+    )
+    filters = {
+        "sample_filter": {"metadata_filters": [{"key": "country", "op": "==", "value": "CH"}]}
+    }
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/metadata/value-counts",
+        json={"filters": filters},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {
+        "city": {
+            "value_counts": [{"value": "Zurich", "count": 2}],
+            "other_count": 1,
+            "missing_count": 3,
+        }
+    }
+    called_filters = resolver.call_args.kwargs["filters"]
+    assert called_filters.model_dump(exclude_none=True) == {
+        "filter_type": "image",
+        "sample_filter": {
+            "filter_type": "sample",
+            "metadata_filters": [{"key": "country", "op": "==", "value": "CH"}],
+        },
+    }
+
+
+def test_get_metadata_value_counts__optional_body(
+    test_client: TestClient, mocker: MockerFixture
+) -> None:
+    collection_id = uuid4()
+    resolver = mocker.patch(
+        "lightly_studio.api.routes.api.metadata."
+        "metadata_value_counts_resolver.get_metadata_value_counts",
+        return_value={},
+    )
+
+    response = test_client.post(f"/api/collections/{collection_id}/metadata/value-counts")
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {}
+    assert resolver.call_args.kwargs["filters"] is None
+
+
+def test_metadata_value_counts__openapi_models(test_client: TestClient) -> None:
+    openapi = test_client.get("/openapi.json").json()
+    schemas = openapi["components"]["schemas"]
+    assert "MetadataValueCountView" in schemas
+    assert "MetadataValueCountsView" in schemas
 
 
 # TODO(Mihnea, 10/2025): Also add tests with passing `embedding_model_name` and/or `metadata_name`

--- a/lightly_studio/tests/database/test_db_json.py
+++ b/lightly_studio/tests/database/test_db_json.py
@@ -118,6 +118,53 @@ def test_json_extract__sqlite_raises() -> None:
         expr.compile(dialect=sqlite.dialect())
 
 
+def test_json_extract_string__duckdb() -> None:
+    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field="location")
+    result = expr.compile(dialect=Dialect())
+    assert str(result) == "json_extract_string(data, %(param_1)s)"
+    assert result.params == {"param_1": "location"}
+
+
+def test_json_extract_string__postgresql() -> None:
+    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field="location")
+    result = expr.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
+    assert str(result) == "data->>%(param_1)s"
+    assert result.params == {"param_1": "location"}
+
+
+@pytest.mark.parametrize("field", ["site.name", "owner's site"])
+def test_json_extract_string__special_key_is_bound(field: str) -> None:
+    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field=field)
+    duckdb_result = expr.compile(dialect=Dialect())
+    postgres_result = expr.compile(
+        dialect=postgresql.dialect()  # type: ignore[no-untyped-call]
+    )
+
+    assert str(duckdb_result) == "json_extract_string(data, %(param_1)s)"
+    assert duckdb_result.params == {"param_1": field}
+    assert str(postgres_result) == "data->>%(param_1)s"
+    assert postgres_result.params == {"param_1": field}
+
+
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    [
+        ("site.name", "/site.name"),
+        ("owner's site", "/owner's site"),
+        ("path/to~site", "/path~1to~0site"),
+    ],
+)
+def test_json_top_level_key_type__duckdb_path(field: str, expected: str) -> None:
+    type_ = db_json._JsonTopLevelKeyType()
+    assert type_.process_bind_param(value=field, dialect=Dialect()) == expected
+
+
+def test_json_extract_string__sqlite_raises() -> None:
+    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field="location")
+    with pytest.raises(NotImplementedError, match="Unsupported dialect: sqlite"):
+        expr.compile(dialect=sqlite.dialect())
+
+
 def test_json_literal__duckdb_string_value() -> None:
     """String values are JSON-encoded for DuckDB."""
     lit = db_json.json_literal("hello")

--- a/lightly_studio/tests/metadata/test_get_metadata_value_counts.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_value_counts.py
@@ -1,0 +1,176 @@
+"""Tests for categorical metadata value counts."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlmodel import Session
+
+from lightly_studio.models.metadata import SampleMetadataTable
+from lightly_studio.resolvers.image_filter import FilterDimensions, ImageFilter
+from lightly_studio.resolvers.metadata_resolver.metadata_filter import MetadataFilter
+from lightly_studio.resolvers.metadata_resolver.sample import categorical_value_counts
+from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
+from tests.helpers_resolvers import create_collection, create_image
+
+
+def test_get_metadata_value_counts__categorical_values_and_missing(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    _create_sample(db_session, collection_id, {"city": "Zurich", "active": True, "score": 1})
+    _create_sample(db_session, collection_id, {"city": "Zurich", "active": False})
+    _create_sample(db_session, collection_id, {"city": "", "active": False})
+    _create_sample(db_session, collection_id, {"city": "Missing", "active": True})
+    _create_sample(db_session, collection_id, {"city": "Other", "active": True})
+    _create_explicit_null_sample(db_session=db_session, collection_id=collection_id)
+    create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/no-metadata.png",
+    )
+
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session, collection_id=collection_id
+    )
+
+    assert set(counts) == {"city", "active"}
+    assert [(entry.value, entry.count) for entry in counts["city"].value_counts] == [
+        ("Zurich", 2),
+        ("", 1),
+        ("Missing", 1),
+        ("Other", 1),
+    ]
+    assert counts["city"].other_count == 0
+    assert counts["city"].missing_count == 2
+    assert [(entry.value, entry.count) for entry in counts["active"].value_counts] == [
+        (True, 3),
+        (False, 2),
+    ]
+    assert counts["active"].missing_count == 2
+
+
+def test_get_metadata_value_counts__top_twenty_and_collection_isolation(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    for index in range(21):
+        _create_sample(db_session, collection.collection_id, {"category": f"value-{index:02d}"})
+    _create_sample(db_session, collection.collection_id, {"category": "value-20"})
+
+    other_collection = create_collection(session=db_session)
+    for _ in range(3):
+        _create_sample(db_session, other_collection.collection_id, {"category": "value-00"})
+
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session, collection_id=collection.collection_id
+    )["category"]
+
+    assert len(counts.value_counts) == 20
+    assert (counts.value_counts[0].value, counts.value_counts[0].count) == ("value-20", 2)
+    assert [entry.value for entry in counts.value_counts[1:]] == [
+        f"value-{index:02d}" for index in range(19)
+    ]
+    assert counts.other_count == 1
+    assert counts.missing_count == 0
+
+
+def test_get_metadata_value_counts__filters_and_own_key_exclusion(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    _create_sample(db_session, collection.collection_id, {"city": "A", "group": "x"})
+    _create_sample(db_session, collection.collection_id, {"city": "B", "group": "x"})
+    _create_sample(db_session, collection.collection_id, {"city": "B", "group": "y"})
+    filters = ImageFilter(
+        sample_filter=SampleFilter(
+            metadata_filters=[
+                MetadataFilter(key="city", op="==", value="A"),
+                MetadataFilter(key="group", op="==", value="x"),
+            ]
+        )
+    )
+
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session,
+        collection_id=collection.collection_id,
+        filters=filters,
+    )
+
+    assert [(entry.value, entry.count) for entry in counts["city"].value_counts] == [
+        ("A", 1),
+        ("B", 1),
+    ]
+    assert [(entry.value, entry.count) for entry in counts["group"].value_counts] == [("x", 1)]
+
+
+def test_get_metadata_value_counts__known_fields_with_no_matches(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    _create_sample(db_session, collection.collection_id, {"city": "A"})
+
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session,
+        collection_id=collection.collection_id,
+        filters=ImageFilter(width=FilterDimensions(min=10_000)),
+    )
+
+    assert counts["city"].value_counts == []
+    assert counts["city"].other_count == 0
+    assert counts["city"].missing_count == 0
+
+
+def test_get_metadata_value_counts__unknown_collection_is_empty(db_session: Session) -> None:
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session, collection_id=uuid4()
+    )
+    assert counts == {}
+
+
+def test_get_metadata_value_counts__literal_top_level_keys(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    _create_sample(
+        db_session,
+        collection.collection_id,
+        {"site.name": "Zurich", "owner's site": "primary"},
+    )
+
+    counts = categorical_value_counts.get_metadata_value_counts(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert counts["site.name"].value_counts[0].value == "Zurich"
+    assert counts["owner's site"].value_counts[0].value == "primary"
+
+
+def _create_sample(
+    db_session: Session,
+    collection_id: UUID,
+    metadata: dict[str, Any],
+) -> None:
+    image = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs=f"/path/to/{uuid4()}.png",
+    )
+    for key, value in metadata.items():
+        image.sample[key] = value
+
+
+def _create_explicit_null_sample(db_session: Session, collection_id: UUID) -> None:
+    image = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/explicit-null.png",
+    )
+    db_session.add(
+        SampleMetadataTable(
+            sample_id=image.sample_id,
+            data={"city": None},
+            metadata_schema={"city": "string"},
+        )
+    )
+    db_session.commit()

--- a/lightly_studio/tests/resolvers/metadata_resolvers/sample/test_sample_metadata_filtering.py
+++ b/lightly_studio/tests/resolvers/metadata_resolvers/sample/test_sample_metadata_filtering.py
@@ -5,6 +5,7 @@ from sqlmodel import Session
 from lightly_studio.resolvers import sample_resolver
 from lightly_studio.resolvers.metadata_resolver.metadata_filter import (
     Metadata,
+    MetadataFilter,
 )
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests.helpers_resolvers import (
@@ -106,3 +107,104 @@ def test_metadata_multiple_filters(db_session: Session) -> None:
     ).samples
     assert len(samples) == 1
     assert samples[0].sample_id == sample2.sample_id
+
+
+def test_metadata_in_filter__concrete_values_and_other_keys(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    first = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/first.png",
+    ).sample
+    second = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/second.png",
+    ).sample
+    third = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/third.png",
+    ).sample
+    first["city"] = "Zurich"
+    first["reviewed"] = True
+    second["city"] = "Berlin"
+    second["reviewed"] = False
+    third["city"] = "Paris"
+    third["reviewed"] = True
+
+    filters = SampleFilter(
+        metadata_filters=[
+            MetadataFilter(key="city", op="in", value=["Zurich", "Berlin"]),
+            MetadataFilter(key="reviewed", op="in", value=[True]),
+        ]
+    )
+    samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    assert [sample.sample_id for sample in samples] == [first.sample_id]
+
+
+def test_metadata_in_filter__missing(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    concrete = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/concrete.png",
+    ).sample
+    other_metadata = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/other-metadata.png",
+    ).sample
+    no_metadata = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/no-metadata.png",
+    ).sample
+    concrete["city"] = "Zurich"
+    other_metadata["country"] = "CH"
+
+    filters = SampleFilter(metadata_filters=[MetadataFilter(key="city", op="in", value=[None])])
+    samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    assert {sample.sample_id for sample in samples} == {
+        other_metadata.sample_id,
+        no_metadata.sample_id,
+    }
+
+
+def test_metadata_in_filter__concrete_and_missing_special_key(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    concrete = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/concrete.png",
+    ).sample
+    missing = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/missing.png",
+    ).sample
+    excluded = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/excluded.png",
+    ).sample
+    concrete["city.name's"] = "Zurich"
+    excluded["city.name's"] = "Paris"
+
+    filters = SampleFilter(
+        metadata_filters=[MetadataFilter(key="city.name's", op="in", value=["Zurich", None])]
+    )
+    samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    assert {sample.sample_id for sample in samples} == {
+        concrete.sample_id,
+        missing.sample_id,
+    }

--- a/lightly_studio/tests/resolvers/metadata_resolvers/test_metadata_filter.py
+++ b/lightly_studio/tests/resolvers/metadata_resolvers/test_metadata_filter.py
@@ -38,7 +38,7 @@ def test_apply_metadata_filters__postgres_missing_and_special_key() -> None:
         metadata_join_condition=col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
     )
 
-    compiled = query.compile(dialect=postgresql.dialect())
+    compiled = query.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
     sql = str(compiled).lower()
     assert "left outer join" in sql
     assert "->>" in sql

--- a/lightly_studio/tests/resolvers/metadata_resolvers/test_metadata_filter.py
+++ b/lightly_studio/tests/resolvers/metadata_resolvers/test_metadata_filter.py
@@ -1,0 +1,47 @@
+"""Tests for generic metadata filters."""
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.dialects import postgresql
+from sqlmodel import col, select
+
+from lightly_studio.models.metadata import SampleMetadataTable
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers.metadata_resolver import metadata_filter
+from lightly_studio.resolvers.metadata_resolver.metadata_filter import MetadataFilter
+
+
+@pytest.mark.parametrize(
+    "value",
+    [[], ["Zurich", True], [1, 2], [None, 1]],
+)
+def test_metadata_filter__invalid_in_value(value: list[object]) -> None:
+    with pytest.raises(ValidationError):
+        MetadataFilter(key="city", op="in", value=value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [["Zurich", "Berlin"], [True, False], ["Zurich", None], [None]],
+)
+def test_metadata_filter__valid_in_value(value: list[object]) -> None:
+    metadata_filter = MetadataFilter(key="city", op="in", value=value)
+
+    assert metadata_filter.value == value
+
+
+def test_apply_metadata_filters__postgres_missing_and_special_key() -> None:
+    query = metadata_filter.apply_metadata_filters(
+        select(SampleTable),
+        [MetadataFilter(key="city.name's", op="in", value=["Zurich", None])],
+        metadata_model=SampleMetadataTable,
+        metadata_join_condition=col(SampleMetadataTable.sample_id) == col(SampleTable.sample_id),
+    )
+
+    compiled = query.compile(dialect=postgresql.dialect())
+    sql = str(compiled).lower()
+    assert "left outer join" in sql
+    assert "->>" in sql
+    assert " in " in sql
+    assert " is null" in sql
+    assert "city.name's" in compiled.params.values()

--- a/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
+++ b/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
@@ -89,7 +89,7 @@
         instance.on('click', (params: { dataIndex?: number }) => {
             if (typeof params.dataIndex !== 'number') return;
             const item = data[params.dataIndex];
-            if (item) onBarClick?.(item);
+            if (item && item.selectable !== false) onBarClick?.(item);
         });
         const resizeObserver = new ResizeObserver(() => instance.resize());
         resizeObserver.observe(container);

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -41,6 +41,24 @@ describe('buildEchartsOption', () => {
         expect(horizontal.xAxis.minInterval).toBe(1);
     });
 
+    it('adds selected and disabled treatments without changing typed category identity', () => {
+        const option = buildEchartsOption([
+            { id: 'selected', label: 'Missing', count: 3, selected: true, selectable: true },
+            { id: 'other', label: 'Other', count: 2, selected: false, selectable: false }
+        ]) as {
+            series: [{ data: { value: number; itemStyle: Record<string, unknown> }[] }];
+        };
+
+        expect(option.series[0].data[0]).toMatchObject({
+            value: 3,
+            itemStyle: { borderWidth: 3, opacity: 1 }
+        });
+        expect(option.series[0].data[1]).toMatchObject({
+            value: 2,
+            itemStyle: { borderWidth: 0, opacity: 0.45 }
+        });
+    });
+
     const getFormatter = (option: unknown) =>
         (
             option as {

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -12,6 +12,7 @@ import type { CategoryCount } from './';
 // Single accent color (the Lightly primary green, --color-lightly-primary #3bd99f):
 // per-class colors carry no meaning in a count distribution.
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
+const SELECTED_BORDER_COLOR = 'rgba(255,255,255,0.95)';
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
 export type BarChartOrientation = 'vertical' | 'horizontal';
@@ -87,7 +88,18 @@ export function buildEchartsOption(
         series: [
             {
                 type: 'bar',
-                data: data.map((item) => item.count),
+                data: data.map((item) => {
+                    if (item.selected == null && item.selectable == null) return item.count;
+                    return {
+                        value: item.count,
+                        itemStyle: {
+                            color: BAR_COLOR,
+                            opacity: item.selectable === false ? 0.45 : 1,
+                            borderColor: item.selected ? SELECTED_BORDER_COLOR : 'transparent',
+                            borderWidth: item.selected ? 3 : 0
+                        }
+                    };
+                }),
                 itemStyle: { color: BAR_COLOR },
                 barCategoryGap: '25%',
                 emphasis: CHART_EMPHASIS

--- a/lightly_studio_view/src/lib/components/BarChart/types.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/types.ts
@@ -1,5 +1,11 @@
 /** A single category (e.g. a class name) with its count. */
 export interface CategoryCount {
+    /** Stable identity when multiple bars share the same display label. */
+    id?: string;
     label: string;
     count: number;
+    /** Whether the category is active in a controlled selection. */
+    selected?: boolean;
+    /** Whether clicking the bar can change selection. */
+    selectable?: boolean;
 }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -18,6 +18,8 @@
         type DistributionSourceGroup
     } from './types';
     import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
+    import MetadataCategoricalFilter from './MetadataCategoricalFilter.svelte';
+    import type { CategoricalMetadataValue } from '$lib/services/types';
 
     interface Props {
         /**
@@ -59,6 +61,12 @@
         histogramBinCount?: number;
         /** Called when the user picks a new histogram bin count. */
         onHistogramBinCountChange?: (binCount: number) => void;
+        /** Called when a concrete categorical value or Missing is toggled. */
+        onCategoricalValueToggle?: (groupId: string, value: CategoricalMetadataValue) => void;
+        /** Removes every categorical value selected for the given group. */
+        onCategoricalValuesClear?: (groupId: string) => void;
+        /** Retries a failed categorical distribution request. */
+        onCategoricalRetry?: () => void;
     }
 
     const {
@@ -72,7 +80,10 @@
         initialCountMode = AnnotationCountMode.OBJECTS,
         onHistogramRangeSelect,
         histogramBinCount = 20,
-        onHistogramBinCountChange
+        onHistogramBinCountChange,
+        onCategoricalValueToggle,
+        onCategoricalValuesClear,
+        onCategoricalRetry
     }: Props = $props();
 
     // Normalise to a source list so the rest of the panel has one code path.
@@ -85,7 +96,7 @@
     let selectedGroupId = $state<string | undefined>(undefined);
 
     const groupHasContent = (group: DistributionSourceGroup): boolean =>
-        (group.data?.length ?? 0) > 0 || group.histogram != null;
+        (group.data?.length ?? 0) > 0 || group.histogram != null || group.categorical != null;
 
     const sourceHasContent = (source: DistributionSource): boolean =>
         (source.data?.length ?? 0) > 0 ||
@@ -109,6 +120,19 @@
     // A group/source carrying bins renders as a histogram instead of a bar
     // chart; the categorical controls (sort, top-N, orientation) don't apply.
     const activeHistogram = $derived(activeGroup?.histogram ?? activeSource.histogram ?? null);
+    const activeCategorical = $derived(activeGroup?.categorical ?? null);
+    const categoricalData = $derived<CategoryCount[]>(
+        (activeCategorical?.buckets ?? []).map((bucket) => ({
+            id: bucket.id,
+            label: bucket.label,
+            count: bucket.count,
+            selectable: bucket.kind !== 'other',
+            selected:
+                bucket.kind !== 'other' &&
+                activeCategorical?.selectedValues.some((value) => Object.is(value, bucket.value))
+        }))
+    );
+    const displayedData = $derived(activeCategorical ? categoricalData : activeData);
     const activeHistogramRange = $derived(activeGroup?.selectedRange ?? activeSource.selectedRange);
     const handleHistogramRangeSelect = (range: HistogramRange) => {
         const groupId = activeGroup?.id ?? activeSource.id;
@@ -153,8 +177,16 @@
         (activeSource.groups ?? []).map((group) => ({ value: group.id, label: group.label }))
     );
 
-    const visible = $derived(selectVisibleCounts(activeData, config));
-    const totalCount = $derived(activeData.reduce((sum, item) => sum + item.count, 0));
+    const visible = $derived(
+        activeCategorical ? displayedData : selectVisibleCounts(displayedData, config)
+    );
+    const totalCount = $derived(displayedData.reduce((sum, item) => sum + item.count, 0));
+
+    const handleCategoricalBarClick = (item: CategoryCount) => {
+        const bucket = activeCategorical?.buckets.find((candidate) => candidate.id === item.id);
+        if (!bucket || bucket.kind === 'other' || !activeGroup) return;
+        onCategoricalValueToggle?.(activeGroup.id, bucket.value);
+    };
 
     function applyConfig(next: DistributionConfig) {
         if (next.countMode !== config.countMode) {
@@ -163,6 +195,10 @@
         config = next;
     }
 </script>
+
+{#snippet categoricalEmptyState()}
+    <span>No matching samples for this metadata field.</span>
+{/snippet}
 
 <div
     class="flex h-full min-w-0 flex-1 flex-col rounded-[1vw] bg-card p-4"
@@ -259,6 +295,34 @@
                 />
             </div>
         </div>
+    {:else if activeCategorical && activeGroup}
+        <MetadataCategoricalFilter
+            buckets={activeCategorical.buckets}
+            selectedValues={activeCategorical.selectedValues}
+            loading={activeCategorical.loading}
+            onToggle={(value) => onCategoricalValueToggle?.(activeGroup.id, value)}
+            onClear={() => onCategoricalValuesClear?.(activeGroup.id)}
+        />
+        {#if activeCategorical.loading && activeCategorical.buckets.length > 0}
+            <p class="mt-1 text-xs text-muted-foreground" role="status">Updating values…</p>
+        {/if}
+        {#if activeCategorical.error && activeCategorical.buckets.length > 0}
+            <div
+                class="mt-1 flex items-center justify-between gap-2 text-xs text-destructive"
+                role="alert"
+            >
+                <span>Could not update metadata distribution.</span>
+                {#if onCategoricalRetry}
+                    <button
+                        class="underline max-sm:min-h-11"
+                        type="button"
+                        onclick={onCategoricalRetry}
+                    >
+                        Retry
+                    </button>
+                {/if}
+            </div>
+        {/if}
     {:else if activeData.length > 0}
         <PanelHeader
             {config}
@@ -289,32 +353,69 @@
                 showAxes
                 onRangeSelect={onHistogramRangeSelect ? handleHistogramRangeSelect : undefined}
             />
+        {:else if activeCategorical?.loading && activeCategorical.buckets.length === 0}
+            <div class="p-8 text-center text-sm text-muted-foreground" role="status">
+                Loading metadata distribution…
+            </div>
+        {:else if activeCategorical?.error && activeCategorical.buckets.length === 0}
+            <div class="space-y-2 p-8 text-center text-sm" role="alert">
+                <p class="text-destructive">Could not load metadata distribution.</p>
+                {#if onCategoricalRetry}
+                    <Button
+                        variant="secondary"
+                        buttonProps={{
+                            size: 'sm',
+                            class: 'max-sm:min-h-11',
+                            onclick: onCategoricalRetry,
+                            'data-testid': 'metadata-categorical-retry'
+                        }}>Retry</Button
+                    >
+                {/if}
+            </div>
         {:else}
+            {#if activeCategorical}
+                <ul class="sr-only" aria-label="Categorical metadata value counts">
+                    {#each activeCategorical.buckets as bucket (bucket.id)}
+                        <li>
+                            {bucket.label}: {bucket.count} samples{bucket.kind === 'other'
+                                ? ', aggregated and not selectable'
+                                : activeCategorical.selectedValues.some((value) =>
+                                        Object.is(value, bucket.value)
+                                    )
+                                  ? ', selected'
+                                  : ''}
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
             <BarChart
                 data={visible}
-                orientation={config.orientation}
+                orientation={activeCategorical ? 'horizontal' : config.orientation}
                 maxHeightPx={chartHeight || undefined}
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
-                {onBarClick}
+                onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
+                emptyState={activeCategorical ? categoricalEmptyState : undefined}
             />
         {/if}
     </div>
 </div>
-<DistributionConfigDialog
-    bind:open={configDialogOpen}
-    allClasses={activeData.map((item) => item.label)}
-    {config}
-    onApply={applyConfig}
-/>
-<ExpandDialog
-    bind:open={expandOpen}
-    data={activeData}
-    {config}
-    {valueNoun}
-    onConfigChange={applyConfig}
-    {onBarClick}
-/>
+{#if !activeCategorical}
+    <DistributionConfigDialog
+        bind:open={configDialogOpen}
+        allClasses={activeData.map((item) => item.label)}
+        {config}
+        onApply={applyConfig}
+    />
+    <ExpandDialog
+        bind:open={expandOpen}
+        data={activeData}
+        {config}
+        {valueNoun}
+        onConfigChange={applyConfig}
+        {onBarClick}
+    />
+{/if}
 {#if activeHistogram}
     <HistogramExpandDialog
         bind:open={histogramExpandOpen}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -8,11 +8,14 @@ import { AnnotationCountMode, AnnotationType } from '$lib/api/lightly_studio_loc
 
 const echartsMock = vi.hoisted(() => {
     const zrHandlers: Record<string, (event: { offsetX: number; offsetY: number }) => void> = {};
+    let clickHandler: ((params: { dataIndex?: number }) => void) | undefined;
     const instance = {
         setOption: vi.fn(),
         resize: vi.fn(),
         dispose: vi.fn(),
-        on: vi.fn(),
+        on: vi.fn((event: string, handler: (params: { dataIndex?: number }) => void) => {
+            if (event === 'click') clickHandler = handler;
+        }),
         // 2 bins across a 200px-wide canvas → 100px per bin index.
         convertFromPixel: vi.fn((_finder: unknown, offsetX: number) => offsetX / 100),
         getZr: () => ({
@@ -22,7 +25,12 @@ const echartsMock = vi.hoisted(() => {
             off: vi.fn()
         })
     };
-    return { init: vi.fn(() => instance), instance, zrHandlers };
+    return {
+        init: vi.fn(() => instance),
+        instance,
+        zrHandlers,
+        getClickHandler: () => clickHandler
+    };
 });
 
 vi.mock('echarts/core', () => ({
@@ -216,6 +224,120 @@ describe('DatasetDistributionPanel', () => {
         expect(screen.getByTestId('histogram')).toBeInTheDocument();
         expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
             '100 samples · 2 bins · 0–1'
+        );
+    });
+
+    it('preserves categorical endpoint order and toggles typed buckets but not Other', () => {
+        const onCategoricalValueToggle = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: ['Missing'],
+                            buckets: [
+                                {
+                                    id: 'literal',
+                                    kind: 'value',
+                                    value: 'Missing',
+                                    label: 'Missing',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 3
+                                },
+                                { id: 'other', kind: 'other', label: 'Other', count: 2 }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources, onCategoricalValueToggle } });
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+            series: [{ data: { itemStyle: { borderWidth: number } }[] }];
+        };
+        expect(option.yAxis.data).toEqual(['Missing', 'Missing', 'Other']);
+        expect(option.series[0].data[0].itemStyle.borderWidth).toBe(3);
+
+        echartsMock.getClickHandler()?.({ dataIndex: 1 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledWith('city', null);
+        echartsMock.getClickHandler()?.({ dataIndex: 2 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledOnce();
+    });
+
+    it('shows categorical loading and retryable error states', async () => {
+        const onCategoricalRetry = vi.fn();
+        const source = (state: { loading?: boolean; error?: string }): DistributionSource[] => [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: { buckets: [], selectedValues: ['Zurich'], ...state }
+                    }
+                ]
+            }
+        ];
+        const view = render(DatasetDistributionPanel, {
+            props: { sources: source({ loading: true }), onCategoricalRetry }
+        });
+        expect(screen.getByRole('status')).toHaveTextContent('Loading metadata distribution');
+
+        await view.rerender({
+            sources: source({ error: 'network failure' }),
+            onCategoricalRetry
+        });
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not load metadata distribution');
+        await fireEvent.click(screen.getByTestId('metadata-categorical-retry'));
+        expect(onCategoricalRetry).toHaveBeenCalledOnce();
+    });
+
+    it('keeps stale categorical bars visible after a refetch error', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                }
+                            ],
+                            selectedValues: [],
+                            error: 'network failure'
+                        }
+                    }
+                ]
+            }
+        ];
+
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not update');
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+        expect(screen.getByLabelText('Categorical metadata value counts')).toHaveTextContent(
+            'Zurich: 4 samples'
         );
     });
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+    import { ChevronsUpDown } from '@lucide/svelte';
+    import * as Popover from '$lib/components/ui/popover';
+    import { Button } from '$lib/components/ui/button';
+    import { Checkbox } from '$lib/components/ui/checkbox';
+    import { Input } from '$lib/components/ui/input';
+    import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution';
+    import type { CategoricalMetadataValue } from '$lib/services/types';
+
+    interface Props {
+        buckets: CategoricalMetadataBucket[];
+        selectedValues: CategoricalMetadataValue[];
+        loading?: boolean;
+        onToggle: (value: CategoricalMetadataValue) => void;
+        onClear: () => void;
+    }
+
+    const { buckets, selectedValues, loading = false, onToggle, onClear }: Props = $props();
+    let search = $state('');
+    type SelectableBucket = Exclude<CategoricalMetadataBucket, { kind: 'other' }>;
+    type FilterOption = { bucket: SelectableBucket; retained: boolean };
+
+    const returnedSelectable = $derived(
+        buckets.filter((bucket): bucket is SelectableBucket => bucket.kind !== 'other')
+    );
+    const options = $derived.by<FilterOption[]>(() => {
+        const returned: FilterOption[] = returnedSelectable.map((bucket) => ({
+            bucket,
+            retained: false
+        }));
+        const retained: FilterOption[] = selectedValues
+            .filter((value) => !returnedSelectable.some((bucket) => Object.is(bucket.value, value)))
+            .map((value) => ({
+                bucket:
+                    value === null
+                        ? {
+                              id: JSON.stringify(['missing']),
+                              kind: 'missing',
+                              value: null,
+                              label: 'Missing',
+                              count: 0
+                          }
+                        : {
+                              id: JSON.stringify(['retained', typeof value, value]),
+                              kind: 'value',
+                              value,
+                              label: String(value),
+                              count: 0
+                          },
+                retained: true
+            }));
+        return [...returned, ...retained];
+    });
+    const optionLabel = (option: FilterOption): string => {
+        const hasMissing = options.some(({ bucket }) => bucket.kind === 'missing');
+        const hasOtherAggregate = buckets.some((bucket) => bucket.kind === 'other');
+        if (
+            option.bucket.kind === 'missing' &&
+            options.some(({ bucket }) => bucket.value === 'Missing')
+        ) {
+            return 'Missing (no value)';
+        }
+        if (option.bucket.kind === 'value' && option.bucket.value === 'Missing' && hasMissing) {
+            return 'Missing (value)';
+        }
+        if (
+            option.bucket.kind === 'value' &&
+            option.bucket.value === 'Other' &&
+            hasOtherAggregate
+        ) {
+            return 'Other (value)';
+        }
+        return option.bucket.label;
+    };
+    const visible = $derived(
+        options.filter((option) => optionLabel(option).toLowerCase().includes(search.toLowerCase()))
+    );
+    const showSearch = $derived(buckets.filter((bucket) => bucket.kind === 'value').length > 5);
+    const summary = $derived(
+        selectedValues.length === 0
+            ? 'All values'
+            : selectedValues.length === 1
+              ? optionLabel(
+                    options.find(({ bucket }) => Object.is(bucket.value, selectedValues[0]))!
+                )
+              : `${selectedValues.length} selected`
+    );
+    const isSelected = (value: CategoricalMetadataValue) =>
+        selectedValues.some((selected) => Object.is(selected, value));
+    const checkboxLabel = (option: FilterOption) =>
+        `${
+            option.bucket.kind === 'missing'
+                ? 'Select missing metadata'
+                : `Select value ${optionLabel(option)}`
+        }, ${option.retained ? 'count unavailable' : `${option.bucket.count} samples`}`;
+</script>
+
+<div class="mt-2 flex items-center gap-2" data-testid="metadata-categorical-filter">
+    <span class="w-[100px] shrink-0 text-xs text-muted-foreground">Values</span>
+    <Popover.Root onOpenChange={(open) => !open && (search = '')}>
+        <Popover.Trigger>
+            {#snippet child({ props })}
+                <Button
+                    {...props}
+                    variant="outline"
+                    size="sm"
+                    class="min-w-0 flex-1 justify-between max-sm:min-h-11"
+                    disabled={loading && buckets.length === 0}
+                    aria-label="Select metadata values"
+                    data-testid="metadata-categorical-filter-trigger"
+                >
+                    <span class="truncate">{loading ? 'Loading…' : summary}</span>
+                    <ChevronsUpDown class="opacity-50" />
+                </Button>
+            {/snippet}
+        </Popover.Trigger>
+        <Popover.Content class="w-[min(320px,calc(100vw-2rem))] p-2" align="end">
+            {#if showSearch}
+                <Input
+                    bind:value={search}
+                    placeholder="Search values…"
+                    aria-label="Search values"
+                    class="max-sm:min-h-11"
+                />
+            {/if}
+            <div class="mt-2 max-h-56 space-y-1 overflow-y-auto">
+                {#each visible as option (option.bucket.id)}
+                    <label
+                        class="flex min-h-8 cursor-pointer items-center gap-2 rounded px-2 text-sm hover:bg-accent max-sm:min-h-11"
+                    >
+                        <Checkbox
+                            checked={isSelected(option.bucket.value)}
+                            onCheckedChange={() => onToggle(option.bucket.value)}
+                            aria-label={checkboxLabel(option)}
+                        />
+                        <span class="min-w-0 flex-1 truncate" title={optionLabel(option)}
+                            >{optionLabel(option)}</span
+                        >
+                        <span class="text-muted-foreground"
+                            >{option.retained ? 'Not in top 20' : option.bucket.count}</span
+                        >
+                    </label>
+                {/each}
+                {#if visible.length === 0}<p class="p-2 text-sm text-muted-foreground">
+                        No values found.
+                    </p>{/if}
+                {#if buckets.some((bucket) => bucket.kind === 'other')}
+                    <p class="p-2 text-xs text-muted-foreground">
+                        Other is an aggregate and cannot be selected.
+                    </p>
+                {/if}
+            </div>
+            {#if selectedValues.length > 0}
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    class="mt-2 w-full max-sm:min-h-11"
+                    onclick={onClear}>Clear</Button
+                >
+            {/if}
+        </Popover.Content>
+    </Popover.Root>
+</div>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.test.ts
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import MetadataCategoricalFilter from './MetadataCategoricalFilter.svelte';
+import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution';
+
+const buckets: CategoricalMetadataBucket[] = [
+    {
+        id: 'literal-missing',
+        kind: 'value',
+        value: 'Missing',
+        label: 'Missing',
+        count: 4
+    },
+    { id: 'missing', kind: 'missing', value: null, label: 'Missing', count: 3 },
+    { id: 'other', kind: 'other', label: 'Other', count: 2 }
+];
+
+describe('MetadataCategoricalFilter', () => {
+    it('keeps literal Missing and semantic Missing distinct and disables Other', async () => {
+        const onToggle = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: { buckets, selectedValues: ['Missing'], onToggle, onClear: vi.fn() }
+        });
+
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        const literal = screen.getByRole('checkbox', {
+            name: 'Select value Missing (value), 4 samples'
+        });
+        const missing = screen.getByRole('checkbox', {
+            name: 'Select missing metadata, 3 samples'
+        });
+        expect(literal).toBeChecked();
+        expect(missing).not.toBeChecked();
+        expect(screen.getByText('Other is an aggregate and cannot be selected.')).toBeVisible();
+        expect(screen.queryByRole('checkbox', { name: /Other/ })).not.toBeInTheDocument();
+
+        await fireEvent.click(missing);
+        expect(onToggle).toHaveBeenCalledWith(null);
+    });
+
+    it('searches values and clears the controlled selection', async () => {
+        const searchableBuckets: CategoricalMetadataBucket[] = [
+            ...buckets,
+            ...Array.from({ length: 5 }, (_, index) => ({
+                id: `value-${index}`,
+                kind: 'value' as const,
+                value: `value-${index}`,
+                label: `value-${index}`,
+                count: index + 1
+            }))
+        ];
+        const onClear = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: {
+                buckets: searchableBuckets,
+                selectedValues: [null],
+                onToggle: vi.fn(),
+                onClear
+            }
+        });
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        await fireEvent.input(screen.getByLabelText('Search values'), {
+            target: { value: 'not present' }
+        });
+        expect(screen.getByText('No values found.')).toBeVisible();
+        await fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+        expect(onClear).toHaveBeenCalledOnce();
+    });
+
+    it('keeps a selected value removable when it is absent from the latest response', async () => {
+        const onToggle = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: { buckets: [], selectedValues: ['stale'], onToggle, onClear: vi.fn() }
+        });
+
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        expect(screen.queryByLabelText('Search values')).not.toBeInTheDocument();
+        expect(screen.getByText('Not in top 20')).toBeVisible();
+        await fireEvent.click(
+            screen.getByRole('checkbox', {
+                name: 'Select value stale, count unavailable'
+            })
+        );
+        expect(onToggle).toHaveBeenCalledWith('stale');
+    });
+
+    it('disambiguates a retained literal Other from the aggregate bucket', async () => {
+        const onToggle = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: { buckets, selectedValues: ['Other'], onToggle, onClear: vi.fn() }
+        });
+
+        expect(screen.getByTestId('metadata-categorical-filter-trigger')).toHaveTextContent(
+            'Other (value)'
+        );
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        expect(screen.getAllByText('Other (value)')).toHaveLength(2);
+        expect(screen.getByText('Other is an aggregate and cannot be selected.')).toBeVisible();
+        await fireEvent.click(
+            screen.getByRole('checkbox', {
+                name: 'Select value Other (value), count unavailable'
+            })
+        );
+        expect(onToggle).toHaveBeenCalledWith('Other');
+    });
+
+    it('shows search only above five returned concrete values', async () => {
+        const fiveConcrete: CategoricalMetadataBucket[] = [
+            ...Array.from({ length: 5 }, (_, index) => ({
+                id: `value-${index}`,
+                kind: 'value' as const,
+                value: `value-${index}`,
+                label: `value-${index}`,
+                count: index + 1
+            })),
+            { id: 'missing', kind: 'missing', value: null, label: 'Missing', count: 3 },
+            { id: 'other', kind: 'other', label: 'Other', count: 2 }
+        ];
+        render(MetadataCategoricalFilter, {
+            props: {
+                buckets: fiveConcrete,
+                selectedValues: ['retained'],
+                onToggle: vi.fn(),
+                onClear: vi.fn()
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        expect(screen.queryByLabelText('Search values')).not.toBeInTheDocument();
+        expect(screen.getByText('Not in top 20')).toBeVisible();
+    });
+});

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -2,6 +2,8 @@ import type { CategoryCount } from '$lib/components/BarChart';
 import type { ClassSetSelection } from '$lib/components/ClassSetConfig';
 import { type AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 import type { HistogramData, HistogramRange } from '$lib/components/Histogram';
+import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution';
+import type { CategoricalMetadataValue } from '$lib/services/types';
 
 export type DistributionSortOption = 'count' | 'name';
 
@@ -32,6 +34,13 @@ export interface DistributionSourceGroup {
      * metadata filter). Bins outside it render dimmed.
      */
     selectedRange?: HistogramRange;
+    /** Controlled categorical distribution and selection state. */
+    categorical?: {
+        buckets: CategoricalMetadataBucket[];
+        selectedValues: CategoricalMetadataValue[];
+        loading?: boolean;
+        error?: string;
+    };
 }
 
 /**

--- a/lightly_studio_view/src/lib/components/Images/Images.svelte
+++ b/lightly_studio_view/src/lib/components/Images/Images.svelte
@@ -45,7 +45,7 @@
     });
 
     const { dimensionsValues: dimensions } = useDimensions();
-    const { metadataValues } = useMetadataFilters(collection_id);
+    const { metadataValues, categoricalMetadataValues } = useMetadataFilters(collection_id);
 
     const {
         getCollectionVersion,
@@ -67,6 +67,7 @@
             dimensions: $dimensions ?? undefined
         },
         metadata_values: $metadataValues,
+        categorical_metadata_values: $categoricalMetadataValues,
         text_embedding: $textEmbedding?.embedding
     });
 
@@ -141,6 +142,7 @@
             `${$dimensions?.min_width}-${$dimensions?.max_width}`,
             `${$dimensions?.min_height}-${$dimensions?.max_height}`,
             JSON.stringify($metadataValues),
+            JSON.stringify($categoricalMetadataValues),
             $textEmbedding?.queryText || '',
             confusionCell ? JSON.stringify(confusionCell) : '',
             JSON.stringify($imageSortBy)

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -8,6 +8,7 @@ export { useTags } from '$lib/hooks/useTags/useTags';
 export { useVideoFramesBounds } from '$lib/hooks/useVideoFramesBounds/useVideoFramesBounds';
 export { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 export { useNumericMetadataDistribution } from '$lib/hooks/useNumericMetadataDistribution/useNumericMetadataDistribution';
+export { useCategoricalMetadataDistribution } from '$lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution';
 export { useFramesFilter } from '$lib/hooks/useFramesFilter/useFramesFilter';
 export { useCaptions } from '$lib/hooks/useCaptions/useCaptions';
 export { useRemoveTagFromSample } from '$lib/hooks/useRemoveTagFromSample/useRemoveTagFromSample';

--- a/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { MetadataValueCountsView } from '$lib/api/lightly_studio_local';
+import {
+    getCategoricalMetadataDistributionRequestOptions,
+    selectCategoricalDistributions
+} from './useCategoricalMetadataDistribution';
+
+describe('selectCategoricalDistributions', () => {
+    it('preserves typed values and keeps semantic buckets distinct from labels', () => {
+        const response: Record<string, MetadataValueCountsView> = {
+            city: {
+                value_counts: [
+                    { value: 'Missing', count: 4 },
+                    { value: true, count: 2 }
+                ],
+                missing_count: 3,
+                other_count: 1
+            }
+        };
+
+        expect(selectCategoricalDistributions(response).city).toEqual([
+            {
+                id: '["value","string","Missing"]',
+                kind: 'value',
+                value: 'Missing',
+                label: 'Missing (value)',
+                count: 4
+            },
+            {
+                id: '["value","boolean",true]',
+                kind: 'value',
+                value: true,
+                label: 'true',
+                count: 2
+            },
+            {
+                id: '["missing"]',
+                kind: 'missing',
+                value: null,
+                label: 'Missing (no value)',
+                count: 3
+            },
+            { id: '["other"]', kind: 'other', label: 'Other', count: 1 }
+        ]);
+    });
+
+    it('omits zero semantic buckets and maps an absent response to an empty record', () => {
+        expect(
+            selectCategoricalDistributions({
+                city: { value_counts: [], missing_count: 0, other_count: 0 }
+            })
+        ).toEqual({ city: [] });
+        expect(selectCategoricalDistributions(undefined)).toEqual({});
+    });
+});
+
+describe('getCategoricalMetadataDistributionRequestOptions', () => {
+    it('forwards the active image filter', () => {
+        expect(
+            getCategoricalMetadataDistributionRequestOptions({
+                collectionId: 'collection-id',
+                filter: { width: { min: 100 } }
+            })
+        ).toEqual({
+            path: { collection_id: 'collection-id' },
+            body: { filters: { width: { min: 100 } } }
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.ts
+++ b/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.ts
@@ -1,0 +1,99 @@
+import { createQuery } from '@tanstack/svelte-query';
+import type { ImageFilter, MetadataValueCountsView } from '$lib/api/lightly_studio_local';
+import { getMetadataValueCountsOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import { getMetadataValueCounts } from '$lib/api/lightly_studio_local/sdk.gen';
+
+export type CategoricalMetadataBucket =
+    | {
+          id: string;
+          kind: 'value';
+          value: string | boolean;
+          label: string;
+          count: number;
+      }
+    | { id: string; kind: 'missing'; value: null; label: string; count: number }
+    | { id: string; kind: 'other'; label: string; count: number };
+
+const valueBucketId = (value: string | boolean): string =>
+    JSON.stringify(['value', typeof value, value]);
+
+export const selectCategoricalDistributions = (
+    response: Record<string, MetadataValueCountsView> | undefined
+): Record<string, CategoricalMetadataBucket[]> =>
+    Object.fromEntries(
+        Object.entries(response ?? {}).map(([key, counts]) => {
+            const hasLiteralMissing = counts.value_counts.some(({ value }) => value === 'Missing');
+            const hasLiteralOther = counts.value_counts.some(({ value }) => value === 'Other');
+            const buckets: CategoricalMetadataBucket[] = counts.value_counts.map(
+                ({ value, count }) => ({
+                    id: valueBucketId(value),
+                    kind: 'value',
+                    value,
+                    label:
+                        value === 'Missing' && counts.missing_count > 0
+                            ? 'Missing (value)'
+                            : value === 'Other' && counts.other_count > 0
+                              ? 'Other (value)'
+                              : String(value),
+                    count
+                })
+            );
+            if (counts.missing_count > 0) {
+                buckets.push({
+                    id: JSON.stringify(['missing']),
+                    kind: 'missing',
+                    value: null,
+                    label: hasLiteralMissing ? 'Missing (no value)' : 'Missing',
+                    count: counts.missing_count
+                });
+            }
+            if (counts.other_count > 0) {
+                buckets.push({
+                    id: JSON.stringify(['other']),
+                    kind: 'other',
+                    label: hasLiteralOther ? 'Other (aggregated)' : 'Other',
+                    count: counts.other_count
+                });
+            }
+            return [key, buckets];
+        })
+    );
+
+export interface CategoricalMetadataDistributionOptions {
+    collectionId: string;
+    filter?: ImageFilter;
+}
+
+export const getCategoricalMetadataDistributionRequestOptions = ({
+    collectionId,
+    filter
+}: CategoricalMetadataDistributionOptions) => ({
+    path: { collection_id: collectionId },
+    ...(filter ? { body: { filters: filter } } : {})
+});
+
+export const useCategoricalMetadataDistribution = (
+    getOptions: () => CategoricalMetadataDistributionOptions & { enabled?: boolean }
+) =>
+    createQuery(() => {
+        const { collectionId, filter, enabled = true } = getOptions();
+        const requestOptions = getCategoricalMetadataDistributionRequestOptions({
+            collectionId,
+            filter
+        });
+        return {
+            ...getMetadataValueCountsOptions(requestOptions),
+            enabled,
+            select: selectCategoricalDistributions,
+            placeholderData: (previous: Record<string, MetadataValueCountsView> | undefined) =>
+                previous,
+            queryFn: async ({ signal }: { signal: AbortSignal }) => {
+                const { data } = await getMetadataValueCounts({
+                    ...requestOptions,
+                    signal,
+                    throwOnError: true
+                });
+                return data;
+            }
+        };
+    });

--- a/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.test.ts
@@ -78,4 +78,21 @@ describe('getFrameFilter', () => {
             frame_number: {}
         });
     });
+
+    it('adds categorical metadata filters', async () => {
+        const { createMetadataFilters } = await import('../useMetadataFilters/useMetadataFilters');
+        vi.mocked(createMetadataFilters).mockReturnValueOnce([
+            { key: 'city', value: ['Zurich', null], op: 'in' }
+        ]);
+
+        const filter = getFrameFilter({
+            collection_id: 'coll-1',
+            filters: { categorical_metadata_values: { city: ['Zurich', null] } }
+        });
+
+        expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+        expect(filter?.sample_filter?.metadata_filters).toEqual([
+            { key: 'city', value: ['Zurich', null], op: 'in' }
+        ]);
+    });
 });

--- a/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.ts
@@ -5,7 +5,7 @@ import type {
     VideoFrameFilter,
     VideoFrameFieldsBoundsView
 } from '$lib/api/lightly_studio_local/types.gen';
-type MetadataValues = Record<string, { min: number; max: number }>;
+import type { CategoricalMetadataValues, MetadataValues } from '$lib/services/types';
 
 export type VideoFrameFilterParams = {
     collection_id: string;
@@ -14,6 +14,7 @@ export type VideoFrameFilterParams = {
         annotation_label_ids?: string[];
         sample_ids?: string[];
         metadata_values?: MetadataValues;
+        categorical_metadata_values?: CategoricalMetadataValues;
     };
     frame_bounds?: VideoFrameFieldsBoundsView | null;
     video_id?: string | null;
@@ -60,8 +61,11 @@ export const getFrameFilter = (params: VideoFrameFilterParams | null): VideoFram
         sampleFilter.tag_ids = tagIds;
     }
 
-    if (params.filters?.metadata_values) {
-        const metadataFilters = createMetadataFilters(params.filters.metadata_values);
+    if (params.filters?.metadata_values || params.filters?.categorical_metadata_values) {
+        const metadataFilters = createMetadataFilters(
+            params.filters.metadata_values ?? {},
+            params.filters.categorical_metadata_values
+        );
         if (metadataFilters.length > 0) {
             sampleFilter.metadata_filters = metadataFilters;
         }

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
@@ -7,6 +7,7 @@ import { useSessionStorage } from './useSessionStorage/useSessionStorage';
 import type { MetadataInfo } from '$lib/services/types';
 import type { MetadataBounds } from '$lib/services/types';
 import type { MetadataValues } from '$lib/services/types';
+import type { CategoricalMetadataValues } from '$lib/services/types';
 import { useReversibleActions } from './useReversibleActions';
 import type { CollectionView, SampleType, TagByFilterBody } from '$lib/api/lightly_studio_local';
 import type { Point } from 'embedding-atlas/svelte';
@@ -59,6 +60,10 @@ const filterPanelCollapsed = useSessionStorage<boolean>(
 // Metadata stores
 const metadataBounds = useSessionStorage<MetadataBounds>('lightlyStudio_metadata_bounds', {});
 const metadataValues = useSessionStorage<MetadataValues>('lightlyStudio_metadata_values', {});
+const categoricalMetadataValues = useSessionStorage<CategoricalMetadataValues>(
+    'lightlyStudio_categorical_metadata_values',
+    {}
+);
 const metadataInfo = useSessionStorage<MetadataInfo[]>('lightlyStudio_metadata_info', []);
 
 // Store the most recently selected annotation label.
@@ -137,6 +142,9 @@ export const useGlobalStorage = () => {
     // Metadata update methods
     const updateMetadataValues = (values: MetadataValues) => {
         metadataValues.set(values);
+    };
+    const updateCategoricalMetadataValues = (values: CategoricalMetadataValues) => {
+        categoricalMetadataValues.set(values);
     };
     const updateMetadataBounds = (bounds: MetadataBounds) => {
         metadataBounds.set(bounds);
@@ -234,8 +242,10 @@ export const useGlobalStorage = () => {
         // Metadata stores
         metadataBounds,
         metadataValues,
+        categoricalMetadataValues,
         metadataInfo,
         updateMetadataValues,
+        updateCategoricalMetadataValues,
         updateMetadataBounds,
         updateMetadataInfo,
         filteredFramesCount,

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
@@ -3,6 +3,7 @@ import { get } from 'svelte/store';
 import { useImageFilters } from './useImageFilters';
 import type { QueryExpr, SortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
 import { SortDirection } from '$lib/api/lightly_studio_local/types.gen';
+import { createMetadataFilters } from '../useMetadataFilters/useMetadataFilters';
 
 const queryExpr = {
     match_expr: {
@@ -67,6 +68,22 @@ describe('useImageFilters', () => {
             updateQueryExpr(undefined);
             expect(get(imageFilter)?.sample_filter?.query_expr).toBeUndefined();
         });
+    });
+
+    it('forwards numeric and categorical metadata state into the shared image filter', () => {
+        vi.mocked(createMetadataFilters).mockReturnValueOnce([
+            { key: 'city', op: 'in', value: ['Zurich', null] }
+        ]);
+        const { imageFilter, updateFilterParams } = useImageFilters();
+        updateFilterParams({
+            ...normalFilterParams,
+            metadata_values: {},
+            categorical_metadata_values: { city: ['Zurich', null] }
+        });
+
+        const metadataFilters = get(imageFilter)?.sample_filter?.metadata_filters;
+        expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+        expect(metadataFilters).toEqual([{ key: 'city', op: 'in', value: ['Zurich', null] }]);
     });
 
     describe('updateConfusionCell', () => {

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -103,8 +103,11 @@ const imageFilter = derived(
             sampleFilter.confusion_cell = confusionCell;
         }
 
-        if ($filterParams.metadata_values) {
-            const metadataFilters = createMetadataFilters($filterParams.metadata_values);
+        if ($filterParams.metadata_values || $filterParams.categorical_metadata_values) {
+            const metadataFilters = createMetadataFilters(
+                $filterParams.metadata_values ?? {},
+                $filterParams.categorical_metadata_values
+            );
             if (metadataFilters.length > 0) {
                 sampleFilter.metadata_filters = metadataFilters;
             }

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.test.ts
@@ -199,5 +199,19 @@ describe('buildRequestBody', () => {
                 metadataFilterFixture
             ]);
         });
+
+        it('applies categorical metadata values via createMetadataFilters', () => {
+            const result = buildRequestBody(
+                {
+                    collection_id: 'col-1',
+                    mode: 'normal',
+                    categorical_metadata_values: { city: ['Zurich', null] }
+                },
+                0
+            );
+            expect(result.filters?.sample_filter?.metadata_filters).toEqual([
+                metadataFilterFixture
+            ]);
+        });
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
@@ -14,9 +14,13 @@ const buildBaseBody = (params: ImagesInfiniteParams, pageParam: number): ReadIma
     filters: {
         sample_filter: {
             query_expr: params.query_expr ?? undefined,
-            metadata_filters: params.metadata_values
-                ? createMetadataFilters(params.metadata_values)
-                : undefined
+            metadata_filters:
+                params.metadata_values || params.categorical_metadata_values
+                    ? createMetadataFilters(
+                          params.metadata_values ?? {},
+                          params.categorical_metadata_values
+                      )
+                    : undefined
         }
     }
 });

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
@@ -93,6 +93,19 @@ describe('createImagesInfiniteOptions', () => {
             });
             expect(options1.queryKey).not.toEqual(options2.queryKey);
         });
+
+        it('includes typed categorical selections in the query key', () => {
+            const categoricalMetadataValues = { city: ['Zurich', null] };
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                categorical_metadata_values: categoricalMetadataValues
+            });
+
+            expect(options.queryKey[4]).toMatchObject({
+                categorical_metadata_values: categoricalMetadataValues
+            });
+        });
     });
 
     describe('enabled', () => {

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.ts
@@ -15,6 +15,7 @@ export const createImagesInfiniteOptions = (params: ImagesInfiniteParams) => {
         params.mode === 'normal' ? params.filters : params.classifierSamples,
         {
             metadata_values: params.metadata_values,
+            categorical_metadata_values: params.categorical_metadata_values,
             text_embedding: params.text_embedding,
             query_expr: params.query_expr
         },

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -8,6 +8,7 @@ import type {
 } from '$lib/api/lightly_studio_local';
 import type { DimensionBounds } from '$lib/services/loadDimensionBounds';
 import type { MetadataValues } from '$lib/services/types';
+import type { CategoricalMetadataValues } from '$lib/services/types';
 
 export interface ClassifierSamples {
     positiveSampleIds: string[];
@@ -25,6 +26,7 @@ export type ImagesInfiniteParams = {
     sort_by?: ReadImagesRequest['sort_by'];
     text_embedding?: ReadImagesRequest['text_embedding'];
     metadata_values?: MetadataValues;
+    categorical_metadata_values?: CategoricalMetadataValues;
 } & (
     | { mode: 'normal'; filters?: NormalModeFilters }
     | { mode: 'classifier'; classifierSamples?: ClassifierSamples }
@@ -37,6 +39,7 @@ export type SamplesQueryKey = readonly [
     NormalModeFilters | ClassifierSamples | undefined,
     {
         metadata_values?: MetadataValues;
+        categorical_metadata_values?: CategoricalMetadataValues;
         text_embedding?: ReadImagesRequest['text_embedding'];
         query_expr?: QueryExpr;
     },

--- a/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.test.ts
@@ -83,6 +83,18 @@ describe('createMetadataFilters', () => {
         expect(filters).toHaveLength(0);
     });
 
+    it('combines numeric ranges with one OR predicate per non-empty categorical key', () => {
+        const filters = createMetadataFilters(
+            { temperature: { min: 20, max: 100 } },
+            { city: ['Zurich', 'Berlin', null], ignored: [] }
+        );
+
+        expect(filters).toEqual([
+            { key: 'temperature', value: 20, op: '>=' },
+            { key: 'city', value: ['Zurich', 'Berlin', null], op: 'in' }
+        ]);
+    });
+
     it('should only create min filter when min is not at bound', () => {
         const metadataValues: MetadataValues = {
             temperature: { min: 20, max: 100 } // Only min is not at bound

--- a/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.ts
@@ -3,6 +3,7 @@ import type { MetadataInfoView, MetadataFilter } from '$lib/api/lightly_studio_l
 import { get, writable } from 'svelte/store';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 import { validate as validateUUID } from 'uuid';
+import type { CategoricalMetadataValues } from '$lib/services/types';
 type MetadataBounds = Record<string, { min: number; max: number }>;
 type MetadataValues = Record<string, { min: number; max: number }>;
 
@@ -16,6 +17,8 @@ const loadInitialMetadataInfo = async (collection_id: string) => {
         return;
     }
     lastCollectionId.set(collection_id);
+    const storage = useGlobalStorage();
+    storage.updateCategoricalMetadataValues({});
 
     const { data: metadataInfoData } = await getMetadataInfo({
         path: {
@@ -26,7 +29,7 @@ const loadInitialMetadataInfo = async (collection_id: string) => {
     if (!metadataInfoData) {
         return;
     }
-    const { updateMetadataBounds, updateMetadataValues, updateMetadataInfo } = useGlobalStorage();
+    const { updateMetadataBounds, updateMetadataValues, updateMetadataInfo } = storage;
 
     // Extract numerical metadata for bounds and values
     const bounds: MetadataBounds = {};
@@ -46,7 +49,10 @@ const loadInitialMetadataInfo = async (collection_id: string) => {
     updateMetadataInfo(metadataInfoData);
 };
 
-export const createMetadataFilters = (metadataValues: MetadataValues): MetadataFilter[] => {
+export const createMetadataFilters = (
+    metadataValues: MetadataValues,
+    categoricalMetadataValues: CategoricalMetadataValues = {}
+): MetadataFilter[] => {
     const filters: MetadataFilter[] = [];
     const { metadataBounds } = useGlobalStorage();
 
@@ -76,6 +82,11 @@ export const createMetadataFilters = (metadataValues: MetadataValues): MetadataF
             }
         }
     }
+    for (const [key, values] of Object.entries(categoricalMetadataValues)) {
+        if (values.length > 0) {
+            filters.push({ key, value: values, op: 'in' });
+        }
+    }
     return filters;
 };
 
@@ -88,7 +99,9 @@ export const useMetadataFilters = (collection_id?: string) => {
         metadataBounds,
         metadataValues,
         metadataInfo,
+        categoricalMetadataValues,
         updateMetadataValues,
+        updateCategoricalMetadataValues,
         updateMetadataBounds,
         updateMetadataInfo
     } = useGlobalStorage();
@@ -97,7 +110,9 @@ export const useMetadataFilters = (collection_id?: string) => {
         metadataBounds,
         metadataValues,
         metadataInfo,
+        categoricalMetadataValues,
         updateMetadataValues,
+        updateCategoricalMetadataValues,
         updateMetadataBounds,
         updateMetadataInfo,
         createMetadataFilters

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
@@ -131,6 +131,24 @@ describe('useVideoFilters', () => {
                 { key: 'temp', value: 10, op: '>=' }
             ]);
         });
+
+        it('includes categorical metadata selections in the sample filter', async () => {
+            const { createMetadataFilters } =
+                await import('../useMetadataFilters/useMetadataFilters');
+            vi.mocked(createMetadataFilters).mockReturnValueOnce([
+                { key: 'city', value: ['Zurich', null], op: 'in' }
+            ]);
+            const { videoFilter, updateFilterParams } = useVideoFilters();
+
+            updateFilterParams({
+                collection_id: 'coll-1',
+                filters: { categorical_metadata_values: { city: ['Zurich', null] } }
+            });
+
+            const metadataFilters = get(videoFilter)?.sample_filter?.metadata_filters;
+            expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+            expect(metadataFilters).toEqual([{ key: 'city', value: ['Zurich', null], op: 'in' }]);
+        });
     });
 
     describe('updateSampleIds', () => {

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
@@ -6,7 +6,7 @@ import type {
     VideoFilter,
     VideoFieldsBoundsView
 } from '$lib/api/lightly_studio_local/types.gen';
-type MetadataValues = Record<string, { min: number; max: number }>;
+import type { CategoricalMetadataValues, MetadataValues } from '$lib/services/types';
 
 export type VideoFilterParams = {
     collection_id: string;
@@ -15,6 +15,7 @@ export type VideoFilterParams = {
         annotation_frames_label_ids?: string[];
         sample_ids?: string[];
         metadata_values?: MetadataValues;
+        categorical_metadata_values?: CategoricalMetadataValues;
     };
     video_bounds?: VideoFieldsBoundsView | null;
 };
@@ -69,8 +70,14 @@ export const buildVideoFilter = ($filterParams: VideoFilterParams | null): Video
         sampleFilter.tag_ids = tagIds;
     }
 
-    if ($filterParams.filters?.metadata_values) {
-        const metadataFilters = createMetadataFilters($filterParams.filters.metadata_values);
+    if (
+        $filterParams.filters?.metadata_values ||
+        $filterParams.filters?.categorical_metadata_values
+    ) {
+        const metadataFilters = createMetadataFilters(
+            $filterParams.filters.metadata_values ?? {},
+            $filterParams.filters.categorical_metadata_values
+        );
         if (metadataFilters.length > 0) {
             sampleFilter.metadata_filters = metadataFilters;
         }

--- a/lightly_studio_view/src/lib/services/types.ts
+++ b/lightly_studio_view/src/lib/services/types.ts
@@ -87,3 +87,5 @@ export type SideEffectHook<T, I = unknown> = (params: I) => SideEffectHookResult
 export type MetadataInfo = MetadataInfoView;
 export type MetadataBounds = Record<string, { min: number; max: number }>;
 export type MetadataValues = Record<string, { min: number; max: number }>;
+export type CategoricalMetadataValue = string | boolean | null;
+export type CategoricalMetadataValues = Record<string, CategoricalMetadataValue[]>;


### PR DESCRIPTION
## Summary

Stacked on p8.

Adds a `categorical` slot to `DistributionSourceGroup`; for each group that carries categorical data the panel now renders:

1. A `MetadataCategoricalFilter` checkbox list (above the chart)
2. A horizontal `BarChart` with selection visuals (green = selected, grey = unselected)
3. Loading, error, and retry states matching the existing numeric histogram pattern

`DatasetDistributionPanel` accepts new `categoricalGroups`, `onToggleCategoricalValue`, and `onClearCategoricalField` props; the existing numeric-only interface is unchanged.

## Test plan

- [ ] `make static-checks` (frontend) passes
- [ ] `npm run test:unit` passes (new tests in `DatasetDistributionPanel.test.ts`)
- [ ] Manual: open a collection with categorical metadata — bar charts appear below each categorical field in the distribution sidebar

Part of LIG-9585.