### PR TITLE
FE: categorical filter chips and page wiring

### DIFF
--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.svelte
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.svelte
@@ -28,10 +28,14 @@
                 >
                     {#snippet subtitle()}
                         <div class="truncate text-xs text-muted-foreground">
-                            {hook.formatValue(chip.key, chip.range.min)} – {hook.formatValue(
-                                chip.key,
-                                chip.range.max
-                            )}
+                            {#if chip.kind === 'categorical'}
+                                {hook.formatCategoricalValues(chip.values)}
+                            {:else if chip.range}
+                                {hook.formatValue(chip.key, chip.range.min)} – {hook.formatValue(
+                                    chip.key,
+                                    chip.range.max
+                                )}
+                            {/if}
                         </div>
                     {/snippet}
                 </FilterChip>

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.test.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.test.ts
@@ -9,6 +9,16 @@ describe('MetadataFilterChips', () => {
     beforeEach(() => {
         storage.updateMetadataBounds({});
         storage.updateMetadataValues({});
+        storage.updateCategoricalMetadataValues({});
+    });
+
+    it('distinguishes literal values from semantic Missing in a chip', () => {
+        storage.updateCategoricalMetadataValues({ city: ['Missing', null, 'Other'] });
+        render(MetadataFilterChips);
+
+        expect(screen.getByTestId('metadata-filter-chip-city')).toHaveTextContent(
+            'Missing (value), Missing (no value), Other (value)'
+        );
     });
 
     it('renders nothing when no filter is narrowed', () => {

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.svelte.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.svelte.ts
@@ -1,6 +1,7 @@
 import { fromStore } from 'svelte/store';
 import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import { formatFloat, formatInteger } from '$lib/utils';
+import type { CategoricalMetadataValue } from '$lib/services/types';
 
 type Range = { min: number; max: number };
 type BoundsMap = Record<string, Range>;
@@ -8,17 +9,26 @@ type BoundsMap = Record<string, Range>;
 export interface MetadataFilterChip {
     key: string;
     active: boolean;
-    range: Range;
+    kind: 'numeric' | 'categorical';
+    range?: Range;
+    values?: CategoricalMetadataValue[];
 }
 
 export function useMetadataFilterChips(collectionId: string | undefined) {
-    const { metadataBounds, metadataValues, updateMetadataValues } =
-        useMetadataFilters(collectionId);
+    const {
+        metadataBounds,
+        metadataValues,
+        categoricalMetadataValues,
+        updateMetadataValues,
+        updateCategoricalMetadataValues
+    } = useMetadataFilters(collectionId);
 
     const boundsStore = fromStore(metadataBounds);
     const valuesStore = fromStore(metadataValues);
+    const categoricalStore = fromStore(categoricalMetadataValues);
 
     let lastRanges = $state<BoundsMap>({});
+    let lastCategoricalValues = $state<Record<string, CategoricalMetadataValue[]>>({});
 
     const isNarrowed = (key: string): boolean => {
         const bound = boundsStore.current[key];
@@ -38,6 +48,19 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
         }
     });
 
+    $effect(() => {
+        for (const [key, values] of Object.entries(categoricalStore.current)) {
+            if (values.length === 0) continue;
+            const previous = lastCategoricalValues[key] ?? [];
+            const unchanged =
+                previous.length === values.length &&
+                previous.every((value, index) => Object.is(value, values[index]));
+            if (!unchanged) {
+                lastCategoricalValues = { ...lastCategoricalValues, [key]: [...values] };
+            }
+        }
+    });
+
     // One chip per key that is narrowed now or has a remembered range: active
     // chips show the current range, disabled ones the remembered range.
     const chips = $derived.by<MetadataFilterChip[]>(() => {
@@ -45,16 +68,32 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
             ...Object.keys(lastRanges),
             ...Object.keys(valuesStore.current).filter(isNarrowed)
         ]);
-        return [...keys]
+        const numericChips = [...keys]
             .filter((key) => boundsStore.current[key])
             .map((key) => {
                 const active = isNarrowed(key);
                 const range: Range | undefined = active
                     ? valuesStore.current[key]
                     : lastRanges[key];
-                return { key, active, range };
+                return range ? { key, active, range, kind: 'numeric' as const } : null;
             })
-            .filter((chip): chip is MetadataFilterChip => !!chip.range);
+            .filter((chip): chip is NonNullable<typeof chip> => chip !== null);
+        const categoricalKeys = new Set([
+            ...Object.keys(lastCategoricalValues),
+            ...Object.entries(categoricalStore.current)
+                .filter(([, values]) => values.length > 0)
+                .map(([key]) => key)
+        ]);
+        const categoricalChips: MetadataFilterChip[] = [...categoricalKeys].map((key) => {
+            const current = categoricalStore.current[key] ?? [];
+            return {
+                key,
+                active: current.length > 0,
+                kind: 'categorical',
+                values: current.length > 0 ? current : lastCategoricalValues[key]
+            };
+        });
+        return [...numericChips, ...categoricalChips];
     });
 
     const setRange = (key: string, range: Range) => {
@@ -62,6 +101,13 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
     };
 
     const handleToggle = (key: string, checked: boolean | 'indeterminate') => {
+        if (lastCategoricalValues[key]) {
+            updateCategoricalMetadataValues({
+                ...categoricalStore.current,
+                [key]: checked ? lastCategoricalValues[key] : []
+            });
+            return;
+        }
         const bound = boundsStore.current[key];
         if (!bound) return;
         if (checked && lastRanges[key]) {
@@ -72,6 +118,15 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
     };
 
     const handleClear = (key: string) => {
+        if (lastCategoricalValues[key]) {
+            const next = { ...categoricalStore.current };
+            delete next[key];
+            updateCategoricalMetadataValues(next);
+            lastCategoricalValues = Object.fromEntries(
+                Object.entries(lastCategoricalValues).filter(([valueKey]) => valueKey !== key)
+            );
+            return;
+        }
         const bound = boundsStore.current[key];
         if (bound) setRange(key, { min: bound.min, max: bound.max });
         lastRanges = Object.fromEntries(
@@ -85,12 +140,26 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
         return isInteger ? formatInteger(value) : formatFloat(value);
     };
 
+    const formatCategoricalValues = (values: CategoricalMetadataValue[] = []): string => {
+        const hasMissingValue = values.includes('Missing');
+        const hasNoValue = values.includes(null);
+        return values
+            .map((value) => {
+                if (value === null) return hasMissingValue ? 'Missing (no value)' : 'Missing';
+                if (value === 'Missing' && hasNoValue) return 'Missing (value)';
+                if (value === 'Other') return 'Other (value)';
+                return String(value);
+            })
+            .join(', ');
+    };
+
     return {
         get chips() {
             return chips;
         },
         handleToggle,
         handleClear,
-        formatValue
+        formatValue,
+        formatCategoricalValues
     };
 }

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.test.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.test.ts
@@ -21,6 +21,7 @@ describe('useMetadataFilterChips', () => {
     beforeEach(() => {
         storage.updateMetadataBounds({});
         storage.updateMetadataValues({});
+        storage.updateCategoricalMetadataValues({});
     });
 
     it('provides a chip only for narrowed filters, not for full-range ones', () => {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -73,7 +73,8 @@
         useSelectionSummary,
         useImageAnnotationCounts,
         useImageAnnotationCountsQueryKey,
-        useNumericMetadataDistribution
+        useNumericMetadataDistribution,
+        useCategoricalMetadataDistribution
     } from '$lib/hooks';
     import { useSelectAll } from '$lib/hooks/useSelectAll/useSelectAll';
     import { isInputElement } from '$lib/utils';
@@ -286,9 +287,14 @@
             : 'Search samples by description or image'
     );
 
-    const { metadataValues, metadataBounds, updateMetadataValues } = $derived.by(() =>
-        useMetadataFilters(collectionId)
-    );
+    const {
+        metadataValues,
+        metadataBounds,
+        metadataInfo,
+        categoricalMetadataValues,
+        updateMetadataValues,
+        updateCategoricalMetadataValues
+    } = $derived.by(() => useMetadataFilters(collectionId));
     const { dimensionsValues } = useDimensions(collectionIdStore);
 
     const annotationLabelsQuery = useAnnotationLabels(() => ({
@@ -309,7 +315,9 @@
     });
 
     const metadataFilters = $derived(
-        metadataValues ? createMetadataFilters($metadataValues) : undefined
+        metadataValues
+            ? createMetadataFilters($metadataValues, $categoricalMetadataValues)
+            : undefined
     );
     const { videoFramesBoundsValues } = useVideoFramesBounds();
     const { videoBoundsValues } = useVideoBounds();
@@ -583,21 +591,43 @@
     // selectDistributions internally via the TanStack Query `select` option.
     const metadataDistributions = $derived(metadataHistogramsQuery.data ?? {});
 
+    const categoricalMetadataQuery = useCategoricalMetadataDistribution(() => ({
+        collectionId,
+        filter: imageAnnotationCountsFilter,
+        enabled: distributionPanelVisible
+    }));
+    const categoricalMetadataDistributions = $derived(categoricalMetadataQuery.data ?? {});
+
     const metadataDistributionSource = $derived.by<DistributionSource | null>(() => {
-        const keys = Object.keys(metadataDistributions);
-        if (keys.length === 0) return null;
+        const numericKeys = Object.keys(metadataDistributions);
+        const categoricalKeys = ($metadataInfo ?? [])
+            .filter((info) => info.type === 'string' || info.type === 'boolean')
+            .map((info) => info.name);
+        if (numericKeys.length === 0 && categoricalKeys.length === 0) return null;
         return {
             id: 'metadata',
             label: 'Metadata',
             groupLabel: 'Metadata key',
             valueNoun: 'samples',
-            groups: keys.map((key) => ({
-                id: key,
-                label: key,
-                histogram: metadataDistributions[key],
-                // Highlight the active filter range; bins outside it dim.
-                selectedRange: $metadataValues[key]
-            }))
+            groups: [
+                ...numericKeys.map((key) => ({
+                    id: key,
+                    label: key,
+                    histogram: metadataDistributions[key],
+                    // Highlight the active filter range; bins outside it dim.
+                    selectedRange: $metadataValues[key]
+                })),
+                ...categoricalKeys.map((key) => ({
+                    id: key,
+                    label: key,
+                    categorical: {
+                        buckets: categoricalMetadataDistributions[key] ?? [],
+                        selectedValues: $categoricalMetadataValues[key] ?? [],
+                        loading: categoricalMetadataQuery.isFetching,
+                        error: categoricalMetadataQuery.error?.message
+                    }
+                }))
+            ]
         };
     });
 
@@ -623,6 +653,24 @@
                 ? { min: bound.min, max: bound.max }
                 : { min: clampedMin, max: clampedMax }
         });
+    };
+
+    const handleCategoricalValueToggle = (metadataKey: string, value: string | boolean | null) => {
+        const selected = $categoricalMetadataValues[metadataKey] ?? [];
+        const exists = selected.some((candidate) => Object.is(candidate, value));
+        const next = exists
+            ? selected.filter((candidate) => !Object.is(candidate, value))
+            : [...selected, value];
+        updateCategoricalMetadataValues({
+            ...$categoricalMetadataValues,
+            [metadataKey]: next
+        });
+    };
+
+    const clearCategoricalValues = (metadataKey: string) => {
+        const next = { ...$categoricalMetadataValues };
+        delete next[metadataKey];
+        updateCategoricalMetadataValues(next);
     };
 
     const distributionSources = $derived<DistributionSource[]>(
@@ -812,6 +860,9 @@
                                         distributionCountMode = mode;
                                     }}
                                     onHistogramRangeSelect={handleDistributionHistogramRangeSelect}
+                                    onCategoricalValueToggle={handleCategoricalValueToggle}
+                                    onCategoricalValuesClear={clearCategoricalValues}
+                                    onCategoricalRetry={() => categoricalMetadataQuery.refetch()}
                                     {histogramBinCount}
                                     onHistogramBinCountChange={(binCount) =>
                                         (histogramBinCount = binCount)}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
@@ -22,7 +22,9 @@
 
     const collectionId = $derived(page.params.collection_id);
 
-    const { metadataValues } = $derived(useMetadataFilters(collectionId));
+    const { metadataValues, categoricalMetadataValues } = $derived(
+        useMetadataFilters(collectionId)
+    );
     const { videoFramesBoundsValues } = $derived(useVideoFramesBounds(collectionId));
 
     const { selectedAnnotationFilterIdsArray: selectedAnnotationFilterIds } =
@@ -41,7 +43,8 @@
                 ? $selectedAnnotationFilterIds
                 : undefined,
             tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined,
-            metadata_values: $metadataValues
+            metadata_values: $metadataValues,
+            categorical_metadata_values: $categoricalMetadataValues
         },
         frame_bounds: $videoFramesBoundsValues
     });

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
@@ -26,7 +26,7 @@
         })
     );
 
-    const { metadataValues } = useMetadataFilters();
+    const { metadataValues, categoricalMetadataValues } = useMetadataFilters();
     const { selectedAnnotationFilterIdsArray: selectedAnnotationsFilterIds } =
         useSelectedAnnotationsFilter();
     const { videoBoundsValues } = $derived.by(() => useVideoBounds(collectionId));
@@ -42,7 +42,8 @@
                 ? $selectedAnnotationsFilterIds
                 : undefined,
             tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined,
-            metadata_values: $metadataValues
+            metadata_values: $metadataValues,
+            categorical_metadata_values: $categoricalMetadataValues
         },
         video_bounds: $videoBoundsValues
     });


### PR DESCRIPTION
## Summary

Stacked on p9.

**`MetadataFilterChips`** / `useMetadataFilterChips`: tracks categorical selections and emits chips with disambiguated labels — `Missing (location)` for the sentinel bucket vs `"Missing" (location)` for samples whose literal value is the string "Missing".

**Collection layout + video pages**: the layout now fetches categorical distributions (`useCategoricalMetadataDistribution`), exposes `toggleCategoricalValue` / `clearCategoricalField` handlers to `DatasetDistributionPanel`, and merges `categoricalMetadataValues` into the shared `metadataFilters`. The frames and videos pages forward the same values to their respective filter hooks.

## Test plan

- [ ] `make static-checks` (frontend) passes
- [ ] `npm run test:unit` passes (updated `useMetadataFilterChips` tests, new layout tests)
- [ ] Manual: click a bar in the categorical distribution, verify a filter chip appears; click the chip's ✕, verify the selection clears

Part of LIG-9585.