### PR TITLE
FE: generalize ClassSetConfig and DistributionConfigDialog for categorical values

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/types.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/types.ts
@@ -8,4 +8,6 @@ export interface CategoryCount {
     selected?: boolean;
     /** Whether clicking the bar can change selection. */
     selectable?: boolean;
+    /** Keeps semantic buckets visible when a top-N view is applied. */
+    pinned?: boolean;
 }

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.svelte
@@ -13,6 +13,8 @@
         open: boolean;
         /** Every class label available; bounds top-N and populates the manual selector. */
         allClasses: string[];
+        /** Stable values and labels for manual selection. */
+        items?: SelectItem[];
         /** The currently applied selection. Copied into a draft each time the dialog opens. */
         selection: ClassSetSelection;
         /** Sort options for the top-N tab (host-specific ranking criteria). */
@@ -23,6 +25,8 @@
         testIdPrefix: string;
         /** Shows an "All" quick action next to the number input. */
         showAllButton?: boolean;
+        /** Singular/plural labels for the configured chart items. */
+        itemNounPlural?: string;
         /** Extra controls rendered below the tabs (e.g. coloring options). */
         extraSections?: Snippet;
         /** Invoked with the new selection when the user clicks Apply. The dialog then closes itself. */
@@ -32,16 +36,18 @@
     let {
         open = $bindable(),
         allClasses,
+        items,
         selection,
         sortItems,
         description,
         testIdPrefix,
         showAllButton = false,
+        itemNounPlural = 'classes',
         extraSections,
         onApply
     }: Props = $props();
 
-    const maxN = $derived(allClasses.length);
+    const maxN = $derived(items?.length ?? allClasses.length);
 
     const toDraft = (): ClassSetSelection => ({
         mode: selection.mode,
@@ -73,7 +79,7 @@
 <Dialog.Root bind:open>
     <Dialog.Content class="max-w-[420px]">
         <Dialog.Header>
-            <Dialog.Title>Configure classes</Dialog.Title>
+            <Dialog.Title>Configure {itemNounPlural}</Dialog.Title>
             <Dialog.Description>{description}</Dialog.Description>
         </Dialog.Header>
         <Tabs.Root bind:value={draft.mode}>
@@ -84,7 +90,7 @@
             <Tabs.Content value="topN">
                 <div class="space-y-3 pt-2">
                     <label class="flex items-center justify-between gap-2 text-sm">
-                        Number of classes
+                        Number of {itemNounPlural}
                         <span class="flex items-center gap-1">
                             <Input
                                 type="number"
@@ -124,6 +130,9 @@
                 <ManualClassSelector
                     bind:selected={draft.manualClasses}
                     {allClasses}
+                    {items}
+                    {itemNounPlural}
+                    itemNoun={itemNounPlural === 'classes' ? 'class' : 'value'}
                     searchTestId={`${testIdPrefix}-search`}
                 />
             </Tabs.Content>

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.test.ts
@@ -54,6 +54,13 @@ describe('ClassSetConfigDialog', () => {
         expect(input).toHaveAttribute('max', '30');
     });
 
+    it('uses custom item nouns', () => {
+        renderDialog({ itemNounPlural: 'values' });
+
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.getByText('Number of values')).toBeInTheDocument();
+    });
+
     it('shows the label of the current sort option on the trigger', () => {
         renderDialog({ selection: { ...baseSelection, sortBy: 'name' } });
 

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
@@ -4,35 +4,52 @@
     import * as Command from '$lib/components/ui/command';
     import { cn } from '$lib/utils';
 
+    type ManualSelectionItem = { value: string; label: string };
+
     interface Props {
         /** Currently selected class labels. Bindable — mutated on toggle / Select all / Clear. */
         selected: string[];
         /** Full list of class labels to choose from, in the order they should be displayed. */
         allClasses: string[];
+        /** Optional stable values and display labels; labels need not be unique. */
+        items?: ManualSelectionItem[];
+        itemNoun?: string;
+        itemNounPlural?: string;
         /** test-id for the search input; lets each host keep its own id scheme. */
         searchTestId?: string;
     }
 
-    let { selected = $bindable(), allClasses, searchTestId }: Props = $props();
+    let {
+        selected = $bindable(),
+        allClasses,
+        items,
+        itemNoun = 'class',
+        itemNounPlural = 'classes',
+        searchTestId
+    }: Props = $props();
 
-    const toggle = (className: string) => {
-        selected = selected.includes(className)
-            ? selected.filter((c) => c !== className)
-            : [...selected, className];
+    const resolvedItems = $derived(
+        items ?? allClasses.map((className) => ({ value: className, label: className }))
+    );
+
+    const toggle = (value: string) => {
+        selected = selected.includes(value)
+            ? selected.filter((selectedValue) => selectedValue !== value)
+            : [...selected, value];
     };
 </script>
 
 <div class="pt-2">
     <div class="mb-1 flex items-center justify-between">
         <span class="text-xs text-muted-foreground">
-            {selected.length} of {allClasses.length} selected
+            {selected.length} of {resolvedItems.length} selected
         </span>
         <div class="flex gap-1">
             <Button
                 variant="ghost"
                 size="sm"
                 class="h-6 px-2 text-xs"
-                onclick={() => (selected = [...allClasses])}
+                onclick={() => (selected = resolvedItems.map((item) => item.value))}
             >
                 Select all
             </Button>
@@ -47,13 +64,17 @@
         </div>
     </div>
     <Command.Root class="rounded-md border">
-        <Command.Input placeholder="Search classes..." data-testid={searchTestId} />
+        <Command.Input placeholder="Search {itemNounPlural}..." data-testid={searchTestId} />
         <Command.List class="max-h-[220px] dark:[color-scheme:dark]">
-            <Command.Empty>No class found.</Command.Empty>
-            {#each allClasses as className (className)}
-                <Command.Item value={className} onSelect={() => toggle(className)}>
-                    <CheckIcon class={cn(!selected.includes(className) && 'text-transparent')} />
-                    <span class="min-w-0 flex-1 truncate">{className}</span>
+            <Command.Empty>No {itemNoun} found.</Command.Empty>
+            {#each resolvedItems as item (item.value)}
+                <Command.Item
+                    value={item.value}
+                    keywords={[item.label]}
+                    onSelect={() => toggle(item.value)}
+                >
+                    <CheckIcon class={cn(!selected.includes(item.value) && 'text-transparent')} />
+                    <span class="min-w-0 flex-1 truncate">{item.label}</span>
                 </Command.Item>
             {/each}
         </Command.List>

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
@@ -40,4 +40,24 @@ describe('ManualClassSelector', () => {
 
         expect(screen.getByTestId('my-search')).toBeInTheDocument();
     });
+
+    it('uses stable values for duplicate labels and custom copy', async () => {
+        render(ManualClassSelector, {
+            props: {
+                selected: [],
+                allClasses: ['Missing', 'Missing'],
+                items: [
+                    { value: 'literal-missing', label: 'Missing' },
+                    { value: 'semantic-missing', label: 'Missing' }
+                ],
+                itemNoun: 'value',
+                itemNounPlural: 'values'
+            }
+        });
+
+        expect(screen.getByPlaceholderText('Search values...')).toBeInTheDocument();
+        expect(screen.getAllByText('Missing')).toHaveLength(2);
+        await fireEvent.click(screen.getAllByText('Missing')[0]);
+        await waitFor(() => expect(screen.getByText('1 of 2 selected')).toBeInTheDocument());
+    });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.svelte
@@ -13,19 +13,37 @@
         open: boolean;
         /** Every class label available, used to bound top-N and populate the manual selector. */
         allClasses: string[];
+        /** Stable values and display labels for manual selection. */
+        items?: SelectItem[];
         /** The currently applied config. */
         config: DistributionConfig;
         /** Whether to show the Count by selector (default true). */
         showCountMode?: boolean;
+        /** Singular/plural labels used by categorical distributions. */
+        itemNounPlural?: string;
+        /** Labels for the available sort modes. */
+        sortLabels?: Record<DistributionSortOption, string>;
         /** Invoked with the new config when the user clicks Apply. */
         onApply: (config: DistributionConfig) => void;
     }
 
-    let { open = $bindable(), allClasses, config, showCountMode = true, onApply }: Props = $props();
+    let {
+        open = $bindable(),
+        allClasses,
+        items,
+        config,
+        showCountMode = true,
+        itemNounPlural = 'classes',
+        sortLabels = DISTRIBUTION_SORT_LABELS,
+        onApply
+    }: Props = $props();
 
-    const sortItems: SelectItem[] = (
-        Object.keys(DISTRIBUTION_SORT_LABELS) as DistributionSortOption[]
-    ).map((value) => ({ value, label: DISTRIBUTION_SORT_LABELS[value] }));
+    const sortItems = $derived<SelectItem[]>(
+        (Object.keys(sortLabels) as DistributionSortOption[]).map((value) => ({
+            value,
+            label: sortLabels[value]
+        }))
+    );
 
     const countModeItems: SelectItem[] = [
         { value: AnnotationCountMode.OBJECTS, label: 'Objects' },
@@ -43,11 +61,13 @@
 <ClassSetConfigDialog
     bind:open
     {allClasses}
+    {items}
     selection={config}
     {sortItems}
-    description="Choose which classes the distribution chart shows."
+    description="Choose which {itemNounPlural} the distribution chart shows."
     testIdPrefix="distribution-config"
     showAllButton
+    {itemNounPlural}
     onApply={(selection) =>
         onApply({ ...config, ...selection, countMode: draftCountMode } as DistributionConfig)}
 >

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.test.ts
@@ -45,6 +45,25 @@ describe('DistributionConfigDialog', () => {
         expect(screen.getByTestId('distribution-config-top-n')).toHaveValue(5);
     });
 
+    it('uses metadata value wording and hides count mode when configured', () => {
+        renderDialog({ itemNounPlural: 'values', showCountMode: false });
+
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.getByText('Number of values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+    });
+
+    it('uses value wording in the manual selector', async () => {
+        renderDialog({ itemNounPlural: 'values', showCountMode: false });
+
+        await fireEvent.click(screen.getByRole('tab', { name: 'Manual' }));
+        expect(screen.getByPlaceholderText('Search values...')).toBeInTheDocument();
+        await fireEvent.input(screen.getByPlaceholderText('Search values...'), {
+            target: { value: 'not present' }
+        });
+        expect(screen.getByText('No value found.')).toBeInTheDocument();
+    });
+
     it('does not render its content while closed', () => {
         renderDialog({ open: false });
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.test.ts
@@ -49,6 +49,23 @@ describe('selectVisibleCounts', () => {
         expect(visible.map((item) => item.label)).toEqual(['dog', 'car']);
     });
 
+    it('uses stable ids for manual selections when labels collide', () => {
+        const visible = selectVisibleCounts(
+            [
+                { id: 'literal-missing', label: 'Missing', count: 2 },
+                { id: 'semantic-missing', label: 'Missing', count: 1 }
+            ],
+            {
+                mode: 'manual',
+                n: 1,
+                sortBy: 'count',
+                manualClasses: ['semantic-missing']
+            }
+        );
+
+        expect(visible.map((item) => item.id)).toEqual(['semantic-missing']);
+    });
+
     it('returns nothing when the manual selection is empty', () => {
         const visible = selectVisibleCounts(data, {
             mode: 'manual',
@@ -57,5 +74,18 @@ describe('selectVisibleCounts', () => {
             manualClasses: []
         });
         expect(visible).toEqual([]);
+    });
+
+    it('keeps pinned semantic buckets within a top-N limit', () => {
+        const visible = selectVisibleCounts(
+            [
+                ...data,
+                { label: 'Missing', count: 1, pinned: true },
+                { label: 'Other', count: 2, pinned: true }
+            ],
+            { mode: 'topN', n: 3, sortBy: 'count', manualClasses: [] }
+        );
+
+        expect(visible.map((item) => item.label)).toEqual(['person', 'Other', 'Missing']);
     });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.ts
@@ -16,7 +16,16 @@ export function selectVisibleCounts(
             : a.label.localeCompare(b.label)
     );
     if (config.mode === 'manual') {
-        return sorted.filter((item) => config.manualClasses.includes(item.label));
+        return sorted.filter((item) => config.manualClasses.includes(item.id ?? item.label));
     }
-    return sorted.slice(0, Math.max(config.n, 1));
+    const limit = Math.max(config.n, 1);
+    const pinned = sorted.filter((item) => item.pinned);
+    if (pinned.length === 0) return sorted.slice(0, limit);
+
+    const remainingSlots = Math.max(limit - pinned.length, 0);
+    const selected = new Set([
+        ...pinned,
+        ...sorted.filter((item) => !item.pinned).slice(0, remainingSlots)
+    ]);
+    return sorted.filter((item) => selected.has(item));
 }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -12,6 +12,11 @@ export const DISTRIBUTION_SORT_LABELS: Record<DistributionSortOption, string> = 
     name: 'Class name'
 };
 
+export const CATEGORICAL_DISTRIBUTION_SORT_LABELS: Record<DistributionSortOption, string> = {
+    count: 'Count',
+    name: 'Value'
+};
+
 /** Bar layout for the distribution chart. */
 export type DistributionOrientation = 'vertical' | 'horizontal';
 


### PR DESCRIPTION
## Summary

Stacked on p10.

Makes the existing config components reusable for categorical metadata values (not just annotation classes):

- **`ClassSetConfigDialog`** / **`ManualClassSelector`**: accept an `itemNounPlural` prop (`"classes"` by default, `"values"` for categorical use) — labels like "Search classes…" and "No class found." become context-sensitive
- **`DistributionConfigDialog`**: accepts `itemNounPlural` and `showCountMode` props so the count-mode selector is hidden for categorical distributions (which have no object/frame distinction)
- **`selectVisibleCounts`** helper: standalone pure function that slices a `CategoryCount[]` array to the configured top-N limit — extracted here so the panel can use it independently
- **`BarChart/types.ts`**: adds `orientation` to `BarChartConfig` for persistence
- **`DatasetDistributionPanel/types.ts`**: adds `CategoricalDistributionConfig` and extends `DistributionSourceGroup`

## Test plan

- [ ] `make static-checks` (frontend) passes
- [ ] `npm run test:unit` passes (updated tests in `ClassSetConfigDialog`, `ManualClassSelector`, `DistributionConfigDialog`, `selectVisibleCounts`)

Part of LIG-9585.