### PR TITLE
FE: categorical distribution config dialog and expanded view

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -12,6 +12,7 @@
     import PanelHeader from './PanelHeader/PanelHeader.svelte';
     import { selectVisibleCounts } from './selectVisibleCounts';
     import {
+        CATEGORICAL_DISTRIBUTION_SORT_LABELS,
         HISTOGRAM_BIN_COUNT_ITEMS,
         type DistributionConfig,
         type DistributionSource,
@@ -127,12 +128,16 @@
             label: bucket.label,
             count: bucket.count,
             selectable: bucket.kind !== 'other',
+            pinned: bucket.kind !== 'value',
             selected:
                 bucket.kind !== 'other' &&
                 activeCategorical?.selectedValues.some((value) => Object.is(value, bucket.value))
         }))
     );
     const displayedData = $derived(activeCategorical ? categoricalData : activeData);
+    const configurationItems = $derived(
+        displayedData.map((item) => ({ value: item.id ?? item.label, label: item.label }))
+    );
     const activeHistogramRange = $derived(activeGroup?.selectedRange ?? activeSource.selectedRange);
     const handleHistogramRangeSelect = (range: HistogramRange) => {
         const groupId = activeGroup?.id ?? activeSource.id;
@@ -154,6 +159,23 @@
         orientation: 'horizontal',
         countMode: initialCountMode
     });
+    const defaultCategoricalConfig: DistributionConfig = {
+        mode: 'topN',
+        n: 1,
+        sortBy: 'count',
+        manualClasses: [],
+        orientation: 'horizontal',
+        countMode: AnnotationCountMode.SAMPLES
+    };
+    let categoricalConfigs = $state<Record<string, DistributionConfig>>({});
+    const categoricalConfig = $derived<DistributionConfig>(
+        activeGroup
+            ? (categoricalConfigs[activeGroup.id] ?? {
+                  ...defaultCategoricalConfig,
+                  n: Math.max(categoricalData.length, 1)
+              })
+            : defaultCategoricalConfig
+    );
     let configDialogOpen = $state(false);
     let expandOpen = $state(false);
     let histogramExpandOpen = $state(false);
@@ -177,9 +199,10 @@
         (activeSource.groups ?? []).map((group) => ({ value: group.id, label: group.label }))
     );
 
-    const visible = $derived(
-        activeCategorical ? displayedData : selectVisibleCounts(displayedData, config)
+    const activeViewConfig = $derived<DistributionConfig>(
+        activeCategorical ? categoricalConfig : config
     );
+    const visible = $derived(selectVisibleCounts(displayedData, activeViewConfig));
     const totalCount = $derived(displayedData.reduce((sum, item) => sum + item.count, 0));
 
     const handleCategoricalBarClick = (item: CategoryCount) => {
@@ -188,7 +211,23 @@
         onCategoricalValueToggle?.(activeGroup.id, bucket.value);
     };
 
+    const setCategoricalConfig = (next: DistributionConfig) => {
+        if (!activeGroup) return;
+        categoricalConfigs = {
+            ...categoricalConfigs,
+            [activeGroup.id]: {
+                ...next,
+                orientation: 'horizontal',
+                countMode: AnnotationCountMode.SAMPLES
+            }
+        };
+    };
+
     function applyConfig(next: DistributionConfig) {
+        if (activeCategorical) {
+            setCategoricalConfig(next);
+            return;
+        }
         if (next.countMode !== config.countMode) {
             onCountModeChange?.(next.countMode ?? AnnotationCountMode.OBJECTS);
         }
@@ -323,6 +362,26 @@
                 {/if}
             </div>
         {/if}
+        {#if categoricalData.length > 0}
+            <PanelHeader
+                config={categoricalConfig}
+                classCount={categoricalData.length}
+                visibleClassCount={visible.length}
+                {totalCount}
+                {valueNoun}
+                categoryNoun="value"
+                categoryNounPlural="values"
+                sortLabels={CATEGORICAL_DISTRIBUTION_SORT_LABELS}
+                onConfigure={() => (configDialogOpen = true)}
+                onShowAll={() =>
+                    setCategoricalConfig({
+                        ...categoricalConfig,
+                        mode: 'topN',
+                        n: categoricalData.length
+                    })}
+                onExpand={() => (expandOpen = true)}
+            />
+        {/if}
     {:else if activeData.length > 0}
         <PanelHeader
             {config}
@@ -390,7 +449,7 @@
             {/if}
             <BarChart
                 data={visible}
-                orientation={activeCategorical ? 'horizontal' : config.orientation}
+                orientation={activeViewConfig.orientation}
                 maxHeightPx={chartHeight || undefined}
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
@@ -400,20 +459,29 @@
         {/if}
     </div>
 </div>
-{#if !activeCategorical}
+{#if !activeHistogram}
     <DistributionConfigDialog
         bind:open={configDialogOpen}
-        allClasses={activeData.map((item) => item.label)}
-        {config}
+        allClasses={displayedData.map((item) => item.label)}
+        items={configurationItems}
+        config={activeViewConfig}
+        showCountMode={!activeCategorical}
+        itemNounPlural={activeCategorical ? 'values' : 'classes'}
+        sortLabels={activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
         onApply={applyConfig}
     />
     <ExpandDialog
         bind:open={expandOpen}
-        data={activeData}
-        {config}
+        data={displayedData}
+        config={activeViewConfig}
         {valueNoun}
+        categoryNoun={activeCategorical ? 'value' : 'class'}
+        categoryNounPlural={activeCategorical ? 'values' : 'classes'}
+        sortLabels={activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
+        showCountMode={!activeCategorical}
+        fixedOrientation={activeCategorical ? 'horizontal' : undefined}
         onConfigChange={applyConfig}
-        {onBarClick}
+        onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
     />
 {/if}
 {#if activeHistogram}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -276,6 +276,107 @@ describe('DatasetDistributionPanel', () => {
         expect(onCategoricalValueToggle).toHaveBeenCalledOnce();
     });
 
+    it('configures and expands categorical values while keeping bars horizontal', async () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                valueNoun: 'samples',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 1
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        expect(screen.getByText(/2 values · sorted by count · 5 samples/)).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('dataset-distribution-toggle-orientation')
+        ).not.toBeInTheDocument();
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+        await fireEvent.click(screen.getByText('Cancel'));
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-expand'));
+        expect(screen.getByTestId('dataset-distribution-expanded-configure')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('dataset-distribution-expanded-toggle-orientation')
+        ).not.toBeInTheDocument();
+    });
+
+    it('manually configures colliding categorical labels by stable bucket id', async () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'status',
+                        label: 'status',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'literal-missing',
+                                    kind: 'value',
+                                    value: 'Missing',
+                                    label: 'Missing',
+                                    count: 4
+                                },
+                                {
+                                    id: 'semantic-missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 3
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        await fireEvent.click(screen.getByRole('tab', { name: 'Manual' }));
+        const missingOptions = screen.getAllByText('Missing');
+        expect(missingOptions).toHaveLength(2);
+        await fireEvent.click(missingOptions[1]);
+        await fireEvent.click(screen.getByTestId('distribution-config-apply'));
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+            series: [{ data: { value: number }[] }];
+        };
+        expect(option.yAxis.data).toEqual(['Missing']);
+        expect(option.series[0].data[0].value).toBe(3);
+    });
+
     it('shows categorical loading and retryable error states', async () => {
         const onCategoricalRetry = vi.fn();
         const source = (state: { loading?: boolean; error?: string }): DistributionSource[] => [

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
@@ -4,7 +4,12 @@
     import DistributionConfigDialog from '../DistributionConfigDialog/DistributionConfigDialog.svelte';
     import PanelHeader from '../PanelHeader/PanelHeader.svelte';
     import { selectVisibleCounts } from '../selectVisibleCounts';
-    import type { DistributionConfig } from '../types';
+    import type {
+        DistributionConfig,
+        DistributionOrientation,
+        DistributionSortOption
+    } from '../types';
+    import { DISTRIBUTION_SORT_LABELS } from '../types';
 
     interface Props {
         /** Two-way bound flag controlling dialog visibility. */
@@ -15,6 +20,12 @@
         config: DistributionConfig;
         /** Noun for the header summary (e.g. 'annotations', 'samples'). */
         valueNoun?: string;
+        categoryNoun?: string;
+        categoryNounPlural?: string;
+        sortLabels?: Record<DistributionSortOption, string>;
+        showCountMode?: boolean;
+        /** Keeps categorical metadata horizontal while reusing the expanded chart. */
+        fixedOrientation?: DistributionOrientation;
         /** Invoked when the user applies a new config from the expanded view. */
         onConfigChange: (config: DistributionConfig) => void;
         onBarClick?: (item: CategoryCount) => void;
@@ -25,6 +36,11 @@
         data,
         config,
         valueNoun = 'annotations',
+        categoryNoun = 'class',
+        categoryNounPlural = 'classes',
+        sortLabels = DISTRIBUTION_SORT_LABELS,
+        showCountMode = true,
+        fixedOrientation,
         onConfigChange,
         onBarClick
     }: Props = $props();
@@ -37,13 +53,19 @@
 
     const visible = $derived(selectVisibleCounts(data, config));
     const totalCount = $derived(data.reduce((sum, item) => sum + item.count, 0));
+    const orientation = $derived(fixedOrientation ?? config.orientation);
+    const configurationItems = $derived(
+        data.map((item) => ({ value: item.id ?? item.label, label: item.label }))
+    );
 </script>
 
 <Dialog.Root bind:open>
     <Dialog.Content class="flex h-[92vh] max-w-[94vw] flex-col sm:max-w-[94vw]">
         <Dialog.Header>
             <Dialog.Title>Distribution</Dialog.Title>
-            <Dialog.Description>Hover a bar for the full class name and count</Dialog.Description>
+            <Dialog.Description>
+                Hover a bar for the full {categoryNoun} name and count
+            </Dialog.Description>
         </Dialog.Header>
         <PanelHeader
             {config}
@@ -51,13 +73,19 @@
             visibleClassCount={visible.length}
             {totalCount}
             {valueNoun}
+            {categoryNoun}
+            {categoryNounPlural}
+            {sortLabels}
             onConfigure={() => (configDialogOpen = true)}
             onShowAll={() => onConfigChange({ ...config, mode: 'topN', n: data.length })}
-            onToggleOrientation={() =>
-                onConfigChange({
-                    ...config,
-                    orientation: config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
-                })}
+            onToggleOrientation={fixedOrientation
+                ? undefined
+                : () =>
+                      onConfigChange({
+                          ...config,
+                          orientation:
+                              config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
+                      })}
             testIdPrefix="dataset-distribution-expanded"
         />
         <div
@@ -66,7 +94,7 @@
         >
             <BarChart
                 data={visible}
-                orientation={config.orientation}
+                {orientation}
                 maxHeightPx={chartHeight || undefined}
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
@@ -79,6 +107,10 @@
 <DistributionConfigDialog
     bind:open={configDialogOpen}
     allClasses={data.map((item) => item.label)}
+    items={configurationItems}
     {config}
+    {showCountMode}
+    itemNounPlural={categoryNounPlural}
+    {sortLabels}
     onApply={onConfigChange}
 />

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.test.ts
@@ -96,4 +96,27 @@ describe('ExpandDialog', () => {
 
         expect(onConfigChange).toHaveBeenCalledWith({ ...config, orientation: 'horizontal' });
     });
+
+    it('keeps categorical values horizontal and exposes value configuration', async () => {
+        renderDialog({
+            fixedOrientation: 'horizontal',
+            categoryNoun: 'value',
+            categoryNounPlural: 'values',
+            showCountMode: false,
+            sortLabels: { count: 'Count', name: 'Value' }
+        });
+
+        expect(screen.getByText(/values · sorted by count/)).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('dataset-distribution-expanded-toggle-orientation')
+        ).not.toBeInTheDocument();
+        await fireEvent.click(screen.getByTestId('dataset-distribution-expanded-configure'));
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+        };
+        expect(option.yAxis.data).toBeDefined();
+    });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
@@ -19,6 +19,11 @@
         totalCount?: number;
         /** Noun for the total count summary (e.g. 'annotations', 'samples'). */
         valueNoun?: string;
+        /** Singular/plural labels for the distributed categories. */
+        categoryNoun?: string;
+        categoryNounPlural?: string;
+        /** Labels for the active sort mode. */
+        sortLabels?: Record<keyof typeof DISTRIBUTION_SORT_LABELS, string>;
         /** Opens the view-config dialog (top-N and sort order). */
         onConfigure: () => void;
         /** Quick action showing all classes; rendered only while a subset is visible. */
@@ -37,6 +42,9 @@
         visibleClassCount,
         totalCount,
         valueNoun = 'annotations',
+        categoryNoun = 'class',
+        categoryNounPlural = 'classes',
+        sortLabels = DISTRIBUTION_SORT_LABELS,
         onConfigure,
         onShowAll,
         onToggleOrientation,
@@ -49,12 +57,13 @@
     <div class="mb-2 flex-1 text-xs text-muted-foreground">
         {#if visibleClassCount < classCount}
             {config.mode === 'manual' ? 'Showing' : 'Top'}
-            {visibleClassCount} of {classCount} classes
+            {visibleClassCount} of {classCount}
+            {categoryNounPlural}
         {:else}
             {classCount}
-            {classCount === 1 ? 'class' : 'classes'}
+            {classCount === 1 ? categoryNoun : categoryNounPlural}
         {/if}
-        · sorted by {DISTRIBUTION_SORT_LABELS[config.sortBy].toLowerCase()}
+        · sorted by {sortLabels[config.sortBy].toLowerCase()}
         {#if totalCount !== undefined}
             · {totalCount.toLocaleString('en-US')}
             {valueNoun}
@@ -89,7 +98,7 @@
     <Button
         variant="ghost"
         icon={SettingsIcon}
-        ariaLabel="Configure distribution classes"
+        ariaLabel="Configure distribution {categoryNounPlural}"
         buttonProps={{
             size: 'sm',
             class: 'h-8 gap-1',

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
@@ -44,6 +44,21 @@ describe('PanelHeader', () => {
         expect(screen.getByText(/491 samples/)).toBeInTheDocument();
     });
 
+    it('uses custom category wording and sort labels', () => {
+        render(PanelHeader, {
+            props: {
+                ...defaultProps,
+                categoryNoun: 'value',
+                categoryNounPlural: 'values',
+                sortLabels: { count: 'Count', name: 'Value' },
+                config: { ...config, sortBy: 'name' }
+            }
+        });
+
+        expect(screen.getByText(/5 values · sorted by value/)).toBeInTheDocument();
+        expect(screen.getByLabelText('Configure distribution values')).toBeInTheDocument();
+    });
+
     it('shows the "Show all" action only for a visible subset and forwards clicks', async () => {
         const onShowAll = vi.fn();
         render(PanelHeader, {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -852,21 +852,24 @@
                             <QueryEditorPanel onClose={() => setActivePanel('none')} />
                         {:else if distributionPanelVisible}
                             {#await import('$lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte') then { default: DatasetDistributionPanel }}
-                                <DatasetDistributionPanel
-                                    sources={distributionSources}
-                                    initialCountMode={distributionCountMode}
-                                    onClose={() => setActivePanel('none')}
-                                    onCountModeChange={(mode) => {
-                                        distributionCountMode = mode;
-                                    }}
-                                    onHistogramRangeSelect={handleDistributionHistogramRangeSelect}
-                                    onCategoricalValueToggle={handleCategoricalValueToggle}
-                                    onCategoricalValuesClear={clearCategoricalValues}
-                                    onCategoricalRetry={() => categoricalMetadataQuery.refetch()}
-                                    {histogramBinCount}
-                                    onHistogramBinCountChange={(binCount) =>
-                                        (histogramBinCount = binCount)}
-                                />
+                                {#key collectionId}
+                                    <DatasetDistributionPanel
+                                        sources={distributionSources}
+                                        initialCountMode={distributionCountMode}
+                                        onClose={() => setActivePanel('none')}
+                                        onCountModeChange={(mode) => {
+                                            distributionCountMode = mode;
+                                        }}
+                                        onHistogramRangeSelect={handleDistributionHistogramRangeSelect}
+                                        onCategoricalValueToggle={handleCategoricalValueToggle}
+                                        onCategoricalValuesClear={clearCategoricalValues}
+                                        onCategoricalRetry={() =>
+                                            categoricalMetadataQuery.refetch()}
+                                        {histogramBinCount}
+                                        onHistogramBinCountChange={(binCount) =>
+                                            (histogramBinCount = binCount)}
+                                    />
+                                {/key}
                             {/await}
                         {/if}
                     </Pane>


### PR DESCRIPTION
## Summary

Stacked on p11.

Wires the config helpers from p11 into the panel and adds an expanded view for categorical bar charts:

- **`DatasetDistributionPanel`**: each categorical group now has a gear icon that opens a `DistributionConfigDialog` (top-N, sort order, manual value selection); the configured top-N is applied via `selectVisibleCounts`
- **`ExpandDialog`**: renders the full categorical bar chart at a larger size; mirrors the orientation and config from the panel state
- **`PanelHeader`**: renders the optional expand and config action buttons passed from the panel
- **`+layout.svelte`**: passes the new config and expand handlers down to `DatasetDistributionPanel`

## Test plan

- [ ] `make static-checks` (frontend) passes
- [ ] `npm run test:unit` passes (new/updated tests in `DatasetDistributionPanel`, `ExpandDialog`, `PanelHeader`)
- [ ] Manual: click the gear icon on a categorical chart, change top-N to 3, verify only 3 bars are shown; click the expand icon, verify a larger chart opens

Part of LIG-9585.