### PR TITLE
FE: categorical distribution orientation toggle and spacing polish

### DIFF
--- a/docs/features/lig-9585-categorical-metadata-distribution-filter.md
+++ b/docs/features/lig-9585-categorical-metadata-distribution-filter.md
@@ -1,0 +1,215 @@
+# Feature: Categorical Metadata Distribution and Filter
+
+**Status:** Implemented; QA ready
+
+**Linear:** [LIG-9585](https://linear.app/lightly/issue/LIG-9585/frontend-categorical-metadata-bar-chart-filter-ui-8-sp)
+
+**Depends on:** [LIG-9584](https://linear.app/lightly/issue/LIG-9584/backend-categorical-metadata-value-counts-endpoint-5-sp)
+
+## Problem and Target User
+
+ML engineers can inspect numeric metadata distributions, but categorical fields such as `city`,
+`camera_id`, or a boolean flag are absent from the distribution panel and cannot be filtered there.
+They need to spot imbalance and missing metadata, then narrow the grid without leaving the plot.
+
+## Proposed User Flow
+
+1. Open the existing dataset distribution panel and select **Metadata**.
+2. Use the existing **Metadata key** selector to choose a numeric or categorical field.
+3. Numeric fields continue to show the current histogram. Categorical fields show a horizontal bar
+   chart and a compact searchable value selector.
+4. Select one or more concrete values or **Missing**. The grid and all distributions update using
+   the shared active filter; alternatives for the edited field remain visible through faceting.
+5. Deselect every value (or use **Clear**) to remove that field's categorical filter.
+
+## Wireframes
+
+### Loaded categorical field
+
+```text
++--------------------------------------------------+
+| Distribution                                  [x]|
+| Distribution  [ Metadata                 v ]     |
+| Metadata key  [ city                     v ]     |
+|                                                  |
+| Values        [ 2 selected · Search values  v ]  |
+|                                                  |
+| Zurich    |████████████████████| 120             |
+| Berlin    |██████████          |  64             |
+| Missing   |██                  |   8             |
+| Other     |█                   |   4  (display)   |
++--------------------------------------------------+
+
+Values popover
++--------------------------------------+
+| Search values…                       |
+| [x] Zurich                       120 |
+| [x] Berlin                        64 |
+| [ ] Missing                        8 |
+|     Other is an aggregate and cannot |
+|     be selected                        |
+| [Clear]                              |
++--------------------------------------+
+```
+
+The bars for selected concrete values and Missing have a non-colour-only selected treatment.
+Clicking a selectable bar toggles the same selection as its checkbox. Other is not interactive.
+
+### Loading, empty, and error
+
+```text
+Loading/refetch                 No categorical fields
++---------------------------+  +---------------------------+
+| Values [Loading…]         |  | No categorical metadata   |
+| Previous bars stay visible|  | is available.             |
++---------------------------+  +---------------------------+
+
+Selected field has no matches  Request failed
++---------------------------+  +---------------------------+
+| No matching samples for   |  | Could not load metadata   |
+| this metadata field.      |  | distribution. [Retry]     |
++---------------------------+  +---------------------------+
+```
+
+## Content and Interaction
+
+- String and boolean fields use categorical bars; integer and float fields keep using histograms.
+- Concrete values are ordered by the endpoint (frequency with deterministic ties). **Missing** and
+  non-zero **Other** are appended as semantic buckets.
+- Values retain typed identity (`string`, `boolean`, or `null`) independently from display labels.
+  Literal strings `"Missing"` and `"Other"` therefore remain ordinary selectable values.
+- **Missing** means absent key, JSON null, or no metadata row and is represented internally by
+  `null`. **Other** is display-only because its members are not returned by the endpoint.
+- Multiple values for one key use OR semantics. Filters for different keys and all other active
+  filters use AND semantics.
+- Selected values remain available in the selector while refetching. A field's own categorical
+  filter is excluded only from that field's count query, matching the numeric faceting behavior.
+- Empty selection means no categorical filter for the field. The UI never sends an empty `in`
+  predicate.
+- The selector summary reads **All values**, the selected value for one item, or **N selected**.
+- Categorical fields expose the existing distribution settings and expanded-chart actions. Settings
+  support top-N, manual value selection, and count/value sorting; they are stored per metadata key.
+  The categorical chart remains horizontal and omits **Count by** because the endpoint counts
+  samples. Missing and Other remain visible in top-N mode; manual mode is explicitly user-selected.
+- For five or fewer concrete values, show direct checkboxes without search. Longer lists add search
+  inside the same compact popover; search only narrows returned options and never changes the grid.
+- Retain selected values when they are absent from the latest top-20 response so users can still
+  deselect them, and summarize active categorical fields in the existing metadata-filter chip area.
+
+## States
+
+- **Loading:** Disable selection until initial data arrives. During later refetches, retain previous
+  bars and selections and show a subtle busy indicator.
+- **Empty:** If no categorical fields exist, omit categorical groups. If a known selected field has
+  no matches, show the field-level empty message rather than an empty chart.
+- **Error:** Keep the panel and selectors usable, show a concise error with Retry, and do not clear
+  active selections.
+- **Success:** Show the chart and value selector. Omit zero-count Missing and Other bars.
+
+## Responsive and Accessibility Requirements
+
+- Keep controls full-width and stacked in the side panel; the value popover must not exceed the
+  viewport and its list scrolls independently.
+- Every selectable value is keyboard reachable and toggleable with Enter or Space. Escape closes
+  the popover and returns focus to its trigger.
+- Expose checkbox state, counts, chart labels, selected state, loading state, and disabled Other
+  semantics to assistive technology. Do not communicate selection through colour alone.
+- Long field/value labels truncate visually but remain available through accessible names/tooltips.
+- Touch targets are at least 32 px in the desktop side panel and 44 px in narrow/touch layouts.
+
+## Decision Rationale
+
+- **Reuse the existing source and field selectors:** numeric and categorical metadata are two
+  renderings of the same concept, so adding another navigation layer would be needless ceremony.
+- **Horizontal bars:** categorical labels remain readable and the existing `BarChart` can be reused.
+- **Compact searchable multi-select:** checkboxes are fast for common low-cardinality fields while
+  search keeps the top-20 list manageable.
+- **Explicit Missing; display-only Other:** Missing maps to a precise predicate; Other does not.
+- **Live faceted counts:** the chart continues to explain the current grid without hiding alternative
+  values for the field being edited.
+- **Follow FiftyOne's useful behavior, not its layout:** FiftyOne supports categorical histograms,
+  current-view updates, low-cardinality checkboxes, and search for longer value lists. Lightly keeps
+  those interaction principles inside its existing distribution panel rather than adding a second
+  full filter sidebar.
+
+## Acceptance Criteria
+
+- [ ] The Metadata source lists numeric, string, and boolean fields in the existing field selector.
+- [ ] Numeric fields still render the existing histogram and range filter behavior.
+- [ ] Categorical fields render endpoint-ordered horizontal bars with counts.
+- [ ] Categorical fields provide a horizontal expanded view and value-specific configuration for
+      top-N, manual selection, and count/value sorting without exposing Count by or orientation.
+- [ ] Concrete string/boolean values and Missing can be selected by checkbox and bar click.
+- [ ] Multiple values for one field filter with OR; filters across fields remain AND.
+- [ ] Literal `"Missing"`/`"Other"` values do not collide with semantic buckets.
+- [ ] Other is visible when non-zero, clearly non-selectable, and never produces a filter.
+- [ ] Grid requests, query keys, filter hashes, counts, and distribution requests use the same
+      categorical selection state and update when it changes.
+- [ ] A categorical field's own predicate is excluded from its returned counts.
+- [ ] Empty selection removes that field's predicate; selections reset on collection change.
+- [ ] Active categorical filters appear in metadata-filter chips and stale selected values remain
+      removable when absent from the latest response.
+- [ ] Loading/refetch, empty, and error states preserve active filters and provide clear feedback.
+- [ ] Keyboard, focus, screen-reader, and responsive requirements are covered by tests or manual QA.
+
+## Architecture Contract
+
+### Backend filter extension
+
+- Extend `MetadataOperator` with `in`.
+- A categorical field is encoded as one predicate, for example:
+
+```json
+{ "key": "city", "op": "in", "value": ["Zurich", "Berlin", null] }
+```
+
+- Array members are OR-ed. `null` matches absent keys, explicit JSON null, and samples without a
+  metadata row. Different filter objects retain existing AND semantics.
+- Concrete members must be homogeneous strings or homogeneous booleans; an optional null may be
+  mixed in. Reject empty arrays and unsupported/mixed values with HTTP 422.
+- Use literal top-level JSON-key extraction and an outer metadata join whenever null is requested.
+  Existing comparison operators and nested-field behavior remain unchanged.
+- The value-count response is unchanged; its resolver already removes all own-key predicates.
+
+### Frontend ownership and data flow
+
+- Shared metadata filter storage owns `Record<string, (string | boolean | null)[]>` categorical
+  selections and resets it when the collection changes.
+- Filter creation combines numeric range predicates with one non-empty categorical `in` predicate
+  per key. The combined predicates drive grid requests and every distribution/count request, and
+  categorical state is included in query keys/filter hashes.
+- `useCategoricalMetadataDistribution.ts` parallels the numeric hook, calls
+  `POST /metadata/value-counts`, forwards the reactive `ImageFilter`, maps semantic buckets without
+  label-based identity, and keeps prior data during refetch.
+- Metadata source groups use a discriminated categorical payload, mutually exclusive with `data`
+  and `histogram`. The panel emits `(groupId, typedValue)` when a concrete/Missing bucket toggles.
+- `MetadataCategoricalFilter.svelte` owns only the value popover and categorical presentation; the
+  shared store remains the source of truth.
+
+### Verification surfaces
+
+- Backend validation/query tests: string/boolean OR, null-only, concrete plus null, AND across keys,
+  dotted/apostrophe keys, no metadata row, empty/mixed-array rejection, DuckDB and PostgreSQL paths.
+- Frontend unit/component tests: response mapping, request forwarding, filter construction/reset,
+  request/query-key propagation, bar/checkbox toggling, Missing versus literal `"Missing"`, disabled
+  Other, loading/empty/error, and selected styling.
+- Regenerate OpenAPI and the frontend client, then run backend and frontend static checks plus focused
+  test suites.
+
+## Non-goals
+
+- Selecting or expanding the aggregated Other bucket.
+- Returning/searching the full high-cardinality tail or adding server-side value search.
+- Moving categorical filters into the existing left filter panel or adding a new permanent sidebar.
+- Changing numeric histogram behavior, class distribution configuration, or count modes.
+- Persisting distributions or adding a database migration.
+
+## Assumptions and Open Questions
+
+- Boolean metadata follows the categorical path.
+- The endpoint's fixed top 20 is sufficient for this first UI; selected top values remain present
+  because own-field filters are excluded.
+- The small `in` extension is part of LIG-9585 because Missing and multi-select cannot meet the
+  ticket's acceptance criteria with scalar comparison operators.
+- Open question for later work: if users need values hidden in Other, add a dedicated value-search
+  endpoint rather than pretending an aggregate bucket identifies its members.

--- a/docs/features/lig-9585-categorical-metadata-distribution-filter.md
+++ b/docs/features/lig-9585-categorical-metadata-distribution-filter.md
@@ -16,8 +16,8 @@ They need to spot imbalance and missing metadata, then narrow the grid without l
 
 1. Open the existing dataset distribution panel and select **Metadata**.
 2. Use the existing **Metadata key** selector to choose a numeric or categorical field.
-3. Numeric fields continue to show the current histogram. Categorical fields show a horizontal bar
-   chart and a compact searchable value selector.
+3. Numeric fields continue to show the current histogram. Categorical fields show a bar chart,
+   horizontal by default, and a compact searchable value selector.
 4. Select one or more concrete values or **Missing**. The grid and all distributions update using
    the shared active filter; alternatives for the edited field remain visible through faceting.
 5. Deselect every value (or use **Clear**) to remove that field's categorical filter.
@@ -89,8 +89,9 @@ Selected field has no matches  Request failed
 - The selector summary reads **All values**, the selected value for one item, or **N selected**.
 - Categorical fields expose the existing distribution settings and expanded-chart actions. Settings
   support top-N, manual value selection, and count/value sorting; they are stored per metadata key.
-  The categorical chart remains horizontal and omits **Count by** because the endpoint counts
-  samples. Missing and Other remain visible in top-N mode; manual mode is explicitly user-selected.
+  The panel and expanded view expose the existing orientation toggle, and that choice is also stored
+  per metadata key. **Count by** remains hidden because the endpoint counts samples. Missing and
+  Other remain visible in top-N mode; manual mode is explicitly user-selected.
 - For five or fewer concrete values, show direct checkboxes without search. Longer lists add search
   inside the same compact popover; search only narrows returned options and never changes the grid.
 - Retain selected values when they are absent from the latest top-20 response so users can still
@@ -121,7 +122,8 @@ Selected field has no matches  Request failed
 
 - **Reuse the existing source and field selectors:** numeric and categorical metadata are two
   renderings of the same concept, so adding another navigation layer would be needless ceremony.
-- **Horizontal bars:** categorical labels remain readable and the existing `BarChart` can be reused.
+- **Horizontal bars by default:** categorical labels remain readable, while the existing orientation
+  toggle lets users switch low-cardinality fields to vertical bars when that view is more useful.
 - **Compact searchable multi-select:** checkboxes are fast for common low-cardinality fields while
   search keeps the top-20 list manageable.
 - **Explicit Missing; display-only Other:** Missing maps to a precise predicate; Other does not.
@@ -136,9 +138,10 @@ Selected field has no matches  Request failed
 
 - [ ] The Metadata source lists numeric, string, and boolean fields in the existing field selector.
 - [ ] Numeric fields still render the existing histogram and range filter behavior.
-- [ ] Categorical fields render endpoint-ordered horizontal bars with counts.
-- [ ] Categorical fields provide a horizontal expanded view and value-specific configuration for
-      top-N, manual selection, and count/value sorting without exposing Count by or orientation.
+- [ ] Categorical fields render endpoint-ordered bars with counts, horizontal by default.
+- [ ] Categorical fields provide an expanded view, a shared per-field orientation toggle, and
+      value-specific configuration for top-N, manual selection, and count/value sorting without
+      exposing Count by.
 - [ ] Concrete string/boolean values and Missing can be selected by checkbox and bar click.
 - [ ] Multiple values for one field filter with OR; filters across fields remain AND.
 - [ ] Literal `"Missing"`/`"Other"` values do not collide with semantic buckets.

--- a/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
+++ b/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
@@ -34,6 +34,8 @@
         onBarClick?: (item: CategoryCount) => void;
         /** Custom content shown when data is empty. Replaces the default message. */
         emptyState?: Snippet;
+        /** Top chart-grid padding in px (default 16). */
+        gridTopPx?: number;
     }
 
     const {
@@ -43,7 +45,8 @@
         maxHeightPx,
         totalCount,
         onBarClick,
-        emptyState
+        emptyState,
+        gridTopPx
     }: Props = $props();
 
     let container: HTMLDivElement | undefined = $state();
@@ -102,7 +105,7 @@
 
     $effect(() => {
         if (!chart) return;
-        chart.setOption(buildEchartsOption(data, { totalCount, orientation }), true);
+        chart.setOption(buildEchartsOption(data, { totalCount, orientation, gridTopPx }), true);
     });
 
     onDestroy(() => chart?.dispose());

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -59,6 +59,16 @@ describe('buildEchartsOption', () => {
         });
     });
 
+    it('accepts compact top padding without changing the default grid', () => {
+        const standard = buildEchartsOption(balanced) as { grid: { top: number } };
+        const compact = buildEchartsOption(balanced, { gridTopPx: 4 }) as {
+            grid: { top: number };
+        };
+
+        expect(standard.grid.top).toBe(16);
+        expect(compact.grid.top).toBe(4);
+    });
+
     const getFormatter = (option: unknown) =>
         (
             option as {

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -26,6 +26,8 @@ interface BuildEchartsOptionOptions {
     totalCount?: number;
     /** Bar orientation (default 'vertical'). */
     orientation?: BarChartOrientation;
+    /** Top chart-grid padding in px (default 16). */
+    gridTopPx?: number;
 }
 
 /** Builds the ECharts option for a category-count bar chart (pass to `setOption`). */
@@ -35,6 +37,7 @@ export function buildEchartsOption(
 ): EChartsCoreOption {
     const totalCount = options.totalCount ?? data.reduce((sum, item) => sum + item.count, 0);
     const orientation = options.orientation ?? 'vertical';
+    const gridTopPx = options.gridTopPx ?? 16;
     const isHorizontal = orientation === 'horizontal';
 
     const labels = data.map((item) => item.label);
@@ -81,7 +84,7 @@ export function buildEchartsOption(
                 return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
             }
         },
-        grid: { left: 8, right: 8, top: 16, bottom: 8, containLabel: true },
+        grid: { left: 8, right: 8, top: gridTopPx, bottom: 8, containLabel: true },
         // Swap which axis holds the categories so bars grow rightward when horizontal.
         xAxis: isHorizontal ? valueAxis : categoryAxis,
         yAxis: isHorizontal ? categoryAxis : valueAxis,

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -372,6 +372,7 @@
                 categoryNoun="value"
                 categoryNounPlural="values"
                 sortLabels={CATEGORICAL_DISTRIBUTION_SORT_LABELS}
+                compact
                 onConfigure={() => (configDialogOpen = true)}
                 onShowAll={() =>
                     setCategoricalConfig({
@@ -455,6 +456,7 @@
                 {totalCount}
                 onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
                 emptyState={activeCategorical ? categoricalEmptyState : undefined}
+                gridTopPx={activeCategorical ? 4 : undefined}
             />
         {/if}
     </div>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -362,50 +362,53 @@
             </div>
         {/if}
         {#if categoricalData.length > 0}
+            <div class="mt-2">
+                <PanelHeader
+                    config={categoricalConfig}
+                    classCount={categoricalData.length}
+                    visibleClassCount={visible.length}
+                    {totalCount}
+                    {valueNoun}
+                    categoryNoun="value"
+                    categoryNounPlural="values"
+                    sortLabels={CATEGORICAL_DISTRIBUTION_SORT_LABELS}
+                    onConfigure={() => (configDialogOpen = true)}
+                    onShowAll={() =>
+                        setCategoricalConfig({
+                            ...categoricalConfig,
+                            mode: 'topN',
+                            n: categoricalData.length
+                        })}
+                    onToggleOrientation={() =>
+                        setCategoricalConfig({
+                            ...categoricalConfig,
+                            orientation:
+                                categoricalConfig.orientation === 'horizontal'
+                                    ? 'vertical'
+                                    : 'horizontal'
+                        })}
+                    onExpand={() => (expandOpen = true)}
+                />
+            </div>
+        {/if}
+    {:else if activeData.length > 0}
+        <div class="mt-2">
             <PanelHeader
-                config={categoricalConfig}
-                classCount={categoricalData.length}
+                {config}
+                classCount={activeData.length}
                 visibleClassCount={visible.length}
-                {totalCount}
+                totalCount={showTotalCount ? totalCount : undefined}
                 {valueNoun}
-                categoryNoun="value"
-                categoryNounPlural="values"
-                sortLabels={CATEGORICAL_DISTRIBUTION_SORT_LABELS}
-                compact
                 onConfigure={() => (configDialogOpen = true)}
-                onShowAll={() =>
-                    setCategoricalConfig({
-                        ...categoricalConfig,
-                        mode: 'topN',
-                        n: categoricalData.length
-                    })}
+                onShowAll={() => (config = { ...config, mode: 'topN', n: activeData.length })}
                 onToggleOrientation={() =>
-                    setCategoricalConfig({
-                        ...categoricalConfig,
-                        orientation:
-                            categoricalConfig.orientation === 'horizontal'
-                                ? 'vertical'
-                                : 'horizontal'
+                    (config = {
+                        ...config,
+                        orientation: config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
                     })}
                 onExpand={() => (expandOpen = true)}
             />
-        {/if}
-    {:else if activeData.length > 0}
-        <PanelHeader
-            {config}
-            classCount={activeData.length}
-            visibleClassCount={visible.length}
-            totalCount={showTotalCount ? totalCount : undefined}
-            {valueNoun}
-            onConfigure={() => (configDialogOpen = true)}
-            onShowAll={() => (config = { ...config, mode: 'topN', n: activeData.length })}
-            onToggleOrientation={() =>
-                (config = {
-                    ...config,
-                    orientation: config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
-                })}
-            onExpand={() => (expandOpen = true)}
-        />
+        </div>
     {/if}
     <div
         class="min-h-0 flex-1 overflow-y-auto dark:[color-scheme:dark]"
@@ -463,7 +466,7 @@
                 {totalCount}
                 onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
                 emptyState={activeCategorical ? categoricalEmptyState : undefined}
-                gridTopPx={activeCategorical ? 4 : undefined}
+                gridTopPx={4}
             />
         {/if}
     </div>
@@ -488,7 +491,6 @@
         categoryNounPlural={activeCategorical ? 'values' : 'classes'}
         sortLabels={activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
         showCountMode={!activeCategorical}
-        compact={Boolean(activeCategorical)}
         onConfigChange={applyConfig}
         onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
     />

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -217,7 +217,6 @@
             ...categoricalConfigs,
             [activeGroup.id]: {
                 ...next,
-                orientation: 'horizontal',
                 countMode: AnnotationCountMode.SAMPLES
             }
         };
@@ -380,6 +379,14 @@
                         mode: 'topN',
                         n: categoricalData.length
                     })}
+                onToggleOrientation={() =>
+                    setCategoricalConfig({
+                        ...categoricalConfig,
+                        orientation:
+                            categoricalConfig.orientation === 'horizontal'
+                                ? 'vertical'
+                                : 'horizontal'
+                    })}
                 onExpand={() => (expandOpen = true)}
             />
         {/if}
@@ -481,7 +488,7 @@
         categoryNounPlural={activeCategorical ? 'values' : 'classes'}
         sortLabels={activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
         showCountMode={!activeCategorical}
-        fixedOrientation={activeCategorical ? 'horizontal' : undefined}
+        compact={Boolean(activeCategorical)}
         onConfigChange={applyConfig}
         onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
     />

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -101,8 +101,10 @@ describe('DatasetDistributionPanel', () => {
         // Horizontal default: categories live on the y-axis.
         const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
             yAxis: { data: string[] };
+            grid: { top: number };
         };
         expect(option.yAxis.data).toEqual(['person', 'dog', 'car']);
+        expect(option.grid.top).toBe(4);
     });
 
     it('applies a new top-N from the config dialog', async () => {

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -266,8 +266,10 @@ describe('DatasetDistributionPanel', () => {
         const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
             yAxis: { data: string[] };
             series: [{ data: { itemStyle: { borderWidth: number } }[] }];
+            grid: { top: number };
         };
         expect(option.yAxis.data).toEqual(['Missing', 'Missing', 'Other']);
+        expect(option.grid.top).toBe(4);
         expect(option.series[0].data[0].itemStyle.borderWidth).toBe(3);
 
         echartsMock.getClickHandler()?.({ dataIndex: 1 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -278,7 +278,41 @@ describe('DatasetDistributionPanel', () => {
         expect(onCategoricalValueToggle).toHaveBeenCalledOnce();
     });
 
-    it('configures and expands categorical values while keeping bars horizontal', async () => {
+    it('stores categorical orientation per metadata field', async () => {
+        const user = userEvent.setup();
+        const categorical = (label: string) => ({
+            selectedValues: [],
+            buckets: [{ id: label, kind: 'value' as const, value: label, label, count: 1 }]
+        });
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groupLabel: 'Metadata key',
+                groups: [
+                    { id: 'city', label: 'city', categorical: categorical('Zurich') },
+                    { id: 'weather', label: 'weather', categorical: categorical('rainy') }
+                ]
+            },
+            { id: 'classes', label: 'Classes', data: [] }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        const orientationToggle = screen.getByTestId('dataset-distribution-toggle-orientation');
+        await fireEvent.click(orientationToggle);
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        const groupSelect = screen.getByTestId('dataset-distribution-group-select');
+        await user.click(groupSelect);
+        await user.click(await screen.findByRole('option', { name: 'weather' }));
+        expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars');
+
+        await user.click(groupSelect);
+        await user.click(await screen.findByRole('option', { name: 'city' }));
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+    });
+
+    it('configures, reorients, and expands categorical values', async () => {
         const sources: DistributionSource[] = [
             {
                 id: 'metadata',
@@ -314,9 +348,17 @@ describe('DatasetDistributionPanel', () => {
         render(DatasetDistributionPanel, { props: { sources } });
 
         expect(screen.getByText(/2 values · sorted by count · 5 samples/)).toBeInTheDocument();
-        expect(
-            screen.queryByTestId('dataset-distribution-toggle-orientation')
-        ).not.toBeInTheDocument();
+        const orientationToggle = screen.getByTestId('dataset-distribution-toggle-orientation');
+        expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars');
+
+        await fireEvent.click(orientationToggle);
+        await waitFor(() =>
+            expect(
+                (echartsMock.instance.setOption.mock.lastCall?.[0] as { xAxis: { type: string } })
+                    .xAxis.type
+            ).toBe('category')
+        );
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
 
         await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
         expect(screen.getByText('Configure values')).toBeInTheDocument();
@@ -325,9 +367,15 @@ describe('DatasetDistributionPanel', () => {
 
         await fireEvent.click(screen.getByTestId('dataset-distribution-expand'));
         expect(screen.getByTestId('dataset-distribution-expanded-configure')).toBeInTheDocument();
-        expect(
-            screen.queryByTestId('dataset-distribution-expanded-toggle-orientation')
-        ).not.toBeInTheDocument();
+        const expandedOrientationToggle = screen.getByTestId(
+            'dataset-distribution-expanded-toggle-orientation'
+        );
+        expect(expandedOrientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        await fireEvent.click(expandedOrientationToggle);
+        await waitFor(() =>
+            expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars')
+        );
     });
 
     it('manually configures colliding categorical labels by stable bucket id', async () => {

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
@@ -76,6 +76,7 @@
             {categoryNoun}
             {categoryNounPlural}
             {sortLabels}
+            compact={fixedOrientation === 'horizontal'}
             onConfigure={() => (configDialogOpen = true)}
             onShowAll={() => onConfigChange({ ...config, mode: 'topN', n: data.length })}
             onToggleOrientation={fixedOrientation
@@ -99,6 +100,7 @@
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
                 {onBarClick}
+                gridTopPx={fixedOrientation === 'horizontal' ? 4 : undefined}
             />
         </div>
     </Dialog.Content>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
@@ -4,11 +4,7 @@
     import DistributionConfigDialog from '../DistributionConfigDialog/DistributionConfigDialog.svelte';
     import PanelHeader from '../PanelHeader/PanelHeader.svelte';
     import { selectVisibleCounts } from '../selectVisibleCounts';
-    import type {
-        DistributionConfig,
-        DistributionOrientation,
-        DistributionSortOption
-    } from '../types';
+    import type { DistributionConfig, DistributionSortOption } from '../types';
     import { DISTRIBUTION_SORT_LABELS } from '../types';
 
     interface Props {
@@ -24,8 +20,8 @@
         categoryNounPlural?: string;
         sortLabels?: Record<DistributionSortOption, string>;
         showCountMode?: boolean;
-        /** Keeps categorical metadata horizontal while reusing the expanded chart. */
-        fixedOrientation?: DistributionOrientation;
+        /** Uses the tighter metadata summary/chart spacing. */
+        compact?: boolean;
         /** Invoked when the user applies a new config from the expanded view. */
         onConfigChange: (config: DistributionConfig) => void;
         onBarClick?: (item: CategoryCount) => void;
@@ -40,7 +36,7 @@
         categoryNounPlural = 'classes',
         sortLabels = DISTRIBUTION_SORT_LABELS,
         showCountMode = true,
-        fixedOrientation,
+        compact = false,
         onConfigChange,
         onBarClick
     }: Props = $props();
@@ -53,7 +49,6 @@
 
     const visible = $derived(selectVisibleCounts(data, config));
     const totalCount = $derived(data.reduce((sum, item) => sum + item.count, 0));
-    const orientation = $derived(fixedOrientation ?? config.orientation);
     const configurationItems = $derived(
         data.map((item) => ({ value: item.id ?? item.label, label: item.label }))
     );
@@ -76,17 +71,14 @@
             {categoryNoun}
             {categoryNounPlural}
             {sortLabels}
-            compact={fixedOrientation === 'horizontal'}
+            {compact}
             onConfigure={() => (configDialogOpen = true)}
             onShowAll={() => onConfigChange({ ...config, mode: 'topN', n: data.length })}
-            onToggleOrientation={fixedOrientation
-                ? undefined
-                : () =>
-                      onConfigChange({
-                          ...config,
-                          orientation:
-                              config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
-                      })}
+            onToggleOrientation={() =>
+                onConfigChange({
+                    ...config,
+                    orientation: config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
+                })}
             testIdPrefix="dataset-distribution-expanded"
         />
         <div
@@ -95,12 +87,12 @@
         >
             <BarChart
                 data={visible}
-                {orientation}
+                orientation={config.orientation}
                 maxHeightPx={chartHeight || undefined}
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
                 {onBarClick}
-                gridTopPx={fixedOrientation === 'horizontal' ? 4 : undefined}
+                gridTopPx={compact ? 4 : undefined}
             />
         </div>
     </Dialog.Content>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
@@ -20,8 +20,6 @@
         categoryNounPlural?: string;
         sortLabels?: Record<DistributionSortOption, string>;
         showCountMode?: boolean;
-        /** Uses the tighter metadata summary/chart spacing. */
-        compact?: boolean;
         /** Invoked when the user applies a new config from the expanded view. */
         onConfigChange: (config: DistributionConfig) => void;
         onBarClick?: (item: CategoryCount) => void;
@@ -36,7 +34,6 @@
         categoryNounPlural = 'classes',
         sortLabels = DISTRIBUTION_SORT_LABELS,
         showCountMode = true,
-        compact = false,
         onConfigChange,
         onBarClick
     }: Props = $props();
@@ -71,7 +68,6 @@
             {categoryNoun}
             {categoryNounPlural}
             {sortLabels}
-            {compact}
             onConfigure={() => (configDialogOpen = true)}
             onShowAll={() => onConfigChange({ ...config, mode: 'topN', n: data.length })}
             onToggleOrientation={() =>
@@ -92,7 +88,7 @@
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
                 {onBarClick}
-                gridTopPx={compact ? 4 : undefined}
+                gridTopPx={4}
             />
         </div>
     </Dialog.Content>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.test.ts
@@ -97,9 +97,9 @@ describe('ExpandDialog', () => {
         expect(onConfigChange).toHaveBeenCalledWith({ ...config, orientation: 'horizontal' });
     });
 
-    it('keeps categorical values horizontal and exposes value configuration', async () => {
+    it('uses compact categorical spacing and exposes value controls', async () => {
         renderDialog({
-            fixedOrientation: 'horizontal',
+            compact: true,
             categoryNoun: 'value',
             categoryNounPlural: 'values',
             showCountMode: false,
@@ -108,15 +108,17 @@ describe('ExpandDialog', () => {
 
         expect(screen.getByText(/values · sorted by count/)).toBeInTheDocument();
         expect(
-            screen.queryByTestId('dataset-distribution-expanded-toggle-orientation')
-        ).not.toBeInTheDocument();
+            screen.getByTestId('dataset-distribution-expanded-toggle-orientation')
+        ).toBeInTheDocument();
         await fireEvent.click(screen.getByTestId('dataset-distribution-expanded-configure'));
         expect(screen.getByText('Configure values')).toBeInTheDocument();
         expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
 
         const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
-            yAxis: { data: string[] };
+            xAxis: { data: string[] };
+            grid: { top: number };
         };
-        expect(option.yAxis.data).toBeDefined();
+        expect(option.xAxis.data).toBeDefined();
+        expect(option.grid.top).toBe(4);
     });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.test.ts
@@ -97,9 +97,8 @@ describe('ExpandDialog', () => {
         expect(onConfigChange).toHaveBeenCalledWith({ ...config, orientation: 'horizontal' });
     });
 
-    it('uses compact categorical spacing and exposes value controls', async () => {
+    it('uses consistent plot spacing and exposes categorical value controls', async () => {
         renderDialog({
-            compact: true,
             categoryNoun: 'value',
             categoryNounPlural: 'values',
             showCountMode: false,

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
@@ -34,6 +34,8 @@
         onExpand?: () => void;
         /** Prefix for button test ids, to disambiguate panel vs. expanded view. */
         testIdPrefix?: string;
+        /** Removes legacy bottom margins for compact metadata layouts. */
+        compact?: boolean;
     }
 
     let {
@@ -49,12 +51,13 @@
         onShowAll,
         onToggleOrientation,
         onExpand,
-        testIdPrefix = 'dataset-distribution'
+        testIdPrefix = 'dataset-distribution',
+        compact = false
     }: Props = $props();
 </script>
 
-<div class="mb-1 flex flex-row items-center gap-2">
-    <div class="mb-2 flex-1 text-xs text-muted-foreground">
+<div class:mb-1={!compact} class="flex flex-row items-center gap-2">
+    <div class:mb-2={!compact} class="flex-1 text-xs text-muted-foreground">
         {#if visibleClassCount < classCount}
             {config.mode === 'manual' ? 'Showing' : 'Top'}
             {visibleClassCount} of {classCount}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
@@ -34,8 +34,6 @@
         onExpand?: () => void;
         /** Prefix for button test ids, to disambiguate panel vs. expanded view. */
         testIdPrefix?: string;
-        /** Removes legacy bottom margins for compact metadata layouts. */
-        compact?: boolean;
     }
 
     let {
@@ -51,13 +49,12 @@
         onShowAll,
         onToggleOrientation,
         onExpand,
-        testIdPrefix = 'dataset-distribution',
-        compact = false
+        testIdPrefix = 'dataset-distribution'
     }: Props = $props();
 </script>
 
-<div class:mb-1={!compact} class="flex flex-row items-center gap-2">
-    <div class:mb-2={!compact} class="flex-1 text-xs text-muted-foreground">
+<div class="flex flex-row items-center gap-2">
+    <div class="flex-1 text-xs text-muted-foreground">
         {#if visibleClassCount < classCount}
             {config.mode === 'manual' ? 'Showing' : 'Top'}
             {visibleClassCount} of {classCount}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
@@ -137,4 +137,12 @@ describe('PanelHeader', () => {
 
         expect(screen.getByTestId('dataset-distribution-expanded-configure')).toBeInTheDocument();
     });
+
+    it('removes bottom margins in compact layouts', () => {
+        render(PanelHeader, { props: { ...defaultProps, compact: true } });
+
+        const summary = screen.getByText(/^5 classes ·/);
+        expect(summary).not.toHaveClass('mb-2');
+        expect(summary.parentElement).not.toHaveClass('mb-1');
+    });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
@@ -138,8 +138,8 @@ describe('PanelHeader', () => {
         expect(screen.getByTestId('dataset-distribution-expanded-configure')).toBeInTheDocument();
     });
 
-    it('removes bottom margins in compact layouts', () => {
-        render(PanelHeader, { props: { ...defaultProps, compact: true } });
+    it('does not add plot-specific bottom margins', () => {
+        render(PanelHeader, { props: defaultProps });
 
         const summary = screen.getByText(/^5 classes ·/);
         expect(summary).not.toHaveClass('mb-2');

--- a/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.test.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.test.ts
@@ -124,6 +124,7 @@ describe('buildHistogramOption', () => {
         };
         expect(xAxis.show).toBe(true);
         expect((option.yAxis as { show: boolean }).show).toBe(true);
+        expect((option.grid as { top: number }).top).toBe(4);
         // Integer ticks land exactly on bin edges: 0 → domain min, N → max.
         expect(xAxis.axisLabel.formatter(0)).toBe('0');
         expect(xAxis.axisLabel.formatter(10)).toBe('50');

--- a/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.ts
@@ -181,7 +181,7 @@ function buildTooltip(bins: HistogramBin[]): Record<string, unknown> {
 function buildGrid(showAxes: boolean): Record<string, unknown> {
     // containLabel reserves gutters for labels; right padding avoids clipping.
     return showAxes
-        ? { left: 4, right: 16, top: 8, bottom: 4, containLabel: true }
+        ? { left: 4, right: 16, top: 4, bottom: 4, containLabel: true }
         : { left: 0, right: 0, top: 2, bottom: 0 };
 }
 


### PR DESCRIPTION
## Summary

Stacked on p13. Polish and UX — no new data fetching or filter logic.

**Spacing polish** (`BarChart.svelte`, `DatasetDistributionPanel`, `ExpandDialog`, `PanelHeader`, `Histogram`):
- Consistent gap between chart header and chart body across numeric histograms and categorical bar charts
- `BarChart` gains an explicit `height` prop instead of relying on implicit container sizing
- Bar label padding tightened

**Orientation toggle** (`DatasetDistributionPanel`, `ExpandDialog`, `PanelHeader`):
- Toggle button in the panel header switches between vertical and horizontal bar chart layouts
- Chosen orientation is persisted in the distribution config so it survives re-renders
- `ExpandDialog` mirrors the orientation from the panel config

**Normalization** (`DatasetDistributionPanel`, `ExpandDialog`, `PanelHeader`): unified spacing constants so both numeric and categorical distribution groups look consistent.

## Test plan

- [ ] `make static-checks` (frontend) passes
- [ ] `npm run test:unit` passes (updated render tests for `DatasetDistributionPanel`, `ExpandDialog`, `PanelHeader`, `buildHistogramOption`)
- [ ] Manual: click the orientation toggle on a categorical chart — verify it switches; check spacing looks uniform next to numeric histograms

Part of LIG-9585.