### PR TITLE
BE: extend e2e seeding script with categorical metadata fields

### DIFF
--- a/lightly_studio/e2e-tests/index_distribution.py
+++ b/lightly_studio/e2e-tests/index_distribution.py
@@ -132,8 +132,9 @@ def _sample_metadata(rng: random.Random) -> Mapping[str, Any]:
         "reviewed": rng.choices([True, False], [0.3, 0.7])[0],
         "camera_id": rng.choices(CAMERA_IDS, CAMERA_WEIGHTS)[0],
     }
+    split_missing_probability = 0.2
     # ~20 % of images have no split — exercises the "Missing" bucket.
-    if rng.random() >= 0.2:
+    if rng.random() >= split_missing_probability:
         metadata["split"] = rng.choices(DATASET_SPLITS, SPLIT_WEIGHTS)[0]
     return metadata
 

--- a/lightly_studio/e2e-tests/index_distribution.py
+++ b/lightly_studio/e2e-tests/index_distribution.py
@@ -7,9 +7,9 @@ seeded (all default to true):
 - ``ADD_OBJECT_DETECTIONS`` a few weighted detection boxes per image
 - ``ADD_SEGMENTATIONS``     one or two weighted segmentation masks per image
 - ``ADD_METADATA``          numeric metadata fields with distinct distribution
-  shapes (bell, flat, skewed, discrete, constant) plus a string field —
-  rendered as histograms in the panel's "Metadata" distribution and above the
-  range sliders in the metadata filter panel
+  shapes (bell, flat, skewed, discrete, constant) plus several categorical
+  fields (string, boolean, many-valued, partially-missing) — rendered as
+  histograms / bar charts in the panel's "Metadata" distribution
 
 Examples::
 
@@ -71,6 +71,20 @@ SEGMENTATION_CLASSES = ["road", "sky", "building", "vegetation", "sidewalk"]
 SEGMENTATION_WEIGHTS = [0.3, 0.25, 0.2, 0.15, 0.1]
 
 LOCATIONS = ["city", "rural", "mountain", "coastal", "desert"]
+LOCATION_WEIGHTS = [0.35, 0.25, 0.20, 0.12, 0.08]
+
+# Skewed weather distribution: sunny dominates, snowy is rare.
+WEATHER_CONDITIONS = ["sunny", "partly_cloudy", "overcast", "rainy", "foggy", "snowy"]
+WEATHER_WEIGHTS = [0.40, 0.25, 0.15, 0.10, 0.07, 0.03]
+
+# Common ML split assignment; ~20 % of samples intentionally left unassigned
+# so the "Missing" bucket appears in the categorical distribution panel.
+DATASET_SPLITS = ["train", "val", "test"]
+SPLIT_WEIGHTS = [0.70, 0.20, 0.10]
+
+# 25 camera IDs: exercises the top-20 "Other" bucket in value-counts.
+CAMERA_IDS = [f"CAM_{i:02d}" for i in range(1, 26)]
+CAMERA_WEIGHTS = [max(1, 26 - i) for i in range(1, 26)]  # CAM_01 most frequent
 
 
 def _box(
@@ -93,16 +107,35 @@ def _rectangle_mask(
 
 
 def _sample_metadata(rng: random.Random) -> Mapping[str, Any]:
-    """Return one sample's metadata, each key with a distinct distribution."""
-    return {
+    """Return one sample's metadata with numeric and categorical fields.
+
+    Numeric fields cover distinct distribution shapes (bell, flat, skewed,
+    discrete, constant).  Categorical fields exercise:
+    - weighted strings with few values  (location, weather)
+    - a boolean field                   (reviewed)
+    - a many-valued string field that   (camera_id — 25 values triggers the
+      overflows the top-20 limit          "Other" bucket in value-counts)
+    - a field present on only ~80 % of  (split — triggers the "Missing" bucket)
+      samples
+    """
+    metadata: dict[str, Any] = {
+        # Numeric fields
         "confidence": min(1.0, max(0.0, rng.gauss(0.75, 0.12))),
         "brightness": rng.uniform(0.0, 255.0),
         "object_size": rng.lognormvariate(3.0, 0.8),
         "temperature": rng.randint(10, 40),
         "num_defects": rng.choices([0, 1, 2, 3, 5, 8], [50, 25, 12, 7, 4, 2])[0],
         "sensor_gain": 1.0,
-        "location": rng.choice(LOCATIONS),
+        # Categorical fields
+        "location": rng.choices(LOCATIONS, LOCATION_WEIGHTS)[0],
+        "weather": rng.choices(WEATHER_CONDITIONS, WEATHER_WEIGHTS)[0],
+        "reviewed": rng.choices([True, False], [0.3, 0.7])[0],
+        "camera_id": rng.choices(CAMERA_IDS, CAMERA_WEIGHTS)[0],
     }
+    # ~20 % of images have no split — exercises the "Missing" bucket.
+    if rng.random() >= 0.2:
+        metadata["split"] = rng.choices(DATASET_SPLITS, SPLIT_WEIGHTS)[0]
+    return metadata
 
 
 def main() -> None:
@@ -171,7 +204,7 @@ def main() -> None:
             ("classifications", ADD_CLASSIFICATIONS),
             ("object detections", ADD_OBJECT_DETECTIONS),
             ("segmentation masks", ADD_SEGMENTATIONS),
-            ("numeric metadata", ADD_METADATA),
+            ("metadata", ADD_METADATA),
         ]
         if enabled
     ]

--- a/lightly_studio/e2e-tests/index_distribution.py
+++ b/lightly_studio/e2e-tests/index_distribution.py
@@ -77,10 +77,14 @@ LOCATION_WEIGHTS = [0.35, 0.25, 0.20, 0.12, 0.08]
 WEATHER_CONDITIONS = ["sunny", "partly_cloudy", "overcast", "rainy", "foggy", "snowy"]
 WEATHER_WEIGHTS = [0.40, 0.25, 0.15, 0.10, 0.07, 0.03]
 
+REVIEWED_VALUES = [True, False]
+REVIEWED_WEIGHTS = [0.3, 0.7]
+
 # Common ML split assignment; ~20 % of samples intentionally left unassigned
 # so the "Missing" bucket appears in the categorical distribution panel.
 DATASET_SPLITS = ["train", "val", "test"]
 SPLIT_WEIGHTS = [0.70, 0.20, 0.10]
+SPLIT_MISSING_PROBABILITY = 0.2
 
 # 25 camera IDs: exercises the top-20 "Other" bucket in value-counts.
 CAMERA_IDS = [f"CAM_{i:02d}" for i in range(1, 26)]
@@ -113,10 +117,8 @@ def _sample_metadata(rng: random.Random) -> Mapping[str, Any]:
     discrete, constant).  Categorical fields exercise:
     - weighted strings with few values  (location, weather)
     - a boolean field                   (reviewed)
-    - a many-valued string field that   (camera_id — 25 values triggers the
-      overflows the top-20 limit          "Other" bucket in value-counts)
-    - a field present on only ~80 % of  (split — triggers the "Missing" bucket)
-      samples
+    - camera_id has 25 values, which triggers the "Other" bucket in value counts
+    - split is present on only ~80 % of samples, which triggers the "Missing" bucket
     """
     metadata: dict[str, Any] = {
         # Numeric fields
@@ -129,12 +131,11 @@ def _sample_metadata(rng: random.Random) -> Mapping[str, Any]:
         # Categorical fields
         "location": rng.choices(LOCATIONS, LOCATION_WEIGHTS)[0],
         "weather": rng.choices(WEATHER_CONDITIONS, WEATHER_WEIGHTS)[0],
-        "reviewed": rng.choices([True, False], [0.3, 0.7])[0],
+        "reviewed": rng.choices(REVIEWED_VALUES, REVIEWED_WEIGHTS)[0],
         "camera_id": rng.choices(CAMERA_IDS, CAMERA_WEIGHTS)[0],
     }
-    split_missing_probability = 0.2
     # ~20 % of images have no split — exercises the "Missing" bucket.
-    if rng.random() >= split_missing_probability:
+    if rng.random() >= SPLIT_MISSING_PROBABILITY:
         metadata["split"] = rng.choices(DATASET_SPLITS, SPLIT_WEIGHTS)[0]
     return metadata
 


### PR DESCRIPTION
## Summary

Standalone utility change — no API or frontend changes.

Extends the distribution e2e seeding script (`index_distribution.py`) with four categorical metadata fields so the upcoming categorical distribution panel has realistic test data:

- `location` — weighted string, few values
- `weather` — skewed string (sunny dominates, snowy is rare)
- `reviewed` — boolean
- `camera_id` — 25 values, exercises the "Other" bucket in value-counts
- `split` — present on ~80% of samples, exercises the "Missing" bucket

Also includes a minor ruff fix: inline magic value `0.2` extracted to `split_missing_probability`.

## Test plan

- [ ] `make static-checks` passes
- [ ] `make start-e2e-distribution` seeds the dataset; verify the new fields appear in the metadata panel

Part of LIG-9585.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded generated dataset metadata to include categorical fields (location, weather, reviewed status, camera ID) alongside existing numeric metadata.
  * Added support for partially missing metadata values in samples (including omission of split labels for a subset).
  * Enhanced metadata visualizations to render updated “Metadata” histograms and bar charts for the new fields.
  * Updated the seeded-data interface summary to reflect the presence of metadata rather than only numeric metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->