### PR TITLE
FE: thread categorical metadata values through all filter hooks

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.ts
@@ -5,6 +5,7 @@ import type {
     VideoFrameFilter,
     VideoFrameFieldsBoundsView
 } from '$lib/api/lightly_studio_local/types.gen';
+import type { CategoricalMetadataValues } from '$lib/services/types';
 type MetadataValues = Record<string, { min: number; max: number }>;
 
 export type VideoFrameFilterParams = {
@@ -14,6 +15,7 @@ export type VideoFrameFilterParams = {
         annotation_label_ids?: string[];
         sample_ids?: string[];
         metadata_values?: MetadataValues;
+        categorical_metadata_values?: CategoricalMetadataValues;
     };
     frame_bounds?: VideoFrameFieldsBoundsView | null;
     video_id?: string | null;
@@ -60,8 +62,11 @@ export const getFrameFilter = (params: VideoFrameFilterParams | null): VideoFram
         sampleFilter.tag_ids = tagIds;
     }
 
-    if (params.filters?.metadata_values) {
-        const metadataFilters = createMetadataFilters(params.filters.metadata_values);
+    if (params.filters?.metadata_values || params.filters?.categorical_metadata_values) {
+        const metadataFilters = createMetadataFilters(
+            params.filters.metadata_values ?? {},
+            params.filters.categorical_metadata_values ?? {}
+        );
         if (metadataFilters.length > 0) {
             sampleFilter.metadata_filters = metadataFilters;
         }

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -103,8 +103,11 @@ const imageFilter = derived(
             sampleFilter.confusion_cell = confusionCell;
         }
 
-        if ($filterParams.metadata_values) {
-            const metadataFilters = createMetadataFilters($filterParams.metadata_values);
+        if ($filterParams.metadata_values || $filterParams.categorical_metadata_values) {
+            const metadataFilters = createMetadataFilters(
+                $filterParams.metadata_values ?? {},
+                $filterParams.categorical_metadata_values ?? {}
+            );
             if (metadataFilters.length > 0) {
                 sampleFilter.metadata_filters = metadataFilters;
             }

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.ts
@@ -14,9 +14,13 @@ const buildBaseBody = (params: ImagesInfiniteParams, pageParam: number): ReadIma
     filters: {
         sample_filter: {
             query_expr: params.query_expr ?? undefined,
-            metadata_filters: params.metadata_values
-                ? createMetadataFilters(params.metadata_values)
-                : undefined
+            metadata_filters:
+                params.metadata_values || params.categorical_metadata_values
+                    ? createMetadataFilters(
+                          params.metadata_values ?? {},
+                          params.categorical_metadata_values ?? {}
+                      )
+                    : undefined
         }
     }
 });

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.ts
@@ -15,6 +15,7 @@ export const createImagesInfiniteOptions = (params: ImagesInfiniteParams) => {
         params.mode === 'normal' ? params.filters : params.classifierSamples,
         {
             metadata_values: params.metadata_values,
+            categorical_metadata_values: params.categorical_metadata_values,
             text_embedding: params.text_embedding,
             query_expr: params.query_expr
         },

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -7,7 +7,7 @@ import type {
     SortFieldExpr
 } from '$lib/api/lightly_studio_local';
 import type { DimensionBounds } from '$lib/services/loadDimensionBounds';
-import type { MetadataValues } from '$lib/services/types';
+import type { CategoricalMetadataValues, MetadataValues } from '$lib/services/types';
 
 export interface ClassifierSamples {
     positiveSampleIds: string[];
@@ -25,6 +25,7 @@ export type ImagesInfiniteParams = {
     sort_by?: ReadImagesRequest['sort_by'];
     text_embedding?: ReadImagesRequest['text_embedding'];
     metadata_values?: MetadataValues;
+    categorical_metadata_values?: CategoricalMetadataValues;
 } & (
     | { mode: 'normal'; filters?: NormalModeFilters }
     | { mode: 'classifier'; classifierSamples?: ClassifierSamples }
@@ -37,6 +38,7 @@ export type SamplesQueryKey = readonly [
     NormalModeFilters | ClassifierSamples | undefined,
     {
         metadata_values?: MetadataValues;
+        categorical_metadata_values?: CategoricalMetadataValues;
         text_embedding?: ReadImagesRequest['text_embedding'];
         query_expr?: QueryExpr;
     },

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
@@ -6,6 +6,7 @@ import type {
     VideoFilter,
     VideoFieldsBoundsView
 } from '$lib/api/lightly_studio_local/types.gen';
+import type { CategoricalMetadataValues } from '$lib/services/types';
 type MetadataValues = Record<string, { min: number; max: number }>;
 
 export type VideoFilterParams = {
@@ -15,6 +16,7 @@ export type VideoFilterParams = {
         annotation_frames_label_ids?: string[];
         sample_ids?: string[];
         metadata_values?: MetadataValues;
+        categorical_metadata_values?: CategoricalMetadataValues;
     };
     video_bounds?: VideoFieldsBoundsView | null;
 };
@@ -69,8 +71,14 @@ export const buildVideoFilter = ($filterParams: VideoFilterParams | null): Video
         sampleFilter.tag_ids = tagIds;
     }
 
-    if ($filterParams.filters?.metadata_values) {
-        const metadataFilters = createMetadataFilters($filterParams.filters.metadata_values);
+    if (
+        $filterParams.filters?.metadata_values ||
+        $filterParams.filters?.categorical_metadata_values
+    ) {
+        const metadataFilters = createMetadataFilters(
+            $filterParams.filters.metadata_values ?? {},
+            $filterParams.filters.categorical_metadata_values ?? {}
+        );
         if (metadataFilters.length > 0) {
             sampleFilter.metadata_filters = metadataFilters;
         }


### PR DESCRIPTION
## Summary

Stacked on p5.

Adds the optional `categorical_metadata_values` parameter to the four filter hooks so that active categorical selections are included in every sample-list request:

- `useImageFilters`
- `useVideoFilters`
- `useFramesFilter`
- `useImagesInfinite` (via `buildRequestBody` and `createImagesInfiniteOptions`)

No UI changes — the parameter defaults to `undefined` so existing callers are unaffected.

## Test plan

- [ ] `make static-checks` (frontend) passes
- [ ] `npm run test:unit` passes (new parametrised tests in all four hooks)

Part of LIG-9585.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering images, videos, and video frames using categorical metadata values.
  * Combined standard and categorical metadata filters for more comprehensive search results.
  * Updated filtering and caching behavior to reflect categorical metadata selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->