### PR TITLE
Tolerate broken files per-item in video embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The left filter panel can now be collapsed entirely to reclaim space for the grid; a "Filters" button in the grid header restores it.
+- Image and video opening paths (indexing and embedding) now handle errors consistently: broken files are tolerated and skipped instead of breaking the whole operation.
 
 ### Deprecated
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -121,15 +121,15 @@ class VideoEmbeddingGenerator(EmbeddingGenerator, Protocol):
     for creating embeddings.
     """
 
-    def embed_videos(self, filepaths: list[str]) -> NDArray[np.float32]:
+    def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
         """Generate embeddings for multiple video samples.
 
         Args:
             filepaths: A list of file paths to the videos to embed.
 
         Returns:
-            A numpy array representing the generated embeddings
-            in the same order as the input file paths.
+            An ``EmbeddingResult`` with embeddings for the readable videos, in the same
+            order as the corresponding input file paths.
         """
         ...
 
@@ -185,6 +185,7 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         _ = show_progress  # Not used for random embeddings.
         return np.random.rand(len(images), self._dimension).astype(np.float32)
 
-    def embed_videos(self, filepaths: list[str]) -> NDArray[np.float32]:
+    def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
         """Generate random embeddings for multiple video samples."""
-        return np.random.rand(len(filepaths), self._dimension).astype(np.float32)
+        embeddings = np.random.rand(len(filepaths), self._dimension).astype(np.float32)
+        return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(filepaths))))

--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -121,15 +121,15 @@ class VideoEmbeddingGenerator(EmbeddingGenerator, Protocol):
     for creating embeddings.
     """
 
-    def embed_videos(self, filepaths: list[str]) -> NDArray[np.float32]:
+    def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
         """Generate embeddings for multiple video samples.
 
         Args:
             filepaths: A list of file paths to the videos to embed.
 
         Returns:
-            A numpy array representing the generated embeddings
-            in the same order as the input file paths.
+            An ``EmbeddingResult`` with embeddings for the readable videos, in the same
+            order as the corresponding input file paths.
         """
         ...
 
@@ -186,6 +186,7 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         _ = show_progress  # Not used for random embeddings.
         return np.random.rand(len(images), self._dimension).astype(np.float32)
 
-    def embed_videos(self, filepaths: list[str]) -> NDArray[np.float32]:
+    def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
         """Generate random embeddings for multiple video samples."""
-        return np.random.rand(len(filepaths), self._dimension).astype(np.float32)
+        embeddings = np.random.rand(len(filepaths), self._dimension).astype(np.float32)
+        return EmbeddingResult(embeddings=embeddings, kept_indices=list(range(len(filepaths))))

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -382,14 +382,16 @@ class EmbeddingManager:
         if len(filepaths) != len(sample_ids):
             raise ValueError("Could not fetch all video paths for the provided IDs.")
 
-        # Generate embeddings for the samples.
-        embeddings = model.embed_videos(filepaths=filepaths)
+        # Generate embeddings for the samples. Broken videos are skipped, so filter the
+        # sample IDs by kept_indices to keep them aligned with the returned embeddings.
+        result = model.embed_videos(filepaths=filepaths)
+        kept_sample_ids = [sample_ids[index] for index in result.kept_indices]
 
         _store_embeddings(
             session=session,
             model_id=model_id,
-            sample_ids=sample_ids,
-            embeddings=embeddings,
+            sample_ids=kept_sample_ids,
+            embeddings=result.embeddings,
         )
 
     def embed_and_store_pil_images(

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -382,8 +382,7 @@ class EmbeddingManager:
         if len(filepaths) != len(sample_ids):
             raise ValueError("Could not fetch all video paths for the provided IDs.")
 
-        # Generate embeddings for the samples. Broken videos are skipped, so filter the
-        # sample IDs by kept_indices to keep them aligned with the returned embeddings.
+        # Generate embeddings for the samples.
         result = model.embed_videos(filepaths=filepaths)
         kept_sample_ids = [sample_ids[index] for index in result.kept_indices]
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -380,14 +380,16 @@ class EmbeddingManager:
         if len(filepaths) != len(sample_ids):
             raise ValueError("Could not fetch all video paths for the provided IDs.")
 
-        # Generate embeddings for the samples.
-        embeddings = model.embed_videos(filepaths=filepaths)
+        # Generate embeddings for the samples. Broken videos are skipped, so filter the
+        # sample IDs by kept_indices to keep them aligned with the returned embeddings.
+        result = model.embed_videos(filepaths=filepaths)
+        kept_sample_ids = [sample_ids[index] for index in result.kept_indices]
 
         _store_embeddings(
             session=session,
             model_id=model_id,
-            sample_ids=sample_ids,
-            embeddings=embeddings,
+            sample_ids=kept_sample_ids,
+            embeddings=result.embeddings,
         )
 
     def embed_and_store_pil_images(

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -173,7 +173,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         embeddings = np.empty((total_videos, self._model.output_dim), dtype=np.float32)
         # Every video yields a fixed VIDEO_FRAMES_PER_SAMPLE-frame tensor of the same shape,
         # so the per-video tensors can be stacked directly into a batch.
-        preprocessed_videos = (
+        preprocessed_videos_iter = (
             _load_video_frames(filepath, self._preprocess) for filepath in filepaths
         )
         position = 0
@@ -181,7 +181,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             tqdm(total=total_videos, desc="Generating embeddings", unit=" videos") as progress_bar,
             torch.no_grad(),
         ):
-            for batch in batching.batched(preprocessed_videos, batch_size=MAX_BATCH_SIZE):
+            for batch in batching.batched(preprocessed_videos_iter, batch_size=MAX_BATCH_SIZE):
                 videos_tensor = torch.stack(batch).to(self._device)
                 batch_embeddings = (
                     self._model.encode_video(videos_tensor, normalize=True).cpu().numpy()

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -9,11 +9,12 @@ from uuid import UUID
 import fsspec
 import numpy as np
 import torch
-from av import container
+from av import FFmpegError, container
 from numpy.typing import NDArray
 from PIL import Image
 from tqdm import tqdm
 
+from lightly_studio.core.file_outcome_report import FileOutcome, FileOutcomeReport
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
@@ -155,35 +156,52 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             ),
         )
 
-    def embed_videos(self, filepaths: list[str]) -> NDArray[np.float32]:
-        """Embed videos with Perception Encoder.
+    def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
+        """Embed videos with Perception Encoder, skipping broken files.
+
+        A video that is unreadable/undecodable is skipped rather than aborting the whole
+        run, and is recorded once as broken.
 
         Args:
             filepaths: A list of file paths to the videos to embed.
 
         Returns:
-            A numpy array representing the generated embeddings
-            in the same order as the input file paths.
+            An ``EmbeddingResult`` whose embeddings cover only the readable videos, with
+            ``kept_indices`` mapping each row back to its input position.
+
+        Raises:
+            AllInputFilesFailedError: If at least one file was attempted and every attempted
+                file was broken (i.e. no file could be read and embedded).
         """
         total_videos = len(filepaths)
         if not total_videos:
-            return np.empty((0, self._model.output_dim), dtype=np.float32)
+            empty = np.empty((0, self._model.output_dim), dtype=np.float32)
+            return EmbeddingResult(embeddings=empty, kept_indices=[])
 
         embeddings = np.empty((total_videos, self._model.output_dim), dtype=np.float32)
+        # Input indices of the videos that were embedded (their file could be read).
+        kept_indices: list[int] = []
         # Reusable batch buffer, lazily sized from the first preprocessed video.
         batch_buffer: torch.Tensor | None = None
         batch_indices: list[int] = []
+        report = FileOutcomeReport()
 
         with (
             tqdm(total=total_videos, desc="Generating embeddings", unit=" videos") as progress_bar,
             torch.no_grad(),
         ):
             for index, filepath in enumerate(filepaths):
-                frames = _load_video_frames(filepath, self._preprocess)
+                try:
+                    frames = _load_video_frames(filepath, self._preprocess)
+                except ValueError:
+                    report.record(path=filepath, outcome=FileOutcome.BROKEN)
+                    continue
+                report.record(path=filepath, outcome=FileOutcome.ADDED)
                 if batch_buffer is None:
                     batch_buffer = torch.empty((MAX_BATCH_SIZE, *frames.shape), dtype=frames.dtype)
                 batch_buffer[len(batch_indices)] = frames
                 batch_indices.append(index)
+                kept_indices.append(index)
                 if len(batch_indices) >= MAX_BATCH_SIZE:
                     self._flush_video_batch(
                         batch_buffer=batch_buffer,
@@ -199,7 +217,11 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
                 progress_bar=progress_bar,
             )
 
-        return embeddings
+        report.raise_if_all_failed()
+        report.log_summary()
+
+        # kept_indices in input order maps each returned row back to its input video.
+        return EmbeddingResult(embeddings=embeddings[kept_indices], kept_indices=kept_indices)
 
     def _flush_video_batch(
         self,
@@ -243,41 +265,45 @@ def _load_video_frames(
         Tensor of shape ``[VIDEO_FRAMES_PER_SAMPLE, C, H, W]``.
 
     Raises:
-        ValueError: If the video has no usable duration to sample frames from.
+        ValueError: If the video is unreadable or undecodable (missing, corrupt, has no
+            video stream, or has no usable duration).
     """
-    fs, fs_path = fsspec.core.url_to_fs(url=filepath)
-    with (
-        fs.open(path=fs_path, mode="rb") as video_file,
-        container.open(file=video_file) as video_container,
-    ):
-        video_stream = video_container.streams.video[DEFAULT_VIDEO_CHANNEL]
-        duration_pts = video_stream.duration
-        time_base = float(video_stream.time_base)
-        if duration_pts is None or duration_pts <= 0 or time_base <= 0.0:
-            raise ValueError(f"Unable to read frames from video '{filepath}'.")
+    try:
+        fs, fs_path = fsspec.core.url_to_fs(url=filepath)
+        with (
+            fs.open(path=fs_path, mode="rb") as video_file,
+            container.open(file=video_file) as video_container,
+        ):
+            video_stream = video_container.streams.video[DEFAULT_VIDEO_CHANNEL]
+            duration_pts = video_stream.duration
+            time_base = float(video_stream.time_base)
+            if duration_pts is None or duration_pts <= 0 or time_base <= 0.0:
+                raise ValueError(f"Unable to read frames from video '{filepath}'.")
 
-        duration_seconds = duration_pts * time_base
+            duration_seconds = duration_pts * time_base
 
-        # Sample VIDEO_FRAMES_PER_SAMPLE evenly spaced inside [0, duration_seconds)
-        ts_to_sample = np.linspace(
-            0.0,
-            duration_seconds,
-            num=VIDEO_FRAMES_PER_SAMPLE,
-            endpoint=False,
-            dtype=np.float64,
-        )
+            # Sample VIDEO_FRAMES_PER_SAMPLE evenly spaced inside [0, duration_seconds)
+            ts_to_sample = np.linspace(
+                0.0,
+                duration_seconds,
+                num=VIDEO_FRAMES_PER_SAMPLE,
+                endpoint=False,
+                dtype=np.float64,
+            )
 
-        frames: list[Image.Image] = []
-        for ts_target in ts_to_sample:
-            pts_target = int(ts_target / time_base)
-            video_container.seek(offset=pts_target, stream=video_stream)
-            try:
-                frame = next(video_container.decode(video=DEFAULT_VIDEO_CHANNEL))
-            except StopIteration:
-                raise ValueError(
-                    f"Unable to decode frame at {ts_target:.3f}s from video '{filepath}'."
-                ) from None
-            frames.append(frame.to_image())
+            frames: list[Image.Image] = []
+            for ts_target in ts_to_sample:
+                pts_target = int(ts_target / time_base)
+                video_container.seek(offset=pts_target, stream=video_stream)
+                try:
+                    frame = next(video_container.decode(video=DEFAULT_VIDEO_CHANNEL))
+                except StopIteration:
+                    raise ValueError(
+                        f"Unable to decode frame at {ts_target:.3f}s from video '{filepath}'."
+                    ) from None
+                frames.append(frame.to_image())
+    except (OSError, FFmpegError, IndexError) as error:
+        raise ValueError(f"Unable to read frames from video '{filepath}'.") from error
 
     processed_frames = [preprocess(frame) for frame in frames]
     return torch.stack(processed_frames)

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -165,9 +165,6 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
     def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
         """Embed videos with Perception Encoder, skipping missing or broken files.
 
-        A video that is missing or unreadable/undecodable is skipped rather than aborting
-        the whole run, and is recorded once as missing or broken.
-
         Args:
             filepaths: A list of file paths to the videos to embed.
 
@@ -176,8 +173,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             ``kept_indices`` mapping each row back to its input position.
 
         Raises:
-            AllInputFilesFailedError: If at least one file was attempted and every attempted
-                file was missing or broken (i.e. no file could be read and embedded).
+            AllInputFilesFailedError: If every attempted file was missing or broken.
         """
         total_videos = len(filepaths)
         if not total_videos:
@@ -185,14 +181,10 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             return EmbeddingResult(embeddings=empty, kept_indices=[])
 
         embeddings = np.empty((total_videos, self._model.output_dim), dtype=np.float32)
-        # Input indices of the videos that were embedded (their file could be read), filled
-        # in input order by the generator below as it yields each readable video.
         kept_indices: list[int] = []
         report = FileOutcomeReport(label_overrides={FileOutcome.ADDED: "embedded"})
 
         def preprocessed_videos_iter() -> Iterator[torch.Tensor]:
-            # A missing/broken video raises a typed signal that report.track records as its
-            # outcome and suppresses, so it is skipped instead of yielded into a batch.
             for index, filepath in enumerate(filepaths):
                 frames: torch.Tensor | None = None
                 with report.track(path=filepath):
@@ -201,8 +193,6 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
                     kept_indices.append(index)
                     yield frames
 
-        # Every readable video yields a fixed VIDEO_FRAMES_PER_SAMPLE-frame tensor of the same
-        # shape, so the per-video tensors can be stacked directly into a batch.
         position = 0
         with (
             tqdm(total=total_videos, desc="Generating embeddings", unit=" videos") as progress_bar,
@@ -221,8 +211,6 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         report.log_summary()
         report.raise_if_all_failed()
 
-        # Readable videos were written contiguously in input order; kept_indices maps each
-        # returned row back to its input position.
         return EmbeddingResult(embeddings=embeddings[:position], kept_indices=kept_indices)
 
 
@@ -253,8 +241,6 @@ def _load_video_frames(
         BrokenInputFileError: If the video is present but unreadable/undecodable (corrupt,
             has no video stream, or has no usable duration).
     """
-    # Detect a missing path proactively: FileNotFoundError is unreliable across fsspec
-    # backends and is a subclass of OSError, which we treat as broken.
     fs, fs_path = fsspec.core.url_to_fs(url=filepath)
     if not fs.exists(fs_path):
         raise MissingInputFileError(f"Video does not exist: '{filepath}'.")

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -9,11 +9,12 @@ from uuid import UUID
 import fsspec
 import numpy as np
 import torch
-from av import container
+from av import FFmpegError, container
 from numpy.typing import NDArray
 from PIL import Image
 from tqdm import tqdm
 
+from lightly_studio.core.file_outcome_report import FileOutcome, FileOutcomeReport
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
@@ -32,7 +33,7 @@ VIDEO_FRAMES_PER_SAMPLE: int = 8
 def _load_video_frames(
     filepath: str,
     preprocess: Callable[[Image.Image], torch.Tensor],
-) -> torch.Tensor:
+) -> torch.Tensor | None:
     """Sample uniformly spaced frames from a video and stack them into a model input.
 
     As in the original paper we subsample N frames from a video and stack them to a tensor.
@@ -45,39 +46,40 @@ def _load_video_frames(
     to be OS independent, however this comes with a performance drop.
 
     Returns:
-        Tensor of shape ``[VIDEO_FRAMES_PER_SAMPLE, C, H, W]``.
-
-    Raises:
-        ValueError: If the video has no usable duration to sample frames from.
+        Tensor of shape ``[VIDEO_FRAMES_PER_SAMPLE, C, H, W]``, or ``None`` if the video is
+        unreadable/undecodable (missing, corrupt, no video stream, or no usable duration).
     """
-    fs, fs_path = fsspec.core.url_to_fs(url=filepath)
-    with (
-        fs.open(path=fs_path, mode="rb") as video_file,
-        container.open(file=video_file) as video_container,
-    ):
-        video_stream = video_container.streams.video[DEFAULT_VIDEO_CHANNEL]
-        duration_pts = video_stream.duration
-        time_base = float(video_stream.time_base)
-        if duration_pts is None or duration_pts <= 0 or time_base <= 0.0:
-            raise ValueError(f"Unable to read frames from video '{filepath}'.")
+    try:
+        fs, fs_path = fsspec.core.url_to_fs(url=filepath)
+        with (
+            fs.open(path=fs_path, mode="rb") as video_file,
+            container.open(file=video_file) as video_container,
+        ):
+            video_stream = video_container.streams.video[DEFAULT_VIDEO_CHANNEL]
+            duration_pts = video_stream.duration
+            time_base = float(video_stream.time_base)
+            if duration_pts is None or duration_pts <= 0 or time_base <= 0.0:
+                return None
 
-        duration_seconds = duration_pts * time_base
+            duration_seconds = duration_pts * time_base
 
-        # Sample VIDEO_FRAMES_PER_SAMPLE evenly spaced inside [0, duration_seconds)
-        ts_to_sample = np.linspace(
-            0.0,
-            duration_seconds,
-            num=VIDEO_FRAMES_PER_SAMPLE,
-            endpoint=False,
-            dtype=np.float64,
-        )
+            # Sample VIDEO_FRAMES_PER_SAMPLE evenly spaced inside [0, duration_seconds)
+            ts_to_sample = np.linspace(
+                0.0,
+                duration_seconds,
+                num=VIDEO_FRAMES_PER_SAMPLE,
+                endpoint=False,
+                dtype=np.float64,
+            )
 
-        frames: list[Image.Image] = []
-        for ts_target in ts_to_sample:
-            pts_target = int(ts_target / time_base)
-            video_container.seek(offset=pts_target, stream=video_stream)
-            frame = next(video_container.decode(video=DEFAULT_VIDEO_CHANNEL))
-            frames.append(frame.to_image())
+            frames: list[Image.Image] = []
+            for ts_target in ts_to_sample:
+                pts_target = int(ts_target / time_base)
+                video_container.seek(offset=pts_target, stream=video_stream)
+                frame = next(video_container.decode(video=DEFAULT_VIDEO_CHANNEL))
+                frames.append(frame.to_image())
+    except (OSError, FFmpegError, IndexError, StopIteration):
+        return None
 
     processed_frames = [preprocess(frame) for frame in frames]
     return torch.stack(processed_frames)
@@ -209,24 +211,35 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             ),
         )
 
-    def embed_videos(self, filepaths: list[str]) -> NDArray[np.float32]:
-        """Embed videos with Perception Encoder.
+    def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
+        """Embed videos with Perception Encoder, skipping broken files.
+
+        A video that is unreadable/undecodable is skipped rather than aborting the whole
+        run, and is recorded once as broken.
 
         Args:
             filepaths: A list of file paths to the videos to embed.
 
         Returns:
-            A numpy array representing the generated embeddings
-            in the same order as the input file paths.
+            An ``EmbeddingResult`` whose embeddings cover only the readable videos, with
+            ``kept_indices`` mapping each row back to its input position.
+
+        Raises:
+            AllInputFilesFailedError: If at least one file was attempted and every attempted
+                file was broken (i.e. no file could be read and embedded).
         """
         total_videos = len(filepaths)
         if not total_videos:
-            return np.empty((0, self._model.output_dim), dtype=np.float32)
+            empty = np.empty((0, self._model.output_dim), dtype=np.float32)
+            return EmbeddingResult(embeddings=empty, kept_indices=[])
 
         embeddings = np.empty((total_videos, self._model.output_dim), dtype=np.float32)
+        # Input indices of the videos that were embedded (their file could be read).
+        kept_indices: list[int] = []
         # Reusable batch buffer, lazily sized from the first preprocessed video.
         batch_buffer: torch.Tensor | None = None
         batch_indices: list[int] = []
+        report = FileOutcomeReport()
 
         with (
             tqdm(total=total_videos, desc="Generating embeddings", unit=" videos") as progress_bar,
@@ -234,10 +247,15 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         ):
             for index, filepath in enumerate(filepaths):
                 frames = _load_video_frames(filepath, self._preprocess)
+                if frames is None:
+                    report.record(path=filepath, outcome=FileOutcome.BROKEN)
+                    continue
+                report.record(path=filepath, outcome=FileOutcome.ADDED)
                 if batch_buffer is None:
                     batch_buffer = torch.empty((MAX_BATCH_SIZE, *frames.shape), dtype=frames.dtype)
                 batch_buffer[len(batch_indices)] = frames
                 batch_indices.append(index)
+                kept_indices.append(index)
                 if len(batch_indices) >= MAX_BATCH_SIZE:
                     self._flush_video_batch(
                         batch_buffer=batch_buffer,
@@ -253,7 +271,11 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
                 progress_bar=progress_bar,
             )
 
-        return embeddings
+        report.raise_if_all_failed()
+        report.log_summary()
+
+        # kept_indices in input order maps each returned row back to its input video.
+        return EmbeddingResult(embeddings=embeddings[kept_indices], kept_indices=kept_indices)
 
     def _flush_video_batch(
         self,

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 from uuid import UUID
 
 import fsspec
@@ -12,7 +12,6 @@ import torch
 from av import container
 from numpy.typing import NDArray
 from PIL import Image
-from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
 
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
@@ -30,78 +29,58 @@ MAX_BATCH_SIZE: int = 16
 VIDEO_FRAMES_PER_SAMPLE: int = 8
 
 
-class _VideoFileDataset(Dataset[torch.Tensor]):
-    """Dataset wrapping video file paths and a preprocess function.
+def _load_video_frames(
+    filepath: str,
+    preprocess: Callable[[Image.Image], torch.Tensor],
+) -> torch.Tensor:
+    """Sample uniformly spaced frames from a video and stack them into a model input.
 
-    Used for efficient batched video loading and preprocessing
+    As in the original paper we subsample N frames from a video and stack them to a tensor.
+    As in the paper, we use a default of 8 frames per video (VIDEO_FRAMES_PER_SAMPLE).
+    Note: the video length in the paper was 16.7 +/- 9.8 sec, hence for longer videos we might
+    consider alternative models or more frames.
+
+    Using seek for sampling is fast, however it may yield slightly different results on
+    different OS (known issue: MacOS vs Linux). Alternative option is to decode frame-by-frame
+    to be OS independent, however this comes with a performance drop.
+
+    Returns:
+        Tensor of shape ``[VIDEO_FRAMES_PER_SAMPLE, C, H, W]``.
+
+    Raises:
+        ValueError: If the video has no usable duration to sample frames from.
     """
+    fs, fs_path = fsspec.core.url_to_fs(url=filepath)
+    with (
+        fs.open(path=fs_path, mode="rb") as video_file,
+        container.open(file=video_file) as video_container,
+    ):
+        video_stream = video_container.streams.video[DEFAULT_VIDEO_CHANNEL]
+        duration_pts = video_stream.duration
+        time_base = float(video_stream.time_base)
+        if duration_pts is None or duration_pts <= 0 or time_base <= 0.0:
+            raise ValueError(f"Unable to read frames from video '{filepath}'.")
 
-    def __init__(
-        self,
-        filepaths: list[str],
-        preprocess: Callable[[Image.Image], torch.Tensor],
-    ) -> None:
-        self.filepaths = filepaths
-        self.preprocess = preprocess
+        duration_seconds = duration_pts * time_base
 
-    def __len__(self) -> int:
-        return len(self.filepaths)
+        # Sample VIDEO_FRAMES_PER_SAMPLE evenly spaced inside [0, duration_seconds)
+        ts_to_sample = np.linspace(
+            0.0,
+            duration_seconds,
+            num=VIDEO_FRAMES_PER_SAMPLE,
+            endpoint=False,
+            dtype=np.float64,
+        )
 
-    def __getitem__(self, idx: int) -> torch.Tensor:
-        """Return tensor [N C H W] for idx-th video.
+        frames: list[Image.Image] = []
+        for ts_target in ts_to_sample:
+            pts_target = int(ts_target / time_base)
+            video_container.seek(offset=pts_target, stream=video_stream)
+            frame = next(video_container.decode(video=DEFAULT_VIDEO_CHANNEL))
+            frames.append(frame.to_image())
 
-        As in the original paper we subsample N frames from a video and stack them to a tensor.
-        As in the paper, we use a default of 8 frames per video (VIDEO_FRAMES_PER_SAMPLE).
-        Note: the video length in the paper was 16.7 +/- 9.8 sec, hence for longer videos we might
-        consider alternative models or more frames.
-        """
-        video_path = self.filepaths[idx]
-        frames = self._load_frames(video_path)
-        if not frames:
-            raise ValueError(f"Unable to read frames from video '{video_path}'.")
-
-        processed_frames = [self.preprocess(frame) for frame in frames]
-        return torch.stack(processed_frames)
-
-    def _load_frames(self, video_path: str) -> list[Image.Image]:
-        """Sample uniformly spaced frames and return them as PIL images.
-
-        Using seek for sampling is fast, however it may yield slightly different results on
-        different OS (known issue: MacOS vs Linux).
-
-        Alternative option is to decode frame-by-frame to be OS independent,
-        however this comes with performance drop.
-        """
-        fs, fs_path = fsspec.core.url_to_fs(url=video_path)
-        with (
-            fs.open(path=fs_path, mode="rb") as video_file,
-            container.open(file=video_file) as video_container,
-        ):
-            video_stream = video_container.streams.video[DEFAULT_VIDEO_CHANNEL]
-            duration_pts = video_stream.duration
-            time_base = float(video_stream.time_base)
-            if duration_pts is None or duration_pts <= 0 or time_base <= 0.0:
-                return []
-
-            duration_seconds = duration_pts * time_base
-
-            # Sample VIDEO_FRAMES_PER_SAMPLE evenly spaced inside [0, duration_seconds)
-            ts_to_sample = np.linspace(
-                0.0,
-                duration_seconds,
-                num=VIDEO_FRAMES_PER_SAMPLE,
-                endpoint=False,
-                dtype=np.float64,
-            )
-
-            frames: list[Image.Image] = []
-            for ts_target in ts_to_sample:
-                pts_target = int(ts_target / time_base)
-                video_container.seek(offset=pts_target, stream=video_stream)
-                frame = next(video_container.decode(video=DEFAULT_VIDEO_CHANNEL))
-                frames.append(frame.to_image())
-
-            return frames
+    processed_frames = [preprocess(frame) for frame in frames]
+    return torch.stack(processed_frames)
 
 
 class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator):
@@ -240,32 +219,56 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             A numpy array representing the generated embeddings
             in the same order as the input file paths.
         """
-        dataset = _VideoFileDataset(filepaths, self._preprocess)
-
-        # To avoid issues with db locking and multiprocessing we set the
-        # number of workers to 0 (no multiprocessing). The DataLoader is still
-        # very useful for batching and async prefetching of videos.
-        loader = DataLoader(
-            dataset,
-            batch_size=MAX_BATCH_SIZE,
-            num_workers=0,  # must be 0 to avoid multiprocessing issues
-        )
         total_videos = len(filepaths)
         if not total_videos:
             return np.empty((0, self._model.output_dim), dtype=np.float32)
 
         embeddings = np.empty((total_videos, self._model.output_dim), dtype=np.float32)
-        position = 0
+        # Reusable batch buffer, lazily sized from the first preprocessed video.
+        batch_buffer: torch.Tensor | None = None
+        batch_indices: list[int] = []
+
         with (
             tqdm(total=total_videos, desc="Generating embeddings", unit=" videos") as progress_bar,
             torch.no_grad(),
         ):
-            for videos_tensor in loader:
-                videos = videos_tensor.to(self._device, non_blocking=True)
-                batch_embeddings = self._model.encode_video(videos, normalize=True).cpu().numpy()
-                batch_size = videos.size(0)
-                embeddings[position : position + batch_size] = batch_embeddings
-                position += batch_size
-                progress_bar.update(batch_size)
+            for index, filepath in enumerate(filepaths):
+                frames = _load_video_frames(filepath, self._preprocess)
+                if batch_buffer is None:
+                    batch_buffer = torch.empty((MAX_BATCH_SIZE, *frames.shape), dtype=frames.dtype)
+                batch_buffer[len(batch_indices)] = frames
+                batch_indices.append(index)
+                if len(batch_indices) >= MAX_BATCH_SIZE:
+                    self._flush_video_batch(
+                        batch_buffer=batch_buffer,
+                        batch_indices=batch_indices,
+                        embeddings=embeddings,
+                        progress_bar=progress_bar,
+                    )
+
+            self._flush_video_batch(
+                batch_buffer=batch_buffer,
+                batch_indices=batch_indices,
+                embeddings=embeddings,
+                progress_bar=progress_bar,
+            )
 
         return embeddings
+
+    def _flush_video_batch(
+        self,
+        batch_buffer: torch.Tensor | None,
+        batch_indices: list[int],
+        embeddings: NDArray[np.float32],
+        progress_bar: Any,
+    ) -> None:
+        """Encode the current video batch and write results into ``embeddings``."""
+        if batch_buffer is None or not batch_indices:
+            return
+        filled = len(batch_indices)
+        videos_tensor = batch_buffer[:filled].to(self._device, non_blocking=True)
+        batch_embeddings = self._model.encode_video(videos_tensor, normalize=True).cpu().numpy()
+        for batch_position, video_index in enumerate(batch_indices):
+            embeddings[video_index] = batch_embeddings[batch_position]
+        progress_bar.update(filled)
+        batch_indices.clear()

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import Any, Callable
 from uuid import UUID
 
 import fsspec
@@ -22,6 +22,7 @@ from lightly_studio.core.file_outcome_report import (
 )
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.utils import batching
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
 
 from . import file_utils, image_crop_embedding, image_embedding
@@ -184,67 +185,45 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             return EmbeddingResult(embeddings=empty, kept_indices=[])
 
         embeddings = np.empty((total_videos, self._model.output_dim), dtype=np.float32)
-        # Input indices of the videos that were embedded (their file could be read).
+        # Input indices of the videos that were embedded (their file could be read), filled
+        # in input order by the generator below as it yields each readable video.
         kept_indices: list[int] = []
-        # Reusable batch buffer, lazily sized from the first preprocessed video.
-        batch_buffer: torch.Tensor | None = None
-        batch_indices: list[int] = []
         report = FileOutcomeReport(label_overrides={FileOutcome.ADDED: "embedded"})
 
+        def preprocessed_videos_iter() -> Iterator[torch.Tensor]:
+            # A missing/broken video raises a typed signal that report.track records as its
+            # outcome and suppresses, so it is skipped instead of yielded into a batch.
+            for index, filepath in enumerate(filepaths):
+                frames: torch.Tensor | None = None
+                with report.track(path=filepath):
+                    frames = _load_video_frames(filepath, self._preprocess)
+                if frames is not None:
+                    kept_indices.append(index)
+                    yield frames
+
+        # Every readable video yields a fixed VIDEO_FRAMES_PER_SAMPLE-frame tensor of the same
+        # shape, so the per-video tensors can be stacked directly into a batch.
+        position = 0
         with (
             tqdm(total=total_videos, desc="Generating embeddings", unit=" videos") as progress_bar,
             torch.no_grad(),
         ):
-            for index, filepath in enumerate(filepaths):
-                # A missing/broken video raises a typed signal that report.track records as
-                # its outcome and suppresses, so the loop skips it and continues.
-                with report.track(path=filepath):
-                    frames = _load_video_frames(filepath, self._preprocess)
-                    if batch_buffer is None:
-                        batch_buffer = torch.empty(
-                            (MAX_BATCH_SIZE, *frames.shape), dtype=frames.dtype
-                        )
-                    batch_buffer[len(batch_indices)] = frames
-                    batch_indices.append(index)
-                    kept_indices.append(index)
-                    if len(batch_indices) >= MAX_BATCH_SIZE:
-                        self._flush_video_batch(
-                            batch_buffer=batch_buffer,
-                            batch_indices=batch_indices,
-                            embeddings=embeddings,
-                            progress_bar=progress_bar,
-                        )
-
-            self._flush_video_batch(
-                batch_buffer=batch_buffer,
-                batch_indices=batch_indices,
-                embeddings=embeddings,
-                progress_bar=progress_bar,
-            )
+            for batch in batching.batched(preprocessed_videos_iter(), batch_size=MAX_BATCH_SIZE):
+                videos_tensor = torch.stack(batch).to(self._device)
+                batch_embeddings = (
+                    self._model.encode_video(videos_tensor, normalize=True).cpu().numpy()
+                )
+                batch_size = videos_tensor.size(0)
+                embeddings[position : position + batch_size] = batch_embeddings
+                position += batch_size
+                progress_bar.update(batch_size)
 
         report.log_summary()
         report.raise_if_all_failed()
 
-        # kept_indices in input order maps each returned row back to its input video.
-        return EmbeddingResult(embeddings=embeddings[kept_indices], kept_indices=kept_indices)
-
-    def _flush_video_batch(
-        self,
-        batch_buffer: torch.Tensor | None,
-        batch_indices: list[int],
-        embeddings: NDArray[np.float32],
-        progress_bar: Any,
-    ) -> None:
-        """Encode the current video batch and write results into ``embeddings``."""
-        if batch_buffer is None or not batch_indices:
-            return
-        filled = len(batch_indices)
-        videos_tensor = batch_buffer[:filled].to(self._device)
-        batch_embeddings = self._model.encode_video(videos_tensor, normalize=True).cpu().numpy()
-        for batch_position, video_index in enumerate(batch_indices):
-            embeddings[video_index] = batch_embeddings[batch_position]
-        progress_bar.update(filled)
-        batch_indices.clear()
+        # Readable videos were written contiguously in input order; kept_indices maps each
+        # returned row back to its input position.
+        return EmbeddingResult(embeddings=embeddings[:position], kept_indices=kept_indices)
 
 
 def _load_video_frames(

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -16,6 +16,7 @@ from tqdm import tqdm
 
 from lightly_studio.core.file_outcome_report import (
     BrokenInputFileError,
+    FileOutcome,
     FileOutcomeReport,
     MissingInputFileError,
 )
@@ -188,7 +189,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         # Reusable batch buffer, lazily sized from the first preprocessed video.
         batch_buffer: torch.Tensor | None = None
         batch_indices: list[int] = []
-        report = FileOutcomeReport()
+        report = FileOutcomeReport(label_overrides={FileOutcome.ADDED: "embedded"})
 
         with (
             tqdm(total=total_videos, desc="Generating embeddings", unit=" videos") as progress_bar,

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable
+from typing import Callable
 from uuid import UUID
 
 import fsspec
@@ -16,6 +16,7 @@ from tqdm import tqdm
 
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.utils import batching
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
 
 from . import file_utils, image_crop_embedding, image_embedding
@@ -170,54 +171,27 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             return np.empty((0, self._model.output_dim), dtype=np.float32)
 
         embeddings = np.empty((total_videos, self._model.output_dim), dtype=np.float32)
-        # Reusable batch buffer, lazily sized from the first preprocessed video.
-        batch_buffer: torch.Tensor | None = None
-        batch_indices: list[int] = []
-
+        # Every video yields a fixed VIDEO_FRAMES_PER_SAMPLE-frame tensor of the same shape,
+        # so the per-video tensors can be stacked directly into a batch.
+        preprocessed_videos = (
+            _load_video_frames(filepath, self._preprocess) for filepath in filepaths
+        )
+        position = 0
         with (
             tqdm(total=total_videos, desc="Generating embeddings", unit=" videos") as progress_bar,
             torch.no_grad(),
         ):
-            for index, filepath in enumerate(filepaths):
-                frames = _load_video_frames(filepath, self._preprocess)
-                if batch_buffer is None:
-                    batch_buffer = torch.empty((MAX_BATCH_SIZE, *frames.shape), dtype=frames.dtype)
-                batch_buffer[len(batch_indices)] = frames
-                batch_indices.append(index)
-                if len(batch_indices) >= MAX_BATCH_SIZE:
-                    self._flush_video_batch(
-                        batch_buffer=batch_buffer,
-                        batch_indices=batch_indices,
-                        embeddings=embeddings,
-                        progress_bar=progress_bar,
-                    )
-
-            self._flush_video_batch(
-                batch_buffer=batch_buffer,
-                batch_indices=batch_indices,
-                embeddings=embeddings,
-                progress_bar=progress_bar,
-            )
+            for batch in batching.batched(preprocessed_videos, batch_size=MAX_BATCH_SIZE):
+                videos_tensor = torch.stack(batch).to(self._device)
+                batch_embeddings = (
+                    self._model.encode_video(videos_tensor, normalize=True).cpu().numpy()
+                )
+                batch_size = videos_tensor.size(0)
+                embeddings[position : position + batch_size] = batch_embeddings
+                position += batch_size
+                progress_bar.update(batch_size)
 
         return embeddings
-
-    def _flush_video_batch(
-        self,
-        batch_buffer: torch.Tensor | None,
-        batch_indices: list[int],
-        embeddings: NDArray[np.float32],
-        progress_bar: Any,
-    ) -> None:
-        """Encode the current video batch and write results into ``embeddings``."""
-        if batch_buffer is None or not batch_indices:
-            return
-        filled = len(batch_indices)
-        videos_tensor = batch_buffer[:filled].to(self._device)
-        batch_embeddings = self._model.encode_video(videos_tensor, normalize=True).cpu().numpy()
-        for batch_position, video_index in enumerate(batch_indices):
-            embeddings[video_index] = batch_embeddings[batch_position]
-        progress_bar.update(filled)
-        batch_indices.clear()
 
 
 def _load_video_frames(

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -29,60 +29,6 @@ MAX_BATCH_SIZE: int = 16
 VIDEO_FRAMES_PER_SAMPLE: int = 8
 
 
-def _load_video_frames(
-    filepath: str,
-    preprocess: Callable[[Image.Image], torch.Tensor],
-) -> torch.Tensor:
-    """Sample uniformly spaced frames from a video and stack them into a model input.
-
-    As in the original paper we subsample N frames from a video and stack them to a tensor.
-    As in the paper, we use a default of 8 frames per video (VIDEO_FRAMES_PER_SAMPLE).
-    Note: the video length in the paper was 16.7 +/- 9.8 sec, hence for longer videos we might
-    consider alternative models or more frames.
-
-    Using seek for sampling is fast, however it may yield slightly different results on
-    different OS (known issue: MacOS vs Linux). Alternative option is to decode frame-by-frame
-    to be OS independent, however this comes with a performance drop.
-
-    Returns:
-        Tensor of shape ``[VIDEO_FRAMES_PER_SAMPLE, C, H, W]``.
-
-    Raises:
-        ValueError: If the video has no usable duration to sample frames from.
-    """
-    fs, fs_path = fsspec.core.url_to_fs(url=filepath)
-    with (
-        fs.open(path=fs_path, mode="rb") as video_file,
-        container.open(file=video_file) as video_container,
-    ):
-        video_stream = video_container.streams.video[DEFAULT_VIDEO_CHANNEL]
-        duration_pts = video_stream.duration
-        time_base = float(video_stream.time_base)
-        if duration_pts is None or duration_pts <= 0 or time_base <= 0.0:
-            raise ValueError(f"Unable to read frames from video '{filepath}'.")
-
-        duration_seconds = duration_pts * time_base
-
-        # Sample VIDEO_FRAMES_PER_SAMPLE evenly spaced inside [0, duration_seconds)
-        ts_to_sample = np.linspace(
-            0.0,
-            duration_seconds,
-            num=VIDEO_FRAMES_PER_SAMPLE,
-            endpoint=False,
-            dtype=np.float64,
-        )
-
-        frames: list[Image.Image] = []
-        for ts_target in ts_to_sample:
-            pts_target = int(ts_target / time_base)
-            video_container.seek(offset=pts_target, stream=video_stream)
-            frame = next(video_container.decode(video=DEFAULT_VIDEO_CHANNEL))
-            frames.append(frame.to_image())
-
-    processed_frames = [preprocess(frame) for frame in frames]
-    return torch.stack(processed_frames)
-
-
 class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator):
     """Perception Encoder Core embedding model."""
 
@@ -266,9 +212,72 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         if batch_buffer is None or not batch_indices:
             return
         filled = len(batch_indices)
-        videos_tensor = batch_buffer[:filled].to(self._device, non_blocking=True)
+        videos_tensor = batch_buffer[:filled].to(self._device)
         batch_embeddings = self._model.encode_video(videos_tensor, normalize=True).cpu().numpy()
         for batch_position, video_index in enumerate(batch_indices):
             embeddings[video_index] = batch_embeddings[batch_position]
         progress_bar.update(filled)
         batch_indices.clear()
+
+
+def _load_video_frames(
+    filepath: str,
+    preprocess: Callable[[Image.Image], torch.Tensor],
+) -> torch.Tensor:
+    """Sample uniformly spaced frames from a video and stack them into a model input.
+
+    As in the original paper we subsample N frames from a video and stack them to a tensor.
+    As in the paper, we use a default of 8 frames per video (VIDEO_FRAMES_PER_SAMPLE).
+    Note: the video length in the paper was 16.7 +/- 9.8 sec, hence for longer videos we might
+    consider alternative models or more frames.
+
+    Using seek for sampling is fast, however it may yield slightly different results on
+    different OS (known issue: MacOS vs Linux). Alternative option is to decode frame-by-frame
+    to be OS independent, however this comes with a performance drop.
+
+    Args:
+        filepath: Path or URL of the video to sample frames from.
+        preprocess: Transform applied to each sampled frame to produce a model input tensor.
+
+    Returns:
+        Tensor of shape ``[VIDEO_FRAMES_PER_SAMPLE, C, H, W]``.
+
+    Raises:
+        ValueError: If the video has no usable duration to sample frames from.
+    """
+    fs, fs_path = fsspec.core.url_to_fs(url=filepath)
+    with (
+        fs.open(path=fs_path, mode="rb") as video_file,
+        container.open(file=video_file) as video_container,
+    ):
+        video_stream = video_container.streams.video[DEFAULT_VIDEO_CHANNEL]
+        duration_pts = video_stream.duration
+        time_base = float(video_stream.time_base)
+        if duration_pts is None or duration_pts <= 0 or time_base <= 0.0:
+            raise ValueError(f"Unable to read frames from video '{filepath}'.")
+
+        duration_seconds = duration_pts * time_base
+
+        # Sample VIDEO_FRAMES_PER_SAMPLE evenly spaced inside [0, duration_seconds)
+        ts_to_sample = np.linspace(
+            0.0,
+            duration_seconds,
+            num=VIDEO_FRAMES_PER_SAMPLE,
+            endpoint=False,
+            dtype=np.float64,
+        )
+
+        frames: list[Image.Image] = []
+        for ts_target in ts_to_sample:
+            pts_target = int(ts_target / time_base)
+            video_container.seek(offset=pts_target, stream=video_stream)
+            try:
+                frame = next(video_container.decode(video=DEFAULT_VIDEO_CHANNEL))
+            except StopIteration:
+                raise ValueError(
+                    f"Unable to decode frame at {ts_target:.3f}s from video '{filepath}'."
+                ) from None
+            frames.append(frame.to_image())
+
+    processed_frames = [preprocess(frame) for frame in frames]
+    return torch.stack(processed_frames)

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -742,6 +742,46 @@ def test_embed_videos(
         assert embedding.sample_id in video_ids
 
 
+def test_embed_videos_skips_broken_videos(
+    db_session: Session,
+) -> None:
+    """A generator that drops a broken video stores embeddings only for the kept ones."""
+
+    class DropsMiddleVideoGenerator(RandomEmbeddingGenerator):
+        def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
+            # Simulate the middle video being broken and skipped.
+            kept_indices = [index for index in range(len(filepaths)) if index != 1]
+            embeddings = np.zeros((len(kept_indices), self._dimension), dtype=np.float32)
+            return EmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
+
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    collection_id = video_collection.collection_id
+    video_ids = create_videos(
+        session=db_session,
+        collection_id=collection_id,
+        videos=[
+            VideoStub(path=f"/videos/video_{idx}.mp4", duration_s=1.0 + idx, fps=24.0)
+            for idx in range(3)
+        ],
+    )
+    manager = EmbeddingManager()
+    model_id = manager.register_embedding_model(
+        session=db_session,
+        embedding_generator=DropsMiddleVideoGenerator(),
+        collection_id=collection_id,
+        set_as_default=True,
+    ).embedding_model_id
+
+    manager.embed_videos(session=db_session, collection_id=collection_id, sample_ids=video_ids)
+
+    stored_embeddings = db_session.exec(
+        select(SampleEmbeddingTable).where(SampleEmbeddingTable.embedding_model_id == model_id)
+    ).all()
+    stored_sample_ids = {embedding.sample_id for embedding in stored_embeddings}
+    # The middle video was skipped, so only the first and third sample IDs are stored.
+    assert stored_sample_ids == {video_ids[0], video_ids[2]}
+
+
 def test_embed_videos_with_incompatible_generator(db_session: Session) -> None:
     """Ensure we raise when the default lacks video support."""
     video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -748,11 +748,12 @@ def test_embed_videos_skips_broken_videos(
     """A generator that drops a broken video stores embeddings only for the kept ones."""
 
     class DropsMiddleVideoGenerator(RandomEmbeddingGenerator):
-        def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
+        def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:  # noqa: ARG002
             # Simulate the middle video being broken and skipped.
-            kept_indices = [index for index in range(len(filepaths)) if index != 1]
-            embeddings = np.zeros((len(kept_indices), self._dimension), dtype=np.float32)
-            return EmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
+            return EmbeddingResult(
+                embeddings=np.zeros((2, self._dimension), dtype=np.float32),
+                kept_indices=[0, 2],
+            )
 
     video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
     collection_id = video_collection.collection_id
@@ -760,8 +761,9 @@ def test_embed_videos_skips_broken_videos(
         session=db_session,
         collection_id=collection_id,
         videos=[
-            VideoStub(path=f"/videos/video_{idx}.mp4", duration_s=1.0 + idx, fps=24.0)
-            for idx in range(3)
+            VideoStub(path="/videos/video_0.mp4", duration_s=1.0, fps=24.0),
+            VideoStub(path="/videos/video_1.mp4", duration_s=2.0, fps=24.0),
+            VideoStub(path="/videos/video_2.mp4", duration_s=3.0, fps=24.0),
         ],
     )
     manager = EmbeddingManager()

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -739,6 +739,46 @@ def test_embed_videos(
         assert embedding.sample_id in video_ids
 
 
+def test_embed_videos_skips_broken_videos(
+    db_session: Session,
+) -> None:
+    """A generator that drops a broken video stores embeddings only for the kept ones."""
+
+    class DropsMiddleVideoGenerator(RandomEmbeddingGenerator):
+        def embed_videos(self, filepaths: list[str]) -> EmbeddingResult:
+            # Simulate the middle video being broken and skipped.
+            kept_indices = [index for index in range(len(filepaths)) if index != 1]
+            embeddings = np.zeros((len(kept_indices), self._dimension), dtype=np.float32)
+            return EmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
+
+    video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    collection_id = video_collection.collection_id
+    video_ids = create_videos(
+        session=db_session,
+        collection_id=collection_id,
+        videos=[
+            VideoStub(path=f"/videos/video_{idx}.mp4", duration_s=1.0 + idx, fps=24.0)
+            for idx in range(3)
+        ],
+    )
+    manager = EmbeddingManager()
+    model_id = manager.register_embedding_model(
+        session=db_session,
+        embedding_generator=DropsMiddleVideoGenerator(),
+        collection_id=collection_id,
+        set_as_default=True,
+    ).embedding_model_id
+
+    manager.embed_videos(session=db_session, collection_id=collection_id, sample_ids=video_ids)
+
+    stored_embeddings = db_session.exec(
+        select(SampleEmbeddingTable).where(SampleEmbeddingTable.embedding_model_id == model_id)
+    ).all()
+    stored_sample_ids = {embedding.sample_id for embedding in stored_embeddings}
+    # The middle video was skipped, so only the first and third sample IDs are stored.
+    assert stored_sample_ids == {video_ids[0], video_ids[2]}
+
+
 def test_embed_videos_with_incompatible_generator(db_session: Session) -> None:
     """Ensure we raise when the default lacks video support."""
     video_collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -123,8 +123,6 @@ class TestPerceptionEncoderEmbeddingGenerator:
         assert np.isclose(dog_video_embedding_normed[3], -0.077, atol=1e-2)
 
     def test_embed_videos__skips_broken_and_missing(self, tmp_path: Path) -> None:
-        # Broken/missing videos are skipped per-file: embeddings cover only readable videos
-        # and kept_indices maps each row back to its input position, so callers stay in sync.
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
         dog_video_path = FIXTURES_DIR / "dog.mp4"
         broken_path = tmp_path / "broken.mp4"

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -4,9 +4,11 @@ import uuid
 from pathlib import Path
 
 import numpy as np
+import pytest
 import torch
 from PIL import Image
 
+from lightly_studio.core.file_outcome_report import AllInputFilesFailedError
 from lightly_studio.dataset.embedding_generator import ImageCrop
 from lightly_studio.dataset.perception_encoder_embedding_generator import (
     PerceptionEncoderEmbeddingGenerator,
@@ -104,8 +106,10 @@ class TestPerceptionEncoderEmbeddingGenerator:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
         dog_video_path = FIXTURES_DIR / "dog.mp4"
 
-        embeddings = perception_encoder.embed_videos([str(dog_video_path)])
+        result = perception_encoder.embed_videos([str(dog_video_path)])
+        embeddings = result.embeddings
 
+        assert result.kept_indices == [0]
         assert len(embeddings) == 1
         cat_video_embedding = embeddings[0]
         assert len(cat_video_embedding) == 512
@@ -117,6 +121,38 @@ class TestPerceptionEncoderEmbeddingGenerator:
         assert np.isclose(dog_video_embedding_normed[1], 0.057, atol=1e-2)
         assert np.isclose(dog_video_embedding_normed[2], 0.057, atol=1e-2)
         assert np.isclose(dog_video_embedding_normed[3], -0.077, atol=1e-2)
+
+    def test_embed_videos__skips_broken_and_missing(self, tmp_path: Path) -> None:
+        # Broken/missing videos are skipped per-file: embeddings cover only readable videos
+        # and kept_indices maps each row back to its input position, so callers stay in sync.
+        perception_encoder = PerceptionEncoderEmbeddingGenerator()
+        dog_video_path = FIXTURES_DIR / "dog.mp4"
+        broken_path = tmp_path / "broken.mp4"
+        broken_path.write_bytes(b"not a valid video")
+        missing_path = tmp_path / "missing.mp4"
+
+        # Interleave the broken/missing files with the readable one.
+        filepaths = [
+            str(broken_path),
+            str(dog_video_path),
+            str(missing_path),
+            str(dog_video_path),
+        ]
+
+        result = perception_encoder.embed_videos(filepaths)
+
+        assert result.kept_indices == [1, 3]
+        assert result.embeddings.shape == (2, 512)
+        # The two kept rows embed the same video, so they must match.
+        assert np.allclose(result.embeddings[0], result.embeddings[1])
+
+    def test_embed_videos__raises_when_all_files_broken(self, tmp_path: Path) -> None:
+        perception_encoder = PerceptionEncoderEmbeddingGenerator()
+        broken_path = tmp_path / "broken.mp4"
+        broken_path.write_bytes(b"not a valid video")
+
+        with pytest.raises(AllInputFilesFailedError):
+            perception_encoder.embed_videos([str(broken_path), str(broken_path)])
 
     def test_classification(self) -> None:
         """End-to-end test for embedding consistency.
@@ -173,7 +209,9 @@ class TestPerceptionEncoderEmbeddingGenerator:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
         dog_video_path = FIXTURES_DIR / "dog.mp4"
 
-        dog_video_emb = torch.tensor(perception_encoder.embed_videos([str(dog_video_path)])[0])
+        dog_video_emb = torch.tensor(
+            perception_encoder.embed_videos([str(dog_video_path)]).embeddings[0]
+        )
         dog_video_emb /= dog_video_emb.norm(dim=-1, keepdim=True)
 
         # Compute softmax similarity as in perception_encoder repo example.


### PR DESCRIPTION
## Summary

Apply the per-item broken-file handling from the full-image (#1691) and crop (#1706) embedding paths to the **video** path.

- `_load_video_frames` returns `None` for an unreadable/undecodable video — catching `(OSError, FFmpegError, IndexError, StopIteration)` plus the no-usable-duration case — instead of raising, so a broken video skips itself rather than aborting the run.
- `embed_videos` records each video once as `BROKEN`/`ADDED` in a `FileOutcomeReport`, returns an `EmbeddingResult` carrying `kept_indices` (input positions of the embedded videos), and raises `AllInputFilesFailedError` when every video is broken.
- `EmbeddingResult` is propagated through the `VideoEmbeddingGenerator.embed_videos` protocol method and `RandomEmbeddingGenerator`.
- `embedding_manager.embed_videos` filters sample IDs by `kept_indices` before storing, keeping sample IDs and embeddings in sync.

`kept_indices` comes out already sorted (videos are processed in input order, unlike the crop path which groups by filepath), so no post-sort is needed.

## Stacking

This PR is **stacked on #1753** (the manual-batch-loop refactor), not `main`. Its base is `jonas-lig-10035-refactor-video-embedding-manual-loop`. Rebase onto `main` once #1753 merges. Review #1753 first — this PR's diff is only the tolerance change.

## Testing

- `make static-checks` — ruff + format + mypy clean.
- `pytest tests/dataset/{test_perception_encoder_embedding_generator,test_embedding_manager,test_embedding_generator}.py` — 41 passed.
- Added video tests: mixed good/broken/missing with `kept_indices` assertions, all-broken raises `AllInputFilesFailedError`, and a manager stub-drop case asserting only kept sample IDs are stored; unwrapped `.embeddings` in the existing video tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Video embedding now returns a structured result that includes both the generated embeddings and a `kept_indices` mapping for successfully processed inputs.
  - Improved fault-tolerance: missing or broken videos are skipped while still returning results for valid inputs.
- **Bug Fixes**
  - Embeddings are now stored only for kept samples, ensuring embeddings remain aligned with the correct videos when some inputs fail.
- **Tests**
  - Added/updated unit tests to verify skipping behavior, correct `kept_indices` alignment, and raising an error when all inputs fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->