### PR TITLE
docs: add collaboration and permissions overview

### DIFF
--- a/lightly_studio/docs/docs/enterprise/collaboration.md
+++ b/lightly_studio/docs/docs/enterprise/collaboration.md
@@ -1,0 +1,29 @@
+# Collaboration and Permissions
+
+LightlyStudio lets your team work on the same datasets together. Each member has
+a role that controls what they can do.
+
+## Inviting Teammates
+
+Admins invite teammates and assign each of them a role on the Users page under
+`Workspace → Users`. An admin can change a member's role at any time.
+
+![User Management page with the Invite User form and user list](https://storage.googleapis.com/lightly-public/studio/docs/enterprise_user_management_v1.0.2.png){ width="100%" }
+
+## Roles
+
+- **Viewer**: explore and export data without changing it.
+- **Labeler**: create tags and edit annotations.
+- **Editor**: everything a labeler can do, plus configure the workspace.
+- **Admin**: everything an editor can do, plus manage members and their roles.
+
+## Permissions
+
+| Capability | Viewer | Labeler | Editor | Admin |
+|---|:--:|:--:|:--:|:--:|
+| View data, tags, and annotations | ✔ | ✔ | ✔ | ✔ |
+| Export data | ✔ | ✔ | ✔ | ✔ |
+| Create and apply tags | ✗ | ✔ | ✔ | ✔ |
+| Edit annotations and labels | ✗ | ✔ | ✔ | ✔ |
+| Few-Shot Classifier, Sampling, Plugins, and Settings | ✗ | ✗ | ✔ | ✔ |
+| Manage users and roles | ✗ | ✗ | ✗ | ✔ |

--- a/lightly_studio/docs/docs/enterprise/index.md
+++ b/lightly_studio/docs/docs/enterprise/index.md
@@ -24,7 +24,7 @@ Contact [sales@lightly.ai](mailto:sales@lightly.ai) to find the right option for
 
 === "User Management"
 
-    ![Multi-user management with roles and permissions](https://storage.googleapis.com/lightly-public/studio/docs/enterprise_user_management_v1.0.0.png){ width="100%" }
+    ![Multi-user management with roles and permissions](https://storage.googleapis.com/lightly-public/studio/docs/enterprise_user_management_v1.0.2.png){ width="100%" }
     _Onboard your team with roles and permissions._
 
 === "Samples Grid"

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - 🏢 Enterprise:
     - Enterprise:
       - enterprise/index.md
+      - Collaboration and Permissions: enterprise/collaboration.md
       - Connect from Python: enterprise/connect.md
       - Security and Architecture: enterprise/security.md
       - On-Premise Deployment: enterprise/on-premise.md


### PR DESCRIPTION
## What

Adds an Enterprise docs page explaining team collaboration and the role permission model, and links it into the Enterprise nav.

Closes LIG-10299.

## Why

A user (Igor) with a viewer account couldn't find any explanation of what each role can do — there was no permissions overview anywhere in the docs. This adds one.

## Changes

- **New page** `enterprise/collaboration.md`:
  - How to invite teammates (from `Workspace → Users`, admins can change roles anytime), with a User Management screenshot.
  - Short role descriptions (Viewer / Labeler / Editor / Admin).
  - A capability-by-role permissions table.
- **Nav**: register the page in the Enterprise section (right after the landing page).
- **Landing page**: refresh the User Management screenshot (`v1.0.0` → `v1.0.2`).

## Notes for reviewers

- The permissions table documents the **intended** model (per the [GUI Gating](https://linear.app/lightly/document/gui-gating-f7d1fa0748c4#roles-actions-02274b5c) design doc). The behavior Igor reported — a viewer being able to create tags — is a separate bug tracked elsewhere and is intentionally **not** documented here.
- I could not run `mkdocs build --strict` locally (mkdocs not installed in my env). Please confirm `make docs` builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on enterprise collaboration and permissions, including team roles and their capabilities.
  * Documented how administrators invite teammates and manage roles.
  * Updated the enterprise user management screenshot.
  * Added the new collaboration and permissions page to the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->