### PR TITLE
Analytics: Track Dataset Curation & Export workflow with PostHog events

### DIFF
--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -13,23 +13,33 @@
     import { useTags } from '$lib/hooks/useTags/useTags';
     import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
     import AnnotationSourceSelect from '$lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte';
+    import { get } from 'svelte/store';
     import { exportCollection } from '$lib/services/exportCollection';
     import type { ExportFilter } from '$lib/services/types';
+    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
     import { useExportSamplesCount } from './useExportSamplesCount/useExportSamplesCount';
     import { PUBLIC_LIGHTLY_STUDIO_API_URL } from '$env/static/public';
     import * as Dialog from '$lib/components/ui/dialog';
     import { Loader2 } from '@lucide/svelte';
     import * as Alert from '$lib/components/ui/alert/index.js';
     import { fade } from 'svelte/transition';
-    import { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
+    import { useExportDialog } from '$lib/hooks';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
 
     const { isExportDialogOpen, openExportDialog, closeExportDialog } = useExportDialog();
     const { imageFilter } = useImageFilters();
+    const { filteredSampleCount } = useGlobalStorage();
+    const { trackEvent } = usePostHog();
 
     $effect(() => {
         if ($isExportDialogOpen) {
-            exportType = isVideoCollection ? 'youtube_vis_segmentation' : 'samples';
+            const defaultType = isVideoCollection ? 'youtube_vis_segmentation' : 'samples';
+            exportType = defaultType;
+            trackEvent('export_dialog_default_format_set', {
+                collection_id: collectionId,
+                export_format: defaultType
+            });
         }
     });
 
@@ -89,6 +99,7 @@
         $tags.find((f) => f.tag_id === tagIdToExport)?.name ??
             'Select a tag to export its samples (required)'
     );
+    const tagNameToExport = $derived($tags.find((f) => f.tag_id === tagIdToExport)?.name ?? null);
 
     // Enable info panel if there are selected samples or annotations or tag is selected
     const isInfoEnabled = $derived(exportType === 'samples' ? !!tagIdToExport : false);
@@ -136,13 +147,39 @@
         return !!errorMessage;
     });
 
+    const handleAnnotationDownloadClick = (exportFormat: string) => {
+        trackEvent('export_download_clicked', {
+            collection_id: collectionId,
+            export_format: exportFormat,
+            sample_count: $filteredSampleCount,
+            tag_name: null
+        });
+    };
+
     const handleExport = async () => {
+        const sampleCount = get(count);
+        trackEvent('export_download_clicked', {
+            collection_id: collectionId,
+            export_format: exportType,
+            sample_count: sampleCount,
+            tag_name: tagNameToExport
+        });
         const response = await exportCollection({
             collection_id: collectionId,
             includeFilter,
             excludeFilter,
             collectionFilter: $imageFilter
         });
+
+        trackEvent('export_triggered', {
+            collection_id: collectionId,
+            export_format: exportType,
+            sample_count: sampleCount,
+            tag_name: tagNameToExport,
+            success: !response.error,
+            error_message: response.error ?? null
+        });
+
         if (response.error) {
             errorMessage = `Export failed: ${response.error}`;
         }
@@ -187,7 +224,13 @@
 
 <Dialog.Root
     open={$isExportDialogOpen}
-    onOpenChange={(open) => (open ? openExportDialog() : closeExportDialog())}
+    onOpenChange={(open) => {
+        if (open) {
+            openExportDialog({ collectionId });
+        } else {
+            closeExportDialog({ collectionId, exportFormat: exportType });
+        }
+    }}
 >
     <Dialog.Portal>
         <Dialog.Overlay />
@@ -210,7 +253,21 @@
                             triggerLabel={exportTypeTriggerContent}
                             class="w-full"
                             testId="export-type-select"
-                            onValueChange={(v) => (exportType = v as typeof exportType)}
+                            onOpenChange={(open) => {
+                                if (open) {
+                                    trackEvent('export_format_select_opened', {
+                                        collection_id: collectionId,
+                                        current_export_format: exportType
+                                    });
+                                }
+                            }}
+                            onValueChange={(v) => {
+                                exportType = v as typeof exportType;
+                                trackEvent('export_format_selected', {
+                                    collection_id: collectionId,
+                                    export_format: v
+                                });
+                            }}
                         >
                             {#snippet children()}
                                 {#if isVideoCollection}
@@ -379,6 +436,7 @@
                             href={exportObjectDetectionCocoURL}
                             target="_blank"
                             data-testid="submit-button-annotations-coco"
+                            onclick={() => handleAnnotationDownloadClick('object_detections_coco')}
                         >
                             Download
                         </Button>
@@ -406,6 +464,7 @@
                             href={exportObjectDetectionYoloURL}
                             target="_blank"
                             data-testid="submit-button-annotations-yolo"
+                            onclick={() => handleAnnotationDownloadClick('object_detections_yolo')}
                         >
                             Download
                         </Button>
@@ -433,6 +492,7 @@
                             href={exportSegmentationMaskURL}
                             target="_blank"
                             data-testid="submit-button-instance-segmentations"
+                            onclick={() => handleAnnotationDownloadClick('segmentation')}
                         >
                             Download
                         </Button>
@@ -449,6 +509,8 @@
                                 href={exportYoutubeVisSegmentationMaskURL}
                                 target="_blank"
                                 data-testid="submit-button-youtube-vis-instance-segmentations"
+                                onclick={() =>
+                                    handleAnnotationDownloadClick('youtube_vis_segmentation')}
                             >
                                 Download
                             </Button>
@@ -476,6 +538,7 @@
                             href={exportPascalVocURL}
                             target="_blank"
                             data-testid="submit-button-semantic-segmentations"
+                            onclick={() => handleAnnotationDownloadClick('semantic_segmentations')}
                         >
                             Download
                         </Button>
@@ -493,6 +556,7 @@
                             href={exportCaptionsURL}
                             target="_blank"
                             data-testid="submit-button-captions"
+                            onclick={() => handleAnnotationDownloadClick('captions')}
                         >
                             Download
                         </Button>

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -27,7 +27,8 @@
     import { useExportDialog } from '$lib/hooks';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
 
-    const { isExportDialogOpen, openExportDialog, closeExportDialog } = useExportDialog();
+    const { isExportDialogOpen, openExportDialog, closeExportDialog, markDownloadClicked } =
+        useExportDialog();
     const { imageFilter } = useImageFilters();
     const { filteredSampleCount } = useGlobalStorage();
     const { trackEvent } = usePostHog();
@@ -148,6 +149,7 @@
     });
 
     const handleAnnotationDownloadClick = (exportFormat: string) => {
+        markDownloadClicked();
         trackEvent('export_download_clicked', {
             collection_id: collectionId,
             export_format: exportFormat,
@@ -158,6 +160,7 @@
 
     const handleExport = async () => {
         const sampleCount = get(count);
+        markDownloadClicked();
         trackEvent('export_download_clicked', {
             collection_id: collectionId,
             export_format: exportType,

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -400,7 +400,8 @@
                             href={exportObjectDetectionCocoURL}
                             target="_blank"
                             data-testid="submit-button-annotations-coco"
-                            onclick={() => tracking.handleAnnotationDownloadClick('object_detections_coco')}
+                            onclick={() =>
+                                tracking.handleAnnotationDownloadClick('object_detections_coco')}
                         >
                             Download
                         </Button>
@@ -428,7 +429,8 @@
                             href={exportObjectDetectionYoloURL}
                             target="_blank"
                             data-testid="submit-button-annotations-yolo"
-                            onclick={() => tracking.handleAnnotationDownloadClick('object_detections_yolo')}
+                            onclick={() =>
+                                tracking.handleAnnotationDownloadClick('object_detections_yolo')}
                         >
                             Download
                         </Button>
@@ -474,7 +476,9 @@
                                 target="_blank"
                                 data-testid="submit-button-youtube-vis-instance-segmentations"
                                 onclick={() =>
-                                    tracking.handleAnnotationDownloadClick('youtube_vis_segmentation')}
+                                    tracking.handleAnnotationDownloadClick(
+                                        'youtube_vis_segmentation'
+                                    )}
                             >
                                 Download
                             </Button>
@@ -502,7 +506,8 @@
                             href={exportPascalVocURL}
                             target="_blank"
                             data-testid="submit-button-semantic-segmentations"
-                            onclick={() => tracking.handleAnnotationDownloadClick('semantic_segmentations')}
+                            onclick={() =>
+                                tracking.handleAnnotationDownloadClick('semantic_segmentations')}
                         >
                             Download
                         </Button>

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -14,10 +14,7 @@
     import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
     import AnnotationSourceSelect from '$lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte';
     import { get } from 'svelte/store';
-    import { exportCollection } from '$lib/services/exportCollection';
     import type { ExportFilter } from '$lib/services/types';
-    import { usePostHog } from '$lib/hooks/usePostHog';
-    import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
     import { useExportSamplesCount } from './useExportSamplesCount/useExportSamplesCount';
     import { PUBLIC_LIGHTLY_STUDIO_API_URL } from '$env/static/public';
     import * as Dialog from '$lib/components/ui/dialog';
@@ -26,21 +23,16 @@
     import { fade } from 'svelte/transition';
     import { useExportDialog } from '$lib/hooks';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
+    import { useExportTracking } from './useExportTracking/useExportTracking';
 
-    const { isExportDialogOpen, openExportDialog, closeExportDialog, markDownloadClicked } =
-        useExportDialog();
+    const { isExportDialogOpen, openExportDialog, closeExportDialog } = useExportDialog();
     const { imageFilter } = useImageFilters();
-    const { filteredSampleCount } = useGlobalStorage();
-    const { trackEvent } = usePostHog();
 
     $effect(() => {
         if ($isExportDialogOpen) {
             const defaultType = isVideoCollection ? 'youtube_vis_segmentation' : 'samples';
             exportType = defaultType;
-            trackEvent('export_dialog_default_format_set', {
-                collection_id: collectionId,
-                export_format: defaultType
-            });
+            tracking.trackDialogDefaultFormatSet(defaultType);
         }
     });
 
@@ -69,6 +61,7 @@
     };
     const exportTypeTriggerContent = $derived(exportTypeLabels[exportType]);
     let collectionId = page.params.collection_id;
+    const tracking = useExportTracking({ collectionId });
 
     //
     // Annotation source selection
@@ -148,45 +141,17 @@
         return !!errorMessage;
     });
 
-    const handleAnnotationDownloadClick = (exportFormat: string) => {
-        markDownloadClicked();
-        trackEvent('export_download_clicked', {
-            collection_id: collectionId,
-            export_format: exportFormat,
-            sample_count: $filteredSampleCount,
-            tag_name: null
-        });
-    };
-
     const handleExport = async () => {
-        const sampleCount = get(count);
-        const snapshotExportType = exportType;
-        const snapshotTagName = tagNameToExport;
-        markDownloadClicked();
-        trackEvent('export_download_clicked', {
-            collection_id: collectionId,
-            export_format: snapshotExportType,
-            sample_count: sampleCount,
-            tag_name: snapshotTagName
-        });
-        const response = await exportCollection({
-            collection_id: collectionId,
+        const { errorMessage: exportError } = await tracking.handleExport({
+            exportType,
+            tagNameToExport,
+            sampleCount: get(count),
             includeFilter,
             excludeFilter,
-            collectionFilter: $imageFilter
+            imageFilter: $imageFilter
         });
-
-        trackEvent('export_triggered', {
-            collection_id: collectionId,
-            export_format: snapshotExportType,
-            sample_count: sampleCount,
-            tag_name: snapshotTagName,
-            success: !response.error,
-            error_message: response.error ?? null
-        });
-
-        if (response.error) {
-            errorMessage = `Export failed: ${response.error}`;
+        if (exportError) {
+            errorMessage = exportError;
         }
     };
 
@@ -260,18 +225,12 @@
                             testId="export-type-select"
                             onOpenChange={(open) => {
                                 if (open) {
-                                    trackEvent('export_format_select_opened', {
-                                        collection_id: collectionId,
-                                        current_export_format: exportType
-                                    });
+                                    tracking.trackFormatSelectOpened(exportType);
                                 }
                             }}
                             onValueChange={(v) => {
                                 exportType = v as typeof exportType;
-                                trackEvent('export_format_selected', {
-                                    collection_id: collectionId,
-                                    export_format: v
-                                });
+                                tracking.trackFormatSelected(v);
                             }}
                         >
                             {#snippet children()}
@@ -441,7 +400,7 @@
                             href={exportObjectDetectionCocoURL}
                             target="_blank"
                             data-testid="submit-button-annotations-coco"
-                            onclick={() => handleAnnotationDownloadClick('object_detections_coco')}
+                            onclick={() => tracking.handleAnnotationDownloadClick('object_detections_coco')}
                         >
                             Download
                         </Button>
@@ -469,7 +428,7 @@
                             href={exportObjectDetectionYoloURL}
                             target="_blank"
                             data-testid="submit-button-annotations-yolo"
-                            onclick={() => handleAnnotationDownloadClick('object_detections_yolo')}
+                            onclick={() => tracking.handleAnnotationDownloadClick('object_detections_yolo')}
                         >
                             Download
                         </Button>
@@ -497,7 +456,7 @@
                             href={exportSegmentationMaskURL}
                             target="_blank"
                             data-testid="submit-button-instance-segmentations"
-                            onclick={() => handleAnnotationDownloadClick('segmentation')}
+                            onclick={() => tracking.handleAnnotationDownloadClick('segmentation')}
                         >
                             Download
                         </Button>
@@ -515,7 +474,7 @@
                                 target="_blank"
                                 data-testid="submit-button-youtube-vis-instance-segmentations"
                                 onclick={() =>
-                                    handleAnnotationDownloadClick('youtube_vis_segmentation')}
+                                    tracking.handleAnnotationDownloadClick('youtube_vis_segmentation')}
                             >
                                 Download
                             </Button>
@@ -543,7 +502,7 @@
                             href={exportPascalVocURL}
                             target="_blank"
                             data-testid="submit-button-semantic-segmentations"
-                            onclick={() => handleAnnotationDownloadClick('semantic_segmentations')}
+                            onclick={() => tracking.handleAnnotationDownloadClick('semantic_segmentations')}
                         >
                             Download
                         </Button>
@@ -561,7 +520,7 @@
                             href={exportCaptionsURL}
                             target="_blank"
                             data-testid="submit-button-captions"
-                            onclick={() => handleAnnotationDownloadClick('captions')}
+                            onclick={() => tracking.handleAnnotationDownloadClick('captions')}
                         >
                             Download
                         </Button>

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -160,12 +160,14 @@
 
     const handleExport = async () => {
         const sampleCount = get(count);
+        const snapshotExportType = exportType;
+        const snapshotTagName = tagNameToExport;
         markDownloadClicked();
         trackEvent('export_download_clicked', {
             collection_id: collectionId,
-            export_format: exportType,
+            export_format: snapshotExportType,
             sample_count: sampleCount,
-            tag_name: tagNameToExport
+            tag_name: snapshotTagName
         });
         const response = await exportCollection({
             collection_id: collectionId,
@@ -176,9 +178,9 @@
 
         trackEvent('export_triggered', {
             collection_id: collectionId,
-            export_format: exportType,
+            export_format: snapshotExportType,
             sample_count: sampleCount,
-            tag_name: tagNameToExport,
+            tag_name: snapshotTagName,
             success: !response.error,
             error_message: response.error ?? null
         });

--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportTracking/useExportTracking.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportTracking/useExportTracking.test.ts
@@ -1,0 +1,234 @@
+import { writable } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useExportTracking } from './useExportTracking';
+
+const mockTrackEvent = vi.fn();
+const mockMarkDownloadClicked = vi.fn();
+const mockExportCollection = vi.fn();
+
+vi.mock('$lib/hooks/usePostHog', () => ({
+    usePostHog: () => ({ trackEvent: mockTrackEvent })
+}));
+
+vi.mock('$lib/hooks/useGlobalStorage', () => ({
+    useGlobalStorage: () => ({ filteredSampleCount: writable(42) })
+}));
+
+vi.mock('$lib/hooks', () => ({
+    useExportDialog: () => ({ markDownloadClicked: mockMarkDownloadClicked })
+}));
+
+vi.mock('$lib/services/exportCollection', () => ({
+    exportCollection: (...args: unknown[]) => mockExportCollection(...args)
+}));
+
+const COLLECTION_ID = 'col-1';
+
+describe('useExportTracking', () => {
+    beforeEach(() => {
+        mockTrackEvent.mockClear();
+        mockMarkDownloadClicked.mockClear();
+        mockExportCollection.mockClear();
+    });
+
+    describe('trackDialogDefaultFormatSet', () => {
+        it('tracks the event with the given format', () => {
+            const { trackDialogDefaultFormatSet } = useExportTracking({
+                collectionId: COLLECTION_ID
+            });
+
+            trackDialogDefaultFormatSet('samples');
+
+            expect(mockTrackEvent).toHaveBeenCalledWith('export_dialog_default_format_set', {
+                collection_id: COLLECTION_ID,
+                export_format: 'samples'
+            });
+        });
+    });
+
+    describe('trackFormatSelectOpened', () => {
+        it('tracks the event with the current format', () => {
+            const { trackFormatSelectOpened } = useExportTracking({ collectionId: COLLECTION_ID });
+
+            trackFormatSelectOpened('captions');
+
+            expect(mockTrackEvent).toHaveBeenCalledWith('export_format_select_opened', {
+                collection_id: COLLECTION_ID,
+                current_export_format: 'captions'
+            });
+        });
+    });
+
+    describe('trackFormatSelected', () => {
+        it('tracks the event with the newly selected format', () => {
+            const { trackFormatSelected } = useExportTracking({ collectionId: COLLECTION_ID });
+
+            trackFormatSelected('object_detections_coco');
+
+            expect(mockTrackEvent).toHaveBeenCalledWith('export_format_selected', {
+                collection_id: COLLECTION_ID,
+                export_format: 'object_detections_coco'
+            });
+        });
+    });
+
+    describe('handleAnnotationDownloadClick', () => {
+        it('marks download clicked and tracks the event', () => {
+            const { handleAnnotationDownloadClick } = useExportTracking({
+                collectionId: COLLECTION_ID
+            });
+
+            handleAnnotationDownloadClick('segmentation');
+
+            expect(mockMarkDownloadClicked).toHaveBeenCalledOnce();
+            expect(mockTrackEvent).toHaveBeenCalledWith('export_download_clicked', {
+                collection_id: COLLECTION_ID,
+                export_format: 'segmentation',
+                sample_count: 42,
+                tag_name: null
+            });
+        });
+    });
+
+    describe('handleExport', () => {
+        it('marks download clicked and tracks export_download_clicked before the request', async () => {
+            mockExportCollection.mockResolvedValue({ error: undefined });
+            const { handleExport } = useExportTracking({ collectionId: COLLECTION_ID });
+
+            await handleExport({
+                exportType: 'samples',
+                tagNameToExport: 'my-tag',
+                sampleCount: 10,
+                includeFilter: undefined,
+                excludeFilter: undefined,
+                imageFilter: null
+            });
+
+            expect(mockMarkDownloadClicked).toHaveBeenCalledOnce();
+            expect(mockTrackEvent).toHaveBeenCalledWith('export_download_clicked', {
+                collection_id: COLLECTION_ID,
+                export_format: 'samples',
+                sample_count: 10,
+                tag_name: 'my-tag'
+            });
+        });
+
+        it('tracks export_triggered with success on a successful response', async () => {
+            mockExportCollection.mockResolvedValue({ error: undefined });
+            const { handleExport } = useExportTracking({ collectionId: COLLECTION_ID });
+
+            await handleExport({
+                exportType: 'samples',
+                tagNameToExport: 'my-tag',
+                sampleCount: 10,
+                includeFilter: undefined,
+                excludeFilter: undefined,
+                imageFilter: null
+            });
+
+            expect(mockTrackEvent).toHaveBeenCalledWith('export_triggered', {
+                collection_id: COLLECTION_ID,
+                export_format: 'samples',
+                sample_count: 10,
+                tag_name: 'my-tag',
+                success: true,
+                error_message: null
+            });
+        });
+
+        it('returns undefined errorMessage on success', async () => {
+            mockExportCollection.mockResolvedValue({ error: undefined });
+            const { handleExport } = useExportTracking({ collectionId: COLLECTION_ID });
+
+            const result = await handleExport({
+                exportType: 'samples',
+                tagNameToExport: null,
+                sampleCount: 5,
+                includeFilter: undefined,
+                excludeFilter: undefined,
+                imageFilter: null
+            });
+
+            expect(result.errorMessage).toBeUndefined();
+        });
+
+        it('tracks export_triggered with failure and returns an errorMessage on error', async () => {
+            mockExportCollection.mockResolvedValue({ error: 'network timeout' });
+            const { handleExport } = useExportTracking({ collectionId: COLLECTION_ID });
+
+            const result = await handleExport({
+                exportType: 'samples',
+                tagNameToExport: null,
+                sampleCount: 5,
+                includeFilter: undefined,
+                excludeFilter: undefined,
+                imageFilter: null
+            });
+
+            expect(mockTrackEvent).toHaveBeenCalledWith('export_triggered', {
+                collection_id: COLLECTION_ID,
+                export_format: 'samples',
+                sample_count: 5,
+                tag_name: null,
+                success: false,
+                error_message: 'network timeout'
+            });
+            expect(result.errorMessage).toBe('Export failed: network timeout');
+        });
+
+        it('passes filters and imageFilter through to exportCollection', async () => {
+            mockExportCollection.mockResolvedValue({ error: undefined });
+            const { handleExport } = useExportTracking({ collectionId: COLLECTION_ID });
+            const includeFilter = { tag_ids: ['tag-1'] };
+            const imageFilter = { brightness: { min: 0.5 } } as never;
+
+            await handleExport({
+                exportType: 'samples',
+                tagNameToExport: null,
+                sampleCount: 3,
+                includeFilter,
+                excludeFilter: undefined,
+                imageFilter
+            });
+
+            expect(mockExportCollection).toHaveBeenCalledWith({
+                collection_id: COLLECTION_ID,
+                includeFilter,
+                excludeFilter: undefined,
+                collectionFilter: imageFilter
+            });
+        });
+
+        it('uses snapshotted values for tracking even if called with different args later', async () => {
+            mockExportCollection.mockResolvedValue({ error: undefined });
+            const { handleExport } = useExportTracking({ collectionId: COLLECTION_ID });
+
+            await handleExport({
+                exportType: 'captions',
+                tagNameToExport: 'original-tag',
+                sampleCount: 7,
+                includeFilter: undefined,
+                excludeFilter: undefined,
+                imageFilter: null
+            });
+
+            const downloadCall = mockTrackEvent.mock.calls.find(
+                ([event]) => event === 'export_download_clicked'
+            );
+            const triggeredCall = mockTrackEvent.mock.calls.find(
+                ([event]) => event === 'export_triggered'
+            );
+
+            expect(downloadCall?.[1]).toMatchObject({
+                export_format: 'captions',
+                tag_name: 'original-tag',
+                sample_count: 7
+            });
+            expect(triggeredCall?.[1]).toMatchObject({
+                export_format: 'captions',
+                tag_name: 'original-tag',
+                sample_count: 7
+            });
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportTracking/useExportTracking.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportTracking/useExportTracking.test.ts
@@ -6,15 +6,9 @@ const mockTrackEvent = vi.fn();
 const mockMarkDownloadClicked = vi.fn();
 const mockExportCollection = vi.fn();
 
-vi.mock('$lib/hooks/usePostHog', () => ({
-    usePostHog: () => ({ trackEvent: mockTrackEvent })
-}));
-
-vi.mock('$lib/hooks/useGlobalStorage', () => ({
-    useGlobalStorage: () => ({ filteredSampleCount: writable(42) })
-}));
-
 vi.mock('$lib/hooks', () => ({
+    usePostHog: () => ({ trackEvent: mockTrackEvent }),
+    useGlobalStorage: () => ({ filteredSampleCount: writable(42) }),
     useExportDialog: () => ({ markDownloadClicked: mockMarkDownloadClicked })
 }));
 

--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportTracking/useExportTracking.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportTracking/useExportTracking.ts
@@ -1,0 +1,106 @@
+import { get } from 'svelte/store';
+import type { ImageFilter } from '$lib/api/lightly_studio_local';
+import { exportCollection } from '$lib/services/exportCollection';
+import type { ExportFilter } from '$lib/services/types';
+import { useExportDialog } from '$lib/hooks';
+import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+import { usePostHog } from '$lib/hooks/usePostHog';
+
+interface UseExportTrackingParams {
+    collectionId: string;
+}
+
+interface HandleExportParams {
+    exportType: string;
+    tagNameToExport: string | null;
+    sampleCount: number;
+    includeFilter: ExportFilter | undefined;
+    excludeFilter: ExportFilter | undefined;
+    imageFilter: ImageFilter | null | undefined;
+}
+
+interface HandleExportResult {
+    errorMessage: string | undefined;
+}
+
+export function useExportTracking({ collectionId }: UseExportTrackingParams) {
+    const { trackEvent } = usePostHog();
+    const { filteredSampleCount } = useGlobalStorage();
+    const { markDownloadClicked } = useExportDialog();
+
+    const trackDialogDefaultFormatSet = (exportFormat: string) => {
+        trackEvent('export_dialog_default_format_set', {
+            collection_id: collectionId,
+            export_format: exportFormat
+        });
+    };
+
+    const trackFormatSelectOpened = (currentFormat: string) => {
+        trackEvent('export_format_select_opened', {
+            collection_id: collectionId,
+            current_export_format: currentFormat
+        });
+    };
+
+    const trackFormatSelected = (exportFormat: string) => {
+        trackEvent('export_format_selected', {
+            collection_id: collectionId,
+            export_format: exportFormat
+        });
+    };
+
+    const handleAnnotationDownloadClick = (exportFormat: string) => {
+        markDownloadClicked();
+        trackEvent('export_download_clicked', {
+            collection_id: collectionId,
+            export_format: exportFormat,
+            sample_count: get(filteredSampleCount),
+            tag_name: null
+        });
+    };
+
+    const handleExport = async ({
+        exportType,
+        tagNameToExport,
+        sampleCount,
+        includeFilter,
+        excludeFilter,
+        imageFilter
+    }: HandleExportParams): Promise<HandleExportResult> => {
+        markDownloadClicked();
+        trackEvent('export_download_clicked', {
+            collection_id: collectionId,
+            export_format: exportType,
+            sample_count: sampleCount,
+            tag_name: tagNameToExport
+        });
+
+        const response = await exportCollection({
+            collection_id: collectionId,
+            includeFilter,
+            excludeFilter,
+            collectionFilter: imageFilter
+        });
+
+        trackEvent('export_triggered', {
+            collection_id: collectionId,
+            export_format: exportType,
+            sample_count: sampleCount,
+            tag_name: tagNameToExport,
+            success: !response.error,
+            error_message: response.error ?? null
+        });
+
+        return {
+            errorMessage: response.error ? `Export failed: ${response.error}` : undefined
+        };
+    };
+
+    return {
+        trackDialogDefaultFormatSet,
+        trackFormatSelectOpened,
+        trackFormatSelected,
+        handleAnnotationDownloadClick,
+        handleExport
+    };
+}

--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportTracking/useExportTracking.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportTracking/useExportTracking.ts
@@ -3,8 +3,7 @@ import type { ImageFilter } from '$lib/api/lightly_studio_local';
 import { exportCollection } from '$lib/services/exportCollection';
 import type { ExportFilter } from '$lib/services/types';
 import { useExportDialog } from '$lib/hooks';
-import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
-import { usePostHog } from '$lib/hooks/usePostHog';
+import { useGlobalStorage, usePostHog } from '$lib/hooks';
 
 interface UseExportTrackingParams {
     collectionId: string;

--- a/lightly_studio_view/src/lib/components/Header/Menu.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Menu.svelte
@@ -88,7 +88,7 @@
                 label: 'Export',
                 icon: DownloadIcon,
                 testId: 'menu-export',
-                onSelect: openExportDialog
+                onSelect: () => openExportDialog({ collectionId: collection.collection_id })
             });
         }
 

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -17,6 +17,7 @@
     import TagActionMenu from './TagActionMenu.svelte';
     import { toast } from 'svelte-sonner';
     import { get } from 'svelte/store';
+    import { usePostHog } from '$lib/hooks/usePostHog';
 
     let { collection_id, gridType }: Parameters<typeof useTags>[0] & { gridType: GridType } =
         $props();
@@ -45,6 +46,8 @@
             ? ($selectedSampleAnnotationCropIds[collection_id] ?? new Set<string>())
             : $selectedSampleIds
     );
+
+    const { trackEvent } = usePostHog();
 
     let assignBusy = $state(false);
     let deletingTagId = $state<string | null>(null);
@@ -86,6 +89,12 @@
                     toast.error('Failed to assign tag. Please try again.');
                     return;
                 }
+                trackEvent('samples_tagged', {
+                    collection_id,
+                    tag_kind: tagKind,
+                    sample_count: selectedIds.size,
+                    is_new_tag: false
+                });
             } else {
                 const createResponse = await createTag({
                     path: { collection_id },
@@ -100,6 +109,12 @@
                     toast.error('Failed to assign tag. Please try again.');
                     return;
                 }
+                trackEvent('samples_tagged', {
+                    collection_id,
+                    tag_kind: tagKind,
+                    sample_count: selectedIds.size,
+                    is_new_tag: true
+                });
             }
             loadTags();
         } catch (error) {

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -17,7 +17,7 @@
     import TagActionMenu from './TagActionMenu.svelte';
     import { toast } from 'svelte-sonner';
     import { get } from 'svelte/store';
-    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { usePostHog } from '$lib/hooks';
 
     let { collection_id, gridType }: Parameters<typeof useTags>[0] & { gridType: GridType } =
         $props();
@@ -80,6 +80,16 @@
     async function handleAssign(name: string) {
         assignBusy = true;
         const snapshotCount = selectedIds.size;
+
+        function trackTagged(is_new_tag: boolean) {
+            trackEvent('samples_tagged', {
+                collection_id,
+                tag_kind: tagKind,
+                sample_count: snapshotCount,
+                is_new_tag
+            });
+        }
+
         try {
             const existingTag = $tags.find(
                 (t: TagView) => t.name.toLowerCase() === name.toLowerCase()
@@ -90,12 +100,7 @@
                     toast.error('Failed to assign tag. Please try again.');
                     return;
                 }
-                trackEvent('samples_tagged', {
-                    collection_id,
-                    tag_kind: tagKind,
-                    sample_count: snapshotCount,
-                    is_new_tag: false
-                });
+                trackTagged(false);
             } else {
                 const createResponse = await createTag({
                     path: { collection_id },
@@ -110,12 +115,7 @@
                     toast.error('Failed to assign tag. Please try again.');
                     return;
                 }
-                trackEvent('samples_tagged', {
-                    collection_id,
-                    tag_kind: tagKind,
-                    sample_count: snapshotCount,
-                    is_new_tag: true
-                });
+                trackTagged(true);
             }
             loadTags();
         } catch (error) {

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -79,6 +79,7 @@
 
     async function handleAssign(name: string) {
         assignBusy = true;
+        const snapshotCount = selectedIds.size;
         try {
             const existingTag = $tags.find(
                 (t: TagView) => t.name.toLowerCase() === name.toLowerCase()
@@ -92,7 +93,7 @@
                 trackEvent('samples_tagged', {
                     collection_id,
                     tag_kind: tagKind,
-                    sample_count: selectedIds.size,
+                    sample_count: snapshotCount,
                     is_new_tag: false
                 });
             } else {
@@ -112,7 +113,7 @@
                 trackEvent('samples_tagged', {
                     collection_id,
                     tag_kind: tagKind,
-                    sample_count: selectedIds.size,
+                    sample_count: snapshotCount,
                     is_new_tag: true
                 });
             }

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -44,6 +44,7 @@ export { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDi
 export { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
 export { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
 export { useSettings } from '$lib/hooks/useSettings';
+export { usePostHog } from '$lib/hooks/usePostHog';
 export { useAnnotationClassVisibility } from '$lib/hooks/useAnnotationClassVisibility/useAnnotationClassVisibility';
 export {
     useImageAnnotationCounts,

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -41,6 +41,7 @@ export { useCreateSampling } from '$lib/hooks/useCreateSampling/useCreateSamplin
 export { useColorPicker } from '$lib/hooks/useColorPicker/useColorPicker.svelte';
 export { useSubmitCombinationSelection } from '$lib/hooks/useSubmitCombinationSelection/useSubmitCombinationSelection';
 export { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
+export { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
 export { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
 export { useSettings } from '$lib/hooks/useSettings';
 export { useAnnotationClassVisibility } from '$lib/hooks/useAnnotationClassVisibility/useAnnotationClassVisibility';

--- a/lightly_studio_view/src/lib/hooks/useExportDialog/useExportDialog.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useExportDialog/useExportDialog.test.ts
@@ -1,0 +1,124 @@
+import { get, writable } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useExportDialog } from './useExportDialog';
+
+const mockTrackEvent = vi.fn();
+
+vi.mock('$lib/hooks/usePostHog', () => ({
+    usePostHog: () => ({ trackEvent: mockTrackEvent })
+}));
+
+vi.mock('$lib/hooks/useGlobalStorage', () => ({
+    useGlobalStorage: () => ({ filteredSampleCount: writable(0) })
+}));
+
+describe('useExportDialog', () => {
+    beforeEach(() => {
+        mockTrackEvent.mockClear();
+
+        // Reset shared store state between tests by closing any open dialog
+        const { closeExportDialog, isExportDialogOpen } = useExportDialog();
+        if (get(isExportDialogOpen)) {
+            closeExportDialog({ collectionId: 'reset', exportFormat: 'samples' });
+        }
+        mockTrackEvent.mockClear();
+    });
+
+    describe('openExportDialog', () => {
+        it('sets isExportDialogOpen to true', () => {
+            const { isExportDialogOpen, openExportDialog } = useExportDialog();
+
+            openExportDialog({ collectionId: 'col-1' });
+
+            expect(get(isExportDialogOpen)).toBe(true);
+        });
+
+        it('tracks export_dialog_opened', () => {
+            const { openExportDialog } = useExportDialog();
+
+            openExportDialog({ collectionId: 'col-1' });
+
+            expect(mockTrackEvent).toHaveBeenCalledWith('export_dialog_opened', {
+                collection_id: 'col-1',
+                filtered_sample_count: expect.anything()
+            });
+        });
+
+        it('does nothing when dialog is already open', () => {
+            const { openExportDialog } = useExportDialog();
+
+            openExportDialog({ collectionId: 'col-1' });
+            openExportDialog({ collectionId: 'col-1' });
+
+            expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('closeExportDialog', () => {
+        it('sets isExportDialogOpen to false', () => {
+            const { isExportDialogOpen, openExportDialog, closeExportDialog } = useExportDialog();
+            openExportDialog({ collectionId: 'col-1' });
+
+            closeExportDialog({ collectionId: 'col-1', exportFormat: 'samples' });
+
+            expect(get(isExportDialogOpen)).toBe(false);
+        });
+
+        it('tracks export_dialog_dismissed when no download occurred', () => {
+            const { openExportDialog, closeExportDialog } = useExportDialog();
+            openExportDialog({ collectionId: 'col-1' });
+            mockTrackEvent.mockClear();
+
+            closeExportDialog({ collectionId: 'col-1', exportFormat: 'samples' });
+
+            expect(mockTrackEvent).toHaveBeenCalledWith('export_dialog_dismissed', {
+                collection_id: 'col-1',
+                export_format: 'samples'
+            });
+        });
+
+        it('does not track export_dialog_dismissed when a download was clicked', () => {
+            const { openExportDialog, closeExportDialog, markDownloadClicked } = useExportDialog();
+            openExportDialog({ collectionId: 'col-1' });
+            markDownloadClicked();
+            mockTrackEvent.mockClear();
+
+            closeExportDialog({ collectionId: 'col-1', exportFormat: 'samples' });
+
+            expect(mockTrackEvent).not.toHaveBeenCalledWith(
+                'export_dialog_dismissed',
+                expect.anything()
+            );
+        });
+
+        it('does nothing when dialog is already closed', () => {
+            const { closeExportDialog } = useExportDialog();
+
+            closeExportDialog({ collectionId: 'col-1', exportFormat: 'samples' });
+
+            expect(mockTrackEvent).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('markDownloadClicked', () => {
+        it('resets between sessions so closing without download after a new open tracks dismissed', () => {
+            const { openExportDialog, closeExportDialog, markDownloadClicked } = useExportDialog();
+
+            // First session: download clicked, close → no dismissed event
+            openExportDialog({ collectionId: 'col-1' });
+            markDownloadClicked();
+            closeExportDialog({ collectionId: 'col-1', exportFormat: 'samples' });
+            mockTrackEvent.mockClear();
+
+            // Second session: no download, close → dismissed event fires
+            openExportDialog({ collectionId: 'col-1' });
+            mockTrackEvent.mockClear();
+            closeExportDialog({ collectionId: 'col-1', exportFormat: 'samples' });
+
+            expect(mockTrackEvent).toHaveBeenCalledWith('export_dialog_dismissed', {
+                collection_id: 'col-1',
+                export_format: 'samples'
+            });
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useExportDialog/useExportDialog.ts
+++ b/lightly_studio_view/src/lib/hooks/useExportDialog/useExportDialog.ts
@@ -1,6 +1,5 @@
 import { get, writable } from 'svelte/store';
-import { usePostHog } from '$lib/hooks/usePostHog';
-import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+import { useGlobalStorage, usePostHog } from '$lib/hooks';
 
 const isExportDialogOpen = writable(false);
 const downloadedInSession = writable(false);

--- a/lightly_studio_view/src/lib/hooks/useExportDialog/useExportDialog.ts
+++ b/lightly_studio_view/src/lib/hooks/useExportDialog/useExportDialog.ts
@@ -1,13 +1,37 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
+import { usePostHog } from '$lib/hooks/usePostHog';
+import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 
 const isExportDialogOpen = writable(false);
 
+interface OpenExportDialogParams {
+    collectionId: string;
+}
+
+interface CloseExportDialogParams {
+    collectionId: string;
+    exportFormat: string;
+}
+
 export function useExportDialog() {
-    const openExportDialog = () => {
+    const { trackEvent } = usePostHog();
+    const { filteredSampleCount } = useGlobalStorage();
+
+    const openExportDialog = ({ collectionId }: OpenExportDialogParams) => {
+        if (get(isExportDialogOpen)) return;
         isExportDialogOpen.set(true);
+        trackEvent('export_dialog_opened', {
+            collection_id: collectionId,
+            filtered_sample_count: get(filteredSampleCount)
+        });
     };
 
-    const closeExportDialog = () => {
+    const closeExportDialog = ({ collectionId, exportFormat }: CloseExportDialogParams) => {
+        if (!get(isExportDialogOpen)) return;
+        trackEvent('export_dialog_dismissed', {
+            collection_id: collectionId,
+            export_format: exportFormat
+        });
         isExportDialogOpen.set(false);
     };
 

--- a/lightly_studio_view/src/lib/hooks/useExportDialog/useExportDialog.ts
+++ b/lightly_studio_view/src/lib/hooks/useExportDialog/useExportDialog.ts
@@ -3,6 +3,7 @@ import { usePostHog } from '$lib/hooks/usePostHog';
 import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
 
 const isExportDialogOpen = writable(false);
+const downloadedInSession = writable(false);
 
 interface OpenExportDialogParams {
     collectionId: string;
@@ -19,6 +20,7 @@ export function useExportDialog() {
 
     const openExportDialog = ({ collectionId }: OpenExportDialogParams) => {
         if (get(isExportDialogOpen)) return;
+        downloadedInSession.set(false);
         isExportDialogOpen.set(true);
         trackEvent('export_dialog_opened', {
             collection_id: collectionId,
@@ -28,16 +30,23 @@ export function useExportDialog() {
 
     const closeExportDialog = ({ collectionId, exportFormat }: CloseExportDialogParams) => {
         if (!get(isExportDialogOpen)) return;
-        trackEvent('export_dialog_dismissed', {
-            collection_id: collectionId,
-            export_format: exportFormat
-        });
+        if (!get(downloadedInSession)) {
+            trackEvent('export_dialog_dismissed', {
+                collection_id: collectionId,
+                export_format: exportFormat
+            });
+        }
         isExportDialogOpen.set(false);
+    };
+
+    const markDownloadClicked = () => {
+        downloadedInSession.set(true);
     };
 
     return {
         isExportDialogOpen,
         openExportDialog,
-        closeExportDialog
+        closeExportDialog,
+        markDownloadClicked
     };
 }

--- a/lightly_studio_view/src/routes/+layout.svelte
+++ b/lightly_studio_view/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { browser } from '$app/environment';
     import { useSettings } from '$lib/hooks/useSettings';
-    import { usePostHog } from '$lib/hooks/usePostHog';
+    import { usePostHog } from '$lib/hooks';
     import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
     import { onMount } from 'svelte';
     import '../app.css';


### PR DESCRIPTION
## What has changed and why?

Instruments eight PostHog events that cover the Dataset Curation & Export workflow.

`export_dialog_opened` - fires when the export dialog becomes visible; captures `collection_id` and `filtered_sample_count`
`export_dialog_dismissed` - fires when the dialog is closed without downloading; captures `collection_id` and `export_format` selected at dismiss time
`export_dialog_default_format_set` - fires once on dialog open when the default format is auto-applied (distinct from a user selection); captures `collection_id` and `export_format`
`export_format_select_opened` - fires when the user opens the export type dropdown; captures `collection_id` and `current_export_format`
`export_format_selected` - fires when the user explicitly changes the export format; captures `collection_id` and `export_format`
`export_download_clicked` - fires on every Download click before the request resolves; captures `collection_id`, `export_format`, `sample_count`, and `tag_name` (null for annotation-based formats)
`export_triggered` - fires after the async export resolves for the `samples` format; captures `collection_id`, `export_format`, `sample_count`, `tag_name`, `success`, and `error_message`
`samples_tagged` - fires when the user saves a selection as a tag (new or existing); captures `collection_id`, `tag_kind`, `sample_count`, and `is_new_tag`

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Export actions now carry the selected collection context consistently through dialog interactions and actual export execution.
  * Export dialog open/close is more robust and now tracks open, dismissal, and “download clicked” session behavior.
  * Export format selection (dropdown open/change) and annotation downloads now generate more consistent analytics.
  * Tag assignment now emits analytics that distinguish assigning to an existing tag vs creating a new one.
* **Tests**
  * Added unit tests covering export tracking and export dialog analytics/state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->