### PR TITLE
BE: treat decompression-bomb images as broken files

### DIFF
--- a/lightly_studio/src/lightly_studio/core/file_outcome_report.py
+++ b/lightly_studio/src/lightly_studio/core/file_outcome_report.py
@@ -5,7 +5,7 @@ Pipeline steps route each per-item file operation through
 by raising one of the typed signals defined here; the report does pure
 bookkeeping and decides the all-failed raise policy. The `FileOutcomeReport`
 itself performs no I/O; the module also exposes `BROKEN_IMAGE_ERRORS`, the shared
-tuple of Pillow exceptions image-open sites map to `BrokenInputFileError`.
+tuple of Pillow exceptions image-open sites map to a broken-file outcome.
 
 Each tracked file ends in exactly one `FileOutcome`:
 
@@ -73,13 +73,8 @@ class BrokenInputFileError(InputFileError):
     """Signal that an input file is present but unreadable/undecodable."""
 
 
-# Exceptions Pillow raises for a file that is present but cannot be turned into a
-# usable image: unreadable/corrupt bytes (``OSError``), an unrecognized format
-# (``UnidentifiedImageError``), or an oversized "decompression bomb" whose pixel
-# count exceeds Pillow's limit (``DecompressionBombError``, which subclasses
-# ``Exception`` directly and is therefore not covered by ``OSError``). Any image
-# open site that maps a decode failure to ``BrokenInputFileError`` should catch
-# this tuple.
+# Pillow exceptions for a present-but-undecodable image; `DecompressionBombError`
+# subclasses `Exception` directly, so it is not covered by `OSError`.
 BROKEN_IMAGE_ERRORS: tuple[type[Exception], ...] = (
     OSError,
     UnidentifiedImageError,

--- a/lightly_studio/src/lightly_studio/core/file_outcome_report.py
+++ b/lightly_studio/src/lightly_studio/core/file_outcome_report.py
@@ -3,7 +3,9 @@
 Pipeline steps route each per-item file operation through
 `FileOutcomeReport.track`. The body classifies *why* a file ended where it did
 by raising one of the typed signals defined here; the report does pure
-bookkeeping and decides the all-failed raise policy. It has no knowledge of I/O.
+bookkeeping and decides the all-failed raise policy. The `FileOutcomeReport`
+itself performs no I/O; the module also exposes `BROKEN_IMAGE_ERRORS`, the shared
+tuple of Pillow exceptions image-open sites map to `BrokenInputFileError`.
 
 Each tracked file ends in exactly one `FileOutcome`:
 
@@ -42,6 +44,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from os import PathLike
 
+from PIL import Image, UnidentifiedImageError
+
 logger = logging.getLogger(__name__)
 
 # Maximum number of example paths kept per outcome for the summary.
@@ -67,6 +71,20 @@ class MissingInputFileError(InputFileError):
 
 class BrokenInputFileError(InputFileError):
     """Signal that an input file is present but unreadable/undecodable."""
+
+
+# Exceptions Pillow raises for a file that is present but cannot be turned into a
+# usable image: unreadable/corrupt bytes (``OSError``), an unrecognized format
+# (``UnidentifiedImageError``), or an oversized "decompression bomb" whose pixel
+# count exceeds Pillow's limit (``DecompressionBombError``, which subclasses
+# ``Exception`` directly and is therefore not covered by ``OSError``). Any image
+# open site that maps a decode failure to ``BrokenInputFileError`` should catch
+# this tuple.
+BROKEN_IMAGE_ERRORS: tuple[type[Exception], ...] = (
+    OSError,
+    UnidentifiedImageError,
+    Image.DecompressionBombError,
+)
 
 
 class AllInputFilesFailedError(Exception):

--- a/lightly_studio/src/lightly_studio/core/image/add_images.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_images.py
@@ -23,6 +23,7 @@ from sqlmodel import Session
 from tqdm import tqdm
 
 from lightly_studio.core.file_outcome_report import (
+    BROKEN_IMAGE_ERRORS,
     AlreadyPresentInputFileError,
     BrokenInputFileError,
     FileOutcome,
@@ -137,7 +138,7 @@ def load_into_dataset_from_paths(
                     image = PIL.Image.open(file)
                     width, height = image.size
                     image.close()
-            except (PIL.UnidentifiedImageError, OSError) as e:
+            except BROKEN_IMAGE_ERRORS as e:
                 raise BrokenInputFileError() from e
 
             sample = ImageCreate(

--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -8,10 +8,14 @@ import fsspec
 import numpy as np
 import torch
 from numpy.typing import NDArray
-from PIL import Image, UnidentifiedImageError
+from PIL import Image
 from tqdm import tqdm
 
-from lightly_studio.core.file_outcome_report import FileOutcome, FileOutcomeReport
+from lightly_studio.core.file_outcome_report import (
+    BROKEN_IMAGE_ERRORS,
+    FileOutcome,
+    FileOutcomeReport,
+)
 from lightly_studio.dataset.embedding_generator import ImageCrop
 from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.dataset.image_embedding import EmbeddingContext
@@ -75,7 +79,7 @@ def embed_image_crops_batched(
             try:
                 with fsspec.open(filepath, "rb") as file:
                     image = Image.open(file).convert("RGB")
-            except (OSError, UnidentifiedImageError):
+            except BROKEN_IMAGE_ERRORS:
                 report.record(path=filepath, outcome=FileOutcome.BROKEN)
                 continue
             report.record(path=filepath, outcome=FileOutcome.ADDED)

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -17,10 +17,14 @@ import fsspec
 import numpy as np
 import torch
 from numpy.typing import NDArray
-from PIL import Image, UnidentifiedImageError
+from PIL import Image
 from tqdm import tqdm
 
-from lightly_studio.core.file_outcome_report import FileOutcome, FileOutcomeReport
+from lightly_studio.core.file_outcome_report import (
+    BROKEN_IMAGE_ERRORS,
+    FileOutcome,
+    FileOutcomeReport,
+)
 from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.utils import batching, parallelize
 
@@ -80,7 +84,7 @@ def embed_image_files_batched(
         try:
             with fsspec.open(filepath, "rb") as file:
                 image = Image.open(file).convert("RGB")
-        except (OSError, UnidentifiedImageError):
+        except BROKEN_IMAGE_ERRORS:
             return None
         return context.preprocess(image)
 

--- a/lightly_studio/tests/core/image/test_add_images.py
+++ b/lightly_studio/tests/core/image/test_add_images.py
@@ -182,6 +182,40 @@ def test_load_into_dataset_from_paths__records_missing_broken_already_present_ou
     assert "broken=4" in caplog.text
 
 
+def test_load_into_dataset_from_paths__records_decompression_bomb_as_broken(
+    db_session: Session,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An oversized "decompression bomb" image raises DecompressionBombError (which is not an
+    # OSError) on open. It must be recorded as broken and skipped, while good files are
+    # still added.
+    collection = helpers_resolvers.create_collection(db_session)
+
+    good_path = tmp_path / "good.jpg"
+    PILImage.new("RGB", (100, 100)).save(str(good_path))  # 10_000 pixels
+    bomb_path = tmp_path / "bomb.jpg"
+    PILImage.new("RGB", (300, 300)).save(str(bomb_path))  # 90_000 pixels
+    # Limit sits between the two: good stays under it, bomb exceeds 2x it and raises.
+    monkeypatch.setattr(PILImage, "MAX_IMAGE_PIXELS", 20_000)
+
+    with caplog.at_level("INFO"):
+        sample_ids = add_images.load_into_dataset_from_paths(
+            session=db_session,
+            root_collection_id=collection.collection_id,
+            image_paths=[str(good_path), str(bomb_path)],
+        )
+
+    assert len(sample_ids) == 1
+    samples = image_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    ).samples
+    assert {sample.file_name for sample in samples} == {"good.jpg"}
+    assert "added=1" in caplog.text
+    assert "broken=1" in caplog.text
+
+
 def test_load_into_collection_from_paths__deduplicates_in_run_duplicates(
     db_session: Session, tmp_path: Path
 ) -> None:

--- a/lightly_studio/tests/core/image/test_add_images.py
+++ b/lightly_studio/tests/core/image/test_add_images.py
@@ -188,16 +188,13 @@ def test_load_into_dataset_from_paths__records_decompression_bomb_as_broken(
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # An oversized "decompression bomb" image raises DecompressionBombError (which is not an
-    # OSError) on open. It must be recorded as broken and skipped, while good files are
-    # still added.
     collection = helpers_resolvers.create_collection(db_session)
 
     good_path = tmp_path / "good.jpg"
     PILImage.new("RGB", (100, 100)).save(str(good_path))  # 10_000 pixels
     bomb_path = tmp_path / "bomb.jpg"
     PILImage.new("RGB", (300, 300)).save(str(bomb_path))  # 90_000 pixels
-    # Limit sits between the two: good stays under it, bomb exceeds 2x it and raises.
+    # Limit sits between the two images so only the bomb exceeds it.
     monkeypatch.setattr(PILImage, "MAX_IMAGE_PIXELS", 20_000)
 
     with caplog.at_level("INFO"):

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -109,6 +109,41 @@ def test_embed_image_crops_batched__skips_broken_file(tmp_path: Path) -> None:
     assert result.embeddings[:, 0].tolist() == [5.0, 7.0]
 
 
+def test_embed_image_crops_batched__skips_decompression_bomb_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A source image whose pixel count exceeds Pillow's decompression-bomb limit raises
+    # DecompressionBombError (which is not an OSError). It must be skipped like any other
+    # broken file, so the good file's crops are still embedded.
+    good_path = tmp_path / "good.png"
+    Image.new("RGB", (100, 100), color=(255, 0, 0)).save(good_path)  # 10_000 pixels
+    bomb_path = tmp_path / "bomb.png"
+    Image.new("RGB", (300, 300), color=(0, 255, 0)).save(bomb_path)  # 90_000 pixels
+    # Limit sits between the two: good stays under it, bomb exceeds 2x it and raises.
+    monkeypatch.setattr(Image, "MAX_IMAGE_PIXELS", 20_000)
+
+    image_crops = [
+        ImageCrop(filepath=str(bomb_path), x=0, y=0, width=4, height=10),
+        ImageCrop(filepath=str(good_path), x=0, y=0, width=5, height=10),
+        ImageCrop(filepath=str(good_path), x=0, y=0, width=7, height=10),
+    ]
+
+    result = image_crop_embedding.embed_image_crops_batched(
+        image_crops=image_crops,
+        context=EmbeddingContext(
+            embedding_dimension=1,
+            max_batch_size=2,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
+        ),
+        show_progress=False,
+    )
+
+    assert result.kept_indices == [1, 2]
+    assert result.embeddings[:, 0].tolist() == [5.0, 7.0]
+
+
 def test_embed_image_crops_batched__raises_when_all_files_broken(tmp_path: Path) -> None:
     broken_path = tmp_path / "broken.png"
     broken_path.write_bytes(b"not a valid image")

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -112,14 +112,11 @@ def test_embed_image_crops_batched__skips_broken_file(tmp_path: Path) -> None:
 def test_embed_image_crops_batched__skips_decompression_bomb_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A source image whose pixel count exceeds Pillow's decompression-bomb limit raises
-    # DecompressionBombError (which is not an OSError). It must be skipped like any other
-    # broken file, so the good file's crops are still embedded.
     good_path = tmp_path / "good.png"
     Image.new("RGB", (100, 100), color=(255, 0, 0)).save(good_path)  # 10_000 pixels
     bomb_path = tmp_path / "bomb.png"
     Image.new("RGB", (300, 300), color=(0, 255, 0)).save(bomb_path)  # 90_000 pixels
-    # Limit sits between the two: good stays under it, bomb exceeds 2x it and raises.
+    # Limit sits between the two images so only the bomb exceeds it.
     monkeypatch.setattr(Image, "MAX_IMAGE_PIXELS", 20_000)
 
     image_crops = [

--- a/lightly_studio/tests/dataset/test_image_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_embedding.py
@@ -119,14 +119,11 @@ def test_embed_image_files_batched__skips_broken_files(tmp_path: Path) -> None:
 def test_embed_image_files_batched__skips_decompression_bomb_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A file whose pixel count exceeds Pillow's decompression-bomb limit raises
-    # DecompressionBombError (which is not an OSError) and must be skipped like any broken
-    # file, so the good file is still embedded.
     good_path = tmp_path / "good.png"
     Image.new("RGB", (100, 100), color=(255, 0, 0)).save(good_path)  # 10_000 pixels
     bomb_path = tmp_path / "bomb.png"
     Image.new("RGB", (300, 300), color=(0, 255, 0)).save(bomb_path)  # 90_000 pixels
-    # Limit sits between the two: good stays under it, bomb exceeds 2x it and raises.
+    # Limit sits between the two images so only the bomb exceeds it.
     monkeypatch.setattr(Image, "MAX_IMAGE_PIXELS", 20_000)
 
     result = image_embedding.embed_image_files_batched(

--- a/lightly_studio/tests/dataset/test_image_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_embedding.py
@@ -116,6 +116,35 @@ def test_embed_image_files_batched__skips_broken_files(tmp_path: Path) -> None:
     assert result.embeddings[:, 0].tolist() == [float(width) for width in widths]
 
 
+def test_embed_image_files_batched__skips_decompression_bomb_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A file whose pixel count exceeds Pillow's decompression-bomb limit raises
+    # DecompressionBombError (which is not an OSError) and must be skipped like any broken
+    # file, so the good file is still embedded.
+    good_path = tmp_path / "good.png"
+    Image.new("RGB", (100, 100), color=(255, 0, 0)).save(good_path)  # 10_000 pixels
+    bomb_path = tmp_path / "bomb.png"
+    Image.new("RGB", (300, 300), color=(0, 255, 0)).save(bomb_path)  # 90_000 pixels
+    # Limit sits between the two: good stays under it, bomb exceeds 2x it and raises.
+    monkeypatch.setattr(Image, "MAX_IMAGE_PIXELS", 20_000)
+
+    result = image_embedding.embed_image_files_batched(
+        filepaths=[str(bomb_path), str(good_path)],
+        context=EmbeddingContext(
+            embedding_dimension=1,
+            max_batch_size=2,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
+        ),
+        show_progress=False,
+    )
+
+    assert result.kept_indices == [1]
+    assert result.embeddings[:, 0].tolist() == [100.0]
+
+
 def test_embed_image_files_batched__raises_when_all_files_broken(tmp_path: Path) -> None:
     broken_paths = []
     for index in range(3):


### PR DESCRIPTION
## What has changed and why?

Pillow raises `Image.DecompressionBombError` when an image's pixel count exceeds its limit. That exception subclasses `Exception` **directly** (not `OSError`), so the existing `except (OSError, UnidentifiedImageError)` handlers never caught it — a single oversized source image aborted the whole `add_images`/embedding run instead of being skipped, defeating the intended per-file tolerance.

Changes:
- Add a shared `BROKEN_IMAGE_ERRORS = (OSError, UnidentifiedImageError, Image.DecompressionBombError)` tuple in `file_outcome_report.py` (the module that owns broken-file semantics), so every image-open site has one source of truth for "what counts as a broken image."
- Catch `BROKEN_IMAGE_ERRORS` at all three image-open sites — `add_images`, `image_embedding`, `image_crop_embedding` — so oversized images are recorded/skipped as `BROKEN` like any other decode failure.

Out of scope (unchanged): the API thumbnail route and `examples/` operator; the `DecompressionBombWarning` band (1×–2× limit, still decodes).

## How has it been tested?

- Added one per-site test asserting a decompression-bomb image is treated as broken while good files still succeed. Each uses a small image plus a monkeypatched `Image.MAX_IMAGE_PIXELS`, with the limit set between the good (10 000 px) and bomb (90 000 px) images.
- `make static-checks` (ruff, mypy over 746 files, format) — all pass.
- Affected unit modules (`test_image_crop_embedding`, `test_image_embedding`, `test_file_outcome_report`, `test_add_images`) — 58 passed.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved robustness when importing and embedding images by consistently detecting unreadable/corrupt/unsupported files, including Pillow “decompression bomb” cases.
  - Broken images are now reliably marked as broken and skipped without stopping valid images from being processed.
  - Import/embedding summaries now more accurately reflect broken vs. added items.

- **Tests**
  - Added coverage to verify decompression-bomb images are skipped and that only valid images contribute to outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->