### PR TITLE
Update: add link to evaluation tutorial in the model evaluation docs page

### DIFF
--- a/lightly_studio/docs/docs/concepts_and_tools/evaluation.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/evaluation.md
@@ -4,6 +4,9 @@ Model evaluation runs let you compare model predictions against ground truth
 [annotations](annotations.md) and surface per-sample quality metrics in LightlyStudio. Supported
 task types are object detection, classification and semantic segmentation.
 
+For a hands-on, end-to-end walkthrough, follow the
+[Evaluate YOLO26 on Your Dataset](../tutorials/yolo26-model-evaluation.md) tutorial.
+
 ## Model Evaluation in the GUI
 
 <video autoplay loop muted playsinline controls style="width: 100%;">


### PR DESCRIPTION
## What has changed and why?

- adds link to evaluation tutorial in the model evaluation docs page

<img width="1271" height="729" alt="image" src="https://github.com/user-attachments/assets/ae25d5f3-54c0-445b-a478-b114cda41da4" />


## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a hands-on walkthrough reference for evaluating YOLO26 on a custom dataset.
  * Expanded the Model Evaluation guide with an end-to-end tutorial link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->