### PR TITLE
Analytics: track samples_tagged in TagsMenu

### DIFF
--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -81,13 +81,17 @@
         assignBusy = true;
         const snapshotCount = selectedIds.size;
 
-        function trackTagged(is_new_tag: boolean) {
-            trackEvent('samples_tagged', {
-                collection_id,
-                tag_kind: tagKind,
-                sample_count: snapshotCount,
-                is_new_tag
-            });
+        function trackTagged(isNewTag: boolean) {
+            try {
+                trackEvent('samples_tagged', {
+                    collection_id,
+                    tag_kind: tagKind,
+                    sample_count: snapshotCount,
+                    is_new_tag: isNewTag
+                });
+            } catch (e) {
+                console.error('Failed to track samples_tagged event', e);
+            }
         }
 
         try {

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagsMenu.svelte
@@ -17,6 +17,7 @@
     import TagActionMenu from './TagActionMenu.svelte';
     import { toast } from 'svelte-sonner';
     import { get } from 'svelte/store';
+    import { usePostHog } from '$lib/hooks';
 
     let { collection_id, gridType }: Parameters<typeof useTags>[0] & { gridType: GridType } =
         $props();
@@ -45,6 +46,8 @@
             ? ($selectedSampleAnnotationCropIds[collection_id] ?? new Set<string>())
             : $selectedSampleIds
     );
+
+    const { trackEvent } = usePostHog();
 
     let assignBusy = $state(false);
     let deletingTagId = $state<string | null>(null);
@@ -76,6 +79,17 @@
 
     async function handleAssign(name: string) {
         assignBusy = true;
+        const snapshotCount = selectedIds.size;
+
+        function trackTagged(is_new_tag: boolean) {
+            trackEvent('samples_tagged', {
+                collection_id,
+                tag_kind: tagKind,
+                sample_count: snapshotCount,
+                is_new_tag
+            });
+        }
+
         try {
             const existingTag = $tags.find(
                 (t: TagView) => t.name.toLowerCase() === name.toLowerCase()
@@ -86,6 +100,7 @@
                     toast.error('Failed to assign tag. Please try again.');
                     return;
                 }
+                trackTagged(false);
             } else {
                 const createResponse = await createTag({
                     path: { collection_id },
@@ -100,6 +115,7 @@
                     toast.error('Failed to assign tag. Please try again.');
                     return;
                 }
+                trackTagged(true);
             }
             loadTags();
         } catch (error) {


### PR DESCRIPTION
## What has changed and why?

Instrumented the `samples_tagged` PostHog event in `TagsMenu`. Fires when the user saves a selection as a new or existing tag, covering both the create and assign paths.

## How has it been tested?

Manual test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Added PostHog tracking for sample tagging actions, including the tag type, number of samples affected, and whether a new tag was created.
  * Events are recorded only after successful assignment for both existing tags and newly created tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->