### PR TITLE
Analytics: Track Model Evaluation workflow events in PostHog

### DIFF
--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.svelte
@@ -15,9 +15,25 @@
         showLegend?: boolean;
         /** Forwarded to the underlying chart; fires on a real class-by-class cell click. */
         onCellClick?: (cell: ConfusionCellSelection) => void;
+        /** Called when the user clicks the expand button. */
+        onExpand?: (data: { visibleClassCount: number; totalClassCount: number }) => void;
+        /** Called when the user applies new class-filter or color settings. */
+        onConfigApplied?: (data: {
+            mode: 'topN' | 'manual';
+            n: number;
+            sortBy: string;
+            visibleClassCount: number;
+        }) => void;
     }
 
-    const { matrix, topN = 5, showLegend = false, onCellClick }: Props = $props();
+    const {
+        matrix,
+        topN = 5,
+        showLegend = false,
+        onCellClick,
+        onExpand,
+        onConfigApplied
+    }: Props = $props();
 
     let config: ClassSetConfig = $state({
         mode: 'topN',
@@ -36,6 +52,21 @@
     const applyConfig = (nextConfig: ClassSetConfig, nextColor: ColorConfig) => {
         config = nextConfig;
         color = nextColor;
+        const newVisibleClasses = selectVisibleClasses(matrix, nextConfig);
+        onConfigApplied?.({
+            mode: nextConfig.mode,
+            n: nextConfig.n,
+            sortBy: nextConfig.sortBy,
+            visibleClassCount: newVisibleClasses.length
+        });
+    };
+
+    const handleExpand = () => {
+        onExpand?.({
+            visibleClassCount: visibleClasses.length,
+            totalClassCount: realClasses.length
+        });
+        expandOpen = true;
     };
 </script>
 
@@ -45,7 +76,7 @@
     realClassCount={realClasses.length}
     visibleClassCount={visibleClasses.length}
     onConfigure={() => (configDialogOpen = true)}
-    onExpand={() => (expandOpen = true)}
+    onExpand={handleExpand}
 />
 <ConfusionMatrix
     matrix={subMatrix}

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunItem/EvaluationRunConfusionMatrixSection/EvaluationRunConfusionMatrixSection.svelte
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunItem/EvaluationRunConfusionMatrixSection/EvaluationRunConfusionMatrixSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { page } from '$app/state';
+    import type { ComponentProps } from 'svelte';
     import { Spinner, Typography } from '$lib/components';
     import {
         ConfusionMatrixPanel,
@@ -7,7 +8,7 @@
         NO_PREDICTION_COL_LABEL,
         type ConfusionCellSelection
     } from '$lib/components/ConfusionMatrix';
-    import { useEvaluationConfusionMatrix } from '$lib/hooks';
+    import { useEvaluationConfusionMatrix, usePostHog } from '$lib/hooks';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
 
     interface Props {
@@ -17,6 +18,9 @@
     const { evaluationRunId }: Props = $props();
 
     const datasetId = $derived(page.params.dataset_id!);
+    const collectionId = $derived(page.params.collection_id!);
+
+    const { trackEvent } = usePostHog();
 
     const query = useEvaluationConfusionMatrix(() => ({
         datasetId,
@@ -31,10 +35,48 @@
     // resolves the false-positive (no ground truth) and false-negative (no prediction)
     // margin buckets.
     const handleCellClick = (cell: ConfusionCellSelection) => {
+        const matrix = query.data;
+        const rowIdx = matrix?.row_labels.indexOf(cell.gtLabel) ?? -1;
+        const colIdx = matrix?.col_labels.indexOf(cell.predLabel) ?? -1;
+        const sampleCount =
+            rowIdx >= 0 && colIdx >= 0 ? (matrix?.counts[rowIdx]?.[colIdx] ?? 0) : 0;
+
+        trackEvent('confusion_matrix_cell_clicked', {
+            collection_id: collectionId,
+            evaluation_run_id: evaluationRunId,
+            actual_label: cell.gtLabel,
+            predicted_label: cell.predLabel,
+            sample_count: sampleCount
+        });
+
         updateConfusionCell({
             evaluation_run_id: evaluationRunId,
             gt_label: cell.gtLabel === NO_GROUND_TRUTH_ROW_LABEL ? null : cell.gtLabel,
             pred_label: cell.predLabel === NO_PREDICTION_COL_LABEL ? null : cell.predLabel
+        });
+    };
+
+    const handleMatrixExpand = (data: { visibleClassCount: number; totalClassCount: number }) => {
+        trackEvent('confusion_matrix_expanded', {
+            collection_id: collectionId,
+            evaluation_run_id: evaluationRunId,
+            visible_class_count: data.visibleClassCount,
+            total_class_count: data.totalClassCount
+        });
+    };
+
+    type MatrixConfigApplied = Parameters<
+        NonNullable<ComponentProps<typeof ConfusionMatrixPanel>['onConfigApplied']>
+    >[0];
+
+    const handleMatrixConfigApplied = (data: MatrixConfigApplied) => {
+        trackEvent('confusion_matrix_configured', {
+            collection_id: collectionId,
+            evaluation_run_id: evaluationRunId,
+            mode: data.mode,
+            n: data.mode === 'topN' ? data.n : null,
+            sort_by: data.sortBy,
+            visible_class_count: data.visibleClassCount
         });
     };
 </script>
@@ -58,7 +100,13 @@
                 </Typography>
             </div>
         {:else if query.data}
-            <ConfusionMatrixPanel matrix={query.data} showLegend onCellClick={handleCellClick} />
+            <ConfusionMatrixPanel
+                matrix={query.data}
+                showLegend
+                onCellClick={handleCellClick}
+                onExpand={handleMatrixExpand}
+                onConfigApplied={handleMatrixConfigApplied}
+            />
         {/if}
     </section>
 {/if}

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunItem/EvaluationRunConfusionMatrixSection/EvaluationRunConfusionMatrixSection.svelte
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunItem/EvaluationRunConfusionMatrixSection/EvaluationRunConfusionMatrixSection.svelte
@@ -56,7 +56,11 @@
         });
     };
 
-    const handleMatrixExpand = (data: { visibleClassCount: number; totalClassCount: number }) => {
+    type MatrixExpandData = Parameters<
+        NonNullable<ComponentProps<typeof ConfusionMatrixPanel>['onExpand']>
+    >[0];
+
+    const handleMatrixExpand = (data: MatrixExpandData) => {
         trackEvent('confusion_matrix_expanded', {
             collection_id: collectionId,
             evaluation_run_id: evaluationRunId,

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunItem/EvaluationRunConfusionMatrixSection/EvaluationRunConfusionMatrixSection.test.ts
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunItem/EvaluationRunConfusionMatrixSection/EvaluationRunConfusionMatrixSection.test.ts
@@ -35,7 +35,8 @@ vi.mock('$app/state', () => ({
 }));
 
 vi.mock('$lib/hooks', () => ({
-    useEvaluationConfusionMatrix: vi.fn(() => queryState)
+    useEvaluationConfusionMatrix: vi.fn(() => queryState),
+    usePostHog: vi.fn(() => ({ trackEvent: vi.fn(), init: vi.fn() }))
 }));
 
 vi.mock('$lib/hooks/useImageFilters/useImageFilters', () => ({

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunsPanel.svelte
@@ -2,6 +2,7 @@
     import { ArrowLeft, Plus, X } from '@lucide/svelte';
     import Button from '$lib/components/ui/button/button.svelte';
     import { Spinner, Typography } from '$lib/components';
+    import { usePostHog } from '$lib/hooks';
 
     import EvaluationRunItem from './EvaluationRunItem/EvaluationRunItem.svelte';
     import TriggerEvaluationDialog from './TriggerEvaluationDialog/TriggerEvaluationDialog.svelte';
@@ -31,6 +32,8 @@
         collectionId
     }: Props = $props();
 
+    const { trackEvent } = usePostHog();
+
     const canTrigger = $derived(!!datasetId && !!collectionId);
     let dialogOpen = $state(false);
 
@@ -40,6 +43,12 @@
     );
     const visibleRuns = $derived(expandedRun ? [expandedRun] : evaluationRuns);
     const toggleExpand = (runId: string) => {
+        if (expandedRunId !== runId && collectionId) {
+            trackEvent('model_evaluation_opened', {
+                collection_id: collectionId,
+                evaluation_run_id: runId
+            });
+        }
         expandedRunId = expandedRunId === runId ? null : runId;
     };
     const collapseExpanded = () => {

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/useTriggerEvaluation.svelte.ts
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/TriggerEvaluationDialog/useTriggerEvaluation.svelte.ts
@@ -6,6 +6,7 @@ import {
 import type { CreateEvaluationRunData } from '$lib/api/lightly_studio_local/types.gen';
 import { createMutation, useQueryClient } from '@tanstack/svelte-query';
 import { toast } from 'svelte-sonner';
+import { usePostHog } from '$lib/hooks';
 
 type EvaluationRunRequest = CreateEvaluationRunData['body'];
 
@@ -22,9 +23,18 @@ interface UseTriggerEvaluationParams {
 export const useTriggerEvaluation = (getParams: () => UseTriggerEvaluationParams) => {
     const mutation = createMutation(() => createEvaluationRunMutation());
     const client = useQueryClient();
+    const { trackEvent } = usePostHog();
 
-    const trigger = (body: EvaluationRunRequest): Promise<boolean> =>
-        new Promise((resolve) => {
+    const trigger = (body: EvaluationRunRequest): Promise<boolean> => {
+        trackEvent('evaluation_run_started', {
+            collection_id: body.collection_id,
+            evaluation_type: body.task_type,
+            iou_threshold:
+                body.task_type === 'object_detection' ? (body.config?.iou_threshold ?? null) : null,
+            class_wise:
+                body.task_type === 'object_detection' ? (body.config?.classwise ?? null) : null
+        });
+        return new Promise((resolve) => {
             const { datasetId } = getParams();
             mutation.mutate(
                 { path: { dataset_id: datasetId }, body },
@@ -51,6 +61,7 @@ export const useTriggerEvaluation = (getParams: () => UseTriggerEvaluationParams
                 }
             );
         });
+    };
 
     return { mutation, trigger };
 };


### PR DESCRIPTION
## What has changed and why?

Instruments five PostHog events covering the Model Evaluation workflow. 

**`model_evaluation_opened`** - fires when the user expands an evaluation run in the panel; captures `collection_id` and `evaluation_run_id`. Instrumented in `EvaluationRunsPanel` inside `toggleExpand`, guarded so it only fires when transitioning to expanded (not on collapse).

**`evaluation_run_started`** - fires when the user submits a new evaluation run, before the API call; captures `collection_id`, `evaluation_type`, and - for object-detection runs only - `iou_threshold` and `class_wise` (both `null` for other task types). Instrumented at the top of `trigger()` in `useTriggerEvaluation.svelte.ts`.

**`confusion_matrix_cell_clicked`** - fires when the user clicks a cell in the confusion matrix; captures `collection_id`, `evaluation_run_id`, `actual_label`, `predicted_label`, and `sample_count`. `sample_count` is derived by looking up the row/col indices in the full matrix from `query.data`; falls back to `0` for synthetic FP/FN margin cells. Instrumented in `EvaluationRunConfusionMatrixSection` inside `handleCellClick`.

**`confusion_matrix_expanded`** - fires when the user clicks the maximize button to open the full-screen matrix view; captures `collection_id`, `evaluation_run_id`, `visible_class_count` (classes shown before expanding), and `total_class_count`. High rate relative to `model_evaluation_opened` signals the default top-5 view is insufficient for most users.

**`confusion_matrix_configured`** - fires when the user applies new class-filter or color settings via the configuration dialog; captures `collection_id`, `evaluation_run_id`, `mode` (`"topN"` or `"manual"`), `n` (null in manual mode), `sort_by`, and `visible_class_count` after applying.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for evaluation workflows, including starting an evaluation run, opening an evaluation, and interacting with confusion matrices.
  * Confusion-matrix cell clicks now emit events with selected labels and counts, while updates to filters continue to work as before.
  * Confusion-matrix expansion and configuration now report visible vs total class counts and applied settings.
  * Confusion-matrix panel now supports optional callbacks for expansion and config-application events.
* **Tests**
  * Updated evaluation panel tests to mock analytics tracking behavior via the analytics hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->