### PR TITLE
feat: adjust buildchart to be able to render foreground bars

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -101,44 +101,4 @@ describe('buildEchartsOption', () => {
         expect(standard.grid.top).toBe(16);
         expect(compact.grid.top).toBe(4);
     });
-
-    const getFormatter = (option: unknown) =>
-        (
-            option as {
-                tooltip: { formatter: (params: { name: string; value: number }[]) => string };
-            }
-        ).tooltip.formatter;
-
-    it('shows the percentage of the data sum in the tooltip', () => {
-        const formatter = getFormatter(
-            buildEchartsOption([
-                { label: 'car', count: 25 },
-                { label: 'dog', count: 75 }
-            ])
-        );
-
-        expect(formatter([{ name: 'car', value: 25 }])).toBe(
-            '<b>car</b><br/>Count: <b>25</b> (25.0%)'
-        );
-    });
-
-    it('uses the provided totalCount as the percentage denominator', () => {
-        const formatter = getFormatter(
-            buildEchartsOption([{ label: 'car', count: 25 }], { totalCount: 1000 })
-        );
-
-        expect(formatter([{ name: 'car', value: 25 }])).toBe(
-            '<b>car</b><br/>Count: <b>25</b> (2.5%)'
-        );
-    });
-
-    it('renders tiny shares as <0.1% and omits percentages for an empty total', () => {
-        const small = getFormatter(
-            buildEchartsOption([{ label: 'car', count: 1 }], { totalCount: 10000 })
-        );
-        expect(small([{ name: 'car', value: 1 }])).toBe('<b>car</b><br/>Count: <b>1</b> (<0.1%)');
-
-        const empty = getFormatter(buildEchartsOption([]));
-        expect(empty([{ name: 'car', value: 0 }])).toBe('<b>car</b><br/>Count: <b>0</b>');
-    });
 });

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -41,6 +41,67 @@ describe('buildEchartsOption', () => {
         expect(horizontal.xAxis.minInterval).toBe(1);
     });
 
+    it('dims unselected bars green when a selection is active; disabled bars keep reduced opacity', () => {
+        const option = buildEchartsOption([
+            { id: 'sel', label: 'Missing', count: 3, selected: true, selectable: true },
+            { id: 'other', label: 'Other', count: 2, selected: false, selectable: false }
+        ]) as {
+            series: [{ data: { value: number; itemStyle: Record<string, unknown> }[] }];
+        };
+
+        // Selected bar: accent green, full opacity.
+        expect(option.series[0].data[0]).toMatchObject({
+            value: 3,
+            itemStyle: { color: 'rgba(59,217,159,0.85)', opacity: 1 }
+        });
+        // Non-selected + non-selectable: dimmed colour and reduced opacity.
+        expect(option.series[0].data[1]).toMatchObject({
+            value: 2,
+            itemStyle: { color: '#4b5563', opacity: 0.45 }
+        });
+    });
+
+    it('overlays a filtered foreground bar on a grey full-count background when filteredCount differs', () => {
+        const option = buildEchartsOption([
+            { label: 'dog', count: 100, filteredCount: 60 },
+            { label: 'cat', count: 50, filteredCount: 50 }
+        ]) as {
+            series: [
+                { type: string; data: { value: number }[] },
+                { type: string; data: { value: number }[]; barGap: string }
+            ];
+        };
+
+        // Two series rendered when filter is active.
+        expect(option.series).toHaveLength(2);
+        // Background series: always full count.
+        expect(option.series[0].data[0].value).toBe(100);
+        expect(option.series[0].data[1].value).toBe(50);
+        // Foreground series: filtered count; uses barGap '-100%' to overlay.
+        expect(option.series[1].data[0]).toMatchObject({ value: 60 });
+        expect(option.series[1].data[1]).toMatchObject({ value: 50 });
+        expect(option.series[1].barGap).toBe('-100%');
+    });
+
+    it('renders a single series and no background when all filteredCounts match full counts', () => {
+        const option = buildEchartsOption([
+            { label: 'dog', count: 100, filteredCount: 100 },
+            { label: 'cat', count: 50, filteredCount: 50 }
+        ]) as { series: unknown[] };
+
+        expect(option.series).toHaveLength(1);
+    });
+
+    it('accepts compact top padding without changing the default grid', () => {
+        const standard = buildEchartsOption(balanced) as { grid: { top: number } };
+        const compact = buildEchartsOption(balanced, { gridTopPx: 4 }) as {
+            grid: { top: number };
+        };
+
+        expect(standard.grid.top).toBe(16);
+        expect(compact.grid.top).toBe(4);
+    });
+
     const getFormatter = (option: unknown) =>
         (
             option as {

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -41,7 +41,7 @@ describe('buildEchartsOption', () => {
         expect(horizontal.xAxis.minInterval).toBe(1);
     });
 
-    it('dims unselected bars green when a selection is active; disabled bars keep reduced opacity', () => {
+    it('unselected bars are dimmed while the selected bar remains green', () => {
         const option = buildEchartsOption([
             { id: 'sel', label: 'Missing', count: 3, selected: true, selectable: true },
             { id: 'other', label: 'Other', count: 2, selected: false, selectable: false }

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -137,6 +137,7 @@ export function buildEchartsOption(
         tooltip: {
             trigger: 'axis',
             axisPointer: { type: 'shadow' },
+            appendTo: 'body',
             formatter
         },
         grid: { left: 8, right: 8, top: gridTopPx, bottom: 8, containLabel: true },

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -9,9 +9,13 @@ import {
 } from '$lib/utils';
 import type { CategoryCount } from './';
 
-// Single accent color (the Lightly primary green, --color-lightly-primary #3bd99f):
-// per-class colors carry no meaning in a count distribution.
+// Same accent as Histogram (the Lightly primary green, --color-lightly-primary #3bd99f).
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
+// Bars not in the active selection render dimmed, matching the histogram behaviour.
+const BAR_COLOR_DIMMED = '#4b5563';
+// Full-dataset context bars drawn behind the filtered foreground bars.
+// Matches CHART_LINE_COLOR so background bars blend with the chart grid lines.
+const BAR_COLOR_BACKGROUND = '#374151';
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
 export type BarChartOrientation = 'vertical' | 'horizontal';
@@ -25,6 +29,8 @@ interface BuildEchartsOptionOptions {
     totalCount?: number;
     /** Bar orientation (default 'vertical'). */
     orientation?: BarChartOrientation;
+    /** Top chart-grid padding in px (default 16). */
+    gridTopPx?: number;
 }
 
 /** Builds the ECharts option for a category-count bar chart (pass to `setOption`). */
@@ -34,9 +40,19 @@ export function buildEchartsOption(
 ): EChartsCoreOption {
     const totalCount = options.totalCount ?? data.reduce((sum, item) => sum + item.count, 0);
     const orientation = options.orientation ?? 'vertical';
+    const gridTopPx = options.gridTopPx ?? 16;
     const isHorizontal = orientation === 'horizontal';
 
     const labels = data.map((item) => item.label);
+    // When any category is actively selected, dim the rest — mirrors the range
+    // highlighting in the numeric Histogram where out-of-range bins go grey.
+    const hasAnySelected = data.some((item) => item.selected === true);
+    // Render a grey background bar at the full count when sidebar filters reduce
+    // some bars below their unfiltered height. This keeps the original distribution
+    // visible as context while the foreground bar communicates the filtered portion.
+    const hasActiveFilter = data.some(
+        (item) => item.filteredCount !== undefined && item.filteredCount !== item.count
+    );
 
     const categoryAxis = {
         type: 'category' as const,
@@ -68,30 +84,87 @@ export function buildEchartsOption(
         splitLine: { lineStyle: { color: CHART_LINE_COLOR } }
     };
 
+    // Tooltip shows "Total / In filter" when a filter is active and actually
+    // reduces the hovered bar; otherwise shows the single "Count" line.
+    const formatter = (params: { name: string; value: number }[]) => {
+        if (params.length >= 2) {
+            const totalValue = params[0].value; // background series = full count
+            const filteredValue = params[1].value; // foreground series = filtered count
+            if (totalValue !== filteredValue) {
+                const totalPct =
+                    totalCount > 0 ? ` (${formatPercent(totalValue / totalCount)})` : '';
+                const filteredPct =
+                    totalCount > 0 ? ` (${formatPercent(filteredValue / totalCount)})` : '';
+                return `<b>${params[0].name}</b><br/>Total: <b>${totalValue}</b>${totalPct}<br/>In filter: <b>${filteredValue}</b>${filteredPct}`;
+            }
+        }
+        const [{ name, value }] = params;
+        const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
+        return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
+    };
+
+    // Foreground bar: coloured at the filtered count (or full count when no filter).
+    const foregroundData = data.map((item) => {
+        // Simple items with no selection/filter state can be returned as raw numbers,
+        // which ECharts renders without per-item itemStyle overhead.
+        if (item.selected == null && item.selectable == null && item.filteredCount == null) {
+            return item.count;
+        }
+        const foregroundCount =
+            hasActiveFilter && item.filteredCount !== undefined ? item.filteredCount : item.count;
+        const isDimmed = hasAnySelected && !item.selected;
+        return {
+            value: foregroundCount,
+            itemStyle: {
+                color: isDimmed ? BAR_COLOR_DIMMED : BAR_COLOR,
+                opacity: item.selectable === false ? 0.45 : 1
+            }
+        };
+    });
+
+    const foregroundSeries = {
+        type: 'bar',
+        data: foregroundData,
+        itemStyle: { color: BAR_COLOR },
+        barCategoryGap: '25%',
+        // Overlay on top of the background series (barGap: '-100%' makes the bar
+        // occupy the same slot as the preceding series instead of shifting right).
+        ...(hasActiveFilter ? { barGap: '-100%' } : {}),
+        emphasis: CHART_EMPHASIS
+    };
+
+    // Background series: full (unfiltered) count, always grey — only rendered
+    // when the filter is active and at least one bar is visibly reduced.
+    const backgroundSeries = hasActiveFilter
+        ? {
+              type: 'bar',
+              data: data.map((item) => ({
+                  value: item.count,
+                  itemStyle: {
+                      color: BAR_COLOR_BACKGROUND,
+                      opacity: item.selectable === false ? 0.45 : 1
+                  }
+              })),
+              barCategoryGap: '25%',
+              // Suppress hover highlight on the background so emphasis styling
+              // (colour change, scale) only fires on the foreground bars.
+              emphasis: { disabled: true }
+          }
+        : null;
+
+    const series = hasActiveFilter ? [backgroundSeries, foregroundSeries] : [foregroundSeries];
+
     return {
         backgroundColor: 'transparent',
         tooltip: {
             trigger: 'axis',
             axisPointer: { type: 'shadow' },
-            appendTo: 'body',
-            formatter: (params: { name: string; value: number }[]) => {
-                const [{ name, value }] = params;
-                const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
-                return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
-            }
+            formatter
         },
-        grid: { left: 8, right: 8, top: 16, bottom: 8, containLabel: true },
+        grid: { left: 8, right: 8, top: gridTopPx, bottom: 8, containLabel: true },
         // Swap which axis holds the categories so bars grow rightward when horizontal.
         xAxis: isHorizontal ? valueAxis : categoryAxis,
         yAxis: isHorizontal ? categoryAxis : valueAxis,
-        series: [
-            {
-                type: 'bar',
-                data: data.map((item) => item.count),
-                itemStyle: { color: BAR_COLOR },
-                barCategoryGap: '25%',
-                emphasis: CHART_EMPHASIS
-            }
-        ]
+        series
     };
 }

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -1,13 +1,8 @@
 import type { EChartsCoreOption } from 'echarts/core';
 import { truncate } from 'lodash-es';
-import {
-    CHART_AXIS_LABEL,
-    CHART_EMPHASIS,
-    CHART_LINE_COLOR,
-    CHART_TEXT_COLOR,
-    formatPercent
-} from '$lib/utils';
+import { CHART_AXIS_LABEL, CHART_EMPHASIS, CHART_LINE_COLOR, CHART_TEXT_COLOR } from '$lib/utils';
 import type { CategoryCount } from './';
+import { buildTooltipFormatter } from './buildTooltipFormatter';
 
 // Same accent as Histogram (the Lightly primary green, --color-lightly-primary #3bd99f).
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
@@ -84,24 +79,7 @@ export function buildEchartsOption(
         splitLine: { lineStyle: { color: CHART_LINE_COLOR } }
     };
 
-    // Tooltip shows "Total / In filter" when a filter is active and actually
-    // reduces the hovered bar; otherwise shows the single "Count" line.
-    const formatter = (params: { name: string; value: number }[]) => {
-        if (params.length >= 2) {
-            const totalValue = params[0].value; // background series = full count
-            const filteredValue = params[1].value; // foreground series = filtered count
-            if (totalValue !== filteredValue) {
-                const totalPct =
-                    totalCount > 0 ? ` (${formatPercent(totalValue / totalCount)})` : '';
-                const filteredPct =
-                    totalCount > 0 ? ` (${formatPercent(filteredValue / totalCount)})` : '';
-                return `<b>${params[0].name}</b><br/>Total: <b>${totalValue}</b>${totalPct}<br/>In filter: <b>${filteredValue}</b>${filteredPct}`;
-            }
-        }
-        const [{ name, value }] = params;
-        const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
-        return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
-    };
+    const formatter = buildTooltipFormatter(totalCount);
 
     // Foreground bar: coloured at the filtered count (or full count when no filter).
     const foregroundData = data.map((item) => {

--- a/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { buildTooltipFormatter } from './buildTooltipFormatter';
+
+describe('buildTooltipFormatter', () => {
+    it('shows the percentage of the data sum in the tooltip', () => {
+        const formatter = buildTooltipFormatter(100);
+
+        expect(formatter([{ name: 'car', value: 25 }])).toBe(
+            '<b>car</b><br/>Count: <b>25</b> (25.0%)'
+        );
+    });
+
+    it('uses the provided totalCount as the percentage denominator', () => {
+        const formatter = buildTooltipFormatter(1000);
+
+        expect(formatter([{ name: 'car', value: 25 }])).toBe(
+            '<b>car</b><br/>Count: <b>25</b> (2.5%)'
+        );
+    });
+
+    it('renders tiny shares as <0.1% and omits percentages for an empty total', () => {
+        const small = buildTooltipFormatter(10000);
+        expect(small([{ name: 'car', value: 1 }])).toBe('<b>car</b><br/>Count: <b>1</b> (<0.1%)');
+
+        const empty = buildTooltipFormatter(0);
+        expect(empty([{ name: 'car', value: 0 }])).toBe('<b>car</b><br/>Count: <b>0</b>');
+    });
+
+    it('shows Total / In filter when two series are present and counts differ', () => {
+        const formatter = buildTooltipFormatter(200);
+
+        expect(
+            formatter([
+                { name: 'dog', value: 100 },
+                { name: 'dog', value: 60 }
+            ])
+        ).toBe('<b>dog</b><br/>Total: <b>100</b> (50.0%)<br/>In filter: <b>60</b> (30.0%)');
+    });
+
+    it('falls back to single Count line when two series have equal counts', () => {
+        const formatter = buildTooltipFormatter(100);
+
+        expect(
+            formatter([
+                { name: 'cat', value: 50 },
+                { name: 'cat', value: 50 }
+            ])
+        ).toBe('<b>cat</b><br/>Count: <b>50</b> (50.0%)');
+    });
+});

--- a/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.test.ts
@@ -47,4 +47,21 @@ describe('buildTooltipFormatter', () => {
             ])
         ).toBe('<b>cat</b><br/>Count: <b>50</b> (50.0%)');
     });
+
+    it('escapes HTML markup in category labels', () => {
+        const formatter = buildTooltipFormatter(100);
+
+        expect(formatter([{ name: '<script>alert(1)</script>', value: 10 }])).toBe(
+            '<b>&lt;script&gt;alert(1)&lt;/script&gt;</b><br/>Count: <b>10</b> (10.0%)'
+        );
+
+        expect(
+            formatter([
+                { name: '<b>bold</b>', value: 80 },
+                { name: '<b>bold</b>', value: 40 }
+            ])
+        ).toBe(
+            '<b>&lt;b&gt;bold&lt;/b&gt;</b><br/>Total: <b>80</b> (80.0%)<br/>In filter: <b>40</b> (40.0%)'
+        );
+    });
 });

--- a/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.ts
@@ -1,4 +1,4 @@
-import escape from 'lodash-es/escape';
+import { escape } from 'lodash-es/escape';
 import { formatPercent } from '$lib/utils';
 
 type TooltipParams = { name: string; value: number };

--- a/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.ts
@@ -1,3 +1,4 @@
+import escape from 'lodash-es/escape';
 import { formatPercent } from '$lib/utils';
 
 type TooltipParams = { name: string; value: number };
@@ -13,11 +14,11 @@ export function buildTooltipFormatter(totalCount: number): (params: TooltipParam
                     totalCount > 0 ? ` (${formatPercent(totalValue / totalCount)})` : '';
                 const filteredPct =
                     totalCount > 0 ? ` (${formatPercent(filteredValue / totalCount)})` : '';
-                return `<b>${params[0].name}</b><br/>Total: <b>${totalValue}</b>${totalPct}<br/>In filter: <b>${filteredValue}</b>${filteredPct}`;
+                return `<b>${escape(params[0].name)}</b><br/>Total: <b>${totalValue}</b>${totalPct}<br/>In filter: <b>${filteredValue}</b>${filteredPct}`;
             }
         }
         const [{ name, value }] = params;
         const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
-        return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
+        return `<b>${escape(name)}</b><br/>Count: <b>${value}</b>${percent}`;
     };
 }

--- a/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.ts
@@ -1,4 +1,4 @@
-import { escape } from 'lodash-es/escape';
+import escape from 'lodash-es/escape';
 import { formatPercent } from '$lib/utils';
 
 type TooltipParams = { name: string; value: number };

--- a/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.ts
@@ -17,6 +17,7 @@ export function buildTooltipFormatter(totalCount: number): (params: TooltipParam
                 return `<b>${escape(params[0].name)}</b><br/>Total: <b>${totalValue}</b>${totalPct}<br/>In filter: <b>${filteredValue}</b>${filteredPct}`;
             }
         }
+        if (params.length === 0) return '';
         const [{ name, value }] = params;
         const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
         return `<b>${escape(name)}</b><br/>Count: <b>${value}</b>${percent}`;

--- a/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/buildTooltipFormatter.ts
@@ -1,0 +1,23 @@
+import { formatPercent } from '$lib/utils';
+
+type TooltipParams = { name: string; value: number };
+
+/** Builds a tooltip formatter for category-count bar charts. */
+export function buildTooltipFormatter(totalCount: number): (params: TooltipParams[]) => string {
+    return (params) => {
+        if (params.length >= 2) {
+            const totalValue = params[0].value; // background series = full count
+            const filteredValue = params[1].value; // foreground series = filtered count
+            if (totalValue !== filteredValue) {
+                const totalPct =
+                    totalCount > 0 ? ` (${formatPercent(totalValue / totalCount)})` : '';
+                const filteredPct =
+                    totalCount > 0 ? ` (${formatPercent(filteredValue / totalCount)})` : '';
+                return `<b>${params[0].name}</b><br/>Total: <b>${totalValue}</b>${totalPct}<br/>In filter: <b>${filteredValue}</b>${filteredPct}`;
+            }
+        }
+        const [{ name, value }] = params;
+        const percent = totalCount > 0 ? ` (${formatPercent(value / totalCount)})` : '';
+        return `<b>${name}</b><br/>Count: <b>${value}</b>${percent}`;
+    };
+}

--- a/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/index.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildTooltipFormatter/index.ts
@@ -1,0 +1,1 @@
+export { buildTooltipFormatter } from './buildTooltipFormatter';

--- a/lightly_studio_view/src/lib/components/BarChart/types.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/types.ts
@@ -1,5 +1,20 @@
 /** A single category (e.g. a class name) with its count. */
 export interface CategoryCount {
+    /** Stable identity when multiple bars share the same display label. */
+    id?: string;
     label: string;
     count: number;
+    /**
+     * Count after the active sidebar filters are applied. When set, a grey
+     * background bar shows the full `count` while a coloured foreground bar
+     * shows this filtered portion, giving a stable distribution context.
+     * Omit (or set equal to `count`) when no filter is active.
+     */
+    filteredCount?: number;
+    /** Whether the category is active in a controlled selection. */
+    selected?: boolean;
+    /** Whether clicking the bar can change selection. */
+    selectable?: boolean;
+    /** Keeps semantic buckets visible when a top-N view is applied. */
+    pinned?: boolean;
 }


### PR DESCRIPTION
## What has changed and why?

We need to be able to render foreground bar for BuildChart to show entire dataset comparing to current selection defined by filters.
<img width="463" height="437" alt="Screenshot 2026-07-28 at 08 56 19" src="https://github.com/user-attachments/assets/27477db1-0aed-4c30-9ab0-0c60f75d897b" />


## How has it been tested?

Covered by unit tests. No braking changes

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Bar charts now show a grey “full total” background context when a filter is active, alongside the filtered bars.
  * Updated bar highlighting to better reflect selected, non-selected, and non-selectable states.
  * Tooltips now use a shared formatter to present total vs in-filter context with accurate percentage calculations.
  * Chart grid top padding is now configurable via `gridTopPx`.

* **Tests**
  * Expanded test coverage for filtering/selection rendering, tooltip formatting behavior (including HTML escaping and edge cases), and `gridTopPx`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->