### PR TITLE
feat: adjust useCategoricalMetadataDistribution

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.test.ts
@@ -1,61 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import type { MetadataValueCountsView } from '$lib/api/lightly_studio_local';
+import { MISSING_CATEGORICAL_VALUE, OTHER_CATEGORICAL_VALUE } from '$lib/services/types';
 import {
     getCategoricalMetadataDistributionRequestOptions,
     selectCategoricalDistributions
-} from './useCategoricalMetadataDistribution.svelte';
+} from './useCategoricalMetadataDistribution';
 
 describe('selectCategoricalDistributions', () => {
-    it('maps concrete value counts to labelled value buckets', () => {
-        const response: Record<string, MetadataValueCountsView> = {
-            city: {
-                value_counts: [
-                    { value: 'Zurich', count: 10 },
-                    { value: true, count: 2 }
-                ]
-            }
-        };
-
-        expect(selectCategoricalDistributions(response).city).toEqual([
-            {
-                id: '["value","string","Zurich"]',
-                kind: 'value',
-                value: 'Zurich',
-                label: 'Zurich',
-                count: 10
-            },
-            { id: '["value","boolean",true]', kind: 'value', value: true, label: 'true', count: 2 }
-        ]);
-    });
-
-    it('maps __missing__ sentinel to a missing bucket', () => {
-        const response: Record<string, MetadataValueCountsView> = {
-            city: { value_counts: [{ value: '__missing__', count: 3 }] }
-        };
-
-        expect(selectCategoricalDistributions(response).city).toEqual([
-            { id: '["missing"]', kind: 'missing', value: null, label: 'Missing', count: 3 }
-        ]);
-    });
-
-    it('maps __other__ sentinel to an other bucket', () => {
-        const response: Record<string, MetadataValueCountsView> = {
-            city: { value_counts: [{ value: '__other__', count: 5 }] }
-        };
-
-        expect(selectCategoricalDistributions(response).city).toEqual([
-            { id: '["other"]', kind: 'other', label: 'Other', count: 5 }
-        ]);
-    });
-
-    it('disambiguates literal "Missing" and "Other" values when sentinels are also present', () => {
+    it('preserves typed values and keeps semantic buckets distinct from labels', () => {
         const response: Record<string, MetadataValueCountsView> = {
             city: {
                 value_counts: [
                     { value: 'Missing', count: 4 },
-                    { value: 'Other', count: 1 },
-                    { value: '__missing__', count: 3 },
-                    { value: '__other__', count: 7 }
+                    { value: true, count: 2 },
+                    { value: MISSING_CATEGORICAL_VALUE, count: 3 },
+                    { value: OTHER_CATEGORICAL_VALUE, count: 1 }
                 ]
             }
         };
@@ -69,11 +28,11 @@ describe('selectCategoricalDistributions', () => {
                 count: 4
             },
             {
-                id: '["value","string","Other"]',
+                id: '["value","boolean",true]',
                 kind: 'value',
-                value: 'Other',
-                label: 'Other (value)',
-                count: 1
+                value: true,
+                label: 'true',
+                count: 2
             },
             {
                 id: '["missing"]',
@@ -82,11 +41,11 @@ describe('selectCategoricalDistributions', () => {
                 label: 'Missing (no value)',
                 count: 3
             },
-            { id: '["other"]', kind: 'other', label: 'Other (aggregated)', count: 7 }
+            { id: '["other"]', kind: 'other', label: 'Other', count: 1 }
         ]);
     });
 
-    it('maps an empty value_counts to an empty array and an absent response to an empty record', () => {
+    it('omits zero semantic buckets and maps an absent response to an empty record', () => {
         expect(selectCategoricalDistributions({ city: { value_counts: [] } })).toEqual({
             city: []
         });

--- a/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.ts
+++ b/lightly_studio_view/src/lib/hooks/useCategoricalMetadataDistribution/useCategoricalMetadataDistribution.ts
@@ -1,0 +1,105 @@
+import { createQuery } from '@tanstack/svelte-query';
+import type { ImageFilter, MetadataValueCountsView } from '$lib/api/lightly_studio_local';
+import { getMetadataValueCountsOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import { getMetadataValueCounts } from '$lib/api/lightly_studio_local/sdk.gen';
+import { MISSING_CATEGORICAL_VALUE, OTHER_CATEGORICAL_VALUE } from '$lib/services/types';
+
+export type CategoricalMetadataBucket =
+    | {
+          id: string;
+          kind: 'value';
+          value: string | boolean;
+          label: string;
+          count: number;
+      }
+    | { id: string; kind: 'missing'; value: null; label: string; count: number }
+    | { id: string; kind: 'other'; label: string; count: number };
+
+const valueBucketId = (value: string | boolean): string =>
+    JSON.stringify(['value', typeof value, value]);
+
+export const selectCategoricalDistributions = (
+    response: Record<string, MetadataValueCountsView> | undefined
+): Record<string, CategoricalMetadataBucket[]> =>
+    Object.fromEntries(
+        Object.entries(response ?? {}).map(([key, counts]) => {
+            const hasLiteralMissing = counts.value_counts.some(({ value }) => value === 'Missing');
+            const hasLiteralOther = counts.value_counts.some(({ value }) => value === 'Other');
+            const buckets: CategoricalMetadataBucket[] = [];
+            for (const { value, count } of counts.value_counts) {
+                if (value === MISSING_CATEGORICAL_VALUE) {
+                    buckets.push({
+                        id: JSON.stringify(['missing']),
+                        kind: 'missing',
+                        value: null,
+                        label: hasLiteralMissing ? 'Missing (no value)' : 'Missing',
+                        count
+                    });
+                } else if (value === OTHER_CATEGORICAL_VALUE) {
+                    buckets.push({
+                        id: JSON.stringify(['other']),
+                        kind: 'other',
+                        label: hasLiteralOther ? 'Other (aggregated)' : 'Other',
+                        count
+                    });
+                } else {
+                    buckets.push({
+                        id: valueBucketId(value),
+                        kind: 'value',
+                        value,
+                        label:
+                            value === 'Missing' &&
+                            counts.value_counts.some((e) => e.value === MISSING_CATEGORICAL_VALUE)
+                                ? 'Missing (value)'
+                                : value === 'Other' &&
+                                    counts.value_counts.some(
+                                        (e) => e.value === OTHER_CATEGORICAL_VALUE
+                                    )
+                                  ? 'Other (value)'
+                                  : String(value),
+                        count
+                    });
+                }
+            }
+            return [key, buckets];
+        })
+    );
+
+export interface CategoricalMetadataDistributionOptions {
+    collectionId: string;
+    filter?: ImageFilter;
+}
+
+export const getCategoricalMetadataDistributionRequestOptions = ({
+    collectionId,
+    filter
+}: CategoricalMetadataDistributionOptions) => ({
+    path: { collection_id: collectionId },
+    ...(filter ? { body: { filters: filter } } : {})
+});
+
+export const useCategoricalMetadataDistribution = (
+    getOptions: () => CategoricalMetadataDistributionOptions & { enabled?: boolean }
+) =>
+    createQuery(() => {
+        const { collectionId, filter, enabled = true } = getOptions();
+        const requestOptions = getCategoricalMetadataDistributionRequestOptions({
+            collectionId,
+            filter
+        });
+        return {
+            ...getMetadataValueCountsOptions(requestOptions),
+            enabled,
+            select: selectCategoricalDistributions,
+            placeholderData: (previous: Record<string, MetadataValueCountsView> | undefined) =>
+                previous,
+            queryFn: async ({ signal }: { signal: AbortSignal }) => {
+                const { data } = await getMetadataValueCounts({
+                    ...requestOptions,
+                    signal,
+                    throwOnError: true
+                });
+                return data;
+            }
+        };
+    });


### PR DESCRIPTION
## What has changed and why?

Introduce hook to get information about categorical metadata distribution

## How has it been tested?

Accompanied with unit test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Categorical metadata distributions now display only values returned by the data source.
  * Empty categorical responses no longer produce zero-count or placeholder buckets.
  * Removed special handling for missing and “other” placeholder values, improving consistency in displayed distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->