### PR TITLE
adjust ClassSetConfigDialog

### DIFF
--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.stories.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.stories.ts
@@ -41,6 +41,7 @@ export const Classes: Story = {
         allClasses: ['dog', 'cat', 'bird', 'horse', 'fish', 'rabbit'],
         selection: classesSelection,
         description: 'Choose how classes are selected for the chart.',
+        itemNoun: 'class',
         itemNounPlural: 'classes'
     }
 };
@@ -57,6 +58,7 @@ export const MetadataValues: Story = {
         ],
         selection: metadataSelection,
         description: 'Choose how categorical values are selected for the chart.',
+        itemNoun: 'value',
         itemNounPlural: 'values'
     }
 };

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.stories.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.stories.ts
@@ -39,14 +39,6 @@ export const Classes: Story = {
     args: {
         ...baseArgs,
         allClasses: ['dog', 'cat', 'bird', 'horse', 'fish', 'rabbit'],
-        items: [
-            { value: 'dog', label: 'Dog' },
-            { value: 'cat', label: 'Cat' },
-            { value: 'bird', label: 'Bird' },
-            { value: 'horse', label: 'Horse' },
-            { value: 'fish', label: 'Fish' },
-            { value: 'rabbit', label: 'Rabbit' }
-        ],
         selection: classesSelection,
         description: 'Choose how classes are selected for the chart.',
         itemNounPlural: 'classes'
@@ -56,7 +48,6 @@ export const Classes: Story = {
 export const MetadataValues: Story = {
     args: {
         ...baseArgs,
-        allClasses: ['city', 'rural', 'desert', 'mountain', 'coastal'],
         items: [
             { value: 'city', label: 'City' },
             { value: 'rural', label: 'Rural' },

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.stories.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.stories.ts
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import ClassSetConfigDialog from './ClassSetConfigDialog.svelte';
+import type { ClassSetSelection } from './types';
+
+const baseArgs = {
+    open: true,
+    sortItems: [
+        { value: 'score', label: 'Score' },
+        { value: 'name', label: 'Name' }
+    ],
+    showAllButton: true,
+    testIdPrefix: 'class-set-config',
+    onApply: () => undefined
+};
+
+const classesSelection: ClassSetSelection = {
+    mode: 'topN',
+    n: 3,
+    sortBy: 'score',
+    manualClasses: ['dog', 'cat']
+};
+
+const metadataSelection: ClassSetSelection = {
+    mode: 'topN',
+    n: 3,
+    sortBy: 'score',
+    manualClasses: ['city', 'rural']
+};
+
+const meta = {
+    title: 'Components/ClassSetConfig/ClassSetConfigDialog',
+    component: ClassSetConfigDialog
+} satisfies Meta<typeof ClassSetConfigDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Classes: Story = {
+    args: {
+        ...baseArgs,
+        allClasses: ['dog', 'cat', 'bird', 'horse', 'fish', 'rabbit'],
+        items: [
+            { value: 'dog', label: 'Dog' },
+            { value: 'cat', label: 'Cat' },
+            { value: 'bird', label: 'Bird' },
+            { value: 'horse', label: 'Horse' },
+            { value: 'fish', label: 'Fish' },
+            { value: 'rabbit', label: 'Rabbit' }
+        ],
+        selection: classesSelection,
+        description: 'Choose how classes are selected for the chart.',
+        itemNounPlural: 'classes'
+    }
+};
+
+export const MetadataValues: Story = {
+    args: {
+        ...baseArgs,
+        allClasses: ['city', 'rural', 'desert', 'mountain', 'coastal'],
+        items: [
+            { value: 'city', label: 'City' },
+            { value: 'rural', label: 'Rural' },
+            { value: 'desert', label: 'Desert' },
+            { value: 'mountain', label: 'Mountain' },
+            { value: 'coastal', label: 'Coastal' }
+        ],
+        selection: metadataSelection,
+        description: 'Choose how categorical values are selected for the chart.',
+        itemNounPlural: 'values'
+    }
+};

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.svelte
@@ -25,7 +25,9 @@
         testIdPrefix: string;
         /** Shows an "All" quick action next to the number input. */
         showAllButton?: boolean;
-        /** Singular/plural labels for the configured chart items. */
+        /** Singular label for the configured chart items. */
+        itemNoun?: string;
+        /** Plural labels for the configured chart items. */
         itemNounPlural?: string;
         /** Extra controls rendered below the tabs (e.g. coloring options). */
         extraSections?: Snippet;
@@ -42,6 +44,7 @@
         description,
         testIdPrefix,
         showAllButton = false,
+        itemNoun = 'class',
         itemNounPlural = 'classes',
         extraSections,
         onApply
@@ -131,8 +134,8 @@
                     bind:selected={draft.manualClasses}
                     {allClasses}
                     {items}
+                    {itemNoun}
                     {itemNounPlural}
-                    itemNoun={itemNounPlural === 'classes' ? 'class' : 'value'}
                     searchTestId={`${testIdPrefix}-search`}
                 />
             </Tabs.Content>

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.svelte
@@ -12,7 +12,9 @@
         /** Two-way bound flag controlling dialog visibility. */
         open: boolean;
         /** Every class label available; bounds top-N and populates the manual selector. */
-        allClasses: string[];
+        allClasses?: string[];
+        /** Stable values and labels for manual selection. */
+        items?: SelectItem[];
         /** The currently applied selection. Copied into a draft each time the dialog opens. */
         selection: ClassSetSelection;
         /** Sort options for the top-N tab (host-specific ranking criteria). */
@@ -23,6 +25,8 @@
         testIdPrefix: string;
         /** Shows an "All" quick action next to the number input. */
         showAllButton?: boolean;
+        /** Singular/plural labels for the configured chart items. */
+        itemNounPlural?: string;
         /** Extra controls rendered below the tabs (e.g. coloring options). */
         extraSections?: Snippet;
         /** Invoked with the new selection when the user clicks Apply. The dialog then closes itself. */
@@ -32,16 +36,18 @@
     let {
         open = $bindable(),
         allClasses,
+        items,
         selection,
         sortItems,
         description,
         testIdPrefix,
         showAllButton = false,
+        itemNounPlural = 'classes',
         extraSections,
         onApply
     }: Props = $props();
 
-    const maxN = $derived(allClasses.length);
+    const maxN = $derived(items?.length ?? allClasses?.length);
 
     const toDraft = (): ClassSetSelection => ({
         mode: selection.mode,
@@ -58,7 +64,7 @@
 
     // The number input can be cleared into a non-finite value; fall back to 1.
     const normalizedN = $derived(
-        Number.isFinite(draft.n) ? Math.min(Math.max(draft.n, 1), maxN) : 1
+        Number.isFinite(draft.n) ? Math.min(Math.max(draft.n as number, 1), maxN ?? Infinity) : 1
     );
     const canApply = $derived(
         draft.mode === 'topN' ? Number.isFinite(draft.n) : draft.manualClasses.length > 0
@@ -73,7 +79,7 @@
 <Dialog.Root bind:open>
     <Dialog.Content class="max-w-[420px]">
         <Dialog.Header>
-            <Dialog.Title>Configure classes</Dialog.Title>
+            <Dialog.Title>Configure {itemNounPlural}</Dialog.Title>
             <Dialog.Description>{description}</Dialog.Description>
         </Dialog.Header>
         <Tabs.Root bind:value={draft.mode}>
@@ -84,7 +90,7 @@
             <Tabs.Content value="topN">
                 <div class="space-y-3 pt-2">
                     <label class="flex items-center justify-between gap-2 text-sm">
-                        Number of classes
+                        Number of {itemNounPlural}
                         <span class="flex items-center gap-1">
                             <Input
                                 type="number"
@@ -99,7 +105,7 @@
                                     variant="ghost"
                                     size="sm"
                                     class="h-8"
-                                    onclick={() => (draft.n = maxN)}
+                                    onclick={() => (draft.n = maxN!)}
                                     data-testid={`${testIdPrefix}-all`}
                                 >
                                     All
@@ -124,6 +130,9 @@
                 <ManualClassSelector
                     bind:selected={draft.manualClasses}
                     {allClasses}
+                    {items}
+                    {itemNounPlural}
+                    itemNoun={itemNounPlural === 'classes' ? 'class' : 'value'}
                     searchTestId={`${testIdPrefix}-search`}
                 />
             </Tabs.Content>

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ClassSetConfigDialog.test.ts
@@ -54,6 +54,13 @@ describe('ClassSetConfigDialog', () => {
         expect(input).toHaveAttribute('max', '30');
     });
 
+    it('uses custom item nouns', () => {
+        renderDialog({ itemNounPlural: 'values' });
+
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.getByText('Number of values')).toBeInTheDocument();
+    });
+
     it('shows the label of the current sort option on the trigger', () => {
         renderDialog({ selection: { ...baseSelection, sortBy: 'name' } });
 

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.stories.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.stories.ts
@@ -3,7 +3,13 @@ import ManualClassSelector from './ManualClassSelector.svelte';
 
 const meta = {
     title: 'Components/ClassSetConfig/ManualClassSelector',
-    component: ManualClassSelector,
+    component: ManualClassSelector
+} satisfies Meta<typeof ManualClassSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Classes: Story = {
     args: {
         selected: ['dog', 'cat'],
         allClasses: ['dog', 'cat', 'bird', 'horse', 'fish'],
@@ -11,9 +17,21 @@ const meta = {
         itemNounPlural: 'animals',
         searchTestId: 'manual-class-selector-search'
     }
-} satisfies Meta<typeof ManualClassSelector>;
+};
 
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {};
+export const MetadataValuesWithItems: Story = {
+    args: {
+        selected: ['city', 'rural'],
+        allClasses: ['city', 'rural', 'desert', 'mountain', 'coastal'],
+        items: [
+            { value: 'city', label: 'City' },
+            { value: 'rural', label: 'Rural' },
+            { value: 'desert', label: 'Desert' },
+            { value: 'mountain', label: 'Mountain' },
+            { value: 'coastal', label: 'Coastal' }
+        ],
+        itemNoun: 'value',
+        itemNounPlural: 'values',
+        searchTestId: 'manual-metadata-selector-search'
+    }
+};

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.stories.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.stories.ts
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import ManualClassSelector from './ManualClassSelector.svelte';
+
+const meta = {
+    title: 'Components/ClassSetConfig/ManualClassSelector',
+    component: ManualClassSelector,
+    args: {
+        selected: ['dog', 'cat'],
+        allClasses: ['dog', 'cat', 'bird', 'horse', 'fish'],
+        itemNoun: 'animal',
+        itemNounPlural: 'animals',
+        searchTestId: 'manual-class-selector-search'
+    }
+} satisfies Meta<typeof ManualClassSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
@@ -4,35 +4,52 @@
     import * as Command from '$lib/components/ui/command';
     import { cn } from '$lib/utils';
 
+    type ManualSelectionItem = { value: string; label: string };
+
     interface Props {
         /** Currently selected class labels. Bindable — mutated on toggle / Select all / Clear. */
         selected: string[];
         /** Full list of class labels to choose from, in the order they should be displayed. */
         allClasses: string[];
+        /** Optional stable values and display labels; labels need not be unique. */
+        items?: ManualSelectionItem[];
+        itemNoun?: string;
+        itemNounPlural?: string;
         /** test-id for the search input; lets each host keep its own id scheme. */
         searchTestId?: string;
     }
 
-    let { selected = $bindable(), allClasses, searchTestId }: Props = $props();
+    let {
+        selected = $bindable(),
+        allClasses,
+        items,
+        itemNoun = 'class',
+        itemNounPlural = 'classes',
+        searchTestId
+    }: Props = $props();
 
-    const toggle = (className: string) => {
-        selected = selected.includes(className)
-            ? selected.filter((c) => c !== className)
-            : [...selected, className];
+    const resolvedItems = $derived(
+        items ?? allClasses.map((className) => ({ value: className, label: className }))
+    );
+
+    const toggle = (value: string) => {
+        selected = selected.includes(value)
+            ? selected.filter((selectedValue) => selectedValue !== value)
+            : [...selected, value];
     };
 </script>
 
 <div class="pt-2">
     <div class="mb-1 flex items-center justify-between">
         <span class="text-xs text-muted-foreground">
-            {selected.length} of {allClasses.length} selected
+            {selected.length} of {resolvedItems.length} selected
         </span>
         <div class="flex gap-1">
             <Button
                 variant="ghost"
                 size="sm"
                 class="h-6 px-2 text-xs"
-                onclick={() => (selected = [...allClasses])}
+                onclick={() => (selected = resolvedItems.map((item) => item.value))}
             >
                 Select all
             </Button>
@@ -47,13 +64,17 @@
         </div>
     </div>
     <Command.Root class="rounded-md border">
-        <Command.Input placeholder="Search classes..." data-testid={searchTestId} />
+        <Command.Input placeholder="Search {itemNounPlural}..." data-testid={searchTestId} />
         <Command.List class="max-h-[220px] dark:[color-scheme:dark]">
-            <Command.Empty>No class found.</Command.Empty>
-            {#each allClasses as className (className)}
-                <Command.Item value={className} onSelect={() => toggle(className)}>
-                    <CheckIcon class={cn(!selected.includes(className) && 'text-transparent')} />
-                    <span class="min-w-0 flex-1 truncate">{className}</span>
+            <Command.Empty>No {itemNoun} found.</Command.Empty>
+            {#each resolvedItems as item (item.value)}
+                <Command.Item
+                    value={item.value}
+                    keywords={[item.label]}
+                    onSelect={() => toggle(item.value)}
+                >
+                    <CheckIcon class={cn(!selected.includes(item.value) && 'text-transparent')} />
+                    <span class="min-w-0 flex-1 truncate">{item.label}</span>
                 </Command.Item>
             {/each}
         </Command.List>

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
@@ -4,7 +4,10 @@
     import * as Command from '$lib/components/ui/command';
     import { cn } from '$lib/utils';
 
-    type ManualSelectionItem = { value: string; label: string };
+    interface ManualSelectionItem {
+        value: string;
+        label: string;
+    }
 
     interface Props {
         /** Currently selected class labels. Bindable — mutated on toggle / Select all / Clear. */

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
@@ -13,7 +13,7 @@
         /** Currently selected class labels. Bindable — mutated on toggle / Select all / Clear. */
         selected: string[];
         /** Full list of class labels to choose from, in the order they should be displayed. */
-        allClasses: string[];
+        allClasses?: string[];
         /** Optional stable values and display labels; labels need not be unique. */
         items?: ManualSelectionItem[];
         itemNoun?: string;
@@ -32,8 +32,10 @@
     }: Props = $props();
 
     const resolvedItems = $derived(
-        items ?? allClasses.map((className) => ({ value: className, label: className }))
+        items ?? (allClasses ?? []).map((className) => ({ value: className, label: className }))
     );
+
+    const isSelected = (value: string) => selected.includes(value);
 
     const toggle = (value: string) => {
         selected = selected.includes(value)
@@ -76,7 +78,7 @@
                     keywords={[item.label]}
                     onSelect={() => toggle(item.value)}
                 >
-                    <CheckIcon class={cn(!selected.includes(item.value) && 'text-transparent')} />
+                    <CheckIcon class={cn(!isSelected(item.value) && 'text-transparent')} />
                     <span class="min-w-0 flex-1 truncate">{item.label}</span>
                 </Command.Item>
             {/each}

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
@@ -41,23 +41,22 @@ describe('ManualClassSelector', () => {
         expect(screen.getByTestId('my-search')).toBeInTheDocument();
     });
 
-    it('uses stable values for duplicate labels and custom copy', async () => {
+    it('selects the provided item values when items are used for metadata values', async () => {
         render(ManualClassSelector, {
             props: {
-                selected: [],
-                allClasses: ['Missing', 'Missing'],
+                selected: ['city'],
                 items: [
-                    { value: 'literal-missing', label: 'Missing' },
-                    { value: 'semantic-missing', label: 'Missing' }
+                    { value: 'city', label: 'City' },
+                    { value: 'mountain', label: 'Mountain' },
+                    { value: 'village', label: 'Village' }
                 ],
                 itemNoun: 'value',
                 itemNounPlural: 'values'
             }
         });
 
-        expect(screen.getByPlaceholderText('Search values...')).toBeInTheDocument();
-        expect(screen.getAllByText('Missing')).toHaveLength(2);
-        await fireEvent.click(screen.getAllByText('Missing')[0]);
-        await waitFor(() => expect(screen.getByText('1 of 2 selected')).toBeInTheDocument());
+        expect(screen.getByText('1 of 3 selected')).toBeInTheDocument();
+        await fireEvent.click(screen.getByText('Mountain'));
+        await waitFor(() => expect(screen.getByText('2 of 3 selected')).toBeInTheDocument());
     });
 });

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
@@ -40,4 +40,24 @@ describe('ManualClassSelector', () => {
 
         expect(screen.getByTestId('my-search')).toBeInTheDocument();
     });
+
+    it('uses stable values for duplicate labels and custom copy', async () => {
+        render(ManualClassSelector, {
+            props: {
+                selected: [],
+                allClasses: ['Missing', 'Missing'],
+                items: [
+                    { value: 'literal-missing', label: 'Missing' },
+                    { value: 'semantic-missing', label: 'Missing' }
+                ],
+                itemNoun: 'value',
+                itemNounPlural: 'values'
+            }
+        });
+
+        expect(screen.getByPlaceholderText('Search values...')).toBeInTheDocument();
+        expect(screen.getAllByText('Missing')).toHaveLength(2);
+        await fireEvent.click(screen.getAllByText('Missing')[0]);
+        await waitFor(() => expect(screen.getByText('1 of 2 selected')).toBeInTheDocument());
+    });
 });


### PR DESCRIPTION
## What has changed and why?

Adjust ClassSetConfigDialog to configure other than classes items

<img width="699" height="579" alt="Screenshot 2026-07-28 at 17 17 26" src="https://github.com/user-attachments/assets/459993fc-ebc1-4c0c-b71c-b3bc8e1151c1" />
<img width="734" height="808" alt="Screenshot 2026-07-28 at 17 17 23" src="https://github.com/user-attachments/assets/e24ed330-ce06-4c4e-a7c2-404dbe4540e7" />


## How has it been tested?

Accompanies with tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Class set configuration dialogs now accept optional item lists plus a configurable plural noun to control the dialog title and “Top N” labeling/behavior.
  * Manual selection can be driven by stable provided options, with the “Top N” maximum derived from those items.
* **Bug Fixes**
  * Dialog text (title and item count label) now correctly reflects custom plural labels (for example, “values” vs “classes”).
* **Tests**
  * Added coverage to verify the UI updates with a custom plural-label prop.
* **Documentation**
  * Added Storybook stories for the dialog with initial and example selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->