### PR TITLE
adjust ManualClassSelector to show metadata values

### DIFF
--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.stories.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.stories.ts
@@ -3,7 +3,13 @@ import ManualClassSelector from './ManualClassSelector.svelte';
 
 const meta = {
     title: 'Components/ClassSetConfig/ManualClassSelector',
-    component: ManualClassSelector,
+    component: ManualClassSelector
+} satisfies Meta<typeof ManualClassSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Classes: Story = {
     args: {
         selected: ['dog', 'cat'],
         allClasses: ['dog', 'cat', 'bird', 'horse', 'fish'],
@@ -11,9 +17,21 @@ const meta = {
         itemNounPlural: 'animals',
         searchTestId: 'manual-class-selector-search'
     }
-} satisfies Meta<typeof ManualClassSelector>;
+};
 
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {};
+export const MetadataValuesWithItems: Story = {
+    args: {
+        selected: ['city', 'rural'],
+        allClasses: ['city', 'rural', 'desert', 'mountain', 'coastal'],
+        items: [
+            { value: 'city', label: 'City' },
+            { value: 'rural', label: 'Rural' },
+            { value: 'desert', label: 'Desert' },
+            { value: 'mountain', label: 'Mountain' },
+            { value: 'coastal', label: 'Coastal' }
+        ],
+        itemNoun: 'value',
+        itemNounPlural: 'values',
+        searchTestId: 'manual-metadata-selector-search'
+    }
+};

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.stories.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.stories.ts
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import ManualClassSelector from './ManualClassSelector.svelte';
+
+const meta = {
+    title: 'Components/ClassSetConfig/ManualClassSelector',
+    component: ManualClassSelector,
+    args: {
+        selected: ['dog', 'cat'],
+        allClasses: ['dog', 'cat', 'bird', 'horse', 'fish'],
+        itemNoun: 'animal',
+        itemNounPlural: 'animals',
+        searchTestId: 'manual-class-selector-search'
+    }
+} satisfies Meta<typeof ManualClassSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
@@ -4,35 +4,52 @@
     import * as Command from '$lib/components/ui/command';
     import { cn } from '$lib/utils';
 
+    type ManualSelectionItem = { value: string; label: string };
+
     interface Props {
         /** Currently selected class labels. Bindable — mutated on toggle / Select all / Clear. */
         selected: string[];
         /** Full list of class labels to choose from, in the order they should be displayed. */
         allClasses: string[];
+        /** Optional stable values and display labels; labels need not be unique. */
+        items?: ManualSelectionItem[];
+        itemNoun?: string;
+        itemNounPlural?: string;
         /** test-id for the search input; lets each host keep its own id scheme. */
         searchTestId?: string;
     }
 
-    let { selected = $bindable(), allClasses, searchTestId }: Props = $props();
+    let {
+        selected = $bindable(),
+        allClasses,
+        items,
+        itemNoun = 'class',
+        itemNounPlural = 'classes',
+        searchTestId
+    }: Props = $props();
 
-    const toggle = (className: string) => {
-        selected = selected.includes(className)
-            ? selected.filter((c) => c !== className)
-            : [...selected, className];
+    const resolvedItems = $derived(
+        items ?? allClasses.map((className) => ({ value: className, label: className }))
+    );
+
+    const toggle = (value: string) => {
+        selected = selected.includes(value)
+            ? selected.filter((selectedValue) => selectedValue !== value)
+            : [...selected, value];
     };
 </script>
 
 <div class="pt-2">
     <div class="mb-1 flex items-center justify-between">
         <span class="text-xs text-muted-foreground">
-            {selected.length} of {allClasses.length} selected
+            {selected.length} of {resolvedItems.length} selected
         </span>
         <div class="flex gap-1">
             <Button
                 variant="ghost"
                 size="sm"
                 class="h-6 px-2 text-xs"
-                onclick={() => (selected = [...allClasses])}
+                onclick={() => (selected = resolvedItems.map((item) => item.value))}
             >
                 Select all
             </Button>
@@ -47,13 +64,17 @@
         </div>
     </div>
     <Command.Root class="rounded-md border">
-        <Command.Input placeholder="Search classes..." data-testid={searchTestId} />
+        <Command.Input placeholder="Search {itemNounPlural}..." data-testid={searchTestId} />
         <Command.List class="max-h-[220px] dark:[color-scheme:dark]">
-            <Command.Empty>No class found.</Command.Empty>
-            {#each allClasses as className (className)}
-                <Command.Item value={className} onSelect={() => toggle(className)}>
-                    <CheckIcon class={cn(!selected.includes(className) && 'text-transparent')} />
-                    <span class="min-w-0 flex-1 truncate">{className}</span>
+            <Command.Empty>No {itemNoun} found.</Command.Empty>
+            {#each resolvedItems as item (item.value)}
+                <Command.Item
+                    value={item.value}
+                    keywords={[item.label]}
+                    onSelect={() => toggle(item.value)}
+                >
+                    <CheckIcon class={cn(!selected.includes(item.value) && 'text-transparent')} />
+                    <span class="min-w-0 flex-1 truncate">{item.label}</span>
                 </Command.Item>
             {/each}
         </Command.List>

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
@@ -4,7 +4,10 @@
     import * as Command from '$lib/components/ui/command';
     import { cn } from '$lib/utils';
 
-    type ManualSelectionItem = { value: string; label: string };
+    interface ManualSelectionItem {
+        value: string;
+        label: string;
+    }
 
     interface Props {
         /** Currently selected class labels. Bindable — mutated on toggle / Select all / Clear. */

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
@@ -13,7 +13,7 @@
         /** Currently selected class labels. Bindable — mutated on toggle / Select all / Clear. */
         selected: string[];
         /** Full list of class labels to choose from, in the order they should be displayed. */
-        allClasses: string[];
+        allClasses?: string[];
         /** Optional stable values and display labels; labels need not be unique. */
         items?: ManualSelectionItem[];
         itemNoun?: string;
@@ -32,8 +32,10 @@
     }: Props = $props();
 
     const resolvedItems = $derived(
-        items ?? allClasses.map((className) => ({ value: className, label: className }))
+        items ?? (allClasses ?? []).map((className) => ({ value: className, label: className }))
     );
+
+    const isSelected = (value: string) => selected.includes(value);
 
     const toggle = (value: string) => {
         selected = selected.includes(value)
@@ -76,7 +78,7 @@
                     keywords={[item.label]}
                     onSelect={() => toggle(item.value)}
                 >
-                    <CheckIcon class={cn(!selected.includes(item.value) && 'text-transparent')} />
+                    <CheckIcon class={cn(!isSelected(item.value) && 'text-transparent')} />
                     <span class="min-w-0 flex-1 truncate">{item.label}</span>
                 </Command.Item>
             {/each}

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
@@ -41,23 +41,22 @@ describe('ManualClassSelector', () => {
         expect(screen.getByTestId('my-search')).toBeInTheDocument();
     });
 
-    it('uses stable values for duplicate labels and custom copy', async () => {
+    it('selects the provided item values when items are used for metadata values', async () => {
         render(ManualClassSelector, {
             props: {
-                selected: [],
-                allClasses: ['Missing', 'Missing'],
+                selected: ['city'],
                 items: [
-                    { value: 'literal-missing', label: 'Missing' },
-                    { value: 'semantic-missing', label: 'Missing' }
+                    { value: 'city', label: 'City' },
+                    { value: 'mountain', label: 'Mountain' },
+                    { value: 'village', label: 'Village' }
                 ],
                 itemNoun: 'value',
                 itemNounPlural: 'values'
             }
         });
 
-        expect(screen.getByPlaceholderText('Search values...')).toBeInTheDocument();
-        expect(screen.getAllByText('Missing')).toHaveLength(2);
-        await fireEvent.click(screen.getAllByText('Missing')[0]);
-        await waitFor(() => expect(screen.getByText('1 of 2 selected')).toBeInTheDocument());
+        expect(screen.getByText('1 of 3 selected')).toBeInTheDocument();
+        await fireEvent.click(screen.getByText('Mountain'));
+        await waitFor(() => expect(screen.getByText('2 of 3 selected')).toBeInTheDocument());
     });
 });

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.test.ts
@@ -40,4 +40,24 @@ describe('ManualClassSelector', () => {
 
         expect(screen.getByTestId('my-search')).toBeInTheDocument();
     });
+
+    it('uses stable values for duplicate labels and custom copy', async () => {
+        render(ManualClassSelector, {
+            props: {
+                selected: [],
+                allClasses: ['Missing', 'Missing'],
+                items: [
+                    { value: 'literal-missing', label: 'Missing' },
+                    { value: 'semantic-missing', label: 'Missing' }
+                ],
+                itemNoun: 'value',
+                itemNounPlural: 'values'
+            }
+        });
+
+        expect(screen.getByPlaceholderText('Search values...')).toBeInTheDocument();
+        expect(screen.getAllByText('Missing')).toHaveLength(2);
+        await fireEvent.click(screen.getAllByText('Missing')[0]);
+        await waitFor(() => expect(screen.getByText('1 of 2 selected')).toBeInTheDocument());
+    });
 });


### PR DESCRIPTION
## What has changed and why?

This PR introduces changes to configure plot for metadata values. It is part of ClassSetConfig component

## How has it been tested?

Accompanied by unit tests and storybook stires
<img width="1792" height="584" alt="Screenshot 2026-07-28 at 12 20 08" src="https://github.com/user-attachments/assets/82544e36-f990-43a7-b9c8-35b900a5bcfa" />
<img width="1800" height="652" alt="Screenshot 2026-07-28 at 12 20 01" src="https://github.com/user-attachments/assets/efa565b6-b171-476a-8d98-a2061b2cd1a3" />



## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced manual class selection to support separate display labels and underlying values.
  - Added configurable singular and plural item wording for search prompts and empty states.
  - Added “select all” support for richer item lists while preserving stable selections.

- **Bug Fixes**
  - Improved handling of duplicate labels so each selectable item remains distinct.

- **Tests**
  - Added coverage for duplicate labels, configurable search text, and selection count updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->