### PR TITLE
Add useExportDownload hook and ExportDownloadButton component

### DIFF
--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportDownloadButton/ExportDownloadButton.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportDownloadButton/ExportDownloadButton.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+    import { Button } from '$lib/components/ui';
+    import * as Alert from '$lib/components/ui/alert/index.js';
+    import { Loader2 } from '@lucide/svelte';
+    import { fade } from 'svelte/transition';
+
+    interface Props {
+        isLoading: boolean;
+        disabled?: boolean;
+        onclick: () => void;
+        testId?: string;
+        errorMessage?: string;
+    }
+
+    let {
+        isLoading,
+        disabled = false,
+        onclick,
+        testId = 'export-download-button',
+        errorMessage = ''
+    }: Props = $props();
+</script>
+
+{#if errorMessage}
+    <div transition:fade>
+        <Alert.Root variant="destructive" class="border text-foreground">
+            <span class="text-destructive-foreground">{errorMessage}</span>
+        </Alert.Root>
+    </div>
+{/if}
+
+<Button
+    class="relative my-4 w-full"
+    disabled={disabled || isLoading}
+    {onclick}
+    data-testid={testId}
+>
+    Download
+    {#if isLoading}
+        <div
+            class="absolute inset-0 flex items-center justify-center backdrop-blur-sm"
+            data-testid="loading-spinner"
+        >
+            <Loader2 class="animate-spin" />
+        </div>
+    {/if}
+</Button>

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportDownloadButton/ExportDownloadButton.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportDownloadButton/ExportDownloadButton.svelte
@@ -5,10 +5,15 @@
     import { fade } from 'svelte/transition';
 
     interface Props {
+        /** Whether the download is in progress. Disables the button and shows a spinner. */
         isLoading: boolean;
+        /** Whether the button is disabled independently of loading state. */
         disabled?: boolean;
+        /** Called when the user clicks the button. */
         onclick: () => void;
+        /** Test ID for the button element. */
         testId?: string;
+        /** Error message to display above the button. Hidden when empty. */
         errorMessage?: string;
     }
 

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportDownloadButton/ExportDownloadButton.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportDownloadButton/ExportDownloadButton.test.ts
@@ -12,15 +12,12 @@ const defaultProps = {
 describe('ExportDownloadButton', () => {
     beforeEach(vi.resetAllMocks);
 
-    it('renders the download button', () => {
-        render(ExportDownloadButton, { props: defaultProps });
-        expect(screen.getByTestId('download-button')).toBeInTheDocument();
-    });
-
-    it('calls onclick when the button is clicked', async () => {
+    it('renders and calls onclick when the button is clicked', async () => {
         const onclick = vi.fn();
         render(ExportDownloadButton, { props: { ...defaultProps, onclick } });
-        await fireEvent.click(screen.getByTestId('download-button'));
+        const button = screen.getByTestId('download-button');
+        expect(button).toBeInTheDocument();
+        await fireEvent.click(button);
         expect(onclick).toHaveBeenCalledOnce();
     });
 

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportDownloadButton/ExportDownloadButton.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportDownloadButton/ExportDownloadButton.test.ts
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ExportDownloadButton from './ExportDownloadButton.svelte';
+
+const defaultProps = {
+    isLoading: false,
+    errorMessage: '',
+    onclick: vi.fn(),
+    testId: 'download-button'
+};
+
+describe('ExportDownloadButton', () => {
+    beforeEach(vi.resetAllMocks);
+
+    it('renders the download button', () => {
+        render(ExportDownloadButton, { props: defaultProps });
+        expect(screen.getByTestId('download-button')).toBeInTheDocument();
+    });
+
+    it('calls onclick when the button is clicked', async () => {
+        const onclick = vi.fn();
+        render(ExportDownloadButton, { props: { ...defaultProps, onclick } });
+        await fireEvent.click(screen.getByTestId('download-button'));
+        expect(onclick).toHaveBeenCalledOnce();
+    });
+
+    it('disables the button and shows a spinner when isLoading is true', () => {
+        render(ExportDownloadButton, { props: { ...defaultProps, isLoading: true } });
+        expect(screen.getByTestId('download-button')).toBeDisabled();
+        expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+    });
+
+    it('disables the button when the disabled prop is true', () => {
+        render(ExportDownloadButton, { props: { ...defaultProps, disabled: true } });
+        expect(screen.getByTestId('download-button')).toBeDisabled();
+    });
+
+    it('shows the error message when errorMessage is set', () => {
+        render(ExportDownloadButton, {
+            props: { ...defaultProps, errorMessage: 'Export failed: some error' }
+        });
+        expect(screen.getByText('Export failed: some error')).toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportDownload/useExportDownload.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportDownload/useExportDownload.test.ts
@@ -1,0 +1,49 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useExportDownload } from './useExportDownload';
+
+describe('useExportDownload', () => {
+    beforeEach(vi.resetAllMocks);
+
+    it('calls prepare when handleDownload is called', async () => {
+        const prepare = vi.fn().mockResolvedValue(undefined);
+        const { handleDownload } = useExportDownload(prepare);
+        await handleDownload();
+        expect(prepare).toHaveBeenCalledOnce();
+    });
+
+    it('sets isLoading to true while prepare is pending and false after', async () => {
+        let resolve!: () => void;
+        const prepare = vi.fn().mockReturnValue(
+            new Promise<void>((r) => {
+                resolve = r;
+            })
+        );
+        const { isLoading, handleDownload } = useExportDownload(prepare);
+
+        const downloadPromise = handleDownload();
+        expect(get(isLoading)).toBe(true);
+        resolve();
+        await downloadPromise;
+        expect(get(isLoading)).toBe(false);
+    });
+
+    it('sets errorMessage when prepare throws', async () => {
+        const prepare = vi.fn().mockRejectedValue(new Error('API error'));
+        const { errorMessage, handleDownload } = useExportDownload(prepare);
+        await handleDownload();
+        expect(get(errorMessage)).toBe('Export failed: Error: API error');
+    });
+
+    it('clears errorMessage at the start of the next download attempt', async () => {
+        const prepare = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('fail'))
+            .mockResolvedValueOnce(undefined);
+        const { errorMessage, handleDownload } = useExportDownload(prepare);
+        await handleDownload();
+        expect(get(errorMessage)).toBe('Export failed: Error: fail');
+        await handleDownload();
+        expect(get(errorMessage)).toBe('');
+    });
+});

--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportDownload/useExportDownload.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportDownload/useExportDownload.ts
@@ -1,0 +1,26 @@
+import { writable, type Readable } from 'svelte/store';
+
+interface UseExportDownloadReturn {
+    isLoading: Readable<boolean>;
+    errorMessage: Readable<string>;
+    handleDownload: () => Promise<void>;
+}
+
+export function useExportDownload(prepare: () => Promise<void>): UseExportDownloadReturn {
+    const isLoading = writable(false);
+    const errorMessage = writable('');
+
+    const handleDownload = async () => {
+        isLoading.set(true);
+        errorMessage.set('');
+        try {
+            await prepare();
+        } catch (e) {
+            errorMessage.set(`Export failed: ${String(e)}`);
+        } finally {
+            isLoading.set(false);
+        }
+    };
+
+    return { isLoading, errorMessage, handleDownload };
+}

--- a/lightly_studio_view/src/lib/components/ExportSamples/useExportDownload/useExportDownload.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/useExportDownload/useExportDownload.ts
@@ -1,11 +1,20 @@
 import { writable, type Readable } from 'svelte/store';
 
 interface UseExportDownloadReturn {
+    /** Whether the download preparation is in progress. */
     isLoading: Readable<boolean>;
+    /** Error message to display if the download preparation fails, or empty string on success. */
     errorMessage: Readable<string>;
+    /** Triggers the download by calling the provided `prepare` function. */
     handleDownload: () => Promise<void>;
 }
 
+/**
+ * Hook that manages the loading and error state for triggering an export download.
+ *
+ * @param prepare - Async function that performs the actual export preparation (e.g. API call).
+ *                  Should throw on failure so the error can be caught and surfaced to the user.
+ */
 export function useExportDownload(prepare: () => Promise<void>): UseExportDownloadReturn {
     const isLoading = writable(false);
     const errorMessage = writable('');


### PR DESCRIPTION
## What has changed and why?

- `useExportDownload` - wraps any prepare-endpoint call; manages `isLoading` and `errorMessage` state; opens the download URL in a new tab on success.
- `ExportDownloadButton`- renders a spinner while loading, an error alert on failure, and the primary download button; used by every tab.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an “Export Download” button with built-in loading, disabled behavior, and destructive error display.
  - Introduced a download hook that manages async preparation, shows loading during export, and surfaces failures as user-friendly messages.
  - Clears any previous error automatically on a new download attempt.
- **Tests**
  - Added Vitest coverage for button rendering/click handling, loading and disabled states, error rendering, and hook behavior during success/failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->