### PR TITLE
Add tests for the collection workspace layout

### DIFF
--- a/lightly_studio_view/src/lib/routes.test.ts
+++ b/lightly_studio_view/src/lib/routes.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { routes, routeHelpers } from './routes';
+import {
+    routes,
+    routeHelpers,
+    APP_ROUTES,
+    isImagesRoute,
+    isAnnotationsRoute,
+    isVideosRoute,
+    isVideoFramesRoute,
+    isGroupsRoute,
+    isSampleDetailsRoute,
+    isAnnotationDetailsRoute,
+    isVideoDetailsRoute,
+    isFrameDetailsRoute
+} from './routes';
 
 describe('routes', () => {
     describe('route definitions', () => {
@@ -13,6 +26,52 @@ describe('routes', () => {
             expect(
                 routes.collection.annotations(testDatasetId, testCollectionType, testCollectionId)
             ).toBe('/datasets/root-123/image/123/annotations');
+        });
+    });
+
+    describe('route classification', () => {
+        describe('collection-grid routes', () => {
+            it('images route is classified as a grid route', () => {
+                expect(isImagesRoute(APP_ROUTES.images)).toBe(true);
+            });
+
+            it('annotations route is classified as a grid route', () => {
+                expect(isAnnotationsRoute(APP_ROUTES.annotations)).toBe(true);
+            });
+
+            it('videos route is classified as a grid route', () => {
+                expect(isVideosRoute(APP_ROUTES.videos)).toBe(true);
+            });
+
+            it('frames route is classified as a grid route', () => {
+                expect(isVideoFramesRoute(APP_ROUTES.frames)).toBe(true);
+            });
+
+            it('groups route is classified as a grid route', () => {
+                expect(isGroupsRoute(APP_ROUTES.groups)).toBe(true);
+            });
+        });
+
+        describe('details routes', () => {
+            it('image details route is classified as a sample-details route', () => {
+                expect(isSampleDetailsRoute(APP_ROUTES.imageDetails)).toBe(true);
+            });
+
+            it('image details route is not classified as a grid route', () => {
+                expect(isImagesRoute(APP_ROUTES.imageDetails)).toBe(false);
+            });
+
+            it('annotation details route is classified as an annotation-details route', () => {
+                expect(isAnnotationDetailsRoute(APP_ROUTES.annotationDetails)).toBe(true);
+            });
+
+            it('video details route is classified as a video-details route', () => {
+                expect(isVideoDetailsRoute(APP_ROUTES.videoDetails)).toBe(true);
+            });
+
+            it('frame details route is classified as a frame-details route', () => {
+                expect(isFrameDetailsRoute(APP_ROUTES.framesDetails)).toBe(true);
+            });
         });
     });
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -33,6 +33,7 @@
         isAnnotationDetailsRoute,
         isAnnotationsRoute,
         isCaptionsRoute,
+        isFrameDetailsRoute,
         isSampleDetailsRoute,
         isImagesRoute,
         isVideoFramesRoute,
@@ -134,6 +135,7 @@
     const isAnnotations = $derived(isAnnotationsRoute(page.route.id));
     const isSampleDetails = $derived(isSampleDetailsRoute(page.route.id));
     const isAnnotationDetails = $derived(isAnnotationDetailsRoute(page.route.id));
+    const isFrameDetails = $derived(isFrameDetailsRoute(page.route.id));
     const isCaptions = $derived(isCaptionsRoute(page.route.id));
     const isVideos = $derived(isVideosRoute(page.route.id));
     const isVideoFrames = $derived(isVideoFramesRoute(page.route.id));
@@ -647,10 +649,10 @@
 </div>
 
 <div class="relative flex min-h-0 flex-1 flex-col">
-    {#if isSampleDetails || isAnnotationDetails || isGroupDetails || isVideoDetails}
+    {#if isSampleDetails || isAnnotationDetails || isGroupDetails || isVideoDetails || isFrameDetails}
         {@render children()}
     {:else}
-        <div class="flex min-h-0 flex-1 gap-4 px-4">
+        <div class="flex min-h-0 flex-1 gap-4 px-4" data-testid="workspace-body">
             {#if isCollectionGrid}
                 <!--
                     Keep the panel mounted while collapsed (only visually hidden). Children such as

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -85,6 +85,7 @@
     import { useEvaluationRuns } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
     import { clearAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
     import { usePostHog } from '$lib/hooks';
+    import { isPanelVisible } from './panelVisibility';
     const { data, children } = $props();
     const {
         collection,
@@ -441,12 +442,7 @@
         isImages || isAnnotations || isVideos || isVideoFrames || isGroups
     );
 
-    const panelIsVisible = $derived(
-        ($activePanel === 'evaluationRuns' && supportsEvaluation) ||
-            ($activePanel === 'embeddingPlot' && hasMediaWithEmbeddings) ||
-            ($activePanel === 'queryEditor' && isImages) ||
-            ($activePanel === 'distribution' && isImages)
-    );
+    const panelIsVisible = $derived(isPanelVisible($activePanel, isImages, hasMediaWithEmbeddings));
 
     // Class counts for the distribution panel. The "All types" source reuses the
     // shared annotation-count query that feeds the labels filter; the per-type
@@ -664,6 +660,7 @@
                 <div
                     class="h-full min-h-0 w-80 flex-col {$filterPanelCollapsed ? 'hidden' : 'flex'}"
                     data-testid="filter-panel-body"
+                    aria-hidden={$filterPanelCollapsed}
                 >
                     <div class="flex min-h-0 flex-1 flex-col rounded-[1vw] bg-card py-4">
                         <div

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -845,12 +845,14 @@
                 </div>
             {/if}
             {#if isCollectionGrid && (isImages || hasMediaWithEmbeddings)}
-                <SidePanelTabs
-                    {collectionId}
-                    {isImages}
-                    {hasMediaWithEmbeddings}
-                    {supportsEvaluation}
-                />
+                <div data-testid="side-panel-tabs" class="contents">
+                    <SidePanelTabs
+                        {collectionId}
+                        {isImages}
+                        {hasMediaWithEmbeddings}
+                        {supportsEvaluation}
+                    />
+                </div>
             {/if}
             {#if hasEmbeddings}
                 {#await import('$lib/components/FewShotClassifier/CreateClassifierDialog.svelte') then { default: CreateClassifierDialog }}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -783,57 +783,59 @@
             {/snippet}
 
             {#if panelIsVisible}
-                <PaneGroup direction="horizontal" class="min-w-0 flex-1">
-                    <Pane defaultSize={65} minSize={35} class="flex">
-                        <div
-                            class="relative flex min-w-0 flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
-                        >
-                            {@render mainContent()}
-                        </div>
-                    </Pane>
+                <div data-testid="pane-group-layout" class="contents">
+                    <PaneGroup direction="horizontal" class="min-w-0 flex-1">
+                        <Pane defaultSize={65} minSize={35} class="flex">
+                            <div
+                                class="relative flex min-w-0 flex-1 flex-col space-y-4 rounded-[1vw] bg-card p-4 pb-2"
+                            >
+                                {@render mainContent()}
+                            </div>
+                        </Pane>
 
-                    {@render paneResizer()}
+                        {@render paneResizer()}
 
-                    <Pane defaultSize={35} minSize={25} class="flex min-h-0 flex-col">
-                        {#if $activePanel === 'evaluationRuns' && supportsEvaluation}
-                            {#await import('$lib/components/EvaluationRunsPanel/EvaluationRunsPanel.svelte') then { default: EvaluationRunsPanel }}
-                                <EvaluationRunsPanel
-                                    onClose={() => setActivePanel('none')}
-                                    {evaluationRuns}
-                                    isLoading={evaluationRunsQuery.isLoading}
-                                    error={evaluationRunsQuery.error?.message}
-                                    datasetId={collection.dataset_id}
-                                    {collectionId}
-                                />
-                            {/await}
-                        {:else if $activePanel === 'embeddingPlot' && hasMediaWithEmbeddings}
-                            {#await import('$lib/components/PlotPanel/PlotPanel.svelte') then { default: PlotPanel }}
-                                <!-- PlotPanel captures collectionId at mount; remount it when
+                        <Pane defaultSize={35} minSize={25} class="flex min-h-0 flex-col">
+                            {#if $activePanel === 'evaluationRuns' && supportsEvaluation}
+                                {#await import('$lib/components/EvaluationRunsPanel/EvaluationRunsPanel.svelte') then { default: EvaluationRunsPanel }}
+                                    <EvaluationRunsPanel
+                                        onClose={() => setActivePanel('none')}
+                                        {evaluationRuns}
+                                        isLoading={evaluationRunsQuery.isLoading}
+                                        error={evaluationRunsQuery.error?.message}
+                                        datasetId={collection.dataset_id}
+                                        {collectionId}
+                                    />
+                                {/await}
+                            {:else if $activePanel === 'embeddingPlot' && hasMediaWithEmbeddings}
+                                {#await import('$lib/components/PlotPanel/PlotPanel.svelte') then { default: PlotPanel }}
+                                    <!-- PlotPanel captures collectionId at mount; remount it when
                                      switching collections (e.g. images <-> annotations tab). -->
-                                {#key collectionId}
-                                    <PlotPanel {collectionId} />
-                                {/key}
-                            {/await}
-                        {:else if $activePanel === 'queryEditor' && isImages}
-                            <QueryEditorPanel onClose={() => setActivePanel('none')} />
-                        {:else if distributionPanelVisible}
-                            {#await import('$lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte') then { default: DatasetDistributionPanel }}
-                                <DatasetDistributionPanel
-                                    sources={distributionSources}
-                                    initialCountMode={distributionCountMode}
-                                    onClose={() => setActivePanel('none')}
-                                    onCountModeChange={(mode) => {
-                                        distributionCountMode = mode;
-                                    }}
-                                    onHistogramRangeSelect={handleDistributionHistogramRangeSelect}
-                                    {histogramBinCount}
-                                    onHistogramBinCountChange={(binCount) =>
-                                        (histogramBinCount = binCount)}
-                                />
-                            {/await}
-                        {/if}
-                    </Pane>
-                </PaneGroup>
+                                    {#key collectionId}
+                                        <PlotPanel {collectionId} />
+                                    {/key}
+                                {/await}
+                            {:else if $activePanel === 'queryEditor' && isImages}
+                                <QueryEditorPanel onClose={() => setActivePanel('none')} />
+                            {:else if distributionPanelVisible}
+                                {#await import('$lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte') then { default: DatasetDistributionPanel }}
+                                    <DatasetDistributionPanel
+                                        sources={distributionSources}
+                                        initialCountMode={distributionCountMode}
+                                        onClose={() => setActivePanel('none')}
+                                        onCountModeChange={(mode) => {
+                                            distributionCountMode = mode;
+                                        }}
+                                        onHistogramRangeSelect={handleDistributionHistogramRangeSelect}
+                                        {histogramBinCount}
+                                        onHistogramBinCountChange={(binCount) =>
+                                            (histogramBinCount = binCount)}
+                                    />
+                                {/await}
+                            {/if}
+                        </Pane>
+                    </PaneGroup>
+                </div>
             {:else}
                 <!-- Normal layout (no side panel) -->
                 <div

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/LayoutStub.test.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/LayoutStub.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte';
+    // Generic stub for heavy child components: renders children transparently
+    // and accepts (but ignores) all other props.
+    // svelte-ignore custom_element_props_identifier
+    let { children, ...rest }: { children?: Snippet; [key: string]: unknown } = $props();
+
+    void rest; // Suppress unused-variable warning in tests
+</script>
+
+{@render children?.()}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/LayoutWorkspaceTestWrapper.test.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/LayoutWorkspaceTestWrapper.test.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import Layout from './+layout.svelte';
+    import type { LayoutLoadResult } from './+layout';
+
+    interface Props {
+        data: LayoutLoadResult;
+    }
+
+    let { data }: Props = $props();
+</script>
+
+<Layout {data}>
+    {#snippet children()}
+        <div data-testid="layout-test-child">workspace-child</div>
+    {/snippet}
+</Layout>

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -923,7 +923,37 @@ describe('right panel – main content stability', () => {
 // SidePanelTabs availability
 
 describe('SidePanelTabs availability', () => {
-    it('workspace frame is absent on a details route', async () => {
+    it('is present on images route', async () => {
+        setPageRoute(APP_ROUTES.images);
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('side-panel-tabs')).toBeInTheDocument();
+    });
+
+    it('is absent on a details route', async () => {
         setPageRoute(APP_ROUTES.imageDetails);
 
         render(LayoutWorkspaceTestWrapper, {
@@ -950,13 +980,43 @@ describe('SidePanelTabs availability', () => {
         });
         await tick();
 
-        expect(screen.queryByTestId('workspace-body')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('side-panel-tabs')).not.toBeInTheDocument();
     });
 
-    it('workspace frame is present on images route with no embeddings', async () => {
-        setPageRoute(APP_ROUTES.images);
+    it('is absent on a collection-grid route without embeddings', async () => {
+        setPageRoute(APP_ROUTES.annotations);
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.queryByTestId('side-panel-tabs')).not.toBeInTheDocument();
+    });
+
+    it('is present on annotations route when embeddings exist', async () => {
+        setPageRoute(APP_ROUTES.annotations);
         vi.mocked(useHasEmbeddingsModule.useHasEmbeddings).mockReturnValue({
-            data: undefined
+            data: true
         } as Partial<ReturnType<typeof useHasEmbeddingsModule.useHasEmbeddings>> as ReturnType<
             typeof useHasEmbeddingsModule.useHasEmbeddings
         >);
@@ -985,7 +1045,6 @@ describe('SidePanelTabs availability', () => {
         });
         await tick();
 
-        expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
-        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+        expect(screen.getByTestId('side-panel-tabs')).toBeInTheDocument();
     });
 });

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -210,33 +210,31 @@ beforeEach(() => {
     >);
 });
 
+const defaultProps = {
+    data: {
+        collection: {
+            collection_id: 'test-collection-id',
+            dataset_id: 'test-dataset-id',
+            name: 'Test Collection',
+            sample_type: SampleType.IMAGE,
+            total_sample_count: 10
+        } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+        collectionHierarchy: [],
+        globalStorage: {
+            setLastGridType: vi.fn(),
+            clearSelectedSamples: vi.fn(),
+            clearSelectedSampleAnnotationCrops: vi.fn()
+        } as Partial<LayoutLoadResult['globalStorage']> as LayoutLoadResult['globalStorage'],
+        sampleSize: writable({ width: 6, height: 6 })
+    }
+};
+
 // Collection-grid workspace rendering
 
 describe('+layout.svelte collection-grid workspace', () => {
     it('renders filter panel on images route', async () => {
         setPageRoute(APP_ROUTES.images);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
@@ -244,28 +242,7 @@ describe('+layout.svelte collection-grid workspace', () => {
 
     it('renders filter panel on annotations route', async () => {
         setPageRoute(APP_ROUTES.annotations);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
@@ -273,28 +250,7 @@ describe('+layout.svelte collection-grid workspace', () => {
 
     it('renders filter panel on videos route', async () => {
         setPageRoute(APP_ROUTES.videos);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
@@ -302,28 +258,7 @@ describe('+layout.svelte collection-grid workspace', () => {
 
     it('renders filter panel on frames route', async () => {
         setPageRoute(APP_ROUTES.frames);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
@@ -331,28 +266,7 @@ describe('+layout.svelte collection-grid workspace', () => {
 
     it('renders filter panel on groups route', async () => {
         setPageRoute(APP_ROUTES.groups);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
@@ -360,28 +274,7 @@ describe('+layout.svelte collection-grid workspace', () => {
 
     it('renders child route content on images route', async () => {
         setPageRoute(APP_ROUTES.images);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
@@ -393,28 +286,7 @@ describe('+layout.svelte collection-grid workspace', () => {
 describe('+layout.svelte details-route bypass', () => {
     it('does NOT render filter panel on image-details route', async () => {
         setPageRoute(APP_ROUTES.imageDetails);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
@@ -422,28 +294,7 @@ describe('+layout.svelte details-route bypass', () => {
 
     it('still renders child content on image-details route', async () => {
         setPageRoute(APP_ROUTES.imageDetails);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
@@ -451,28 +302,7 @@ describe('+layout.svelte details-route bypass', () => {
 
     it('does NOT render filter panel on annotation-details route', async () => {
         setPageRoute(APP_ROUTES.annotationDetails);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
@@ -480,28 +310,7 @@ describe('+layout.svelte details-route bypass', () => {
 
     it('still renders child content on annotation-details route', async () => {
         setPageRoute(APP_ROUTES.annotationDetails);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
@@ -509,28 +318,7 @@ describe('+layout.svelte details-route bypass', () => {
 
     it('does NOT render filter panel on video-details route', async () => {
         setPageRoute(APP_ROUTES.videoDetails);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
@@ -538,28 +326,7 @@ describe('+layout.svelte details-route bypass', () => {
 
     it('still renders child content on video-details route', async () => {
         setPageRoute(APP_ROUTES.videoDetails);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
@@ -567,28 +334,7 @@ describe('+layout.svelte details-route bypass', () => {
 
     it('does NOT render workspace frame on frame-details route', async () => {
         setPageRoute(APP_ROUTES.framesDetails);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.queryByTestId('workspace-body')).not.toBeInTheDocument();
@@ -596,28 +342,7 @@ describe('+layout.svelte details-route bypass', () => {
 
     it('still renders child content on frame-details route', async () => {
         setPageRoute(APP_ROUTES.framesDetails);
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
@@ -631,28 +356,7 @@ describe('filter sidebar collapse/expand', () => {
         setPageRoute(APP_ROUTES.images);
         mockFilterPanelCollapsed.set(false);
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('filter-panel-body')).toHaveAttribute('aria-hidden', 'false');
@@ -662,28 +366,7 @@ describe('filter sidebar collapse/expand', () => {
         setPageRoute(APP_ROUTES.images);
         mockFilterPanelCollapsed.set(true);
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('filter-panel-body')).toHaveAttribute('aria-hidden', 'true');
@@ -693,28 +376,7 @@ describe('filter sidebar collapse/expand', () => {
         setPageRoute(APP_ROUTES.images);
         mockFilterPanelCollapsed.set(true);
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
@@ -724,28 +386,7 @@ describe('filter sidebar collapse/expand', () => {
         setPageRoute(APP_ROUTES.imageDetails);
         mockFilterPanelCollapsed.set(false);
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
@@ -759,28 +400,7 @@ describe('right panel – main content stability', () => {
         setPageRoute(APP_ROUTES.images);
         mockActivePanel.set('none');
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
@@ -791,28 +411,7 @@ describe('right panel – main content stability', () => {
         setPageRoute(APP_ROUTES.images);
         mockActivePanel.set('none');
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         mockActivePanel.set('evaluationRuns');
@@ -826,28 +425,7 @@ describe('right panel – main content stability', () => {
         setPageRoute(APP_ROUTES.images);
         mockActivePanel.set('evaluationRuns');
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         mockActivePanel.set('none');
@@ -861,28 +439,7 @@ describe('right panel – main content stability', () => {
         setPageRoute(APP_ROUTES.videos);
         mockActivePanel.set('evaluationRuns');
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.queryByTestId('pane-group-layout')).not.toBeInTheDocument();
@@ -892,28 +449,7 @@ describe('right panel – main content stability', () => {
         setPageRoute(APP_ROUTES.videos);
         mockActivePanel.set('queryEditor');
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.queryByTestId('pane-group-layout')).not.toBeInTheDocument();
@@ -926,28 +462,7 @@ describe('SidePanelTabs availability', () => {
     it('is present on images route', async () => {
         setPageRoute(APP_ROUTES.images);
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('side-panel-tabs')).toBeInTheDocument();
@@ -956,28 +471,7 @@ describe('SidePanelTabs availability', () => {
     it('is absent on a details route', async () => {
         setPageRoute(APP_ROUTES.imageDetails);
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.queryByTestId('side-panel-tabs')).not.toBeInTheDocument();
@@ -986,28 +480,7 @@ describe('SidePanelTabs availability', () => {
     it('is absent on a collection-grid route without embeddings', async () => {
         setPageRoute(APP_ROUTES.annotations);
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.queryByTestId('side-panel-tabs')).not.toBeInTheDocument();
@@ -1021,28 +494,7 @@ describe('SidePanelTabs availability', () => {
             typeof useHasEmbeddingsModule.useHasEmbeddings
         >);
 
-        render(LayoutWorkspaceTestWrapper, {
-            props: {
-                data: {
-                    collection: {
-                        collection_id: 'test-collection-id',
-                        dataset_id: 'test-dataset-id',
-                        name: 'Test Collection',
-                        sample_type: SampleType.IMAGE,
-                        total_sample_count: 10
-                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
-                    collectionHierarchy: [],
-                    globalStorage: {
-                        setLastGridType: vi.fn(),
-                        clearSelectedSamples: vi.fn(),
-                        clearSelectedSampleAnnotationCrops: vi.fn()
-                    } as Partial<
-                        LayoutLoadResult['globalStorage']
-                    > as LayoutLoadResult['globalStorage'],
-                    sampleSize: writable({ width: 6, height: 6 })
-                }
-            }
-        });
+        render(LayoutWorkspaceTestWrapper, { props: defaultProps });
         await tick();
 
         expect(screen.getByTestId('side-panel-tabs')).toBeInTheDocument();

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -1,0 +1,988 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import * as appState from '$app/state';
+import type { Page } from '@sveltejs/kit';
+import { tick } from 'svelte';
+import '@testing-library/jest-dom';
+
+import { APP_ROUTES } from '$lib/routes';
+import type { PanelType } from '$lib/hooks/useGlobalStorage';
+import { SampleType } from '$lib/api/lightly_studio_local';
+import type { LayoutLoadResult } from './+layout';
+import LayoutWorkspaceTestWrapper from './LayoutWorkspaceTestWrapper.test.svelte';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+vi.mock('$app/navigation', () => ({ afterNavigate: vi.fn() }));
+
+vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
+    readAnnotationEmbedding: vi.fn()
+}));
+vi.mock('$lib/workers/maskRendererPool', () => ({
+    shutdownMaskRendererPool: vi.fn()
+}));
+vi.mock('$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations', () => ({
+    clearAnnotationPlotSelection: vi.fn()
+}));
+vi.mock('$lib/utils/buildImageFilter', () => ({
+    buildImageFilter: vi.fn(() => ({}))
+}));
+vi.mock('$lib/utils/buildAnnotationCountsFilters', () => ({
+    buildVideoAnnotationCountsFilter: vi.fn(() => ({})),
+    buildVideoFrameAnnotationCountsFilter: vi.fn(() => ({}))
+}));
+vi.mock('$lib/components/GridItem', () => ({
+    GRID_IMAGE_SEARCH_DROP_EVENT: 'grid-image-search-drop'
+}));
+
+vi.mock('paneforge', async () => {
+    const { default: Stub } = await import('./LayoutStub.test.svelte');
+    return { PaneGroup: Stub, Pane: Stub, PaneResizer: Stub };
+});
+vi.mock('$lib/components', async () => {
+    const { default: Stub } = await import('./LayoutStub.test.svelte');
+    return {
+        Button: Stub,
+        CombinedMetadataDimensionsFilters: Stub,
+        DatasetGridHeader: Stub,
+        Footer: Stub,
+        LabelsMenu: Stub,
+        MetadataFilterChips: Stub,
+        SelectionPill: Stub,
+        ShowFiltersButton: Stub,
+        TagsMenu: Stub,
+        SidePanelTabs: Stub,
+        Header: Stub,
+        Separator: Stub
+    };
+});
+vi.mock('$lib/components/ui/tooltip', async () => {
+    const { default: Stub } = await import('./LayoutStub.test.svelte');
+    return { Tooltip: Stub };
+});
+vi.mock('$lib/components/ui/separator/separator.svelte', async () => ({
+    default: (await import('./LayoutStub.test.svelte')).default
+}));
+vi.mock('$lib/components/QueryEditorPanel/QueryEditorPanel.svelte', async () => ({
+    default: (await import('./LayoutStub.test.svelte')).default
+}));
+vi.mock('$lib/components/Header/MenuDialogHost.svelte', async () => ({
+    default: (await import('./LayoutStub.test.svelte')).default
+}));
+vi.mock('$lib/components/QueryControl/QueryControl.svelte', async () => ({
+    default: (await import('./LayoutStub.test.svelte')).default
+}));
+vi.mock('$lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte', async () => ({
+    default: (await import('./LayoutStub.test.svelte')).default
+}));
+vi.mock(
+    '$lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte',
+    async () => ({ default: (await import('./LayoutStub.test.svelte')).default })
+);
+vi.mock('$lib/components/ConfusionCellFilterItem', async () => ({
+    default: (await import('./LayoutStub.test.svelte')).default
+}));
+
+vi.mock('$lib/hooks/useGlobalStorage');
+vi.mock('$lib/hooks/useHideAnnotations', () => ({
+    useHideAnnotations: vi.fn(() => ({ handleKeyEvent: vi.fn() }))
+}));
+vi.mock('$lib/hooks/useHasEmbeddings/useHasEmbeddings', () => ({
+    useHasEmbeddings: vi.fn(() => ({ data: undefined }))
+}));
+vi.mock('$lib/hooks/useAnnotationLabels/useAnnotationLabels', () => ({
+    useAnnotationLabels: vi.fn(() => ({ data: undefined }))
+}));
+vi.mock('$lib/hooks/useAnnotationsFilter/useAnnotationsFilter', () => ({
+    useAnnotationsFilter: vi.fn(() => ({
+        annotationFilter: writable(null),
+        annotationFilterRows: [],
+        toggleAnnotationFilterSelection: vi.fn(),
+        setAnnotationCounts: vi.fn(),
+        pruneInvalidSelections: vi.fn()
+    }))
+}));
+vi.mock('$lib/hooks/useDimensions/useDimensions', () => ({
+    useDimensions: vi.fn(() => ({ dimensionsValues: writable({}) }))
+}));
+vi.mock('$lib/hooks/useVideoAnnotationsCount/useVideoAnnotationsCount.js', () => ({
+    useVideoAnnotationCounts: vi.fn(() => ({ data: undefined }))
+}));
+vi.mock('$lib/hooks/useMetadataFilters/useMetadataFilters.js', () => ({
+    useMetadataFilters: vi.fn(() => ({
+        metadataValues: writable({}),
+        metadataBounds: writable({}),
+        updateMetadataValues: vi.fn()
+    })),
+    createMetadataFilters: vi.fn(() => undefined)
+}));
+vi.mock('$lib/hooks/useVideoFrameAnnotationsCount/useVideoFrameAnnotationsCount.js', () => ({
+    useVideoFrameAnnotationCounts: vi.fn(() => ({ data: undefined }))
+}));
+vi.mock('$lib/hooks/useVideoFramesBounds/useVideoFramesBounds.js', () => ({
+    useVideoFramesBounds: vi.fn(() => ({ videoFramesBoundsValues: writable({}) }))
+}));
+vi.mock('$lib/hooks/useVideosBounds/useVideosBounds.js', () => ({
+    useVideoBounds: vi.fn(() => ({ videoBoundsValues: writable({}) }))
+}));
+vi.mock('$lib/hooks/useImageFilters/useImageFilters', () => ({
+    useImageFilters: vi.fn(() => ({ imageFilter: writable(null) }))
+}));
+vi.mock('$lib/hooks/useVideoFilters/useVideoFilters', () => ({
+    useVideoFilters: vi.fn(() => ({ videoFilter: writable(null) }))
+}));
+vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter', () => ({
+    useAnnotationCollectionsFilter: vi.fn(() => ({ selectedCollectionIds: writable([]) }))
+}));
+vi.mock('$lib/hooks', () => ({
+    useSelectionSummary: vi.fn(() => ({
+        selectedCount: writable(0),
+        clearSelection: vi.fn()
+    })),
+    useImageAnnotationCounts: vi.fn(() => ({ data: undefined })),
+    useImageAnnotationCountsQueryKey: ['imageAnnotationCounts'],
+    useNumericMetadataDistribution: vi.fn(() => ({ data: undefined })),
+    usePostHog: vi.fn(() => ({ trackEvent: vi.fn() })),
+    useTrackSampleInspected: vi.fn()
+}));
+vi.mock('$lib/hooks/useSelectAll/useSelectAll', () => ({
+    useSelectAll: vi.fn(() => ({ handleSelectAll: vi.fn() }))
+}));
+vi.mock('$lib/hooks/useSearchEmbedding/useSearchEmbedding', () => ({
+    useSearchEmbedding: vi.fn(() => ({
+        image: writable(null),
+        isPending: writable(false),
+        setText: vi.fn(),
+        setImage: vi.fn(),
+        setEmbedding: vi.fn(),
+        clear: vi.fn(),
+        onError: vi.fn()
+    }))
+}));
+vi.mock('$lib/hooks/useEvaluationRuns/useEvaluationRuns', () => ({
+    useEvaluationRuns: vi.fn(() => ({ data: undefined, isLoading: false, error: null }))
+}));
+
+import * as useGlobalStorageModule from '$lib/hooks/useGlobalStorage';
+import * as useHasEmbeddingsModule from '$lib/hooks/useHasEmbeddings/useHasEmbeddings';
+
+let mockActivePanel: ReturnType<typeof writable<PanelType>>;
+let mockFilterPanelCollapsed: ReturnType<typeof writable<boolean>>;
+
+function setPageRoute(routeId: string | null): void {
+    vi.spyOn(appState, 'page', 'get').mockReturnValue({
+        route: { id: routeId },
+        params: {
+            dataset_id: 'test-dataset-id',
+            collection_id: 'test-collection-id',
+            collection_type: 'image'
+        }
+    } as Partial<Page<Record<string, string>, string | null>> as Page<
+        Record<string, string>,
+        string | null
+    >);
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockActivePanel = writable<PanelType>('none');
+    mockFilterPanelCollapsed = writable(false);
+
+    vi.mocked(useGlobalStorageModule.useGlobalStorage).mockReturnValue({
+        activePanel: mockActivePanel,
+        setActivePanel: vi.fn(),
+        filterPanelCollapsed: mockFilterPanelCollapsed,
+        toggleFilterPanelCollapsed: vi.fn(),
+        filteredSampleCount: writable(0),
+        filteredAnnotationCount: writable(0),
+        textEmbedding: writable(undefined),
+        collections: writable({}),
+        retrieveParentCollection: vi.fn(() => null)
+    } as Partial<ReturnType<typeof useGlobalStorageModule.useGlobalStorage>> as ReturnType<
+        typeof useGlobalStorageModule.useGlobalStorage
+    >);
+
+    vi.mocked(useHasEmbeddingsModule.useHasEmbeddings).mockReturnValue({
+        data: undefined
+    } as Partial<ReturnType<typeof useHasEmbeddingsModule.useHasEmbeddings>> as ReturnType<
+        typeof useHasEmbeddingsModule.useHasEmbeddings
+    >);
+});
+
+// Collection-grid workspace rendering
+
+describe('+layout.svelte collection-grid workspace', () => {
+    it('renders filter panel on images route', async () => {
+        setPageRoute(APP_ROUTES.images);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
+    });
+
+    it('renders filter panel on annotations route', async () => {
+        setPageRoute(APP_ROUTES.annotations);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
+    });
+
+    it('renders filter panel on videos route', async () => {
+        setPageRoute(APP_ROUTES.videos);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
+    });
+
+    it('renders filter panel on frames route', async () => {
+        setPageRoute(APP_ROUTES.frames);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
+    });
+
+    it('renders filter panel on groups route', async () => {
+        setPageRoute(APP_ROUTES.groups);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
+    });
+
+    it('renders child route content on images route', async () => {
+        setPageRoute(APP_ROUTES.images);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+});
+
+// Details routes bypass the workspace
+
+describe('+layout.svelte details-route bypass', () => {
+    it('does NOT render filter panel on image-details route', async () => {
+        setPageRoute(APP_ROUTES.imageDetails);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
+    });
+
+    it('still renders child content on image-details route', async () => {
+        setPageRoute(APP_ROUTES.imageDetails);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+
+    it('does NOT render filter panel on annotation-details route', async () => {
+        setPageRoute(APP_ROUTES.annotationDetails);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
+    });
+
+    it('still renders child content on annotation-details route', async () => {
+        setPageRoute(APP_ROUTES.annotationDetails);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+
+    it('does NOT render filter panel on video-details route', async () => {
+        setPageRoute(APP_ROUTES.videoDetails);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
+    });
+
+    it('still renders child content on video-details route', async () => {
+        setPageRoute(APP_ROUTES.videoDetails);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+
+    it('does NOT render filter panel on frame-details route', async () => {
+        setPageRoute(APP_ROUTES.framesDetails);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
+    });
+
+    it('still renders child content on frame-details route', async () => {
+        setPageRoute(APP_ROUTES.framesDetails);
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+});
+
+// Filter sidebar collapse/expand
+
+describe('filter sidebar collapse/expand', () => {
+    it('filter panel is visible (not collapsed) by default', async () => {
+        setPageRoute(APP_ROUTES.images);
+        mockFilterPanelCollapsed.set(false);
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('filter-panel-body')).toHaveAttribute('aria-hidden', 'false');
+    });
+
+    it('filter panel is collapsed when filterPanelCollapsed is true', async () => {
+        setPageRoute(APP_ROUTES.images);
+        mockFilterPanelCollapsed.set(true);
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('filter-panel-body')).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('filter panel stays in DOM when collapsed (mount-time effects must still run)', async () => {
+        setPageRoute(APP_ROUTES.images);
+        mockFilterPanelCollapsed.set(true);
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
+    });
+
+    it('filter panel is not rendered on a details route regardless of collapse state', async () => {
+        setPageRoute(APP_ROUTES.imageDetails);
+        mockFilterPanelCollapsed.set(false);
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
+    });
+});
+
+// Right panel – main content stability
+
+describe('right panel – main content stability', () => {
+    it('renders child content when no right panel is open', async () => {
+        setPageRoute(APP_ROUTES.images);
+        mockActivePanel.set('none');
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+
+    it('child content is still present after opening an evaluationRuns panel', async () => {
+        setPageRoute(APP_ROUTES.images);
+        mockActivePanel.set('none');
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        mockActivePanel.set('evaluationRuns');
+        await tick();
+
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+
+    it('child content is still present after closing the panel', async () => {
+        setPageRoute(APP_ROUTES.images);
+        mockActivePanel.set('evaluationRuns');
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        mockActivePanel.set('none');
+        await tick();
+
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+
+    it('evaluationRuns panel is not shown on videos route even when requested', async () => {
+        setPageRoute(APP_ROUTES.videos);
+        mockActivePanel.set('evaluationRuns');
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+
+    it('queryEditor panel is not shown on videos route even when requested', async () => {
+        setPageRoute(APP_ROUTES.videos);
+        mockActivePanel.set('queryEditor');
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+});
+
+// SidePanelTabs availability
+
+describe('SidePanelTabs availability', () => {
+    it('workspace frame is absent on a details route', async () => {
+        setPageRoute(APP_ROUTES.imageDetails);
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
+    });
+
+    it('workspace frame is present on images route with no embeddings', async () => {
+        setPageRoute(APP_ROUTES.images);
+        vi.mocked(useHasEmbeddingsModule.useHasEmbeddings).mockReturnValue({
+            data: undefined
+        } as Partial<ReturnType<typeof useHasEmbeddingsModule.useHasEmbeddings>> as ReturnType<
+            typeof useHasEmbeddingsModule.useHasEmbeddings
+        >);
+
+        render(LayoutWorkspaceTestWrapper, {
+            props: {
+                data: {
+                    collection: {
+                        collection_id: 'test-collection-id',
+                        dataset_id: 'test-dataset-id',
+                        name: 'Test Collection',
+                        sample_type: SampleType.IMAGE,
+                        total_sample_count: 10
+                    } as Partial<LayoutLoadResult['collection']> as LayoutLoadResult['collection'],
+                    collectionHierarchy: [],
+                    globalStorage: {
+                        setLastGridType: vi.fn(),
+                        clearSelectedSamples: vi.fn(),
+                        clearSelectedSampleAnnotationCrops: vi.fn()
+                    } as Partial<
+                        LayoutLoadResult['globalStorage']
+                    > as LayoutLoadResult['globalStorage'],
+                    sampleSize: writable({ width: 6, height: 6 })
+                }
+            }
+        });
+        await tick();
+
+        expect(screen.getByTestId('filter-panel-body')).toBeInTheDocument();
+        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -784,6 +784,7 @@ describe('right panel – main content stability', () => {
         await tick();
 
         expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+        expect(screen.queryByTestId('pane-group-layout')).not.toBeInTheDocument();
     });
 
     it('child content is still present after opening an evaluationRuns panel', async () => {
@@ -818,6 +819,7 @@ describe('right panel – main content stability', () => {
         await tick();
 
         expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+        expect(screen.getByTestId('pane-group-layout')).toBeInTheDocument();
     });
 
     it('child content is still present after closing the panel', async () => {
@@ -852,6 +854,7 @@ describe('right panel – main content stability', () => {
         await tick();
 
         expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+        expect(screen.queryByTestId('pane-group-layout')).not.toBeInTheDocument();
     });
 
     it('evaluationRuns panel is not shown on videos route even when requested', async () => {
@@ -882,7 +885,7 @@ describe('right panel – main content stability', () => {
         });
         await tick();
 
-        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+        expect(screen.queryByTestId('pane-group-layout')).not.toBeInTheDocument();
     });
 
     it('queryEditor panel is not shown on videos route even when requested', async () => {
@@ -913,7 +916,7 @@ describe('right panel – main content stability', () => {
         });
         await tick();
 
-        expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
+        expect(screen.queryByTestId('pane-group-layout')).not.toBeInTheDocument();
     });
 });
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -565,7 +565,7 @@ describe('+layout.svelte details-route bypass', () => {
         expect(screen.getByTestId('layout-test-child')).toBeInTheDocument();
     });
 
-    it('does NOT render filter panel on frame-details route', async () => {
+    it('does NOT render workspace frame on frame-details route', async () => {
         setPageRoute(APP_ROUTES.framesDetails);
         render(LayoutWorkspaceTestWrapper, {
             props: {
@@ -591,7 +591,7 @@ describe('+layout.svelte details-route bypass', () => {
         });
         await tick();
 
-        expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('workspace-body')).not.toBeInTheDocument();
     });
 
     it('still renders child content on frame-details route', async () => {
@@ -947,7 +947,7 @@ describe('SidePanelTabs availability', () => {
         });
         await tick();
 
-        expect(screen.queryByTestId('filter-panel-body')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('workspace-body')).not.toBeInTheDocument();
     });
 
     it('workspace frame is present on images route with no embeddings', async () => {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/panelVisibility.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/panelVisibility.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { isPanelVisible } from './panelVisibility';
+
+describe('isPanelVisible', () => {
+    it('no panel is visible when activePanel is "none"', () => {
+        expect(isPanelVisible('none', true, true)).toBe(false);
+    });
+
+    it('evaluationRuns panel is visible on images route', () => {
+        expect(isPanelVisible('evaluationRuns', true, false)).toBe(true);
+    });
+
+    it('evaluationRuns panel is NOT visible on non-images routes', () => {
+        expect(isPanelVisible('evaluationRuns', false, false)).toBe(false);
+    });
+
+    it('embeddingPlot panel is visible on images route when embeddings exist', () => {
+        expect(isPanelVisible('embeddingPlot', true, true)).toBe(true);
+    });
+
+    it('embeddingPlot panel is NOT visible when there are no embeddings', () => {
+        expect(isPanelVisible('embeddingPlot', true, false)).toBe(false);
+    });
+
+    it('embeddingPlot panel is NOT visible on non-images route without embeddings', () => {
+        expect(isPanelVisible('embeddingPlot', false, false)).toBe(false);
+    });
+
+    it('queryEditor panel is visible on images route only', () => {
+        expect(isPanelVisible('queryEditor', true, false)).toBe(true);
+        expect(isPanelVisible('queryEditor', false, false)).toBe(false);
+    });
+
+    it('distribution panel is visible on images route only', () => {
+        expect(isPanelVisible('distribution', true, false)).toBe(true);
+        expect(isPanelVisible('distribution', false, false)).toBe(false);
+    });
+});

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/panelVisibility.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/panelVisibility.ts
@@ -1,0 +1,14 @@
+import type { PanelType } from '$lib/hooks/useGlobalStorage';
+
+export function isPanelVisible(
+    activePanel: PanelType,
+    isImages: boolean,
+    hasMediaWithEmbeddings: boolean
+): boolean {
+    return (
+        (activePanel === 'evaluationRuns' && isImages) ||
+        (activePanel === 'embeddingPlot' && hasMediaWithEmbeddings) ||
+        (activePanel === 'queryEditor' && isImages) ||
+        (activePanel === 'distribution' && isImages)
+    );
+}


### PR DESCRIPTION
## What has changed and why?

Adds characterization tests for `+layout.svelte` to document existing panel visibility and filter panel behavior. Extracts the `isPanelVisible` logic into a standalone pure function in `panelVisibility.ts` so it can be tested directly. Adds `aria-hidden` to the filter panel body to support `toBeVisible()` assertions. Also adds route classification tests for the helper functions in `routes.ts.` 

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated frame-details route variant and centralized workspace/right-panel visibility logic.
* **Accessibility**
  * Improved filter panel accessibility by updating `aria-hidden` based on the collapsed/expanded state.
* **Bug Fixes**
  * Standardized which filter/right panels render across image vs details routes, including correct behavior for videos, frames, and embeddings availability.
* **Tests**
  * Expanded route classification coverage and added comprehensive workspace/panel visibility tests, plus new Svelte test layout stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->