### PR TITLE
feat: lig-9585 Introduce changes in hooks required to render categorical metadata in distribution panel

### DIFF
--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.svelte
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.svelte
@@ -28,10 +28,14 @@
                 >
                     {#snippet subtitle()}
                         <div class="truncate text-xs text-muted-foreground">
-                            {hook.formatValue(chip.key, chip.range.min)} – {hook.formatValue(
-                                chip.key,
-                                chip.range.max
-                            )}
+                            {#if chip.kind === 'categorical'}
+                                {hook.formatCategoricalValues(chip.values)}
+                            {:else if chip.range}
+                                {hook.formatValue(chip.key, chip.range.min)} – {hook.formatValue(
+                                    chip.key,
+                                    chip.range.max
+                                )}
+                            {/if}
                         </div>
                     {/snippet}
                 </FilterChip>

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.test.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.test.ts
@@ -9,6 +9,16 @@ describe('MetadataFilterChips', () => {
     beforeEach(() => {
         storage.updateMetadataBounds({});
         storage.updateMetadataValues({});
+        storage.updateCategoricalMetadataValues({});
+    });
+
+    it('distinguishes literal values from semantic Missing in a chip', () => {
+        storage.updateCategoricalMetadataValues({ city: ['Missing', null, 'Other'] });
+        render(MetadataFilterChips);
+
+        expect(screen.getByTestId('metadata-filter-chip-city')).toHaveTextContent(
+            'Missing (value), Missing (no value), Other (value)'
+        );
     });
 
     it('renders nothing when no filter is narrowed', () => {

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.svelte.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.svelte.ts
@@ -2,6 +2,7 @@ import { fromStore } from 'svelte/store';
 import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import { formatFloat, formatInteger } from '$lib/utils';
 import { usePostHog } from '$lib/hooks';
+import type { CategoricalMetadataValue } from '$lib/services/types';
 
 type Range = { min: number; max: number };
 type BoundsMap = Record<string, Range>;
@@ -9,18 +10,27 @@ type BoundsMap = Record<string, Range>;
 export interface MetadataFilterChip {
     key: string;
     active: boolean;
-    range: Range;
+    kind: 'numeric' | 'categorical';
+    range?: Range;
+    values?: CategoricalMetadataValue[];
 }
 
 export function useMetadataFilterChips(collectionId: string | undefined) {
-    const { metadataBounds, metadataValues, updateMetadataValues } =
-        useMetadataFilters(collectionId);
+    const {
+        metadataBounds,
+        metadataValues,
+        categoricalMetadataValues,
+        updateMetadataValues,
+        updateCategoricalMetadataValues
+    } = useMetadataFilters(collectionId);
     const { trackEvent } = usePostHog();
 
     const boundsStore = fromStore(metadataBounds);
     const valuesStore = fromStore(metadataValues);
+    const categoricalStore = fromStore(categoricalMetadataValues);
 
     let lastRanges = $state<BoundsMap>({});
+    let lastCategoricalValues = $state<Record<string, CategoricalMetadataValue[]>>({});
 
     const isNarrowed = (key: string): boolean => {
         const bound = boundsStore.current[key];
@@ -40,6 +50,19 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
         }
     });
 
+    $effect(() => {
+        for (const [key, values] of Object.entries(categoricalStore.current)) {
+            if (values.length === 0) continue;
+            const previous = lastCategoricalValues[key] ?? [];
+            const unchanged =
+                previous.length === values.length &&
+                previous.every((value, index) => Object.is(value, values[index]));
+            if (!unchanged) {
+                lastCategoricalValues = { ...lastCategoricalValues, [key]: [...values] };
+            }
+        }
+    });
+
     // One chip per key that is narrowed now or has a remembered range: active
     // chips show the current range, disabled ones the remembered range.
     const chips = $derived.by<MetadataFilterChip[]>(() => {
@@ -47,16 +70,32 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
             ...Object.keys(lastRanges),
             ...Object.keys(valuesStore.current).filter(isNarrowed)
         ]);
-        return [...keys]
+        const numericChips = [...keys]
             .filter((key) => boundsStore.current[key])
             .map((key) => {
                 const active = isNarrowed(key);
                 const range: Range | undefined = active
                     ? valuesStore.current[key]
                     : lastRanges[key];
-                return { key, active, range };
+                return range ? { key, active, range, kind: 'numeric' as const } : null;
             })
-            .filter((chip): chip is MetadataFilterChip => !!chip.range);
+            .filter((chip): chip is NonNullable<typeof chip> => chip !== null);
+        const categoricalKeys = new Set([
+            ...Object.keys(lastCategoricalValues),
+            ...Object.entries(categoricalStore.current)
+                .filter(([, values]) => values.length > 0)
+                .map(([key]) => key)
+        ]);
+        const categoricalChips: MetadataFilterChip[] = [...categoricalKeys].map((key) => {
+            const current = categoricalStore.current[key] ?? [];
+            return {
+                key,
+                active: current.length > 0,
+                kind: 'categorical',
+                values: current.length > 0 ? current : lastCategoricalValues[key]
+            };
+        });
+        return [...numericChips, ...categoricalChips];
     });
 
     const setRange = (key: string, range: Range) => {
@@ -73,6 +112,13 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
     };
 
     const handleToggle = (key: string, checked: boolean | 'indeterminate') => {
+        if (lastCategoricalValues[key]) {
+            updateCategoricalMetadataValues({
+                ...categoricalStore.current,
+                [key]: checked ? lastCategoricalValues[key] : []
+            });
+            return;
+        }
         const bound = boundsStore.current[key];
         if (!bound) return;
         if (checked && lastRanges[key]) {
@@ -84,6 +130,15 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
     };
 
     const handleClear = (key: string) => {
+        if (lastCategoricalValues[key]) {
+            const next = { ...categoricalStore.current };
+            delete next[key];
+            updateCategoricalMetadataValues(next);
+            lastCategoricalValues = Object.fromEntries(
+                Object.entries(lastCategoricalValues).filter(([valueKey]) => valueKey !== key)
+            );
+            return;
+        }
         const bound = boundsStore.current[key];
         if (bound) setRange(key, { min: bound.min, max: bound.max });
         lastRanges = Object.fromEntries(
@@ -98,12 +153,26 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
         return isInteger ? formatInteger(value) : formatFloat(value);
     };
 
+    const formatCategoricalValues = (values: CategoricalMetadataValue[] = []): string => {
+        const hasMissingValue = values.includes('Missing');
+        const hasNoValue = values.includes(null);
+        return values
+            .map((value) => {
+                if (value === null) return hasMissingValue ? 'Missing (no value)' : 'Missing';
+                if (value === 'Missing' && hasNoValue) return 'Missing (value)';
+                if (value === 'Other') return 'Other (value)';
+                return String(value);
+            })
+            .join(', ');
+    };
+
     return {
         get chips() {
             return chips;
         },
         handleToggle,
         handleClear,
-        formatValue
+        formatValue,
+        formatCategoricalValues
     };
 }

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.test.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.test.ts
@@ -27,6 +27,7 @@ describe('useMetadataFilterChips', () => {
         storage.updateMetadataBounds({});
         storage.updateMetadataValues({});
         trackEvent.mockClear();
+        storage.updateCategoricalMetadataValues({});
     });
 
     it('provides a chip only for narrowed filters, not for full-range ones', () => {

--- a/lightly_studio_view/src/lib/hooks/useDimensions/useDimensions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useDimensions/useDimensions.test.ts
@@ -112,23 +112,33 @@ describe('useDimensions', () => {
     it('loads and refetches when collection_id readable store changes', async () => {
         const { useDimensions } = await import('./useDimensions');
         const collectionId = writable('collection-store-a');
-        const { dimensionsValues } = useDimensions(collectionId);
+        const { dimensionsValues, updateDimensionsValues } = useDimensions(collectionId);
+        const values: unknown[] = [];
+        const unsubscribe = dimensionsValues.subscribe((value) => values.push(value));
 
-        get(dimensionsValues);
         expect(loadDimensionBoundsMock).toHaveBeenCalledTimes(1);
         expect(loadDimensionBoundsMock).toHaveBeenLastCalledWith({
             collection_id: 'collection-store-a'
         });
 
         collectionId.set('collection-store-a');
-        get(dimensionsValues);
         expect(loadDimensionBoundsMock).toHaveBeenCalledTimes(1);
 
         collectionId.set('collection-store-b');
-        get(dimensionsValues);
         expect(loadDimensionBoundsMock).toHaveBeenCalledTimes(2);
         expect(loadDimensionBoundsMock).toHaveBeenLastCalledWith({
             collection_id: 'collection-store-b'
         });
+
+        const updatedValues = {
+            min_width: 30,
+            max_width: 90,
+            min_height: 40,
+            max_height: 180
+        };
+        updateDimensionsValues(updatedValues);
+
+        expect(values.at(-1)).toEqual(updatedValues);
+        unsubscribe();
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useDimensions/useDimensions.ts
+++ b/lightly_studio_view/src/lib/hooks/useDimensions/useDimensions.ts
@@ -2,7 +2,7 @@ import type { DimensionBounds } from '$lib/services/loadDimensionBounds';
 import { loadDimensionBounds } from '$lib/services/loadDimensionBounds';
 import { useSessionStorage } from '$lib/hooks/useSessionStorage/useSessionStorage';
 import { isReadableStore } from '$lib/hooks/utils/isReadableStore';
-import { derived, get, writable, type Readable } from 'svelte/store';
+import { get, readable, writable, type Readable } from 'svelte/store';
 
 const dimensionsBounds = useSessionStorage<DimensionBounds | null>(
     'lightlyStudio_dimensions_bounds',
@@ -23,7 +23,7 @@ const updateDimensionsBounds = (bounds: DimensionBounds) => {
 };
 
 const lastCollectionId = writable<string | null>(null);
-type CollectionIdInput = string | Readable<string> | undefined;
+type CollectionIdInput = string | Readable<string | undefined> | undefined;
 
 const loadInitialDimensionBounds = async (collection_id: string) => {
     if (get(lastCollectionId) === collection_id) {
@@ -53,17 +53,23 @@ const bindCollectionLoader = <T>(source: Readable<T>, collectionId: CollectionId
         return source;
     }
 
-    if (!isReadableStore<string>(collectionId)) {
+    if (!isReadableStore<string | undefined>(collectionId)) {
         loadInitialDimensionBounds(collectionId);
         return source;
     }
 
-    return derived([source, collectionId], ([$source, $collectionId]) => {
-        if ($collectionId) {
-            loadInitialDimensionBounds($collectionId);
-        }
+    return readable(get(source), (set) => {
+        const unsubscribeSource = source.subscribe(set);
+        const unsubscribeCollectionId = collectionId.subscribe(($collectionId) => {
+            if ($collectionId) {
+                loadInitialDimensionBounds($collectionId);
+            }
+        });
 
-        return $source;
+        return () => {
+            unsubscribeSource();
+            unsubscribeCollectionId();
+        };
     });
 };
 

--- a/lightly_studio_view/src/lib/hooks/useFrames/useFrames.ts
+++ b/lightly_studio_view/src/lib/hooks/useFrames/useFrames.ts
@@ -1,0 +1,43 @@
+import { getAllFramesInfiniteOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+
+import { createInfiniteQuery, useQueryClient } from '@tanstack/svelte-query';
+import type { VideoFrameFilter } from '$lib/api/lightly_studio_local/types.gen';
+import { GRID_PAGE_SIZE } from '$lib/constants';
+
+export const useFrames = (
+    getParams: () => { video_frame_collection_id: string; filter: VideoFrameFilter }
+) => {
+    const query = createInfiniteQuery(() => {
+        const { video_frame_collection_id, filter } = getParams();
+        return {
+            ...getAllFramesInfiniteOptions({
+                path: { video_frame_collection_id },
+                query: { limit: GRID_PAGE_SIZE },
+                body: { filter }
+            }),
+            getNextPageParam: (lastPage) => lastPage.nextCursor || undefined
+        };
+    });
+    const client = useQueryClient();
+    const refresh = () => {
+        const { video_frame_collection_id, filter } = getParams();
+        const options = getAllFramesInfiniteOptions({
+            path: { video_frame_collection_id },
+            query: { limit: GRID_PAGE_SIZE },
+            body: { filter }
+        });
+        client.invalidateQueries({ queryKey: options.queryKey });
+    };
+
+    const loadMore = () => {
+        if (query.hasNextPage && !query.isFetchingNextPage) {
+            query.fetchNextPage();
+        }
+    };
+
+    return {
+        query,
+        loadMore,
+        refresh
+    };
+};

--- a/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.test.ts
@@ -78,4 +78,21 @@ describe('getFrameFilter', () => {
             frame_number: {}
         });
     });
+
+    it('adds categorical metadata filters', async () => {
+        const { createMetadataFilters } = await import('../useMetadataFilters/useMetadataFilters');
+        vi.mocked(createMetadataFilters).mockReturnValueOnce([
+            { key: 'city', value: ['Zurich', null], op: 'in' }
+        ]);
+
+        const filter = getFrameFilter({
+            collection_id: 'coll-1',
+            filters: { categorical_metadata_values: { city: ['Zurich', null] } }
+        });
+
+        expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+        expect(filter?.sample_filter?.metadata_filters).toEqual([
+            { key: 'city', value: ['Zurich', null], op: 'in' }
+        ]);
+    });
 });

--- a/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.ts
@@ -5,8 +5,7 @@ import type {
     VideoFrameFilter,
     VideoFrameFieldsBoundsView
 } from '$lib/api/lightly_studio_local/types.gen';
-import type { CategoricalMetadataValues } from '$lib/services/types';
-type MetadataValues = Record<string, { min: number; max: number }>;
+import type { CategoricalMetadataValues, MetadataValues } from '$lib/services/types';
 
 export type VideoFrameFilterParams = {
     collection_id: string;

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
@@ -3,6 +3,7 @@ import { get } from 'svelte/store';
 import { useImageFilters } from './useImageFilters';
 import type { QueryExpr, SortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
 import { SortDirection } from '$lib/api/lightly_studio_local/types.gen';
+import { createMetadataFilters } from '../useMetadataFilters/useMetadataFilters';
 
 const queryExpr = {
     match_expr: {
@@ -67,6 +68,22 @@ describe('useImageFilters', () => {
             updateQueryExpr(undefined);
             expect(get(imageFilter)?.sample_filter?.query_expr).toBeUndefined();
         });
+    });
+
+    it('forwards numeric and categorical metadata state into the shared image filter', () => {
+        vi.mocked(createMetadataFilters).mockReturnValueOnce([
+            { key: 'city', op: 'in', value: ['Zurich', null] }
+        ]);
+        const { imageFilter, updateFilterParams } = useImageFilters();
+        updateFilterParams({
+            ...normalFilterParams,
+            metadata_values: {},
+            categorical_metadata_values: { city: ['Zurich', null] }
+        });
+
+        const metadataFilters = get(imageFilter)?.sample_filter?.metadata_filters;
+        expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+        expect(metadataFilters).toEqual([{ key: 'city', op: 'in', value: ['Zurich', null] }]);
     });
 
     describe('updateConfusionCell', () => {

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.test.ts
@@ -199,5 +199,19 @@ describe('buildRequestBody', () => {
                 metadataFilterFixture
             ]);
         });
+
+        it('applies categorical metadata values via createMetadataFilters', () => {
+            const result = buildRequestBody(
+                {
+                    collection_id: 'col-1',
+                    mode: 'normal',
+                    categorical_metadata_values: { city: ['Zurich', null] }
+                },
+                0
+            );
+            expect(result.filters?.sample_filter?.metadata_filters).toEqual([
+                metadataFilterFixture
+            ]);
+        });
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
@@ -93,6 +93,19 @@ describe('createImagesInfiniteOptions', () => {
             });
             expect(options1.queryKey).not.toEqual(options2.queryKey);
         });
+
+        it('includes typed categorical selections in the query key', () => {
+            const categoricalMetadataValues = { city: ['Zurich', null] };
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                categorical_metadata_values: categoricalMetadataValues
+            });
+
+            expect(options.queryKey[4]).toMatchObject({
+                categorical_metadata_values: categoricalMetadataValues
+            });
+        });
     });
 
     describe('enabled', () => {

--- a/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.test.ts
@@ -86,12 +86,12 @@ describe('createMetadataFilters', () => {
     it('combines numeric ranges with one OR predicate per non-empty categorical key', () => {
         const filters = createMetadataFilters(
             { temperature: { min: 20, max: 100 } },
-            { city: ['Zurich', 'Berlin', '__missing__'], ignored: [] }
+            { city: ['Zurich', 'Berlin', null], ignored: [] }
         );
 
         expect(filters).toEqual([
             { key: 'temperature', value: 20, op: '>=' },
-            { key: 'city', value: ['Zurich', 'Berlin', '__missing__'], op: 'in' }
+            { key: 'city', value: ['Zurich', 'Berlin', null], op: 'in' }
         ]);
     });
 

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
@@ -131,6 +131,24 @@ describe('useVideoFilters', () => {
                 { key: 'temp', value: 10, op: '>=' }
             ]);
         });
+
+        it('includes categorical metadata selections in the sample filter', async () => {
+            const { createMetadataFilters } =
+                await import('../useMetadataFilters/useMetadataFilters');
+            vi.mocked(createMetadataFilters).mockReturnValueOnce([
+                { key: 'city', value: ['Zurich', null], op: 'in' }
+            ]);
+            const { videoFilter, updateFilterParams } = useVideoFilters();
+
+            updateFilterParams({
+                collection_id: 'coll-1',
+                filters: { categorical_metadata_values: { city: ['Zurich', null] } }
+            });
+
+            const metadataFilters = get(videoFilter)?.sample_filter?.metadata_filters;
+            expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+            expect(metadataFilters).toEqual([{ key: 'city', value: ['Zurich', null], op: 'in' }]);
+        });
     });
 
     describe('updateSampleIds', () => {

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
@@ -6,8 +6,7 @@ import type {
     VideoFilter,
     VideoFieldsBoundsView
 } from '$lib/api/lightly_studio_local/types.gen';
-import type { CategoricalMetadataValues } from '$lib/services/types';
-type MetadataValues = Record<string, { min: number; max: number }>;
+import type { CategoricalMetadataValues, MetadataValues } from '$lib/services/types';
 
 export type VideoFilterParams = {
     collection_id: string;

--- a/lightly_studio_view/src/lib/services/loadDimensionBounds.test.ts
+++ b/lightly_studio_view/src/lib/services/loadDimensionBounds.test.ts
@@ -80,6 +80,18 @@ describe('loadDimensionBounds', () => {
         });
     });
 
+    it('should return an error when dimension data is incomplete', async () => {
+        vi.spyOn(sdk, 'getImageDimensions').mockResolvedValue({
+            data: {},
+            error: undefined
+        } as unknown as GetImageDimensionsReturn);
+
+        await expect(loadDimensionBounds({ collection_id: '1' })).resolves.toEqual({
+            data: undefined,
+            error: 'Error loading dimension bounds: Error: No dimension bounds data'
+        });
+    });
+
     it('should return an error when promise is rejected', async () => {
         vi.spyOn(sdk, 'getImageDimensions').mockRejectedValue('oops');
 

--- a/lightly_studio_view/src/lib/services/loadDimensionBounds.ts
+++ b/lightly_studio_view/src/lib/services/loadDimensionBounds.ts
@@ -13,6 +13,18 @@ type LoadDimensionBoundsParams = {
     annotation_label_ids?: string[];
 };
 
+const isDimensionBounds = (value: unknown): value is DimensionBounds => {
+    if (!value || typeof value !== 'object') return false;
+
+    const bounds = value as Record<keyof DimensionBounds, unknown>;
+    return (
+        typeof bounds.min_width === 'number' &&
+        typeof bounds.max_width === 'number' &&
+        typeof bounds.min_height === 'number' &&
+        typeof bounds.max_height === 'number'
+    );
+};
+
 export const loadDimensionBounds = async ({
     collection_id,
     annotation_label_ids
@@ -36,11 +48,11 @@ export const loadDimensionBounds = async ({
             throw new Error(JSON.stringify(response.error, null, 2));
         }
 
-        if (!response.data) {
+        if (!isDimensionBounds(response.data)) {
             throw new Error('No dimension bounds data');
         }
 
-        result.data = response.data as DimensionBounds;
+        result.data = response.data;
     } catch (e) {
         result.error = 'Error loading dimension bounds: ' + String(e);
     }

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -85,6 +85,8 @@
     import { useSearchEmbedding } from '$lib/hooks/useSearchEmbedding/useSearchEmbedding';
     import { useEvaluationRuns } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
     import { clearAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
+    import { getDimensionsCollectionId } from './getDimensionsCollectionId';
+    import { getMetadataCollectionId } from './getMetadataCollectionId';
     const { data, children } = $props();
     const {
         collection,
@@ -140,6 +142,21 @@
     const canSelectAll = $derived(isImages || isVideos || isVideoFrames || isAnnotations);
     const showAnnotationVisibilityToggle = $derived(
         isAnnotations || isImages || isVideos || isVideoFrames
+    );
+    const dimensionsCollectionId = $derived(
+        getDimensionsCollectionId({
+            collectionId,
+            collectionSampleType: collection.sample_type,
+            parentCollection
+        })
+    );
+    const dimensionsCollectionIdStore = toStore(() => dimensionsCollectionId);
+    const metadataCollectionId = $derived(
+        getMetadataCollectionId({
+            collectionId,
+            collectionSampleType: collection.sample_type,
+            parentCollection
+        })
     );
 
     let gridType = $state<GridType>('images');
@@ -300,9 +317,9 @@
     );
 
     const { metadataValues, metadataBounds, updateMetadataValues } = $derived.by(() =>
-        useMetadataFilters(collectionId)
+        useMetadataFilters(metadataCollectionId)
     );
-    const { dimensionsValues } = useDimensions(collectionIdStore);
+    const { dimensionsValues } = useDimensions(dimensionsCollectionIdStore);
 
     const annotationLabelsQuery = useAnnotationLabels(() => ({
         collectionId: collectionId ?? ''

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getDimensionsCollectionId.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getDimensionsCollectionId.test.ts
@@ -1,0 +1,34 @@
+import { SampleType } from '$lib/api/lightly_studio_local/types.gen';
+import { getDimensionsCollectionId } from './getDimensionsCollectionId';
+
+describe('getDimensionsCollectionId', () => {
+    it('uses the image collection for image and image-annotation views only', () => {
+        expect(
+            getDimensionsCollectionId({
+                collectionId: 'images',
+                collectionSampleType: SampleType.IMAGE,
+                parentCollection: null
+            })
+        ).toBe('images');
+        expect(
+            getDimensionsCollectionId({
+                collectionId: 'annotations',
+                collectionSampleType: SampleType.ANNOTATION,
+                parentCollection: {
+                    collectionId: 'images',
+                    sampleType: SampleType.IMAGE
+                }
+            })
+        ).toBe('images');
+        expect(
+            getDimensionsCollectionId({
+                collectionId: 'annotations',
+                collectionSampleType: SampleType.ANNOTATION,
+                parentCollection: {
+                    collectionId: 'frames',
+                    sampleType: SampleType.VIDEO_FRAME
+                }
+            })
+        ).toBeUndefined();
+    });
+});

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getDimensionsCollectionId.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getDimensionsCollectionId.test.ts
@@ -31,4 +31,27 @@ describe('getDimensionsCollectionId', () => {
             })
         ).toBeUndefined();
     });
+
+    it('uses the parent image collection for caption views', () => {
+        expect(
+            getDimensionsCollectionId({
+                collectionId: 'captions',
+                collectionSampleType: SampleType.CAPTION,
+                parentCollection: {
+                    collectionId: 'images',
+                    sampleType: SampleType.IMAGE
+                }
+            })
+        ).toBe('images');
+        expect(
+            getDimensionsCollectionId({
+                collectionId: 'captions',
+                collectionSampleType: SampleType.CAPTION,
+                parentCollection: {
+                    collectionId: 'frames',
+                    sampleType: SampleType.VIDEO_FRAME
+                }
+            })
+        ).toBeUndefined();
+    });
 });

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getDimensionsCollectionId.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getDimensionsCollectionId.ts
@@ -1,0 +1,30 @@
+import {
+    SampleType,
+    type SampleType as SampleTypeValue
+} from '$lib/api/lightly_studio_local/types.gen';
+
+interface ParentCollection {
+    collectionId: string;
+    sampleType: SampleTypeValue;
+}
+
+interface GetDimensionsCollectionIdParams {
+    collectionId: string;
+    collectionSampleType: SampleTypeValue;
+    parentCollection: ParentCollection | null;
+}
+
+export const getDimensionsCollectionId = ({
+    collectionId,
+    collectionSampleType,
+    parentCollection
+}: GetDimensionsCollectionIdParams): string | undefined => {
+    if (collectionSampleType === SampleType.IMAGE) return collectionId;
+    if (
+        collectionSampleType === SampleType.ANNOTATION &&
+        parentCollection?.sampleType === SampleType.IMAGE
+    ) {
+        return parentCollection.collectionId;
+    }
+    return undefined;
+};

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getDimensionsCollectionId.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getDimensionsCollectionId.ts
@@ -21,7 +21,8 @@ export const getDimensionsCollectionId = ({
 }: GetDimensionsCollectionIdParams): string | undefined => {
     if (collectionSampleType === SampleType.IMAGE) return collectionId;
     if (
-        collectionSampleType === SampleType.ANNOTATION &&
+        (collectionSampleType === SampleType.ANNOTATION ||
+            collectionSampleType === SampleType.CAPTION) &&
         parentCollection?.sampleType === SampleType.IMAGE
     ) {
         return parentCollection.collectionId;

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getMetadataCollectionId.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getMetadataCollectionId.test.ts
@@ -1,0 +1,34 @@
+import { SampleType } from '$lib/api/lightly_studio_local/types.gen';
+import { getMetadataCollectionId } from './getMetadataCollectionId';
+
+describe('getMetadataCollectionId', () => {
+    it('uses the current collection for sample views', () => {
+        expect(
+            getMetadataCollectionId({
+                collectionId: 'images',
+                collectionSampleType: SampleType.IMAGE,
+                parentCollection: null
+            })
+        ).toBe('images');
+    });
+
+    it('uses the parent sample collection for annotation views', () => {
+        expect(
+            getMetadataCollectionId({
+                collectionId: 'annotations',
+                collectionSampleType: SampleType.ANNOTATION,
+                parentCollection: { collectionId: 'images' }
+            })
+        ).toBe('images');
+    });
+
+    it('falls back to the annotation collection when no parent is available', () => {
+        expect(
+            getMetadataCollectionId({
+                collectionId: 'annotations',
+                collectionSampleType: SampleType.ANNOTATION,
+                parentCollection: null
+            })
+        ).toBe('annotations');
+    });
+});

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getMetadataCollectionId.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getMetadataCollectionId.test.ts
@@ -31,4 +31,24 @@ describe('getMetadataCollectionId', () => {
             })
         ).toBe('annotations');
     });
+
+    it('uses the parent sample collection for caption views', () => {
+        expect(
+            getMetadataCollectionId({
+                collectionId: 'captions',
+                collectionSampleType: SampleType.CAPTION,
+                parentCollection: { collectionId: 'images' }
+            })
+        ).toBe('images');
+    });
+
+    it('falls back to the caption collection when no parent is available', () => {
+        expect(
+            getMetadataCollectionId({
+                collectionId: 'captions',
+                collectionSampleType: SampleType.CAPTION,
+                parentCollection: null
+            })
+        ).toBe('captions');
+    });
 });

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getMetadataCollectionId.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getMetadataCollectionId.ts
@@ -18,11 +18,7 @@ export const getMetadataCollectionId = ({
     collectionSampleType,
     parentCollection
 }: GetMetadataCollectionIdParams): string => {
-    if (
-        (collectionSampleType === SampleType.ANNOTATION ||
-            collectionSampleType === SampleType.CAPTION) &&
-        parentCollection
-    ) {
+    if (collectionSampleType !== SampleType.IMAGE && parentCollection) {
         return parentCollection.collectionId;
     }
     return collectionId;

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getMetadataCollectionId.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getMetadataCollectionId.ts
@@ -1,0 +1,25 @@
+import {
+    SampleType,
+    type SampleType as SampleTypeValue
+} from '$lib/api/lightly_studio_local/types.gen';
+
+interface ParentCollection {
+    collectionId: string;
+}
+
+interface GetMetadataCollectionIdParams {
+    collectionId: string;
+    collectionSampleType: SampleTypeValue;
+    parentCollection: ParentCollection | null;
+}
+
+export const getMetadataCollectionId = ({
+    collectionId,
+    collectionSampleType,
+    parentCollection
+}: GetMetadataCollectionIdParams): string => {
+    if (collectionSampleType === SampleType.ANNOTATION && parentCollection) {
+        return parentCollection.collectionId;
+    }
+    return collectionId;
+};

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getMetadataCollectionId.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/getMetadataCollectionId.ts
@@ -18,7 +18,11 @@ export const getMetadataCollectionId = ({
     collectionSampleType,
     parentCollection
 }: GetMetadataCollectionIdParams): string => {
-    if (collectionSampleType === SampleType.ANNOTATION && parentCollection) {
+    if (
+        (collectionSampleType === SampleType.ANNOTATION ||
+            collectionSampleType === SampleType.CAPTION) &&
+        parentCollection
+    ) {
         return parentCollection.collectionId;
     }
     return collectionId;


### PR DESCRIPTION
## What has changed and why?

This PR introduces changes required to render dataset distribution panel with categorical metadata values

## How has it been tested?

Accompanied by unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added categorical metadata filter chips alongside numeric range chips, including toggle/clear behavior, formatted categorical labels, and remembered selections.
  * Enabled categorical filtering end-to-end across image, video, and frame filter flows, with dimensions and metadata scoped to their respective derived collection IDs.
* **Bug Fixes**
  * Missing categorical values are now represented as `null` in filter predicates and chip labels.
  * Improved dimension-bounds loading validation with clearer errors for incomplete responses.
* **Tests**
  * Expanded unit coverage for chip rendering, categorical filter request construction, query-key generation, and selection persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->