### PR TITLE
Backend, Part 1: Add TableParameter to the plugin parameter types

### DIFF
--- a/lightly_studio/src/lightly_studio/plugins/parameter.py
+++ b/lightly_studio/src/lightly_studio/plugins/parameter.py
@@ -35,7 +35,6 @@ class BuiltinParameter(BaseParameter, Generic[T]):
 
     def __post_init__(self) -> None:
         """Set up type information and validate default value."""
-        
         if not hasattr(self, "_parameter_type") or self._parameter_type is None:
             raise NotImplementedError("Subclasses must define _parameter_type class attribute")
         self._type = self._parameter_type

--- a/lightly_studio/src/lightly_studio/plugins/parameter.py
+++ b/lightly_studio/src/lightly_studio/plugins/parameter.py
@@ -79,9 +79,10 @@ class StringParameter(BuiltinParameter[str]):
 class TableParameter(BaseParameter):
     """Represents a tabular operator parameter.
 
-    The value is a list of rows, where each row maps every column name to a string cell. Use it
-    when an operator needs a variable number of homogeneous multi-field inputs, for example
-    segmentation prompts paired with the annotation label to assign to the resulting masks:
+    The value is a list of rows, where each row maps every column name to a cell of that column's
+    type. Use it when an operator needs a variable number of homogeneous multi-field inputs, for
+    example segmentation prompts paired with the annotation label to assign to the resulting masks
+    and the confidence threshold to apply:
 
     ```python
     TableParameter(
@@ -90,41 +91,78 @@ class TableParameter(BaseParameter):
         columns=[
             StringParameter(name="prompt", description="What to segment."),
             StringParameter(name="label", default="pedestrian", required=False),
+            FloatParameter(name="threshold", default=0.5, required=False),
         ],
     )
     ```
 
-    Every column is a `StringParameter`, so a column ships its own description, default and
-    required flag. The GUI renders one editable text column per entry, pre-fills new cells with the
-    column default and lets the user add and remove rows.
+    A column is any built-in parameter, so it carries its own type, description, default and
+    required flag. The GUI renders one editable column per entry using the editor for the column
+    type, pre-fills new cells with the column default and lets the user add and remove rows. Tables
+    cannot be nested because the GUI cannot render a table inside a cell.
 
     Attributes:
         columns: The columns every row must provide. At least one column is required.
     """
 
-    columns: Sequence[StringParameter] = field(default_factory=tuple)
+    columns: Sequence[BuiltinParameter[Any]] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
         """Set up type information, check the columns and validate the default value.
 
         Raises:
-            TypeError: If a column is not a `StringParameter`.
+            TypeError: If a column is not a `BuiltinParameter`.
             ValueError: If ``columns`` is empty or contains duplicate names.
         """
         self.param_type = "table"
         self.columns = _validated_columns(name=self.name, columns=self.columns)
         super().__post_init__()
 
-    def _validate(self, value: Any) -> list[dict[str, str]]:
+    def _validate(self, value: Any) -> list[dict[str, Any]]:
         if not isinstance(value, list):
             raise TypeError(f"Expected value of type 'list' but got {type(value)}")
         columns = _validated_columns(name=self.name, columns=self.columns)
         return [
-            _validated_row(row=row, index=index, columns=columns) for index, row in enumerate(value)
+            self._validated_row(row=row, index=index, columns=columns)
+            for index, row in enumerate(value)
         ]
 
+    def _validated_row(
+        self, row: Any, index: int, columns: Sequence[BuiltinParameter[Any]]
+    ) -> dict[str, Any]:
+        """Check a single row of the table value, validating each cell against its column.
 
-def _validated_columns(name: str, columns: Sequence[StringParameter]) -> list[StringParameter]:
+        Args:
+            row: The row to check.
+            index: Position of the row in the value, used in error messages.
+            columns: The columns the row must provide.
+
+        Returns:
+            The row with its cells ordered like `columns`.
+
+        Raises:
+            TypeError: If `row` is not a dict or a cell does not have the type of its column.
+            ValueError: If the keys of `row` do not match the column names exactly.
+        """
+        if not isinstance(row, dict):
+            raise TypeError(f"Expected row {index} of type 'dict' but got {type(row)}")
+        column_names = [column.name for column in columns]
+        if set(row) != set(column_names):
+            raise ValueError(
+                f"Row {index} must have exactly the columns {column_names} but got {sorted(row)}"
+            )
+        validated_row = {}
+        for column in columns:
+            try:
+                validated_row[column.name] = column._validate(row[column.name])  # noqa: SLF001
+            except TypeError as ex:
+                raise TypeError(f"Invalid cell '{column.name}' in row {index}: {ex}") from ex
+        return validated_row
+
+
+def _validated_columns(
+    name: str, columns: Sequence[BuiltinParameter[Any]]
+) -> list[BuiltinParameter[Any]]:
     """Check the columns of a table parameter.
 
     Args:
@@ -135,48 +173,17 @@ def _validated_columns(name: str, columns: Sequence[StringParameter]) -> list[St
         The columns as a list.
 
     Raises:
-        TypeError: If a column is not a `StringParameter`.
+        TypeError: If a column is not a `BuiltinParameter`.
         ValueError: If `columns` is empty or contains duplicate names.
     """
     if not columns:
         raise ValueError(f"Table parameter '{name}' must define at least one column")
     for column in columns:
-        if not isinstance(column, StringParameter):
-            raise TypeError(f"Expected column of type 'StringParameter' but got {type(column)}")
+        if not isinstance(column, BuiltinParameter):
+            raise TypeError(f"Expected column of type 'BuiltinParameter' but got {type(column)}")
     column_names = [column.name for column in columns]
     if len(set(column_names)) != len(column_names):
         raise ValueError(
             f"Columns of table parameter '{name}' must be unique but got {column_names}"
         )
     return list(columns)
-
-
-def _validated_row(row: Any, index: int, columns: Sequence[StringParameter]) -> dict[str, str]:
-    """Check a single row of a table parameter value.
-
-    Args:
-        row: The row to check.
-        index: Position of the row in the value, used in error messages.
-        columns: The columns the row must provide.
-
-    Returns:
-        The row with its cells ordered like `columns`.
-
-    Raises:
-        TypeError: If `row` is not a dict or a cell is not a string.
-        ValueError: If the keys of `row` do not match the column names exactly.
-    """
-    if not isinstance(row, dict):
-        raise TypeError(f"Expected row {index} of type 'dict' but got {type(row)}")
-    column_names = [column.name for column in columns]
-    if set(row) != set(column_names):
-        raise ValueError(
-            f"Row {index} must have exactly the columns {column_names} but got {sorted(row)}"
-        )
-    for column_name in column_names:
-        if not isinstance(row[column_name], str):
-            raise TypeError(
-                f"Expected cell '{column_name}' in row {index} of type 'str' "
-                f"but got {type(row[column_name])}"
-            )
-    return {column_name: row[column_name] for column_name in column_names}

--- a/lightly_studio/src/lightly_studio/plugins/parameter.py
+++ b/lightly_studio/src/lightly_studio/plugins/parameter.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from collections.abc import Sequence
+from dataclasses import dataclass, field
 from typing import Any, Generic, TypeVar
 
 T = TypeVar("T")
@@ -33,7 +34,11 @@ class BuiltinParameter(BaseParameter, Generic[T]):
     """Represents a built-in operator parameter."""
 
     def __post_init__(self) -> None:
-        """Set up type information and validate default value."""
+        """Set up type information and validate default value.
+
+        Raises:
+            NotImplementedError: If the subclass does not define ``_parameter_type``.
+        """
         if not hasattr(self, "_parameter_type") or self._parameter_type is None:
             raise NotImplementedError("Subclasses must define _parameter_type class attribute")
         self._type = self._parameter_type
@@ -68,3 +73,110 @@ class StringParameter(BuiltinParameter[str]):
     """Represents a string operator parameter."""
 
     _parameter_type = str
+
+
+@dataclass
+class TableParameter(BaseParameter):
+    """Represents a tabular operator parameter.
+
+    The value is a list of rows, where each row maps every column name to a string cell. Use it
+    when an operator needs a variable number of homogeneous multi-field inputs, for example
+    segmentation prompts paired with the annotation label to assign to the resulting masks:
+
+    ```python
+    TableParameter(
+        name="prompts",
+        description="Prompt to segment with and the label to assign to the masks.",
+        columns=[
+            StringParameter(name="prompt", description="What to segment."),
+            StringParameter(name="label", default="pedestrian", required=False),
+        ],
+    )
+    ```
+
+    Every column is a `StringParameter`, so a column ships its own description, default and
+    required flag. The GUI renders one editable text column per entry, pre-fills new cells with the
+    column default and lets the user add and remove rows.
+
+    Attributes:
+        columns: The columns every row must provide. At least one column is required.
+    """
+
+    columns: Sequence[StringParameter] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        """Set up type information, check the columns and validate the default value.
+
+        Raises:
+            TypeError: If a column is not a `StringParameter`.
+            ValueError: If ``columns`` is empty or contains duplicate names.
+        """
+        self.param_type = "table"
+        self.columns = _validated_columns(name=self.name, columns=self.columns)
+        super().__post_init__()
+
+    def _validate(self, value: Any) -> list[dict[str, str]]:
+        if not isinstance(value, list):
+            raise TypeError(f"Expected value of type 'list' but got {type(value)}")
+        columns = _validated_columns(name=self.name, columns=self.columns)
+        return [
+            _validated_row(row=row, index=index, columns=columns) for index, row in enumerate(value)
+        ]
+
+
+def _validated_columns(name: str, columns: Sequence[StringParameter]) -> list[StringParameter]:
+    """Check the columns of a table parameter.
+
+    Args:
+        name: Name of the parameter, used in error messages.
+        columns: The columns to check.
+
+    Returns:
+        The columns as a list.
+
+    Raises:
+        TypeError: If a column is not a `StringParameter`.
+        ValueError: If `columns` is empty or contains duplicate names.
+    """
+    if not columns:
+        raise ValueError(f"Table parameter '{name}' must define at least one column")
+    for column in columns:
+        if not isinstance(column, StringParameter):
+            raise TypeError(f"Expected column of type 'StringParameter' but got {type(column)}")
+    column_names = [column.name for column in columns]
+    if len(set(column_names)) != len(column_names):
+        raise ValueError(
+            f"Columns of table parameter '{name}' must be unique but got {column_names}"
+        )
+    return list(columns)
+
+
+def _validated_row(row: Any, index: int, columns: Sequence[StringParameter]) -> dict[str, str]:
+    """Check a single row of a table parameter value.
+
+    Args:
+        row: The row to check.
+        index: Position of the row in the value, used in error messages.
+        columns: The columns the row must provide.
+
+    Returns:
+        The row with its cells ordered like `columns`.
+
+    Raises:
+        TypeError: If `row` is not a dict or a cell is not a string.
+        ValueError: If the keys of `row` do not match the column names exactly.
+    """
+    if not isinstance(row, dict):
+        raise TypeError(f"Expected row {index} of type 'dict' but got {type(row)}")
+    column_names = [column.name for column in columns]
+    if set(row) != set(column_names):
+        raise ValueError(
+            f"Row {index} must have exactly the columns {column_names} but got {sorted(row)}"
+        )
+    for column_name in column_names:
+        if not isinstance(row[column_name], str):
+            raise TypeError(
+                f"Expected cell '{column_name}' in row {index} of type 'str' "
+                f"but got {type(row[column_name])}"
+            )
+    return {column_name: row[column_name] for column_name in column_names}

--- a/lightly_studio/src/lightly_studio/plugins/parameter.py
+++ b/lightly_studio/src/lightly_studio/plugins/parameter.py
@@ -111,24 +111,17 @@ class TableParameter(BaseParameter):
     def _validate(self, value: Any) -> list[dict[str, Any]]:
         if not isinstance(value, list):
             raise TypeError(f"Expected value of type 'list' but got {type(value)}")
-        columns = _validated_columns(name=self.name, columns=self.columns)
-        return [
-            self._validated_row(row=row, index=index, columns=columns)
-            for index, row in enumerate(value)
-        ]
+        return [self._validated_row(row=row, index=index) for index, row in enumerate(value)]
 
-    def _validated_row(
-        self, row: Any, index: int, columns: Sequence[BuiltinParameter[Any]]
-    ) -> dict[str, Any]:
+    def _validated_row(self, row: Any, index: int) -> dict[str, Any]:
         """Check a single row of the table value, validating each cell against its column.
 
         Args:
             row: The row to check.
             index: Position of the row in the value, used in error messages.
-            columns: The columns the row must provide.
 
         Returns:
-            The row with its cells ordered like `columns`.
+            The row with its cells ordered like `self.columns`.
 
         Raises:
             TypeError: If `row` is not a dict or a cell does not have the type of its column.
@@ -136,13 +129,13 @@ class TableParameter(BaseParameter):
         """
         if not isinstance(row, dict):
             raise TypeError(f"Expected row {index} of type 'dict' but got {type(row)}")
-        column_names = [column.name for column in columns]
+        column_names = [column.name for column in self.columns]
         if set(row) != set(column_names):
             raise ValueError(
                 f"Row {index} must have exactly the columns {column_names} but got {list(row)}"
             )
         validated_row = {}
-        for column in columns:
+        for column in self.columns:
             try:
                 validated_row[column.name] = column._validate(row[column.name])  # noqa: SLF001
             except TypeError as ex:

--- a/lightly_studio/src/lightly_studio/plugins/parameter.py
+++ b/lightly_studio/src/lightly_studio/plugins/parameter.py
@@ -34,11 +34,8 @@ class BuiltinParameter(BaseParameter, Generic[T]):
     """Represents a built-in operator parameter."""
 
     def __post_init__(self) -> None:
-        """Set up type information and validate default value.
-
-        Raises:
-            NotImplementedError: If the subclass does not define ``_parameter_type``.
-        """
+        """Set up type information and validate default value."""
+        
         if not hasattr(self, "_parameter_type") or self._parameter_type is None:
             raise NotImplementedError("Subclasses must define _parameter_type class attribute")
         self._type = self._parameter_type
@@ -80,9 +77,7 @@ class TableParameter(BaseParameter):
     """Represents a tabular operator parameter.
 
     The value is a list of rows, where each row maps every column name to a cell of that column's
-    type. Use it when an operator needs a variable number of homogeneous multi-field inputs, for
-    example segmentation prompts paired with the annotation label to assign to the resulting masks
-    and the confidence threshold to apply:
+    type. Use it for a variable number of multi-field inputs:
 
     ```python
     TableParameter(
@@ -96,13 +91,9 @@ class TableParameter(BaseParameter):
     )
     ```
 
-    A column is any built-in parameter, so it carries its own type, description, default and
-    required flag. The GUI renders one editable column per entry using the editor for the column
-    type, pre-fills new cells with the column default and lets the user add and remove rows. Tables
-    cannot be nested because the GUI cannot render a table inside a cell.
-
     Attributes:
-        columns: The columns every row must provide. At least one column is required.
+        columns: The columns every row must provide. Must be non-empty built-in parameters with
+            unique names. Tables cannot be nested.
     """
 
     columns: Sequence[BuiltinParameter[Any]] = field(default_factory=tuple)

--- a/lightly_studio/src/lightly_studio/plugins/parameter.py
+++ b/lightly_studio/src/lightly_studio/plugins/parameter.py
@@ -139,7 +139,7 @@ class TableParameter(BaseParameter):
         column_names = [column.name for column in columns]
         if set(row) != set(column_names):
             raise ValueError(
-                f"Row {index} must have exactly the columns {column_names} but got {sorted(row)}"
+                f"Row {index} must have exactly the columns {column_names} but got {list(row)}"
             )
         validated_row = {}
         for column in columns:

--- a/lightly_studio/tests/plugins/test_parameter.py
+++ b/lightly_studio/tests/plugins/test_parameter.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import asdict
 
 import pytest
@@ -5,6 +6,8 @@ import pytest
 from lightly_studio.plugins.parameter import (
     FloatParameter,
     IntParameter,
+    StringParameter,
+    TableParameter,
 )
 
 
@@ -35,3 +38,185 @@ def test_builtin_parameters() -> None:
         _ = IntParameter(name="test_int", default=42.0)
     with pytest.raises(TypeError, match="Expected value of type 'float' but got <class 'int'>"):
         _ = FloatParameter(name="test_float", default=42)
+
+
+class TestTableParameter:
+    def test_init(self) -> None:
+        param = TableParameter(
+            name="prompts",
+            description="abc",
+            columns=[StringParameter(name="prompt"), StringParameter(name="label")],
+            default=[{"prompt": "person", "label": "pedestrian"}],
+            required=False,
+        )
+
+        assert asdict(param) == {
+            "name": "prompts",
+            "description": "abc",
+            "default": [{"prompt": "person", "label": "pedestrian"}],
+            "required": False,
+            "param_type": "table",
+            "columns": [
+                {
+                    "name": "prompt",
+                    "description": "",
+                    "default": None,
+                    "required": True,
+                    "param_type": "str",
+                },
+                {
+                    "name": "label",
+                    "description": "",
+                    "default": None,
+                    "required": True,
+                    "param_type": "str",
+                },
+            ],
+        }
+
+    def test_init__no_default(self) -> None:
+        param = TableParameter(
+            name="prompts",
+            columns=[StringParameter(name="prompt"), StringParameter(name="label")],
+        )
+
+        assert param.default is None
+        assert [column.name for column in param.columns] == ["prompt", "label"]
+
+    def test_init__column_default_and_required(self) -> None:
+        # A column carries its own default and required flag, which the GUI uses to pre-fill new
+        # cells and to decide which cells must be filled in.
+        param = TableParameter(
+            name="prompts",
+            columns=[
+                StringParameter(name="prompt"),
+                StringParameter(name="label", default="pedestrian", required=False),
+            ],
+        )
+
+        assert param.columns[0].default is None
+        assert param.columns[0].required
+        assert param.columns[1].default == "pedestrian"
+        assert not param.columns[1].required
+
+    def test_init__empty_default(self) -> None:
+        # An empty table is a valid default and must not be confused with "no default".
+        param = TableParameter(name="prompts", columns=[StringParameter(name="prompt")], default=[])
+
+        assert param.default == []
+
+    def test_init__default_cells_ordered_like_columns(self) -> None:
+        param = TableParameter(
+            name="prompts",
+            columns=[StringParameter(name="prompt"), StringParameter(name="label")],
+            default=[{"label": "pedestrian", "prompt": "person"}],
+        )
+
+        assert list(param.default[0]) == ["prompt", "label"]
+
+    def test_init__missing_columns(self) -> None:
+        with pytest.raises(
+            ValueError, match="Table parameter 'prompts' must define at least one column"
+        ):
+            _ = TableParameter(name="prompts")
+
+    def test_init__empty_columns(self) -> None:
+        with pytest.raises(
+            ValueError, match="Table parameter 'prompts' must define at least one column"
+        ):
+            _ = TableParameter(name="prompts", columns=[])
+
+    def test_init__duplicate_columns(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Columns of table parameter 'prompts' must be unique but got ['prompt', 'prompt']"
+            ),
+        ):
+            _ = TableParameter(
+                name="prompts",
+                columns=[StringParameter(name="prompt"), StringParameter(name="prompt")],
+            )
+
+    def test_init__column_not_a_parameter(self) -> None:
+        with pytest.raises(
+            TypeError,
+            match=re.escape("Expected column of type 'StringParameter' but got <class 'str'>"),
+        ):
+            _ = TableParameter(name="prompts", columns=["prompt"])  # type: ignore[list-item]
+
+    def test_init__nested_table_column(self) -> None:
+        # A table inside a table is not supported by the GUI, so it must fail loudly instead of
+        # being rendered as an empty column.
+        nested = TableParameter(name="nested", columns=[StringParameter(name="prompt")])
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "Expected column of type 'StringParameter' but got "
+                "<class 'lightly_studio.plugins.parameter.TableParameter'>"
+            ),
+        ):
+            _ = TableParameter(name="prompts", columns=[nested])  # type: ignore[list-item]
+
+    def test_init__default_not_a_list(self) -> None:
+        with pytest.raises(
+            TypeError, match=re.escape("Expected value of type 'list' but got <class 'dict'>")
+        ):
+            _ = TableParameter(
+                name="prompts",
+                columns=[StringParameter(name="prompt")],
+                default={"prompt": "person"},
+            )
+
+    def test_init__row_not_a_dict(self) -> None:
+        with pytest.raises(
+            TypeError, match=re.escape("Expected row 0 of type 'dict' but got <class 'str'>")
+        ):
+            _ = TableParameter(
+                name="prompts", columns=[StringParameter(name="prompt")], default=["person"]
+            )
+
+    def test_init__missing_column(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Row 0 must have exactly the columns ['prompt', 'label'] but got ['prompt']"
+            ),
+        ):
+            _ = TableParameter(
+                name="prompts",
+                columns=[StringParameter(name="prompt"), StringParameter(name="label")],
+                default=[{"prompt": "person"}],
+            )
+
+    def test_init__extra_column(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Row 0 must have exactly the columns ['prompt'] but got ['confidence', 'prompt']"
+            ),
+        ):
+            _ = TableParameter(
+                name="prompts",
+                columns=[StringParameter(name="prompt")],
+                default=[{"prompt": "person", "confidence": "0.5"}],
+            )
+
+    def test_init__cell_not_a_string(self) -> None:
+        with pytest.raises(
+            TypeError,
+            match=re.escape("Expected cell 'prompt' in row 0 of type 'str' but got <class 'int'>"),
+        ):
+            _ = TableParameter(
+                name="prompts", columns=[StringParameter(name="prompt")], default=[{"prompt": 1}]
+            )
+
+    def test_init__reports_second_row_index(self) -> None:
+        # The row index in the message must point at the offending row, not always row 0.
+        with pytest.raises(ValueError, match="Row 1 must have exactly"):
+            _ = TableParameter(
+                name="prompts",
+                columns=[StringParameter(name="prompt")],
+                default=[{"prompt": "person"}, {}],
+            )

--- a/lightly_studio/tests/plugins/test_parameter.py
+++ b/lightly_studio/tests/plugins/test_parameter.py
@@ -4,6 +4,7 @@ from dataclasses import asdict
 import pytest
 
 from lightly_studio.plugins.parameter import (
+    BoolParameter,
     FloatParameter,
     IntParameter,
     StringParameter,
@@ -141,7 +142,7 @@ class TestTableParameter:
     def test_init__column_not_a_parameter(self) -> None:
         with pytest.raises(
             TypeError,
-            match=re.escape("Expected column of type 'StringParameter' but got <class 'str'>"),
+            match=re.escape("Expected column of type 'BuiltinParameter' but got <class 'str'>"),
         ):
             _ = TableParameter(name="prompts", columns=["prompt"])  # type: ignore[list-item]
 
@@ -153,7 +154,7 @@ class TestTableParameter:
         with pytest.raises(
             TypeError,
             match=re.escape(
-                "Expected column of type 'StringParameter' but got "
+                "Expected column of type 'BuiltinParameter' but got "
                 "<class 'lightly_studio.plugins.parameter.TableParameter'>"
             ),
         ):
@@ -203,13 +204,34 @@ class TestTableParameter:
                 default=[{"prompt": "person", "confidence": "0.5"}],
             )
 
-    def test_init__cell_not_a_string(self) -> None:
+    def test_init__mixed_column_types(self) -> None:
+        param = TableParameter(
+            name="prompts",
+            columns=[
+                StringParameter(name="prompt"),
+                FloatParameter(name="threshold"),
+                IntParameter(name="max_masks"),
+                BoolParameter(name="enabled"),
+            ],
+            default=[{"prompt": "person", "threshold": 0.5, "max_masks": 3, "enabled": True}],
+        )
+
+        assert param.default == [
+            {"prompt": "person", "threshold": 0.5, "max_masks": 3, "enabled": True}
+        ]
+
+    def test_init__cell_type_does_not_match_column(self) -> None:
         with pytest.raises(
             TypeError,
-            match=re.escape("Expected cell 'prompt' in row 0 of type 'str' but got <class 'int'>"),
+            match=re.escape(
+                "Invalid cell 'threshold' in row 0: Expected value of type 'float' but got "
+                "<class 'str'>"
+            ),
         ):
             _ = TableParameter(
-                name="prompts", columns=[StringParameter(name="prompt")], default=[{"prompt": 1}]
+                name="prompts",
+                columns=[FloatParameter(name="threshold")],
+                default=[{"threshold": "0.5"}],
             )
 
     def test_init__reports_second_row_index(self) -> None:

--- a/lightly_studio/tests/plugins/test_parameter.py
+++ b/lightly_studio/tests/plugins/test_parameter.py
@@ -115,6 +115,22 @@ class TestTableParameter:
 
         assert list(param.default[0]) == ["prompt", "label"]
 
+    def test_init__mixed_column_types(self) -> None:
+        param = TableParameter(
+            name="prompts",
+            columns=[
+                StringParameter(name="prompt"),
+                FloatParameter(name="threshold"),
+                IntParameter(name="max_masks"),
+                BoolParameter(name="enabled"),
+            ],
+            default=[{"prompt": "person", "threshold": 0.5, "max_masks": 3, "enabled": True}],
+        )
+
+        assert param.default == [
+            {"prompt": "person", "threshold": 0.5, "max_masks": 3, "enabled": True}
+        ]
+
     def test_init__missing_columns(self) -> None:
         with pytest.raises(
             ValueError, match="Table parameter 'prompts' must define at least one column"
@@ -203,22 +219,6 @@ class TestTableParameter:
                 columns=[StringParameter(name="prompt")],
                 default=[{"prompt": "person", "confidence": "0.5"}],
             )
-
-    def test_init__mixed_column_types(self) -> None:
-        param = TableParameter(
-            name="prompts",
-            columns=[
-                StringParameter(name="prompt"),
-                FloatParameter(name="threshold"),
-                IntParameter(name="max_masks"),
-                BoolParameter(name="enabled"),
-            ],
-            default=[{"prompt": "person", "threshold": 0.5, "max_masks": 3, "enabled": True}],
-        )
-
-        assert param.default == [
-            {"prompt": "person", "threshold": 0.5, "max_masks": 3, "enabled": True}
-        ]
 
     def test_init__cell_type_does_not_match_column(self) -> None:
         with pytest.raises(

--- a/lightly_studio/tests/plugins/test_parameter.py
+++ b/lightly_studio/tests/plugins/test_parameter.py
@@ -195,7 +195,7 @@ class TestTableParameter:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "Row 0 must have exactly the columns ['prompt'] but got ['confidence', 'prompt']"
+                "Row 0 must have exactly the columns ['prompt'] but got ['prompt', 'confidence']"
             ),
         ):
             _ = TableParameter(


### PR DESCRIPTION
## What has changed and why?

Adds a new `TableParameter` type to the plugin parameter types (backend part 1).

Operators sometimes need a variable number of homogeneous multi-field inputs — e.g. a list of segmentation prompts, each paired with the annotation label to assign to the resulting masks and a confidence threshold. The existing scalar parameters (`Int`/`Float`/`Bool`/`StringParameter`) can't express that.

`TableParameter` holds a list of rows, where each row maps every column name to a cell of that column's type:

```python
TableParameter(
    name="prompts",
    description="Prompt to segment with and the label to assign to the masks.",
    columns=[
        StringParameter(name="prompt", description="What to segment."),
        StringParameter(name="label", default="pedestrian", required=False),
        FloatParameter(name="threshold", default=0.5, required=False),
    ],
)
```

Details:

- A column is any built-in parameter (`Int`/`Float`/`Bool`/`StringParameter`), so each column carries its own type, description, default and required flag. Cell validation is delegated to the column's own parameter, so types stay in one place.
- Columns are validated at construction: at least one column, no duplicate names, and every column must be a `BuiltinParameter` (nested tables fail loudly rather than rendering as an empty column).
- Row validation reports the offending row index and column name, and normalizes cell ordering to match the declared column order.

No API/frontend changes yet — this is backend-only groundwork. Note for the follow-up GUI PR: since columns are typed, the table editor needs a per-type cell editor, not just text inputs.

## How has it been tested?

New unit tests in `lightly_studio/tests/plugins/test_parameter.py` covering:

- `asdict()` serialization of a table parameter incl. its nested columns
- column defaults / required flags, no-default and empty-list-default cases
- cell ordering normalized to the column order
- a mixed-type table (string/float/int/bool columns) validating through its defaults
- error cases: missing/empty columns, duplicate column names, non-`BuiltinParameter` column, nested `TableParameter` column, non-list default, non-dict row, missing/extra column in a row, cell type not matching its column, and correct row index reporting for a later row

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for table-based parameters with configurable built-in columns.
  * Table values now validate column definitions, row structure, required fields, and cell types.
  * Preserves the configured column order and provides clear error messages identifying invalid rows and values.

* **Tests**
  * Added comprehensive coverage for table serialization, defaults, configuration, supported column types, and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->