### PR TITLE
Backend, Part 2: expose operator parameter columns over the API

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/operator.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/operator.py
@@ -14,10 +14,27 @@ from lightly_studio.plugins import operator_context
 from lightly_studio.plugins.base_operator import OperatorResult, OperatorStatus
 from lightly_studio.plugins.operator_context import AnyFilter, ExecutionContext
 from lightly_studio.plugins.operator_registry import RegisteredOperatorMetadata, operator_registry
-from lightly_studio.plugins.parameter import BaseParameter
+from lightly_studio.plugins.parameter import BaseParameter, TableParameter
 from lightly_studio.resolvers import collection_resolver
 
 operator_router = APIRouter(prefix="/operators", tags=["operators"])
+
+
+class ParameterColumnView(BaseModel):
+    """A single column of a table parameter as exposed to the GUI."""
+
+    name: str
+    description: str
+    default: Any = None
+    required: bool
+    param_type: str | None
+
+
+class ParameterView(ParameterColumnView):
+    """An operator parameter as exposed to the GUI."""
+
+    columns: list[ParameterColumnView] | None = None
+    """The columns of a table parameter, `None` for every other parameter type."""
 
 
 class OperatorContextRequest(BaseModel):
@@ -44,7 +61,7 @@ def get_operators() -> list[RegisteredOperatorMetadata]:
 
 
 @operator_router.get("/{operator_id}/parameters")
-def get_operator_parameters(operator_id: str) -> list[BaseParameter]:
+def get_operator_parameters(operator_id: str) -> list[ParameterView]:
     """Get the parameters for a registered operator."""
     operator = operator_registry.get_by_id(operator_id=operator_id)
     if operator is None:
@@ -52,7 +69,7 @@ def get_operator_parameters(operator_id: str) -> list[BaseParameter]:
             status_code=HTTP_STATUS_NOT_FOUND,
             detail=f"Operator '{operator_id}' not found",
         )
-    return operator.parameters
+    return [_parameter_view(parameter=parameter) for parameter in operator.parameters]
 
 
 @operator_router.post("/{operator_id}/execute", response_model=OperatorResult)
@@ -120,4 +137,46 @@ def execute_operator(
             collection_id=context.collection_id, context_filter=context.context_filter
         ),
         parameters=request.parameters,
+    )
+
+
+def _parameter_view(parameter: BaseParameter) -> ParameterView:
+    """Convert an operator parameter into its API representation.
+
+    Args:
+        parameter: The parameter as declared by the operator.
+
+    Returns:
+        The parameter as exposed to the GUI, with the columns filled in for table parameters.
+    """
+    columns = (
+        [_parameter_column_view(parameter=column) for column in parameter.columns]
+        if isinstance(parameter, TableParameter)
+        else None
+    )
+    return ParameterView(
+        name=parameter.name,
+        description=parameter.description,
+        default=parameter.default,
+        required=parameter.required,
+        param_type=parameter.param_type,
+        columns=columns,
+    )
+
+
+def _parameter_column_view(parameter: BaseParameter) -> ParameterColumnView:
+    """Convert a table parameter column into its API representation.
+
+    Args:
+        parameter: The column as declared by the operator.
+
+    Returns:
+        The column as exposed to the GUI.
+    """
+    return ParameterColumnView(
+        name=parameter.name,
+        description=parameter.description,
+        default=parameter.default,
+        required=parameter.required,
+        param_type=parameter.param_type,
     )

--- a/lightly_studio/tests/api/routes/api/test_operator.py
+++ b/lightly_studio/tests/api/routes/api/test_operator.py
@@ -133,13 +133,6 @@ def test_get_operator_parameters__table_parameter(
     test_client: TestClient,
     isolated_operator_registry: OperatorRegistry,
 ) -> None:
-    """The full column definitions must reach the client.
-
-    Regression guard: `columns` lives on `TableParameter` only, so the route has to map the
-    parameters onto `ParameterView` to expose them. Returning the plugin dataclasses directly would
-    make pydantic serialize each item against the base class and silently drop the columns, leaving
-    the GUI without column information and without any error.
-    """
     isolated_operator_registry.register(TableParamsOperator(name="table"))
 
     operator_id = _get_operator_id_by_name(isolated_operator_registry, "table")
@@ -363,11 +356,6 @@ def test_execute_operator__table_parameter_rows_reach_the_operator(
     collection_id: UUID,
     isolated_operator_registry: OperatorRegistry,
 ) -> None:
-    """Table rows must arrive in `execute()` as a list of dicts.
-
-    `ExecuteOperatorRequest.parameters` is a `dict[str, Any]`, so the rows pass through untouched.
-    This pins that contract, since it is what plugins index into.
-    """
     operator = TableParamsOperator(name="table")
     isolated_operator_registry.register(operator)
     operator_id = _get_operator_id_by_name(isolated_operator_registry, "table")

--- a/lightly_studio/tests/api/routes/api/test_operator.py
+++ b/lightly_studio/tests/api/routes/api/test_operator.py
@@ -22,6 +22,7 @@ from lightly_studio.plugins.operator_registry import OperatorRegistry
 from lightly_studio.plugins.parameter import (
     BaseParameter,
     BoolParameter,
+    FloatParameter,
     StringParameter,
     TableParameter,
 )
@@ -144,7 +145,7 @@ def test_get_operator_parameters__table_parameter(
         {
             "name": "prompts",
             "description": "Prompts and labels.",
-            "default": [{"prompt": "person", "label": "pedestrian"}],
+            "default": [{"prompt": "person", "threshold": 0.5}],
             "required": True,
             "param_type": "table",
             "columns": [
@@ -156,11 +157,11 @@ def test_get_operator_parameters__table_parameter(
                     "param_type": "str",
                 },
                 {
-                    "name": "label",
+                    "name": "threshold",
                     "description": "",
-                    "default": "pedestrian",
+                    "default": 0.5,
                     "required": False,
-                    "param_type": "str",
+                    "param_type": "float",
                 },
             ],
         }
@@ -360,7 +361,7 @@ def test_execute_operator__table_parameter_rows_reach_the_operator(
     isolated_operator_registry.register(operator)
     operator_id = _get_operator_id_by_name(isolated_operator_registry, "table")
 
-    rows = [{"prompt": "person", "label": "pedestrian"}, {"prompt": "car", "label": "vehicle"}]
+    rows = [{"prompt": "person", "threshold": 0.5}, {"prompt": "car", "threshold": 0.25}]
     response = test_client.post(
         f"/api/operators/{operator_id}/execute",
         json={
@@ -470,9 +471,9 @@ class TableParamsOperator(TestOperator):
                 description="Prompts and labels.",
                 columns=[
                     StringParameter(name="prompt", description="What to segment."),
-                    StringParameter(name="label", default="pedestrian", required=False),
+                    FloatParameter(name="threshold", default=0.5, required=False),
                 ],
-                default=[{"prompt": "person", "label": "pedestrian"}],
+                default=[{"prompt": "person", "threshold": 0.5}],
             )
         ]
 

--- a/lightly_studio/tests/api/routes/api/test_operator.py
+++ b/lightly_studio/tests/api/routes/api/test_operator.py
@@ -19,7 +19,12 @@ from lightly_studio.models.collection import SampleType
 from lightly_studio.plugins.base_operator import BaseOperator, OperatorResult, OperatorStatus
 from lightly_studio.plugins.operator_context import ExecutionContext, OperatorScope
 from lightly_studio.plugins.operator_registry import OperatorRegistry
-from lightly_studio.plugins.parameter import BaseParameter, BoolParameter, StringParameter
+from lightly_studio.plugins.parameter import (
+    BaseParameter,
+    BoolParameter,
+    StringParameter,
+    TableParameter,
+)
 from lightly_studio.resolvers.image_filter import FilterDimensions, ImageFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from tests import helpers_resolvers
@@ -111,6 +116,7 @@ def test_get_operator_parameters__multiple_parameters(
             "default": None,
             "required": True,
             "param_type": "bool",
+            "columns": None,
         },
         {
             "name": "test str",
@@ -118,7 +124,53 @@ def test_get_operator_parameters__multiple_parameters(
             "default": None,
             "required": True,
             "param_type": "str",
+            "columns": None,
         },
+    ]
+
+
+def test_get_operator_parameters__table_parameter(
+    test_client: TestClient,
+    isolated_operator_registry: OperatorRegistry,
+) -> None:
+    """The full column definitions must reach the client.
+
+    Regression guard: `columns` lives on `TableParameter` only, so the route has to map the
+    parameters onto `ParameterView` to expose them. Returning the plugin dataclasses directly would
+    make pydantic serialize each item against the base class and silently drop the columns, leaving
+    the GUI without column information and without any error.
+    """
+    isolated_operator_registry.register(TableParamsOperator(name="table"))
+
+    operator_id = _get_operator_id_by_name(isolated_operator_registry, "table")
+
+    response = test_client.get(f"/api/operators/{operator_id}/parameters")
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == [
+        {
+            "name": "prompts",
+            "description": "Prompts and labels.",
+            "default": [{"prompt": "person", "label": "pedestrian"}],
+            "required": True,
+            "param_type": "table",
+            "columns": [
+                {
+                    "name": "prompt",
+                    "description": "What to segment.",
+                    "default": None,
+                    "required": True,
+                    "param_type": "str",
+                },
+                {
+                    "name": "label",
+                    "description": "",
+                    "default": "pedestrian",
+                    "required": False,
+                    "param_type": "str",
+                },
+            ],
+        }
     ]
 
 
@@ -306,6 +358,33 @@ def test_execute_operator__filter_is_passed_through(
     assert operator.captured_context.context_filter == expected_filter
 
 
+def test_execute_operator__table_parameter_rows_reach_the_operator(
+    test_client: TestClient,
+    collection_id: UUID,
+    isolated_operator_registry: OperatorRegistry,
+) -> None:
+    """Table rows must arrive in `execute()` as a list of dicts.
+
+    `ExecuteOperatorRequest.parameters` is a `dict[str, Any]`, so the rows pass through untouched.
+    This pins that contract, since it is what plugins index into.
+    """
+    operator = TableParamsOperator(name="table")
+    isolated_operator_registry.register(operator)
+    operator_id = _get_operator_id_by_name(isolated_operator_registry, "table")
+
+    rows = [{"prompt": "person", "label": "pedestrian"}, {"prompt": "car", "label": "vehicle"}]
+    response = test_client.post(
+        f"/api/operators/{operator_id}/execute",
+        json={
+            "parameters": {"prompts": rows},
+            "context": {"collection_id": str(collection_id)},
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert operator.captured_parameters == {"prompts": rows}
+
+
 def test_execute_operator__sample_ids_filter_resolves_to_sample_filter(
     test_client: TestClient,
     collection_id: UUID,
@@ -389,6 +468,35 @@ class EmptyParamsOperator(TestOperator):
     @property
     def parameters(self) -> list[BaseParameter]:
         return []
+
+
+class TableParamsOperator(TestOperator):
+    status: OperatorStatus = OperatorStatus.READY
+    captured_parameters: dict[str, Any] | None = None
+
+    @property
+    def parameters(self) -> list[BaseParameter]:
+        return [
+            TableParameter(
+                name="prompts",
+                description="Prompts and labels.",
+                columns=[
+                    StringParameter(name="prompt", description="What to segment."),
+                    StringParameter(name="label", default="pedestrian", required=False),
+                ],
+                default=[{"prompt": "person", "label": "pedestrian"}],
+            )
+        ]
+
+    def execute(
+        self,
+        session: Session,
+        context: ExecutionContext,
+        parameters: dict[str, Any],
+    ) -> OperatorResult:
+        _, _ = session, context
+        self.captured_parameters = parameters
+        return OperatorResult(success=True, message="captured")
 
 
 @dataclass

--- a/lightly_studio_view/src/lib/hooks/useOperators/useOperators.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperators/useOperators.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { createOperatorFromMetadata } from './useOperators';
+import type {
+    ParameterColumnView,
+    ParameterView,
+    RegisteredOperatorMetadata
+} from '$lib/api/lightly_studio_local';
+
+const metadata: RegisteredOperatorMetadata = {
+    operator_id: 'op-1',
+    name: 'Blur detection'
+};
+
+const defaultColumn: ParameterColumnView = {
+    name: 'label',
+    description: 'The label to assign',
+    default: 'blurry',
+    required: true,
+    param_type: 'str'
+};
+
+const defaultParameter: ParameterView = {
+    name: 'threshold',
+    description: 'The blur threshold',
+    default: 0.5,
+    required: true,
+    param_type: 'float',
+    columns: null
+};
+
+describe('createOperatorFromMetadata', () => {
+    it('maps the operator metadata and its parameters', () => {
+        const operator = createOperatorFromMetadata(metadata, [defaultParameter]);
+
+        expect(operator).toEqual({
+            id: 'op-1',
+            name: 'Blur detection',
+            parameters: [
+                {
+                    name: 'threshold',
+                    description: 'The blur threshold',
+                    default: 0.5,
+                    required: true,
+                    type: 'float',
+                    columns: undefined
+                }
+            ]
+        });
+    });
+
+    it('falls back to the string type when param_type is null', () => {
+        const operator = createOperatorFromMetadata(metadata, [
+            { ...defaultParameter, param_type: null }
+        ]);
+
+        expect(operator.parameters[0].type).toBe('string');
+    });
+
+    it('maps the columns of a table parameter', () => {
+        const operator = createOperatorFromMetadata(metadata, [
+            { ...defaultParameter, param_type: 'table', columns: [defaultColumn] }
+        ]);
+
+        expect(operator.parameters[0].columns).toEqual([
+            {
+                name: 'label',
+                description: 'The label to assign',
+                default: 'blurry',
+                required: true,
+                paramType: 'str'
+            }
+        ]);
+    });
+
+    it('converts a null column param_type to undefined', () => {
+        const operator = createOperatorFromMetadata(metadata, [
+            {
+                ...defaultParameter,
+                param_type: 'table',
+                columns: [{ ...defaultColumn, param_type: null }]
+            }
+        ]);
+
+        expect(operator.parameters[0].columns?.[0].paramType).toBeUndefined();
+    });
+
+    it('maps an empty column list of a table parameter without columns', () => {
+        const operator = createOperatorFromMetadata(metadata, [
+            { ...defaultParameter, param_type: 'table', columns: [] }
+        ]);
+
+        expect(operator.parameters[0].columns).toEqual([]);
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useOperators/useOperators.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperators/useOperators.ts
@@ -1,6 +1,22 @@
-import type { BaseParameter, RegisteredOperatorMetadata } from '$lib/api/lightly_studio_local';
+import type {
+    ParameterColumnView,
+    ParameterView,
+    RegisteredOperatorMetadata
+} from '$lib/api/lightly_studio_local';
 
 export type OperatorParameterType = 'string' | 'int' | 'float' | 'bool';
+
+export type OperatorParameterColumn = {
+    name: string;
+    description?: string;
+    default?: unknown;
+    required: boolean;
+    /**
+     * Python type name of the column, e.g. `'str'`, `'int'`, `'float'` or `'bool'`. Columns accept
+     * any built-in parameter type, so this is not an `OperatorParameterType`.
+     */
+    paramType?: string;
+};
 
 export type OperatorParameter = {
     name: string;
@@ -8,6 +24,7 @@ export type OperatorParameter = {
     default?: unknown;
     required?: boolean;
     type: OperatorParameterType;
+    columns?: OperatorParameterColumn[];
 };
 
 export type Operator = {
@@ -16,17 +33,26 @@ export type Operator = {
     parameters: OperatorParameter[];
 };
 
-const mapParameter = (parameter: BaseParameter): OperatorParameter => ({
+const mapColumn = (column: ParameterColumnView): OperatorParameterColumn => ({
+    name: column.name,
+    description: column.description,
+    default: column.default,
+    required: column.required,
+    paramType: column.param_type ?? undefined
+});
+
+const mapParameter = (parameter: ParameterView): OperatorParameter => ({
     name: parameter.name,
     description: parameter.description,
     default: parameter.default,
     required: parameter.required,
-    type: (parameter.param_type as OperatorParameterType) ?? 'string'
+    type: (parameter.param_type as OperatorParameterType) ?? 'string',
+    columns: parameter.columns?.map(mapColumn)
 });
 
 export const createOperatorFromMetadata = (
     metadata: RegisteredOperatorMetadata,
-    parameters: BaseParameter[]
+    parameters: ParameterView[]
 ): Operator => ({
     id: metadata.operator_id,
     name: metadata.name,

--- a/lightly_studio_view/src/lib/hooks/useOperators/useOperators.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperators/useOperators.ts
@@ -6,17 +6,17 @@ import type {
 
 export type OperatorParameterType = 'string' | 'int' | 'float' | 'bool';
 
-export type OperatorParameterColumn = {
-    name: string;
-    description?: string;
-    default?: unknown;
-    required: boolean;
+const mapColumn = (column: ParameterColumnView) => ({
+    name: column.name,
+    description: column.description,
+    default: column.default as unknown,
+    required: column.required,
     /**
      * Python type name of the column, e.g. `'str'`, `'int'`, `'float'` or `'bool'`. Columns accept
      * any built-in parameter type, so this is not an `OperatorParameterType`.
      */
-    paramType?: string;
-};
+    paramType: column.param_type ?? undefined
+});
 
 export type OperatorParameter = {
     name: string;
@@ -24,7 +24,7 @@ export type OperatorParameter = {
     default?: unknown;
     required?: boolean;
     type: OperatorParameterType;
-    columns?: OperatorParameterColumn[];
+    columns?: ReturnType<typeof mapColumn>[];
 };
 
 export type Operator = {
@@ -32,14 +32,6 @@ export type Operator = {
     name: string;
     parameters: OperatorParameter[];
 };
-
-const mapColumn = (column: ParameterColumnView): OperatorParameterColumn => ({
-    name: column.name,
-    description: column.description,
-    default: column.default,
-    required: column.required,
-    paramType: column.param_type ?? undefined
-});
 
 const mapParameter = (parameter: ParameterView): OperatorParameter => ({
     name: parameter.name,


### PR DESCRIPTION
## What has changed and why?


Backend part 2 of the table parameter stack. Part 1 (#1798, `TableParameter` in `plugins/parameter.py`) has landed, so this now targets `main` directly.

Part 1 let a plugin *declare* a table parameter; the GUI parts render one. Neither is reachable from the other, because the columns never survived the trip to the browser:

`GET /operators/{operator_id}/parameters` was annotated with the base class `list[BaseParameter]`. Pydantic serialises against the *declared* type, so it validated each item against the base class and dropped `columns` — a field that only exists on `TableParameter`. An operator could declare a fully specified table and the GUI had no way to learn its columns existed.

- Return explicit `ParameterView` / `ParameterColumnView` models instead of the plugin dataclasses, which also keeps the API shape independent of the plugin dataclasses per `ai_guidelines/backend.md`.
- Migrate `useOperators.ts` to `ParameterView` and map `columns` onto a new `OperatorParameterColumn`. This has to happen in the same PR: the generated client no longer exports `BaseParameter`, so `check-typescript` / `test-frontend` would break on an intermediate commit.

`OperatorParameterColumn` passes every column field through unchanged, including `param_type` as `paramType`. Part 1 permits a column of any built-in type, so a `FloatParameter(name="threshold", default=0.5)` column has to keep both its type and its numeric default — narrowing either one here would discard it silently at the one boundary
where the loss is invisible to every later caller, which is the same class of bug this PR exists to fix. `paramType` holds the Python type name (`'str'`, `'float'`, …) and is deliberately typed `string` rather than `OperatorParameterType`, whose members spell `'string'`.

## How has it been tested?

`make static-checks` and `make test` in `lightly_studio`, plus `npm run check` in `lightly_studio_view` (0 errors).

New tests in `tests/api/routes/api/test_operator.py`:

- `test_get_operator_parameters__table_parameter` — asserts the full response JSON for a table parameter. This is the regression guard for the dropped columns: it fails against the old `list[BaseParameter]` annotation.
- `test_execute_operator__table_parameter_rows_reach_the_operator` — rows arrive in `execute()` as a list of dicts.

Existing multi-parameter test updated for the additive `"columns": null`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator parameter metadata now includes table columns, descriptions, defaults, required status, and types.
  * Added support for displaying nested table parameter definitions in the operator interface.

* **Bug Fixes**
  * Table parameter rows are now passed to operators without modification.
  * Parameter metadata is presented consistently, including correct handling of optional or unspecified types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->