### PR TITLE
Export filtering: add download endpoint

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/exceptions.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/exceptions.py
@@ -13,9 +13,10 @@ from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_BAD_REQUEST,
     HTTP_STATUS_CONFLICT,
     HTTP_STATUS_INTERNAL_SERVER_ERROR,
+    HTTP_STATUS_NOT_FOUND,
     HTTP_STATUS_UNPROCESSABLE_ENTITY,
 )
-from lightly_studio.errors import QueryExprError
+from lightly_studio.errors import NotFoundError, QueryExprError
 
 # Set up logger for error handling
 logger = logging.getLogger("lightly_studio.api.exceptions")
@@ -112,6 +113,14 @@ def register_exception_handlers(app: FastAPI) -> None:
         return JSONResponse(
             status_code=HTTP_STATUS_UNPROCESSABLE_ENTITY,
             content={"detail": exc.errors()},
+        )
+
+    @app.exception_handler(NotFoundError)
+    async def _not_found_error_handler(_request: Request, _exc: NotFoundError) -> JSONResponse:
+        """Handle not-found errors."""
+        return JSONResponse(
+            status_code=HTTP_STATUS_NOT_FOUND,
+            content={"error": str(_exc) or "Resource not found."},
         )
 
     @app.exception_handler(QueryExprError)

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -17,10 +17,10 @@ from pydantic import BaseModel
 from sqlmodel import Field, Session
 
 from lightly_studio.api.routes.api import collection as collection_api
-from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND
 from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
 from lightly_studio.core.video.video_sample import VideoSample
 from lightly_studio.database.db_manager import SessionDep
+from lightly_studio.errors import NotFoundError
 from lightly_studio.export import image_dataset_export, video_dataset_export
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.export_format import ExportFormat
@@ -325,14 +325,11 @@ def export_download(
     """Stream the export identified by *export_key*."""
     job = export_job_resolver.get(session=session, export_key=export_key)
     if job is None:
-        raise HTTPException(status_code=HTTP_STATUS_NOT_FOUND, detail="Export key not found.")
+        raise NotFoundError("Export key not found.")
 
     export_path = PathlibPath(job.export_path)
     if not export_path.exists():
-        raise HTTPException(
-            status_code=HTTP_STATUS_NOT_FOUND,
-            detail="Export file not found.",
-        )
+        raise NotFoundError("Export file not found.")
     if export_path.is_dir():
         return StreamingResponse(
             content=_stream_dir_and_cleanup(export_path, session=session, export_key=export_key),

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -394,7 +394,9 @@ def _stream_dir_and_cleanup(
             )
         raise
     shutil.rmtree(dir_path, ignore_errors=True)
-    yield from _stream_file_and_cleanup(export_path=archive_path, session=session, export_key=export_key)
+    yield from _stream_file_and_cleanup(
+        export_path=archive_path, session=session, export_key=export_key
+    )
 
 
 def _media_type_for_path(path: PathlibPath) -> str:

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -394,7 +394,7 @@ def _stream_dir_and_cleanup(
             )
         raise
     shutil.rmtree(dir_path, ignore_errors=True)
-    yield from _stream_file_and_cleanup(archive_path, session=session, export_key=export_key)
+    yield from _stream_file_and_cleanup(export_path=archive_path, session=session, export_key=export_key)
 
 
 def _media_type_for_path(path: PathlibPath) -> str:

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -357,13 +357,13 @@ def _stream_file_and_cleanup(
     session: Session,
     export_key: UUID,
 ) -> Generator[bytes, None, None]:
-    """Stream a file, remove its parent temp directory, and delete the DB row afterwards."""
+    """Stream a file, remove it, and delete the DB row afterwards."""
     try:
         with export_path.open("rb") as file:
             while chunk := file.read(_STREAM_CHUNK_SIZE_BYTES):
                 yield chunk
     finally:
-        shutil.rmtree(export_path.parent, ignore_errors=True)
+        export_path.unlink(missing_ok=True)
         try:
             export_job_resolver.delete(session=session, export_key=export_key)
         except Exception as exc:
@@ -377,7 +377,7 @@ def _stream_dir_and_cleanup(
     session: Session,
     export_key: UUID,
 ) -> Generator[bytes, None, None]:
-    """Zip a directory, stream the archive, remove the temp directory, and delete the DB row."""
+    """Zip the export directory, stream the archive, remove both, and delete the DB row."""
     try:
         archive_path = PathlibPath(
             shutil.make_archive(
@@ -388,7 +388,7 @@ def _stream_dir_and_cleanup(
             )
         )
     except Exception:
-        shutil.rmtree(dir_path.parent, ignore_errors=True)
+        shutil.rmtree(dir_path, ignore_errors=True)
         try:
             export_job_resolver.delete(session=session, export_key=export_key)
         except Exception as exc:
@@ -396,6 +396,7 @@ def _stream_dir_and_cleanup(
                 "Failed to delete export job %s from database: %s", export_key, exc, exc_info=True
             )
         raise
+    shutil.rmtree(dir_path, ignore_errors=True)
     yield from _stream_file_and_cleanup(archive_path, session=session, export_key=export_key)
 
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 from collections.abc import Generator
 from datetime import datetime, timezone
@@ -13,21 +14,23 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
-from sqlmodel import Field
+from sqlmodel import Field, Session
 
 from lightly_studio.api.routes.api import collection as collection_api
+from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND
 from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
 from lightly_studio.core.video.video_sample import VideoSample
 from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.export import image_dataset_export, video_dataset_export
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.export_format import ExportFormat
-from lightly_studio.resolvers import collection_resolver
+from lightly_studio.resolvers import collection_resolver, export_job_resolver
 from lightly_studio.resolvers.collection_resolver.export import ExportFilter
 from lightly_studio.resolvers.image_filter import ImageFilter
 
 export_router = APIRouter(prefix="/collections/{collection_id}", tags=["export"])
 _STREAM_CHUNK_SIZE_BYTES = 64 * 1024
+logger = logging.getLogger(__name__)
 
 
 @export_router.get("/export/annotations")
@@ -263,19 +266,6 @@ def export_collection_stats(
     )
 
 
-def _stream_export_file(
-    temp_dir: TemporaryDirectory[str],
-    file_path: PathlibPath,
-) -> Generator[bytes, None, None]:
-    """Stream the export file and clean up the temporary directory afterwards."""
-    try:
-        with file_path.open("rb") as file:
-            while chunk := file.read(_STREAM_CHUNK_SIZE_BYTES):
-                yield chunk
-    finally:
-        temp_dir.cleanup()
-
-
 @export_router.get("/export/youtube-vis")
 def export_collection_youtube_vis(
     collection: Annotated[
@@ -320,6 +310,114 @@ def export_collection_youtube_vis(
             "Content-Disposition": f"attachment; filename={output_path.name}",
         },
     )
+
+
+@export_router.get("/export/download/{export_key}")
+def export_download(
+    _collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(collection_api.get_and_validate_collection_id),
+    ],
+    session: SessionDep,
+    export_key: UUID,
+) -> StreamingResponse:
+    """Stream the export identified by *export_key*."""
+    job = export_job_resolver.get(session=session, export_key=export_key)
+    if job is None:
+        raise HTTPException(status_code=HTTP_STATUS_NOT_FOUND, detail="Export key not found.")
+
+    export_path = PathlibPath(job.export_path)
+    if not export_path.exists():
+        raise HTTPException(
+            status_code=HTTP_STATUS_NOT_FOUND,
+            detail="Export file not found.",
+        )
+    if export_path.is_dir():
+        return StreamingResponse(
+            content=_stream_dir_and_cleanup(export_path, session=session, export_key=export_key),
+            media_type="application/zip",
+            headers={
+                "Access-Control-Expose-Headers": "Content-Disposition",
+                "Content-Disposition": f"attachment; filename={export_path.name}.zip",
+            },
+        )
+    return StreamingResponse(
+        content=_stream_file_and_cleanup(export_path, session=session, export_key=export_key),
+        media_type=_media_type_for_path(export_path),
+        headers={
+            "Access-Control-Expose-Headers": "Content-Disposition",
+            "Content-Disposition": f"attachment; filename={export_path.name}",
+        },
+    )
+
+
+def _stream_file_and_cleanup(
+    export_path: PathlibPath,
+    session: Session,
+    export_key: UUID,
+) -> Generator[bytes, None, None]:
+    """Stream a file, remove its parent temp directory, and delete the DB row afterwards."""
+    try:
+        with export_path.open("rb") as file:
+            while chunk := file.read(_STREAM_CHUNK_SIZE_BYTES):
+                yield chunk
+    finally:
+        shutil.rmtree(export_path.parent, ignore_errors=True)
+        try:
+            export_job_resolver.delete(session=session, export_key=export_key)
+        except Exception as exc:
+            logger.error(
+                "Failed to delete export job %s from database: %s", export_key, exc, exc_info=True
+            )
+
+
+def _stream_dir_and_cleanup(
+    dir_path: PathlibPath,
+    session: Session,
+    export_key: UUID,
+) -> Generator[bytes, None, None]:
+    """Zip a directory, stream the archive, remove the temp directory, and delete the DB row."""
+    try:
+        archive_path = PathlibPath(
+            shutil.make_archive(
+                base_name=str(dir_path),
+                format="zip",
+                root_dir=dir_path.parent,
+                base_dir=dir_path.name,
+            )
+        )
+    except Exception:
+        shutil.rmtree(dir_path.parent, ignore_errors=True)
+        try:
+            export_job_resolver.delete(session=session, export_key=export_key)
+        except Exception as exc:
+            logger.error(
+                "Failed to delete export job %s from database: %s", export_key, exc, exc_info=True
+            )
+        raise
+    yield from _stream_file_and_cleanup(archive_path, session=session, export_key=export_key)
+
+
+def _media_type_for_path(path: PathlibPath) -> str:
+    if path.suffix == ".json":
+        return "application/json"
+    if path.suffix == ".txt":
+        return "text/plain"
+    return "application/octet-stream"
+
+
+def _stream_export_file(
+    temp_dir: TemporaryDirectory[str],
+    file_path: PathlibPath,
+) -> Generator[bytes, None, None]:
+    """Stream the export file and clean up the temporary directory afterwards."""
+    try:
+        with file_path.open("rb") as file:
+            while chunk := file.read(_STREAM_CHUNK_SIZE_BYTES):
+                yield chunk
+    finally:
+        temp_dir.cleanup()
 
 
 def _stream_export_dir(

--- a/lightly_studio/src/lightly_studio/errors.py
+++ b/lightly_studio/src/lightly_studio/errors.py
@@ -1,6 +1,10 @@
 """Lightly Studio Exceptions types."""
 
 
+class NotFoundError(Exception):
+    """Exception signaling that a requested resource has not been found."""
+
+
 class TagNotFoundError(Exception):
     """Exception signaling that a tag has not been found."""
 

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -544,6 +544,8 @@ def test_export_download__json_file__streams_content_and_deletes_job(
     assert response.headers["Content-Disposition"] == "attachment; filename=export.json"
     assert response.json() == {"items": [1, 2, 3]}
     assert export_job_resolver.get(session=db_session, export_key=job.export_key) is None
+    assert not export_path.exists()
+    assert export_dir.exists()
 
 
 def test_export_download__txt_file__streams_content_and_deletes_job(
@@ -569,6 +571,8 @@ def test_export_download__txt_file__streams_content_and_deletes_job(
     assert response.headers["Content-Disposition"] == "attachment; filename=export.txt"
     assert response.text == "path/a.jpg\npath/b.jpg\n"
     assert export_job_resolver.get(session=db_session, export_key=job.export_key) is None
+    assert not export_path.exists()
+    assert export_dir.exists()
 
 
 def test_export_download__directory__streams_as_zip_and_deletes_job(
@@ -599,3 +603,5 @@ def test_export_download__directory__streams_as_zip_and_deletes_job(
         assert zip_ref.read("my_export/labels.txt") == b"cat\ndog\n"
 
     assert export_job_resolver.get(session=db_session, export_key=job.export_key) is None
+    assert not export_dir.exists()
+    assert container.exists()

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import io
 import json
 import zipfile
+from pathlib import Path
+from uuid import uuid4
 
 import yaml
 from fastapi.testclient import TestClient
 from PIL import Image as PILImage
 from sqlmodel import Session
 
-from lightly_studio.api.routes.api.status import HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_OK
+from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_BAD_REQUEST,
+    HTTP_STATUS_NOT_FOUND,
+    HTTP_STATUS_OK,
+)
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
     AnnotationType,
@@ -21,6 +27,7 @@ from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
+    export_job_resolver,
     object_track_resolver,
     tag_resolver,
 )
@@ -498,3 +505,97 @@ def test_export_collection_youtube_vis__wrong_export_format(
     )
 
     assert response.status_code == HTTP_STATUS_BAD_REQUEST
+
+
+def test_export_download__not_found__returns_404(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    export_key = uuid4()
+
+    response = test_client.get(
+        f"/api/collections/{collection.collection_id}/export/download/{export_key}"
+    )
+
+    assert response.status_code == HTTP_STATUS_NOT_FOUND
+
+
+def test_export_download__json_file__streams_content_and_deletes_job(
+    tmp_path: Path,
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+
+    export_dir = tmp_path / "container"
+    export_dir.mkdir()
+    export_path = export_dir / "export.json"
+    export_path.write_text('{"items": [1, 2, 3]}')
+
+    job = export_job_resolver.create(session=db_session, export_path=str(export_path))
+
+    response = test_client.get(
+        f"/api/collections/{collection.collection_id}/export/download/{job.export_key}"
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.headers["Content-Type"] == "application/json"
+    assert response.headers["Content-Disposition"] == "attachment; filename=export.json"
+    assert response.json() == {"items": [1, 2, 3]}
+    assert export_job_resolver.get(session=db_session, export_key=job.export_key) is None
+
+
+def test_export_download__txt_file__streams_content_and_deletes_job(
+    tmp_path: Path,
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+
+    export_dir = tmp_path / "container"
+    export_dir.mkdir()
+    export_path = export_dir / "export.txt"
+    export_path.write_text("path/a.jpg\npath/b.jpg\n")
+
+    job = export_job_resolver.create(session=db_session, export_path=str(export_path))
+
+    response = test_client.get(
+        f"/api/collections/{collection.collection_id}/export/download/{job.export_key}"
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.headers["Content-Type"].startswith("text/plain")
+    assert response.headers["Content-Disposition"] == "attachment; filename=export.txt"
+    assert response.text == "path/a.jpg\npath/b.jpg\n"
+    assert export_job_resolver.get(session=db_session, export_key=job.export_key) is None
+
+
+def test_export_download__directory__streams_as_zip_and_deletes_job(
+    tmp_path: Path,
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+
+    container = tmp_path / "container"
+    container.mkdir()
+    export_dir = container / "my_export"
+    export_dir.mkdir()
+    (export_dir / "labels.txt").write_text("cat\ndog\n")
+
+    job = export_job_resolver.create(session=db_session, export_path=str(export_dir))
+
+    response = test_client.get(
+        f"/api/collections/{collection.collection_id}/export/download/{job.export_key}"
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.headers["Content-Type"] == "application/zip"
+    assert response.headers["Content-Disposition"] == "attachment; filename=my_export.zip"
+
+    with zipfile.ZipFile(io.BytesIO(response.content)) as zip_ref:
+        assert "my_export/labels.txt" in zip_ref.namelist()
+        assert zip_ref.read("my_export/labels.txt") == b"cat\ndog\n"
+
+    assert export_job_resolver.get(session=db_session, export_key=job.export_key) is None

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -507,7 +507,7 @@ def test_export_collection_youtube_vis__wrong_export_format(
     assert response.status_code == HTTP_STATUS_BAD_REQUEST
 
 
-def test_export_download__not_found__returns_404(
+def test_export_download__not_found_returns_404(
     db_session: Session,
     test_client: TestClient,
 ) -> None:
@@ -521,7 +521,7 @@ def test_export_download__not_found__returns_404(
     assert response.status_code == HTTP_STATUS_NOT_FOUND
 
 
-def test_export_download__json_file__streams_content_and_deletes_job(
+def test_export_download__json_file_streams_content_and_deletes_job(
     tmp_path: Path,
     db_session: Session,
     test_client: TestClient,
@@ -548,7 +548,7 @@ def test_export_download__json_file__streams_content_and_deletes_job(
     assert export_dir.exists()
 
 
-def test_export_download__txt_file__streams_content_and_deletes_job(
+def test_export_download__txt_file_streams_content_and_deletes_job(
     tmp_path: Path,
     db_session: Session,
     test_client: TestClient,
@@ -575,7 +575,7 @@ def test_export_download__txt_file__streams_content_and_deletes_job(
     assert export_dir.exists()
 
 
-def test_export_download__directory__streams_as_zip_and_deletes_job(
+def test_export_download__directory_streams_as_zip_and_deletes_job(
     tmp_path: Path,
     db_session: Session,
     test_client: TestClient,


### PR DESCRIPTION
## What has changed and why?

Adds the shared download endpoint

- `GET /export/download/{export_key}` - streams any export file or directory; deletes the DB row after streaming.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to download previously generated exports by key.
  * Supports streaming individual files and directory exports as ZIP, with automatic content types and downloadable filenames.

* **Bug Fixes**
  * Improved not-found handling when an export key or export path is missing.
  * Ensures exported artifacts and completed export records are cleaned up after download.

* **Tests**
  * Added API tests for 404 and successful downloads (JSON, text, and directory ZIP), including verification of cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->