### PR TITLE
Export filtering: add export filename prepare endpoint

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -6,7 +6,7 @@ import shutil
 from collections.abc import Generator
 from datetime import datetime, timezone
 from pathlib import Path as PathlibPath
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, mkdtemp
 from typing import Annotated
 from uuid import UUID
 
@@ -22,7 +22,7 @@ from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.export import image_dataset_export, video_dataset_export
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.export_format import ExportFormat
-from lightly_studio.resolvers import collection_resolver
+from lightly_studio.resolvers import collection_resolver, export_job_resolver
 from lightly_studio.resolvers.collection_resolver.export import ExportFilter
 from lightly_studio.resolvers.image_filter import ImageFilter
 
@@ -320,6 +320,43 @@ def export_collection_youtube_vis(
             "Content-Disposition": f"attachment; filename={output_path.name}",
         },
     )
+
+
+class ExportKeyResponse(BaseModel):
+    """Response body for all prepare endpoints."""
+
+    export_key: UUID
+
+
+@export_router.post("/export/prepare")
+def export_collection_prepare(
+    collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(collection_api.get_and_validate_collection_id),
+    ],
+    session: SessionDep,
+    body: ExportBody,
+) -> ExportKeyResponse:
+    """Generate the filename export and persist its path."""
+    exported = collection_resolver.export(
+        session=session,
+        collection_id=collection.collection_id,
+        include=body.include,
+        exclude=body.exclude,
+        collection_filter=body.collection_filter,
+    )
+
+    temp_dir = PathlibPath(mkdtemp())
+    filename = f"{collection.name}_exported_{datetime.now(timezone.utc)}.txt"
+    output_path = temp_dir / filename
+    try:
+        output_path.write_text("\n".join(exported))
+        export = export_job_resolver.create(session=session, export_path=str(output_path))
+    except Exception:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
+    return ExportKeyResponse(export_key=export.export_key)
 
 
 def _stream_export_dir(

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import shutil
+import tempfile
 from collections.abc import Generator
 from datetime import datetime, timezone
 from pathlib import Path as PathlibPath
-from tempfile import TemporaryDirectory, mkdtemp
+from tempfile import TemporaryDirectory
 from typing import Annotated
 from uuid import UUID
 
@@ -204,6 +205,12 @@ class ExportBody(BaseModel):
     )
 
 
+class ExportKeyResponse(BaseModel):
+    """Response body for all prepare endpoints."""
+
+    export_key: UUID
+
+
 # This endpoint should be a GET, however due to the potential huge size
 # of sample_ids, it is a POST request to avoid URL length limitations.
 # A body with a GET request is supported by fastAPI however it has undefined
@@ -322,12 +329,6 @@ def export_collection_youtube_vis(
     )
 
 
-class ExportKeyResponse(BaseModel):
-    """Response body for all prepare endpoints."""
-
-    export_key: UUID
-
-
 @export_router.post("/export/prepare")
 def export_collection_prepare(
     collection: Annotated[
@@ -347,7 +348,7 @@ def export_collection_prepare(
         collection_filter=body.collection_filter,
     )
 
-    temp_dir = PathlibPath(mkdtemp())
+    temp_dir = PathlibPath(tempfile.mkdtemp())
     filename = f"{collection.name}_exported_{datetime.now(timezone.utc)}.txt"
     output_path = temp_dir / filename
     try:

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import io
 import json
 import zipfile
+from pathlib import Path as PathlibPath
+from uuid import UUID
 
 import yaml
 from fastapi.testclient import TestClient
@@ -18,6 +20,7 @@ from lightly_studio.models.annotation.annotation_base import (
 )
 from lightly_studio.models.annotation.object_track import ObjectTrackCreate
 from lightly_studio.models.collection import SampleType
+from lightly_studio.models.export_job import ExportJobTable
 from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
@@ -498,3 +501,101 @@ def test_export_collection_youtube_vis__wrong_export_format(
     )
 
     assert response.status_code == HTTP_STATUS_BAD_REQUEST
+
+
+def test_export_collection_prepare(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session, collection_name="my_collection")
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/a.png",
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/b.png",
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/prepare",
+        json={"include": {"sample_ids": [str(image_a.sample_id), str(image_b.sample_id)]}},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    file_content = PathlibPath(export_job.export_path).read_text()
+    assert file_content == "path/a.png\npath/b.png"
+
+
+def test_export_collection_prepare__with_tag_filter(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/a.png",
+    )
+    create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/b.png",
+    )
+    image_c = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/c.png",
+    )
+
+    tag = create_tag(session=db_session, collection_id=collection.collection_id)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_a.sample)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_c.sample)
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/prepare",
+        json={"include": {"tag_ids": [str(tag.tag_id)]}},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    file_content = PathlibPath(export_job.export_path).read_text()
+    assert file_content == "path/a.png\npath/c.png"
+
+
+def test_export_collection_prepare__exclude_filter(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/a.png",
+    )
+    create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/b.png",
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/prepare",
+        json={"exclude": {"sample_ids": [str(image_a.sample_id)]}},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    assert PathlibPath(export_job.export_path).read_text() == "path/b.png"


### PR DESCRIPTION
## What has changed and why?

Adds a new endpoint that runs the same export query as POST /export but instead of streaming the result, writes it to a temp file and returns an export_key UUID.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collection export preparation.
  * Export preparation returns an export key for tracking and file retrieval.
  * Supports selecting samples by ID, tag, or exclusion filters.
  * Export files are stored temporarily and cleaned up automatically if preparation fails.
* **Tests**
  * Added coverage for export preparation, including export-job records and generated file contents for inclusion and exclusion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->