### PR TITLE
fixed version to merge

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
+++ b/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
@@ -34,6 +34,8 @@
         onBarClick?: (item: CategoryCount) => void;
         /** Custom content shown when data is empty. Replaces the default message. */
         emptyState?: Snippet;
+        /** Top chart-grid padding in px (default 16). */
+        gridTopPx?: number;
     }
 
     const {
@@ -43,7 +45,8 @@
         maxHeightPx,
         totalCount,
         onBarClick,
-        emptyState
+        emptyState,
+        gridTopPx
     }: Props = $props();
 
     let container: HTMLDivElement | undefined = $state();
@@ -89,7 +92,7 @@
         instance.on('click', (params: { dataIndex?: number }) => {
             if (typeof params.dataIndex !== 'number') return;
             const item = data[params.dataIndex];
-            if (item) onBarClick?.(item);
+            if (item && item.selectable !== false) onBarClick?.(item);
         });
         const resizeObserver = new ResizeObserver(() => instance.resize());
         resizeObserver.observe(container);
@@ -102,7 +105,7 @@
 
     $effect(() => {
         if (!chart) return;
-        chart.setOption(buildEchartsOption(data, { totalCount, orientation }), true);
+        chart.setOption(buildEchartsOption(data, { totalCount, orientation, gridTopPx }), true);
     });
 
     onDestroy(() => chart?.dispose());

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -12,12 +12,15 @@
     import PanelHeader from './PanelHeader/PanelHeader.svelte';
     import { selectVisibleCounts } from './selectVisibleCounts';
     import {
+        CATEGORICAL_DISTRIBUTION_SORT_LABELS,
         HISTOGRAM_BIN_COUNT_ITEMS,
         type DistributionConfig,
         type DistributionSource,
         type DistributionSourceGroup
     } from './types';
     import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
+    import MetadataCategoricalFilter from './MetadataCategoricalFilter.svelte';
+    import type { CategoricalMetadataValue } from '$lib/services/types';
 
     interface Props {
         /**
@@ -59,6 +62,12 @@
         histogramBinCount?: number;
         /** Called when the user picks a new histogram bin count. */
         onHistogramBinCountChange?: (binCount: number) => void;
+        /** Called when a concrete categorical value or Missing is toggled. */
+        onCategoricalValueToggle?: (groupId: string, value: CategoricalMetadataValue) => void;
+        /** Removes every categorical value selected for the given group. */
+        onCategoricalValuesClear?: (groupId: string) => void;
+        /** Retries a failed categorical distribution request. */
+        onCategoricalRetry?: () => void;
     }
 
     const {
@@ -72,7 +81,10 @@
         initialCountMode = AnnotationCountMode.OBJECTS,
         onHistogramRangeSelect,
         histogramBinCount = 20,
-        onHistogramBinCountChange
+        onHistogramBinCountChange,
+        onCategoricalValueToggle,
+        onCategoricalValuesClear,
+        onCategoricalRetry
     }: Props = $props();
 
     // Normalise to a source list so the rest of the panel has one code path.
@@ -85,7 +97,7 @@
     let selectedGroupId = $state<string | undefined>(undefined);
 
     const groupHasContent = (group: DistributionSourceGroup): boolean =>
-        (group.data?.length ?? 0) > 0 || group.histogram != null;
+        (group.data?.length ?? 0) > 0 || group.histogram != null || group.categorical != null;
 
     const sourceHasContent = (source: DistributionSource): boolean =>
         (source.data?.length ?? 0) > 0 ||
@@ -109,6 +121,37 @@
     // A group/source carrying bins renders as a histogram instead of a bar
     // chart; the categorical controls (sort, top-N, orientation) don't apply.
     const activeHistogram = $derived(activeGroup?.histogram ?? activeSource.histogram ?? null);
+    const activeCategorical = $derived(activeGroup?.categorical ?? null);
+    const categoricalData = $derived<CategoryCount[]>(
+        (activeCategorical?.buckets ?? []).map((bucket) => {
+            // When filteredBuckets is defined (query has returned) look up the
+            // filtered count for this bucket. Absent = 0 (filter removed it entirely).
+            const filteredBucket = activeCategorical?.filteredBuckets?.find(
+                (fb) => fb.id === bucket.id
+            );
+            const filteredCount =
+                activeCategorical?.filteredBuckets !== undefined
+                    ? (filteredBucket?.count ?? 0)
+                    : undefined;
+            return {
+                id: bucket.id,
+                label: bucket.label,
+                count: bucket.count,
+                filteredCount,
+                selectable: bucket.kind !== 'other',
+                pinned: bucket.kind !== 'value',
+                selected:
+                    bucket.kind !== 'other' &&
+                    activeCategorical?.selectedValues.some((value) =>
+                        Object.is(value, bucket.value)
+                    )
+            };
+        })
+    );
+    const displayedData = $derived(activeCategorical ? categoricalData : activeData);
+    const configurationItems = $derived(
+        displayedData.map((item) => ({ value: item.id ?? item.label, label: item.label }))
+    );
     const activeHistogramRange = $derived(activeGroup?.selectedRange ?? activeSource.selectedRange);
     const handleHistogramRangeSelect = (range: HistogramRange) => {
         const groupId = activeGroup?.id ?? activeSource.id;
@@ -130,6 +173,23 @@
         orientation: 'horizontal',
         countMode: initialCountMode
     });
+    const defaultCategoricalConfig: DistributionConfig = {
+        mode: 'topN',
+        n: 1,
+        sortBy: 'count',
+        manualClasses: [],
+        orientation: 'horizontal',
+        countMode: AnnotationCountMode.SAMPLES
+    };
+    let categoricalConfigs = $state<Record<string, DistributionConfig>>({});
+    const categoricalConfig = $derived<DistributionConfig>(
+        activeGroup
+            ? (categoricalConfigs[activeGroup.id] ?? {
+                  ...defaultCategoricalConfig,
+                  n: Math.max(categoricalData.length, 1)
+              })
+            : defaultCategoricalConfig
+    );
     let configDialogOpen = $state(false);
     let expandOpen = $state(false);
     let histogramExpandOpen = $state(false);
@@ -153,16 +213,44 @@
         (activeSource.groups ?? []).map((group) => ({ value: group.id, label: group.label }))
     );
 
-    const visible = $derived(selectVisibleCounts(activeData, config));
-    const totalCount = $derived(activeData.reduce((sum, item) => sum + item.count, 0));
+    const activeViewConfig = $derived<DistributionConfig>(
+        activeCategorical ? categoricalConfig : config
+    );
+    const visible = $derived(selectVisibleCounts(displayedData, activeViewConfig));
+    const totalCount = $derived(displayedData.reduce((sum, item) => sum + item.count, 0));
+
+    const handleCategoricalBarClick = (item: CategoryCount) => {
+        const bucket = activeCategorical?.buckets.find((candidate) => candidate.id === item.id);
+        if (!bucket || bucket.kind === 'other' || !activeGroup) return;
+        onCategoricalValueToggle?.(activeGroup.id, bucket.value);
+    };
+
+    const setCategoricalConfig = (next: DistributionConfig) => {
+        if (!activeGroup) return;
+        categoricalConfigs = {
+            ...categoricalConfigs,
+            [activeGroup.id]: {
+                ...next,
+                countMode: AnnotationCountMode.SAMPLES
+            }
+        };
+    };
 
     function applyConfig(next: DistributionConfig) {
+        if (activeCategorical) {
+            setCategoricalConfig(next);
+            return;
+        }
         if (next.countMode !== config.countMode) {
             onCountModeChange?.(next.countMode ?? AnnotationCountMode.OBJECTS);
         }
         config = next;
     }
 </script>
+
+{#snippet categoricalEmptyState()}
+    <span>No matching samples for this metadata field.</span>
+{/snippet}
 
 <div
     class="flex h-full min-w-0 flex-1 flex-col rounded-[1vw] bg-card p-4"
@@ -259,22 +347,82 @@
                 />
             </div>
         </div>
-    {:else if activeData.length > 0}
-        <PanelHeader
-            {config}
-            classCount={activeData.length}
-            visibleClassCount={visible.length}
-            totalCount={showTotalCount ? totalCount : undefined}
-            {valueNoun}
-            onConfigure={() => (configDialogOpen = true)}
-            onShowAll={() => (config = { ...config, mode: 'topN', n: activeData.length })}
-            onToggleOrientation={() =>
-                (config = {
-                    ...config,
-                    orientation: config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
-                })}
-            onExpand={() => (expandOpen = true)}
+    {:else if activeCategorical && activeGroup}
+        <MetadataCategoricalFilter
+            buckets={activeCategorical.buckets}
+            selectedValues={activeCategorical.selectedValues}
+            loading={activeCategorical.loading}
+            onToggle={(value) => onCategoricalValueToggle?.(activeGroup.id, value)}
+            onClear={() => onCategoricalValuesClear?.(activeGroup.id)}
         />
+        {#if activeCategorical.loading && activeCategorical.buckets.length > 0}
+            <p class="mt-1 text-xs text-muted-foreground" role="status">Updating values…</p>
+        {/if}
+        {#if activeCategorical.error && activeCategorical.buckets.length > 0}
+            <div
+                class="mt-1 flex items-center justify-between gap-2 text-xs text-destructive"
+                role="alert"
+            >
+                <span>Could not update metadata distribution.</span>
+                {#if onCategoricalRetry}
+                    <button
+                        class="underline max-sm:min-h-11"
+                        type="button"
+                        onclick={onCategoricalRetry}
+                    >
+                        Retry
+                    </button>
+                {/if}
+            </div>
+        {/if}
+        {#if categoricalData.length > 0}
+            <div class="mt-2">
+                <PanelHeader
+                    config={categoricalConfig}
+                    classCount={categoricalData.length}
+                    visibleClassCount={visible.length}
+                    {totalCount}
+                    {valueNoun}
+                    categoryNoun="value"
+                    categoryNounPlural="values"
+                    sortLabels={CATEGORICAL_DISTRIBUTION_SORT_LABELS}
+                    onConfigure={() => (configDialogOpen = true)}
+                    onShowAll={() =>
+                        setCategoricalConfig({
+                            ...categoricalConfig,
+                            mode: 'topN',
+                            n: categoricalData.length
+                        })}
+                    onToggleOrientation={() =>
+                        setCategoricalConfig({
+                            ...categoricalConfig,
+                            orientation:
+                                categoricalConfig.orientation === 'horizontal'
+                                    ? 'vertical'
+                                    : 'horizontal'
+                        })}
+                    onExpand={() => (expandOpen = true)}
+                />
+            </div>
+        {/if}
+    {:else if activeData.length > 0}
+        <div class="mt-2">
+            <PanelHeader
+                {config}
+                classCount={activeData.length}
+                visibleClassCount={visible.length}
+                totalCount={showTotalCount ? totalCount : undefined}
+                {valueNoun}
+                onConfigure={() => (configDialogOpen = true)}
+                onShowAll={() => (config = { ...config, mode: 'topN', n: activeData.length })}
+                onToggleOrientation={() =>
+                    (config = {
+                        ...config,
+                        orientation: config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
+                    })}
+                onExpand={() => (expandOpen = true)}
+            />
+        </div>
     {/if}
     <div
         class="min-h-0 flex-1 overflow-y-auto dark:[color-scheme:dark]"
@@ -289,32 +437,79 @@
                 showAxes
                 onRangeSelect={onHistogramRangeSelect ? handleHistogramRangeSelect : undefined}
             />
+        {:else if activeCategorical?.loading && activeCategorical.buckets.length === 0}
+            <div class="p-8 text-center text-sm text-muted-foreground" role="status">
+                Loading metadata distribution…
+            </div>
+        {:else if activeCategorical?.error && activeCategorical.buckets.length === 0}
+            <div class="space-y-2 p-8 text-center text-sm" role="alert">
+                <p class="text-destructive">Could not load metadata distribution.</p>
+                {#if onCategoricalRetry}
+                    <Button
+                        variant="secondary"
+                        buttonProps={{
+                            size: 'sm',
+                            class: 'max-sm:min-h-11',
+                            onclick: onCategoricalRetry,
+                            'data-testid': 'metadata-categorical-retry'
+                        }}>Retry</Button
+                    >
+                {/if}
+            </div>
         {:else}
+            {#if activeCategorical}
+                <ul class="sr-only" aria-label="Categorical metadata value counts">
+                    {#each activeCategorical.buckets as bucket (bucket.id)}
+                        <li>
+                            {bucket.label}: {bucket.count} samples{bucket.kind === 'other'
+                                ? ', aggregated and not selectable'
+                                : activeCategorical.selectedValues.some((value) =>
+                                        Object.is(value, bucket.value)
+                                    )
+                                  ? ', selected'
+                                  : ''}
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
             <BarChart
                 data={visible}
-                orientation={config.orientation}
+                orientation={activeViewConfig.orientation}
                 maxHeightPx={chartHeight || undefined}
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
-                {onBarClick}
+                onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
+                emptyState={activeCategorical ? categoricalEmptyState : undefined}
+                gridTopPx={4}
             />
         {/if}
     </div>
 </div>
-<DistributionConfigDialog
-    bind:open={configDialogOpen}
-    allClasses={activeData.map((item) => item.label)}
-    {config}
-    onApply={applyConfig}
-/>
-<ExpandDialog
-    bind:open={expandOpen}
-    data={activeData}
-    {config}
-    {valueNoun}
-    onConfigChange={applyConfig}
-    {onBarClick}
-/>
+{#if !activeHistogram}
+    <DistributionConfigDialog
+        bind:open={configDialogOpen}
+        allClasses={displayedData.map((item) => item.label)}
+        items={configurationItems}
+        config={activeViewConfig}
+        showCountMode={!activeCategorical}
+        itemNoun={activeCategorical ? 'value' : 'class'}
+        itemNounPlural={activeCategorical ? 'values' : 'classes'}
+        sortLabels={activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
+        onApply={applyConfig}
+    />
+    <ExpandDialog
+        bind:open={expandOpen}
+        data={displayedData}
+        config={activeViewConfig}
+        {valueNoun}
+        categoryNoun={activeCategorical ? 'value' : 'class'}
+        categoryNounPlural={activeCategorical ? 'values' : 'classes'}
+        sortLabels={activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
+        showCountMode={!activeCategorical}
+        onConfigChange={applyConfig}
+        onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
+    />
+{/if}
 {#if activeHistogram}
     <HistogramExpandDialog
         bind:open={histogramExpandOpen}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -8,11 +8,14 @@ import { AnnotationCountMode, AnnotationType } from '$lib/api/lightly_studio_loc
 
 const echartsMock = vi.hoisted(() => {
     const zrHandlers: Record<string, (event: { offsetX: number; offsetY: number }) => void> = {};
+    let clickHandler: ((params: { dataIndex?: number }) => void) | undefined;
     const instance = {
         setOption: vi.fn(),
         resize: vi.fn(),
         dispose: vi.fn(),
-        on: vi.fn(),
+        on: vi.fn((event: string, handler: (params: { dataIndex?: number }) => void) => {
+            if (event === 'click') clickHandler = handler;
+        }),
         // 2 bins across a 200px-wide canvas → 100px per bin index.
         convertFromPixel: vi.fn((_finder: unknown, offsetX: number) => offsetX / 100),
         getZr: () => ({
@@ -22,7 +25,12 @@ const echartsMock = vi.hoisted(() => {
             off: vi.fn()
         })
     };
-    return { init: vi.fn(() => instance), instance, zrHandlers };
+    return {
+        init: vi.fn(() => instance),
+        instance,
+        zrHandlers,
+        getClickHandler: () => clickHandler
+    };
 });
 
 vi.mock('echarts/core', () => ({
@@ -93,8 +101,10 @@ describe('DatasetDistributionPanel', () => {
         // Horizontal default: categories live on the y-axis.
         const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
             yAxis: { data: string[] };
+            grid: { top: number };
         };
         expect(option.yAxis.data).toEqual(['person', 'dog', 'car']);
+        expect(option.grid.top).toBe(4);
     });
 
     it('applies a new top-N from the config dialog', async () => {
@@ -216,6 +226,272 @@ describe('DatasetDistributionPanel', () => {
         expect(screen.getByTestId('histogram')).toBeInTheDocument();
         expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
             '100 samples · 2 bins · 0–1'
+        );
+    });
+
+    it('preserves categorical endpoint order and toggles typed buckets but not Other', () => {
+        const onCategoricalValueToggle = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: ['Missing'],
+                            buckets: [
+                                {
+                                    id: 'literal',
+                                    kind: 'value',
+                                    value: 'Missing',
+                                    label: 'Missing',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 3
+                                },
+                                { id: 'other', kind: 'other', label: 'Other', count: 2 }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources, onCategoricalValueToggle } });
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+            series: [{ data: { itemStyle: { color: string } }[] }];
+            grid: { top: number };
+        };
+        expect(option.yAxis.data).toEqual(['Missing', 'Missing', 'Other']);
+        expect(option.grid.top).toBe(4);
+        // 'Missing' (value) is selected → accent green; the others are dimmed grey.
+        expect(option.series[0].data[0].itemStyle.color).toBe('rgba(59,217,159,0.85)');
+
+        echartsMock.getClickHandler()?.({ dataIndex: 1 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledWith('city', null);
+        echartsMock.getClickHandler()?.({ dataIndex: 2 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledOnce();
+    });
+
+    it('stores categorical orientation per metadata field', async () => {
+        const user = userEvent.setup();
+        const categorical = (label: string) => ({
+            selectedValues: [],
+            buckets: [{ id: label, kind: 'value' as const, value: label, label, count: 1 }]
+        });
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groupLabel: 'Metadata key',
+                groups: [
+                    { id: 'city', label: 'city', categorical: categorical('Zurich') },
+                    { id: 'weather', label: 'weather', categorical: categorical('rainy') }
+                ]
+            },
+            { id: 'classes', label: 'Classes', data: [] }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        const orientationToggle = screen.getByTestId('dataset-distribution-toggle-orientation');
+        await fireEvent.click(orientationToggle);
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        const groupSelect = screen.getByTestId('dataset-distribution-group-select');
+        await user.click(groupSelect);
+        await user.click(await screen.findByRole('option', { name: 'weather' }));
+        expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars');
+
+        await user.click(groupSelect);
+        await user.click(await screen.findByRole('option', { name: 'city' }));
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+    });
+
+    it('configures, reorients, and expands categorical values', async () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                valueNoun: 'samples',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 1
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        expect(screen.getByText(/2 values · sorted by count · 5 samples/)).toBeInTheDocument();
+        const orientationToggle = screen.getByTestId('dataset-distribution-toggle-orientation');
+        expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars');
+
+        await fireEvent.click(orientationToggle);
+        await waitFor(() =>
+            expect(
+                (echartsMock.instance.setOption.mock.lastCall?.[0] as { xAxis: { type: string } })
+                    .xAxis.type
+            ).toBe('category')
+        );
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+        await fireEvent.click(screen.getByText('Cancel'));
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-expand'));
+        expect(screen.getByTestId('dataset-distribution-expanded-configure')).toBeInTheDocument();
+        const expandedOrientationToggle = screen.getByTestId(
+            'dataset-distribution-expanded-toggle-orientation'
+        );
+        expect(expandedOrientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        await fireEvent.click(expandedOrientationToggle);
+        await waitFor(() =>
+            expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars')
+        );
+    });
+
+    it('manually configures colliding categorical labels by stable bucket id', async () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'status',
+                        label: 'status',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'literal-missing',
+                                    kind: 'value',
+                                    value: 'Missing',
+                                    label: 'Missing',
+                                    count: 4
+                                },
+                                {
+                                    id: 'semantic-missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 3
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        await fireEvent.click(screen.getByRole('tab', { name: 'Manual' }));
+        const missingOptions = screen.getAllByText('Missing');
+        expect(missingOptions).toHaveLength(2);
+        await fireEvent.click(missingOptions[1]);
+        await fireEvent.click(screen.getByTestId('distribution-config-apply'));
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+            series: [{ data: { value: number }[] }];
+        };
+        expect(option.yAxis.data).toEqual(['Missing']);
+        expect(option.series[0].data[0].value).toBe(3);
+    });
+
+    it('shows categorical loading and retryable error states', async () => {
+        const onCategoricalRetry = vi.fn();
+        const source = (state: { loading?: boolean; error?: string }): DistributionSource[] => [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: { buckets: [], selectedValues: ['Zurich'], ...state }
+                    }
+                ]
+            }
+        ];
+        const view = render(DatasetDistributionPanel, {
+            props: { sources: source({ loading: true }), onCategoricalRetry }
+        });
+        expect(screen.getByRole('status')).toHaveTextContent('Loading metadata distribution');
+
+        await view.rerender({
+            sources: source({ error: 'network failure' }),
+            onCategoricalRetry
+        });
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not load metadata distribution');
+        await fireEvent.click(screen.getByTestId('metadata-categorical-retry'));
+        expect(onCategoricalRetry).toHaveBeenCalledOnce();
+    });
+
+    it('keeps stale categorical bars visible after a refetch error', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                }
+                            ],
+                            selectedValues: [],
+                            error: 'network failure'
+                        }
+                    }
+                ]
+            }
+        ];
+
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not update');
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+        expect(screen.getByLabelText('Categorical metadata value counts')).toHaveTextContent(
+            'Zurich: 4 samples'
         );
     });
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.svelte
@@ -13,19 +13,39 @@
         open: boolean;
         /** Every class label available, used to bound top-N and populate the manual selector. */
         allClasses: string[];
+        /** Stable values and display labels for manual selection. */
+        items?: SelectItem[];
         /** The currently applied config. */
         config: DistributionConfig;
         /** Whether to show the Count by selector (default true). */
         showCountMode?: boolean;
+        /** Singular/plural labels used by categorical distributions. */
+        itemNoun?: string;
+        itemNounPlural?: string;
+        /** Labels for the available sort modes. */
+        sortLabels?: Record<DistributionSortOption, string>;
         /** Invoked with the new config when the user clicks Apply. */
         onApply: (config: DistributionConfig) => void;
     }
 
-    let { open = $bindable(), allClasses, config, showCountMode = true, onApply }: Props = $props();
+    let {
+        open = $bindable(),
+        allClasses,
+        items,
+        config,
+        showCountMode = true,
+        itemNoun = 'class',
+        itemNounPlural = 'classes',
+        sortLabels = DISTRIBUTION_SORT_LABELS,
+        onApply
+    }: Props = $props();
 
-    const sortItems: SelectItem[] = (
-        Object.keys(DISTRIBUTION_SORT_LABELS) as DistributionSortOption[]
-    ).map((value) => ({ value, label: DISTRIBUTION_SORT_LABELS[value] }));
+    const sortItems = $derived<SelectItem[]>(
+        (Object.keys(sortLabels) as DistributionSortOption[]).map((value) => ({
+            value,
+            label: sortLabels[value]
+        }))
+    );
 
     const countModeItems: SelectItem[] = [
         { value: AnnotationCountMode.OBJECTS, label: 'Objects' },
@@ -43,11 +63,14 @@
 <ClassSetConfigDialog
     bind:open
     {allClasses}
+    {items}
     selection={config}
     {sortItems}
-    description="Choose which classes the distribution chart shows."
+    description="Choose which {itemNounPlural} the distribution chart shows."
     testIdPrefix="distribution-config"
     showAllButton
+    {itemNoun}
+    {itemNounPlural}
     onApply={(selection) =>
         onApply({ ...config, ...selection, countMode: draftCountMode } as DistributionConfig)}
 >

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.test.ts
@@ -45,6 +45,25 @@ describe('DistributionConfigDialog', () => {
         expect(screen.getByTestId('distribution-config-top-n')).toHaveValue(5);
     });
 
+    it('uses metadata value wording and hides count mode when configured', () => {
+        renderDialog({ itemNounPlural: 'values', showCountMode: false });
+
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.getByText('Number of values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+    });
+
+    it('uses value wording in the manual selector', async () => {
+        renderDialog({ itemNoun: 'value', itemNounPlural: 'values', showCountMode: false });
+
+        await fireEvent.click(screen.getByRole('tab', { name: 'Manual' }));
+        expect(screen.getByPlaceholderText('Search values...')).toBeInTheDocument();
+        await fireEvent.input(screen.getByPlaceholderText('Search values...'), {
+            target: { value: 'not present' }
+        });
+        expect(screen.getByText('No value found.')).toBeInTheDocument();
+    });
+
     it('does not render its content while closed', () => {
         renderDialog({ open: false });
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
@@ -4,7 +4,8 @@
     import DistributionConfigDialog from '../DistributionConfigDialog/DistributionConfigDialog.svelte';
     import PanelHeader from '../PanelHeader/PanelHeader.svelte';
     import { selectVisibleCounts } from '../selectVisibleCounts';
-    import type { DistributionConfig } from '../types';
+    import type { DistributionConfig, DistributionSortOption } from '../types';
+    import { DISTRIBUTION_SORT_LABELS } from '../types';
 
     interface Props {
         /** Two-way bound flag controlling dialog visibility. */
@@ -15,6 +16,10 @@
         config: DistributionConfig;
         /** Noun for the header summary (e.g. 'annotations', 'samples'). */
         valueNoun?: string;
+        categoryNoun?: string;
+        categoryNounPlural?: string;
+        sortLabels?: Record<DistributionSortOption, string>;
+        showCountMode?: boolean;
         /** Invoked when the user applies a new config from the expanded view. */
         onConfigChange: (config: DistributionConfig) => void;
         onBarClick?: (item: CategoryCount) => void;
@@ -25,6 +30,10 @@
         data,
         config,
         valueNoun = 'annotations',
+        categoryNoun = 'class',
+        categoryNounPlural = 'classes',
+        sortLabels = DISTRIBUTION_SORT_LABELS,
+        showCountMode = true,
         onConfigChange,
         onBarClick
     }: Props = $props();
@@ -37,13 +46,18 @@
 
     const visible = $derived(selectVisibleCounts(data, config));
     const totalCount = $derived(data.reduce((sum, item) => sum + item.count, 0));
+    const configurationItems = $derived(
+        data.map((item) => ({ value: item.id ?? item.label, label: item.label }))
+    );
 </script>
 
 <Dialog.Root bind:open>
     <Dialog.Content class="flex h-[92vh] max-w-[94vw] flex-col sm:max-w-[94vw]">
         <Dialog.Header>
             <Dialog.Title>Distribution</Dialog.Title>
-            <Dialog.Description>Hover a bar for the full class name and count</Dialog.Description>
+            <Dialog.Description>
+                Hover a bar for the full {categoryNoun} name and count
+            </Dialog.Description>
         </Dialog.Header>
         <PanelHeader
             {config}
@@ -51,6 +65,9 @@
             visibleClassCount={visible.length}
             {totalCount}
             {valueNoun}
+            {categoryNoun}
+            {categoryNounPlural}
+            {sortLabels}
             onConfigure={() => (configDialogOpen = true)}
             onShowAll={() => onConfigChange({ ...config, mode: 'topN', n: data.length })}
             onToggleOrientation={() =>
@@ -71,6 +88,7 @@
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
                 {onBarClick}
+                gridTopPx={4}
             />
         </div>
     </Dialog.Content>
@@ -79,6 +97,10 @@
 <DistributionConfigDialog
     bind:open={configDialogOpen}
     allClasses={data.map((item) => item.label)}
+    items={configurationItems}
     {config}
+    {showCountMode}
+    itemNounPlural={categoryNounPlural}
+    {sortLabels}
     onApply={onConfigChange}
 />

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.test.ts
@@ -96,4 +96,28 @@ describe('ExpandDialog', () => {
 
         expect(onConfigChange).toHaveBeenCalledWith({ ...config, orientation: 'horizontal' });
     });
+
+    it('uses consistent plot spacing and exposes categorical value controls', async () => {
+        renderDialog({
+            categoryNoun: 'value',
+            categoryNounPlural: 'values',
+            showCountMode: false,
+            sortLabels: { count: 'Count', name: 'Value' }
+        });
+
+        expect(screen.getByText(/values · sorted by count/)).toBeInTheDocument();
+        expect(
+            screen.getByTestId('dataset-distribution-expanded-toggle-orientation')
+        ).toBeInTheDocument();
+        await fireEvent.click(screen.getByTestId('dataset-distribution-expanded-configure'));
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            xAxis: { data: string[] };
+            grid: { top: number };
+        };
+        expect(option.xAxis.data).toBeDefined();
+        expect(option.grid.top).toBe(4);
+    });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+    import { ChevronsUpDown } from '@lucide/svelte';
+    import * as Popover from '$lib/components/ui/popover';
+    import { Button } from '$lib/components/ui/button';
+    import { Checkbox } from '$lib/components/ui/checkbox';
+    import { Input } from '$lib/components/ui/input';
+    import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+    import type { CategoricalMetadataValue } from '$lib/services/types';
+
+    interface Props {
+        buckets: CategoricalMetadataBucket[];
+        selectedValues: CategoricalMetadataValue[];
+        loading?: boolean;
+        onToggle: (value: CategoricalMetadataValue) => void;
+        onClear: () => void;
+    }
+
+    const { buckets, selectedValues, loading = false, onToggle, onClear }: Props = $props();
+    let search = $state('');
+    type SelectableBucket = Exclude<CategoricalMetadataBucket, { kind: 'other' }>;
+    type FilterOption = { bucket: SelectableBucket; retained: boolean };
+
+    const returnedSelectable = $derived(
+        buckets.filter((bucket): bucket is SelectableBucket => bucket.kind !== 'other')
+    );
+    const options = $derived.by<FilterOption[]>(() => {
+        const returned: FilterOption[] = returnedSelectable.map((bucket) => ({
+            bucket,
+            retained: false
+        }));
+        const retained: FilterOption[] = selectedValues
+            .filter((value) => !returnedSelectable.some((bucket) => Object.is(bucket.value, value)))
+            .map((value) => ({
+                bucket:
+                    value === null
+                        ? {
+                              id: JSON.stringify(['missing']),
+                              kind: 'missing',
+                              value: null,
+                              label: 'Missing',
+                              count: 0
+                          }
+                        : {
+                              id: JSON.stringify(['retained', typeof value, value]),
+                              kind: 'value',
+                              value,
+                              label: String(value),
+                              count: 0
+                          },
+                retained: true
+            }));
+        return [...returned, ...retained];
+    });
+    const optionLabel = (option: FilterOption): string => {
+        const hasMissing = options.some(({ bucket }) => bucket.kind === 'missing');
+        const hasOtherAggregate = buckets.some((bucket) => bucket.kind === 'other');
+        if (
+            option.bucket.kind === 'missing' &&
+            options.some(({ bucket }) => bucket.value === 'Missing')
+        ) {
+            return 'Missing (no value)';
+        }
+        if (option.bucket.kind === 'value' && option.bucket.value === 'Missing' && hasMissing) {
+            return 'Missing (value)';
+        }
+        if (
+            option.bucket.kind === 'value' &&
+            option.bucket.value === 'Other' &&
+            hasOtherAggregate
+        ) {
+            return 'Other (value)';
+        }
+        return option.bucket.label;
+    };
+    const visible = $derived(
+        options.filter((option) => optionLabel(option).toLowerCase().includes(search.toLowerCase()))
+    );
+    const showSearch = $derived(buckets.filter((bucket) => bucket.kind === 'value').length > 5);
+    const summary = $derived(
+        selectedValues.length === 0
+            ? 'All values'
+            : selectedValues.length === 1
+              ? optionLabel(
+                    options.find(({ bucket }) => Object.is(bucket.value, selectedValues[0]))!
+                )
+              : `${selectedValues.length} selected`
+    );
+    const isSelected = (value: CategoricalMetadataValue) =>
+        selectedValues.some((selected) => Object.is(selected, value));
+    const checkboxLabel = (option: FilterOption) =>
+        `${
+            option.bucket.kind === 'missing'
+                ? 'Select missing metadata'
+                : `Select value ${optionLabel(option)}`
+        }, ${option.retained ? 'count unavailable' : `${option.bucket.count} samples`}`;
+</script>
+
+<div class="mt-2 flex items-center gap-2" data-testid="metadata-categorical-filter">
+    <span class="w-[100px] shrink-0 text-xs text-muted-foreground">Values</span>
+    <Popover.Root onOpenChange={(open) => !open && (search = '')}>
+        <Popover.Trigger>
+            {#snippet child({ props })}
+                <Button
+                    {...props}
+                    variant="outline"
+                    size="sm"
+                    class="min-w-0 flex-1 justify-between max-sm:min-h-11"
+                    disabled={loading && buckets.length === 0}
+                    aria-label="Select metadata values"
+                    data-testid="metadata-categorical-filter-trigger"
+                >
+                    <span class="truncate">{loading ? 'Loading…' : summary}</span>
+                    <ChevronsUpDown class="opacity-50" />
+                </Button>
+            {/snippet}
+        </Popover.Trigger>
+        <Popover.Content class="w-[min(320px,calc(100vw-2rem))] p-2" align="end">
+            {#if showSearch}
+                <Input
+                    bind:value={search}
+                    placeholder="Search values…"
+                    aria-label="Search values"
+                    class="max-sm:min-h-11"
+                />
+            {/if}
+            <div class="mt-2 max-h-56 space-y-1 overflow-y-auto">
+                {#each visible as option (option.bucket.id)}
+                    <label
+                        class="flex min-h-8 cursor-pointer items-center gap-2 rounded px-2 text-sm hover:bg-accent max-sm:min-h-11"
+                    >
+                        <Checkbox
+                            checked={isSelected(option.bucket.value)}
+                            onCheckedChange={() => onToggle(option.bucket.value)}
+                            aria-label={checkboxLabel(option)}
+                        />
+                        <span class="min-w-0 flex-1 truncate" title={optionLabel(option)}
+                            >{optionLabel(option)}</span
+                        >
+                        <span class="text-muted-foreground"
+                            >{option.retained ? 'Not in top 20' : option.bucket.count}</span
+                        >
+                    </label>
+                {/each}
+                {#if visible.length === 0}<p class="p-2 text-sm text-muted-foreground">
+                        No values found.
+                    </p>{/if}
+                {#if buckets.some((bucket) => bucket.kind === 'other')}
+                    <p class="p-2 text-xs text-muted-foreground">
+                        Other is an aggregate and cannot be selected.
+                    </p>
+                {/if}
+            </div>
+            {#if selectedValues.length > 0}
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    class="mt-2 w-full max-sm:min-h-11"
+                    onclick={onClear}>Clear</Button
+                >
+            {/if}
+        </Popover.Content>
+    </Popover.Root>
+</div>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter.test.ts
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import MetadataCategoricalFilter from './MetadataCategoricalFilter.svelte';
+import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+
+const buckets: CategoricalMetadataBucket[] = [
+    {
+        id: 'literal-missing',
+        kind: 'value',
+        value: 'Missing',
+        label: 'Missing',
+        count: 4
+    },
+    { id: 'missing', kind: 'missing', value: null, label: 'Missing', count: 3 },
+    { id: 'other', kind: 'other', label: 'Other', count: 2 }
+];
+
+describe('MetadataCategoricalFilter', () => {
+    it('keeps literal Missing and semantic Missing distinct and disables Other', async () => {
+        const onToggle = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: { buckets, selectedValues: ['Missing'], onToggle, onClear: vi.fn() }
+        });
+
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        const literal = screen.getByRole('checkbox', {
+            name: 'Select value Missing (value), 4 samples'
+        });
+        const missing = screen.getByRole('checkbox', {
+            name: 'Select missing metadata, 3 samples'
+        });
+        expect(literal).toBeChecked();
+        expect(missing).not.toBeChecked();
+        expect(screen.getByText('Other is an aggregate and cannot be selected.')).toBeVisible();
+        expect(screen.queryByRole('checkbox', { name: /Other/ })).not.toBeInTheDocument();
+
+        await fireEvent.click(missing);
+        expect(onToggle).toHaveBeenCalledWith(null);
+    });
+
+    it('searches values and clears the controlled selection', async () => {
+        const searchableBuckets: CategoricalMetadataBucket[] = [
+            ...buckets,
+            ...Array.from({ length: 5 }, (_, index) => ({
+                id: `value-${index}`,
+                kind: 'value' as const,
+                value: `value-${index}`,
+                label: `value-${index}`,
+                count: index + 1
+            }))
+        ];
+        const onClear = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: {
+                buckets: searchableBuckets,
+                selectedValues: [null],
+                onToggle: vi.fn(),
+                onClear
+            }
+        });
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        await fireEvent.input(screen.getByLabelText('Search values'), {
+            target: { value: 'not present' }
+        });
+        expect(screen.getByText('No values found.')).toBeVisible();
+        await fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+        expect(onClear).toHaveBeenCalledOnce();
+    });
+
+    it('keeps a selected value removable when it is absent from the latest response', async () => {
+        const onToggle = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: { buckets: [], selectedValues: ['stale'], onToggle, onClear: vi.fn() }
+        });
+
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        expect(screen.queryByLabelText('Search values')).not.toBeInTheDocument();
+        expect(screen.getByText('Not in top 20')).toBeVisible();
+        await fireEvent.click(
+            screen.getByRole('checkbox', {
+                name: 'Select value stale, count unavailable'
+            })
+        );
+        expect(onToggle).toHaveBeenCalledWith('stale');
+    });
+
+    it('disambiguates a retained literal Other from the aggregate bucket', async () => {
+        const onToggle = vi.fn();
+        render(MetadataCategoricalFilter, {
+            props: { buckets, selectedValues: ['Other'], onToggle, onClear: vi.fn() }
+        });
+
+        expect(screen.getByTestId('metadata-categorical-filter-trigger')).toHaveTextContent(
+            'Other (value)'
+        );
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        expect(screen.getAllByText('Other (value)')).toHaveLength(2);
+        expect(screen.getByText('Other is an aggregate and cannot be selected.')).toBeVisible();
+        await fireEvent.click(
+            screen.getByRole('checkbox', {
+                name: 'Select value Other (value), count unavailable'
+            })
+        );
+        expect(onToggle).toHaveBeenCalledWith('Other');
+    });
+
+    it('shows search only above five returned concrete values', async () => {
+        const fiveConcrete: CategoricalMetadataBucket[] = [
+            ...Array.from({ length: 5 }, (_, index) => ({
+                id: `value-${index}`,
+                kind: 'value' as const,
+                value: `value-${index}`,
+                label: `value-${index}`,
+                count: index + 1
+            })),
+            { id: 'missing', kind: 'missing', value: null, label: 'Missing', count: 3 },
+            { id: 'other', kind: 'other', label: 'Other', count: 2 }
+        ];
+        render(MetadataCategoricalFilter, {
+            props: {
+                buckets: fiveConcrete,
+                selectedValues: ['retained'],
+                onToggle: vi.fn(),
+                onClear: vi.fn()
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('metadata-categorical-filter-trigger'));
+        expect(screen.queryByLabelText('Search values')).not.toBeInTheDocument();
+        expect(screen.getByText('Not in top 20')).toBeVisible();
+    });
+});

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
@@ -19,6 +19,11 @@
         totalCount?: number;
         /** Noun for the total count summary (e.g. 'annotations', 'samples'). */
         valueNoun?: string;
+        /** Singular/plural labels for the distributed categories. */
+        categoryNoun?: string;
+        categoryNounPlural?: string;
+        /** Labels for the active sort mode. */
+        sortLabels?: Record<keyof typeof DISTRIBUTION_SORT_LABELS, string>;
         /** Opens the view-config dialog (top-N and sort order). */
         onConfigure: () => void;
         /** Quick action showing all classes; rendered only while a subset is visible. */
@@ -37,6 +42,9 @@
         visibleClassCount,
         totalCount,
         valueNoun = 'annotations',
+        categoryNoun = 'class',
+        categoryNounPlural = 'classes',
+        sortLabels = DISTRIBUTION_SORT_LABELS,
         onConfigure,
         onShowAll,
         onToggleOrientation,
@@ -45,16 +53,17 @@
     }: Props = $props();
 </script>
 
-<div class="mb-1 flex flex-row items-center gap-2">
-    <div class="mb-2 flex-1 text-xs text-muted-foreground">
+<div class="flex flex-row items-center gap-2">
+    <div class="flex-1 text-xs text-muted-foreground">
         {#if visibleClassCount < classCount}
             {config.mode === 'manual' ? 'Showing' : 'Top'}
-            {visibleClassCount} of {classCount} classes
+            {visibleClassCount} of {classCount}
+            {categoryNounPlural}
         {:else}
             {classCount}
-            {classCount === 1 ? 'class' : 'classes'}
+            {classCount === 1 ? categoryNoun : categoryNounPlural}
         {/if}
-        · sorted by {DISTRIBUTION_SORT_LABELS[config.sortBy].toLowerCase()}
+        · sorted by {sortLabels[config.sortBy].toLowerCase()}
         {#if totalCount !== undefined}
             · {totalCount.toLocaleString('en-US')}
             {valueNoun}
@@ -89,7 +98,7 @@
     <Button
         variant="ghost"
         icon={SettingsIcon}
-        ariaLabel="Configure distribution classes"
+        ariaLabel="Configure distribution {categoryNounPlural}"
         buttonProps={{
             size: 'sm',
             class: 'h-8 gap-1',

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
@@ -44,6 +44,21 @@ describe('PanelHeader', () => {
         expect(screen.getByText(/491 samples/)).toBeInTheDocument();
     });
 
+    it('uses custom category wording and sort labels', () => {
+        render(PanelHeader, {
+            props: {
+                ...defaultProps,
+                categoryNoun: 'value',
+                categoryNounPlural: 'values',
+                sortLabels: { count: 'Count', name: 'Value' },
+                config: { ...config, sortBy: 'name' }
+            }
+        });
+
+        expect(screen.getByText(/5 values · sorted by value/)).toBeInTheDocument();
+        expect(screen.getByLabelText('Configure distribution values')).toBeInTheDocument();
+    });
+
     it('shows the "Show all" action only for a visible subset and forwards clicks', async () => {
         const onShowAll = vi.fn();
         render(PanelHeader, {
@@ -121,5 +136,13 @@ describe('PanelHeader', () => {
         });
 
         expect(screen.getByTestId('dataset-distribution-expanded-configure')).toBeInTheDocument();
+    });
+
+    it('does not add plot-specific bottom margins', () => {
+        render(PanelHeader, { props: defaultProps });
+
+        const summary = screen.getByText(/^5 classes ·/);
+        expect(summary).not.toHaveClass('mb-2');
+        expect(summary.parentElement).not.toHaveClass('mb-1');
     });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.test.ts
@@ -49,6 +49,23 @@ describe('selectVisibleCounts', () => {
         expect(visible.map((item) => item.label)).toEqual(['dog', 'car']);
     });
 
+    it('uses stable ids for manual selections when labels collide', () => {
+        const visible = selectVisibleCounts(
+            [
+                { id: 'literal-missing', label: 'Missing', count: 2 },
+                { id: 'semantic-missing', label: 'Missing', count: 1 }
+            ],
+            {
+                mode: 'manual',
+                n: 1,
+                sortBy: 'count',
+                manualClasses: ['semantic-missing']
+            }
+        );
+
+        expect(visible.map((item) => item.id)).toEqual(['semantic-missing']);
+    });
+
     it('returns nothing when the manual selection is empty', () => {
         const visible = selectVisibleCounts(data, {
             mode: 'manual',
@@ -57,5 +74,18 @@ describe('selectVisibleCounts', () => {
             manualClasses: []
         });
         expect(visible).toEqual([]);
+    });
+
+    it('keeps pinned semantic buckets within a top-N limit', () => {
+        const visible = selectVisibleCounts(
+            [
+                ...data,
+                { label: 'Missing', count: 1, pinned: true },
+                { label: 'Other', count: 2, pinned: true }
+            ],
+            { mode: 'topN', n: 3, sortBy: 'count', manualClasses: [] }
+        );
+
+        expect(visible.map((item) => item.label)).toEqual(['person', 'Other', 'Missing']);
     });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.ts
@@ -16,7 +16,16 @@ export function selectVisibleCounts(
             : a.label.localeCompare(b.label)
     );
     if (config.mode === 'manual') {
-        return sorted.filter((item) => config.manualClasses.includes(item.label));
+        return sorted.filter((item) => config.manualClasses.includes(item.id ?? item.label));
     }
-    return sorted.slice(0, Math.max(config.n, 1));
+    const limit = Math.max(config.n, 1);
+    const pinned = sorted.filter((item) => item.pinned);
+    if (pinned.length === 0) return sorted.slice(0, limit);
+
+    const remainingSlots = Math.max(limit - pinned.length, 0);
+    const selected = new Set([
+        ...pinned,
+        ...sorted.filter((item) => !item.pinned).slice(0, remainingSlots)
+    ]);
+    return sorted.filter((item) => selected.has(item));
 }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -2,12 +2,19 @@ import type { CategoryCount } from '$lib/components/BarChart';
 import type { ClassSetSelection } from '$lib/components/ClassSetConfig';
 import { type AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 import type { HistogramData, HistogramRange } from '$lib/components/Histogram';
+import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+import type { CategoricalMetadataValue } from '$lib/services/types';
 
 export type DistributionSortOption = 'count' | 'name';
 
 export const DISTRIBUTION_SORT_LABELS: Record<DistributionSortOption, string> = {
     count: 'Count',
     name: 'Class name'
+};
+
+export const CATEGORICAL_DISTRIBUTION_SORT_LABELS: Record<DistributionSortOption, string> = {
+    count: 'Count',
+    name: 'Value'
 };
 
 /** Bar layout for the distribution chart. */
@@ -32,6 +39,21 @@ export interface DistributionSourceGroup {
      * metadata filter). Bins outside it render dimmed.
      */
     selectedRange?: HistogramRange;
+    /** Controlled categorical distribution and selection state. */
+    categorical?: {
+        buckets: CategoricalMetadataBucket[];
+        /**
+         * Buckets from the same query with all sidebar filters applied.
+         * When provided, each bar shows a grey background at the full `count`
+         * with a coloured foreground at the filtered count, giving context for
+         * how active filters affect the distribution.
+         * Omit (undefined) while the filtered query is still loading.
+         */
+        filteredBuckets?: CategoricalMetadataBucket[];
+        selectedValues: CategoricalMetadataValue[];
+        loading?: boolean;
+        error?: string;
+    };
 }
 
 /**

--- a/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.test.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.test.ts
@@ -124,6 +124,7 @@ describe('buildHistogramOption', () => {
         };
         expect(xAxis.show).toBe(true);
         expect((option.yAxis as { show: boolean }).show).toBe(true);
+        expect((option.grid as { top: number }).top).toBe(4);
         // Integer ticks land exactly on bin edges: 0 → domain min, N → max.
         expect(xAxis.axisLabel.formatter(0)).toBe('0');
         expect(xAxis.axisLabel.formatter(10)).toBe('50');

--- a/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.ts
+++ b/lightly_studio_view/src/lib/components/Histogram/buildHistogramOption.ts
@@ -181,7 +181,7 @@ function buildTooltip(bins: HistogramBin[]): Record<string, unknown> {
 function buildGrid(showAxes: boolean): Record<string, unknown> {
     // containLabel reserves gutters for labels; right padding avoids clipping.
     return showAxes
-        ? { left: 4, right: 16, top: 8, bottom: 4, containLabel: true }
+        ? { left: 4, right: 16, top: 4, bottom: 4, containLabel: true }
         : { left: 0, right: 0, top: 2, bottom: 0 };
 }
 

--- a/lightly_studio_view/src/lib/components/Images/Images.svelte
+++ b/lightly_studio_view/src/lib/components/Images/Images.svelte
@@ -45,7 +45,7 @@
     });
 
     const { dimensionsValues: dimensions } = useDimensions();
-    const { metadataValues } = useMetadataFilters(collection_id);
+    const { metadataValues, categoricalMetadataValues } = useMetadataFilters(collection_id);
 
     const {
         getCollectionVersion,
@@ -67,6 +67,7 @@
             dimensions: $dimensions ?? undefined
         },
         metadata_values: $metadataValues,
+        categorical_metadata_values: $categoricalMetadataValues,
         text_embedding: $textEmbedding?.embedding
     });
 
@@ -141,6 +142,7 @@
             `${$dimensions?.min_width}-${$dimensions?.max_width}`,
             `${$dimensions?.min_height}-${$dimensions?.max_height}`,
             JSON.stringify($metadataValues),
+            JSON.stringify($categoricalMetadataValues),
             $textEmbedding?.queryText || '',
             confusionCell ? JSON.stringify(confusionCell) : '',
             JSON.stringify($imageSortBy)

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.svelte
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.svelte
@@ -28,10 +28,14 @@
                 >
                     {#snippet subtitle()}
                         <div class="truncate text-xs text-muted-foreground">
-                            {hook.formatValue(chip.key, chip.range.min)} – {hook.formatValue(
-                                chip.key,
-                                chip.range.max
-                            )}
+                            {#if chip.kind === 'categorical'}
+                                {hook.formatCategoricalValues(chip.values)}
+                            {:else if chip.range}
+                                {hook.formatValue(chip.key, chip.range.min)} – {hook.formatValue(
+                                    chip.key,
+                                    chip.range.max
+                                )}
+                            {/if}
                         </div>
                     {/snippet}
                 </FilterChip>

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.test.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.test.ts
@@ -9,6 +9,16 @@ describe('MetadataFilterChips', () => {
     beforeEach(() => {
         storage.updateMetadataBounds({});
         storage.updateMetadataValues({});
+        storage.updateCategoricalMetadataValues({});
+    });
+
+    it('distinguishes literal values from semantic Missing in a chip', () => {
+        storage.updateCategoricalMetadataValues({ city: ['Missing', null, 'Other'] });
+        render(MetadataFilterChips);
+
+        expect(screen.getByTestId('metadata-filter-chip-city')).toHaveTextContent(
+            'Missing (value), Missing (no value), Other (value)'
+        );
     });
 
     it('renders nothing when no filter is narrowed', () => {

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.svelte.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.svelte.ts
@@ -2,6 +2,7 @@ import { fromStore } from 'svelte/store';
 import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import { formatFloat, formatInteger } from '$lib/utils';
 import { usePostHog } from '$lib/hooks';
+import type { CategoricalMetadataValue } from '$lib/services/types';
 
 type Range = { min: number; max: number };
 type BoundsMap = Record<string, Range>;
@@ -9,18 +10,27 @@ type BoundsMap = Record<string, Range>;
 export interface MetadataFilterChip {
     key: string;
     active: boolean;
-    range: Range;
+    kind: 'numeric' | 'categorical';
+    range?: Range;
+    values?: CategoricalMetadataValue[];
 }
 
 export function useMetadataFilterChips(collectionId: string | undefined) {
-    const { metadataBounds, metadataValues, updateMetadataValues } =
-        useMetadataFilters(collectionId);
+    const {
+        metadataBounds,
+        metadataValues,
+        categoricalMetadataValues,
+        updateMetadataValues,
+        updateCategoricalMetadataValues
+    } = useMetadataFilters(collectionId);
     const { trackEvent } = usePostHog();
 
     const boundsStore = fromStore(metadataBounds);
     const valuesStore = fromStore(metadataValues);
+    const categoricalStore = fromStore(categoricalMetadataValues);
 
     let lastRanges = $state<BoundsMap>({});
+    let lastCategoricalValues = $state<Record<string, CategoricalMetadataValue[]>>({});
 
     const isNarrowed = (key: string): boolean => {
         const bound = boundsStore.current[key];
@@ -40,6 +50,19 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
         }
     });
 
+    $effect(() => {
+        for (const [key, values] of Object.entries(categoricalStore.current)) {
+            if (values.length === 0) continue;
+            const previous = lastCategoricalValues[key] ?? [];
+            const unchanged =
+                previous.length === values.length &&
+                previous.every((value, index) => Object.is(value, values[index]));
+            if (!unchanged) {
+                lastCategoricalValues = { ...lastCategoricalValues, [key]: [...values] };
+            }
+        }
+    });
+
     // One chip per key that is narrowed now or has a remembered range: active
     // chips show the current range, disabled ones the remembered range.
     const chips = $derived.by<MetadataFilterChip[]>(() => {
@@ -47,16 +70,32 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
             ...Object.keys(lastRanges),
             ...Object.keys(valuesStore.current).filter(isNarrowed)
         ]);
-        return [...keys]
+        const numericChips = [...keys]
             .filter((key) => boundsStore.current[key])
             .map((key) => {
                 const active = isNarrowed(key);
                 const range: Range | undefined = active
                     ? valuesStore.current[key]
                     : lastRanges[key];
-                return { key, active, range };
+                return range ? { key, active, range, kind: 'numeric' as const } : null;
             })
-            .filter((chip): chip is MetadataFilterChip => !!chip.range);
+            .filter((chip): chip is NonNullable<typeof chip> => chip !== null);
+        const categoricalKeys = new Set([
+            ...Object.keys(lastCategoricalValues),
+            ...Object.entries(categoricalStore.current)
+                .filter(([, values]) => values.length > 0)
+                .map(([key]) => key)
+        ]);
+        const categoricalChips: MetadataFilterChip[] = [...categoricalKeys].map((key) => {
+            const current = categoricalStore.current[key] ?? [];
+            return {
+                key,
+                active: current.length > 0,
+                kind: 'categorical',
+                values: current.length > 0 ? current : lastCategoricalValues[key]
+            };
+        });
+        return [...numericChips, ...categoricalChips];
     });
 
     const setRange = (key: string, range: Range) => {
@@ -73,6 +112,13 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
     };
 
     const handleToggle = (key: string, checked: boolean | 'indeterminate') => {
+        if (lastCategoricalValues[key]) {
+            updateCategoricalMetadataValues({
+                ...categoricalStore.current,
+                [key]: checked ? lastCategoricalValues[key] : []
+            });
+            return;
+        }
         const bound = boundsStore.current[key];
         if (!bound) return;
         if (checked && lastRanges[key]) {
@@ -84,6 +130,15 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
     };
 
     const handleClear = (key: string) => {
+        if (lastCategoricalValues[key]) {
+            const next = { ...categoricalStore.current };
+            delete next[key];
+            updateCategoricalMetadataValues(next);
+            lastCategoricalValues = Object.fromEntries(
+                Object.entries(lastCategoricalValues).filter(([valueKey]) => valueKey !== key)
+            );
+            return;
+        }
         const bound = boundsStore.current[key];
         if (bound) setRange(key, { min: bound.min, max: bound.max });
         lastRanges = Object.fromEntries(
@@ -98,12 +153,26 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
         return isInteger ? formatInteger(value) : formatFloat(value);
     };
 
+    const formatCategoricalValues = (values: CategoricalMetadataValue[] = []): string => {
+        const hasMissingValue = values.includes('Missing');
+        const hasNoValue = values.includes(null);
+        return values
+            .map((value) => {
+                if (value === null) return hasMissingValue ? 'Missing (no value)' : 'Missing';
+                if (value === 'Missing' && hasNoValue) return 'Missing (value)';
+                if (value === 'Other') return 'Other (value)';
+                return String(value);
+            })
+            .join(', ');
+    };
+
     return {
         get chips() {
             return chips;
         },
         handleToggle,
         handleClear,
-        formatValue
+        formatValue,
+        formatCategoricalValues
     };
 }

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.test.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.test.ts
@@ -27,6 +27,7 @@ describe('useMetadataFilterChips', () => {
         storage.updateMetadataBounds({});
         storage.updateMetadataValues({});
         trackEvent.mockClear();
+        storage.updateCategoricalMetadataValues({});
     });
 
     it('provides a chip only for narrowed filters, not for full-range ones', () => {

--- a/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.test.ts
@@ -78,4 +78,21 @@ describe('getFrameFilter', () => {
             frame_number: {}
         });
     });
+
+    it('adds categorical metadata filters', async () => {
+        const { createMetadataFilters } = await import('../useMetadataFilters/useMetadataFilters');
+        vi.mocked(createMetadataFilters).mockReturnValueOnce([
+            { key: 'city', value: ['Zurich', null], op: 'in' }
+        ]);
+
+        const filter = getFrameFilter({
+            collection_id: 'coll-1',
+            filters: { categorical_metadata_values: { city: ['Zurich', null] } }
+        });
+
+        expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+        expect(filter?.sample_filter?.metadata_filters).toEqual([
+            { key: 'city', value: ['Zurich', null], op: 'in' }
+        ]);
+    });
 });

--- a/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useFramesFilter/frameFilter.ts
@@ -5,8 +5,7 @@ import type {
     VideoFrameFilter,
     VideoFrameFieldsBoundsView
 } from '$lib/api/lightly_studio_local/types.gen';
-import type { CategoricalMetadataValues } from '$lib/services/types';
-type MetadataValues = Record<string, { min: number; max: number }>;
+import type { CategoricalMetadataValues, MetadataValues } from '$lib/services/types';
 
 export type VideoFrameFilterParams = {
     collection_id: string;

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
@@ -3,6 +3,7 @@ import { get } from 'svelte/store';
 import { useImageFilters } from './useImageFilters';
 import type { QueryExpr, SortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
 import { SortDirection } from '$lib/api/lightly_studio_local/types.gen';
+import { createMetadataFilters } from '../useMetadataFilters/useMetadataFilters';
 
 const queryExpr = {
     match_expr: {
@@ -67,6 +68,22 @@ describe('useImageFilters', () => {
             updateQueryExpr(undefined);
             expect(get(imageFilter)?.sample_filter?.query_expr).toBeUndefined();
         });
+    });
+
+    it('forwards numeric and categorical metadata state into the shared image filter', () => {
+        vi.mocked(createMetadataFilters).mockReturnValueOnce([
+            { key: 'city', op: 'in', value: ['Zurich', null] }
+        ]);
+        const { imageFilter, updateFilterParams } = useImageFilters();
+        updateFilterParams({
+            ...normalFilterParams,
+            metadata_values: {},
+            categorical_metadata_values: { city: ['Zurich', null] }
+        });
+
+        const metadataFilters = get(imageFilter)?.sample_filter?.metadata_filters;
+        expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+        expect(metadataFilters).toEqual([{ key: 'city', op: 'in', value: ['Zurich', null] }]);
     });
 
     describe('updateConfusionCell', () => {

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/buildRequestBody.test.ts
@@ -199,5 +199,19 @@ describe('buildRequestBody', () => {
                 metadataFilterFixture
             ]);
         });
+
+        it('applies categorical metadata values via createMetadataFilters', () => {
+            const result = buildRequestBody(
+                {
+                    collection_id: 'col-1',
+                    mode: 'normal',
+                    categorical_metadata_values: { city: ['Zurich', null] }
+                },
+                0
+            );
+            expect(result.filters?.sample_filter?.metadata_filters).toEqual([
+                metadataFilterFixture
+            ]);
+        });
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
@@ -93,6 +93,19 @@ describe('createImagesInfiniteOptions', () => {
             });
             expect(options1.queryKey).not.toEqual(options2.queryKey);
         });
+
+        it('includes typed categorical selections in the query key', () => {
+            const categoricalMetadataValues = { city: ['Zurich', null] };
+            const options = createImagesInfiniteOptions({
+                collection_id: 'col-1',
+                mode: 'normal',
+                categorical_metadata_values: categoricalMetadataValues
+            });
+
+            expect(options.queryKey[4]).toMatchObject({
+                categorical_metadata_values: categoricalMetadataValues
+            });
+        });
     });
 
     describe('enabled', () => {

--- a/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.test.ts
@@ -86,12 +86,12 @@ describe('createMetadataFilters', () => {
     it('combines numeric ranges with one OR predicate per non-empty categorical key', () => {
         const filters = createMetadataFilters(
             { temperature: { min: 20, max: 100 } },
-            { city: ['Zurich', 'Berlin', '__missing__'], ignored: [] }
+            { city: ['Zurich', 'Berlin', null], ignored: [] }
         );
 
         expect(filters).toEqual([
             { key: 'temperature', value: 20, op: '>=' },
-            { key: 'city', value: ['Zurich', 'Berlin', '__missing__'], op: 'in' }
+            { key: 'city', value: ['Zurich', 'Berlin', null], op: 'in' }
         ]);
     });
 

--- a/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useMetadataFilters/useMetadataFilters.ts
@@ -18,7 +18,6 @@ const loadInitialMetadataInfo = async (collection_id: string) => {
     }
     lastCollectionId.set(collection_id);
     const storage = useGlobalStorage();
-    storage.updateCategoricalMetadataValues({});
 
     const { data: metadataInfoData } = await getMetadataInfo({
         path: {

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
@@ -131,6 +131,24 @@ describe('useVideoFilters', () => {
                 { key: 'temp', value: 10, op: '>=' }
             ]);
         });
+
+        it('includes categorical metadata selections in the sample filter', async () => {
+            const { createMetadataFilters } =
+                await import('../useMetadataFilters/useMetadataFilters');
+            vi.mocked(createMetadataFilters).mockReturnValueOnce([
+                { key: 'city', value: ['Zurich', null], op: 'in' }
+            ]);
+            const { videoFilter, updateFilterParams } = useVideoFilters();
+
+            updateFilterParams({
+                collection_id: 'coll-1',
+                filters: { categorical_metadata_values: { city: ['Zurich', null] } }
+            });
+
+            const metadataFilters = get(videoFilter)?.sample_filter?.metadata_filters;
+            expect(createMetadataFilters).toHaveBeenCalledWith({}, { city: ['Zurich', null] });
+            expect(metadataFilters).toEqual([{ key: 'city', value: ['Zurich', null], op: 'in' }]);
+        });
     });
 
     describe('updateSampleIds', () => {

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
@@ -6,8 +6,7 @@ import type {
     VideoFilter,
     VideoFieldsBoundsView
 } from '$lib/api/lightly_studio_local/types.gen';
-import type { CategoricalMetadataValues } from '$lib/services/types';
-type MetadataValues = Record<string, { min: number; max: number }>;
+import type { CategoricalMetadataValues, MetadataValues } from '$lib/services/types';
 
 export type VideoFilterParams = {
     collection_id: string;

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -76,7 +76,8 @@
         useImageAnnotationCounts,
         useImageAnnotationCountsQueryKey,
         useNumericMetadataDistribution,
-        usePostHog
+        usePostHog,
+        useCategoricalMetadataDistribution
     } from '$lib/hooks';
     import { useSelectAll } from '$lib/hooks/useSelectAll/useSelectAll';
     import { isInputElement } from '$lib/utils';
@@ -302,9 +303,14 @@
             : 'Search samples by description or image'
     );
 
-    const { metadataValues, metadataBounds, updateMetadataValues } = $derived.by(() =>
-        useMetadataFilters(collectionId)
-    );
+    const {
+        metadataValues,
+        metadataBounds,
+        metadataInfo,
+        categoricalMetadataValues,
+        updateMetadataValues,
+        updateCategoricalMetadataValues
+    } = $derived.by(() => useMetadataFilters(collectionId));
     const { dimensionsValues } = useDimensions(collectionIdStore);
 
     const annotationLabelsQuery = useAnnotationLabels(() => ({
@@ -325,7 +331,9 @@
     });
 
     const metadataFilters = $derived(
-        metadataValues ? createMetadataFilters($metadataValues) : undefined
+        metadataValues
+            ? createMetadataFilters($metadataValues, $categoricalMetadataValues)
+            : undefined
     );
     const { videoFramesBoundsValues } = useVideoFramesBounds();
     const { videoBoundsValues } = useVideoBounds();
@@ -371,6 +379,24 @@
             dimensionsValues: $dimensionsValues,
             annotationFilter: annotationFilterForCounts,
             metadataFilters,
+            sampleIds: isAnnotations ? [] : plotFilterImageSampleIds,
+            tagIds: isAnnotations ? [] : plotFilterTagIds,
+            confusionCell: isAnnotations ? null : plotFilterConfusionCell,
+            queryExpr: isAnnotations ? null : plotFilterQueryExpr
+        })
+    );
+
+    // Distribution queries always show the full dataset so bar heights stay
+    // stable as sidebar filters are applied.  Filtering is communicated through
+    // bar colour (green = in selection, grey = out of selection) rather than
+    // through shrinking bars, which loses the original distribution context.
+    // Tag / sample / confusion-cell / query context is kept so the distributions
+    // stay scoped to the collection the user is currently exploring.
+    const distributionBaseFilter = $derived(
+        buildImageFilter({
+            dimensionsValues: null,
+            annotationFilter: undefined,
+            metadataFilters: undefined,
             sampleIds: isAnnotations ? [] : plotFilterImageSampleIds,
             tagIds: isAnnotations ? [] : plotFilterTagIds,
             confusionCell: isAnnotations ? null : plotFilterConfusionCell,
@@ -576,17 +602,16 @@
         return { ...base, groups: [allTypesGroup, ...typeGroups] };
     });
 
-    // Numeric metadata fields as histogram groups. Bin edges span the full
-    // collection (stable axis); counts track the active filters — the query
-    // refetches whenever the grid filter changes. Each key's own metadata
-    // filter is excluded server-side (faceted-search behavior). Disabled while
-    // the distribution panel is closed to avoid background fetching.
+    // Numeric metadata fields as histogram groups. Bin edges and counts both
+    // span the full collection (distributionBaseFilter strips analysis filters)
+    // so bar heights stay stable while the user adjusts sidebar filters.
+    // Disabled while the distribution panel is closed to avoid background fetching.
     // User-configurable bin count for the metadata histograms.
     let histogramBinCount = $state(20);
 
     const metadataHistogramsQuery = useNumericMetadataDistribution(() => ({
         collectionId: collectionId,
-        filter: imageAnnotationCountsFilter,
+        filter: distributionBaseFilter,
         binCount: histogramBinCount,
         enabled: distributionPanelVisible
     }));
@@ -594,21 +619,60 @@
     // selectDistributions internally via the TanStack Query `select` option.
     const metadataDistributions = $derived(metadataHistogramsQuery.data ?? {});
 
+    const categoricalMetadataQuery = useCategoricalMetadataDistribution(() => ({
+        collectionId,
+        filter: distributionBaseFilter,
+        enabled: distributionPanelVisible
+    }));
+    const categoricalMetadataDistributions = $derived(categoricalMetadataQuery.data ?? {});
+
+    // Second categorical query with the full sidebar filter applied.  Its counts
+    // are passed as `filteredBuckets` so each bar can show a grey background at
+    // the unfiltered height with a coloured foreground at the filtered height.
+    const categoricalMetadataFilteredQuery = useCategoricalMetadataDistribution(() => ({
+        collectionId,
+        filter: imageAnnotationCountsFilter,
+        enabled: distributionPanelVisible
+    }));
+    // Keep undefined (not {}) while loading so DatasetDistributionPanel defers
+    // rendering the background bars until the filtered data is ready.
+    const categoricalMetadataFilteredDistributions = $derived(
+        categoricalMetadataFilteredQuery.data
+    );
+
     const metadataDistributionSource = $derived.by<DistributionSource | null>(() => {
-        const keys = Object.keys(metadataDistributions);
-        if (keys.length === 0) return null;
+        const numericKeys = Object.keys(metadataDistributions);
+        const categoricalKeys = ($metadataInfo ?? [])
+            .filter((info) => info.type === 'string' || info.type === 'boolean')
+            .map((info) => info.name);
+        if (numericKeys.length === 0 && categoricalKeys.length === 0) return null;
         return {
             id: 'metadata',
             label: 'Metadata',
             groupLabel: 'Metadata key',
             valueNoun: 'samples',
-            groups: keys.map((key) => ({
-                id: key,
-                label: key,
-                histogram: metadataDistributions[key],
-                // Highlight the active filter range; bins outside it dim.
-                selectedRange: $metadataValues[key]
-            }))
+            groups: [
+                ...numericKeys.map((key) => ({
+                    id: key,
+                    label: key,
+                    histogram: metadataDistributions[key],
+                    // Highlight the active filter range; bins outside it dim.
+                    selectedRange: $metadataValues[key]
+                })),
+                ...categoricalKeys.map((key) => ({
+                    id: key,
+                    label: key,
+                    categorical: {
+                        buckets: categoricalMetadataDistributions[key] ?? [],
+                        // undefined until the filtered query has returned so the
+                        // distribution panel waits before showing background bars.
+                        filteredBuckets: categoricalMetadataFilteredDistributions?.[key],
+                        selectedValues: $categoricalMetadataValues[key] ?? [],
+                        loading: categoricalMetadataQuery.isFetching,
+                        error: categoricalMetadataQuery.error?.message
+                    }
+                }))
+            ]
         };
     });
 
@@ -634,6 +698,24 @@
                 ? { min: bound.min, max: bound.max }
                 : { min: clampedMin, max: clampedMax }
         });
+    };
+
+    const handleCategoricalValueToggle = (metadataKey: string, value: string | boolean | null) => {
+        const selected = $categoricalMetadataValues[metadataKey] ?? [];
+        const exists = selected.some((candidate) => Object.is(candidate, value));
+        const next = exists
+            ? selected.filter((candidate) => !Object.is(candidate, value))
+            : [...selected, value];
+        updateCategoricalMetadataValues({
+            ...$categoricalMetadataValues,
+            [metadataKey]: next
+        });
+    };
+
+    const clearCategoricalValues = (metadataKey: string) => {
+        const next = { ...$categoricalMetadataValues };
+        delete next[metadataKey];
+        updateCategoricalMetadataValues(next);
     };
 
     const distributionSources = $derived<DistributionSource[]>(
@@ -833,18 +915,24 @@
                                 <QueryEditorPanel onClose={() => setActivePanel('none')} />
                             {:else if distributionPanelVisible}
                                 {#await import('$lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte') then { default: DatasetDistributionPanel }}
-                                    <DatasetDistributionPanel
-                                        sources={distributionSources}
-                                        initialCountMode={distributionCountMode}
-                                        onClose={() => setActivePanel('none')}
-                                        onCountModeChange={(mode) => {
-                                            distributionCountMode = mode;
-                                        }}
-                                        onHistogramRangeSelect={handleDistributionHistogramRangeSelect}
-                                        {histogramBinCount}
-                                        onHistogramBinCountChange={(binCount) =>
-                                            (histogramBinCount = binCount)}
-                                    />
+                                    {#key collectionId}
+                                        <DatasetDistributionPanel
+                                            sources={distributionSources}
+                                            initialCountMode={distributionCountMode}
+                                            onClose={() => setActivePanel('none')}
+                                            onCountModeChange={(mode) => {
+                                                distributionCountMode = mode;
+                                            }}
+                                            onHistogramRangeSelect={handleDistributionHistogramRangeSelect}
+                                            onCategoricalValueToggle={handleCategoricalValueToggle}
+                                            onCategoricalValuesClear={clearCategoricalValues}
+                                            onCategoricalRetry={() =>
+                                                categoricalMetadataQuery.refetch()}
+                                            {histogramBinCount}
+                                            onHistogramBinCountChange={(binCount) =>
+                                                (histogramBinCount = binCount)}
+                                        />
+                                    {/key}
                                 {/await}
                             {/if}
                         </Pane>

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
@@ -22,7 +22,9 @@
 
     const collectionId = $derived(page.params.collection_id);
 
-    const { metadataValues } = $derived(useMetadataFilters(collectionId));
+    const { metadataValues, categoricalMetadataValues } = $derived(
+        useMetadataFilters(collectionId)
+    );
     const { videoFramesBoundsValues } = $derived(useVideoFramesBounds(collectionId));
 
     const { selectedAnnotationFilterIdsArray: selectedAnnotationFilterIds } =
@@ -41,7 +43,8 @@
                 ? $selectedAnnotationFilterIds
                 : undefined,
             tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined,
-            metadata_values: $metadataValues
+            metadata_values: $metadataValues,
+            categorical_metadata_values: $categoricalMetadataValues
         },
         frame_bounds: $videoFramesBoundsValues
     });

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -142,6 +142,12 @@ vi.mock('$lib/hooks', () => ({
     useImageAnnotationCounts: vi.fn(() => ({ data: undefined })),
     useImageAnnotationCountsQueryKey: ['imageAnnotationCounts'],
     useNumericMetadataDistribution: vi.fn(() => ({ data: undefined })),
+    useCategoricalMetadataDistribution: vi.fn(() => ({
+        data: undefined,
+        isFetching: false,
+        error: null,
+        refetch: vi.fn()
+    })),
     usePostHog: vi.fn(() => ({ trackEvent: vi.fn() })),
     useTrackSampleInspected: vi.fn()
 }));

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
@@ -26,7 +26,7 @@
         })
     );
 
-    const { metadataValues } = useMetadataFilters();
+    const { metadataValues, categoricalMetadataValues } = useMetadataFilters();
     const { selectedAnnotationFilterIdsArray: selectedAnnotationsFilterIds } =
         useSelectedAnnotationsFilter();
     const { videoBoundsValues } = $derived.by(() => useVideoBounds(collectionId));
@@ -42,7 +42,8 @@
                 ? $selectedAnnotationsFilterIds
                 : undefined,
             tag_ids: $tagsSelected.size > 0 ? Array.from($tagsSelected) : undefined,
-            metadata_values: $metadataValues
+            metadata_values: $metadataValues,
+            categorical_metadata_values: $categoricalMetadataValues
         },
         video_bounds: $videoBoundsValues
     });


### PR DESCRIPTION
- Add useCategoricalMetadataDistribution to the $lib/hooks mock in layout.workspace.test.ts (missing after the merge brought in its usage in +layout.svelte)
- Add itemNoun prop to DistributionConfigDialog and pass it through to ClassSetConfigDialog so the manual-selector empty state reads "No value found." for categorical distributions
- Pass itemNoun to DistributionConfigDialog from DatasetDistributionPanel
- Update DistributionConfigDialog test to supply itemNoun: 'value'

## What has changed and why?

(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added categorical metadata distributions alongside existing numeric distributions.
  * Added filtering, searching, selection, clearing, sorting, and orientation controls for metadata values.
  * Categorical selections now apply consistently to image, frame, and video results.
  * Added clearer, context-aware labels such as “values” and improved handling of missing or unavailable values.

* **Bug Fixes**
  * Preserved pinned and manually selected distribution items reliably.
  * Improved chart spacing and ignored clicks on non-selectable bars.
  * Preserved categorical selections and displayed results during loading or retryable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->