### PR TITLE
feat: use dynamic labels for PanelHeader

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
@@ -19,6 +19,11 @@
         totalCount?: number;
         /** Noun for the total count summary (e.g. 'annotations', 'samples'). */
         valueNoun?: string;
+        /** Singular/plural labels for the distributed categories. */
+        categoryNoun?: string;
+        categoryNounPlural?: string;
+        /** Labels for the active sort mode. */
+        sortLabels?: Record<keyof typeof DISTRIBUTION_SORT_LABELS, string>;
         /** Opens the view-config dialog (top-N and sort order). */
         onConfigure: () => void;
         /** Quick action showing all classes; rendered only while a subset is visible. */
@@ -37,6 +42,9 @@
         visibleClassCount,
         totalCount,
         valueNoun = 'annotations',
+        categoryNoun = 'class',
+        categoryNounPlural = 'classes',
+        sortLabels = DISTRIBUTION_SORT_LABELS,
         onConfigure,
         onShowAll,
         onToggleOrientation,
@@ -45,16 +53,17 @@
     }: Props = $props();
 </script>
 
-<div class="mb-1 flex flex-row items-center gap-2">
-    <div class="mb-2 flex-1 text-xs text-muted-foreground">
+<div class="flex flex-row items-center gap-2">
+    <div class="flex-1 text-xs text-muted-foreground">
         {#if visibleClassCount < classCount}
             {config.mode === 'manual' ? 'Showing' : 'Top'}
-            {visibleClassCount} of {classCount} classes
+            {visibleClassCount} of {classCount}
+            {categoryNounPlural}
         {:else}
             {classCount}
-            {classCount === 1 ? 'class' : 'classes'}
+            {classCount === 1 ? categoryNoun : categoryNounPlural}
         {/if}
-        · sorted by {DISTRIBUTION_SORT_LABELS[config.sortBy].toLowerCase()}
+        · sorted by {sortLabels[config.sortBy].toLowerCase()}
         {#if totalCount !== undefined}
             · {totalCount.toLocaleString('en-US')}
             {valueNoun}
@@ -89,7 +98,7 @@
     <Button
         variant="ghost"
         icon={SettingsIcon}
-        ariaLabel="Configure distribution classes"
+        ariaLabel="Configure distribution {categoryNounPlural}"
         buttonProps={{
             size: 'sm',
             class: 'h-8 gap-1',

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
@@ -19,8 +19,9 @@
         totalCount?: number;
         /** Noun for the total count summary (e.g. 'annotations', 'samples'). */
         valueNoun?: string;
-        /** Singular/plural labels for the distributed categories. */
+        /** Singular label for the distributed categories. */
         categoryNoun?: string;
+        /** Plural labels for the distributed categories. */
         categoryNounPlural?: string;
         /** Labels for the active sort mode. */
         sortLabels?: Record<keyof typeof DISTRIBUTION_SORT_LABELS, string>;

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.test.ts
@@ -44,6 +44,21 @@ describe('PanelHeader', () => {
         expect(screen.getByText(/491 samples/)).toBeInTheDocument();
     });
 
+    it('uses custom category wording and sort labels', () => {
+        render(PanelHeader, {
+            props: {
+                ...defaultProps,
+                categoryNoun: 'value',
+                categoryNounPlural: 'values',
+                sortLabels: { count: 'Count', name: 'Value' },
+                config: { ...config, sortBy: 'name' }
+            }
+        });
+
+        expect(screen.getByText(/5 values · sorted by value/)).toBeInTheDocument();
+        expect(screen.getByLabelText('Configure distribution values')).toBeInTheDocument();
+    });
+
     it('shows the "Show all" action only for a visible subset and forwards clicks', async () => {
         const onShowAll = vi.fn();
         render(PanelHeader, {
@@ -121,5 +136,13 @@ describe('PanelHeader', () => {
         });
 
         expect(screen.getByTestId('dataset-distribution-expanded-configure')).toBeInTheDocument();
+    });
+
+    it('does not add plot-specific bottom margins', () => {
+        render(PanelHeader, { props: defaultProps });
+
+        const summary = screen.getByText(/^5 classes ·/);
+        expect(summary).not.toHaveClass('mb-2');
+        expect(summary.parentElement).not.toHaveClass('mb-1');
     });
 });


### PR DESCRIPTION
## What has changed and why?

Changes in PanelHeader component to reuse it for categorical metadata

## How has it been tested?

By unit tests, no bracking changes

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable category terminology and sorting labels to dataset distribution headers.
  * Updated summary text and accessibility labels to reflect configured terminology.
  * Preserved existing “class/classes” wording and sorting labels as defaults.

* **Bug Fixes**
  * Corrected layout spacing behavior when using default distribution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->