### PR TITLE
Adjust DatasetDistributionPanel to be able to render categorical metadata values

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+    import DistributionChart from './DistributionChart/DistributionChart.svelte';
+    import type { CategoryCount } from '$lib/components/BarChart';
+    import type { HistogramRange } from '$lib/components/Histogram';
+    import type { useDistributionPanel } from './useDistributionPanel.svelte';
+
+    interface Props {
+        panel: ReturnType<typeof useDistributionPanel>;
+        onHistogramRangeSelect?: (groupId: string, range: HistogramRange) => void;
+        onBarClick?: (item: CategoryCount) => void;
+        onCategoricalRetry?: () => void;
+    }
+
+    const { panel, onHistogramRangeSelect, onBarClick, onCategoricalRetry }: Props = $props();
+</script>
+
+<DistributionChart
+    activeHistogram={panel.activeHistogram}
+    activeCategorical={panel.activeCategorical}
+    viewConfig={panel.activeViewConfig}
+    visible={panel.visible}
+    totalCount={panel.totalCount}
+    selectedRange={panel.activeHistogramRange}
+    onHistogramRangeSelect={onHistogramRangeSelect ? panel.handleHistogramRangeSelect : undefined}
+    onBarClick={panel.activeCategorical ? panel.handleCategoricalBarClick : onBarClick}
+    {onCategoricalRetry}
+/>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-    import DistributionChart from './DistributionChart/DistributionChart.svelte';
+    import DistributionChart from '../DistributionChart/DistributionChart.svelte';
     import type { CategoryCount } from '$lib/components/BarChart';
     import type { HistogramRange } from '$lib/components/Histogram';
-    import type { useDistributionPanel } from './useDistributionPanel.svelte';
+    import type { useDistributionPanel } from '../useDistributionPanel.svelte';
 
     interface Props {
         panel: ReturnType<typeof useDistributionPanel>;

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.test.ts
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import DatasetDistributionContent from './DatasetDistributionContent.svelte';
-import { useDistributionPanel } from './useDistributionPanel.svelte';
-import type { DistributionSource } from './types';
+import { useDistributionPanel } from '../useDistributionPanel.svelte';
+import type { DistributionSource } from '../types';
 
 const echartsMock = vi.hoisted(() => {
     let clickHandler: ((params: { dataIndex?: number }) => void) | undefined;

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.test.ts
@@ -1,0 +1,170 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import DatasetDistributionContent from './DatasetDistributionContent.svelte';
+import { useDistributionPanel } from './useDistributionPanel.svelte';
+import type { DistributionSource } from './types';
+
+const echartsMock = vi.hoisted(() => {
+    let clickHandler: ((params: { dataIndex?: number }) => void) | undefined;
+    const instance = {
+        setOption: vi.fn(),
+        resize: vi.fn(),
+        dispose: vi.fn(),
+        on: vi.fn((event: string, handler: (params: { dataIndex?: number }) => void) => {
+            if (event === 'click') clickHandler = handler;
+        }),
+        convertFromPixel: vi.fn((_finder: unknown, offsetX: number) => offsetX / 100),
+        getZr: () => ({ on: vi.fn(), off: vi.fn() })
+    };
+    return { init: vi.fn(() => instance), instance, getClickHandler: () => clickHandler };
+});
+
+vi.mock('echarts/core', () => ({ init: echartsMock.init, use: vi.fn() }));
+vi.mock('echarts/charts', () => ({ BarChart: {}, CustomChart: {} }));
+vi.mock('echarts/components', () => ({ GridComponent: {}, TooltipComponent: {} }));
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as unknown as typeof ResizeObserver;
+}
+
+const renderContent = (sources: DistributionSource[], overrides: Record<string, unknown> = {}) => {
+    const panel = useDistributionPanel(() => ({ sources }));
+    return render(DatasetDistributionContent, { props: { panel, ...overrides } });
+};
+
+describe('DatasetDistributionContent', () => {
+    it('renders a bar chart for bar data', () => {
+        renderContent([{ id: 'classes', label: 'Classes', data: [{ label: 'car', count: 10 }] }]);
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+        expect(screen.queryByTestId('histogram')).not.toBeInTheDocument();
+    });
+
+    it('renders the empty chart state when no data', () => {
+        renderContent([{ id: 'classes', label: 'Classes', data: [] }]);
+        expect(screen.getByTestId('bar-chart-empty')).toBeInTheDocument();
+    });
+
+    it('renders a histogram for a histogram group', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                valueNoun: 'samples',
+                groups: [
+                    {
+                        id: 'confidence',
+                        label: 'confidence',
+                        histogram: { binEdges: [0, 0.5, 1], counts: [30, 70] }
+                    }
+                ]
+            }
+        ];
+        renderContent(sources);
+        expect(screen.getByTestId('histogram')).toBeInTheDocument();
+        expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
+    });
+
+    it('renders a bar chart for categorical data', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        renderContent(sources);
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    });
+
+    it('forwards onBarClick when a bar is clicked', () => {
+        const onBarClick = vi.fn();
+        renderContent([{ id: 'classes', label: 'Classes', data: [{ label: 'car', count: 10 }] }], {
+            onBarClick
+        });
+        echartsMock.getClickHandler()?.({ dataIndex: 0 });
+        expect(onBarClick).toHaveBeenCalledOnce();
+    });
+
+    it('does not forward onHistogramRangeSelect when the prop is omitted', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'confidence',
+                        label: 'confidence',
+                        histogram: { binEdges: [0, 0.5, 1], counts: [30, 70] }
+                    }
+                ]
+            }
+        ];
+        // No error should be thrown and no handler registered when prop is absent.
+        expect(() => renderContent(sources)).not.toThrow();
+    });
+
+    it('shows the loading status when categorical buckets are empty and loading', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: { buckets: [], selectedValues: [], loading: true }
+                    }
+                ]
+            }
+        ];
+        renderContent(sources);
+        expect(screen.getByRole('status')).toHaveTextContent('Loading metadata distribution');
+    });
+
+    it('shows the error alert with retry when categorical buckets are empty and there is an error', async () => {
+        const onCategoricalRetry = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            buckets: [],
+                            selectedValues: ['Zurich'],
+                            error: 'network failure'
+                        }
+                    }
+                ]
+            }
+        ];
+        renderContent(sources, { onCategoricalRetry });
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not load metadata distribution');
+        await fireEvent.click(screen.getByTestId('metadata-categorical-retry'));
+        expect(onCategoricalRetry).toHaveBeenCalledOnce();
+    });
+});

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionHeader/DatasetDistributionHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionHeader/DatasetDistributionHeader.svelte
@@ -2,19 +2,18 @@
     import { X } from '@lucide/svelte';
     import { Button } from '$lib/components';
     import Typography from '$lib/components/Typography/Typography.svelte';
-    import SourceGroupSelector from './SourceGroupSelector/SourceGroupSelector.svelte';
-    import HistogramToolbar from './HistogramToolbar/HistogramToolbar.svelte';
-    import PanelHeader from './PanelHeader/PanelHeader.svelte';
-    import { MetadataCategoricalFilter } from './MetadataCategoricalFilter';
-    import { CATEGORICAL_DISTRIBUTION_SORT_LABELS } from './types';
-    import type { useDistributionPanel } from './useDistributionPanel.svelte';
+    import SourceGroupSelector from '../SourceGroupSelector/SourceGroupSelector.svelte';
+    import HistogramToolbar from '../HistogramToolbar/HistogramToolbar.svelte';
+    import PanelHeader from '../PanelHeader/PanelHeader.svelte';
+    import { MetadataCategoricalFilter } from '../MetadataCategoricalFilter';
+    import { CATEGORICAL_DISTRIBUTION_SORT_LABELS } from '../types';
+    import type { useDistributionPanel } from '../useDistributionPanel.svelte';
 
     interface Props {
         title: string;
         panel: ReturnType<typeof useDistributionPanel>;
         histogramBinCount: number;
         onHistogramBinCountChange?: (binCount: number) => void;
-        onCategoricalRetry?: () => void;
         onClose?: () => void;
         onOpenConfig: () => void;
         onOpenExpand: () => void;
@@ -26,7 +25,6 @@
         panel,
         histogramBinCount,
         onHistogramBinCountChange,
-        onCategoricalRetry,
         onClose,
         onOpenConfig,
         onOpenExpand,

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionHeader/DatasetDistributionHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionHeader/DatasetDistributionHeader.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+    import { X } from '@lucide/svelte';
+    import { Button } from '$lib/components';
+    import Typography from '$lib/components/Typography/Typography.svelte';
+    import SourceGroupSelector from './SourceGroupSelector/SourceGroupSelector.svelte';
+    import HistogramToolbar from './HistogramToolbar/HistogramToolbar.svelte';
+    import PanelHeader from './PanelHeader/PanelHeader.svelte';
+    import { MetadataCategoricalFilter } from './MetadataCategoricalFilter';
+    import { CATEGORICAL_DISTRIBUTION_SORT_LABELS } from './types';
+    import type { useDistributionPanel } from './useDistributionPanel.svelte';
+
+    interface Props {
+        title: string;
+        panel: ReturnType<typeof useDistributionPanel>;
+        histogramBinCount: number;
+        onHistogramBinCountChange?: (binCount: number) => void;
+        onCategoricalRetry?: () => void;
+        onClose?: () => void;
+        onOpenConfig: () => void;
+        onOpenExpand: () => void;
+        onOpenHistogramExpand: () => void;
+    }
+
+    const {
+        title,
+        panel,
+        histogramBinCount,
+        onHistogramBinCountChange,
+        onCategoricalRetry,
+        onClose,
+        onOpenConfig,
+        onOpenExpand,
+        onOpenHistogramExpand
+    }: Props = $props();
+</script>
+
+<div class="flex items-center justify-between">
+    <Typography variant="h5" component="h2" className="text-foreground">
+        {title}
+    </Typography>
+    {#if onClose}
+        <Button
+            variant="ghost"
+            icon={X}
+            ariaLabel="Close distribution panel"
+            buttonProps={{
+                size: 'sm',
+                class: 'h-8 w-8 p-0',
+                onclick: onClose,
+                'data-testid': 'dataset-distribution-close-button'
+            }}
+        />
+    {/if}
+</div>
+{#if panel.hasSourceSelector}
+    <SourceGroupSelector
+        sourceItems={panel.sourceItems}
+        groupItems={panel.groupItems}
+        activeSourceId={panel.activeSource.id}
+        activeGroupId={panel.activeGroup?.id}
+        groupLabel={panel.activeSource.groupLabel ?? 'Field'}
+        onSourceChange={(value) => {
+            panel.setSelectedSourceId(value);
+            panel.setSelectedGroupId(undefined);
+        }}
+        onGroupChange={(value) => panel.setSelectedGroupId(value)}
+    />
+{/if}
+{#if panel.activeHistogram}
+    <HistogramToolbar
+        histogram={panel.activeHistogram}
+        histogramTotal={panel.histogramTotal}
+        valueNoun={panel.valueNoun}
+        {histogramBinCount}
+        binCountItems={panel.binCountItems}
+        {onHistogramBinCountChange}
+        onExpand={onOpenHistogramExpand}
+    />
+{:else if panel.activeCategorical && panel.activeGroup}
+    <MetadataCategoricalFilter
+        buckets={panel.activeCategorical.buckets}
+        selectedValues={panel.activeCategorical.selectedValues}
+        loading={panel.activeCategorical.loading}
+        onToggle={panel.handleCategoricalFilterToggle}
+        onClear={panel.handleCategoricalFilterClear}
+    />
+    {#if panel.categoricalData.length > 0}
+        <div class="mt-2">
+            <PanelHeader
+                config={panel.categoricalConfig}
+                classCount={panel.categoricalData.length}
+                visibleClassCount={panel.visible.length}
+                totalCount={panel.totalCount}
+                valueNoun={panel.valueNoun}
+                categoryNoun="value"
+                categoryNounPlural="values"
+                sortLabels={CATEGORICAL_DISTRIBUTION_SORT_LABELS}
+                onConfigure={onOpenConfig}
+                onShowAll={() =>
+                    panel.setCategoricalConfig({
+                        ...panel.categoricalConfig,
+                        mode: 'topN',
+                        n: panel.categoricalData.length
+                    })}
+                onToggleOrientation={() =>
+                    panel.setCategoricalConfig({
+                        ...panel.categoricalConfig,
+                        orientation:
+                            panel.categoricalConfig.orientation === 'horizontal'
+                                ? 'vertical'
+                                : 'horizontal'
+                    })}
+                onExpand={onOpenExpand}
+            />
+        </div>
+    {/if}
+{:else if panel.activeData.length > 0}
+    <div class="mt-2">
+        <PanelHeader
+            config={panel.config}
+            classCount={panel.activeData.length}
+            visibleClassCount={panel.visible.length}
+            totalCount={panel.showTotalCount ? panel.totalCount : undefined}
+            valueNoun={panel.valueNoun}
+            onConfigure={onOpenConfig}
+            onShowAll={() =>
+                panel.applyConfig({
+                    ...panel.config,
+                    mode: 'topN',
+                    n: panel.activeData.length
+                })}
+            onToggleOrientation={() =>
+                panel.applyConfig({
+                    ...panel.config,
+                    orientation:
+                        panel.config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
+                })}
+            onExpand={onOpenExpand}
+        />
+    </div>
+{/if}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionHeader/DatasetDistributionHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionHeader/DatasetDistributionHeader.test.ts
@@ -1,0 +1,233 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import DatasetDistributionHeader from './DatasetDistributionHeader.svelte';
+import { useDistributionPanel } from './useDistributionPanel.svelte';
+import type { DistributionSource } from './types';
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as unknown as typeof ResizeObserver;
+}
+
+const barSource = (overrides: Partial<DistributionSource> = {}): DistributionSource => ({
+    id: 'classes',
+    label: 'Classes',
+    data: [{ label: 'car', count: 10 }],
+    ...overrides
+});
+
+const histogramSource = (): DistributionSource => ({
+    id: 'metadata',
+    label: 'Metadata',
+    valueNoun: 'samples',
+    groups: [
+        {
+            id: 'confidence',
+            label: 'confidence',
+            histogram: { binEdges: [0, 0.5, 1], counts: [30, 70] }
+        }
+    ]
+});
+
+const categoricalSource = (
+    state: { loading?: boolean; error?: string } = {}
+): DistributionSource => ({
+    id: 'metadata',
+    label: 'Metadata',
+    valueNoun: 'samples',
+    groups: [
+        {
+            id: 'city',
+            label: 'city',
+            categorical: {
+                selectedValues: [],
+                buckets: [
+                    { id: 'zurich', kind: 'value', value: 'Zurich', label: 'Zurich', count: 4 },
+                    { id: 'bern', kind: 'value', value: 'Bern', label: 'Bern', count: 2 }
+                ],
+                ...state
+            }
+        }
+    ]
+});
+
+const defaultCallbacks = {
+    onOpenConfig: vi.fn(),
+    onOpenExpand: vi.fn(),
+    onOpenHistogramExpand: vi.fn()
+};
+
+const renderHeader = (sources: DistributionSource[], overrides: Record<string, unknown> = {}) => {
+    const panel = useDistributionPanel(() => ({ sources }));
+    return render(DatasetDistributionHeader, {
+        props: {
+            title: 'Distribution',
+            panel,
+            histogramBinCount: 20,
+            ...defaultCallbacks,
+            ...overrides
+        }
+    });
+};
+
+describe('DatasetDistributionHeader', () => {
+    beforeAll(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+        Element.prototype.hasPointerCapture = vi.fn(() => false);
+        Element.prototype.setPointerCapture = vi.fn();
+        Element.prototype.releasePointerCapture = vi.fn();
+    });
+
+    it('renders the title', () => {
+        renderHeader([barSource()]);
+        expect(screen.getByText('Distribution')).toBeInTheDocument();
+    });
+
+    it('shows a close button when onClose is provided', () => {
+        const onClose = vi.fn();
+        const panel = useDistributionPanel(() => ({ sources: [barSource()] }));
+        render(DatasetDistributionHeader, {
+            props: {
+                title: 'Distribution',
+                panel,
+                histogramBinCount: 20,
+                ...defaultCallbacks,
+                onClose
+            }
+        });
+        expect(screen.getByTestId('dataset-distribution-close-button')).toBeInTheDocument();
+    });
+
+    it('omits the close button when onClose is not provided', () => {
+        renderHeader([barSource()]);
+        expect(screen.queryByTestId('dataset-distribution-close-button')).not.toBeInTheDocument();
+    });
+
+    it('calls onClose when the close button is clicked', async () => {
+        const onClose = vi.fn();
+        const panel = useDistributionPanel(() => ({ sources: [barSource()] }));
+        render(DatasetDistributionHeader, {
+            props: {
+                title: 'Distribution',
+                panel,
+                histogramBinCount: 20,
+                ...defaultCallbacks,
+                onClose
+            }
+        });
+        await fireEvent.click(screen.getByTestId('dataset-distribution-close-button'));
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('shows the source selector when multiple sources are provided', () => {
+        renderHeader([
+            barSource({ id: 'a', label: 'Source A' }),
+            barSource({ id: 'b', label: 'Source B' })
+        ]);
+        expect(screen.getByTestId('dataset-distribution-source-select')).toBeInTheDocument();
+    });
+
+    it('omits the source selector for a single source', () => {
+        renderHeader([barSource()]);
+        expect(screen.queryByTestId('dataset-distribution-source-select')).not.toBeInTheDocument();
+    });
+
+    it('shows the histogram summary for a histogram group', () => {
+        renderHeader([histogramSource()]);
+        expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
+            '100 samples · 2 bins · 0–1'
+        );
+    });
+
+    it('shows the expand button for histogram sources and calls onOpenHistogramExpand on click', async () => {
+        const onOpenHistogramExpand = vi.fn();
+        const panel = useDistributionPanel(() => ({ sources: [histogramSource()] }));
+        render(DatasetDistributionHeader, {
+            props: {
+                title: 'Distribution',
+                panel,
+                histogramBinCount: 20,
+                ...defaultCallbacks,
+                onOpenHistogramExpand
+            }
+        });
+        await fireEvent.click(screen.getByTestId('dataset-distribution-histogram-expand'));
+        expect(onOpenHistogramExpand).toHaveBeenCalledOnce();
+    });
+
+    it('shows the class/annotation summary for bar chart data', () => {
+        renderHeader([barSource()]);
+        expect(screen.getByText(/1 class · sorted by count · 10 annotations/)).toBeInTheDocument();
+    });
+
+    it('calls onOpenConfig when the configure button is clicked for bar chart data', async () => {
+        const onOpenConfig = vi.fn();
+        const panel = useDistributionPanel(() => ({ sources: [barSource()] }));
+        render(DatasetDistributionHeader, {
+            props: {
+                title: 'Distribution',
+                panel,
+                histogramBinCount: 20,
+                ...defaultCallbacks,
+                onOpenConfig
+            }
+        });
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        expect(onOpenConfig).toHaveBeenCalledOnce();
+    });
+
+    it('calls onOpenExpand when the expand button is clicked for bar chart data', async () => {
+        const onOpenExpand = vi.fn();
+        const panel = useDistributionPanel(() => ({ sources: [barSource()] }));
+        render(DatasetDistributionHeader, {
+            props: {
+                title: 'Distribution',
+                panel,
+                histogramBinCount: 20,
+                ...defaultCallbacks,
+                onOpenExpand
+            }
+        });
+        await fireEvent.click(screen.getByTestId('dataset-distribution-expand'));
+        expect(onOpenExpand).toHaveBeenCalledOnce();
+    });
+
+    it('shows the categorical value summary and configure/expand buttons', () => {
+        renderHeader([categoricalSource()]);
+        expect(screen.getByText(/2 values · sorted by count · 6 samples/)).toBeInTheDocument();
+        expect(screen.getByTestId('dataset-distribution-configure')).toBeInTheDocument();
+        expect(screen.getByTestId('dataset-distribution-expand')).toBeInTheDocument();
+    });
+
+    it('calls onOpenConfig when configure is clicked for categorical data', async () => {
+        const onOpenConfig = vi.fn();
+        const panel = useDistributionPanel(() => ({ sources: [categoricalSource()] }));
+        render(DatasetDistributionHeader, {
+            props: {
+                title: 'Distribution',
+                panel,
+                histogramBinCount: 20,
+                ...defaultCallbacks,
+                onOpenConfig
+            }
+        });
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        expect(onOpenConfig).toHaveBeenCalledOnce();
+    });
+
+    it('shows an inline updating banner when stale buckets are present and loading', () => {
+        // Non-empty buckets → CategoricalStatusBanner shows "Updating values…" inline.
+        renderHeader([categoricalSource({ loading: true })]);
+        expect(screen.getByRole('status')).toHaveTextContent('Updating values');
+    });
+
+    it('shows an inline error banner when stale buckets are present and there is an error', () => {
+        // Non-empty buckets + error → CategoricalStatusBanner shows "Could not update" inline.
+        // The chart remains visible in DatasetDistributionContent (not rendered here).
+        renderHeader([categoricalSource({ error: 'network failure' })]);
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not update');
+    });
+});

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionHeader/DatasetDistributionHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionHeader/DatasetDistributionHeader.test.ts
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import DatasetDistributionHeader from './DatasetDistributionHeader.svelte';
-import { useDistributionPanel } from './useDistributionPanel.svelte';
-import type { DistributionSource } from './types';
+import { useDistributionPanel } from '../useDistributionPanel.svelte';
+import type { DistributionSource } from '../types';
 
 if (typeof globalThis.ResizeObserver === 'undefined') {
     globalThis.ResizeObserver = class {

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.stories.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.stories.svelte
@@ -17,7 +17,12 @@
     import { GripVertical } from '@lucide/svelte';
     import { Pane, PaneGroup, PaneResizer } from 'paneforge';
     import { balanced, empty, longLabels, longTail, many80Classes } from '../BarChart/fixtures';
-    import { exampleSources, numericMetadataSources } from './sourceFixtures';
+    import {
+        categoricalMetadataSources,
+        exampleSources,
+        mixedSources,
+        numericMetadataSources
+    } from './sourceFixtures';
 </script>
 
 {#snippet sidePanel(args)}
@@ -49,6 +54,29 @@
 <Story
     name="Multi-source (class / tags / metadata / eval)"
     args={{ sources: exampleSources, title: 'Distribution', onClose: () => {} }}
+    template={sidePanel}
+/>
+
+<!-- Categorical metadata: location_type key with city / suburban / rural / village
+     values. Demonstrates value buckets, a missing-value bucket, and an active
+     filter (city + rural) with dimmed background bars for context. -->
+<Story
+    name="Categorical metadata (location_type)"
+    args={{
+        sources: categoricalMetadataSources,
+        title: 'Distribution',
+        onClose: () => {}
+    }}
+    template={sidePanel}
+/>
+
+<!-- Classes + categorical + numeric in one panel. Switching between sources
+     demonstrates chart-type transitions: bar chart (class labels) →
+     categorical bar chart with active filter (location_type) →
+     histogram (confidence). -->
+<Story
+    name="Mixed (class / categorical / numeric)"
+    args={{ sources: mixedSources, title: 'Distribution', onClose: () => {} }}
     template={sidePanel}
 />
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -70,7 +70,6 @@
         {panel}
         {histogramBinCount}
         {onHistogramBinCountChange}
-        {onCategoricalRetry}
         {onClose}
         onOpenConfig={() => (configDialogOpen = true)}
         onOpenExpand={() => (expandOpen = true)}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -1,64 +1,31 @@
 <script lang="ts">
-    import { Maximize2 as Maximize2Icon, X } from '@lucide/svelte';
-    import { Button } from '$lib/components';
-    import Typography from '$lib/components/Typography/Typography.svelte';
-    import { Select, type SelectItem } from '$lib/components/Select';
-    import { BarChart, type CategoryCount } from '$lib/components/BarChart';
-    import { Histogram, type HistogramRange } from '$lib/components/Histogram';
-    import { formatFloat, formatInteger } from '$lib/utils';
+    import { type CategoryCount } from '$lib/components/BarChart';
+    import { type HistogramRange } from '$lib/components/Histogram';
     import DistributionConfigDialog from './DistributionConfigDialog/DistributionConfigDialog.svelte';
     import ExpandDialog from './ExpandDialog/ExpandDialog.svelte';
     import HistogramExpandDialog from './HistogramExpandDialog/HistogramExpandDialog.svelte';
-    import PanelHeader from './PanelHeader/PanelHeader.svelte';
-    import { selectVisibleCounts } from './selectVisibleCounts';
-    import {
-        HISTOGRAM_BIN_COUNT_ITEMS,
-        type DistributionConfig,
-        type DistributionSource,
-        type DistributionSourceGroup
-    } from './types';
+    import DatasetDistributionHeader from './DatasetDistributionHeader/DatasetDistributionHeader.svelte';
+    import DatasetDistributionContent from './DatasetDistributionContent/DatasetDistributionContent.svelte';
+    import { CATEGORICAL_DISTRIBUTION_SORT_LABELS, type DistributionSource } from './types';
     import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
+    import type { CategoricalMetadataValue } from '$lib/services/types';
+    import { useDistributionPanel } from './useDistributionPanel.svelte';
 
     interface Props {
-        /**
-         * Counts for the default (class) source. Ignored when `sources` is
-         * provided. Ranking and top-N selection are user-configurable.
-         */
         data?: CategoryCount[];
-        /**
-         * Multiple selectable sources (class labels, tags, metadata keys,
-         * eval …). When provided, a source selector is shown in the header and
-         * `data` is ignored. Sources with a `histogram` field render as a
-         * histogram instead of a bar chart.
-         */
         sources?: DistributionSource[];
         title?: string;
-        /** Top classes shown by default. */
         topN?: number;
-        /** Renders a close button in the header when provided. */
         onClose?: () => void;
-        /** Called with the clicked class. */
         onBarClick?: (item: CategoryCount) => void;
-        /**
-         * Called when the user switches the count mode via the config dialog.
-         */
         onCountModeChange?: (mode: AnnotationCountMode) => void;
-        /**
-         * Initial count mode to use when the panel first mounts. Lets the
-         * parent preserve the mode across close/reopen cycles.
-         */
         initialCountMode?: AnnotationCountMode;
-        /**
-         * Called when a histogram range is selected (single-bin click or
-         * press-drag-release across bins), with the group id (e.g. the
-         * metadata key) and the spanned value interval — lets the host narrow
-         * the matching filter to that range.
-         */
         onHistogramRangeSelect?: (groupId: string, range: HistogramRange) => void;
-        /** Applied histogram bin count, controlled by the host (server default: 20). */
         histogramBinCount?: number;
-        /** Called when the user picks a new histogram bin count. */
         onHistogramBinCountChange?: (binCount: number) => void;
+        onCategoricalValueToggle?: (groupId: string, value: CategoricalMetadataValue) => void;
+        onCategoricalValuesClear?: (groupId: string) => void;
+        onCategoricalRetry?: () => void;
     }
 
     const {
@@ -72,258 +39,84 @@
         initialCountMode = AnnotationCountMode.OBJECTS,
         onHistogramRangeSelect,
         histogramBinCount = 20,
-        onHistogramBinCountChange
+        onHistogramBinCountChange,
+        onCategoricalValueToggle,
+        onCategoricalValuesClear,
+        onCategoricalRetry
     }: Props = $props();
 
-    // Normalise to a source list so the rest of the panel has one code path.
-    const resolvedSources = $derived<DistributionSource[]>(
-        sources ?? [{ id: 'class', label: 'Annotation classes', data: data ?? [] }]
-    );
-    const hasSourceSelector = $derived(resolvedSources.length > 1);
+    const panel = useDistributionPanel(() => ({
+        sources,
+        data,
+        topN,
+        initialCountMode,
+        onCountModeChange,
+        onHistogramRangeSelect,
+        onCategoricalValueToggle,
+        onCategoricalValuesClear
+    }));
 
-    let selectedSourceId = $state<string | undefined>(undefined);
-    let selectedGroupId = $state<string | undefined>(undefined);
-
-    const groupHasContent = (group: DistributionSourceGroup): boolean =>
-        (group.data?.length ?? 0) > 0 || group.histogram != null;
-
-    const sourceHasContent = (source: DistributionSource): boolean =>
-        (source.data?.length ?? 0) > 0 ||
-        source.histogram != null ||
-        (source.groups?.some(groupHasContent) ?? false);
-
-    // With nothing explicitly selected, land on the first source that actually
-    // has something to show. Otherwise an empty leading source (e.g. "All types"
-    // before any labeling) would render as empty while a populated source like
-    // metadata sits one click away.
-    const defaultSource = $derived(resolvedSources.find(sourceHasContent) ?? resolvedSources[0]);
-    const activeSource = $derived(
-        resolvedSources.find((source) => source.id === selectedSourceId) ?? defaultSource
-    );
-    const activeGroup = $derived(
-        activeSource.groups?.find((group) => group.id === selectedGroupId) ??
-            activeSource.groups?.find(groupHasContent) ??
-            activeSource.groups?.[0]
-    );
-    const activeData = $derived<CategoryCount[]>(activeGroup?.data ?? activeSource.data ?? []);
-    // A group/source carrying bins renders as a histogram instead of a bar
-    // chart; the categorical controls (sort, top-N, orientation) don't apply.
-    const activeHistogram = $derived(activeGroup?.histogram ?? activeSource.histogram ?? null);
-    const activeHistogramRange = $derived(activeGroup?.selectedRange ?? activeSource.selectedRange);
-    const handleHistogramRangeSelect = (range: HistogramRange) => {
-        const groupId = activeGroup?.id ?? activeSource.id;
-        onHistogramRangeSelect?.(groupId, range);
-    };
-    const histogramTotal = $derived(
-        activeHistogram ? activeHistogram.counts.reduce((sum, count) => sum + count, 0) : 0
-    );
-    const valueNoun = $derived(activeSource.valueNoun ?? 'annotations');
-
-    // Default to horizontal bars: categories stack down the left gutter and the
-    // chart scrolls vertically, avoiding the initial horizontal scroll that
-    // vertical bars produce once there are more than a handful of classes.
-    let config: DistributionConfig = $state({
-        mode: 'topN',
-        n: topN,
-        sortBy: 'count',
-        manualClasses: [],
-        orientation: 'horizontal',
-        countMode: initialCountMode
-    });
     let configDialogOpen = $state(false);
     let expandOpen = $state(false);
     let histogramExpandOpen = $state(false);
-
-    const binCountItems: SelectItem[] = HISTOGRAM_BIN_COUNT_ITEMS.map((count) => ({
-        value: String(count),
-        label: `${count} bins`
-    }));
-    // Measured height of the chart viewport; drives the chart's height budget and
-    // tracks container resizes (bind:clientHeight is backed by a ResizeObserver).
-    let chartHeight = $state(0);
-    let clientWidth = $state(0);
-
-    const activeCountMode = $derived(config.countMode ?? AnnotationCountMode.OBJECTS);
-    const showTotalCount = $derived(activeCountMode !== AnnotationCountMode.SAMPLES);
-
-    const sourceItems = $derived<SelectItem[]>(
-        resolvedSources.map((source) => ({ value: source.id, label: source.label }))
-    );
-    const groupItems = $derived<SelectItem[]>(
-        (activeSource.groups ?? []).map((group) => ({ value: group.id, label: group.label }))
-    );
-
-    const visible = $derived(selectVisibleCounts(activeData, config));
-    const totalCount = $derived(activeData.reduce((sum, item) => sum + item.count, 0));
-
-    function applyConfig(next: DistributionConfig) {
-        if (next.countMode !== config.countMode) {
-            onCountModeChange?.(next.countMode ?? AnnotationCountMode.OBJECTS);
-        }
-        config = next;
-    }
 </script>
 
 <div
     class="flex h-full min-w-0 flex-1 flex-col rounded-[1vw] bg-card p-4"
     data-testid="dataset-distribution-panel"
 >
-    <div class="flex items-center justify-between">
-        <Typography variant="h5" component="h2" className="text-foreground">
-            {title}
-        </Typography>
-        {#if onClose}
-            <Button
-                variant="ghost"
-                icon={X}
-                ariaLabel="Close distribution panel"
-                buttonProps={{
-                    size: 'sm',
-                    class: 'h-8 w-8 p-0',
-                    onclick: onClose,
-                    'data-testid': 'dataset-distribution-close-button'
-                }}
-            />
-        {/if}
-    </div>
-    {#if hasSourceSelector}
-        <!-- Fixed-width labels + flex-1 triggers keep both selects the same
-             width, filling the panel row. -->
-        <div class="mt-2 flex flex-col gap-2" data-testid="dataset-distribution-source">
-            <div class="flex items-center gap-2">
-                <span class="w-[100px] shrink-0 text-xs text-muted-foreground">Distribution</span>
-                <Select
-                    items={sourceItems}
-                    value={activeSource.id}
-                    size="xs"
-                    class="min-w-0 flex-1"
-                    testId="dataset-distribution-source-select"
-                    onValueChange={(value) => {
-                        selectedSourceId = value;
-                        selectedGroupId = undefined;
-                    }}
-                />
-            </div>
-
-            {#if groupItems.length > 0}
-                <div class="flex items-center gap-2">
-                    <span class="w-[100px] shrink-0 text-xs text-muted-foreground"
-                        >{activeSource.groupLabel ?? 'Field'}</span
-                    >
-                    <Select
-                        items={groupItems}
-                        value={activeGroup?.id}
-                        size="xs"
-                        class="min-w-0 flex-1"
-                        testId="dataset-distribution-group-select"
-                        onValueChange={(value) => (selectedGroupId = value)}
-                    />
-                </div>
-            {/if}
-        </div>
-    {/if}
-    {#if activeHistogram}
-        <div class="mt-2 flex flex-wrap items-center justify-between gap-2">
-            <span
-                class="text-xs text-muted-foreground"
-                data-testid="dataset-distribution-histogram-summary"
-            >
-                {formatInteger(histogramTotal)}
-                {valueNoun} · {activeHistogram.counts.length}
-                {activeHistogram.counts.length === 1 ? 'bin' : 'bins'} · {formatFloat(
-                    activeHistogram.binEdges[0]
-                )}–{formatFloat(activeHistogram.binEdges[activeHistogram.binEdges.length - 1])}
-            </span>
-            <div class="flex items-center gap-1">
-                {#if onHistogramBinCountChange}
-                    <Select
-                        items={binCountItems}
-                        value={String(histogramBinCount)}
-                        size="xs"
-                        class="w-24"
-                        testId="dataset-distribution-bin-count"
-                        selectProps={{ 'aria-label': 'Histogram bin count' }}
-                        onValueChange={(value) => onHistogramBinCountChange(Number(value))}
-                    />
-                {/if}
-                <Button
-                    variant="ghost"
-                    icon={Maximize2Icon}
-                    ariaLabel="Expand distribution"
-                    buttonProps={{
-                        size: 'sm',
-                        class: 'h-8 w-8 p-0',
-                        onclick: () => (histogramExpandOpen = true),
-                        'data-testid': 'dataset-distribution-histogram-expand'
-                    }}
-                />
-            </div>
-        </div>
-    {:else if activeData.length > 0}
-        <PanelHeader
-            {config}
-            classCount={activeData.length}
-            visibleClassCount={visible.length}
-            totalCount={showTotalCount ? totalCount : undefined}
-            {valueNoun}
-            onConfigure={() => (configDialogOpen = true)}
-            onShowAll={() => (config = { ...config, mode: 'topN', n: activeData.length })}
-            onToggleOrientation={() =>
-                (config = {
-                    ...config,
-                    orientation: config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
-                })}
-            onExpand={() => (expandOpen = true)}
-        />
-    {/if}
-    <div
-        class="min-h-0 flex-1 overflow-y-auto dark:[color-scheme:dark]"
-        bind:clientHeight={chartHeight}
-        bind:clientWidth
-    >
-        {#if activeHistogram}
-            <Histogram
-                data={activeHistogram}
-                selectedRange={activeHistogramRange}
-                heightPx={chartHeight || 240}
-                showAxes
-                onRangeSelect={onHistogramRangeSelect ? handleHistogramRangeSelect : undefined}
-            />
-        {:else}
-            <BarChart
-                data={visible}
-                orientation={config.orientation}
-                maxHeightPx={chartHeight || undefined}
-                maxWidthPx={clientWidth || undefined}
-                {totalCount}
-                {onBarClick}
-            />
-        {/if}
-    </div>
+    <DatasetDistributionHeader
+        {title}
+        {panel}
+        {histogramBinCount}
+        {onHistogramBinCountChange}
+        {onCategoricalRetry}
+        {onClose}
+        onOpenConfig={() => (configDialogOpen = true)}
+        onOpenExpand={() => (expandOpen = true)}
+        onOpenHistogramExpand={() => (histogramExpandOpen = true)}
+    />
+    <DatasetDistributionContent
+        {panel}
+        {onHistogramRangeSelect}
+        {onBarClick}
+        {onCategoricalRetry}
+    />
 </div>
-<DistributionConfigDialog
-    bind:open={configDialogOpen}
-    allClasses={activeData.map((item) => item.label)}
-    {config}
-    onApply={applyConfig}
-/>
-<ExpandDialog
-    bind:open={expandOpen}
-    data={activeData}
-    {config}
-    {valueNoun}
-    onConfigChange={applyConfig}
-    {onBarClick}
-/>
-{#if activeHistogram}
+
+{#if panel.activeHistogram}
     <HistogramExpandDialog
         bind:open={histogramExpandOpen}
-        data={activeHistogram}
-        label={activeGroup?.label ?? activeSource.label}
-        selectedRange={activeHistogramRange}
-        {valueNoun}
+        data={panel.activeHistogram}
+        label={panel.activeGroup?.label ?? panel.activeSource.label}
+        selectedRange={panel.activeHistogramRange}
+        valueNoun={panel.valueNoun}
         binCount={histogramBinCount}
         onBinCountChange={onHistogramBinCountChange}
-        onRangeSelect={onHistogramRangeSelect ? handleHistogramRangeSelect : undefined}
+        onRangeSelect={onHistogramRangeSelect ? panel.handleHistogramRangeSelect : undefined}
+    />
+{:else}
+    <DistributionConfigDialog
+        bind:open={configDialogOpen}
+        allClasses={panel.displayedData.map((item) => item.label)}
+        items={panel.configurationItems}
+        config={panel.activeViewConfig}
+        showCountMode={!panel.activeCategorical}
+        itemNoun={panel.activeCategorical ? 'value' : 'class'}
+        itemNounPlural={panel.activeCategorical ? 'values' : 'classes'}
+        sortLabels={panel.activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
+        onApply={panel.applyConfig}
+    />
+    <ExpandDialog
+        bind:open={expandOpen}
+        data={panel.displayedData}
+        config={panel.activeViewConfig}
+        valueNoun={panel.valueNoun}
+        categoryNoun={panel.activeCategorical ? 'value' : 'class'}
+        categoryNounPlural={panel.activeCategorical ? 'values' : 'classes'}
+        sortLabels={panel.activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
+        showCountMode={!panel.activeCategorical}
+        onConfigChange={panel.applyConfig}
+        onBarClick={panel.activeCategorical ? panel.handleCategoricalBarClick : onBarClick}
     />
 {/if}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -8,11 +8,14 @@ import { AnnotationCountMode, AnnotationType } from '$lib/api/lightly_studio_loc
 
 const echartsMock = vi.hoisted(() => {
     const zrHandlers: Record<string, (event: { offsetX: number; offsetY: number }) => void> = {};
+    let clickHandler: ((params: { dataIndex?: number }) => void) | undefined;
     const instance = {
         setOption: vi.fn(),
         resize: vi.fn(),
         dispose: vi.fn(),
-        on: vi.fn(),
+        on: vi.fn((event: string, handler: (params: { dataIndex?: number }) => void) => {
+            if (event === 'click') clickHandler = handler;
+        }),
         // 2 bins across a 200px-wide canvas → 100px per bin index.
         convertFromPixel: vi.fn((_finder: unknown, offsetX: number) => offsetX / 100),
         getZr: () => ({
@@ -22,7 +25,12 @@ const echartsMock = vi.hoisted(() => {
             off: vi.fn()
         })
     };
-    return { init: vi.fn(() => instance), instance, zrHandlers };
+    return {
+        init: vi.fn(() => instance),
+        instance,
+        zrHandlers,
+        getClickHandler: () => clickHandler
+    };
 });
 
 vi.mock('echarts/core', () => ({
@@ -93,8 +101,10 @@ describe('DatasetDistributionPanel', () => {
         // Horizontal default: categories live on the y-axis.
         const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
             yAxis: { data: string[] };
+            grid: { top: number };
         };
         expect(option.yAxis.data).toEqual(['person', 'dog', 'car']);
+        expect(option.grid.top).toBe(4);
     });
 
     it('applies a new top-N from the config dialog', async () => {
@@ -216,6 +226,272 @@ describe('DatasetDistributionPanel', () => {
         expect(screen.getByTestId('histogram')).toBeInTheDocument();
         expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
             '100 samples · 2 bins · 0–1'
+        );
+    });
+
+    it('preserves categorical endpoint order and toggles typed buckets but not Other', () => {
+        const onCategoricalValueToggle = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: ['Missing'],
+                            buckets: [
+                                {
+                                    id: 'literal',
+                                    kind: 'value',
+                                    value: 'Missing',
+                                    label: 'Missing',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 3
+                                },
+                                { id: 'other', kind: 'other', label: 'Other', count: 2 }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources, onCategoricalValueToggle } });
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+            series: [{ data: { itemStyle: { color: string } }[] }];
+            grid: { top: number };
+        };
+        expect(option.yAxis.data).toEqual(['Missing', 'Missing', 'Other']);
+        expect(option.grid.top).toBe(4);
+        // 'Missing' (value) is selected → accent green; the others are dimmed grey.
+        expect(option.series[0].data[0].itemStyle.color).toBe('rgba(59,217,159,0.85)');
+
+        echartsMock.getClickHandler()?.({ dataIndex: 1 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledWith('city', null);
+        echartsMock.getClickHandler()?.({ dataIndex: 2 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledOnce();
+    });
+
+    it('stores categorical orientation per metadata field', async () => {
+        const user = userEvent.setup();
+        const categorical = (label: string) => ({
+            selectedValues: [],
+            buckets: [{ id: label, kind: 'value' as const, value: label, label, count: 1 }]
+        });
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groupLabel: 'Metadata key',
+                groups: [
+                    { id: 'city', label: 'city', categorical: categorical('Zurich') },
+                    { id: 'weather', label: 'weather', categorical: categorical('rainy') }
+                ]
+            },
+            { id: 'classes', label: 'Classes', data: [] }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        const orientationToggle = screen.getByTestId('dataset-distribution-toggle-orientation');
+        await fireEvent.click(orientationToggle);
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        const groupSelect = screen.getByTestId('dataset-distribution-group-select');
+        await user.click(groupSelect);
+        await user.click(await screen.findByRole('option', { name: 'weather' }));
+        expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars');
+
+        await user.click(groupSelect);
+        await user.click(await screen.findByRole('option', { name: 'city' }));
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+    });
+
+    it('configures, reorients, and expands categorical values', async () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                valueNoun: 'samples',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 1
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        expect(screen.getByText(/2 values · sorted by count · 5 samples/)).toBeInTheDocument();
+        const orientationToggle = screen.getByTestId('dataset-distribution-toggle-orientation');
+        expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars');
+
+        await fireEvent.click(orientationToggle);
+        await waitFor(() =>
+            expect(
+                (echartsMock.instance.setOption.mock.lastCall?.[0] as { xAxis: { type: string } })
+                    .xAxis.type
+            ).toBe('category')
+        );
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+        await fireEvent.click(screen.getByText('Cancel'));
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-expand'));
+        expect(screen.getByTestId('dataset-distribution-expanded-configure')).toBeInTheDocument();
+        const expandedOrientationToggle = screen.getByTestId(
+            'dataset-distribution-expanded-toggle-orientation'
+        );
+        expect(expandedOrientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        await fireEvent.click(expandedOrientationToggle);
+        await waitFor(() =>
+            expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars')
+        );
+    });
+
+    it('manually configures colliding categorical labels by stable bucket id', async () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'status',
+                        label: 'status',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'literal-missing',
+                                    kind: 'value',
+                                    value: 'Missing',
+                                    label: 'Missing',
+                                    count: 4
+                                },
+                                {
+                                    id: 'semantic-missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 3
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        await fireEvent.click(screen.getByRole('tab', { name: 'Manual' }));
+        const missingOptions = screen.getAllByText('Missing');
+        expect(missingOptions).toHaveLength(2);
+        await fireEvent.click(missingOptions[1]);
+        await fireEvent.click(screen.getByTestId('distribution-config-apply'));
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+            series: [{ data: { value: number }[] }];
+        };
+        expect(option.yAxis.data).toEqual(['Missing']);
+        expect(option.series[0].data[0].value).toBe(3);
+    });
+
+    it('shows categorical loading and retryable error states', async () => {
+        const onCategoricalRetry = vi.fn();
+        const source = (state: { loading?: boolean; error?: string }): DistributionSource[] => [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: { buckets: [], selectedValues: ['Zurich'], ...state }
+                    }
+                ]
+            }
+        ];
+        const view = render(DatasetDistributionPanel, {
+            props: { sources: source({ loading: true }), onCategoricalRetry }
+        });
+        expect(screen.getByRole('status')).toHaveTextContent('Loading metadata distribution');
+
+        await view.rerender({
+            sources: source({ error: 'network failure' }),
+            onCategoricalRetry
+        });
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not load metadata distribution');
+        await fireEvent.click(screen.getByTestId('metadata-categorical-retry'));
+        expect(onCategoricalRetry).toHaveBeenCalledOnce();
+    });
+
+    it('keeps stale categorical bars visible after a refetch error', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                }
+                            ],
+                            selectedValues: [],
+                            error: 'network failure'
+                        }
+                    }
+                ]
+            }
+        ];
+
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not update');
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+        expect(screen.getByLabelText('Categorical metadata value counts')).toHaveTextContent(
+            'Zurich: 4 samples'
         );
     });
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionChart/DistributionChart.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionChart/DistributionChart.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+    import { BarChart, type CategoryCount } from '$lib/components/BarChart';
+    import { Histogram, type HistogramRange } from '$lib/components/Histogram';
+    import { Button } from '$lib/components';
+    import type { DistributionConfig, DistributionSourceGroup } from '../types';
+
+    type Categorical = NonNullable<DistributionSourceGroup['categorical']>;
+
+    interface Props {
+        activeHistogram: NonNullable<DistributionSourceGroup['histogram']> | null;
+        activeCategorical: Categorical | null;
+        viewConfig: DistributionConfig;
+        visible: CategoryCount[];
+        totalCount: number;
+        selectedRange: HistogramRange | undefined;
+        onHistogramRangeSelect?: (range: HistogramRange) => void;
+        onBarClick?: (item: CategoryCount) => void;
+        onCategoricalRetry?: () => void;
+    }
+
+    const {
+        activeHistogram,
+        activeCategorical,
+        viewConfig,
+        visible,
+        totalCount,
+        selectedRange,
+        onHistogramRangeSelect,
+        onBarClick,
+        onCategoricalRetry
+    }: Props = $props();
+
+    let chartHeight = $state(0);
+    let clientWidth = $state(0);
+</script>
+
+{#snippet categoricalEmptyState()}
+    <span>No matching samples for this metadata field.</span>
+{/snippet}
+
+<div
+    class="min-h-0 flex-1 overflow-y-auto dark:[color-scheme:dark]"
+    bind:clientHeight={chartHeight}
+    bind:clientWidth
+>
+    {#if activeHistogram}
+        <Histogram
+            data={activeHistogram}
+            {selectedRange}
+            heightPx={chartHeight || 240}
+            showAxes
+            onRangeSelect={onHistogramRangeSelect}
+        />
+    {:else if activeCategorical?.loading && activeCategorical.buckets.length === 0}
+        <div class="p-8 text-center text-sm text-muted-foreground" role="status">
+            Loading metadata distribution…
+        </div>
+    {:else if activeCategorical?.error && activeCategorical.buckets.length === 0}
+        <div class="space-y-2 p-8 text-center text-sm" role="alert">
+            <p class="text-destructive">Could not load metadata distribution.</p>
+            {#if onCategoricalRetry}
+                <Button
+                    variant="secondary"
+                    buttonProps={{
+                        size: 'sm',
+                        class: 'max-sm:min-h-11',
+                        onclick: onCategoricalRetry,
+                        'data-testid': 'metadata-categorical-retry'
+                    }}>Retry</Button
+                >
+            {/if}
+        </div>
+    {:else}
+        {#if activeCategorical}
+            <ul class="sr-only" aria-label="Categorical metadata value counts">
+                {#each activeCategorical.buckets as bucket (bucket.id)}
+                    <li>
+                        {bucket.label}: {bucket.count} samples{bucket.kind === 'other'
+                            ? ', aggregated and not selectable'
+                            : activeCategorical.selectedValues.some((value) =>
+                                    Object.is(value, bucket.value)
+                                )
+                              ? ', selected'
+                              : ''}
+                    </li>
+                {/each}
+            </ul>
+        {/if}
+        <BarChart
+            data={visible}
+            orientation={viewConfig.orientation}
+            maxHeightPx={chartHeight || undefined}
+            maxWidthPx={clientWidth || undefined}
+            {totalCount}
+            {onBarClick}
+            emptyState={activeCategorical ? categoricalEmptyState : undefined}
+            gridTopPx={4}
+        />
+    {/if}
+</div>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionChart/DistributionChart.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionChart/DistributionChart.test.ts
@@ -1,0 +1,178 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import DistributionChart from './DistributionChart.svelte';
+import type { HistogramData } from '$lib/components/Histogram';
+import type { DistributionConfig } from '../types';
+import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+import type { CategoryCount } from '$lib/components/BarChart';
+
+const echartsMock = vi.hoisted(() => {
+    const instance = {
+        setOption: vi.fn(),
+        resize: vi.fn(),
+        dispose: vi.fn(),
+        on: vi.fn(),
+        convertFromPixel: vi.fn(),
+        getZr: () => ({ on: vi.fn(), off: vi.fn() })
+    };
+    return { init: vi.fn(() => instance), instance };
+});
+
+vi.mock('echarts/core', () => ({ init: echartsMock.init, use: vi.fn() }));
+vi.mock('echarts/charts', () => ({ BarChart: {}, CustomChart: {} }));
+vi.mock('echarts/components', () => ({ GridComponent: {}, TooltipComponent: {} }));
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as unknown as typeof ResizeObserver;
+}
+
+const histogram: HistogramData = { binEdges: [0, 0.5, 1], counts: [30, 70] };
+
+const viewConfig: DistributionConfig = {
+    mode: 'topN',
+    n: 10,
+    sortBy: 'count',
+    manualClasses: [],
+    orientation: 'horizontal'
+};
+
+const barData: CategoryCount[] = [
+    { label: 'cat', count: 10 },
+    { label: 'dog', count: 5 }
+];
+
+const buckets: CategoricalMetadataBucket[] = [
+    { id: 'a', kind: 'value', value: 'red', label: 'Red', count: 8 },
+    { id: 'b', kind: 'missing', value: null, label: 'Missing', count: 2 }
+];
+
+const defaultProps = {
+    activeHistogram: null,
+    activeCategorical: null,
+    viewConfig,
+    visible: barData,
+    totalCount: 15,
+    selectedRange: undefined,
+    onHistogramRangeSelect: undefined,
+    onBarClick: undefined,
+    onCategoricalRetry: undefined
+};
+
+describe('DistributionChart', () => {
+    it('renders the bar chart when there is no active histogram or categorical data', () => {
+        render(DistributionChart, { props: defaultProps });
+
+        expect(echartsMock.instance.setOption).toHaveBeenCalled();
+    });
+
+    it('renders the histogram when activeHistogram is provided', () => {
+        echartsMock.instance.setOption.mockClear();
+        render(DistributionChart, { props: { ...defaultProps, activeHistogram: histogram } });
+
+        expect(echartsMock.instance.setOption).toHaveBeenCalled();
+    });
+
+    it('shows the loading state when categorical is loading with no buckets', () => {
+        render(DistributionChart, {
+            props: {
+                ...defaultProps,
+                activeCategorical: { buckets: [], selectedValues: [], loading: true }
+            }
+        });
+
+        expect(screen.getByRole('status')).toHaveTextContent('Loading metadata distribution…');
+    });
+
+    it('shows the error state with retry when categorical errors with no buckets', () => {
+        const onCategoricalRetry = vi.fn();
+        render(DistributionChart, {
+            props: {
+                ...defaultProps,
+                activeCategorical: {
+                    buckets: [],
+                    selectedValues: [],
+                    error: 'Failed to load'
+                },
+                onCategoricalRetry
+            }
+        });
+
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            'Could not load metadata distribution.'
+        );
+        expect(screen.getByTestId('metadata-categorical-retry')).toBeInTheDocument();
+    });
+
+    it('calls onCategoricalRetry when the retry button is clicked', async () => {
+        const onCategoricalRetry = vi.fn();
+        render(DistributionChart, {
+            props: {
+                ...defaultProps,
+                activeCategorical: { buckets: [], selectedValues: [], error: 'oops' },
+                onCategoricalRetry
+            }
+        });
+
+        await fireEvent.click(screen.getByTestId('metadata-categorical-retry'));
+
+        expect(onCategoricalRetry).toHaveBeenCalledOnce();
+    });
+
+    it('hides the retry button in the error state when no handler is provided', () => {
+        render(DistributionChart, {
+            props: {
+                ...defaultProps,
+                activeCategorical: { buckets: [], selectedValues: [], error: 'oops' }
+            }
+        });
+
+        expect(screen.queryByTestId('metadata-categorical-retry')).not.toBeInTheDocument();
+    });
+
+    it('renders a sr-only accessibility list for categorical buckets', () => {
+        render(DistributionChart, {
+            props: {
+                ...defaultProps,
+                activeCategorical: { buckets, selectedValues: [] }
+            }
+        });
+
+        const list = screen.getByRole('list', { name: 'Categorical metadata value counts' });
+        expect(list).toBeInTheDocument();
+        expect(list.querySelectorAll('li')).toHaveLength(2);
+    });
+
+    it('marks selected categorical values in the accessibility list', () => {
+        render(DistributionChart, {
+            props: {
+                ...defaultProps,
+                activeCategorical: { buckets, selectedValues: ['red'] }
+            }
+        });
+
+        const items = screen
+            .getByRole('list', { name: 'Categorical metadata value counts' })
+            .querySelectorAll('li');
+        expect(items[0].textContent).toContain(', selected');
+        expect(items[1].textContent).not.toContain(', selected');
+    });
+
+    it('falls through to the bar chart when categorical has buckets but is still loading', () => {
+        echartsMock.instance.setOption.mockClear();
+        render(DistributionChart, {
+            props: {
+                ...defaultProps,
+                activeCategorical: { buckets, selectedValues: [], loading: true }
+            }
+        });
+
+        // Loading spinner only appears for the zero-bucket case; with buckets the bar chart renders.
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+        expect(echartsMock.instance.setOption).toHaveBeenCalled();
+    });
+});

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/HistogramToolbar/HistogramToolbar.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/HistogramToolbar/HistogramToolbar.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+    import { Maximize2 as Maximize2Icon } from '@lucide/svelte';
+    import { Button } from '$lib/components';
+    import { Select, type SelectItem } from '$lib/components/Select';
+    import { formatFloat, formatInteger } from '$lib/utils';
+    import type { HistogramData } from '$lib/components/Histogram';
+
+    interface Props {
+        histogram: HistogramData;
+        histogramTotal: number;
+        valueNoun: string;
+        histogramBinCount: number;
+        binCountItems: SelectItem[];
+        onHistogramBinCountChange?: (binCount: number) => void;
+        onExpand: () => void;
+    }
+
+    const {
+        histogram,
+        histogramTotal,
+        valueNoun,
+        histogramBinCount,
+        binCountItems,
+        onHistogramBinCountChange,
+        onExpand
+    }: Props = $props();
+</script>
+
+<div class="mt-2 flex flex-wrap items-center justify-between gap-2">
+    <span
+        class="text-xs text-muted-foreground"
+        data-testid="dataset-distribution-histogram-summary"
+    >
+        {formatInteger(histogramTotal)}
+        {valueNoun} · {histogram.counts.length}
+        {histogram.counts.length === 1 ? 'bin' : 'bins'} · {formatFloat(
+            histogram.binEdges[0]
+        )}–{formatFloat(histogram.binEdges[histogram.binEdges.length - 1])}
+    </span>
+    <div class="flex items-center gap-1">
+        {#if onHistogramBinCountChange}
+            <Select
+                items={binCountItems}
+                value={String(histogramBinCount)}
+                size="xs"
+                class="w-24"
+                testId="dataset-distribution-bin-count"
+                selectProps={{ 'aria-label': 'Histogram bin count' }}
+                onValueChange={(value) => onHistogramBinCountChange(Number(value))}
+            />
+        {/if}
+        <Button
+            variant="ghost"
+            icon={Maximize2Icon}
+            ariaLabel="Expand distribution"
+            buttonProps={{
+                size: 'sm',
+                class: 'h-8 w-8 p-0',
+                onclick: onExpand,
+                'data-testid': 'dataset-distribution-histogram-expand'
+            }}
+        />
+    </div>
+</div>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/HistogramToolbar/HistogramToolbar.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/HistogramToolbar/HistogramToolbar.test.ts
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import HistogramToolbar from './HistogramToolbar.svelte';
+import type { HistogramData } from '$lib/components/Histogram';
+import { HISTOGRAM_BIN_COUNT_ITEMS } from '../types';
+import type { SelectItem } from '$lib/components/Select';
+
+const histogram: HistogramData = { binEdges: [0, 0.5, 1], counts: [30, 70] };
+
+const binCountItems: SelectItem[] = HISTOGRAM_BIN_COUNT_ITEMS.map((count) => ({
+    value: String(count),
+    label: `${count} bins`
+}));
+
+const defaultProps = {
+    histogram,
+    histogramTotal: 100,
+    valueNoun: 'annotations',
+    histogramBinCount: 20,
+    binCountItems,
+    onHistogramBinCountChange: vi.fn(),
+    onExpand: vi.fn()
+};
+
+describe('HistogramToolbar', () => {
+    beforeAll(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+        Element.prototype.hasPointerCapture = vi.fn(() => false);
+        Element.prototype.setPointerCapture = vi.fn();
+        Element.prototype.releasePointerCapture = vi.fn();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        document.body.style.pointerEvents = '';
+    });
+
+    it('renders the summary with total count, bin count, and range', () => {
+        render(HistogramToolbar, { props: defaultProps });
+
+        expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
+            '100 annotations · 2 bins · 0–1'
+        );
+    });
+
+    it('uses the singular "bin" when there is only one bin', () => {
+        render(HistogramToolbar, {
+            props: {
+                ...defaultProps,
+                histogram: { binEdges: [0, 1], counts: [50] },
+                histogramTotal: 50
+            }
+        });
+
+        expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
+            '1 bin ·'
+        );
+    });
+
+    it('shows the bin-count selector with the applied bin count', () => {
+        render(HistogramToolbar, { props: { ...defaultProps, histogramBinCount: 50 } });
+
+        expect(screen.getByTestId('dataset-distribution-bin-count')).toHaveTextContent('50 bins');
+    });
+
+    it('hides the bin-count selector when no change handler is provided', () => {
+        render(HistogramToolbar, {
+            props: { ...defaultProps, onHistogramBinCountChange: undefined }
+        });
+
+        expect(screen.queryByTestId('dataset-distribution-bin-count')).not.toBeInTheDocument();
+    });
+
+    it('calls onHistogramBinCountChange with the selected count', async () => {
+        const onHistogramBinCountChange = vi.fn();
+        const user = userEvent.setup();
+        render(HistogramToolbar, { props: { ...defaultProps, onHistogramBinCountChange } });
+
+        await user.click(screen.getByTestId('dataset-distribution-bin-count'));
+        const option = await waitFor(() => screen.getByRole('option', { name: '10 bins' }));
+        await user.click(option);
+
+        expect(onHistogramBinCountChange).toHaveBeenCalledWith(10);
+    });
+
+    it('calls onExpand when the expand button is clicked', async () => {
+        const onExpand = vi.fn();
+        const user = userEvent.setup();
+        render(HistogramToolbar, { props: { ...defaultProps, onExpand } });
+
+        await user.click(screen.getByTestId('dataset-distribution-histogram-expand'));
+
+        expect(onExpand).toHaveBeenCalledOnce();
+    });
+
+    it('uses the provided valueNoun in the summary', () => {
+        render(HistogramToolbar, { props: { ...defaultProps, valueNoun: 'samples' } });
+
+        expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
+            '100 samples ·'
+        );
+    });
+});

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/MetadataCategoricalFilter.stories.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/MetadataCategoricalFilter.stories.ts
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/sveltekit';
 import MetadataCategoricalFilter from './MetadataCategoricalFilter.svelte';
-import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+import type { CategoricalBucket } from '../types';
 import { fn } from 'storybook/test';
 
-const buckets: CategoricalMetadataBucket[] = [
+const buckets: CategoricalBucket[] = [
     { id: 'city-1', kind: 'value', value: 'Berlin', label: 'Berlin', count: 42 },
     { id: 'city-2', kind: 'value', value: 'Paris', label: 'Paris', count: 31 },
     { id: 'city-3', kind: 'value', value: 'Tokyo', label: 'Tokyo', count: 18 }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/MetadataCategoricalFilter.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/MetadataCategoricalFilter.svelte
@@ -4,12 +4,12 @@
     import { Button } from '$lib/components/ui/button';
     import { Checkbox } from '$lib/components/ui/checkbox';
     import { Input } from '$lib/components/ui/input';
-    import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+    import type { CategoricalBucket } from '../types';
     import type { CategoricalMetadataValue } from '$lib/services/types';
     import { getOptionLabel, getCheckboxLabel, buildOptions, type FilterOption } from './helpers';
 
     interface Props {
-        buckets: CategoricalMetadataBucket[];
+        buckets: CategoricalBucket[];
         selectedValues: CategoricalMetadataValue[];
         loading?: boolean;
         onToggle: (value: CategoricalMetadataValue) => void;

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/MetadataCategoricalFilter.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/MetadataCategoricalFilter.test.ts
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import MetadataCategoricalFilter from './MetadataCategoricalFilter.svelte';
-import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+import type { CategoricalBucket } from '../types';
 
-const buckets: CategoricalMetadataBucket[] = [
+const buckets: CategoricalBucket[] = [
     {
         id: 'literal-missing',
         kind: 'value',
@@ -46,7 +46,7 @@ describe('MetadataCategoricalFilter', () => {
     });
 
     it('searches values and clears the controlled selection', async () => {
-        const searchableBuckets: CategoricalMetadataBucket[] = [
+        const searchableBuckets: CategoricalBucket[] = [
             ...buckets,
             ...Array.from({ length: 5 }, (_, index) => ({
                 id: `value-${index}`,
@@ -107,7 +107,7 @@ describe('MetadataCategoricalFilter', () => {
     });
 
     it('shows search only above five returned concrete values', async () => {
-        const fiveConcrete: CategoricalMetadataBucket[] = [
+        const fiveConcrete: CategoricalBucket[] = [
             ...Array.from({ length: 5 }, (_, index) => ({
                 id: `value-${index}`,
                 kind: 'value' as const,

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/helpers/buildOptions.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/helpers/buildOptions.test.ts
@@ -1,22 +1,22 @@
 import { describe, expect, it } from 'vitest';
-import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+import type { CategoricalBucket } from '../../types';
 import { buildOptions } from './buildOptions';
 
-const value = (id: string, v: string, count = 1): CategoricalMetadataBucket => ({
+const value = (id: string, v: string, count = 1): CategoricalBucket => ({
     id,
     kind: 'value',
     value: v,
     label: v,
     count
 });
-const missing = (count = 1): CategoricalMetadataBucket => ({
+const missing = (count = 1): CategoricalBucket => ({
     id: 'missing',
     kind: 'missing',
     value: null,
     label: 'Missing',
     count
 });
-const other = (): CategoricalMetadataBucket => ({
+const other = (): CategoricalBucket => ({
     id: 'other',
     kind: 'other',
     label: 'Other',

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/helpers/buildOptions.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/helpers/buildOptions.ts
@@ -1,11 +1,11 @@
-import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+import type { CategoricalBucket } from '../../types';
 import type { CategoricalMetadataValue } from '$lib/services/types';
 
-type SelectableBucket = Exclude<CategoricalMetadataBucket, { kind: 'other' }>;
+type SelectableBucket = Exclude<CategoricalBucket, { kind: 'other' }>;
 export type FilterOption = { bucket: SelectableBucket; retained: boolean };
 
 export function buildOptions(
-    buckets: CategoricalMetadataBucket[],
+    buckets: CategoricalBucket[],
     selectedValues: CategoricalMetadataValue[]
 ): FilterOption[] {
     const selectable = buckets.filter((b): b is SelectableBucket => b.kind !== 'other');

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/helpers/getOptionLabel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/helpers/getOptionLabel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+import type { CategoricalBucket } from '../../types';
 import type { FilterOption } from './buildOptions';
 import { getOptionLabel } from './getOptionLabel';
 
@@ -11,7 +11,7 @@ const missingOption = (): FilterOption => ({
     bucket: { id: 'missing', kind: 'missing', value: null, label: 'Missing', count: 1 },
     retained: false
 });
-const otherBucket = (): CategoricalMetadataBucket => ({
+const otherBucket = (): CategoricalBucket => ({
     id: 'other',
     kind: 'other',
     label: 'Other',

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/helpers/getOptionLabel.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/MetadataCategoricalFilter/helpers/getOptionLabel.ts
@@ -1,10 +1,10 @@
-import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+import type { CategoricalBucket } from '../../types';
 import type { FilterOption } from './buildOptions';
 
 export function getOptionLabel(
     option: FilterOption,
     options: FilterOption[],
-    buckets: CategoricalMetadataBucket[]
+    buckets: CategoricalBucket[]
 ): string {
     const hasMissing = options.some(({ bucket }) => bucket.kind === 'missing');
     const hasOtherAggregate = buckets.some((bucket) => bucket.kind === 'other');

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/SourceGroupSelector/SourceGroupSelector.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/SourceGroupSelector/SourceGroupSelector.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+    import { Select, type SelectItem } from '$lib/components/Select';
+
+    interface Props {
+        sourceItems: SelectItem[];
+        groupItems: SelectItem[];
+        activeSourceId: string;
+        activeGroupId: string | undefined;
+        groupLabel: string;
+        onSourceChange: (id: string) => void;
+        onGroupChange: (id: string) => void;
+    }
+
+    const {
+        sourceItems,
+        groupItems,
+        activeSourceId,
+        activeGroupId,
+        groupLabel,
+        onSourceChange,
+        onGroupChange
+    }: Props = $props();
+</script>
+
+<!-- Fixed-width labels + flex-1 triggers keep both selects the same
+     width, filling the panel row. -->
+<div class="mt-2 flex flex-col gap-2" data-testid="dataset-distribution-source">
+    <div class="flex items-center gap-2">
+        <span class="w-[100px] shrink-0 text-xs text-muted-foreground">Distribution</span>
+        <Select
+            items={sourceItems}
+            value={activeSourceId}
+            size="xs"
+            class="min-w-0 flex-1"
+            testId="dataset-distribution-source-select"
+            onValueChange={onSourceChange}
+        />
+    </div>
+
+    {#if groupItems.length > 0}
+        <div class="flex items-center gap-2">
+            <span class="w-[100px] shrink-0 text-xs text-muted-foreground">{groupLabel}</span>
+            <Select
+                items={groupItems}
+                value={activeGroupId}
+                size="xs"
+                class="min-w-0 flex-1"
+                testId="dataset-distribution-group-select"
+                onValueChange={onGroupChange}
+            />
+        </div>
+    {/if}
+</div>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/SourceGroupSelector/SourceGroupSelector.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/SourceGroupSelector/SourceGroupSelector.test.ts
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import SourceGroupSelector from './SourceGroupSelector.svelte';
+import type { SelectItem } from '$lib/components/Select';
+
+const sourceItems: SelectItem[] = [
+    { value: 'classes', label: 'Annotation classes' },
+    { value: 'metadata', label: 'Metadata' }
+];
+
+const groupItems: SelectItem[] = [
+    { value: 'key1', label: 'Key 1' },
+    { value: 'key2', label: 'Key 2' }
+];
+
+const defaultProps = {
+    sourceItems,
+    groupItems: [] as SelectItem[],
+    activeSourceId: 'classes',
+    activeGroupId: undefined,
+    groupLabel: 'Field',
+    onSourceChange: vi.fn(),
+    onGroupChange: vi.fn()
+};
+
+describe('SourceGroupSelector', () => {
+    beforeAll(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+        Element.prototype.hasPointerCapture = vi.fn(() => false);
+        Element.prototype.setPointerCapture = vi.fn();
+        Element.prototype.releasePointerCapture = vi.fn();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        document.body.style.pointerEvents = '';
+    });
+
+    it('renders the distribution label and source select', () => {
+        render(SourceGroupSelector, { props: defaultProps });
+
+        expect(screen.getByText('Distribution')).toBeInTheDocument();
+        expect(screen.getByTestId('dataset-distribution-source-select')).toBeInTheDocument();
+    });
+
+    it('hides the group select when groupItems is empty', () => {
+        render(SourceGroupSelector, { props: defaultProps });
+
+        expect(screen.queryByTestId('dataset-distribution-group-select')).not.toBeInTheDocument();
+    });
+
+    it('shows the group select with the provided groupLabel when groups exist', () => {
+        render(SourceGroupSelector, {
+            props: { ...defaultProps, groupItems, activeGroupId: 'key1' }
+        });
+
+        expect(screen.getByText('Field')).toBeInTheDocument();
+        expect(screen.getByTestId('dataset-distribution-group-select')).toBeInTheDocument();
+    });
+
+    it('calls onSourceChange when a new source is selected', async () => {
+        const onSourceChange = vi.fn();
+        const user = userEvent.setup();
+        render(SourceGroupSelector, { props: { ...defaultProps, onSourceChange } });
+
+        await user.click(screen.getByTestId('dataset-distribution-source-select'));
+        const option = await waitFor(() => screen.getByRole('option', { name: 'Metadata' }));
+        await user.click(option);
+
+        expect(onSourceChange).toHaveBeenCalledWith('metadata');
+    });
+
+    it('calls onGroupChange when a new group is selected', async () => {
+        const onGroupChange = vi.fn();
+        const user = userEvent.setup();
+        render(SourceGroupSelector, {
+            props: { ...defaultProps, groupItems, activeGroupId: 'key1', onGroupChange }
+        });
+
+        await user.click(screen.getByTestId('dataset-distribution-group-select'));
+        const option = await waitFor(() => screen.getByRole('option', { name: 'Key 2' }));
+        await user.click(option);
+
+        expect(onGroupChange).toHaveBeenCalledWith('key2');
+    });
+});

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.test.ts
@@ -49,6 +49,23 @@ describe('selectVisibleCounts', () => {
         expect(visible.map((item) => item.label)).toEqual(['dog', 'car']);
     });
 
+    it('uses stable ids for manual selections when labels collide', () => {
+        const visible = selectVisibleCounts(
+            [
+                { id: 'literal-missing', label: 'Missing', count: 2 },
+                { id: 'semantic-missing', label: 'Missing', count: 1 }
+            ],
+            {
+                mode: 'manual',
+                n: 1,
+                sortBy: 'count',
+                manualClasses: ['semantic-missing']
+            }
+        );
+
+        expect(visible.map((item) => item.id)).toEqual(['semantic-missing']);
+    });
+
     it('returns nothing when the manual selection is empty', () => {
         const visible = selectVisibleCounts(data, {
             mode: 'manual',
@@ -57,5 +74,18 @@ describe('selectVisibleCounts', () => {
             manualClasses: []
         });
         expect(visible).toEqual([]);
+    });
+
+    it('keeps pinned semantic buckets within a top-N limit', () => {
+        const visible = selectVisibleCounts(
+            [
+                ...data,
+                { label: 'Missing', count: 1, pinned: true },
+                { label: 'Other', count: 2, pinned: true }
+            ],
+            { mode: 'topN', n: 3, sortBy: 'count', manualClasses: [] }
+        );
+
+        expect(visible.map((item) => item.label)).toEqual(['person', 'Other', 'Missing']);
     });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.ts
@@ -16,7 +16,16 @@ export function selectVisibleCounts(
             : a.label.localeCompare(b.label)
     );
     if (config.mode === 'manual') {
-        return sorted.filter((item) => config.manualClasses.includes(item.label));
+        return sorted.filter((item) => config.manualClasses.includes(item.id ?? item.label));
     }
-    return sorted.slice(0, Math.max(config.n, 1));
+    const limit = Math.max(config.n, 1);
+    const pinned = sorted.filter((item) => item.pinned);
+    if (pinned.length === 0) return sorted.slice(0, limit);
+
+    const remainingSlots = Math.max(limit - pinned.length, 0);
+    const selected = new Set([
+        ...pinned,
+        ...sorted.filter((item) => !item.pinned).slice(0, remainingSlots)
+    ]);
+    return sorted.filter((item) => selected.has(item));
 }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/sourceFixtures.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/sourceFixtures.ts
@@ -1,4 +1,6 @@
 import type { CategoryCount } from '$lib/components/BarChart';
+import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+import type { CategoricalMetadataValue } from '$lib/services/types';
 import type { DistributionSource } from './types';
 import { longTail } from '$lib/components/BarChart/fixtures';
 import {
@@ -76,6 +78,40 @@ const evalErrors: CategoryCount[] = counts([
     ['duplicate_pred', 176]
 ]);
 
+function categoricalBuckets(
+    entries: [string | boolean | null, number][]
+): CategoricalMetadataBucket[] {
+    return entries.map(([value, count], i) => {
+        const id = String(i);
+        if (value === null) return { id, kind: 'missing', value: null, label: '(missing)', count };
+        return { id, kind: 'value', value, label: String(value), count };
+    });
+}
+
+/** Location-type metadata: urban / rural classification per sample. */
+const locationTypeBuckets = categoricalBuckets([
+    ['city', 5840],
+    ['suburban', 3210],
+    ['rural', 2470],
+    ['village', 1390],
+    ['town', 980],
+    ['industrial', 540],
+    ['highway', 420],
+    [null, 115]
+]);
+
+/** Same distribution with an active filter on city + rural (foreground bars). */
+const locationTypeFilteredBuckets = categoricalBuckets([
+    ['city', 2910],
+    ['suburban', 3210],
+    ['rural', 1230],
+    ['village', 1390],
+    ['town', 980],
+    ['industrial', 540],
+    ['highway', 420],
+    [null, 115]
+]);
+
 /**
  * A metadata-only source list with a numeric key first, so the histogram
  * rendering is visible immediately. Switching to `weather` demonstrates the
@@ -91,6 +127,64 @@ export const numericMetadataSources: DistributionSource[] = [
             { id: 'confidence', label: 'confidence (numeric)', histogram: numericConfidence },
             { id: 'brightness', label: 'brightness (numeric)', histogram: numericBrightness },
             { id: 'weather', label: 'weather', data: metadataWeather }
+        ]
+    }
+];
+
+/**
+ * Single-source fixture for the categorical metadata story. Shows:
+ * - value / missing bucket kinds
+ * - active filter selection (city + rural) with filtered counts as foreground bars
+ */
+export const categoricalMetadataSources: DistributionSource[] = [
+    {
+        id: 'metadata',
+        label: 'Metadata',
+        groupLabel: 'Metadata key',
+        valueNoun: 'samples',
+        groups: [
+            {
+                id: 'location_type',
+                label: 'location_type',
+                categorical: {
+                    buckets: locationTypeBuckets,
+                    filteredBuckets: locationTypeFilteredBuckets,
+                    selectedValues: ['city', 'rural'] satisfies CategoricalMetadataValue[]
+                }
+            }
+        ]
+    }
+];
+
+/**
+ * All three data kinds in one panel: class labels (bar chart), categorical
+ * metadata with an active filter (location_type), and numeric metadata
+ * (confidence histogram). Useful for reviewing how source-switching feels
+ * when the chart type changes between selections.
+ */
+export const mixedSources: DistributionSource[] = [
+    {
+        id: 'class',
+        label: 'Class labels',
+        data: longTail,
+        valueNoun: 'annotations'
+    },
+    {
+        id: 'metadata',
+        label: 'Metadata',
+        groupLabel: 'Metadata key',
+        valueNoun: 'samples',
+        groups: [
+            {
+                id: 'location_type',
+                label: 'location_type',
+                categorical: {
+                    buckets: locationTypeBuckets,
+                    filteredBuckets: locationTypeFilteredBuckets,
+                    selectedValues: ['city', 'rural'] satisfies CategoricalMetadataValue[]
+                }
+            },
+            { id: 'confidence', label: 'confidence (numeric)', histogram: numericConfidence }
         ]
     }
 ];

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -27,6 +27,11 @@ export const DISTRIBUTION_SORT_LABELS: Record<DistributionSortOption, string> = 
     name: 'Class name'
 };
 
+export const CATEGORICAL_DISTRIBUTION_SORT_LABELS: Record<DistributionSortOption, string> = {
+    count: 'Count',
+    name: 'Value'
+};
+
 /** Bar layout for the distribution chart. */
 export type DistributionOrientation = 'vertical' | 'horizontal';
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -20,6 +20,8 @@ export interface CategoricalDistribution {
     buckets: CategoricalBucket[];
     filteredBuckets?: Pick<CategoricalBucket, 'id' | 'count'>[];
     selectedValues: CategoricalMetadataValue[];
+    loading?: boolean;
+    error?: string;
 }
 
 export const DISTRIBUTION_SORT_LABELS: Record<DistributionSortOption, string> = {

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -2,8 +2,25 @@ import type { CategoryCount } from '$lib/components/BarChart';
 import type { ClassSetSelection } from '$lib/components/ClassSetConfig';
 import { type AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 import type { HistogramData, HistogramRange } from '$lib/components/Histogram';
+import type { CategoricalMetadataValue } from '$lib/services/types';
 
 export type DistributionSortOption = 'count' | 'name';
+
+export type CategoricalBucket =
+    | {
+          id: string;
+          kind: 'value' | 'missing';
+          label: string;
+          count: number;
+          value: CategoricalMetadataValue;
+      }
+    | { id: string; kind: 'other'; label: string; count: number; value?: never };
+
+export interface CategoricalDistribution {
+    buckets: CategoricalBucket[];
+    filteredBuckets?: Pick<CategoricalBucket, 'id' | 'count'>[];
+    selectedValues: CategoricalMetadataValue[];
+}
 
 export const DISTRIBUTION_SORT_LABELS: Record<DistributionSortOption, string> = {
     count: 'Count',
@@ -32,6 +49,8 @@ export interface DistributionSourceGroup {
      * metadata filter). Bins outside it render dimmed.
      */
     selectedRange?: HistogramRange;
+    /** Categorical distribution rendered as a bar chart with selection state. */
+    categorical?: CategoricalDistribution;
 }
 
 /**

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/useDistributionPanel.svelte.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/useDistributionPanel.svelte.ts
@@ -1,0 +1,253 @@
+import { type SelectItem } from '$lib/components/Select';
+import { type CategoryCount } from '$lib/components/BarChart';
+import { type HistogramRange } from '$lib/components/Histogram';
+import {
+    HISTOGRAM_BIN_COUNT_ITEMS,
+    type DistributionConfig,
+    type DistributionSource,
+    type DistributionSourceGroup
+} from './types';
+import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
+import { selectVisibleCounts } from './selectVisibleCounts';
+import type { CategoricalMetadataValue } from '$lib/services/types';
+
+export interface UseDistributionPanelParams {
+    sources?: DistributionSource[];
+    data?: CategoryCount[];
+    topN?: number;
+    initialCountMode?: AnnotationCountMode;
+    onCountModeChange?: (mode: AnnotationCountMode) => void;
+    onHistogramRangeSelect?: (groupId: string, range: HistogramRange) => void;
+    onCategoricalValueToggle?: (groupId: string, value: CategoricalMetadataValue) => void;
+    onCategoricalValuesClear?: (groupId: string) => void;
+}
+
+const defaultCategoricalConfig: DistributionConfig = {
+    mode: 'topN',
+    n: 1,
+    sortBy: 'count',
+    manualClasses: [],
+    orientation: 'horizontal',
+    countMode: AnnotationCountMode.SAMPLES
+};
+
+export function useDistributionPanel(getProps: () => UseDistributionPanelParams) {
+    const groupHasContent = (group: DistributionSourceGroup): boolean =>
+        (group.data?.length ?? 0) > 0 || group.histogram != null || group.categorical != null;
+
+    const sourceHasContent = (source: DistributionSource): boolean =>
+        (source.data?.length ?? 0) > 0 ||
+        source.histogram != null ||
+        (source.groups?.some(groupHasContent) ?? false);
+
+    let selectedSourceId = $state<string | undefined>(undefined);
+    let selectedGroupId = $state<string | undefined>(undefined);
+
+    const resolvedSources = $derived<DistributionSource[]>(
+        getProps().sources ?? [
+            { id: 'class', label: 'Annotation classes', data: getProps().data ?? [] }
+        ]
+    );
+    const hasSourceSelector = $derived(resolvedSources.length > 1);
+
+    const defaultSource = $derived(resolvedSources.find(sourceHasContent) ?? resolvedSources[0]);
+    const activeSource = $derived(
+        resolvedSources.find((source) => source.id === selectedSourceId) ?? defaultSource
+    );
+    const activeGroup = $derived(
+        activeSource.groups?.find((group) => group.id === selectedGroupId) ??
+            activeSource.groups?.find(groupHasContent) ??
+            activeSource.groups?.[0]
+    );
+    const activeData = $derived<CategoryCount[]>(activeGroup?.data ?? activeSource.data ?? []);
+    const activeHistogram = $derived(activeGroup?.histogram ?? activeSource.histogram ?? null);
+    const activeCategorical = $derived(activeGroup?.categorical ?? null);
+    const categoricalData = $derived<CategoryCount[]>(
+        (activeCategorical?.buckets ?? []).map((bucket) => {
+            const filteredBucket = activeCategorical?.filteredBuckets?.find(
+                (fb) => fb.id === bucket.id
+            );
+            const filteredCount =
+                activeCategorical?.filteredBuckets !== undefined
+                    ? (filteredBucket?.count ?? 0)
+                    : undefined;
+            return {
+                id: bucket.id,
+                label: bucket.label,
+                count: bucket.count,
+                filteredCount,
+                selectable: bucket.kind !== 'other',
+                pinned: bucket.kind !== 'value',
+                selected:
+                    bucket.kind !== 'other' &&
+                    activeCategorical?.selectedValues.some((value) =>
+                        Object.is(value, bucket.value)
+                    )
+            };
+        })
+    );
+    const displayedData = $derived(activeCategorical ? categoricalData : activeData);
+    const configurationItems = $derived(
+        displayedData.map((item) => ({ value: item.id ?? item.label, label: item.label }))
+    );
+    const activeHistogramRange = $derived(activeGroup?.selectedRange ?? activeSource.selectedRange);
+    const histogramTotal = $derived(
+        activeHistogram ? activeHistogram.counts.reduce((sum, count) => sum + count, 0) : 0
+    );
+    const valueNoun = $derived(activeSource.valueNoun ?? 'annotations');
+
+    let config: DistributionConfig = $state({
+        mode: 'topN',
+        n: getProps().topN ?? 20,
+        sortBy: 'count',
+        manualClasses: [],
+        orientation: 'horizontal',
+        countMode: getProps().initialCountMode ?? AnnotationCountMode.OBJECTS
+    });
+    let categoricalConfigs = $state<Record<string, DistributionConfig>>({});
+    const categoricalConfig = $derived<DistributionConfig>(
+        activeGroup
+            ? (categoricalConfigs[activeGroup.id] ?? {
+                  ...defaultCategoricalConfig,
+                  n: Math.max(categoricalData.length, 1)
+              })
+            : defaultCategoricalConfig
+    );
+
+    const sourceItems = $derived<SelectItem[]>(
+        resolvedSources.map((source) => ({ value: source.id, label: source.label }))
+    );
+    const groupItems = $derived<SelectItem[]>(
+        (activeSource.groups ?? []).map((group) => ({ value: group.id, label: group.label }))
+    );
+
+    const activeViewConfig = $derived<DistributionConfig>(
+        activeCategorical ? categoricalConfig : config
+    );
+    const visible = $derived(selectVisibleCounts(displayedData, activeViewConfig));
+    const totalCount = $derived(displayedData.reduce((sum, item) => sum + item.count, 0));
+    const showTotalCount = $derived(
+        (config.countMode ?? AnnotationCountMode.OBJECTS) !== AnnotationCountMode.SAMPLES
+    );
+
+    const binCountItems: SelectItem[] = HISTOGRAM_BIN_COUNT_ITEMS.map((count) => ({
+        value: String(count),
+        label: `${count} bins`
+    }));
+
+    const handleHistogramRangeSelect = (range: HistogramRange) => {
+        const groupId = activeGroup?.id ?? activeSource.id;
+        getProps().onHistogramRangeSelect?.(groupId, range);
+    };
+
+    const handleCategoricalBarClick = (item: CategoryCount) => {
+        const bucket = activeCategorical?.buckets.find((candidate) => candidate.id === item.id);
+        if (!bucket || bucket.kind === 'other' || !activeGroup) return;
+        getProps().onCategoricalValueToggle?.(activeGroup.id, bucket.value);
+    };
+
+    const handleCategoricalFilterToggle = (value: CategoricalMetadataValue) => {
+        if (!activeGroup) return;
+        getProps().onCategoricalValueToggle?.(activeGroup.id, value);
+    };
+
+    const handleCategoricalFilterClear = () => {
+        if (!activeGroup) return;
+        getProps().onCategoricalValuesClear?.(activeGroup.id);
+    };
+
+    const setCategoricalConfig = (next: DistributionConfig) => {
+        if (!activeGroup) return;
+        categoricalConfigs = {
+            ...categoricalConfigs,
+            [activeGroup.id]: { ...next, countMode: AnnotationCountMode.SAMPLES }
+        };
+    };
+
+    function applyConfig(next: DistributionConfig) {
+        if (activeCategorical) {
+            setCategoricalConfig(next);
+            return;
+        }
+        if (next.countMode !== config.countMode) {
+            getProps().onCountModeChange?.(next.countMode ?? AnnotationCountMode.OBJECTS);
+        }
+        config = next;
+    }
+
+    return {
+        get hasSourceSelector() {
+            return hasSourceSelector;
+        },
+        get sourceItems() {
+            return sourceItems;
+        },
+        get groupItems() {
+            return groupItems;
+        },
+        get activeSource() {
+            return activeSource;
+        },
+        get activeGroup() {
+            return activeGroup;
+        },
+        get activeData() {
+            return activeData;
+        },
+        get activeHistogram() {
+            return activeHistogram;
+        },
+        get activeCategorical() {
+            return activeCategorical;
+        },
+        get categoricalData() {
+            return categoricalData;
+        },
+        get displayedData() {
+            return displayedData;
+        },
+        get configurationItems() {
+            return configurationItems;
+        },
+        get activeHistogramRange() {
+            return activeHistogramRange;
+        },
+        get histogramTotal() {
+            return histogramTotal;
+        },
+        get valueNoun() {
+            return valueNoun;
+        },
+        get config() {
+            return config;
+        },
+        get categoricalConfig() {
+            return categoricalConfig;
+        },
+        get activeViewConfig() {
+            return activeViewConfig;
+        },
+        get visible() {
+            return visible;
+        },
+        get totalCount() {
+            return totalCount;
+        },
+        get showTotalCount() {
+            return showTotalCount;
+        },
+        binCountItems,
+        setSelectedSourceId: (id: string) => {
+            selectedSourceId = id;
+        },
+        setSelectedGroupId: (id: string | undefined) => {
+            selectedGroupId = id;
+        },
+        handleHistogramRangeSelect,
+        handleCategoricalBarClick,
+        handleCategoricalFilterToggle,
+        handleCategoricalFilterClear,
+        setCategoricalConfig,
+        applyConfig
+    };
+}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/useDistributionPanel.svelte.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/useDistributionPanel.svelte.ts
@@ -11,7 +11,7 @@ import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 import { selectVisibleCounts } from './selectVisibleCounts';
 import type { CategoricalMetadataValue } from '$lib/services/types';
 
-export interface UseDistributionPanelParams {
+interface UseDistributionPanelParams {
     sources?: DistributionSource[];
     data?: CategoryCount[];
     topN?: number;

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/useDistributionPanel.svelte.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/useDistributionPanel.svelte.ts
@@ -22,6 +22,14 @@ export interface UseDistributionPanelParams {
     onCategoricalValuesClear?: (groupId: string) => void;
 }
 
+function makeGetters<T extends Record<string, unknown>>(fns: { [K in keyof T]: () => T[K] }): T {
+    const result = {} as T;
+    for (const key in fns) {
+        Object.defineProperty(result, key, { get: fns[key], enumerable: true, configurable: true });
+    }
+    return result;
+}
+
 const defaultCategoricalConfig: DistributionConfig = {
     mode: 'topN',
     n: 1,
@@ -175,79 +183,43 @@ export function useDistributionPanel(getProps: () => UseDistributionPanelParams)
         config = next;
     }
 
-    return {
-        get hasSourceSelector() {
-            return hasSourceSelector;
-        },
-        get sourceItems() {
-            return sourceItems;
-        },
-        get groupItems() {
-            return groupItems;
-        },
-        get activeSource() {
-            return activeSource;
-        },
-        get activeGroup() {
-            return activeGroup;
-        },
-        get activeData() {
-            return activeData;
-        },
-        get activeHistogram() {
-            return activeHistogram;
-        },
-        get activeCategorical() {
-            return activeCategorical;
-        },
-        get categoricalData() {
-            return categoricalData;
-        },
-        get displayedData() {
-            return displayedData;
-        },
-        get configurationItems() {
-            return configurationItems;
-        },
-        get activeHistogramRange() {
-            return activeHistogramRange;
-        },
-        get histogramTotal() {
-            return histogramTotal;
-        },
-        get valueNoun() {
-            return valueNoun;
-        },
-        get config() {
-            return config;
-        },
-        get categoricalConfig() {
-            return categoricalConfig;
-        },
-        get activeViewConfig() {
-            return activeViewConfig;
-        },
-        get visible() {
-            return visible;
-        },
-        get totalCount() {
-            return totalCount;
-        },
-        get showTotalCount() {
-            return showTotalCount;
-        },
-        binCountItems,
-        setSelectedSourceId: (id: string) => {
-            selectedSourceId = id;
-        },
-        setSelectedGroupId: (id: string | undefined) => {
-            selectedGroupId = id;
-        },
-        handleHistogramRangeSelect,
-        handleCategoricalBarClick,
-        handleCategoricalFilterToggle,
-        handleCategoricalFilterClear,
-        setCategoricalConfig,
-        applyConfig
-    };
+    return Object.assign(
+        makeGetters({
+            hasSourceSelector: () => hasSourceSelector,
+            sourceItems: () => sourceItems,
+            groupItems: () => groupItems,
+            activeSource: () => activeSource,
+            activeGroup: () => activeGroup,
+            activeData: () => activeData,
+            activeHistogram: () => activeHistogram,
+            activeCategorical: () => activeCategorical,
+            categoricalData: () => categoricalData,
+            displayedData: () => displayedData,
+            configurationItems: () => configurationItems,
+            activeHistogramRange: () => activeHistogramRange,
+            histogramTotal: () => histogramTotal,
+            valueNoun: () => valueNoun,
+            config: () => config,
+            categoricalConfig: () => categoricalConfig,
+            activeViewConfig: () => activeViewConfig,
+            visible: () => visible,
+            totalCount: () => totalCount,
+            showTotalCount: () => showTotalCount
+        }),
+        {
+            binCountItems,
+            setSelectedSourceId: (id: string) => {
+                selectedSourceId = id;
+            },
+            setSelectedGroupId: (id: string | undefined) => {
+                selectedGroupId = id;
+            },
+            handleHistogramRangeSelect,
+            handleCategoricalBarClick,
+            handleCategoricalFilterToggle,
+            handleCategoricalFilterClear,
+            setCategoricalConfig,
+            applyConfig
+        }
+    );
 }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/useDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/useDistributionPanel.test.ts
@@ -1,12 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import {
-    useDistributionPanel,
-    type UseDistributionPanelParams
-} from './useDistributionPanel.svelte';
+import { useDistributionPanel } from './useDistributionPanel.svelte';
 import type { DistributionSource } from './types';
 import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 
-const renderHook = (props: UseDistributionPanelParams = {}) => useDistributionPanel(() => props);
+const renderHook = (props: ReturnType<Parameters<typeof useDistributionPanel>[0]> = {}) =>
+    useDistributionPanel(() => props);
 
 describe('useDistributionPanel', () => {
     it('normalizes data to a single source when sources is not provided', () => {

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/useDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/useDistributionPanel.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    useDistributionPanel,
+    type UseDistributionPanelParams
+} from './useDistributionPanel.svelte';
+import type { DistributionSource } from './types';
+import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
+
+const renderHook = (props: UseDistributionPanelParams = {}) => useDistributionPanel(() => props);
+
+describe('useDistributionPanel', () => {
+    it('normalizes data to a single source when sources is not provided', () => {
+        const data = [{ label: 'car', count: 10 }];
+        const panel = renderHook({ data });
+
+        expect(panel.activeSource.id).toBe('class');
+        expect(panel.activeData).toEqual(data);
+    });
+
+    it('defaults to the first source with content, skipping empty leading sources', () => {
+        const sources: DistributionSource[] = [
+            { id: 'empty', label: 'Empty', data: [] },
+            { id: 'full', label: 'Full', data: [{ label: 'car', count: 5 }] }
+        ];
+        const panel = renderHook({ sources });
+
+        expect(panel.activeSource.id).toBe('full');
+    });
+
+    it('defaults to a source with a histogram when the first source has no bar data', () => {
+        const sources: DistributionSource[] = [
+            { id: 'all', label: 'All', data: [] },
+            {
+                id: 'meta',
+                label: 'Meta',
+                groups: [
+                    { id: 'conf', label: 'conf', histogram: { binEdges: [0, 1], counts: [10] } }
+                ]
+            }
+        ];
+        const panel = renderHook({ sources });
+
+        expect(panel.activeSource.id).toBe('meta');
+        expect(panel.activeHistogram).not.toBeNull();
+    });
+
+    it('changes active source via setSelectedSourceId', () => {
+        const sources: DistributionSource[] = [
+            { id: 'a', label: 'A', data: [{ label: 'x', count: 1 }] },
+            { id: 'b', label: 'B', data: [{ label: 'y', count: 2 }] }
+        ];
+        const panel = renderHook({ sources });
+
+        panel.setSelectedSourceId('b');
+
+        expect(panel.activeSource.id).toBe('b');
+        expect(panel.activeData).toEqual([{ label: 'y', count: 2 }]);
+    });
+
+    it('changes active group via setSelectedGroupId', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'meta',
+                label: 'Meta',
+                groups: [
+                    {
+                        id: 'g1',
+                        label: 'G1',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [{ id: 'a', kind: 'value', value: 'A', label: 'A', count: 1 }]
+                        }
+                    },
+                    {
+                        id: 'g2',
+                        label: 'G2',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [{ id: 'b', kind: 'value', value: 'B', label: 'B', count: 2 }]
+                        }
+                    }
+                ]
+            }
+        ];
+        const panel = renderHook({ sources });
+        expect(panel.activeGroup?.id).toBe('g1');
+
+        panel.setSelectedGroupId('g2');
+
+        expect(panel.activeGroup?.id).toBe('g2');
+    });
+
+    it('maps categorical buckets to CategoryCount with correct selection and pin flags', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'meta',
+                label: 'Meta',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: ['Zurich'],
+                            buckets: [
+                                {
+                                    id: 'z',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 2
+                                },
+                                { id: 'other', kind: 'other', label: 'Other', count: 1 }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        const panel = renderHook({ sources });
+
+        expect(panel.categoricalData).toEqual([
+            expect.objectContaining({ id: 'z', selected: true, selectable: true, pinned: false }),
+            expect.objectContaining({
+                id: 'missing',
+                selected: false,
+                selectable: true,
+                pinned: true
+            }),
+            expect.objectContaining({
+                id: 'other',
+                selected: false,
+                selectable: false,
+                pinned: true
+            })
+        ]);
+    });
+
+    it('applyConfig updates config and fires onCountModeChange when mode changes', () => {
+        const onCountModeChange = vi.fn();
+        const panel = renderHook({ data: [{ label: 'car', count: 5 }], onCountModeChange });
+
+        panel.applyConfig({ ...panel.config, countMode: AnnotationCountMode.SAMPLES });
+
+        expect(onCountModeChange).toHaveBeenCalledWith(AnnotationCountMode.SAMPLES);
+        expect(panel.config.countMode).toBe(AnnotationCountMode.SAMPLES);
+    });
+
+    it('applyConfig does not fire onCountModeChange when mode is unchanged', () => {
+        const onCountModeChange = vi.fn();
+        const panel = renderHook({ data: [{ label: 'car', count: 5 }], onCountModeChange });
+
+        panel.applyConfig({ ...panel.config, n: 5 });
+
+        expect(onCountModeChange).not.toHaveBeenCalled();
+    });
+
+    it('applyConfig routes to setCategoricalConfig for categorical sources', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'meta',
+                label: 'Meta',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [{ id: 'z', kind: 'value', value: 'Z', label: 'Z', count: 4 }]
+                        }
+                    }
+                ]
+            }
+        ];
+        const panel = renderHook({ sources });
+
+        panel.applyConfig({ ...panel.categoricalConfig, n: 5 });
+
+        expect(panel.categoricalConfig.n).toBe(5);
+        expect(panel.categoricalConfig.countMode).toBe(AnnotationCountMode.SAMPLES);
+    });
+
+    it('setCategoricalConfig stores config per group independently', () => {
+        const makeCategorical = (label: string) => ({
+            selectedValues: [] as string[],
+            buckets: [{ id: label, kind: 'value' as const, value: label, label, count: 1 }]
+        });
+        const sources: DistributionSource[] = [
+            {
+                id: 'meta',
+                label: 'Meta',
+                groups: [
+                    { id: 'city', label: 'city', categorical: makeCategorical('Zurich') },
+                    { id: 'weather', label: 'weather', categorical: makeCategorical('rainy') }
+                ]
+            }
+        ];
+        const panel = renderHook({ sources });
+
+        panel.setCategoricalConfig({ ...panel.categoricalConfig, n: 3 });
+        expect(panel.categoricalConfig.n).toBe(3);
+
+        panel.setSelectedGroupId('weather');
+        expect(panel.categoricalConfig.n).toBe(1);
+
+        panel.setSelectedGroupId('city');
+        expect(panel.categoricalConfig.n).toBe(3);
+    });
+
+    it('handleHistogramRangeSelect forwards the range with the active group id', () => {
+        const onHistogramRangeSelect = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'meta',
+                label: 'Meta',
+                groups: [
+                    {
+                        id: 'confidence',
+                        label: 'confidence',
+                        histogram: { binEdges: [0, 0.5, 1], counts: [30, 70] }
+                    }
+                ]
+            }
+        ];
+        const panel = renderHook({ sources, onHistogramRangeSelect });
+
+        panel.handleHistogramRangeSelect({ min: 0.5, max: 1 });
+
+        expect(onHistogramRangeSelect).toHaveBeenCalledWith('confidence', { min: 0.5, max: 1 });
+    });
+
+    it('handleCategoricalBarClick forwards value/missing bucket clicks but ignores other', () => {
+        const onCategoricalValueToggle = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'meta',
+                label: 'Meta',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'z',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                },
+                                { id: 'other', kind: 'other', label: 'Other', count: 1 }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        const panel = renderHook({ sources, onCategoricalValueToggle });
+
+        panel.handleCategoricalBarClick({ id: 'z', label: 'Zurich', count: 4 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledWith('city', 'Zurich');
+
+        panel.handleCategoricalBarClick({ id: 'other', label: 'Other', count: 1 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledOnce();
+    });
+
+    it('handleCategoricalFilterToggle and handleCategoricalFilterClear use the active group id', () => {
+        const onCategoricalValueToggle = vi.fn();
+        const onCategoricalValuesClear = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'meta',
+                label: 'Meta',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'z',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        const panel = renderHook({ sources, onCategoricalValueToggle, onCategoricalValuesClear });
+
+        panel.handleCategoricalFilterToggle('Zurich');
+        expect(onCategoricalValueToggle).toHaveBeenCalledWith('city', 'Zurich');
+
+        panel.handleCategoricalFilterClear();
+        expect(onCategoricalValuesClear).toHaveBeenCalledWith('city');
+    });
+
+    it('showTotalCount is true for Objects mode and false for Samples mode', () => {
+        const panel = renderHook({ data: [{ label: 'car', count: 5 }] });
+        expect(panel.showTotalCount).toBe(true);
+
+        panel.applyConfig({ ...panel.config, countMode: AnnotationCountMode.SAMPLES });
+        expect(panel.showTotalCount).toBe(false);
+    });
+});

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.svelte.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.svelte.ts
@@ -7,13 +7,9 @@ import type { CategoricalMetadataValue } from '$lib/services/types';
 type Range = { min: number; max: number };
 type BoundsMap = Record<string, Range>;
 
-export interface MetadataFilterChip {
-    key: string;
-    active: boolean;
-    kind: 'numeric' | 'categorical';
-    range?: Range;
-    values?: CategoricalMetadataValue[];
-}
+export type MetadataFilterChip =
+    | { key: string; active: boolean; kind: 'numeric'; range: Range }
+    | { key: string; active: boolean; kind: 'categorical'; values: CategoricalMetadataValue[] };
 
 export function useMetadataFilterChips(collectionId: string | undefined) {
     const {
@@ -77,22 +73,26 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
                 const range: Range | undefined = active
                     ? valuesStore.current[key]
                     : lastRanges[key];
-                return range ? { key, active, range, kind: 'numeric' as const } : null;
+                return range ? { key, active, kind: 'numeric' as const, range } : null;
             })
-            .filter((chip): chip is NonNullable<typeof chip> => chip !== null);
+            .filter(
+                (chip): chip is Extract<MetadataFilterChip, { kind: 'numeric' }> => chip !== null
+            );
         const categoricalKeys = new Set([
             ...Object.keys(lastCategoricalValues),
             ...Object.entries(categoricalStore.current)
                 .filter(([, values]) => values.length > 0)
                 .map(([key]) => key)
         ]);
-        const categoricalChips: MetadataFilterChip[] = [...categoricalKeys].map((key) => {
+        const categoricalChips: Extract<MetadataFilterChip, { kind: 'categorical' }>[] = [
+            ...categoricalKeys
+        ].map((key) => {
             const current = categoricalStore.current[key] ?? [];
             return {
                 key,
                 active: current.length > 0,
-                kind: 'categorical',
-                values: current.length > 0 ? current : lastCategoricalValues[key]
+                kind: 'categorical' as const,
+                values: current.length > 0 ? current : (lastCategoricalValues[key] ?? [])
             };
         });
         return [...numericChips, ...categoricalChips];
@@ -153,6 +153,8 @@ export function useMetadataFilterChips(collectionId: string | undefined) {
         return isInteger ? formatInteger(value) : formatFloat(value);
     };
 
+    // Disambiguates null ("no value") from the literal string "Missing", and
+    // "Other" (a value) from any other sentinel, only when ambiguity exists.
     const formatCategoricalValues = (values: CategoricalMetadataValue[] = []): string => {
         const hasMissingValue = values.includes('Missing');
         const hasNoValue = values.includes(null);


### PR DESCRIPTION
## What has changed and why?

This PR introduces ability to render categorical metadata values within distribution Panel.

There is no breaking changes for existing functionality for classes and numeric metadata values.


## How has it been tested?

Accompanied by test and storybook stores to show how dataset distribition panel looks with categorical metadata values.
<img width="929" height="677" alt="Screenshot 2026-07-30 at 16 50 22" src="https://github.com/user-attachments/assets/d5437160-c3a1-4981-b6d4-be1326a03371" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?
<img width="1502" height="790" alt="Screenshot 2026-07-30 at 16 46 52" src="https://github.com/user-attachments/assets/686bc14f-56d1-45bf-9a95-109ac90b25ff" />


- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added categorical metadata distributions with filtering, sorting, selection, and retry support.
  * Added mixed distribution views combining categorical, class-label, and numeric data.
  * Added histogram controls for bin counts, ranges, summaries, and expanded viewing.
  * Improved distribution panel navigation with source and group selectors.
  * Added accessible loading, error, empty, and categorical summary states.

* **Bug Fixes**
  * Improved selection behavior when labels are duplicated.
  * Preserved pinned items in top-N results and prevented stale chart bars after errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->