### PR TITLE
Export filtering: add YouTube-VIS prepare export endpoint

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -6,7 +6,7 @@ import shutil
 from collections.abc import Generator
 from datetime import datetime, timezone
 from pathlib import Path as PathlibPath
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, mkdtemp
 from typing import Annotated
 from uuid import UUID
 
@@ -22,7 +22,7 @@ from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.export import image_dataset_export, video_dataset_export
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.models.export_format import ExportFormat
-from lightly_studio.resolvers import collection_resolver
+from lightly_studio.resolvers import collection_resolver, export_job_resolver
 from lightly_studio.resolvers.collection_resolver.export import ExportFilter
 from lightly_studio.resolvers.image_filter import ImageFilter
 
@@ -320,6 +320,43 @@ def export_collection_youtube_vis(
             "Content-Disposition": f"attachment; filename={output_path.name}",
         },
     )
+
+
+class ExportKeyResponse(BaseModel):
+    """Response body for all prepare endpoints."""
+
+    export_key: UUID
+
+
+@export_router.post("/export/prepare")
+def export_collection_prepare(
+    collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(collection_api.get_and_validate_collection_id),
+    ],
+    session: SessionDep,
+    body: ExportBody,
+) -> ExportKeyResponse:
+    """Generate the filename export and persist its path."""
+    exported = collection_resolver.export(
+        session=session,
+        collection_id=collection.collection_id,
+        include=body.include,
+        exclude=body.exclude,
+        collection_filter=body.collection_filter,
+    )
+
+    temp_dir = PathlibPath(mkdtemp())
+    filename = f"{collection.name}_exported_{datetime.now(timezone.utc)}.txt"
+    output_path = temp_dir / filename
+    try:
+        output_path.write_text("\n".join(exported))
+        export = export_job_resolver.create(session=session, export_path=str(output_path))
+    except Exception:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
+    return ExportKeyResponse(export_key=export.export_key)
 
 
 def _stream_export_dir(

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -306,10 +306,15 @@ def export_collection_youtube_vis(
 ) -> StreamingResponse:
     """Export collection video annotations in the selected export format."""
     if collection.sample_type != SampleType.VIDEO:
-        raise ValueError("YouTube-VIS export is only supported for video collections.")
+        raise HTTPException(
+            status_code=400, detail="YouTube-VIS export is only supported for video collections."
+        )
 
     if export_format != ExportFormat.YOUTUBE_VIS_SEGMENTATION:
-        raise ValueError("Only YouTube-VIS segmentation format is supported for this endpoint.")
+        raise HTTPException(
+            status_code=400,
+            detail="Only YouTube-VIS segmentation format is supported for this endpoint.",
+        )
     dataset_query = DatasetQuery(dataset=collection, session=session, sample_class=VideoSample)
 
     temp_dir = TemporaryDirectory()

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -26,6 +26,7 @@ from lightly_studio.models.export_format import ExportFormat
 from lightly_studio.resolvers import collection_resolver, export_job_resolver
 from lightly_studio.resolvers.collection_resolver.export import ExportFilter
 from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
 
 export_router = APIRouter(prefix="/collections/{collection_id}", tags=["export"])
 _STREAM_CHUNK_SIZE_BYTES = 64 * 1024
@@ -211,6 +212,12 @@ class ExportKeyResponse(BaseModel):
     export_key: UUID
 
 
+class ExportYoutubeVisPrepareBody(BaseModel):
+    """Request body for the YouTube-VIS prepare endpoint."""
+
+    video_filter: VideoFilter | None = None
+
+
 class ExportAnnotationsPrepareBody(BaseModel):
     """Request body for the annotations prepare endpoint."""
 
@@ -309,15 +316,10 @@ def export_collection_youtube_vis(
 ) -> StreamingResponse:
     """Export collection video annotations in the selected export format."""
     if collection.sample_type != SampleType.VIDEO:
-        raise HTTPException(
-            status_code=400, detail="YouTube-VIS export is only supported for video collections."
-        )
+        raise ValueError("YouTube-VIS export is only supported for video collections.")
 
     if export_format != ExportFormat.YOUTUBE_VIS_SEGMENTATION:
-        raise HTTPException(
-            status_code=400,
-            detail="Only YouTube-VIS segmentation format is supported for this endpoint.",
-        )
+        raise ValueError("Only YouTube-VIS segmentation format is supported for this endpoint.")
     dataset_query = DatasetQuery(dataset=collection, session=session, sample_class=VideoSample)
 
     temp_dir = TemporaryDirectory()
@@ -371,6 +373,42 @@ def export_collection_prepare(
     except Exception:
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise
+    return ExportKeyResponse(export_key=export.export_key)
+
+
+@export_router.post("/export/youtube-vis/prepare")
+def export_collection_youtube_vis_prepare(
+    collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(collection_api.get_and_validate_collection_id),
+    ],
+    session: SessionDep,
+    body: ExportYoutubeVisPrepareBody,
+) -> ExportKeyResponse:
+    """Generate the YouTube-VIS export and persist its path."""
+    if collection.sample_type != SampleType.VIDEO:
+        raise ValueError("YouTube-VIS export is only supported for video collections.")
+
+    dataset_query = DatasetQuery(dataset=collection, session=session, sample_class=VideoSample)
+    if body.video_filter is not None:
+        dataset_query.filter_by_sample_ids(
+            body.video_filter.build_sample_ids_query(collection.collection_id)
+        )
+
+    temp_dir = PathlibPath(tempfile.mkdtemp())
+    output_path = temp_dir / "youtube_vis_segmentation_mask_export.json"
+    try:
+        video_dataset_export.to_youtube_vis_segmentation_mask(
+            session=session,
+            samples=dataset_query,
+            output_json=output_path,
+        )
+        export = export_job_resolver.create(session=session, export_path=str(output_path))
+    except Exception:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
+
     return ExportKeyResponse(export_key=export.export_key)
 
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -219,6 +219,12 @@ class ExportAnnotationsPrepareBody(BaseModel):
     image_filter: ImageFilter | None = None
 
 
+class ExportCaptionsPrepareBody(BaseModel):
+    """Request body for the captions prepare endpoint."""
+
+    image_filter: ImageFilter | None = None
+
+
 # This endpoint should be a GET, however due to the potential huge size
 # of sample_ids, it is a POST request to avoid URL length limitations.
 # A body with a GET request is supported by fastAPI however it has undefined
@@ -399,6 +405,39 @@ def export_collection_annotations_prepare(
             temp_dir=temp_dir,
         )
         export = export_job_resolver.create(session=session, export_path=str(export_path))
+    except Exception:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
+
+    return ExportKeyResponse(export_key=export.export_key)
+
+
+@export_router.post("/export/captions/prepare")
+def export_collection_captions_prepare(
+    collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(collection_api.get_and_validate_collection_id),
+    ],
+    session: SessionDep,
+    body: ExportCaptionsPrepareBody,
+) -> ExportKeyResponse:
+    """Generate the captions export and persist its path."""
+    dataset_query = DatasetQuery(dataset=collection, session=session)
+    if body.image_filter is not None:
+        dataset_query.filter_by_sample_ids(
+            body.image_filter.build_sample_ids_query(collection.collection_id)
+        )
+
+    temp_dir = PathlibPath(tempfile.mkdtemp())
+    output_path = temp_dir / "coco_captions_export.json"
+    try:
+        image_dataset_export.ImageDatasetExport(
+            session=session,
+            dataset_id=collection.dataset_id,
+            samples=dataset_query,
+        ).to_coco_captions(output_json=output_path)
+        export = export_job_resolver.create(session=session, export_path=str(output_path))
     except Exception:
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -211,6 +211,14 @@ class ExportKeyResponse(BaseModel):
     export_key: UUID
 
 
+class ExportAnnotationsPrepareBody(BaseModel):
+    """Request body for the annotations prepare endpoint."""
+
+    export_format: ExportFormat = ExportFormat.OBJECT_DETECTION_COCO
+    annotation_collection_id: UUID | None = None
+    image_filter: ImageFilter | None = None
+
+
 # This endpoint should be a GET, however due to the potential huge size
 # of sample_ids, it is a POST request to avoid URL length limitations.
 # A body with a GET request is supported by fastAPI however it has undefined
@@ -358,6 +366,82 @@ def export_collection_prepare(
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise
     return ExportKeyResponse(export_key=export.export_key)
+
+
+@export_router.post("/export/annotations/prepare")
+def export_collection_annotations_prepare(
+    collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(collection_api.get_and_validate_collection_id),
+    ],
+    session: SessionDep,
+    body: ExportAnnotationsPrepareBody,
+) -> ExportKeyResponse:
+    """Generate the annotations export and persist its path."""
+    dataset_query = DatasetQuery(dataset=collection, session=session)
+    if body.image_filter is not None:
+        dataset_query.filter_by_sample_ids(
+            body.image_filter.build_sample_ids_query(collection.collection_id)
+        )
+    exporter = image_dataset_export.ImageDatasetExport(
+        session=session,
+        dataset_id=collection.dataset_id,
+        samples=dataset_query,
+    )
+
+    temp_dir = PathlibPath(tempfile.mkdtemp())
+    try:
+        export_path = _generate_annotations_export(
+            exporter=exporter,
+            export_format=body.export_format,
+            annotation_collection_id=body.annotation_collection_id,
+            temp_dir=temp_dir,
+        )
+        export = export_job_resolver.create(session=session, export_path=str(export_path))
+    except Exception:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
+
+    return ExportKeyResponse(export_key=export.export_key)
+
+
+def _generate_annotations_export(
+    exporter: image_dataset_export.ImageDatasetExport,
+    export_format: ExportFormat,
+    annotation_collection_id: UUID | None,
+    temp_dir: PathlibPath,
+) -> PathlibPath:
+    """Run the annotations export and return the output path."""
+    if export_format == ExportFormat.OBJECT_DETECTION_COCO:
+        output_path = temp_dir / "coco_export.json"
+        exporter.to_coco_object_detections(
+            output_json=output_path,
+            annotation_collection_id=annotation_collection_id,
+        )
+        return output_path
+    if export_format == ExportFormat.OBJECT_DETECTION_YOLO:
+        output_path = temp_dir / "yolo"
+        exporter.to_yolo_object_detections(
+            output_folder=output_path,
+            annotation_collection_id=annotation_collection_id,
+        )
+        return output_path
+    if export_format == ExportFormat.SEGMENTATION_MASK_COCO:
+        output_path = temp_dir / "coco_segmentation_mask_export.json"
+        exporter.to_coco_segmentation_masks(
+            output_json=output_path,
+            annotation_collection_id=annotation_collection_id,
+        )
+        return output_path
+    if export_format == ExportFormat.PASCAL_VOC:
+        output_path = temp_dir / "pascalvoc"
+        exporter.to_pascalvoc_segmentation_mask(
+            output_folder=output_path,
+            annotation_collection_id=annotation_collection_id,
+        )
+        return output_path
+    raise ValueError(f"Export format '{export_format.value}' is not supported for this endpoint.")
 
 
 def _stream_export_dir(

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import shutil
+import tempfile
 from collections.abc import Generator
 from datetime import datetime, timezone
 from pathlib import Path as PathlibPath
-from tempfile import TemporaryDirectory, mkdtemp
+from tempfile import TemporaryDirectory
 from typing import Annotated
 from uuid import UUID
 
@@ -204,6 +205,12 @@ class ExportBody(BaseModel):
     )
 
 
+class ExportKeyResponse(BaseModel):
+    """Response body for all prepare endpoints."""
+
+    export_key: UUID
+
+
 # This endpoint should be a GET, however due to the potential huge size
 # of sample_ids, it is a POST request to avoid URL length limitations.
 # A body with a GET request is supported by fastAPI however it has undefined
@@ -322,12 +329,6 @@ def export_collection_youtube_vis(
     )
 
 
-class ExportKeyResponse(BaseModel):
-    """Response body for all prepare endpoints."""
-
-    export_key: UUID
-
-
 @export_router.post("/export/prepare")
 def export_collection_prepare(
     collection: Annotated[
@@ -347,7 +348,7 @@ def export_collection_prepare(
         collection_filter=body.collection_filter,
     )
 
-    temp_dir = PathlibPath(mkdtemp())
+    temp_dir = PathlibPath(tempfile.mkdtemp())
     filename = f"{collection.name}_exported_{datetime.now(timezone.utc)}.txt"
     output_path = temp_dir / filename
     try:

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -599,3 +599,324 @@ def test_export_collection_prepare__exclude_filter(
     export_job = db_session.get(ExportJobTable, export_key)
     assert export_job is not None
     assert PathlibPath(export_job.export_path).read_text() == "path/b.png"
+
+
+def test_export_collection_annotations_prepare__coco(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="img1.jpg",
+        width=100,
+        height=100,
+    )
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    annotation_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        annotations=[
+            AnnotationCreate(
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+                parent_sample_id=image.sample_id,
+                x=10,
+                y=20,
+                width=30,
+                height=40,
+            )
+        ],
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/annotations/prepare",
+        json={
+            "export_format": "object_detection_coco",
+            "annotation_collection_id": str(annotation_collection_id),
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    content = json.loads(PathlibPath(export_job.export_path).read_text())
+    assert content == {
+        "images": [{"id": 0, "file_name": "img1.jpg", "width": 100, "height": 100}],
+        "categories": [{"id": 0, "name": "cat"}],
+        "annotations": [{"image_id": 0, "category_id": 0, "bbox": [10.0, 20.0, 30.0, 40.0]}],
+    }
+
+
+def test_export_collection_annotations_prepare__yolo(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="img1.jpg",
+        width=100,
+        height=100,
+    )
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    annotation_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        annotations=[
+            AnnotationCreate(
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+                parent_sample_id=image.sample_id,
+                x=10,
+                y=20,
+                width=30,
+                height=40,
+            )
+        ],
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/annotations/prepare",
+        json={
+            "export_format": "object_detection_yolo",
+            "annotation_collection_id": str(annotation_collection_id),
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    export_dir = PathlibPath(export_job.export_path)
+    assert (export_dir / "data.yaml").exists()
+    assert (export_dir / "labels" / "img1.txt").exists()
+
+
+def test_export_collection_annotations_prepare__segmentation_mask_coco(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="img1.jpg",
+        width=10,
+        height=10,
+    )
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    annotation_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        annotations=[
+            AnnotationCreate(
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.SEGMENTATION_MASK,
+                parent_sample_id=image.sample_id,
+                x=2,
+                y=0,
+                width=3,
+                height=2,
+                segmentation_mask=[2, 3, 7, 2, 86],
+            )
+        ],
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/annotations/prepare",
+        json={
+            "export_format": "segmentation_mask_coco",
+            "annotation_collection_id": str(annotation_collection_id),
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    content = json.loads(PathlibPath(export_job.export_path).read_text())
+    assert content == {
+        "images": [{"id": 0, "file_name": "img1.jpg", "width": 10, "height": 10}],
+        "categories": [{"id": 0, "name": "cat"}],
+        "annotations": [
+            {
+                "image_id": 0,
+                "category_id": 0,
+                "segmentation": {"counts": [20, 2, 8, 2, 8, 1, 59], "size": [10, 10]},
+                "bbox": [2.0, 0.0, 3.0, 2.0],
+                "iscrowd": 1,
+            }
+        ],
+    }
+
+
+def test_export_collection_annotations_prepare__pascal_voc(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="img1.jpg",
+        width=3,
+        height=2,
+    )
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="dog"
+    )
+    annotation_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        annotations=[
+            AnnotationCreate(
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.SEGMENTATION_MASK,
+                parent_sample_id=image.sample_id,
+                x=1,
+                y=0,
+                width=1,
+                height=1,
+                segmentation_mask=[1, 1, 4],
+            )
+        ],
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/annotations/prepare",
+        json={
+            "export_format": "pascal_voc",
+            "annotation_collection_id": str(annotation_collection_id),
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    export_dir = PathlibPath(export_job.export_path)
+    assert (export_dir / "class_id_to_name.json").exists()
+    assert (export_dir / "SegmentationClass" / "img1.png").exists()
+
+
+def test_export_collection_annotations_prepare__unsupported_format(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/annotations/prepare",
+        json={"export_format": "youtube_vis_segmentation"},
+    )
+
+    assert response.status_code == HTTP_STATUS_BAD_REQUEST
+
+
+def test_export_collection_annotations_prepare__image_filter(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    # image_a is included via image_filter; image_b is excluded.
+    collection = create_collection(session=db_session)
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="img_a.jpg",
+        width=100,
+        height=100,
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="img_b.jpg",
+        width=100,
+        height=100,
+    )
+    label = create_annotation_label(
+        session=db_session, root_collection_id=collection.collection_id, label_name="cat"
+    )
+    annotation_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        annotations=[
+            AnnotationCreate(
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+                parent_sample_id=image_a.sample_id,
+                x=10,
+                y=20,
+                width=30,
+                height=40,
+            ),
+            AnnotationCreate(
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+                parent_sample_id=image_b.sample_id,
+                x=10,
+                y=20,
+                width=30,
+                height=40,
+            ),
+        ],
+    )
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/annotations/prepare",
+        json={
+            "export_format": "object_detection_coco",
+            "annotation_collection_id": str(annotation_collection_id),
+            "image_filter": {
+                "filter_type": "image",
+                "sample_filter": {"sample_ids": [str(image_a.sample_id)]},
+            },
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    content = json.loads(PathlibPath(export_job.export_path).read_text())
+    assert len(content["images"]) == 1
+    assert content["images"][0]["file_name"] == "img_a.jpg"

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -920,3 +920,94 @@ def test_export_collection_annotations_prepare__image_filter(
     content = json.loads(PathlibPath(export_job.export_path).read_text())
     assert len(content["images"]) == 1
     assert content["images"][0]["file_name"] == "img_a.jpg"
+
+
+def test_export_collection_captions_prepare(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="img1.jpg",
+        width=100,
+        height=100,
+    )
+    create_caption(
+        session=db_session,
+        collection_id=collection.collection_id,
+        parent_sample_id=image.sample_id,
+        text="a cat on a mat",
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/captions/prepare",
+        json={},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    content = json.loads(PathlibPath(export_job.export_path).read_text())
+    assert content == {
+        "images": [{"id": 0, "file_name": "img1.jpg", "width": 100, "height": 100}],
+        "annotations": [{"id": 0, "image_id": 0, "caption": "a cat on a mat"}],
+    }
+
+
+def test_export_collection_captions_prepare__image_filter(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    # image_a is included via image_filter; image_b is excluded.
+    collection = create_collection(session=db_session)
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="img_a.jpg",
+        width=100,
+        height=100,
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="img_b.jpg",
+        width=100,
+        height=100,
+    )
+    create_caption(
+        session=db_session,
+        collection_id=collection.collection_id,
+        parent_sample_id=image_a.sample_id,
+        text="caption for a",
+    )
+    create_caption(
+        session=db_session,
+        collection_id=collection.collection_id,
+        parent_sample_id=image_b.sample_id,
+        text="caption for b",
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/captions/prepare",
+        json={
+            "image_filter": {
+                "filter_type": "image",
+                "sample_filter": {"sample_ids": [str(image_a.sample_id)]},
+            },
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    content = json.loads(PathlibPath(export_job.export_path).read_text())
+    assert len(content["images"]) == 1
+    assert content["images"][0]["file_name"] == "img_a.jpg"
+    assert len(content["annotations"]) == 1
+    assert content["annotations"][0]["caption"] == "caption for a"

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -601,6 +601,143 @@ def test_export_collection_prepare__exclude_filter(
     assert PathlibPath(export_job.export_path).read_text() == "path/b.png"
 
 
+def test_export_collection_youtube_vis_prepare(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_with_frames = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="video_001.mp4", width=3, height=2, duration_s=2.0, fps=1.0),
+    )
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="cat",
+    )
+    object_track_id = object_track_resolver.create_many(
+        session=db_session,
+        tracks=[
+            ObjectTrackCreate(
+                object_track_number=99,
+                dataset_id=collection.dataset_id,
+            )
+        ],
+    )[0]
+    frame_0, _frame_1 = video_with_frames.frame_sample_ids
+    annotation_resolver.create_many(
+        session=db_session,
+        parent_collection_id=video_with_frames.video_frames_collection_id,
+        annotations=[
+            AnnotationCreate(
+                parent_sample_id=frame_0,
+                annotation_label_id=label.annotation_label_id,
+                annotation_type=AnnotationType.SEGMENTATION_MASK,
+                x=0,
+                y=1,
+                width=1,
+                height=1,
+                segmentation_mask=[1, 1, 4],
+                object_track_id=object_track_id,
+            )
+        ],
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/youtube-vis/prepare",
+        json={},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    content = json.loads(PathlibPath(export_job.export_path).read_text())
+    assert content == {
+        "info": {"description": "YouTube-VIS export"},
+        "categories": [{"id": 1, "name": "cat"}],
+        "videos": [
+            {
+                "id": 1,
+                "file_names": ["video_001.mp4/00000.jpg", "video_001.mp4/00001.jpg"],
+                "width": 3,
+                "height": 2,
+                "length": 2,
+            }
+        ],
+        "annotations": [
+            {
+                "id": 99,
+                "video_id": 1,
+                "category_id": 1,
+                "bboxes": [[0.0, 1.0, 1.0, 1.0], None],
+                "segmentations": [
+                    {"counts": [2, 1, 3], "size": [2, 3]},
+                    None,
+                ],
+                "areas": [1.0, None],
+                "iscrowd": 1,
+                "height": 2,
+                "width": 3,
+                "length": 2,
+            }
+        ],
+    }
+
+
+def test_export_collection_youtube_vis_prepare__wrong_collection_type(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/youtube-vis/prepare",
+        json={},
+    )
+
+    assert response.status_code == HTTP_STATUS_BAD_REQUEST
+
+
+def test_export_collection_youtube_vis_prepare__video_filter(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    # video_a is included via video_filter; video_b is excluded.
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_a = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="video_a.mp4", width=3, height=2, duration_s=1.0, fps=1.0),
+    )
+    create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="video_b.mp4", width=3, height=2, duration_s=1.0, fps=1.0),
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/youtube-vis/prepare",
+        json={
+            "video_filter": {
+                "filter_type": "video",
+                "sample_filter": {"sample_ids": [str(video_a.video_sample_id)]},
+            },
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    content = json.loads(PathlibPath(export_job.export_path).read_text())
+    assert len(content["videos"]) == 1
+    assert content["videos"][0]["file_names"] == ["video_a.mp4/00000.jpg"]
+
+
 def test_export_collection_annotations_prepare__coco(
     db_session: Session,
     test_client: TestClient,

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -1117,6 +1117,7 @@ def test_export_collection_captions_prepare__image_filter(
     assert len(content["annotations"]) == 1
     assert content["annotations"][0]["caption"] == "caption for a"
 
+
 def test_export_collection_youtube_vis_prepare(
     db_session: Session,
     test_client: TestClient,

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import io
 import json
 import zipfile
+from pathlib import Path as PathlibPath
+from uuid import UUID
 
 import yaml
 from fastapi.testclient import TestClient
@@ -18,6 +20,7 @@ from lightly_studio.models.annotation.annotation_base import (
 )
 from lightly_studio.models.annotation.object_track import ObjectTrackCreate
 from lightly_studio.models.collection import SampleType
+from lightly_studio.models.export_job import ExportJobTable
 from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
@@ -498,3 +501,101 @@ def test_export_collection_youtube_vis__wrong_export_format(
     )
 
     assert response.status_code == HTTP_STATUS_BAD_REQUEST
+
+
+def test_export_collection_prepare(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session, collection_name="my_collection")
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/a.png",
+    )
+    image_b = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/b.png",
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/prepare",
+        json={"include": {"sample_ids": [str(image_a.sample_id), str(image_b.sample_id)]}},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    file_content = PathlibPath(export_job.export_path).read_text()
+    assert file_content == "path/a.png\npath/b.png"
+
+
+def test_export_collection_prepare__with_tag_filter(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/a.png",
+    )
+    create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/b.png",
+    )
+    image_c = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/c.png",
+    )
+
+    tag = create_tag(session=db_session, collection_id=collection.collection_id)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_a.sample)
+    tag_resolver.add_tag_to_sample(session=db_session, tag_id=tag.tag_id, sample=image_c.sample)
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/prepare",
+        json={"include": {"tag_ids": [str(tag.tag_id)]}},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    file_content = PathlibPath(export_job.export_path).read_text()
+    assert file_content == "path/a.png\npath/c.png"
+
+
+def test_export_collection_prepare__exclude_filter(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    image_a = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/a.png",
+    )
+    create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="path/b.png",
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection.collection_id}/export/prepare",
+        json={"exclude": {"sample_ids": [str(image_a.sample_id)]}},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    export_key = UUID(response.json()["export_key"])
+
+    export_job = db_session.get(ExportJobTable, export_key)
+    assert export_job is not None
+    assert PathlibPath(export_job.export_path).read_text() == "path/b.png"


### PR DESCRIPTION
## What has changed and why?

Extends the prepare endpoint to YouTube-VIS segmentation exports.

- `POST /export/youtube-vis/prepare` - validates video collection and generates the file

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preparing YouTube-VIS exports from video collections.
  * Added optional video filtering to include only selected videos in an export.
  * Export jobs are created with generated JSON content for download or processing.

* **Bug Fixes**
  * Added validation to reject collections that do not contain video data.
  * Improved cleanup when export preparation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->