### PR TITLE
Update Svelte Kit

### DIFF
--- a/lightly_studio_view/package-lock.json
+++ b/lightly_studio_view/package-lock.json
@@ -40,10 +40,10 @@
         "@storybook/addon-docs": "^10.4.1",
         "@storybook/addon-svelte-csf": "^5.1.2",
         "@storybook/sveltekit": "^10.4.1",
-        "@sveltejs/adapter-auto": "^3.0.0",
+        "@sveltejs/adapter-auto": "^7.0.1",
         "@sveltejs/adapter-static": "^3.0.6",
         "@sveltejs/kit": "^2.0.0",
-        "@sveltejs/vite-plugin-svelte": "^5.1.1",
+        "@sveltejs/vite-plugin-svelte": "^6.2.4",
         "@testing-library/svelte": "^5.2.6",
         "@types/d3-selection": "^3.0.11",
         "@types/d3-transition": "^3.0.9",
@@ -75,8 +75,7 @@
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.0.0",
         "vite": "^6.4.2",
-        "vitest": "^3.2.4",
-        "vitest-svelte-kit": "^0.0.7"
+        "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=24"
@@ -2825,6 +2824,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@storybook/addon-docs": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.4.1.tgz",
@@ -3059,22 +3065,19 @@
       }
     },
     "node_modules/@sveltejs/adapter-auto": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.3.1.tgz",
-      "integrity": "sha512-5Sc7WAxYdL6q9j/+D0jJKjGREGlfIevDyHSQ2eNETHcB1TKlQWHcAo8AS8H1QdjNvSXpvOwNjykDUHPEAyGgdQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-7.0.1.tgz",
+      "integrity": "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "import-meta-resolve": "^4.1.0"
-      },
       "peerDependencies": {
         "@sveltejs/kit": "^2.0.0"
       }
     },
     "node_modules/@sveltejs/adapter-static": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.8.tgz",
-      "integrity": "sha512-YaDrquRpZwfcXbnlDsSrBQNCChVOT9MGuSg+dMAyfsAa1SmiAhrA5jUYUiIMC59G92kIbY/AaQOWcBdq+lh+zg==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.10.tgz",
+      "integrity": "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3082,22 +3085,23 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.19.0.tgz",
-      "integrity": "sha512-UTx28Ad4sYsLU//gqkEo5aFOPFBRT2uXCmXTsURqhurDCvzkVwXruJgBcHDaMiK6RKKpYRteDUaXYqZyGPgCXQ==",
+      "version": "2.70.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.1.tgz",
+      "integrity": "sha512-nY9SPHGOZro3doud9vZXDBwl9tCZIouuJztjgSHs6PAIrv9M/z5O7eOhPV5xU7CgVHA976Jwu3BA1hIFvXztkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@sveltejs/acorn-typescript": "^1.0.9",
         "@types/cookie": "^0.6.0",
+        "acorn": "^8.16.0",
         "cookie": "^0.6.0",
-        "devalue": "^5.1.0",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.2",
-        "import-meta-resolve": "^4.1.0",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
         "mrmime": "^2.0.0",
-        "sade": "^1.8.1",
-        "set-cookie-parser": "^2.6.0",
+        "set-cookie-parser": "^3.0.0",
         "sirv": "^3.0.0"
       },
       "bin": {
@@ -3107,49 +3111,68 @@
         "node": ">=18.13"
       },
       "peerDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "vite": "^5.0.3 || ^6.0.0"
+        "typescript": "^5.3.3 || ^6.0.0",
+        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.1.tgz",
+      "integrity": "sha512-5m3B2cbqQ4TbwW6Xkh66Ntw6dD7gNc77cCxABTTesWcq9jxIzMgTk97pZx5vEtvQx8iokgi7GIphqZe+PGwcZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
-      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.4.tgz",
+      "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
-        "debug": "^4.4.1",
+        "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
-        "kleur": "^4.1.5",
-        "magic-string": "^0.30.17",
-        "vitefu": "^1.0.6"
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.0",
+        "vitefu": "^1.1.1"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22"
+        "node": "^20.19 || ^22.12 || >=24"
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
-        "vite": "^6.0.0"
+        "vite": "^6.3.0 || ^7.0.0"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
-      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-5.0.2.tgz",
+      "integrity": "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.7"
+        "obug": "^2.1.0"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22"
+        "node": "^20.19 || ^22.12 || >=24"
       },
       "peerDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
         "svelte": "^5.0.0",
-        "vite": "^6.0.0"
+        "vite": "^6.3.0 || ^7.0.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -3589,8 +3612,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -5564,7 +5586,6 @@
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/didyoumean": {
@@ -6702,17 +6723,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -7789,6 +7799,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/ohash": {
@@ -8993,9 +9017,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9376,21 +9400,23 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.39.10",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.39.10.tgz",
-      "integrity": "sha512-Q3gqCGIgl4r0CR7OaWYjVo22nqFmLLSfn1MiWNFaITamvqhGBD3kyqk51EKuO4Nd1z8QliO5KIz7a2Ka9Rxilw==",
+      "version": "5.56.8",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
+      "integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.10",
         "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
-        "aria-query": "^5.3.1",
+        "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.1.0",
+        "esrap": "^2.2.12",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -9446,13 +9472,14 @@
       "license": "MIT"
     },
     "node_modules/svelte-check": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.8.tgz",
-      "integrity": "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.4.tgz",
+      "integrity": "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.1",
         "chokidar": "^4.0.1",
         "fdir": "^6.2.0",
         "picocolors": "^1.0.0",
@@ -9466,7 +9493,7 @@
       },
       "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "typescript": ">=5.0.0"
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/svelte-check/node_modules/fdir": {
@@ -9641,9 +9668,9 @@
       }
     },
     "node_modules/svelte/node_modules/esrap": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
-      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.0.tgz",
+      "integrity": "sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -11116,14 +11143,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/vitest-svelte-kit": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/vitest-svelte-kit/-/vitest-svelte-kit-0.0.7.tgz",
-      "integrity": "sha512-B83C14BAQEwNqTHcZ1dEV9EuCwOEKglcix32zBqRFonTmnc652JUOPJhMDAkQmOzHlA+SIXZ3FNEKiJjXyd1JA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vitest/node_modules/pathe": {
       "version": "2.0.3",

--- a/lightly_studio_view/package.json
+++ b/lightly_studio_view/package.json
@@ -38,10 +38,10 @@
     "@storybook/addon-docs": "^10.4.1",
     "@storybook/addon-svelte-csf": "^5.1.2",
     "@storybook/sveltekit": "^10.4.1",
-    "@sveltejs/adapter-auto": "^3.0.0",
+    "@sveltejs/adapter-auto": "^7.0.1",
     "@sveltejs/adapter-static": "^3.0.6",
     "@sveltejs/kit": "^2.0.0",
-    "@sveltejs/vite-plugin-svelte": "^5.1.1",
+    "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@testing-library/svelte": "^5.2.6",
     "@types/d3-selection": "^3.0.11",
     "@types/d3-transition": "^3.0.9",
@@ -73,8 +73,7 @@
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.0.0",
     "vite": "^6.4.2",
-    "vitest": "^3.2.4",
-    "vitest-svelte-kit": "^0.0.7"
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.2",

--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
@@ -62,7 +62,7 @@
     let hasOffscreen = false;
     let resizeObserver: ResizeObserver | null = null;
     // Shared workers multiplex multiple canvases
-    const canvasId = `${sampleId}-${createCanvasInstanceSuffix()}`;
+    const canvasId = $derived(`${sampleId}-${createCanvasInstanceSuffix()}`);
 
     type ColorParser = (color: string) => [number, number, number, number];
 

--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <script lang="ts">
-    import { onDestroy, onMount } from 'svelte';
+    import { onDestroy, onMount, untrack } from 'svelte';
     import { useCustomLabelColors, type CustomColor } from '$lib/hooks/useCustomLabelColors';
     import { getColorByLabel, rgbaFromBytes } from '$lib/utils';
     import type { BoundingBox } from '$lib/types';
@@ -61,8 +61,10 @@
     let workerReady = false;
     let hasOffscreen = false;
     let resizeObserver: ResizeObserver | null = null;
-    // Shared workers multiplex multiple canvases
-    const canvasId = $derived(`${sampleId}-${createCanvasInstanceSuffix()}`);
+    // Shared workers multiplex multiple canvases. Captured once — never re-derived — so that
+    // setupWorker(), render(), handleWorkerMessage(), and onDestroy() all reference the same ID
+    // even if sampleId changes after the worker has been initialised.
+    const canvasId = `${untrack(() => sampleId)}-${createCanvasInstanceSuffix()}`;
 
     type ColorParser = (color: string) => [number, number, number, number];
 

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsBreadcrumb/AnnotationDetailsBreadcrumb.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsBreadcrumb/AnnotationDetailsBreadcrumb.svelte
@@ -26,7 +26,7 @@
 
     const { query: sampleAdjacentQuery } = $derived(
         useAdjacentAnnotations({
-            sampleId: page.params.annotationId,
+            sampleId: page.params.annotationId!,
             collectionId: collectionId
         })
     );

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsNavigation/AnnotationDetailsNavigation.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsNavigation/AnnotationDetailsNavigation.svelte
@@ -8,7 +8,7 @@
     const collectionId = $derived(page.params.collection_id!);
     const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type!);
-    const annotationId = $derived(page.params.annotationId);
+    const annotationId = $derived(page.params.annotationId!);
 
     const { query: sampleAdjacentQuery } = $derived(
         useAdjacentAnnotations({

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationDetailsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationDetailsPanel.svelte
@@ -26,11 +26,7 @@
 
     const { isEditingMode } = page.data.globalStorage;
 
-    const { deleteAnnotation } = $derived.by(() =>
-        useDeleteAnnotation({
-            collectionId
-        })
-    );
+    const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => collectionId });
 
     const handleDeleteAnnotation = async () => {
         try {

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationDetailsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationDetailsPanel.svelte
@@ -26,9 +26,11 @@
 
     const { isEditingMode } = page.data.globalStorage;
 
-    const { deleteAnnotation } = useDeleteAnnotation({
-        collectionId
-    });
+    const { deleteAnnotation } = $derived.by(() =>
+        useDeleteAnnotation({
+            collectionId
+        })
+    );
 
     const handleDeleteAnnotation = async () => {
         try {

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationMetadata/AnnotationMetadataLabel/AnnotationMetadataLabel.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationMetadata/AnnotationMetadataLabel/AnnotationMetadataLabel.svelte
@@ -36,9 +36,11 @@
         onUpdate
     }));
 
-    const { updateAnnotations: updateAnnotationsRaw } = useUpdateAnnotationsMutation({
-        collectionId
-    });
+    const { updateAnnotations: updateAnnotationsRaw } = $derived.by(() =>
+        useUpdateAnnotationsMutation({
+            collectionId
+        })
+    );
 
     const items = $derived(getSelectionItems(result.data || []));
 

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationMetadata/AnnotationMetadataLabel/AnnotationMetadataLabel.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationMetadata/AnnotationMetadataLabel/AnnotationMetadataLabel.svelte
@@ -36,11 +36,9 @@
         onUpdate
     }));
 
-    const { updateAnnotations: updateAnnotationsRaw } = $derived.by(() =>
-        useUpdateAnnotationsMutation({
-            collectionId
-        })
-    );
+    const { updateAnnotations: updateAnnotationsRaw } = useUpdateAnnotationsMutation({
+        getCollectionId: () => collectionId
+    });
 
     const items = $derived(getSelectionItems(result.data || []));
 

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { type AnnotationWithPayloadView } from '$lib/api/lightly_studio_local';
     import { useSettings } from '$lib/hooks';
     import SampleClassificationPills from '$lib/components/SampleClassificationPills/SampleClassificationPills.svelte';
@@ -33,7 +34,7 @@
 
     // Stable id captured at init — same pattern as AnnotationItem (avoids re-reading
     // the annotation prop during effect cleanup after the grid array shrinks).
-    const annotationId = $derived(annotation.annotation.sample_id);
+    const annotationId = untrack(() => annotation.annotation.sample_id);
 
     const thumbnailUrl = $derived(
         getThumbnailUrl({

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
@@ -33,7 +33,7 @@
 
     // Stable id captured at init — same pattern as AnnotationItem (avoids re-reading
     // the annotation prop during effect cleanup after the grid array shrinks).
-    const annotationId = annotation.annotation.sample_id;
+    const annotationId = $derived(annotation.annotation.sample_id);
 
     const thumbnailUrl = $derived(
         getThumbnailUrl({

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationImageGridItem/AnnotationImageGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationImageGridItem/AnnotationImageGridItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import type { AnnotationView, ImageAnnotationView } from '$lib/api/lightly_studio_local';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
     import { useSettings } from '$lib/hooks/useSettings';
@@ -32,8 +33,8 @@
     const { gridViewThumbnailQualityStore } = useSettings();
 
     // Store collection version for cache busting
-    let collectionVersion = $state(cachedCollectionVersion);
-    let collectionVersionLoaded = $state(!!cachedCollectionVersion);
+    let collectionVersion = $state(untrack(() => cachedCollectionVersion));
+    let collectionVersionLoaded = $state(untrack(() => !!cachedCollectionVersion));
 
     // Component is loaded when both collection version and image are loaded
     const isLoaded = $derived(collectionVersionLoaded);

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import type { AnnotationView } from '$lib/api/lightly_studio_local';
     import { SampleAnnotationSegmentationRLE } from '$lib/components';
     import { getBoundingBox } from '$lib/components/SampleAnnotation/utils';
@@ -40,20 +41,22 @@
     const { customLabelColorsStore } = useCustomLabelColors();
     const { isClassHidden } = useAnnotationClassVisibility();
 
-    if (!annotation.object_detection_details && !annotation.segmentation_details) {
+    if (
+        !untrack(() => annotation.object_detection_details) &&
+        !untrack(() => annotation.segmentation_details)
+    ) {
         throw new Error(
             'Unsupported annotation: Only annotations with object_detection_details or segmentation_details are supported. Please check the annotation data.'
         );
     }
 
-    const {
-        width: annotationWidth,
-        height: annotationHeight,
-        x: annotationX,
-        y: annotationY
-    } = getBoundingBox(annotation);
+    const bbox = $derived(getBoundingBox(annotation));
+    const annotationWidth = $derived(bbox.width);
+    const annotationHeight = $derived(bbox.height);
+    const annotationX = $derived(bbox.x);
+    const annotationY = $derived(bbox.y);
 
-    const segmentationMask = annotation?.segmentation_details?.segmentation_mask;
+    const segmentationMask = $derived(annotation?.segmentation_details?.segmentation_mask);
     // Calculate values directly without using state
     const scale = $derived(
         Math.min(
@@ -76,8 +79,8 @@
         );
     }
 
-    let labelName = annotation.annotation_label.annotation_label_name;
-    const isAnnotationClassHidden = isClassHidden(labelName);
+    const labelName = $derived(annotation.annotation_label.annotation_label_name);
+    const isAnnotationClassHidden = $derived(isClassHidden(labelName));
 
     const colorStroke = $derived.by(
         () => $customLabelColorsStore[labelName]?.color ?? getColorByLabel(labelName, 1).color
@@ -89,7 +92,7 @@
     });
     const opacity = $derived($customLabelColorsStore[labelName]?.alpha ?? 0.4);
 
-    const isRLESegmentation = !!segmentationMask;
+    const isRLESegmentation = $derived(!!segmentationMask);
 
     // Calculate values for use in template
     const xOffset = $derived(getXOffset());
@@ -99,7 +102,7 @@
     // effect cleanup would re-evaluate `annotations[index]` in the grid against an
     // already-shrunken array (crash on filter changes). The id is constant per instance —
     // the {#key} wrapper in the grid remounts this component when it changes.
-    const annotationId = annotation.sample_id;
+    const annotationId = $derived(annotation.sample_id);
 
     // Report the crop geometry (not a rendered image) upward. The grid turns it into a
     // preview blob only when a drag actually starts, so no canvas work happens per tile.
@@ -163,7 +166,7 @@
                     viewBox={`${annotationX} ${annotationY} ${annotationWidth} ${annotationHeight}`}
                 >
                     <SampleAnnotationSegmentationRLE
-                        segmentation={segmentationMask}
+                        segmentation={segmentationMask!}
                         width={sample.width}
                         {colorFill}
                         {opacity}

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
@@ -80,7 +80,7 @@
     }
 
     const labelName = $derived(annotation.annotation_label.annotation_label_name);
-    const isAnnotationClassHidden = $derived(isClassHidden(labelName));
+    const isAnnotationClassHidden = isClassHidden(untrack(() => labelName));
 
     const colorStroke = $derived.by(
         () => $customLabelColorsStore[labelName]?.color ?? getColorByLabel(labelName, 1).color

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationItem/AnnotationItem.svelte
@@ -102,7 +102,7 @@
     // effect cleanup would re-evaluate `annotations[index]` in the grid against an
     // already-shrunken array (crash on filter changes). The id is constant per instance —
     // the {#key} wrapper in the grid remounts this component when it changes.
-    const annotationId = $derived(annotation.sample_id);
+    const annotationId = untrack(() => annotation.sample_id);
 
     // Report the crop geometry (not a rendered image) upward. The grid turns it into a
     // preview blob only when a drag actually starts, so no canvas work happens per tile.

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -144,11 +144,9 @@
         isPending
     } = useAnnotationsInfinite(() => queryParams);
 
-    const { updateAnnotations: updateAnnotationsRaw } = $derived.by(() =>
-        useUpdateAnnotationsMutation({
-            collectionId: collection_id
-        })
-    );
+    const { updateAnnotations: updateAnnotationsRaw } = useUpdateAnnotationsMutation({
+        getCollectionId: () => collection_id
+    });
     let infiniteLoaderIdentifier = $derived(
         $selectedAnnotationFilterIds.join(',') +
             Array.from($tagsSelected).join(',') +

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -144,9 +144,11 @@
         isPending
     } = useAnnotationsInfinite(() => queryParams);
 
-    const { updateAnnotations: updateAnnotationsRaw } = useUpdateAnnotationsMutation({
-        collectionId: collection_id
-    });
+    const { updateAnnotations: updateAnnotationsRaw } = $derived.by(() =>
+        useUpdateAnnotationsMutation({
+            collectionId: collection_id
+        })
+    );
     let infiniteLoaderIdentifier = $derived(
         $selectedAnnotationFilterIds.join(',') +
             Array.from($tagsSelected).join(',') +

--- a/lightly_studio_view/src/lib/components/CollectionSearch/CollectionSearch.svelte
+++ b/lightly_studio_view/src/lib/components/CollectionSearch/CollectionSearch.svelte
@@ -5,6 +5,7 @@
   image chip + pending state.
 -->
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { useFileDrop } from '$lib/hooks';
     import { CollectionSearchInput, CollectionSearchImage } from '$lib/components';
 
@@ -35,8 +36,8 @@
         onError
     }: Props = $props();
 
-    let queryText = $state(initialQueryText);
-    let submittedQueryText = $state(initialQueryText);
+    let queryText = $state(untrack(() => initialQueryText));
+    let submittedQueryText = $state(untrack(() => initialQueryText));
     let fileInput = $state<HTMLInputElement | null>(null);
 
     const { dragOver, handleDragOver, handleDragLeave, handleDrop, handlePaste, handleFileSelect } =
@@ -44,7 +45,7 @@
             onFileAccepted: async (file) => {
                 await onSubmitFile(file);
             },
-            onError
+            onError: (message) => onError(message)
         });
 
     const handleClear = () => {

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ClassSetDialog/ClassSetDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ClassSetDialog/ClassSetDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { ClassSetConfigDialog } from '$lib/components/ClassSetConfig';
     import type { SelectItem } from '$lib/components/Select';
     import { CLASS_SORT_LABELS, type ClassSortOption } from '../topNMatrix';
@@ -22,7 +23,7 @@
 
     // Coloring is confusion-matrix-specific; it lives here and commits together
     // with the class selection when the shared dialog fires Apply.
-    let colorDraft: ColorConfig = $state({ ...color });
+    let colorDraft: ColorConfig = $state(untrack(() => ({ ...color })));
     $effect(() => {
         if (open) colorDraft = { ...color };
     });

--- a/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.svelte
+++ b/lightly_studio_view/src/lib/components/ConfusionMatrix/ConfusionMatrixPanel/ConfusionMatrixPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import ConfusionMatrix from '../ConfusionMatrix.svelte';
     import type { ConfusionCellSelection, ConfusionMatrix as ConfusionMatrixData } from '../types';
     import ClassSetDialog from '../ClassSetDialog/ClassSetDialog.svelte';
@@ -37,7 +38,7 @@
 
     let config: ClassSetConfig = $state({
         mode: 'topN',
-        n: topN,
+        n: untrack(() => topN),
         sortBy: 'most-confused',
         manualClasses: []
     });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { Maximize2 as Maximize2Icon, X } from '@lucide/svelte';
     import { Button } from '$lib/components';
     import Typography from '$lib/components/Typography/Typography.svelte';
@@ -124,11 +125,11 @@
     // vertical bars produce once there are more than a handful of classes.
     let config: DistributionConfig = $state({
         mode: 'topN',
-        n: topN,
+        n: untrack(() => topN),
         sortBy: 'count',
         manualClasses: [],
         orientation: 'horizontal',
-        countMode: initialCountMode
+        countMode: untrack(() => initialCountMode)
     });
     let configDialogOpen = $state(false);
     let expandOpen = $state(false);

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DistributionConfigDialog/DistributionConfigDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { ClassSetConfigDialog } from '$lib/components/ClassSetConfig';
     import { Select, type SelectItem } from '$lib/components/Select';
     import {
@@ -33,7 +34,7 @@
     ];
 
     let draftCountMode = $state<AnnotationCountMode>(
-        config.countMode ?? AnnotationCountMode.OBJECTS
+        untrack(() => config.countMode ?? AnnotationCountMode.OBJECTS)
     );
     $effect(() => {
         if (open) draftCountMode = config.countMode ?? AnnotationCountMode.OBJECTS;

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -20,24 +20,22 @@
 
     // Instantiate all variants once and pick reactively: this component lives in the
     // layout, which persists when switching between the images/annotations tabs.
-    const imagesEmbeddingFilter = useEmbeddingFilterForImages(
-        collectionIdStore,
-        setRangeSelectionForCollection
-    );
-    const videosEmbeddingFilter = useEmbeddingFilterForVideos(
-        collectionIdStore,
-        setRangeSelectionForCollection
-    );
-    const annotationsEmbeddingFilter = useEmbeddingFilterForAnnotations(
-        collectionIdStore,
-        setRangeSelectionForCollection
-    );
+    // All three hooks are created in a single $derived.by so they are all eagerly evaluated
+    // together (rather than lazily skipped by the ternary).
+    const embeddingFilters = $derived.by(() => ({
+        images: useEmbeddingFilterForImages(collectionIdStore, setRangeSelectionForCollection),
+        videos: useEmbeddingFilterForVideos(collectionIdStore, setRangeSelectionForCollection),
+        annotations: useEmbeddingFilterForAnnotations(
+            collectionIdStore,
+            setRangeSelectionForCollection
+        )
+    }));
     const embeddingFilter = $derived(
         isAnnotations
-            ? annotationsEmbeddingFilter
+            ? embeddingFilters.annotations
             : isVideos
-              ? videosEmbeddingFilter
-              : imagesEmbeddingFilter
+              ? embeddingFilters.videos
+              : embeddingFilters.images
     );
 
     const plotFilterCountStore = $derived(embeddingFilter.effectiveCount);

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -20,14 +20,20 @@
 
     // Instantiate all variants once: this component lives in the layout, which persists
     // when switching between the images/annotations tabs.
-    const imagesFilter = $derived.by(() =>
-        useEmbeddingFilterForImages(collectionIdStore, setRangeSelectionForCollection)
+    // svelte-ignore state_referenced_locally
+    const imagesFilter = useEmbeddingFilterForImages(
+        collectionIdStore,
+        setRangeSelectionForCollection
     );
-    const videosFilter = $derived.by(() =>
-        useEmbeddingFilterForVideos(collectionIdStore, setRangeSelectionForCollection)
+    // svelte-ignore state_referenced_locally
+    const videosFilter = useEmbeddingFilterForVideos(
+        collectionIdStore,
+        setRangeSelectionForCollection
     );
-    const annotationsFilter = $derived.by(() =>
-        useEmbeddingFilterForAnnotations(collectionIdStore, setRangeSelectionForCollection)
+    // svelte-ignore state_referenced_locally
+    const annotationsFilter = useEmbeddingFilterForAnnotations(
+        collectionIdStore,
+        setRangeSelectionForCollection
     );
     const embeddingFilter = $derived(
         isAnnotations ? annotationsFilter : isVideos ? videosFilter : imagesFilter

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -18,24 +18,19 @@
 
     const { setRangeSelectionForCollection } = useGlobalStorage();
 
-    // Instantiate all variants once and pick reactively: this component lives in the
-    // layout, which persists when switching between the images/annotations tabs.
-    // All three hooks are created in a single $derived.by so they are all eagerly evaluated
-    // together (rather than lazily skipped by the ternary).
-    const embeddingFilters = $derived.by(() => ({
-        images: useEmbeddingFilterForImages(collectionIdStore, setRangeSelectionForCollection),
-        videos: useEmbeddingFilterForVideos(collectionIdStore, setRangeSelectionForCollection),
-        annotations: useEmbeddingFilterForAnnotations(
-            collectionIdStore,
-            setRangeSelectionForCollection
-        )
-    }));
+    // Instantiate all variants once: this component lives in the layout, which persists
+    // when switching between the images/annotations tabs.
+    const imagesFilter = $derived.by(() =>
+        useEmbeddingFilterForImages(collectionIdStore, setRangeSelectionForCollection)
+    );
+    const videosFilter = $derived.by(() =>
+        useEmbeddingFilterForVideos(collectionIdStore, setRangeSelectionForCollection)
+    );
+    const annotationsFilter = $derived.by(() =>
+        useEmbeddingFilterForAnnotations(collectionIdStore, setRangeSelectionForCollection)
+    );
     const embeddingFilter = $derived(
-        isAnnotations
-            ? embeddingFilters.annotations
-            : isVideos
-              ? embeddingFilters.videos
-              : embeddingFilters.images
+        isAnnotations ? annotationsFilter : isVideos ? videosFilter : imagesFilter
     );
 
     const plotFilterCountStore = $derived(embeddingFilter.effectiveCount);

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -28,7 +28,7 @@
     const { isExportDialogOpen, openExportDialog, closeExportDialog } = useExportDialog();
     const { imageFilter } = useImageFilters();
 
-    let collectionId = page.params.collection_id;
+    let collectionId = page.params.collection_id!;
 
     const tracking = useExportTracking({ collectionId });
 

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/ClassifiersMenu.svelte
@@ -21,7 +21,7 @@
     const exportOptions: ClassifierExportType[] = ['sklearn', 'lightly'];
 
     // Subscribe to page params
-    const collectionId = page.params.collection_id;
+    const collectionId = page.params.collection_id!;
 
     const client = useQueryClient();
 

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/CreateClassifierDialog.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/CreateClassifierDialog.svelte
@@ -14,7 +14,7 @@
     const { createClassifier } = useClassifiers();
 
     let classifierName = $state('');
-    let collectionId = page.params.collection_id;
+    let collectionId = page.params.collection_id!;
     let isSubmitting = $state(false);
     let submitError = $state<string | null>(null);
 

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/RefineClassifierDialog.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/RefineClassifierDialog.svelte
@@ -29,7 +29,7 @@
     const { openClassifiersMenu, switchToManageTab, scrollToAndSelectClassifier } =
         useClassifiersMenu();
 
-    let collectionId = page.params.collection_id;
+    let collectionId = page.params.collection_id!;
     let isSubmitting = $state(false);
     let showInstructions = $state(false);
     let submitError = $state<string | null>(null);

--- a/lightly_studio_view/src/lib/components/FewShotClassifier/RefineClassifierDialog.svelte
+++ b/lightly_studio_view/src/lib/components/FewShotClassifier/RefineClassifierDialog.svelte
@@ -29,7 +29,7 @@
     const { openClassifiersMenu, switchToManageTab, scrollToAndSelectClassifier } =
         useClassifiersMenu();
 
-    let collectionId = page.params.collection_id!;
+    const collectionId = $derived(page.params.collection_id!);
     let isSubmitting = $state(false);
     let showInstructions = $state(false);
     let submitError = $state<string | null>(null);

--- a/lightly_studio_view/src/lib/components/FrameDetailsNavigation/FrameDetailsNavigation.svelte
+++ b/lightly_studio_view/src/lib/components/FrameDetailsNavigation/FrameDetailsNavigation.svelte
@@ -8,8 +8,8 @@
 
     const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type!);
-    const collectionId = $derived(page.params.collection_id);
-    const sampleId = $derived(page.params.sample_id);
+    const collectionId = $derived(page.params.collection_id!);
+    const sampleId = $derived(page.params.sample_id!);
     const isFromVideos = $derived(Boolean(page.url.searchParams.get('from_video')));
 
     const { query: sampleAdjacentQuery } = $derived(

--- a/lightly_studio_view/src/lib/components/Grid/Grid.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import VirtualGrid from 'svelte-virtual/grid';
-    import type { ComponentProps, Snippet } from 'svelte';
+    import { untrack, type ComponentProps, type Snippet } from 'svelte';
     import type { HTMLAttributes } from 'svelte/elements';
     import { cn } from '$lib/utils';
 
@@ -52,7 +52,7 @@
         gridProps?: Partial<ComponentProps<typeof VirtualGrid>>;
     } = $props();
 
-    let previousScrollResetKey = scrollResetKey;
+    let previousScrollResetKey = $state(untrack(() => scrollResetKey));
     let previousInitialScrollPosition = $state<number | undefined>(undefined);
     let pendingRestoreRaf: number | undefined;
 

--- a/lightly_studio_view/src/lib/components/GroupsComponentsMenu/GroupsComponentsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/GroupsComponentsMenu/GroupsComponentsMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { useGroupComponents } from '$lib/hooks/useGroupComponents/useGroupComponents';
     import { SampleType, type GroupComponentView } from '$lib/api/lightly_studio_local';
     import { GroupComponents } from '$lib/components/GroupComponents';
@@ -19,9 +20,9 @@
         collectionId: string;
     } = $props();
 
-    const { groupComponents } = useGroupComponents({ groupId });
+    const { groupComponents } = $derived.by(() => useGroupComponents({ groupId }));
     const components = $derived<GroupComponentView[]>(groupComponents.data ?? []);
-    let selectedComponentId = $state(componentId);
+    let selectedComponentId = $state(untrack(() => componentId));
     const selectedIndex = $derived(
         components.findIndex((c) => c.details?.sample_id === selectedComponentId)
     );

--- a/lightly_studio_view/src/lib/components/GroupsComponentsMenu/GroupsComponentsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/GroupsComponentsMenu/GroupsComponentsMenu.svelte
@@ -20,7 +20,7 @@
         collectionId: string;
     } = $props();
 
-    const { groupComponents } = $derived.by(() => useGroupComponents({ groupId }));
+    const { groupComponents } = useGroupComponents({ getGroupId: () => groupId });
     const components = $derived<GroupComponentView[]>(groupComponents.data ?? []);
     let selectedComponentId = $state(untrack(() => componentId));
     const selectedIndex = $derived(

--- a/lightly_studio_view/src/lib/components/Header/Header.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Header.svelte
@@ -27,9 +27,9 @@
     const hasEmbeddings = $derived(!!hasEmbeddingsQuery.data);
 
     const datasetId = $derived(page.params.dataset_id!);
-    const { collection: datasetCollection } = $derived.by(() =>
-        useCollectionWithChildren({ collectionId: datasetId })
-    );
+    const { collection: datasetCollection } = useCollectionWithChildren({
+        getCollectionId: () => datasetId
+    });
 
     const { setIsEditingMode, isEditingMode, reversibleActions, executeReversibleAction } =
         page.data.globalStorage;

--- a/lightly_studio_view/src/lib/components/Images/Images.svelte
+++ b/lightly_studio_view/src/lib/components/Images/Images.svelte
@@ -39,13 +39,15 @@
     const { selectedAnnotationFilterIdsArray: selectedAnnotationFilterIds } =
         useSelectedAnnotationsFilter();
 
-    const { tagsSelected } = useTags({
-        collection_id,
-        kind: ['sample']
-    });
+    const { tagsSelected } = $derived.by(() =>
+        useTags({
+            collection_id,
+            kind: ['sample']
+        })
+    );
 
     const { dimensionsValues: dimensions } = useDimensions();
-    const { metadataValues } = useMetadataFilters(collection_id);
+    const { metadataValues } = $derived.by(() => useMetadataFilters(collection_id));
 
     const {
         getCollectionVersion,
@@ -107,7 +109,7 @@
             ? infiniteSamples.data.pages.flatMap((page: { data?: ImageView[] }) => page.data ?? [])
             : []
     );
-    const selectedSampleIds = getSelectedSampleIds(collection_id);
+    const selectedSampleIds = $derived(getSelectedSampleIds(collection_id));
     let selectionAnchorSampleId = $state<string | null>(null);
 
     let isReady = $state(false);

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.svelte
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/MetadataFilterChips.svelte
@@ -9,7 +9,7 @@
 
     const { collectionId }: Props = $props();
 
-    const hook = useMetadataFilterChips(collectionId);
+    const hook = $derived.by(() => useMetadataFilterChips(collectionId));
 </script>
 
 {#if hook.chips.length > 0}

--- a/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { page } from '$app/stores';
     import { derived as storeDerived } from 'svelte/store';
     import { Button } from '$lib/components/ui/button';
@@ -48,7 +49,7 @@
         ($p) =>
             ({
                 routeId: $p.route.id,
-                collectionId: $p.params.collection_id,
+                collectionId: $p.params.collection_id!,
                 sampleId: $p.params.sampleId || $p.params.sample_id || null,
                 annotationId: $p.params.annotationId || null,
                 sampleType: ($p.params.collection_type as SampleType) ?? null
@@ -58,7 +59,7 @@
     const queryClient = useQueryClient();
     const { setPluginExecuting } = useOperatorsDialog();
 
-    const collectionId = $page.params.collection_id;
+    const collectionId = $page.params.collection_id!;
 
     const { tagsSelected } = useTags({ collection_id: collectionId, kind: ['annotation'] });
 
@@ -103,7 +104,7 @@
         }
     });
 
-    let previousIsOpen = isOpen;
+    let previousIsOpen = $state(untrack(() => isOpen));
     $effect(() => {
         if (!isOpen && previousIsOpen) {
             parameters = operator ? buildInitialParameters(operator) : {};

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
@@ -26,7 +26,7 @@
         handleFieldClick,
         toggleDirection,
         dispose
-    } = useOrderBy({ collectionId: () => collectionId, datasetId });
+    } = useOrderBy({ collectionId: () => collectionId, datasetId: () => datasetId });
 
     $effect(() => {
         return () => dispose();

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
@@ -26,7 +26,7 @@
         handleFieldClick,
         toggleDirection,
         dispose
-    } = useOrderBy({ collectionId: () => collectionId, datasetId });
+    } = $derived.by(() => useOrderBy({ collectionId: () => collectionId, datasetId }));
 
     $effect(() => {
         return () => dispose();

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
@@ -26,7 +26,7 @@
         handleFieldClick,
         toggleDirection,
         dispose
-    } = $derived.by(() => useOrderBy({ collectionId: () => collectionId, datasetId }));
+    } = useOrderBy({ collectionId: () => collectionId, datasetId });
 
     $effect(() => {
         return () => dispose();

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.test.ts
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.test.ts
@@ -14,7 +14,8 @@ const mocks = vi.hoisted(() => ({
     updateSortBy: vi.fn(),
     metadataInfoValue: [] as MetadataInfoView[],
     metricsProxy: { data: null as EvaluationRunMetricsInfoView[] | null, dataUpdatedAt: 0 },
-    textEmbeddingValue: undefined as TextEmbedding | undefined
+    textEmbeddingValue: undefined as TextEmbedding | undefined,
+    capturedDatasetIdGetter: undefined as (() => string) | undefined
 }));
 
 vi.mock('$lib/hooks/useImageFilters/useImageFilters', () => ({
@@ -31,7 +32,10 @@ vi.mock('$lib/hooks/useMetadataFilters/useMetadataFilters', () => ({
 }));
 
 vi.mock('$lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo', () => ({
-    useEvaluationSampleMetricsInfo: () => mocks.metricsProxy
+    useEvaluationSampleMetricsInfo: ({ datasetId }: { datasetId: () => string }) => {
+        mocks.capturedDatasetIdGetter = datasetId;
+        return mocks.metricsProxy;
+    }
 }));
 
 vi.mock('$lib/hooks/useGlobalStorage', () => ({
@@ -55,6 +59,7 @@ describe('OrderBy', () => {
         mocks.metricsProxy.data = null;
         mocks.metricsProxy.dataUpdatedAt = 0;
         mocks.textEmbeddingValue = undefined;
+        mocks.capturedDatasetIdGetter = undefined;
     });
 
     it('shows placeholder text when no field is selected', () => {
@@ -499,5 +504,15 @@ describe('OrderBy', () => {
                 direction: SortDirection.DESC
             }
         ]);
+    });
+
+    it('passes a reactive datasetId getter that tracks the current prop after navigation', async () => {
+        const { rerender } = render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+
+        expect(mocks.capturedDatasetIdGetter!()).toBe('ds1');
+
+        await rerender({ collectionId: 'col1', datasetId: 'ds2' });
+
+        expect(mocks.capturedDatasetIdGetter!()).toBe('ds2');
     });
 });

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotColorByPopover/PlotColorByPopover.svelte
@@ -22,9 +22,10 @@
     let { collectionId, selectedKey, onSelectedKeyChange, withTags, withAnnotationLabels }: Props =
         $props();
 
-    const { metadataInfo } = useMetadataFilters(collectionId);
-    const { selectedColorByType, setSelectedColorByType, clearSelectedColorByType } =
-        usePlotColorByType(collectionId);
+    const { metadataInfo } = $derived.by(() => useMetadataFilters(collectionId));
+    const { selectedColorByType, setSelectedColorByType, clearSelectedColorByType } = $derived.by(
+        () => usePlotColorByType(collectionId)
+    );
     const { trackEvent } = usePostHog();
 
     const colorableFields = $derived(

--- a/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
+++ b/lightly_studio_view/src/lib/components/PlotPanel/PlotPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
     import { Button } from '$lib/components/ui/button';
     import {
@@ -49,7 +50,7 @@
     const { trackEvent } = usePostHog();
     const { setShowEmbeddingPlot, getRangeSelection, setRangeSelectionForCollection } =
         useGlobalStorage();
-    const rangeSelection = getRangeSelection(collectionId);
+    const rangeSelection = $derived(getRangeSelection(collectionId));
     const setRangeSelection = (selection: Point[] | null) => {
         setRangeSelectionForCollection(collectionId, selection);
     };
@@ -79,8 +80,9 @@
     );
 
     // The active annotation label/tag filter, mirroring what the annotations grid applies.
-    const { annotationFilter: selectedAnnotationsFilter } =
-        useSelectedAnnotationsFilter(collectionId);
+    const { annotationFilter: selectedAnnotationsFilter } = $derived.by(() =>
+        useSelectedAnnotationsFilter(collectionId)
+    );
 
     // Prepare filter for embeddings API - use VideoFilter for videos, ImageFilter for images
     const filter = $derived.by(() => {
@@ -108,11 +110,11 @@
         };
     });
 
-    const { selectedColorByType } = usePlotColorByType(collectionId);
+    const { selectedColorByType } = usePlotColorByType(untrack(() => collectionId));
     // Annotation samples carry annotation-kind tags. Captured once at mount, like
     // collectionId above.
     const { tags } = useTags({
-        collection_id: collectionId,
+        collection_id: untrack(() => collectionId),
         kind: isAnnotationsRoute(page.route?.id ?? null) ? ['annotation'] : ['sample']
     });
     const annotationLabelsQuery = useAnnotationLabels(() => ({ collectionId }));

--- a/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
+++ b/lightly_studio_view/src/lib/components/QueryEditor/QueryEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
+    import { onMount, untrack } from 'svelte';
     import { toast } from 'svelte-sonner';
     import { Button } from '$lib/components/ui/button';
 
@@ -26,7 +26,7 @@ AND object_detection(class_name = "person" AND x > 10)
         onSave
     }: QueryEditorProps = $props();
 
-    const initialValue = valueProp ?? LIGHTLY_QUERY_DEFAULT_VALUE;
+    const initialValue = $derived(valueProp ?? LIGHTLY_QUERY_DEFAULT_VALUE);
 
     let containerEl: HTMLDivElement | null = null;
 
@@ -55,8 +55,8 @@ AND object_detection(class_name = "person" AND x > 10)
         lastAppliedValue = draftValue;
     }
 
-    let draftValue = $state(initialValue);
-    let lastAppliedValue = $state<string | null>(valueProp ?? null);
+    let draftValue = $state(untrack(() => initialValue));
+    let lastAppliedValue = $state<string | null>(untrack(() => valueProp ?? null));
 
     onMount(() => {
         if (!containerEl) return;

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import {
         SampleAnnotationBox,
         SampleAnnotationLabel,
@@ -54,7 +55,7 @@
         return $collectionIdToName[annotation.annotation_collection_id] ?? label;
     });
 
-    const segmentationMask = annotation?.segmentation_details?.segmentation_mask;
+    const segmentationMask = $derived(annotation?.segmentation_details?.segmentation_mask);
 
     const annotationId = $derived(annotation.sample_id);
 
@@ -90,7 +91,7 @@
         segmentationMask ? 0 : ($customLabelColorsStore[colorLabel]?.alpha ?? 1.0) * 0.4
     );
 
-    let boundingBox = $state<BoundingBox>(getBoundingBox(annotation));
+    let boundingBox = $state<BoundingBox>(untrack(() => getBoundingBox(annotation)));
 
     const onResize = (newBbox: BoundingBox) => {
         boundingBox = constraintBox

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationBox/SampleAnnotationBox.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationBox/SampleAnnotationBox.svelte
@@ -15,11 +15,14 @@
         annotationId: string;
         isPrediction?: boolean;
     } = $props();
-    const [x, y, width, height] = bbox;
+    const x = $derived(bbox[0]);
+    const y = $derived(bbox[1]);
+    const width = $derived(bbox[2]);
+    const height = $derived(bbox[3]);
 
     // Define different styles for predictions vs. ground truth
-    const strokeDashArray = isPrediction ? '5,5' : 'none';
-    const strokeOpacity = isPrediction ? 0.8 : 1;
+    const strokeDashArray = $derived(isPrediction ? '5,5' : 'none');
+    const strokeOpacity = $derived(isPrediction ? 0.8 : 1);
 </script>
 
 <rect

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationLabel/SampleAnnotationLabel.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationLabel/SampleAnnotationLabel.svelte
@@ -44,8 +44,8 @@
     const paddingX = 5;
 
     // Adjust styling for prediction labels
-    const labelOpacity = isPrediction ? 0.8 : 1;
-    const labelFontStyle = isPrediction ? 'italic' : 'normal';
+    const labelOpacity = $derived(isPrediction ? 0.8 : 1);
+    const labelFontStyle = $derived(isPrediction ? 'italic' : 'normal');
 </script>
 
 <!-- This is a tricky way to have 'unscaled components, in this case we need to have unscaled text -->

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationSegmentationRLE/SampleAnnotationSegmentationRLE.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationSegmentationRLE/SampleAnnotationSegmentationRLE.svelte
@@ -18,9 +18,11 @@
         prerenderedHeight?: number;
     } = $props();
 
-    if (!segmentation) {
-        throw new Error('Segmentation data is required');
-    }
+    $effect(() => {
+        if (!segmentation) {
+            throw new Error('Segmentation data is required');
+        }
+    });
 
     // Use prerendered data URL if available, otherwise calculate from segmentation
     const { dataUrl: maskDataUrl, height } = $derived.by(() => {

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationSegmentationRLE/SampleAnnotationSegmentationRLE.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotationSegmentationRLE/SampleAnnotationSegmentationRLE.svelte
@@ -18,14 +18,12 @@
         prerenderedHeight?: number;
     } = $props();
 
-    $effect(() => {
+    // Use prerendered data URL if available, otherwise calculate from segmentation
+    const { dataUrl: maskDataUrl, height } = $derived.by(() => {
         if (!segmentation) {
             throw new Error('Segmentation data is required');
         }
-    });
 
-    // Use prerendered data URL if available, otherwise calculate from segmentation
-    const { dataUrl: maskDataUrl, height } = $derived.by(() => {
         if (prerenderedDataUrl && prerenderedHeight !== undefined) {
             return { dataUrl: prerenderedDataUrl, height: prerenderedHeight };
         }

--- a/lightly_studio_view/src/lib/components/SampleDetails/ImageDetails.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/ImageDetails.svelte
@@ -22,7 +22,7 @@
         children?: Snippet;
     } = $props();
 
-    const collectionId = collection.collection_id!;
+    const collectionId = $derived(collection.collection_id!);
 
     // Get route parameters from page
     const datasetId = $derived(page.params.dataset_id!);

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.svelte
@@ -53,12 +53,16 @@
     } = useAnnotationLabelContext();
 
     const annotationLabels = useAnnotationLabels(() => ({ collectionId }));
-    const { createAnnotation } = useCreateAnnotation({
-        collectionId
-    });
-    const { deleteAnnotation } = useDeleteAnnotation({
-        collectionId
-    });
+    const { createAnnotation } = $derived.by(() =>
+        useCreateAnnotation({
+            collectionId
+        })
+    );
+    const { deleteAnnotation } = $derived.by(() =>
+        useDeleteAnnotation({
+            collectionId
+        })
+    );
     const { selectAnnotation } = useAnnotationSelection();
 
     const annotationCollectionsQuery = useAnnotationCollections(() => ({ collectionId }));

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.svelte
@@ -53,16 +53,8 @@
     } = useAnnotationLabelContext();
 
     const annotationLabels = useAnnotationLabels(() => ({ collectionId }));
-    const { createAnnotation } = $derived.by(() =>
-        useCreateAnnotation({
-            collectionId
-        })
-    );
-    const { deleteAnnotation } = $derived.by(() =>
-        useDeleteAnnotation({
-            collectionId
-        })
-    );
+    const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => collectionId });
+    const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => collectionId });
     const { selectAnnotation } = useAnnotationSelection();
 
     const annotationCollectionsQuery = useAnnotationCollections(() => ({ collectionId }));

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSourceGroup/SampleDetailsAnnotationSourceGroup.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSourceGroup/SampleDetailsAnnotationSourceGroup.svelte
@@ -7,7 +7,7 @@
     import { ColorMarker } from '$lib/components/SideMenu';
     import { ChevronDown, Eye, EyeOff } from '@lucide/svelte';
     import { Tooltip } from '$lib/components/ui/tooltip';
-    import type { Snippet } from 'svelte';
+    import { untrack, type Snippet } from 'svelte';
     import { slide } from 'svelte/transition';
 
     interface Props {
@@ -36,12 +36,12 @@
         children
     }: Props = $props();
 
-    let open = $state(initiallyOpen);
+    let open = $state(untrack(() => initiallyOpen));
 
     // The component is reused across samples (the parent's {#each} is keyed by source id), so
     // re-apply the seeded collapse on sample change. Tracked by sampleId so a manual toggle
     // persists within a sample and the chevron stays independent of the eye.
-    let appliedSampleId = sampleId;
+    let appliedSampleId = $state(untrack(() => sampleId));
     $effect(() => {
         if (appliedSampleId === sampleId) return;
         appliedSampleId = sampleId;

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsBreadcrumb/SampleDetailsBreadcrumb.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsBreadcrumb/SampleDetailsBreadcrumb.svelte
@@ -26,7 +26,7 @@
 
     const { query: sampleAdjacentQuery } = $derived(
         useAdjacentImages({
-            sampleId: page.params.sampleId,
+            sampleId: page.params.sampleId!,
             collectionId
         })
     );

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsCaptionsSegment/SampleDetailsCaptionSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsCaptionsSegment/SampleDetailsCaptionSegment.svelte
@@ -24,9 +24,9 @@
     const { deleteCaption } = useDeleteCaption();
     const { createCaption } = useCreateCaption();
     const datasetId = $derived(page.params.dataset_id!);
-    const { refetch: refetchRootCollection } = $derived.by(() =>
-        useCollectionWithChildren({ collectionId: datasetId })
-    );
+    const { refetch: refetchRootCollection } = useCollectionWithChildren({
+        getCollectionId: () => datasetId
+    });
 
     const handleDeleteCaption = async (captionId: string) => {
         const caption = captions?.find((c) => c.sample_id === captionId);

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -42,10 +42,10 @@
     const { enforceColoringByClassStore } = useSettings();
 
     const annotationLabels = useAnnotationLabels(() => ({ collectionId }));
-    const { createAnnotation } = useCreateAnnotation({ collectionId });
-    const { deleteAnnotation } = useDeleteAnnotation({ collectionId });
-    const { createLabel } = useCreateLabel({ collectionId });
-    const { updateAnnotations } = useUpdateAnnotationsMutation({ collectionId });
+    const { createAnnotation } = $derived.by(() => useCreateAnnotation({ collectionId }));
+    const { deleteAnnotation } = $derived.by(() => useDeleteAnnotation({ collectionId }));
+    const { createLabel } = $derived.by(() => useCreateLabel({ collectionId }));
+    const { updateAnnotations } = $derived.by(() => useUpdateAnnotationsMutation({ collectionId }));
     const { context: annotationLabelContext, setLastCreatedAnnotationId } =
         useAnnotationLabelContext();
     const datasetId = $derived(page.params.dataset_id!);

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -42,16 +42,18 @@
     const { enforceColoringByClassStore } = useSettings();
 
     const annotationLabels = useAnnotationLabels(() => ({ collectionId }));
-    const { createAnnotation } = $derived.by(() => useCreateAnnotation({ collectionId }));
-    const { deleteAnnotation } = $derived.by(() => useDeleteAnnotation({ collectionId }));
-    const { createLabel } = $derived.by(() => useCreateLabel({ collectionId }));
-    const { updateAnnotations } = $derived.by(() => useUpdateAnnotationsMutation({ collectionId }));
+    const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => collectionId });
+    const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => collectionId });
+    const { createLabel } = useCreateLabel({ getCollectionId: () => collectionId });
+    const { updateAnnotations } = useUpdateAnnotationsMutation({
+        getCollectionId: () => collectionId
+    });
     const { context: annotationLabelContext, setLastCreatedAnnotationId } =
         useAnnotationLabelContext();
     const datasetId = $derived(page.params.dataset_id!);
-    const { refetch: refetchRootCollection } = $derived.by(() =>
-        useCollectionWithChildren({ collectionId: datasetId })
-    );
+    const { refetch: refetchRootCollection } = useCollectionWithChildren({
+        getCollectionId: () => datasetId
+    });
 
     const items = $derived(getSelectionItems(annotationLabels.data || []));
 

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsNavigation/SampleDetailsNavigation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsNavigation/SampleDetailsNavigation.svelte
@@ -8,11 +8,11 @@
 
     const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type!);
-    const collectionId = $derived(page.params.collection_id);
+    const collectionId = $derived(page.params.collection_id!);
 
     const { query: sampleAdjacentQuery } = $derived(
         useAdjacentImages({
-            sampleId: page.params.sampleId,
+            sampleId: page.params.sampleId!,
             collectionId
         })
     );

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsPanel.svelte
@@ -7,7 +7,7 @@
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
     import { useHideAnnotations } from '$lib/hooks/useHideAnnotations';
     import { useSettings } from '$lib/hooks/useSettings';
-    import { onMount, type Snippet } from 'svelte';
+    import { onMount, untrack, type Snippet } from 'svelte';
 
     import { get } from 'svelte/store';
     import { getAnnotations } from '../SampleAnnotation/utils';
@@ -79,10 +79,16 @@
     const { settingsStore } = useSettings();
     const { isEditingMode, lastAnnotationLabel, lastAnnotationSource } = useGlobalStorage();
 
-    // Annotation details must use the first annotation from sample.annotations
-    const annotationLabelContext = createAnnotationLabelContext({
-        isOnAnnotationDetailsView: isOnAnnotationDetailsView,
-        annotationId: isOnAnnotationDetailsView ? sample.annotations![0].sample_id : null
+    // Annotation details must use the first annotation from sample.annotations.
+    // isOnAnnotationDetailsView is re-synced via $effect when the prop changes.
+    const annotationLabelContext = createAnnotationLabelContext(
+        untrack(() => ({
+            isOnAnnotationDetailsView,
+            annotationId: isOnAnnotationDetailsView ? sample.annotations![0].sample_id : null
+        }))
+    );
+    $effect(() => {
+        annotationLabelContext.isOnAnnotationDetailsView = isOnAnnotationDetailsView;
     });
     createSampleDetailsToolbarContext();
 

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSelectableBox/SampleDetailsSelectableBox.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSelectableBox/SampleDetailsSelectableBox.svelte
@@ -12,7 +12,7 @@
 
     const { getSelectedSampleIds, toggleSampleSelection } = useGlobalStorage();
 
-    const selectedSampleIds = getSelectedSampleIds(collectionId);
+    const selectedSampleIds = $derived(getSelectedSampleIds(collectionId));
 </script>
 
 <div class="absolute right-4 top-2 z-30 flex items-center gap-2">

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
@@ -96,7 +96,7 @@
     }));
 
     const { updateAnnotations: updateAnnotationsRaw } = useUpdateAnnotationsMutation({
-        collectionId: page.params.collection_id!
+        getCollectionId: () => page.params.collection_id!
     });
 
     const annotation = $derived(annotationResp.data || annotationProp);

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsToolbarTooltip/SampleDetailsToolbarTooltip.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsToolbarTooltip/SampleDetailsToolbarTooltip.svelte
@@ -19,6 +19,7 @@
 
 <div
     class="relative"
+    role="region"
     onpointerenter={() => (visible = true)}
     onpointerleave={() => (visible = false)}
     onpointerdown={() => (visible = false)}

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleEraserRect/SampleEraserRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleEraserRect/SampleEraserRect.svelte
@@ -54,18 +54,10 @@
         setAnnotationId
     } = useAnnotationLabelContext();
 
-    const { deleteAnnotation } = $derived.by(() =>
-        useDeleteAnnotation({
-            collectionId
-        })
-    );
+    const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => collectionId });
     const annotationLabels = useAnnotationLabels(() => ({ collectionId }));
     const { addReversibleAction } = useGlobalStorage();
-    const { createAnnotation } = $derived.by(() =>
-        useCreateAnnotation({
-            collectionId
-        })
-    );
+    const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => collectionId });
     const eraserApi = $derived.by(() =>
         useSegmentationMaskEraser({
             collectionId,

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleEraserRect/SampleEraserRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleEraserRect/SampleEraserRect.svelte
@@ -54,14 +54,18 @@
         setAnnotationId
     } = useAnnotationLabelContext();
 
-    const { deleteAnnotation } = useDeleteAnnotation({
-        collectionId
-    });
+    const { deleteAnnotation } = $derived.by(() =>
+        useDeleteAnnotation({
+            collectionId
+        })
+    );
     const annotationLabels = useAnnotationLabels(() => ({ collectionId }));
     const { addReversibleAction } = useGlobalStorage();
-    const { createAnnotation } = useCreateAnnotation({
-        collectionId
-    });
+    const { createAnnotation } = $derived.by(() =>
+        useCreateAnnotation({
+            collectionId
+        })
+    );
     const eraserApi = $derived.by(() =>
         useSegmentationMaskEraser({
             collectionId,
@@ -154,7 +158,7 @@
         refetch();
     };
 
-    const datasetId = $derived(page.params.dataset_id);
+    const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type ?? page.data.collectionType);
     const currentAnnotationId = $derived(
         annotationLabelContext.annotationId ?? sample.annotations[0]?.sample_id ?? ''

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleObjectDetectionRect/SampleObjectDetectionRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleObjectDetectionRect/SampleObjectDetectionRect.svelte
@@ -64,13 +64,17 @@
         handleCancel: handleClassDialogCancel
     } = useSelectClassDialog();
 
-    const { createLabel } = useCreateLabel({ collectionId });
-    const { createAnnotation } = useCreateAnnotation({
-        collectionId
-    });
-    const { deleteAnnotation } = useDeleteAnnotation({
-        collectionId
-    });
+    const { createLabel } = $derived.by(() => useCreateLabel({ collectionId }));
+    const { createAnnotation } = $derived.by(() =>
+        useCreateAnnotation({
+            collectionId
+        })
+    );
+    const { deleteAnnotation } = $derived.by(() =>
+        useDeleteAnnotation({
+            collectionId
+        })
+    );
     const { addReversibleAction, updateLastAnnotationLabel } = useGlobalStorage();
 
     const {

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleObjectDetectionRect/SampleObjectDetectionRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleObjectDetectionRect/SampleObjectDetectionRect.svelte
@@ -64,17 +64,9 @@
         handleCancel: handleClassDialogCancel
     } = useSelectClassDialog();
 
-    const { createLabel } = $derived.by(() => useCreateLabel({ collectionId }));
-    const { createAnnotation } = $derived.by(() =>
-        useCreateAnnotation({
-            collectionId
-        })
-    );
-    const { deleteAnnotation } = $derived.by(() =>
-        useDeleteAnnotation({
-            collectionId
-        })
-    );
+    const { createLabel } = useCreateLabel({ getCollectionId: () => collectionId });
+    const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => collectionId });
+    const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => collectionId });
     const { addReversibleAction, updateLastAnnotationLabel } = useGlobalStorage();
 
     const {
@@ -95,9 +87,9 @@
     };
 
     const datasetId = $derived(page.params.dataset_id!);
-    const { refetch: refetchRootCollection } = $derived.by(() =>
-        useCollectionWithChildren({ collectionId: datasetId })
-    );
+    const { refetch: refetchRootCollection } = useCollectionWithChildren({
+        getCollectionId: () => datasetId
+    });
 
     const BOX_MIN_SIZE_PX = 4;
     const setupDragBehavior = () => {

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect/SampleSegmentationMaskRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect/SampleSegmentationMaskRect.svelte
@@ -63,7 +63,7 @@
     const { trackEvent } = usePostHog();
     let drawStartFired = false;
 
-    const { deleteAnnotation } = $derived.by(() => useDeleteAnnotation({ collectionId }));
+    const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => collectionId });
 
     const labels = useAnnotationLabels(() => ({ collectionId }));
 
@@ -82,9 +82,9 @@
         enabled: !!activeAnnotationId
     }));
     const datasetId = $derived(page.params.dataset_id!);
-    const { refetch: refetchRootCollection } = $derived.by(() =>
-        useCollectionWithChildren({ collectionId: datasetId })
-    );
+    const { refetch: refetchRootCollection } = useCollectionWithChildren({
+        getCollectionId: () => datasetId
+    });
 
     const {
         open: selectClassDialogOpen,

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect/SampleSegmentationMaskRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleSegmentationMaskRect/SampleSegmentationMaskRect.svelte
@@ -63,7 +63,7 @@
     const { trackEvent } = usePostHog();
     let drawStartFired = false;
 
-    const { deleteAnnotation } = useDeleteAnnotation({ collectionId });
+    const { deleteAnnotation } = $derived.by(() => useDeleteAnnotation({ collectionId }));
 
     const labels = useAnnotationLabels(() => ({ collectionId }));
 

--- a/lightly_studio_view/src/lib/components/SegmentTags/SegmentTags.svelte
+++ b/lightly_studio_view/src/lib/components/SegmentTags/SegmentTags.svelte
@@ -21,7 +21,7 @@
 
     let { tags, collectionId, sampleId, onRefetch = () => {} }: Props = $props();
 
-    const { removeTagFromSample } = $derived.by(() => useRemoveTagFromSample({ collectionId }));
+    const { removeTagFromSample } = useRemoveTagFromSample({ getCollectionId: () => collectionId });
 
     async function handleRemoveTag(tagId: string) {
         try {
@@ -46,15 +46,13 @@
         busy: addTagBusy,
         addExisting,
         createAndAdd
-    } = $derived.by(() =>
-        useAddTagToSample({
-            collectionId,
-            sampleId,
-            getTagKind: () => tagKind,
-            onRefetch: (...args) => onRefetch(...args),
-            onTagsRefetch: () => loadTags()
-        })
-    );
+    } = useAddTagToSample({
+        getCollectionId: () => collectionId,
+        getSampleId: () => sampleId,
+        getTagKind: () => tagKind,
+        onRefetch: (...args) => onRefetch(...args),
+        onTagsRefetch: () => loadTags()
+    });
 
     const options = $derived(
         $allCollectionTags.filter(

--- a/lightly_studio_view/src/lib/components/SegmentTags/SegmentTags.svelte
+++ b/lightly_studio_view/src/lib/components/SegmentTags/SegmentTags.svelte
@@ -21,7 +21,7 @@
 
     let { tags, collectionId, sampleId, onRefetch = () => {} }: Props = $props();
 
-    const { removeTagFromSample } = useRemoveTagFromSample({ collectionId });
+    const { removeTagFromSample } = $derived.by(() => useRemoveTagFromSample({ collectionId }));
 
     async function handleRemoveTag(tagId: string) {
         try {
@@ -46,13 +46,15 @@
         busy: addTagBusy,
         addExisting,
         createAndAdd
-    } = useAddTagToSample({
-        collectionId,
-        sampleId,
-        getTagKind: () => tagKind,
-        onRefetch,
-        onTagsRefetch: () => loadTags()
-    });
+    } = $derived.by(() =>
+        useAddTagToSample({
+            collectionId,
+            sampleId,
+            getTagKind: () => tagKind,
+            onRefetch: (...args) => onRefetch(...args),
+            onTagsRefetch: () => loadTags()
+        })
+    );
 
     const options = $derived(
         $allCollectionTags.filter(

--- a/lightly_studio_view/src/lib/components/SelectList/SelectList.svelte
+++ b/lightly_studio_view/src/lib/components/SelectList/SelectList.svelte
@@ -4,7 +4,7 @@
         ChevronsUpDown as ChevronsUpDownIcon,
         LoaderCircle as Loader2Icon
     } from '@lucide/svelte';
-    import { tick, type Snippet } from 'svelte';
+    import { tick, untrack, type Snippet } from 'svelte';
     import * as Command from '$lib/components/ui/command/index.js';
     import * as Popover from '$lib/components/ui/popover/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
@@ -60,7 +60,7 @@
         onKeyboardConfirm?: (item: ListItem) => void;
     } = $props();
 
-    let open = $state(autoOpen);
+    let open = $state(untrack(() => autoOpen));
     let inputValue = $state('');
     let highlightedValue = $state('');
 

--- a/lightly_studio_view/src/lib/components/SelectableSvgGroup/SelectableSvgGroup.svelte
+++ b/lightly_studio_view/src/lib/components/SelectableSvgGroup/SelectableSvgGroup.svelte
@@ -16,7 +16,10 @@
         box: BoundingBox;
     } = $props();
 
-    const { x, y, width, height } = box;
+    const x = $derived(box.x);
+    const y = $derived(box.y);
+    const width = $derived(box.width);
+    const height = $derived(box.height);
     const handleSelect = () => {
         onSelect(groupId);
     };

--- a/lightly_studio_view/src/lib/components/SideMenu/SideMenu/SideMenu.svelte
+++ b/lightly_studio_view/src/lib/components/SideMenu/SideMenu/SideMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import MenuItem from '../MenuItem/MenuItem.svelte';
     import { type MenuItemType } from '../types';
     import type { HTMLAttributes } from 'svelte/elements';
@@ -27,7 +28,7 @@
         enableColorPicker
     }: SideMenuProps = $props();
 
-    let internalSelectedItemsIds = $state(initialSelectedItemsIds ?? []);
+    let internalSelectedItemsIds = $state(untrack(() => initialSelectedItemsIds ?? []));
     const selected = $derived(selectedItemsIds ?? internalSelectedItemsIds);
 
     const handleCheckedChange = (id: string) => {

--- a/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.svelte
+++ b/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.svelte
@@ -12,7 +12,7 @@
     }
     const { collectionId, isImages, hasMediaWithEmbeddings, supportsEvaluation }: Props = $props();
 
-    const { activePanel, toggle } = $derived.by(() => useSidePanelTabs({ collectionId }));
+    const { activePanel, toggle } = useSidePanelTabs({ getCollectionId: () => collectionId });
 </script>
 
 <div class="flex w-14 flex-col gap-2 rounded-xl bg-card p-1.5">

--- a/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.svelte
+++ b/lightly_studio_view/src/lib/components/SidePanelTabs/SidePanelTabs.svelte
@@ -12,7 +12,7 @@
     }
     const { collectionId, isImages, hasMediaWithEmbeddings, supportsEvaluation }: Props = $props();
 
-    const { activePanel, toggle } = useSidePanelTabs({ collectionId });
+    const { activePanel, toggle } = $derived.by(() => useSidePanelTabs({ collectionId }));
 </script>
 
 <div class="flex w-14 flex-col gap-2 rounded-xl bg-card p-1.5">

--- a/lightly_studio_view/src/lib/components/SidePanelTabs/useSidePanelTabs.ts
+++ b/lightly_studio_view/src/lib/components/SidePanelTabs/useSidePanelTabs.ts
@@ -3,10 +3,10 @@ import { useGlobalStorage, usePostHog } from '$lib/hooks';
 type PanelType = Parameters<ReturnType<typeof useGlobalStorage>['setActivePanel']>[0];
 
 interface UseSidePanelTabsParams {
-    collectionId: string;
+    getCollectionId: () => string;
 }
 
-export function useSidePanelTabs({ collectionId }: UseSidePanelTabsParams) {
+export function useSidePanelTabs({ getCollectionId }: UseSidePanelTabsParams) {
     const { activePanel, setActivePanel } = useGlobalStorage();
     const { trackEvent } = usePostHog();
 
@@ -14,7 +14,10 @@ export function useSidePanelTabs({ collectionId }: UseSidePanelTabsParams) {
         const nextPanel = activePanel === panel ? 'none' : panel;
         setActivePanel(nextPanel);
         if (nextPanel !== 'none') {
-            trackEvent('tool_panel_opened', { collection_id: collectionId, panel_type: nextPanel });
+            trackEvent('tool_panel_opened', {
+                collection_id: getCollectionId(),
+                panel_type: nextPanel
+            });
         }
     }
 

--- a/lightly_studio_view/src/lib/components/TagsMenu/TagRenameInput.svelte
+++ b/lightly_studio_view/src/lib/components/TagsMenu/TagRenameInput.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { tick } from 'svelte';
+    import { tick, untrack } from 'svelte';
     import { Checkbox as CheckboxPrimitive } from '$lib/components/ui/checkbox';
     import { Input } from '$lib/components/ui/input';
     import { Check } from '@lucide/svelte';
@@ -21,7 +21,7 @@
         onCancel: () => void;
     } = $props();
 
-    let renameValue = $state(tag.name);
+    let renameValue = $state(untrack(() => tag.name));
     let renameInputRef = $state<HTMLInputElement | null>(null);
 
     const trimmedRenameValue = $derived(renameValue.trim());

--- a/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
+++ b/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
@@ -55,10 +55,12 @@
     const eventCollectionId = untrack(
         () => (video.sample as SampleView)?.collection_id ?? datasetId
     );
-    const { updateAnnotations } = useUpdateAnnotationsMutation({ collectionId: eventCollectionId });
-    const { createAnnotation } = useCreateAnnotation({ collectionId: eventCollectionId });
-    const { createLabel } = useCreateLabel({ collectionId: eventCollectionId });
-    const { deleteAnnotation } = useDeleteAnnotation({ collectionId: eventCollectionId });
+    const { updateAnnotations } = useUpdateAnnotationsMutation({
+        getCollectionId: () => eventCollectionId
+    });
+    const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => eventCollectionId });
+    const { createLabel } = useCreateLabel({ getCollectionId: () => eventCollectionId });
+    const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => eventCollectionId });
     const annotationLabels = useAnnotationLabels(() => ({ collectionId: eventCollectionId }));
 
     const {

--- a/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
+++ b/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
@@ -27,7 +27,7 @@
     import { useCreateLabel } from '$lib/hooks/useCreateLabel/useCreateLabel';
     import { useSelectClassDialog } from '$lib/hooks/useSelectClassDialog/useSelectClassDialog';
     import { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
-    import { onMount } from 'svelte';
+    import { onMount, untrack } from 'svelte';
     import { toast } from 'svelte-sonner';
     import { routeHelpers } from '$lib/routes';
     import VideoFrameAnnotationItem, {
@@ -52,7 +52,7 @@
     const { isEditingMode } = useGlobalStorage();
 
     // Events live on the video's own collection; labels are shared per dataset.
-    const eventCollectionId = (video.sample as SampleView)?.collection_id ?? datasetId;
+    const eventCollectionId = untrack(() => (video.sample as SampleView)?.collection_id ?? datasetId);
     const { updateAnnotations } = useUpdateAnnotationsMutation({ collectionId: eventCollectionId });
     const { createAnnotation } = useCreateAnnotation({ collectionId: eventCollectionId });
     const { createLabel } = useCreateLabel({ collectionId: eventCollectionId });
@@ -136,9 +136,11 @@
         frames: videoFrames,
         loadFrameByPlaybackTime,
         loadFramesFromFrameNumber
-    } = useVideoFrames({
-        video
-    });
+    } = $derived.by(() =>
+        useVideoFrames({
+            video
+        })
+    );
 
     // Pre-render all frame annotations as dataURLs for efficient playback
     const frameAnnotationMap = $derived(
@@ -194,7 +196,7 @@
     };
 
     // null = waiting for the frame deep-link timestamp; 0 = start of video.
-    let startTimeS = $state<number | null>(frameNumber !== undefined ? null : 0);
+    let startTimeS = $state<number | null>(untrack(() => (frameNumber !== undefined ? null : 0)));
 
     // #key remounts on navigation, so onMount suffices; an $effect could re-fire
     // and stop the play sync loop.

--- a/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
+++ b/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
@@ -140,7 +140,7 @@
         frames: videoFrames,
         loadFrameByPlaybackTime,
         loadFramesFromFrameNumber
-    } = useVideoFrames(() => video);
+    } = untrack(() => useVideoFrames({ video }));
 
     // Pre-render all frame annotations as dataURLs for efficient playback
     const frameAnnotationMap = $derived(

--- a/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
+++ b/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
@@ -138,11 +138,7 @@
         frames: videoFrames,
         loadFrameByPlaybackTime,
         loadFramesFromFrameNumber
-    } = $derived.by(() =>
-        useVideoFrames({
-            video
-        })
-    );
+    } = useVideoFrames(() => video);
 
     // Pre-render all frame annotations as dataURLs for efficient playback
     const frameAnnotationMap = $derived(

--- a/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
+++ b/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
@@ -52,7 +52,9 @@
     const { isEditingMode } = useGlobalStorage();
 
     // Events live on the video's own collection; labels are shared per dataset.
-    const eventCollectionId = untrack(() => (video.sample as SampleView)?.collection_id ?? datasetId);
+    const eventCollectionId = untrack(
+        () => (video.sample as SampleView)?.collection_id ?? datasetId
+    );
     const { updateAnnotations } = useUpdateAnnotationsMutation({ collectionId: eventCollectionId });
     const { createAnnotation } = useCreateAnnotation({ collectionId: eventCollectionId });
     const { createLabel } = useCreateLabel({ collectionId: eventCollectionId });

--- a/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.test.ts
+++ b/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/svelte';
 import { flushSync } from 'svelte';
-import { writable, type Writable } from 'svelte/store';
+import { writable, get, type Writable } from 'svelte/store';
 import type { FrameView, VideoView } from '$lib/api/lightly_studio_local';
 import { useVideoFrames } from '$lib/hooks/useVideoFrames/useVideoFrames';
 import { capturedProps, resetCapturedProps } from './VideoDetails.stub.svelte';
@@ -157,5 +157,38 @@ describe('VideoDetails', () => {
 
         // A non-matching frame must not resolve the start time.
         expect(lastStartTimeS()).toBeNull();
+    });
+
+    it('does not reinitialize the frame controller when the same video is re-fetched', () => {
+        const { rerender } = render(VideoDetails, {
+            props: { video, datasetId: 'dataset-1', onVideoUpdate: vi.fn(), frameNumber: undefined }
+        });
+        flushSync();
+
+        // Seed the current frame as if playback has started.
+        flushSync(() =>
+            currentFrame.set({
+                frame_number: 5,
+                frame_timestamp_s: 0.5,
+                sample: {}
+            } as unknown as FrameView)
+        );
+
+        const callsBefore = vi.mocked(useVideoFrames).mock.calls.length;
+
+        // Simulate a same-video refetch: parent produces a new VideoView object with the same sample_id.
+        const refetchedVideo = { ...video } as unknown as VideoView;
+        rerender({
+            video: refetchedVideo,
+            datasetId: 'dataset-1',
+            onVideoUpdate: vi.fn(),
+            frameNumber: undefined
+        });
+        flushSync();
+
+        // The controller must not be recreated on a same-ID prop update.
+        expect(vi.mocked(useVideoFrames).mock.calls.length).toBe(callsBefore);
+        // The current frame must still be set — the overlay stays initialized.
+        expect(get(currentFrame)).toBeDefined();
     });
 });

--- a/lightly_studio_view/src/lib/components/VideoDetailsNavigation/VideoDetailsNavigation.svelte
+++ b/lightly_studio_view/src/lib/components/VideoDetailsNavigation/VideoDetailsNavigation.svelte
@@ -7,8 +7,8 @@
 
     const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type!);
-    const collectionId = $derived(page.params.collection_id);
-    const sampleId = $derived(page.params.sample_id);
+    const collectionId = $derived(page.params.collection_id!);
+    const sampleId = $derived(page.params.sample_id!);
 
     const { query: sampleAdjacentQuery } = $derived(
         useAdjacentVideos({

--- a/lightly_studio_view/src/lib/components/VideoItem/VideoItem.svelte
+++ b/lightly_studio_view/src/lib/components/VideoItem/VideoItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { PUBLIC_VIDEOS_MEDIA_URL } from '$env/static/public';
     import {
         getAllFrames,
@@ -38,7 +39,7 @@
     const HOVER_DELAY = 200;
     let isHovering = false;
     // Start it with the initial frame
-    let frames = $state<FrameView[]>(video.frame == null ? [] : [video.frame]);
+    let frames = $state<FrameView[]>(untrack(() => (video.frame == null ? [] : [video.frame])));
 
     async function handleMouseEnter() {
         isHovering = true;

--- a/lightly_studio_view/src/lib/components/VideoPlayer/UseVideoPlaybackHarness.svelte
+++ b/lightly_studio_view/src/lib/components/VideoPlayer/UseVideoPlaybackHarness.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { useVideoPlayback } from './useVideoPlayback.svelte';
 
     interface Props {
@@ -12,15 +13,13 @@
 
     const { videoEl, regionEl = null, src, startTimeS, initialMuted, onReady }: Props = $props();
 
-    const playback = $derived.by(() =>
-        useVideoPlayback({
-            getVideoEl: () => videoEl,
-            getRegionEl: () => regionEl,
-            getSrc: () => src,
-            getStartTimeS: () => startTimeS,
-            initialMuted
-        })
-    );
+    const playback = useVideoPlayback({
+        getVideoEl: () => videoEl,
+        getRegionEl: () => regionEl,
+        getSrc: () => src,
+        getStartTimeS: () => startTimeS,
+        initialMuted: untrack(() => initialMuted)
+    });
 
     $effect(() => {
         onReady(playback);

--- a/lightly_studio_view/src/lib/components/VideoPlayer/UseVideoPlaybackHarness.svelte
+++ b/lightly_studio_view/src/lib/components/VideoPlayer/UseVideoPlaybackHarness.svelte
@@ -12,13 +12,17 @@
 
     const { videoEl, regionEl = null, src, startTimeS, initialMuted, onReady }: Props = $props();
 
-    const playback = useVideoPlayback({
-        getVideoEl: () => videoEl,
-        getRegionEl: () => regionEl,
-        getSrc: () => src,
-        getStartTimeS: () => startTimeS,
-        initialMuted
-    });
+    const playback = $derived.by(() =>
+        useVideoPlayback({
+            getVideoEl: () => videoEl,
+            getRegionEl: () => regionEl,
+            getSrc: () => src,
+            getStartTimeS: () => startTimeS,
+            initialMuted
+        })
+    );
 
-    onReady(playback);
+    $effect(() => {
+        onReady(playback);
+    });
 </script>

--- a/lightly_studio_view/src/lib/hooks/useAddTagToSample/useAddTagToSample.ts
+++ b/lightly_studio_view/src/lib/hooks/useAddTagToSample/useAddTagToSample.ts
@@ -4,16 +4,16 @@ import { get, readonly, writable } from 'svelte/store';
 import { toast } from 'svelte-sonner';
 
 interface Options {
-    collectionId: string;
-    sampleId: string;
+    getCollectionId: () => string;
+    getSampleId: () => string;
     getTagKind: () => TagView['kind'];
     onRefetch: () => void;
     onTagsRefetch: () => void;
 }
 
 export function useAddTagToSample({
-    collectionId,
-    sampleId,
+    getCollectionId,
+    getSampleId,
     getTagKind,
     onRefetch,
     onTagsRefetch
@@ -26,8 +26,8 @@ export function useAddTagToSample({
         _busy.set(true);
         try {
             const response = await addSampleIdsToTagId({
-                path: { collection_id: collectionId, tag_id: tag.tag_id },
-                body: { sample_ids: [sampleId] }
+                path: { collection_id: getCollectionId(), tag_id: tag.tag_id },
+                body: { sample_ids: [getSampleId()] }
             });
             if (response.error) throw new Error('assign tag failed');
         } catch {
@@ -43,6 +43,7 @@ export function useAddTagToSample({
         const trimmed = name.trim();
         if (!trimmed || get(_busy)) return;
         _busy.set(true);
+        const collectionId = getCollectionId();
         try {
             const response = await createTag({
                 path: { collection_id: collectionId },
@@ -52,7 +53,7 @@ export function useAddTagToSample({
             if (response.data?.tag_id) {
                 const addResponse = await addSampleIdsToTagId({
                     path: { collection_id: collectionId, tag_id: response.data.tag_id },
-                    body: { sample_ids: [sampleId] }
+                    body: { sample_ids: [getSampleId()] }
                 });
                 if (addResponse.error) throw new Error('assign tag failed');
             }

--- a/lightly_studio_view/src/lib/hooks/useAnnotation/useAnnotation.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotation/useAnnotation.ts
@@ -18,9 +18,8 @@ export const useAnnotation = (
 ) => {
     const client = useQueryClient();
 
-    // Evaluate collectionId once at construction for mutation setup (stable route param)
     const { updateAnnotations } = useUpdateAnnotationsMutation({
-        collectionId: getParams().collectionId
+        getCollectionId: () => getParams().collectionId
     });
 
     const annotation = createQuery(() => ({

--- a/lightly_studio_view/src/lib/hooks/useAnnotationDetails/useAnnotationsDetails.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationDetails/useAnnotationsDetails.ts
@@ -26,7 +26,7 @@ export const useAnnotationDetails = ({
     const client = useQueryClient();
 
     const { updateAnnotations } = useUpdateAnnotationsMutation({
-        collectionId
+        getCollectionId: () => collectionId
     });
     const annotation = createQuery(() => annotationOptions);
 

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/useAnnotationsInfinite.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/useAnnotationsInfinite.ts
@@ -21,9 +21,8 @@ export const useAnnotationsInfinite = (getParams: () => AnnotationsInfiniteParam
         });
     };
 
-    const collection_id = getParams().collection_id;
     const { updateAnnotations } = useUpdateAnnotationsMutation({
-        collectionId: collection_id
+        getCollectionId: () => getParams().collection_id
     });
 
     return {

--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifierUtils.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifierUtils.ts
@@ -115,7 +115,7 @@ export function useClassifierUtils(): UseClassifierUtilsReturn {
     };
 
     async function prepareSamples(): Promise<PrepareSamplesResponse> {
-        const collectionId = page.params.collection_id;
+        const collectionId = page.params.collection_id!;
         const selectedSampleIds = getSelectedSampleIds(collectionId);
         const selectedIds = get(selectedSampleIds);
         const positives = Array.from(selectedIds);

--- a/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassifiers/useClassifiers.ts
@@ -102,7 +102,7 @@ export function useClassifiers(): UseClassifiersReturn {
 
         try {
             const response = await getAllClassifiers({
-                query: { collection_id: page.params.collection_id }
+                query: { collection_id: page.params.collection_id! }
             });
             if (response.data?.classifiers) {
                 // Extract just the classifiers array from the response.
@@ -234,7 +234,7 @@ export function useClassifiers(): UseClassifiersReturn {
                     await runClassifierRoute({
                         path: {
                             classifier_id: classifier_id,
-                            collection_id: page.params.collection_id
+                            collection_id: page.params.collection_id!
                         }
                     });
 

--- a/lightly_studio_view/src/lib/hooks/useCollection/useCollection.ts
+++ b/lightly_studio_view/src/lib/hooks/useCollection/useCollection.ts
@@ -28,11 +28,16 @@ export const useCollection = ({ collectionId }: { collectionId: string }) => {
  * Use this when you need the root collection with all child collections populated
  * (e.g., for navigation menus that need to show all available collections).
  */
-export const useCollectionWithChildren = ({ collectionId }: { collectionId: string }) => {
-    const options = readCollectionHierarchyOptions({ path: { collection_id: collectionId } });
+export const useCollectionWithChildren = ({
+    getCollectionId
+}: {
+    getCollectionId: () => string;
+}) => {
     const client = useQueryClient();
 
-    const hierarchyQuery = createQuery(() => options);
+    const hierarchyQuery = createQuery(() =>
+        readCollectionHierarchyOptions({ path: { collection_id: getCollectionId() } })
+    );
 
     // readCollectionHierarchy returns an array starting from the root
     // We need to get the first item (root collection) which has all children
@@ -49,7 +54,10 @@ export const useCollectionWithChildren = ({ collectionId }: { collectionId: stri
     }) as typeof hierarchyQuery & { data: CollectionView | undefined };
 
     const refetch = () => {
-        client.invalidateQueries({ queryKey: options.queryKey });
+        client.invalidateQueries({
+            queryKey: readCollectionHierarchyOptions({ path: { collection_id: getCollectionId() } })
+                .queryKey
+        });
     };
 
     return {

--- a/lightly_studio_view/src/lib/hooks/useCreateAnnotation/useCreateAnnotation.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateAnnotation/useCreateAnnotation.test.ts
@@ -42,7 +42,7 @@ describe('useCreateAnnotation', () => {
             }
         } as unknown as ReturnType<typeof createMutation>);
 
-        const { createAnnotation } = useCreateAnnotation({ collectionId: 'col-1' });
+        const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => 'col-1' });
         await createAnnotation({
             parent_sample_id: 's1',
             annotation_type: 'classification',
@@ -68,7 +68,7 @@ describe('useCreateAnnotation', () => {
             }
         } as unknown as ReturnType<typeof createMutation>);
 
-        const { createAnnotation } = useCreateAnnotation({ collectionId: 'col-1' });
+        const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => 'col-1' });
         await createAnnotation({
             parent_sample_id: 's1',
             annotation_type: 'object_detection',

--- a/lightly_studio_view/src/lib/hooks/useCreateAnnotation/useCreateAnnotation.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateAnnotation/useCreateAnnotation.ts
@@ -11,12 +11,12 @@ import { useImageAnnotationCountsQueryKey } from '$lib/hooks/useImageAnnotationC
 import { usePostHog } from '$lib/hooks';
 import { page } from '$app/state';
 
-export const useCreateAnnotation = ({ collectionId }: { collectionId: string }) => {
+export const useCreateAnnotation = ({ getCollectionId }: { getCollectionId: () => string }) => {
     const mutation = createMutation(() => createAnnotationMutation());
     const client = useQueryClient();
     const { trackEvent } = usePostHog();
 
-    const refetch = () => {
+    const refetch = (collectionId: string) => {
         client.invalidateQueries({
             queryKey: useImageAnnotationCountsQueryKey
         });
@@ -29,6 +29,7 @@ export const useCreateAnnotation = ({ collectionId }: { collectionId: string }) 
 
     const createAnnotation = (inputs: AnnotationCreateInput) =>
         new Promise<CreateAnnotationResponse>((resolve, reject) => {
+            const collectionId = getCollectionId();
             mutation.mutate(
                 {
                     path: {
@@ -38,7 +39,7 @@ export const useCreateAnnotation = ({ collectionId }: { collectionId: string }) 
                 },
                 {
                     onSuccess: (data) => {
-                        refetch();
+                        refetch(collectionId);
                         trackEvent('annotation_created', {
                             collection_id: collectionId,
                             annotation_type: data.annotation_type,

--- a/lightly_studio_view/src/lib/hooks/useCreateLabel/useCreateLabel.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateLabel/useCreateLabel.ts
@@ -5,14 +5,14 @@ import {
 import { createAnnotationLabelMutation } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
 import { createMutation } from '@tanstack/svelte-query';
 
-export const useCreateLabel = ({ collectionId }: { collectionId: string }) => {
+export const useCreateLabel = ({ getCollectionId }: { getCollectionId: () => string }) => {
     const mutation = createMutation(() => createAnnotationLabelMutation());
 
     const createLabel = (inputs: AnnotationLabelCreate) =>
         new Promise<CreateAnnotationLabelResponse>((resolve, reject) => {
             mutation.mutate(
                 {
-                    path: { collection_id: collectionId },
+                    path: { collection_id: getCollectionId() },
                     body: inputs
                 },
                 {

--- a/lightly_studio_view/src/lib/hooks/useDeleteAnnotation/useDeleteAnnotation.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useDeleteAnnotation/useDeleteAnnotation.test.ts
@@ -29,7 +29,7 @@ describe('useDeleteAnnotation', () => {
             }
         } as unknown as ReturnType<typeof createMutation>);
 
-        const { deleteAnnotation } = useDeleteAnnotation({ collectionId: 'col-1' });
+        const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => 'col-1' });
         await deleteAnnotation('ann-1', 'classification');
 
         expect(trackEvent).toHaveBeenCalledWith('annotation_deleted', {
@@ -45,7 +45,7 @@ describe('useDeleteAnnotation', () => {
             }
         } as unknown as ReturnType<typeof createMutation>);
 
-        const { deleteAnnotation } = useDeleteAnnotation({ collectionId: 'col-1' });
+        const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => 'col-1' });
         await deleteAnnotation('ann-1', 'object_detection');
 
         expect(trackEvent).toHaveBeenCalledWith('annotation_deleted', {

--- a/lightly_studio_view/src/lib/hooks/useDeleteAnnotation/useDeleteAnnotation.ts
+++ b/lightly_studio_view/src/lib/hooks/useDeleteAnnotation/useDeleteAnnotation.ts
@@ -3,7 +3,7 @@ import { createMutation, useQueryClient } from '@tanstack/svelte-query';
 import { useImageAnnotationCountsQueryKey } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
 import { usePostHog } from '$lib/hooks';
 
-export const useDeleteAnnotation = ({ collectionId }: { collectionId: string }) => {
+export const useDeleteAnnotation = ({ getCollectionId }: { getCollectionId: () => string }) => {
     const mutation = createMutation(() => deleteAnnotationMutation());
 
     const client = useQueryClient();
@@ -17,6 +17,7 @@ export const useDeleteAnnotation = ({ collectionId }: { collectionId: string }) 
 
     const deleteAnnotation = (annotationId: string, annotationType: string) =>
         new Promise<void>((resolve, reject) => {
+            const collectionId = getCollectionId();
             mutation.mutate(
                 {
                     path: {

--- a/lightly_studio_view/src/lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo.test.ts
@@ -23,28 +23,45 @@ describe('useEvaluationSampleMetricsInfo', () => {
     });
 
     it('creates the query with the correct query key for the given dataset id', () => {
-        const datasetId = 'dataset-1';
         const createQuerySpy = vi.spyOn(tanstackQuery, 'createQuery');
 
-        useEvaluationSampleMetricsInfo({ datasetId });
+        useEvaluationSampleMetricsInfo({ datasetId: () => 'dataset-1' });
 
         const optionsArg = createQuerySpy.mock.calls[0][0]() as CreateQueryOptions;
         const expectedOptions = getEvaluationSampleMetricsInfoOptions({
-            path: { dataset_id: datasetId }
+            path: { dataset_id: 'dataset-1' }
         });
 
         expect(optionsArg.queryKey).toEqual(expectedOptions.queryKey);
     });
 
+    it('reacts to datasetId getter changes — query key switches to the new id', () => {
+        const createQuerySpy = vi.spyOn(tanstackQuery, 'createQuery');
+
+        let datasetId = 'ds1';
+        useEvaluationSampleMetricsInfo({ datasetId: () => datasetId });
+
+        const optionsFn = createQuerySpy.mock.calls[0][0] as () => CreateQueryOptions;
+
+        expect(optionsFn().queryKey).toEqual(
+            getEvaluationSampleMetricsInfoOptions({ path: { dataset_id: 'ds1' } }).queryKey
+        );
+
+        datasetId = 'ds2';
+
+        expect(optionsFn().queryKey).toEqual(
+            getEvaluationSampleMetricsInfoOptions({ path: { dataset_id: 'ds2' } }).queryKey
+        );
+    });
+
     it('calls the SDK function with the correct dataset id', async () => {
-        const datasetId = 'dataset-2';
         const createQuerySpy = vi.spyOn(tanstackQuery, 'createQuery');
 
         vi.mocked(getEvaluationSampleMetricsInfo).mockResolvedValue(
             [] as unknown as Awaited<ReturnType<typeof getEvaluationSampleMetricsInfo>>
         );
 
-        useEvaluationSampleMetricsInfo({ datasetId });
+        useEvaluationSampleMetricsInfo({ datasetId: () => 'dataset-2' });
 
         const optionsArg = createQuerySpy.mock.calls[0][0]() as CreateQueryOptions;
 
@@ -60,7 +77,7 @@ describe('useEvaluationSampleMetricsInfo', () => {
 
         expect(getEvaluationSampleMetricsInfo).toHaveBeenCalledWith(
             expect.objectContaining({
-                path: { dataset_id: datasetId },
+                path: { dataset_id: 'dataset-2' },
                 throwOnError: true,
                 signal: expect.any(AbortSignal)
             })
@@ -68,7 +85,7 @@ describe('useEvaluationSampleMetricsInfo', () => {
     });
 
     it('returns the result of createQuery', () => {
-        const result = useEvaluationSampleMetricsInfo({ datasetId: 'dataset-3' });
+        const result = useEvaluationSampleMetricsInfo({ datasetId: () => 'dataset-3' });
 
         expect(result).toMatchObject({ data: [], isSuccess: true });
     });

--- a/lightly_studio_view/src/lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo.ts
+++ b/lightly_studio_view/src/lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo.ts
@@ -3,7 +3,7 @@ import type { EvaluationRunMetricsInfoView } from '$lib/api/lightly_studio_local
 import { createQuery, type CreateQueryResult } from '@tanstack/svelte-query';
 
 interface UseEvaluationSampleMetricsInfoParams {
-    datasetId: string;
+    datasetId: () => string;
 }
 
 export const useEvaluationSampleMetricsInfo = ({
@@ -14,7 +14,7 @@ export const useEvaluationSampleMetricsInfo = ({
 > => {
     return createQuery(() =>
         getEvaluationSampleMetricsInfoOptions({
-            path: { dataset_id: datasetId }
+            path: { dataset_id: datasetId() }
         })
     );
 };

--- a/lightly_studio_view/src/lib/hooks/useGroupComponents/useGroupComponents.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useGroupComponents/useGroupComponents.test.ts
@@ -57,7 +57,7 @@ describe('useGroupComponents Hook', () => {
     });
 
     it('should return groupComponents and refetch', () => {
-        const result = useGroupComponents({ groupId: 'group123' });
+        const result = useGroupComponents({ getGroupId: () => 'group123' });
 
         expect(result.groupComponents).toBeDefined();
         expect(result.refetch).toBeDefined();
@@ -65,7 +65,7 @@ describe('useGroupComponents Hook', () => {
     });
 
     it('should call invalidateQueries when refetch is called', () => {
-        const { refetch } = useGroupComponents({ groupId: 'group123' });
+        const { refetch } = useGroupComponents({ getGroupId: () => 'group123' });
 
         refetch();
 
@@ -77,7 +77,7 @@ describe('useGroupComponents Hook', () => {
     it('should call createQuery with correct options', () => {
         const createQuerySpy = vi.spyOn(tanstackQuery, 'createQuery');
 
-        useGroupComponents({ groupId: 'group123' });
+        useGroupComponents({ getGroupId: () => 'group123' });
 
         const optionsArg = createQuerySpy.mock.calls[0][0]();
         expect(optionsArg).toEqual(
@@ -88,7 +88,7 @@ describe('useGroupComponents Hook', () => {
     });
 
     it('should return group components data', () => {
-        const { groupComponents } = useGroupComponents({ groupId: 'group123' });
+        const { groupComponents } = useGroupComponents({ getGroupId: () => 'group123' });
 
         const data = groupComponents.data;
         expect(data).toHaveLength(2);
@@ -97,8 +97,8 @@ describe('useGroupComponents Hook', () => {
     });
 
     it('should handle different group IDs', () => {
-        const { refetch: refetch1 } = useGroupComponents({ groupId: 'group1' });
-        const { refetch: refetch2 } = useGroupComponents({ groupId: 'group2' });
+        const { refetch: refetch1 } = useGroupComponents({ getGroupId: () => 'group1' });
+        const { refetch: refetch2 } = useGroupComponents({ getGroupId: () => 'group2' });
 
         refetch1();
         refetch2();

--- a/lightly_studio_view/src/lib/hooks/useGroupComponents/useGroupComponents.ts
+++ b/lightly_studio_view/src/lib/hooks/useGroupComponents/useGroupComponents.ts
@@ -3,19 +3,19 @@ import type { GroupComponentView } from '$lib/api/lightly_studio_local/types.gen
 import { createQuery, useQueryClient, type CreateQueryResult } from '@tanstack/svelte-query';
 
 export const useGroupComponents = ({
-    groupId
+    getGroupId
 }: {
-    groupId: string;
+    getGroupId: () => string;
 }): { groupComponents: CreateQueryResult<GroupComponentView[], Error>; refetch: () => void } => {
-    const readGroupComponents = getGroupComponentsByGroupIdOptions({
-        path: {
-            group_id: groupId
-        }
-    });
     const client = useQueryClient();
-    const groupComponents = createQuery(() => readGroupComponents);
+    const groupComponents = createQuery(() =>
+        getGroupComponentsByGroupIdOptions({ path: { group_id: getGroupId() } })
+    );
     const refetch = () => {
-        client.invalidateQueries({ queryKey: readGroupComponents.queryKey });
+        client.invalidateQueries({
+            queryKey: getGroupComponentsByGroupIdOptions({ path: { group_id: getGroupId() } })
+                .queryKey
+        });
     };
 
     return {

--- a/lightly_studio_view/src/lib/hooks/useGroupsInfinite/UseGroupsInfiniteHarness.svelte
+++ b/lightly_studio_view/src/lib/hooks/useGroupsInfinite/UseGroupsInfiniteHarness.svelte
@@ -9,5 +9,7 @@
     const { collectionId, onReady }: Props = $props();
     const result = useGroupsInfinite(() => collectionId);
 
-    onReady(result);
+    $effect(() => {
+        onReady(result);
+    });
 </script>

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.test.ts
@@ -34,7 +34,7 @@ describe('useOrderBy', () => {
         it('returns ASC when no sort is active', () => {
             const { selectedDirection } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
             expect(get(selectedDirection)).toBe(SortDirection.ASC);
         });
@@ -50,7 +50,7 @@ describe('useOrderBy', () => {
             ]);
             const { selectedDirection } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
             expect(get(selectedDirection)).toBe(SortDirection.DESC);
         });
@@ -58,7 +58,7 @@ describe('useOrderBy', () => {
 
     describe('selectedLabel', () => {
         it('returns null when no sort is active', () => {
-            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: () => 'ds1' });
             expect(get(selectedLabel)).toBeNull();
         });
 
@@ -71,7 +71,7 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: () => 'ds1' });
             expect(get(selectedLabel)).toBe('file name');
         });
 
@@ -93,7 +93,7 @@ describe('useOrderBy', () => {
                     is_numeric: true
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: () => 'ds1' });
             expect(get(selectedLabel)).toBe('metadata.brightness');
         });
 
@@ -115,7 +115,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: 'ds1' });
+            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: () => 'ds1' });
             expect(get(selectedLabel)).toBe('run1.precision');
         });
     });
@@ -124,7 +124,7 @@ describe('useOrderBy', () => {
         it('returns false for any field when no sort is active', () => {
             const { isFieldSelected } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
             const check = get(isFieldSelected);
 
@@ -142,7 +142,7 @@ describe('useOrderBy', () => {
             ]);
             const { isFieldSelected } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
             const check = get(isFieldSelected);
 
@@ -161,7 +161,7 @@ describe('useOrderBy', () => {
             ]);
             const { isFieldSelected } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
             const check = get(isFieldSelected);
 
@@ -186,7 +186,7 @@ describe('useOrderBy', () => {
         it('updates reactively when imageSortBy changes', () => {
             const { isFieldSelected } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
             const field = { source: 'image' as const, value: 'width', label: 'width' };
 
@@ -209,7 +209,7 @@ describe('useOrderBy', () => {
         it('selects an image field with ASC direction by default', () => {
             const { handleFieldClick } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
 
             handleFieldClick({ source: 'image', value: 'file_name', label: 'file name' });
@@ -235,7 +235,7 @@ describe('useOrderBy', () => {
             ]);
             const { handleFieldClick } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
 
             handleFieldClick({ source: 'image', value: 'file_name', label: 'file name' });
@@ -254,7 +254,7 @@ describe('useOrderBy', () => {
             ]);
             const { handleFieldClick } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
 
             handleFieldClick({ source: 'image', value: 'width', label: 'width' });
@@ -272,7 +272,7 @@ describe('useOrderBy', () => {
         it('sets is_numeric true for numeric metadata fields', () => {
             const { handleFieldClick } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
 
             handleFieldClick({
@@ -295,7 +295,7 @@ describe('useOrderBy', () => {
         it('selects an evaluation metric field', () => {
             const { handleFieldClick } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
 
             handleFieldClick({
@@ -320,7 +320,7 @@ describe('useOrderBy', () => {
         it('does nothing when no sort is active', () => {
             const { toggleDirection } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
 
             toggleDirection();
@@ -339,7 +339,7 @@ describe('useOrderBy', () => {
             ]);
             const { toggleDirection } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
 
             toggleDirection();
@@ -382,7 +382,7 @@ describe('useOrderBy', () => {
             ]);
             const { toggleDirection } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
 
             toggleDirection();
@@ -408,7 +408,7 @@ describe('useOrderBy', () => {
             ]);
             const { toggleDirection } = useOrderBy({
                 collectionId: () => 'col1',
-                datasetId: 'ds1'
+                datasetId: () => 'ds1'
             });
 
             toggleDirection();

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.test.ts
@@ -58,7 +58,10 @@ describe('useOrderBy', () => {
 
     describe('selectedLabel', () => {
         it('returns null when no sort is active', () => {
-            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: () => 'ds1' });
+            const { selectedLabel } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: () => 'ds1'
+            });
             expect(get(selectedLabel)).toBeNull();
         });
 
@@ -71,7 +74,10 @@ describe('useOrderBy', () => {
                     is_numeric: false
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: () => 'ds1' });
+            const { selectedLabel } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: () => 'ds1'
+            });
             expect(get(selectedLabel)).toBe('file name');
         });
 
@@ -93,7 +99,10 @@ describe('useOrderBy', () => {
                     is_numeric: true
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: () => 'ds1' });
+            const { selectedLabel } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: () => 'ds1'
+            });
             expect(get(selectedLabel)).toBe('metadata.brightness');
         });
 
@@ -115,7 +124,10 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { selectedLabel } = useOrderBy({ collectionId: () => 'col1', datasetId: () => 'ds1' });
+            const { selectedLabel } = useOrderBy({
+                collectionId: () => 'col1',
+                datasetId: () => 'ds1'
+            });
             expect(get(selectedLabel)).toBe('run1.precision');
         });
     });

--- a/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useOrderBy/useOrderBy.ts
@@ -12,7 +12,7 @@ import type { SortExpr } from '$lib/hooks/useImagesInfinite/types';
 
 interface UseOrderByParams {
     collectionId: () => string;
-    datasetId: string;
+    datasetId: () => string;
 }
 
 interface UseOrderByReturn {

--- a/lightly_studio_view/src/lib/hooks/useRemoveTagFromSample/useRemoveTagFromSample.ts
+++ b/lightly_studio_view/src/lib/hooks/useRemoveTagFromSample/useRemoveTagFromSample.ts
@@ -1,7 +1,7 @@
 import { removeTagFromSampleMutation } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
 import { createMutation } from '@tanstack/svelte-query';
 
-export const useRemoveTagFromSample = ({ collectionId }: { collectionId: string }) => {
+export const useRemoveTagFromSample = ({ getCollectionId }: { getCollectionId: () => string }) => {
     const mutation = createMutation(() => removeTagFromSampleMutation());
 
     const removeTagFromSample = (sampleId: string, tagId: string) =>
@@ -9,7 +9,7 @@ export const useRemoveTagFromSample = ({ collectionId }: { collectionId: string 
             mutation.mutate(
                 {
                     path: {
-                        collection_id: collectionId,
+                        collection_id: getCollectionId(),
                         sample_id: sampleId,
                         tag_id: tagId
                     }

--- a/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.ts
+++ b/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.ts
@@ -40,8 +40,8 @@ export function useSegmentationMaskBrush({
      *  the chosen class, or null if the user cancelled. */
     requestLabel?: () => Promise<{ label: string } | null>;
 }) {
-    const { createLabel } = useCreateLabel({ collectionId });
-    const { createAnnotation } = useCreateAnnotation({ collectionId });
+    const { createLabel } = useCreateLabel({ getCollectionId: () => collectionId });
+    const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => collectionId });
     const { addReversibleAction, updateLastAnnotationLabel } = useGlobalStorage();
     const {
         context: annotationLabelContext,
@@ -51,7 +51,9 @@ export function useSegmentationMaskBrush({
         setAnnotationId,
         setAnnotationType
     } = useAnnotationLabelContext();
-    const { updateAnnotations } = useUpdateAnnotationsMutation({ collectionId });
+    const { updateAnnotations } = useUpdateAnnotationsMutation({
+        getCollectionId: () => collectionId
+    });
 
     const finishBrush = async (
         workingMask: Uint8Array | null,

--- a/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.svelte.ts
@@ -20,7 +20,7 @@ export interface EvalSortField {
 export type SortField = ImageSortField | EvalSortField;
 
 interface UseSortFieldsParams {
-    datasetId: string;
+    datasetId: () => string;
 }
 
 interface UseSortFieldsReturn {

--- a/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useSortFields/useSortFields.test.ts
@@ -31,7 +31,7 @@ describe('useSortFields', () => {
 
     describe('allSortFields', () => {
         it('contains the five base image sort fields', () => {
-            const { allSortFields } = useSortFields({ datasetId: 'ds1' });
+            const { allSortFields } = useSortFields({ datasetId: () => 'ds1' });
             flushSync();
             const fields = get(allSortFields);
 
@@ -53,7 +53,7 @@ describe('useSortFields', () => {
                 { name: 'label', type: 'string' },
                 { name: 'active', type: 'boolean' }
             ]);
-            const { allSortFields } = useSortFields({ datasetId: 'ds1' });
+            const { allSortFields } = useSortFields({ datasetId: () => 'ds1' });
             flushSync();
             const fields = get(allSortFields);
 
@@ -93,7 +93,7 @@ describe('useSortFields', () => {
                 { name: 'nested', type: 'dict' },
                 { name: 'score', type: 'float' }
             ]);
-            const { allSortFields } = useSortFields({ datasetId: 'ds1' });
+            const { allSortFields } = useSortFields({ datasetId: () => 'ds1' });
             flushSync();
             const fields = get(allSortFields);
 
@@ -111,7 +111,7 @@ describe('useSortFields', () => {
                     ]
                 }
             ];
-            const { allSortFields } = useSortFields({ datasetId: 'ds1' });
+            const { allSortFields } = useSortFields({ datasetId: () => 'ds1' });
             flushSync();
             const fields = get(allSortFields);
 
@@ -134,7 +134,7 @@ describe('useSortFields', () => {
         });
 
         it('updates reactively when metadataInfo changes', () => {
-            const { allSortFields } = useSortFields({ datasetId: 'ds1' });
+            const { allSortFields } = useSortFields({ datasetId: () => 'ds1' });
             flushSync();
 
             expect(

--- a/lightly_studio_view/src/lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation.test.ts
@@ -29,7 +29,9 @@ describe('useUpdateAnnotationsMutation', () => {
             }
         } as unknown as ReturnType<typeof createMutation>);
 
-        const { updateAnnotations } = useUpdateAnnotationsMutation({ collectionId: 'col-1' });
+        const { updateAnnotations } = useUpdateAnnotationsMutation({
+            getCollectionId: () => 'col-1'
+        });
         await updateAnnotations([
             { annotation_id: 'ann-1', collection_id: 'col-1', label_name: 'dog' }
         ]);
@@ -48,7 +50,9 @@ describe('useUpdateAnnotationsMutation', () => {
             }
         } as unknown as ReturnType<typeof createMutation>);
 
-        const { updateAnnotations } = useUpdateAnnotationsMutation({ collectionId: 'col-1' });
+        const { updateAnnotations } = useUpdateAnnotationsMutation({
+            getCollectionId: () => 'col-1'
+        });
         await updateAnnotations([
             { annotation_id: 'ann-1', collection_id: 'col-1', label_name: 'dog' },
             { annotation_id: 'ann-2', collection_id: 'col-1', label_name: 'cat' }
@@ -68,7 +72,9 @@ describe('useUpdateAnnotationsMutation', () => {
             }
         } as unknown as ReturnType<typeof createMutation>);
 
-        const { updateAnnotations } = useUpdateAnnotationsMutation({ collectionId: 'col-1' });
+        const { updateAnnotations } = useUpdateAnnotationsMutation({
+            getCollectionId: () => 'col-1'
+        });
         await updateAnnotations([
             {
                 annotation_id: 'ann-1',

--- a/lightly_studio_view/src/lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation.ts
+++ b/lightly_studio_view/src/lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation.ts
@@ -4,7 +4,11 @@ import { createMutation, useQueryClient } from '@tanstack/svelte-query';
 import { useImageAnnotationCountsQueryKey } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
 import { usePostHog } from '$lib/hooks';
 
-export const useUpdateAnnotationsMutation = ({ collectionId }: { collectionId: string }) => {
+export const useUpdateAnnotationsMutation = ({
+    getCollectionId
+}: {
+    getCollectionId: () => string;
+}) => {
     const mutation = createMutation(() => updateAnnotationsMutation());
 
     const client = useQueryClient();
@@ -18,6 +22,7 @@ export const useUpdateAnnotationsMutation = ({ collectionId }: { collectionId: s
 
     const updateAnnotations = (inputs: AnnotationUpdateInput[]) =>
         new Promise<void>((resolve, reject) => {
+            const collectionId = getCollectionId();
             mutation.mutate(
                 {
                     path: {

--- a/lightly_studio_view/src/lib/hooks/useVideo/UseVideoHarness.svelte
+++ b/lightly_studio_view/src/lib/hooks/useVideo/UseVideoHarness.svelte
@@ -8,5 +8,7 @@
     const { onReady }: Props = $props();
     const result = useVideo();
 
-    onReady(result);
+    $effect(() => {
+        onReady(result);
+    });
 </script>

--- a/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.test.ts
@@ -79,7 +79,7 @@ describe('useVideoFrames', () => {
     });
 
     it('should initialize with default values', () => {
-        const hook = useVideoFrames(() => mockVideoData);
+        const hook = useVideoFrames({ video: mockVideoData });
 
         expect(get(hook.frames)).toEqual([]);
         expect(get(hook.currentFrame)).toBeUndefined();
@@ -97,7 +97,7 @@ describe('useVideoFrames', () => {
             error: undefined
         } as unknown as MockGetAllFramesResponse);
 
-        const hook = useVideoFrames(() => mockVideoData);
+        const hook = useVideoFrames({ video: mockVideoData });
 
         // Subscribe to currentFrame store to verify reactivity
         const currentFrameValues: (FrameView | undefined)[] = [];
@@ -143,7 +143,7 @@ describe('useVideoFrames', () => {
             error: undefined
         } as unknown as MockGetAllFramesResponse);
 
-        const hook = useVideoFrames(() => mockVideoData);
+        const hook = useVideoFrames({ video: mockVideoData });
 
         // 0.05 * 30 = 1.5, which floors to 1
         await hook.loadFrameByPlaybackTime(0.05, 30);
@@ -162,7 +162,7 @@ describe('useVideoFrames', () => {
             error: undefined
         } as unknown as MockGetAllFramesResponse);
 
-        const hook = useVideoFrames(() => mockVideoData);
+        const hook = useVideoFrames({ video: mockVideoData });
         await hook.loadFramesFromFrameNumber(0);
 
         vi.mocked(api.getAllFrames).mockClear();
@@ -182,7 +182,7 @@ describe('useVideoFrames', () => {
             error: undefined
         } as unknown as MockGetAllFramesResponse);
 
-        const hook = useVideoFrames(() => mockVideoData);
+        const hook = useVideoFrames({ video: mockVideoData });
 
         expect(hook.loading).toBe(false);
         expect(hook.reachedEnd).toBe(false);
@@ -215,7 +215,7 @@ describe('useVideoFrames', () => {
             apiPromise as ReturnType<typeof api.getAllFrames>
         );
 
-        const hook = useVideoFrames(() => mockVideoData);
+        const hook = useVideoFrames({ video: mockVideoData });
 
         // Start loading frames
         const firstLoad = hook.loadFrames();
@@ -249,7 +249,7 @@ describe('useVideoFrames', () => {
             error: undefined
         } as unknown as MockGetAllFramesResponse);
 
-        const hook = useVideoFrames(() => mockVideoData);
+        const hook = useVideoFrames({ video: mockVideoData });
 
         await expect(hook.loadFramesFromFrameNumber(100)).rejects.toThrow(
             'Frame not found for the given frame number'
@@ -257,7 +257,7 @@ describe('useVideoFrames', () => {
     });
 
     it('should throw error when video data is not available', async () => {
-        const hook = useVideoFrames(() => null as unknown as VideoView);
+        const hook = useVideoFrames({ video: null as unknown as VideoView });
 
         await expect(hook.loadFrameByPlaybackTime(0, 30)).rejects.toThrow(
             'No video data available'
@@ -274,7 +274,7 @@ describe('useVideoFrames', () => {
                 error: undefined
             } as unknown as MockGetAllFramesResponse);
 
-            const hook = useVideoFrames(() => mockVideoData);
+            const hook = useVideoFrames({ video: mockVideoData });
 
             const currentFrameValues: (FrameView | undefined)[] = [];
             const unsubscribeCurrentFrame = hook.currentFrame.subscribe((value) => {
@@ -328,7 +328,7 @@ describe('useVideoFrames', () => {
                 error: undefined
             } as unknown as MockGetAllFramesResponse);
 
-            const hook = useVideoFrames(() => mockVideoData);
+            const hook = useVideoFrames({ video: mockVideoData });
             await hook.loadFramesFromFrameNumber(0);
 
             vi.mocked(api.getAllFrames).mockClear();

--- a/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.test.ts
@@ -79,7 +79,7 @@ describe('useVideoFrames', () => {
     });
 
     it('should initialize with default values', () => {
-        const hook = useVideoFrames({ video: mockVideoData });
+        const hook = useVideoFrames(() => mockVideoData);
 
         expect(get(hook.frames)).toEqual([]);
         expect(get(hook.currentFrame)).toBeUndefined();
@@ -97,7 +97,7 @@ describe('useVideoFrames', () => {
             error: undefined
         } as unknown as MockGetAllFramesResponse);
 
-        const hook = useVideoFrames({ video: mockVideoData });
+        const hook = useVideoFrames(() => mockVideoData);
 
         // Subscribe to currentFrame store to verify reactivity
         const currentFrameValues: (FrameView | undefined)[] = [];
@@ -143,7 +143,7 @@ describe('useVideoFrames', () => {
             error: undefined
         } as unknown as MockGetAllFramesResponse);
 
-        const hook = useVideoFrames({ video: mockVideoData });
+        const hook = useVideoFrames(() => mockVideoData);
 
         // 0.05 * 30 = 1.5, which floors to 1
         await hook.loadFrameByPlaybackTime(0.05, 30);
@@ -162,7 +162,7 @@ describe('useVideoFrames', () => {
             error: undefined
         } as unknown as MockGetAllFramesResponse);
 
-        const hook = useVideoFrames({ video: mockVideoData });
+        const hook = useVideoFrames(() => mockVideoData);
         await hook.loadFramesFromFrameNumber(0);
 
         vi.mocked(api.getAllFrames).mockClear();
@@ -182,7 +182,7 @@ describe('useVideoFrames', () => {
             error: undefined
         } as unknown as MockGetAllFramesResponse);
 
-        const hook = useVideoFrames({ video: mockVideoData });
+        const hook = useVideoFrames(() => mockVideoData);
 
         expect(hook.loading).toBe(false);
         expect(hook.reachedEnd).toBe(false);
@@ -215,7 +215,7 @@ describe('useVideoFrames', () => {
             apiPromise as ReturnType<typeof api.getAllFrames>
         );
 
-        const hook = useVideoFrames({ video: mockVideoData });
+        const hook = useVideoFrames(() => mockVideoData);
 
         // Start loading frames
         const firstLoad = hook.loadFrames();
@@ -249,7 +249,7 @@ describe('useVideoFrames', () => {
             error: undefined
         } as unknown as MockGetAllFramesResponse);
 
-        const hook = useVideoFrames({ video: mockVideoData });
+        const hook = useVideoFrames(() => mockVideoData);
 
         await expect(hook.loadFramesFromFrameNumber(100)).rejects.toThrow(
             'Frame not found for the given frame number'
@@ -257,7 +257,7 @@ describe('useVideoFrames', () => {
     });
 
     it('should throw error when video data is not available', async () => {
-        const hook = useVideoFrames({ video: null as unknown as VideoView });
+        const hook = useVideoFrames(() => null as unknown as VideoView);
 
         await expect(hook.loadFrameByPlaybackTime(0, 30)).rejects.toThrow(
             'No video data available'
@@ -274,7 +274,7 @@ describe('useVideoFrames', () => {
                 error: undefined
             } as unknown as MockGetAllFramesResponse);
 
-            const hook = useVideoFrames({ video: mockVideoData });
+            const hook = useVideoFrames(() => mockVideoData);
 
             const currentFrameValues: (FrameView | undefined)[] = [];
             const unsubscribeCurrentFrame = hook.currentFrame.subscribe((value) => {
@@ -328,7 +328,7 @@ describe('useVideoFrames', () => {
                 error: undefined
             } as unknown as MockGetAllFramesResponse);
 
-            const hook = useVideoFrames({ video: mockVideoData });
+            const hook = useVideoFrames(() => mockVideoData);
             await hook.loadFramesFromFrameNumber(0);
 
             vi.mocked(api.getAllFrames).mockClear();

--- a/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.ts
@@ -58,7 +58,7 @@ interface UseVideoFramesState {
  * await loadFramesFromFrameNumber(42); // Load and display frame 42
  * ```
  */
-export function useVideoFrames({ video }: { video: VideoView }) {
+export function useVideoFrames(getVideo: () => VideoView) {
     const frames = writable<FrameView[]>([]);
     const currentFrame = writable<FrameView | undefined>(undefined);
     const playbackTime = writable<number>(0);
@@ -107,6 +107,7 @@ export function useVideoFrames({ video }: { video: VideoView }) {
             return;
         }
 
+        const video = getVideo();
         const frameCollectionId = (video?.frame?.sample as SampleView)?.collection_id;
         if (!frameCollectionId) {
             return;
@@ -178,6 +179,7 @@ export function useVideoFrames({ video }: { video: VideoView }) {
         state.hasStarted = true;
 
         // Set lastVideoId after initial load to track future changes
+        const video = getVideo();
         if (video && state.lastVideoId === null) {
             state.lastVideoId = video.sample_id;
         }
@@ -197,7 +199,7 @@ export function useVideoFrames({ video }: { video: VideoView }) {
             state.seekFrameNumber = false;
         }
 
-        if (!video) throw new Error('No video data available');
+        if (!getVideo()) throw new Error('No video data available');
 
         const frameIndex = Math.floor(currentTime * fps);
         const existingFrame = getFrameByNumber(frameIndex);

--- a/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFrames/useVideoFrames.ts
@@ -58,7 +58,7 @@ interface UseVideoFramesState {
  * await loadFramesFromFrameNumber(42); // Load and display frame 42
  * ```
  */
-export function useVideoFrames(getVideo: () => VideoView) {
+export function useVideoFrames({ video }: { video: VideoView }) {
     const frames = writable<FrameView[]>([]);
     const currentFrame = writable<FrameView | undefined>(undefined);
     const playbackTime = writable<number>(0);
@@ -107,7 +107,6 @@ export function useVideoFrames(getVideo: () => VideoView) {
             return;
         }
 
-        const video = getVideo();
         const frameCollectionId = (video?.frame?.sample as SampleView)?.collection_id;
         if (!frameCollectionId) {
             return;
@@ -179,7 +178,6 @@ export function useVideoFrames(getVideo: () => VideoView) {
         state.hasStarted = true;
 
         // Set lastVideoId after initial load to track future changes
-        const video = getVideo();
         if (video && state.lastVideoId === null) {
             state.lastVideoId = video.sample_id;
         }
@@ -199,7 +197,7 @@ export function useVideoFrames(getVideo: () => VideoView) {
             state.seekFrameNumber = false;
         }
 
-        if (!getVideo()) throw new Error('No video data available');
+        if (!video) throw new Error('No video data available');
 
         const frameIndex = Math.floor(currentTime * fps);
         const existingFrame = getFrameByNumber(frameIndex);

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/LayoutStub.test.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/LayoutStub.test.svelte
@@ -2,10 +2,7 @@
     import type { Snippet } from 'svelte';
     // Generic stub for heavy child components: renders children transparently
     // and accepts (but ignores) all other props.
-    // svelte-ignore custom_element_props_identifier
-    let { children, ...rest }: { children?: Snippet; [key: string]: unknown } = $props();
-
-    void rest; // Suppress unused-variable warning in tests
+    let { children }: { children?: Snippet; [key: string]: unknown } = $props();
 </script>
 
 {@render children?.()}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/annotations/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/annotations/+page.svelte
@@ -1,17 +1,14 @@
 <script lang="ts">
     import { AnnotationsGrid } from '$lib/components';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
-    import type { PageData } from './$types';
     import { useTags } from '$lib/hooks/useTags/useTags';
 
     import { page } from '$app/state';
 
-    const { data }: { data: PageData } = $props();
-    const sampleSize = $derived(data.sampleSize);
     const datasetId = $derived(page.params.dataset_id!);
     const collectionId = $derived(page.params.collection_id!);
 
-    const { lastGridType } = useGlobalStorage();
+    const { lastGridType, sampleSize } = useGlobalStorage();
 
     // Use root collection ID for tags - tags should always use root collection, not child collections
     const tagsCollectionId = $derived(datasetId ?? collectionId);

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/annotations/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/annotations/+page.svelte
@@ -7,7 +7,7 @@
     import { page } from '$app/state';
 
     const { data }: { data: PageData } = $props();
-    const { sampleSize } = $derived(data);
+    const sampleSize = $derived(data.sampleSize);
     const datasetId = $derived(page.params.dataset_id!);
     const collectionId = $derived(page.params.collection_id!);
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/annotations/[annotationId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/annotations/[annotationId]/+page.svelte
@@ -12,7 +12,7 @@
 
     const collectionId = $derived(page.params.collection_id!);
 
-    const annotationId = $derived(page.params.annotationId);
+    const annotationId = $derived(page.params.annotationId!);
 
     const {
         annotation: annotationDetailsResponse,

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/captions/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/captions/+page.svelte
@@ -2,7 +2,7 @@
     import { page } from '$app/state';
     import Captions from '$lib/components/Captions/Captions.svelte';
 
-    const collectionId = $derived(page.params.collection_id);
+    const collectionId = $derived(page.params.collection_id!);
 </script>
 
 {#key collectionId}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/frames/+page.svelte
@@ -20,7 +20,7 @@
     import { useScrollRestoration } from '$lib/hooks/useScrollRestoration/useScrollRestoration';
     import { onMount } from 'svelte';
 
-    const collectionId = $derived(page.params.collection_id);
+    const collectionId = $derived(page.params.collection_id!);
 
     const { metadataValues } = $derived(useMetadataFilters(collectionId));
     const { videoFramesBoundsValues } = $derived(useVideoFramesBounds(collectionId));

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/+page.svelte
@@ -6,10 +6,8 @@
 
     const { data } = $props();
 
-    const {
-        sampleSize,
-        globalStorage: { textEmbedding }
-    } = data;
+    const sampleSize = $derived(data.sampleSize);
+    const textEmbedding = $derived(data.globalStorage.textEmbedding);
 
     const collection_id = $derived(page.params.collection_id!);
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/images/[sampleId]/+page.svelte
@@ -11,7 +11,7 @@
 
     createSampleDetailsToolbarContext();
 
-    const sampleId = $derived(page.params.sampleId);
+    const sampleId = $derived(page.params.sampleId!);
     const datasetId = $derived(page.params.dataset_id!);
     const collectionType = $derived(page.params.collection_type);
     const collection = page.data.collection;

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import * as appState from '$app/state';
-import type { Page } from '@sveltejs/kit';
 import { tick } from 'svelte';
 import '@testing-library/jest-dom';
 
@@ -177,10 +176,7 @@ function setPageRoute(routeId: string | null): void {
             collection_id: 'test-collection-id',
             collection_type: 'image'
         }
-    } as Partial<Page<Record<string, string>, string | null>> as Page<
-        Record<string, string>,
-        string | null
-    >);
+    } as unknown as typeof appState.page);
 }
 
 beforeEach(() => {

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
@@ -25,11 +25,9 @@
             ? ((n) => (Number.isNaN(n) ? undefined : n))(parseInt(data.frameNumber, 10))
             : undefined
     );
-    const { collection } = $derived.by(() =>
-        useCollectionWithChildren({
-            collectionId: data.params.collection_id
-        })
-    );
+    const { collection } = useCollectionWithChildren({
+        getCollectionId: () => data.params.collection_id
+    });
 </script>
 
 {#if typeof $video !== 'undefined'}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
@@ -27,7 +27,7 @@
     );
     const { collection } = $derived.by(() =>
         useCollectionWithChildren({
-            collectionId: data.params.dataset_id
+            collectionId: data.params.collection_id
         })
     );
 </script>

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/[sample_id]/+page.svelte
@@ -25,9 +25,11 @@
             ? ((n) => (Number.isNaN(n) ? undefined : n))(parseInt(data.frameNumber, 10))
             : undefined
     );
-    const { collection } = useCollectionWithChildren({
-        collectionId: data.params.dataset_id
-    });
+    const { collection } = $derived.by(() =>
+        useCollectionWithChildren({
+            collectionId: data.params.dataset_id
+        })
+    );
 </script>
 
 {#if typeof $video !== 'undefined'}


### PR DESCRIPTION
## What has changed and why?

Upgrades @sveltejs/adapter-auto to v7 and @sveltejs/vite-plugin-svelte to v6. 

To fix the reactivity warnings that surfaced after the upgrade, hooks that previously accepted plain string IDs now accept getter functions (getCollectionId: () => string) so values are read lazily inside reactive contexts.                                                         

A few remaining call sites use $derived.by() as a temporary workaround - a follow-up issue will clean those up.

## How has it been tested?

Unit tests + e2e + manual test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when navigating annotation, image, video, frame, and collection detail views.
  * Fixed reactive updates for filters, selections, annotations, labels, metadata, plots, and dataset distributions.
  * Improved annotation creation, editing, deletion, and segmentation behavior.
  * Improved video playback readiness, frame loading, and evaluation metric updates.
* **Accessibility**
  * Added semantic region labeling to the sample details toolbar.
* **Chores**
  * Updated application build and testing tooling for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->