### PR TITLE
Drop placeholder path defaults from example scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,9 +124,7 @@ This clones the data into `lightly_studio/datasets`, which is where the `EXAMPLE
 
 ### Define Environment Variables
 
-The example scripts and `make start` read their dataset paths from environment variables, so
-this step is required, not optional — without it they fail immediately with
-`Environment variable "EXAMPLES_..." not set`. Copy `.env.example` to `.env`:
+Copy `.env.example` to `.env`:
 
 ```shell
 cd lightly_studio

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,9 @@ This clones the data into `lightly_studio/datasets`, which is where the `EXAMPLE
 
 ### Define Environment Variables
 
-We recommend using the `.env` file to set up environment variables. Start by copying `.env.example`
-file to `.env`:
+The example scripts and `make start` read their dataset paths from environment variables, so
+this step is required, not optional — without it they fail immediately with
+`Environment variable "EXAMPLES_..." not set`. Copy `.env.example` to `.env`:
 
 ```shell
 cd lightly_studio

--- a/lightly_studio/src/lightly_studio/examples/coco_plugins_demo/example_coco_plugins.py
+++ b/lightly_studio/src/lightly_studio/examples/coco_plugins_demo/example_coco_plugins.py
@@ -19,7 +19,7 @@ Development setup:
   them via `pip install --upgrade` to avoid runtime or import errors.
 """
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -40,8 +40,22 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define data paths
-annotations_json = env.path("EXAMPLES_COCO_JSON_PATH", "/path/to/your/dataset/annotations.json")
-images_path = env.path("EXAMPLES_COCO_IMAGES_PATH", "/path/to/your/dataset")
+try:
+    annotations_json = env.path("EXAMPLES_COCO_JSON_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_COCO_JSON_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_COCO_JSON_PATH (see CONTRIBUTING.md)."
+    ) from e
+try:
+    images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_COCO_IMAGES_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_COCO_IMAGES_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 # Create the dataset
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/coco_plugins_demo/example_coco_plugins.py
+++ b/lightly_studio/src/lightly_studio/examples/coco_plugins_demo/example_coco_plugins.py
@@ -19,7 +19,7 @@ Development setup:
   them via `pip install --upgrade` to avoid runtime or import errors.
 """
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -40,22 +40,8 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define data paths
-try:
-    annotations_json = env.path("EXAMPLES_COCO_JSON_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_COCO_JSON_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_COCO_JSON_PATH (see CONTRIBUTING.md)."
-    ) from e
-try:
-    images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_COCO_IMAGES_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_COCO_IMAGES_PATH (see CONTRIBUTING.md)."
-    ) from e
+annotations_json = env.path("EXAMPLES_COCO_JSON_PATH")
+images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
 
 # Create the dataset
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example.py
+++ b/lightly_studio/src/lightly_studio/examples/example.py
@@ -1,6 +1,6 @@
 """Example of how to load samples from path with the dataset class."""
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,14 +13,7 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-try:
-    dataset_path = env.path("EXAMPLES_DATASET_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_DATASET_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_DATASET_PATH (see CONTRIBUTING.md)."
-    ) from e
+dataset_path = env.path("EXAMPLES_DATASET_PATH")
 
 # Create a Dataset from a path
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example.py
+++ b/lightly_studio/src/lightly_studio/examples/example.py
@@ -1,6 +1,6 @@
 """Example of how to load samples from path with the dataset class."""
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,7 +13,13 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-dataset_path = env.path("EXAMPLES_DATASET_PATH", "/path/to/your/dataset")
+try:
+    dataset_path = env.path("EXAMPLES_DATASET_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_DATASET_PATH is not set. Run `cp .env.example .env` in "
+        "lightly_studio/ and set EXAMPLES_DATASET_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 # Create a Dataset from a path
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example.py
+++ b/lightly_studio/src/lightly_studio/examples/example.py
@@ -17,8 +17,9 @@ try:
     dataset_path = env.path("EXAMPLES_DATASET_PATH")
 except EnvError as e:
     raise EnvError(
-        "EXAMPLES_DATASET_PATH is not set. Run `cp .env.example .env` in "
-        "lightly_studio/ and set EXAMPLES_DATASET_PATH (see CONTRIBUTING.md)."
+        "EXAMPLES_DATASET_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_DATASET_PATH (see CONTRIBUTING.md)."
     ) from e
 
 # Create a Dataset from a path

--- a/lightly_studio/src/lightly_studio/examples/example_coco.py
+++ b/lightly_studio/src/lightly_studio/examples/example_coco.py
@@ -1,6 +1,6 @@
 """Example of how to add samples in coco format to a dataset."""
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,8 +13,22 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define data paths
-annotations_json = env.path("EXAMPLES_COCO_JSON_PATH", "/path/to/your/dataset/annotations.json")
-images_path = env.path("EXAMPLES_COCO_IMAGES_PATH", "/path/to/your/dataset")
+try:
+    annotations_json = env.path("EXAMPLES_COCO_JSON_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_COCO_JSON_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_COCO_JSON_PATH (see CONTRIBUTING.md)."
+    ) from e
+try:
+    images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_COCO_IMAGES_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_COCO_IMAGES_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 # Create a DatasetLoader from a path
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_coco.py
+++ b/lightly_studio/src/lightly_studio/examples/example_coco.py
@@ -1,6 +1,6 @@
 """Example of how to add samples in coco format to a dataset."""
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,22 +13,8 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define data paths
-try:
-    annotations_json = env.path("EXAMPLES_COCO_JSON_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_COCO_JSON_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_COCO_JSON_PATH (see CONTRIBUTING.md)."
-    ) from e
-try:
-    images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_COCO_IMAGES_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_COCO_IMAGES_PATH (see CONTRIBUTING.md)."
-    ) from e
+annotations_json = env.path("EXAMPLES_COCO_JSON_PATH")
+images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
 
 # Create a DatasetLoader from a path
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_coco_caption.py
+++ b/lightly_studio/src/lightly_studio/examples/example_coco_caption.py
@@ -1,6 +1,6 @@
 """Example of how to add samples in coco caption format to a dataset."""
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,10 +13,23 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define data paths
-annotations_json = env.path(
-    "EXAMPLES_COCO_CAPTION_JSON_PATH", "/path/to/your/dataset/annotations.json"
-)
-images_path = env.path("EXAMPLES_COCO_CAPTION_IMAGES_PATH", "/path/to/your/dataset")
+try:
+    annotations_json = env.path("EXAMPLES_COCO_CAPTION_JSON_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_COCO_CAPTION_JSON_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_COCO_CAPTION_JSON_PATH (see CONTRIBUTING.md)."
+    ) from e
+try:
+    images_path = env.path("EXAMPLES_COCO_CAPTION_IMAGES_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_COCO_CAPTION_IMAGES_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_COCO_CAPTION_IMAGES_PATH "
+        "(see CONTRIBUTING.md)."
+    ) from e
 
 
 # Create a DatasetLoader from a path

--- a/lightly_studio/src/lightly_studio/examples/example_coco_caption.py
+++ b/lightly_studio/src/lightly_studio/examples/example_coco_caption.py
@@ -1,6 +1,6 @@
 """Example of how to add samples in coco caption format to a dataset."""
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,23 +13,8 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define data paths
-try:
-    annotations_json = env.path("EXAMPLES_COCO_CAPTION_JSON_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_COCO_CAPTION_JSON_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_COCO_CAPTION_JSON_PATH (see CONTRIBUTING.md)."
-    ) from e
-try:
-    images_path = env.path("EXAMPLES_COCO_CAPTION_IMAGES_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_COCO_CAPTION_IMAGES_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_COCO_CAPTION_IMAGES_PATH "
-        "(see CONTRIBUTING.md)."
-    ) from e
+annotations_json = env.path("EXAMPLES_COCO_CAPTION_JSON_PATH")
+images_path = env.path("EXAMPLES_COCO_CAPTION_IMAGES_PATH")
 
 
 # Create a DatasetLoader from a path

--- a/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
@@ -151,7 +151,7 @@ db_manager.connect(cleanup_existing=True)
 ls.set_default_embedding_model(CustomEmbeddingGenerator())
 
 # Define the path to the dataset directory
-dataset_path = env.path("EXAMPLES_DATASET_PATH", "/path/to/your/dataset")
+dataset_path = env.path("EXAMPLES_DATASET_PATH")
 
 # Create a Dataset from a path. Images are embedded with the custom model.
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_evaluation.py
+++ b/lightly_studio/src/lightly_studio/examples/example_evaluation.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from time import perf_counter
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.core.dataset_query import ImageSampleField
@@ -82,31 +82,9 @@ def main() -> None:
 
     db_manager.connect(cleanup_existing=True)
 
-    try:
-        images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
-    except EnvError as e:
-        raise EnvError(
-            "EXAMPLES_COCO_IMAGES_PATH is not set. In lightly_studio/, clone the example "
-            "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-            "run `cp .env.example .env` and set EXAMPLES_COCO_IMAGES_PATH (see CONTRIBUTING.md)."
-        ) from e
-    try:
-        gt_annotations_json = env.path("EXAMPLES_COCO_JSON_PATH")
-    except EnvError as e:
-        raise EnvError(
-            "EXAMPLES_COCO_JSON_PATH is not set. In lightly_studio/, clone the example "
-            "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-            "run `cp .env.example .env` and set EXAMPLES_COCO_JSON_PATH (see CONTRIBUTING.md)."
-        ) from e
-    try:
-        pred_annotations_json = env.path("EXAMPLES_PRED_ANNOTATIONS_JSON")
-    except EnvError as e:
-        raise EnvError(
-            "EXAMPLES_PRED_ANNOTATIONS_JSON is not set. In lightly_studio/, clone the example "
-            "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-            "run `cp .env.example .env` and set EXAMPLES_PRED_ANNOTATIONS_JSON "
-            "(see CONTRIBUTING.md)."
-        ) from e
+    images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
+    gt_annotations_json = env.path("EXAMPLES_COCO_JSON_PATH")
+    pred_annotations_json = env.path("EXAMPLES_PRED_ANNOTATIONS_JSON")
     evaluation_config = ObjectDetectionEvaluationConfig(
         iou_threshold=0.5,
         classwise=True,

--- a/lightly_studio/src/lightly_studio/examples/example_evaluation.py
+++ b/lightly_studio/src/lightly_studio/examples/example_evaluation.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from time import perf_counter
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.core.dataset_query import ImageSampleField
@@ -82,9 +82,31 @@ def main() -> None:
 
     db_manager.connect(cleanup_existing=True)
 
-    images_path = env.path("EXAMPLES_COCO_IMAGES_PATH", "/path/to/your/images")
-    gt_annotations_json = env.path("EXAMPLES_COCO_JSON_PATH", "/path/to/your/gt.json")
-    pred_annotations_json = env.path("EXAMPLES_PRED_ANNOTATIONS_JSON", "/path/to/your/pred.json")
+    try:
+        images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
+    except EnvError as e:
+        raise EnvError(
+            "EXAMPLES_COCO_IMAGES_PATH is not set. In lightly_studio/, clone the example "
+            "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+            "run `cp .env.example .env` and set EXAMPLES_COCO_IMAGES_PATH (see CONTRIBUTING.md)."
+        ) from e
+    try:
+        gt_annotations_json = env.path("EXAMPLES_COCO_JSON_PATH")
+    except EnvError as e:
+        raise EnvError(
+            "EXAMPLES_COCO_JSON_PATH is not set. In lightly_studio/, clone the example "
+            "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+            "run `cp .env.example .env` and set EXAMPLES_COCO_JSON_PATH (see CONTRIBUTING.md)."
+        ) from e
+    try:
+        pred_annotations_json = env.path("EXAMPLES_PRED_ANNOTATIONS_JSON")
+    except EnvError as e:
+        raise EnvError(
+            "EXAMPLES_PRED_ANNOTATIONS_JSON is not set. In lightly_studio/, clone the example "
+            "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+            "run `cp .env.example .env` and set EXAMPLES_PRED_ANNOTATIONS_JSON "
+            "(see CONTRIBUTING.md)."
+        ) from e
     evaluation_config = ObjectDetectionEvaluationConfig(
         iou_threshold=0.5,
         classwise=True,

--- a/lightly_studio/src/lightly_studio/examples/example_evaluation_classification.py
+++ b/lightly_studio/src/lightly_studio/examples/example_evaluation_classification.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from time import perf_counter
 from uuid import UUID
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.core.annotation.annotation_create import CreateClassification
@@ -135,7 +135,14 @@ def main() -> None:
 
     db_manager.connect(cleanup_existing=True)
 
-    images_path = env.path("EXAMPLES_COCO_IMAGES_PATH", "/path/to/your/images")
+    try:
+        images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
+    except EnvError as e:
+        raise EnvError(
+            "EXAMPLES_COCO_IMAGES_PATH is not set. In lightly_studio/, clone the example "
+            "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+            "run `cp .env.example .env` and set EXAMPLES_COCO_IMAGES_PATH (see CONTRIBUTING.md)."
+        ) from e
 
     dataset = ImageDataset.create(name=DATASET_NAME)
     dataset.add_images_from_path(path=images_path)

--- a/lightly_studio/src/lightly_studio/examples/example_evaluation_classification.py
+++ b/lightly_studio/src/lightly_studio/examples/example_evaluation_classification.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from time import perf_counter
 from uuid import UUID
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.core.annotation.annotation_create import CreateClassification
@@ -135,14 +135,7 @@ def main() -> None:
 
     db_manager.connect(cleanup_existing=True)
 
-    try:
-        images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
-    except EnvError as e:
-        raise EnvError(
-            "EXAMPLES_COCO_IMAGES_PATH is not set. In lightly_studio/, clone the example "
-            "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-            "run `cp .env.example .env` and set EXAMPLES_COCO_IMAGES_PATH (see CONTRIBUTING.md)."
-        ) from e
+    images_path = env.path("EXAMPLES_COCO_IMAGES_PATH")
 
     dataset = ImageDataset.create(name=DATASET_NAME)
     dataset.add_images_from_path(path=images_path)

--- a/lightly_studio/src/lightly_studio/examples/example_evaluation_semantic_segmentation.py
+++ b/lightly_studio/src/lightly_studio/examples/example_evaluation_semantic_segmentation.py
@@ -92,18 +92,13 @@ def main() -> None:
     db_manager.connect(cleanup_existing=True)
 
     # Define data paths
-    images_path = env.path("EXAMPLES_PASCALVOC_IMAGES_PATH", "/path/to/your/dataset/images")
-    gt_masks_path = env.path("EXAMPLES_PASCALVOC_MASKS_PATH", "/path/to/your/dataset/masks")
-    pred_masks_path = env.path(
-        "EXAMPLES_PASCALVOC_PRED_MASKS_PATH", "/path/to/your/dataset/pred_masks"
-    )
+    images_path = env.path("EXAMPLES_PASCALVOC_IMAGES_PATH")
+    gt_masks_path = env.path("EXAMPLES_PASCALVOC_MASKS_PATH")
+    pred_masks_path = env.path("EXAMPLES_PASCALVOC_PRED_MASKS_PATH")
 
     # A mapping from class IDs to class names must be provided. We load it from a JSON file,
     # the file is not part of the Pascal VOC format.
-    class_id_to_name_path = env.path(
-        "EXAMPLES_PASCALVOC_CATEGORIES_JSON_PATH",
-        "/path/to/your/dataset/class_id_to_name.json",
-    )
+    class_id_to_name_path = env.path("EXAMPLES_PASCALVOC_CATEGORIES_JSON_PATH")
     json_dict = json.loads(Path(class_id_to_name_path).read_text())
     class_id_to_name = {int(k): v for k, v in json_dict.items()}
 

--- a/lightly_studio/src/lightly_studio/examples/example_group.py
+++ b/lightly_studio/src/lightly_studio/examples/example_group.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 
@@ -11,14 +11,7 @@ env = Env()
 env.read_env()
 
 # Set the path to the dataset directory
-try:
-    dataset_path = env.path("EXAMPLES_MIDV_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_MIDV_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_MIDV_PATH (see CONTRIBUTING.md)."
-    ) from e
+dataset_path = env.path("EXAMPLES_MIDV_PATH")
 
 # Cleanup an existing database
 ls.db_manager.connect(cleanup_existing=True)

--- a/lightly_studio/src/lightly_studio/examples/example_group.py
+++ b/lightly_studio/src/lightly_studio/examples/example_group.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 
@@ -11,7 +11,14 @@ env = Env()
 env.read_env()
 
 # Set the path to the dataset directory
-dataset_path = env.path("EXAMPLES_MIDV_PATH", "/path/to/midv/dataset")
+try:
+    dataset_path = env.path("EXAMPLES_MIDV_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_MIDV_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_MIDV_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 # Cleanup an existing database
 ls.db_manager.connect(cleanup_existing=True)

--- a/lightly_studio/src/lightly_studio/examples/example_group_operators.py
+++ b/lightly_studio/src/lightly_studio/examples/example_group_operators.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from environs import Env
+from environs import Env, EnvError
 from sqlmodel import Session
 
 import lightly_studio as ls
@@ -312,7 +312,14 @@ operator_registry.register(operator=DemoVideoOperator())
 operator_registry.register(operator=DemoAnnotationOperator())
 operator_registry.register(operator=DemoGroupOperator())
 
-dataset_path = env.path("EXAMPLES_MIDV_PATH", "/path/to/midv/dataset")
+try:
+    dataset_path = env.path("EXAMPLES_MIDV_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_MIDV_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_MIDV_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 dataset = ls.GroupDataset.create(
     components=[

--- a/lightly_studio/src/lightly_studio/examples/example_group_operators.py
+++ b/lightly_studio/src/lightly_studio/examples/example_group_operators.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from environs import Env, EnvError
+from environs import Env
 from sqlmodel import Session
 
 import lightly_studio as ls
@@ -312,14 +312,7 @@ operator_registry.register(operator=DemoVideoOperator())
 operator_registry.register(operator=DemoAnnotationOperator())
 operator_registry.register(operator=DemoGroupOperator())
 
-try:
-    dataset_path = env.path("EXAMPLES_MIDV_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_MIDV_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_MIDV_PATH (see CONTRIBUTING.md)."
-    ) from e
+dataset_path = env.path("EXAMPLES_MIDV_PATH")
 
 dataset = ls.GroupDataset.create(
     components=[

--- a/lightly_studio/src/lightly_studio/examples/example_metadata.py
+++ b/lightly_studio/src/lightly_studio/examples/example_metadata.py
@@ -15,7 +15,7 @@ from collections.abc import Mapping
 from typing import Any
 from uuid import UUID
 
-from environs import Env, EnvError
+from environs import Env
 from sqlmodel import Session
 
 import lightly_studio as ls
@@ -30,14 +30,7 @@ from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 # Environment variables
 env = Env()
 env.read_env()
-try:
-    dataset_path = env.path("EXAMPLES_DATASET_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_DATASET_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_DATASET_PATH (see CONTRIBUTING.md)."
-    ) from e
+dataset_path = env.path("EXAMPLES_DATASET_PATH")
 
 
 def load_existing_dataset() -> tuple[ls.ImageDataset, list[ImageSample]]:

--- a/lightly_studio/src/lightly_studio/examples/example_metadata.py
+++ b/lightly_studio/src/lightly_studio/examples/example_metadata.py
@@ -15,7 +15,7 @@ from collections.abc import Mapping
 from typing import Any
 from uuid import UUID
 
-from environs import Env
+from environs import Env, EnvError
 from sqlmodel import Session
 
 import lightly_studio as ls
@@ -30,7 +30,14 @@ from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 # Environment variables
 env = Env()
 env.read_env()
-dataset_path = env.path("EXAMPLES_DATASET_PATH", "/path/to/your/dataset")
+try:
+    dataset_path = env.path("EXAMPLES_DATASET_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_DATASET_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_DATASET_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 
 def load_existing_dataset() -> tuple[ls.ImageDataset, list[ImageSample]]:

--- a/lightly_studio/src/lightly_studio/examples/example_operators.py
+++ b/lightly_studio/src/lightly_studio/examples/example_operators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from environs import Env, EnvError
+from environs import Env
 from sqlmodel import Session
 
 import lightly_studio as ls
@@ -107,14 +107,7 @@ for i in range(20):
     operator_registry.register(operator=TestOperator(name=f"test_{i}"))
 
 # Define data path
-try:
-    dataset_path = env.path("EXAMPLES_DATASET_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_DATASET_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_DATASET_PATH (see CONTRIBUTING.md)."
-    ) from e
+dataset_path = env.path("EXAMPLES_DATASET_PATH")
 
 # Create a DatasetLoader from a path
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_operators.py
+++ b/lightly_studio/src/lightly_studio/examples/example_operators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from environs import Env
+from environs import Env, EnvError
 from sqlmodel import Session
 
 import lightly_studio as ls
@@ -107,7 +107,14 @@ for i in range(20):
     operator_registry.register(operator=TestOperator(name=f"test_{i}"))
 
 # Define data path
-dataset_path = env.path("EXAMPLES_DATASET_PATH", "/path/to/your/dataset")
+try:
+    dataset_path = env.path("EXAMPLES_DATASET_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_DATASET_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_DATASET_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 # Create a DatasetLoader from a path
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_pascal_voc.py
+++ b/lightly_studio/src/lightly_studio/examples/example_pascal_voc.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -16,15 +16,34 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define data paths
-images_path = env.path("EXAMPLES_PASCALVOC_IMAGES_PATH", "/path/to/your/dataset/images")
-masks_path = env.path("EXAMPLES_PASCALVOC_MASKS_PATH", "/path/to/your/dataset/masks")
+try:
+    images_path = env.path("EXAMPLES_PASCALVOC_IMAGES_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_PASCALVOC_IMAGES_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_PASCALVOC_IMAGES_PATH (see CONTRIBUTING.md)."
+    ) from e
+try:
+    masks_path = env.path("EXAMPLES_PASCALVOC_MASKS_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_PASCALVOC_MASKS_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_PASCALVOC_MASKS_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 # A mapping from class IDs to class names must be provided. We load it from a JSON file,
 # the file is not part of the Pascal VOC format.
-class_id_to_name_path = env.path(
-    "EXAMPLES_PASCALVOC_CATEGORIES_JSON_PATH",
-    "/path/to/your/dataset/class_id_to_name.json",
-)
+try:
+    class_id_to_name_path = env.path("EXAMPLES_PASCALVOC_CATEGORIES_JSON_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_PASCALVOC_CATEGORIES_JSON_PATH is not set. In lightly_studio/, clone the "
+        "example dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_PASCALVOC_CATEGORIES_JSON_PATH "
+        "(see CONTRIBUTING.md)."
+    ) from e
 json_dict = json.loads(Path(class_id_to_name_path).read_text())
 class_id_to_name = {int(k): v for k, v in json_dict.items()}
 

--- a/lightly_studio/src/lightly_studio/examples/example_pascal_voc.py
+++ b/lightly_studio/src/lightly_studio/examples/example_pascal_voc.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -16,34 +16,12 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define data paths
-try:
-    images_path = env.path("EXAMPLES_PASCALVOC_IMAGES_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_PASCALVOC_IMAGES_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_PASCALVOC_IMAGES_PATH (see CONTRIBUTING.md)."
-    ) from e
-try:
-    masks_path = env.path("EXAMPLES_PASCALVOC_MASKS_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_PASCALVOC_MASKS_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_PASCALVOC_MASKS_PATH (see CONTRIBUTING.md)."
-    ) from e
+images_path = env.path("EXAMPLES_PASCALVOC_IMAGES_PATH")
+masks_path = env.path("EXAMPLES_PASCALVOC_MASKS_PATH")
 
 # A mapping from class IDs to class names must be provided. We load it from a JSON file,
 # the file is not part of the Pascal VOC format.
-try:
-    class_id_to_name_path = env.path("EXAMPLES_PASCALVOC_CATEGORIES_JSON_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_PASCALVOC_CATEGORIES_JSON_PATH is not set. In lightly_studio/, clone the "
-        "example dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_PASCALVOC_CATEGORIES_JSON_PATH "
-        "(see CONTRIBUTING.md)."
-    ) from e
+class_id_to_name_path = env.path("EXAMPLES_PASCALVOC_CATEGORIES_JSON_PATH")
 json_dict = json.loads(Path(class_id_to_name_path).read_text())
 class_id_to_name = {int(k): v for k, v in json_dict.items()}
 

--- a/lightly_studio/src/lightly_studio/examples/example_predictions_lightly_format.py
+++ b/lightly_studio/src/lightly_studio/examples/example_predictions_lightly_format.py
@@ -1,6 +1,6 @@
 """Example of how to add samples with predictions in Lightly format to a dataset."""
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,7 +13,14 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define data paths
-input_folder = env.path("EXAMPLES_LIGHTLY_PREDICTIONS", "/path/to/your/dataset/annotations.json")
+try:
+    input_folder = env.path("EXAMPLES_LIGHTLY_PREDICTIONS")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_LIGHTLY_PREDICTIONS is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_LIGHTLY_PREDICTIONS (see CONTRIBUTING.md)."
+    ) from e
 
 # Create a DatasetLoader from a path
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_predictions_lightly_format.py
+++ b/lightly_studio/src/lightly_studio/examples/example_predictions_lightly_format.py
@@ -1,6 +1,6 @@
 """Example of how to add samples with predictions in Lightly format to a dataset."""
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,14 +13,7 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define data paths
-try:
-    input_folder = env.path("EXAMPLES_LIGHTLY_PREDICTIONS")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_LIGHTLY_PREDICTIONS is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_LIGHTLY_PREDICTIONS (see CONTRIBUTING.md)."
-    ) from e
+input_folder = env.path("EXAMPLES_LIGHTLY_PREDICTIONS")
 
 # Create a DatasetLoader from a path
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_sampling.py
+++ b/lightly_studio/src/lightly_studio/examples/example_sampling.py
@@ -1,6 +1,6 @@
 """Example of how to run sampling class."""
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,14 +13,7 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-try:
-    dataset_path = env.path("EXAMPLES_DATASET_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_DATASET_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_DATASET_PATH (see CONTRIBUTING.md)."
-    ) from e
+dataset_path = env.path("EXAMPLES_DATASET_PATH")
 
 # Create a Dataset from a path
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_sampling.py
+++ b/lightly_studio/src/lightly_studio/examples/example_sampling.py
@@ -1,6 +1,6 @@
 """Example of how to run sampling class."""
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,7 +13,14 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-dataset_path = env.path("EXAMPLES_DATASET_PATH", "/path/to/your/dataset")
+try:
+    dataset_path = env.path("EXAMPLES_DATASET_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_DATASET_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_DATASET_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 # Create a Dataset from a path
 dataset = ls.ImageDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_split_work.py
+++ b/lightly_studio/src/lightly_studio/examples/example_split_work.py
@@ -2,7 +2,7 @@
 
 import math
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -18,7 +18,14 @@ db_manager.connect(cleanup_existing=True)
 dataset = ls.ImageDataset.create()
 
 # Define the path to the dataset (folder containing data.yaml)
-dataset_path = env.path("EXAMPLES_YOLO_YAML_PATH", "/path/to/your/yolo/dataset/data.yaml")
+try:
+    dataset_path = env.path("EXAMPLES_YOLO_YAML_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_YOLO_YAML_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_YOLO_YAML_PATH (see CONTRIBUTING.md)."
+    ) from e
 input_split = env.str("EXAMPLES_YOLO_SPLIT", "test")
 
 # Load YOLO dataset using data.yaml path

--- a/lightly_studio/src/lightly_studio/examples/example_split_work.py
+++ b/lightly_studio/src/lightly_studio/examples/example_split_work.py
@@ -2,7 +2,7 @@
 
 import math
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -18,14 +18,7 @@ db_manager.connect(cleanup_existing=True)
 dataset = ls.ImageDataset.create()
 
 # Define the path to the dataset (folder containing data.yaml)
-try:
-    dataset_path = env.path("EXAMPLES_YOLO_YAML_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_YOLO_YAML_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_YOLO_YAML_PATH (see CONTRIBUTING.md)."
-    ) from e
+dataset_path = env.path("EXAMPLES_YOLO_YAML_PATH")
 input_split = env.str("EXAMPLES_YOLO_SPLIT", "test")
 
 # Load YOLO dataset using data.yaml path

--- a/lightly_studio/src/lightly_studio/examples/example_video.py
+++ b/lightly_studio/src/lightly_studio/examples/example_video.py
@@ -1,6 +1,6 @@
 """Example of how to load videos from path with the dataset class."""
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.core.video.video_dataset import VideoDataset
@@ -14,14 +14,7 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-try:
-    dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_VIDEO_DATASET_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_VIDEO_DATASET_PATH (see CONTRIBUTING.md)."
-    ) from e
+dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH")
 
 # Create a Dataset from a path
 dataset = VideoDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_video.py
+++ b/lightly_studio/src/lightly_studio/examples/example_video.py
@@ -1,6 +1,6 @@
 """Example of how to load videos from path with the dataset class."""
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.core.video.video_dataset import VideoDataset
@@ -14,7 +14,14 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH", "/path/to/your/dataset")
+try:
+    dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_VIDEO_DATASET_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_VIDEO_DATASET_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 # Create a Dataset from a path
 dataset = VideoDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_video_annotations.py
+++ b/lightly_studio/src/lightly_studio/examples/example_video_annotations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.core.video.video_dataset import VideoDataset
@@ -17,8 +17,23 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH", "/path/to/your/dataset")
-annotations_path = env.path("EXAMPLES_VIDEO_YVIS_JSON_PATH", "/path/to/your/dataset/instances.json")
+try:
+    dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_VIDEO_DATASET_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_VIDEO_DATASET_PATH (see CONTRIBUTING.md)."
+    ) from e
+
+try:
+    annotations_path = env.path("EXAMPLES_VIDEO_YVIS_JSON_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_VIDEO_YVIS_JSON_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_VIDEO_YVIS_JSON_PATH (see CONTRIBUTING.md)."
+    ) from e
 
 # Create a Dataset from a path
 dataset = VideoDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_video_annotations.py
+++ b/lightly_studio/src/lightly_studio/examples/example_video_annotations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.core.video.video_dataset import VideoDataset
@@ -17,23 +17,8 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-try:
-    dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_VIDEO_DATASET_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_VIDEO_DATASET_PATH (see CONTRIBUTING.md)."
-    ) from e
-
-try:
-    annotations_path = env.path("EXAMPLES_VIDEO_YVIS_JSON_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_VIDEO_YVIS_JSON_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_VIDEO_YVIS_JSON_PATH (see CONTRIBUTING.md)."
-    ) from e
+dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH")
+annotations_path = env.path("EXAMPLES_VIDEO_YVIS_JSON_PATH")
 
 # Create a Dataset from a path
 dataset = VideoDataset.create()

--- a/lightly_studio/src/lightly_studio/examples/example_video_frames.py
+++ b/lightly_studio/src/lightly_studio/examples/example_video_frames.py
@@ -21,7 +21,7 @@ from lightly_studio.database import db_manager
 env = Env()
 env.read_env()
 db_manager.connect(cleanup_existing=True)
-dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH", "/path/to/your/dataset")
+dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH")
 
 dataset = ls.VideoDataset.create()
 dataset.add_videos_from_path(path=dataset_path, embed=False, target_fps=1)

--- a/lightly_studio/src/lightly_studio/examples/example_yolo.py
+++ b/lightly_studio/src/lightly_studio/examples/example_yolo.py
@@ -1,6 +1,6 @@
 """Example of how to add samples in yolo format to a dataset."""
 
-from environs import Env
+from environs import Env, EnvError
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,7 +13,14 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-dataset_path = env.path("EXAMPLES_YOLO_YAML_PATH", "/path/to/your/dataset/data.yaml")
+try:
+    dataset_path = env.path("EXAMPLES_YOLO_YAML_PATH")
+except EnvError as e:
+    raise EnvError(
+        "EXAMPLES_YOLO_YAML_PATH is not set. In lightly_studio/, clone the example "
+        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
+        "run `cp .env.example .env` and set EXAMPLES_YOLO_YAML_PATH (see CONTRIBUTING.md)."
+    ) from e
 input_split = env.str("EXAMPLES_YOLO_SPLIT", "train")
 
 # Create a DatasetLoader from a path

--- a/lightly_studio/src/lightly_studio/examples/example_yolo.py
+++ b/lightly_studio/src/lightly_studio/examples/example_yolo.py
@@ -1,6 +1,6 @@
 """Example of how to add samples in yolo format to a dataset."""
 
-from environs import Env, EnvError
+from environs import Env
 
 import lightly_studio as ls
 from lightly_studio.database import db_manager
@@ -13,14 +13,7 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-try:
-    dataset_path = env.path("EXAMPLES_YOLO_YAML_PATH")
-except EnvError as e:
-    raise EnvError(
-        "EXAMPLES_YOLO_YAML_PATH is not set. In lightly_studio/, clone the example "
-        "dataset (`git clone https://github.com/lightly-ai/dataset_examples`), then "
-        "run `cp .env.example .env` and set EXAMPLES_YOLO_YAML_PATH (see CONTRIBUTING.md)."
-    ) from e
+dataset_path = env.path("EXAMPLES_YOLO_YAML_PATH")
 input_split = env.str("EXAMPLES_YOLO_SPLIT", "train")
 
 # Create a DatasetLoader from a path


### PR DESCRIPTION
## What has changed and why?

Every example script fell back to a literal `"/path/to/your/dataset"` placeholder when its `EXAMPLES_*` env var wasn't set, then failed deep inside dataset-loading code with an unrelated-looking error. Nobody actually relies on those placeholder defaults — everyone sets up `.env`. Dropping them lets `environs` raise its own clear `Environment variable "EXAMPLES_..." not set` error instead. Also reworded the `.env` setup step in CONTRIBUTING.md to make clear it's required, not optional.

## How has it been tested?

Ran `example.py` with no `.env` present — now raises `environs.EnvError: Environment variable "EXAMPLES_DATASET_PATH" not set` instead of the old confusing downstream error. `make static-checks` passes.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to require copying `.env.example` to `.env`.
  * Clarified that example scripts and startup commands fail when required configuration is missing.

* **Bug Fixes**
  * Removed placeholder fallback paths from example datasets, annotations, images, videos, and prediction files.
  * Example workflows now require the corresponding `EXAMPLES_*` environment variables to be configured explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->