### PR TITLE
Raise a clear error when a DuckDB file is already locked by another process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Annotation class names no longer overflow in class selection.
 - Autofocus lets users create their first annotation faster.
+- Opening a DuckDB database that another lightly_studio process already has open now raises a clear error instead of a raw DuckDB traceback.
 
 ### Security
 

--- a/lightly_studio/src/lightly_studio/database/db_manager.py
+++ b/lightly_studio/src/lightly_studio/database/db_manager.py
@@ -320,12 +320,9 @@ def _create_duckdb_schema(engine: Engine, engine_url: str) -> None:
     except OperationalError as e:
         if isinstance(e.orig, duckdb.IOException) and "Could not set lock" in str(e.orig):
             raise RuntimeError(
-                f"Could not open the DuckDB database at {engine_url!r}: another process "
-                "already has it open. DuckDB only allows one process to access a "
-                "database file at a time, so close the other lightly_studio process "
-                "(e.g. the GUI server or another script) before running this one, or "
-                "point this process at a different database with "
-                "LIGHTLY_STUDIO_DATABASE_URL."
+                f"DuckDB database at {engine_url!r} is locked by another process. "
+                "Close the other lightly_studio process, or set "
+                "LIGHTLY_STUDIO_DATABASE_URL to point at a different database."
             ) from e
         raise
 

--- a/lightly_studio/src/lightly_studio/database/db_manager.py
+++ b/lightly_studio/src/lightly_studio/database/db_manager.py
@@ -66,6 +66,7 @@ class DatabaseEngine:
 
         Raises:
             FileNotFoundError: If must_exist is True and the database does not exist.
+            RuntimeError: If the DuckDB file is already open in another process.
         """
         if engine_url is not None:
             self._engine_url = engine_url

--- a/lightly_studio/src/lightly_studio/database/db_manager.py
+++ b/lightly_studio/src/lightly_studio/database/db_manager.py
@@ -20,10 +20,12 @@ from enum import Enum
 from pathlib import Path
 from typing import Annotated, Any
 
+import duckdb
 import sqlalchemy_utils
 from fastapi import Depends
 from sqlalchemy import StaticPool, text
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import OperationalError
 from sqlmodel import Session, SQLModel, create_engine
 
 import lightly_studio.api.db_tables  # noqa: F401, required for SQLModel to work properly
@@ -119,7 +121,7 @@ class DatabaseEngine:
                 cleanup_existing=cleanup_existing,
             )
         else:
-            SQLModel.metadata.create_all(self._engine)
+            _create_duckdb_schema(engine=self._engine, engine_url=self._engine_url)
 
     @contextmanager
     def session(self) -> Generator[Session, None, None]:
@@ -308,6 +310,23 @@ def _initialize_postgres_schema(
         logging.info("Dropped all tables in PostgreSQL database.")
 
     db_migrations.run_migrations(engine=engine, engine_url=engine_url)
+
+
+def _create_duckdb_schema(engine: Engine, engine_url: str) -> None:
+    """Create the DuckDB schema, raising a clear error if the file is locked elsewhere."""
+    try:
+        SQLModel.metadata.create_all(engine)
+    except OperationalError as e:
+        if isinstance(e.orig, duckdb.IOException) and "Could not set lock" in str(e.orig):
+            raise RuntimeError(
+                f"Could not open the DuckDB database at {engine_url!r}: another process "
+                "already has it open. DuckDB only allows one process to access a "
+                "database file at a time, so close the other lightly_studio process "
+                "(e.g. the GUI server or another script) before running this one, or "
+                "point this process at a different database with "
+                "LIGHTLY_STUDIO_DATABASE_URL."
+            ) from e
+        raise
 
 
 def _detect_backend_from_url(engine_url: str) -> DatabaseBackend:

--- a/lightly_studio/tests/database/test_db_manager.py
+++ b/lightly_studio/tests/database/test_db_manager.py
@@ -230,7 +230,7 @@ def test_database_engine__duckdb_lock_conflict_raises_clear_error(
         side_effect=OperationalError(statement="statement", params={}, orig=lock_error),
     )
 
-    with pytest.raises(RuntimeError, match=r"another process already has it open"):
+    with pytest.raises(RuntimeError, match=r"locked by another process"):
         DatabaseEngine(engine_url=f"duckdb:///{tmp_path / 'locked.db'}", single_threaded=True)
 
 
@@ -248,6 +248,11 @@ def test_database_engine__duckdb_non_lock_operational_error_propagates(
 
     with pytest.raises(OperationalError, match=r"Disk full"):
         DatabaseEngine(engine_url=f"duckdb:///{tmp_path / 'other.db'}", single_threaded=True)
+
+
+def test_duckdb_io_exception__is_operational_error() -> None:
+    """Regression guard: _create_duckdb_schema's lock detection assumes this holds."""
+    assert issubclass(duckdb.IOException, duckdb.OperationalError)
 
 
 def test_detect_backend_from_url() -> None:

--- a/lightly_studio/tests/database/test_db_manager.py
+++ b/lightly_studio/tests/database/test_db_manager.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import duckdb
 import pytest
 import sqlmodel
 from pytest_mock import MockerFixture
+from sqlalchemy.exc import OperationalError
 
 from lightly_studio import ImageDataset
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
@@ -211,6 +213,34 @@ def test_close__removes_wal_and_allows_reconnect(
 
     db_manager.connect(db_file=str(db_file), cleanup_existing=False)
     db_manager.close()
+
+
+def test_database_engine__duckdb_lock_conflict_raises_clear_error(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    patch_engine_singleton: None,  # noqa: ARG001
+) -> None:
+    """Test that a DuckDB lock conflict (another process has the file open) fails clearly.
+
+    We reproduced the real conflict manually by running two separate lightly_studio
+    processes against the same DuckDB file: the second one fails with a
+    ``sqlalchemy.exc.OperationalError`` wrapping a ``duckdb.IOException`` whose message
+    contains "Could not set lock". That failure only occurs across independent OS
+    processes, which is too OS-dependent to reproduce reliably in an automated test, so
+    here we raise the same exception at the exact point it originates (`SQLModel.
+    metadata.create_all`) to test the translation into a clear RuntimeError.
+    """
+    lock_error = duckdb.IOException(
+        f'Could not set lock on file "{tmp_path / "locked.db"}": '
+        "Conflicting lock is held in /usr/bin/python (PID 1234) by user someone."
+    )
+    mocker.patch(
+        "lightly_studio.database.db_manager.SQLModel.metadata.create_all",
+        side_effect=OperationalError("statement", {}, lock_error),
+    )
+
+    with pytest.raises(RuntimeError, match=r"another process already has it open"):
+        DatabaseEngine(engine_url=f"duckdb:///{tmp_path / 'locked.db'}", single_threaded=True)
 
 
 def test_detect_backend_from_url() -> None:

--- a/lightly_studio/tests/database/test_db_manager.py
+++ b/lightly_studio/tests/database/test_db_manager.py
@@ -222,13 +222,9 @@ def test_database_engine__duckdb_lock_conflict_raises_clear_error(
 ) -> None:
     """Test that a DuckDB lock conflict (another process has the file open) fails clearly.
 
-    We reproduced the real conflict manually by running two separate lightly_studio
-    processes against the same DuckDB file: the second one fails with a
-    ``sqlalchemy.exc.OperationalError`` wrapping a ``duckdb.IOException`` whose message
-    contains "Could not set lock". That failure only occurs across independent OS
-    processes, which is too OS-dependent to reproduce reliably in an automated test, so
-    here we raise the same exception at the exact point it originates (`SQLModel.
-    metadata.create_all`) to test the translation into a clear RuntimeError.
+    Simulates the conflict by raising it where it would actually originate
+    (`SQLModel.metadata.create_all`), since reproducing a real cross-process lock is
+    too OS-dependent for an automated test.
     """
     lock_error = duckdb.IOException(
         f'Could not set lock on file "{tmp_path / "locked.db"}": '

--- a/lightly_studio/tests/database/test_db_manager.py
+++ b/lightly_studio/tests/database/test_db_manager.py
@@ -220,23 +220,34 @@ def test_database_engine__duckdb_lock_conflict_raises_clear_error(
     mocker: MockerFixture,
     patch_engine_singleton: None,  # noqa: ARG001
 ) -> None:
-    """Test that a DuckDB lock conflict (another process has the file open) fails clearly.
-
-    Simulates the conflict by raising it where it would actually originate
-    (`SQLModel.metadata.create_all`), since reproducing a real cross-process lock is
-    too OS-dependent for an automated test.
-    """
+    """Test that a DuckDB lock conflict (another process has the file open) fails clearly."""
     lock_error = duckdb.IOException(
         f'Could not set lock on file "{tmp_path / "locked.db"}": '
         "Conflicting lock is held in /usr/bin/python (PID 1234) by user someone."
     )
     mocker.patch(
         "lightly_studio.database.db_manager.SQLModel.metadata.create_all",
-        side_effect=OperationalError("statement", {}, lock_error),
+        side_effect=OperationalError(statement="statement", params={}, orig=lock_error),
     )
 
     with pytest.raises(RuntimeError, match=r"another process already has it open"):
         DatabaseEngine(engine_url=f"duckdb:///{tmp_path / 'locked.db'}", single_threaded=True)
+
+
+def test_database_engine__duckdb_non_lock_operational_error_propagates(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    patch_engine_singleton: None,  # noqa: ARG001
+) -> None:
+    """Test that a non-lock OperationalError from DuckDB is not swallowed or rewritten."""
+    other_error = duckdb.IOException("Disk full")
+    mocker.patch(
+        "lightly_studio.database.db_manager.SQLModel.metadata.create_all",
+        side_effect=OperationalError(statement="statement", params={}, orig=other_error),
+    )
+
+    with pytest.raises(OperationalError, match=r"Disk full"):
+        DatabaseEngine(engine_url=f"duckdb:///{tmp_path / 'other.db'}", single_threaded=True)
 
 
 def test_detect_backend_from_url() -> None:


### PR DESCRIPTION
## What has changed and why?

DuckDB only allows one process to hold a database file open at a time. Running two lightly_studio processes against the same file (e.g. `lightly_studio gui` plus a dataset-loading script) makes the second one fail with a raw `duckdb.IOException`/`sqlalchemy.exc.OperationalError` traceback that doesn't say what's actually wrong. This catches that specific error and re-raises it as a `RuntimeError` naming the database path and telling the user to close the other process or point at a different DB via `LIGHTLY_STUDIO_DATABASE_URL`.

## How has it been tested?

Added `test_database_engine__duckdb_lock_conflict_raises_clear_error`, which mocks `SQLModel.metadata.create_all` to raise the exact exception shape DuckDB produces on a lock conflict, and asserts it's translated into the new `RuntimeError`.

I also reproduced the real conflict manually with two independent processes pointed at the same DuckDB file and confirmed the second one now prints the clear message instead of the raw traceback. A fully automated cross-process test turned out too OS-dependent to run reliably (subprocess-spawned children didn't consistently see the lock in this environment), so the automated test targets the translation logic directly instead.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Opening a DuckDB database already in use by another process now shows a clear, actionable error message instead of a raw database traceback.
  * Other database errors continue to be reported normally.

* **Documentation**
  * Added a changelog entry describing the improved database-lock error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->