### PR TITLE
Add: Output-sized annotation renderer

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.svelte
@@ -15,44 +15,67 @@
 <script lang="ts">
     import { onDestroy, onMount } from 'svelte';
     import { useCustomLabelColors, type CustomColor } from '$lib/hooks/useCustomLabelColors';
-    import { getColorByLabel, rgbaFromBytes } from '$lib/utils';
+    import { getColorByLabel } from '$lib/utils';
     import type { BoundingBox } from '$lib/types';
     import {
         acquireMaskRendererWorker,
         releaseMaskRendererWorker
     } from '$lib/workers/maskRendererPool';
+    import {
+        drawBoxesOnContext,
+        transformBoxes,
+        type RenderGeometry,
+        type SourceCrop
+    } from '$lib/workers/maskRendererUtils';
 
-    type InstanceAnnotation = {
+    interface InstanceAnnotation {
         annotation_type: 'segmentation_mask';
         annotation_label_name: string;
         segmentation_mask?: number[] | null;
         object_detection_details?: BoundingBox;
-    };
+        color?: string;
+        opacity?: number;
+    }
 
-    type ObjectDetectionAnnotation = {
+    interface ObjectDetectionAnnotation {
         annotation_type: 'object_detection';
         annotation_label_name: string;
         object_detection_details: BoundingBox;
         segmentation_mask?: undefined;
-    };
+        color?: string;
+        opacity?: number;
+    }
 
     type AnnotationCanvasAnnotation = InstanceAnnotation | ObjectDetectionAnnotation;
 
-    const {
-        sampleId,
-        width,
-        height,
-        annotations = [],
-        alpha = 0.4,
-        className = ''
-    }: {
+    interface Props {
         sampleId: string;
-        width: number;
-        height: number;
+        sourceWidth: number;
+        sourceHeight: number;
+        outputWidth?: number;
+        outputHeight?: number;
+        objectFit?: 'contain' | 'cover';
+        sourceCrop?: SourceCrop;
         annotations?: AnnotationCanvasAnnotation[];
         alpha?: number;
         className?: string;
-    } = $props();
+    }
+
+    const {
+        sampleId,
+        sourceWidth,
+        sourceHeight,
+        outputWidth,
+        outputHeight,
+        objectFit = 'contain',
+        sourceCrop,
+        annotations = [],
+        alpha = 0.4,
+        className = ''
+    }: Props = $props();
+
+    const canvasWidth = $derived(Math.max(1, Math.round(outputWidth ?? sourceWidth)));
+    const canvasHeight = $derived(Math.max(1, Math.round(outputHeight ?? sourceHeight)));
 
     const { customLabelColorsStore } = useCustomLabelColors();
 
@@ -60,7 +83,7 @@
     let worker: Worker | null = null;
     let workerReady = false;
     let hasOffscreen = false;
-    let resizeObserver: ResizeObserver | null = null;
+    let hasMainThreadContext = false;
     // Shared workers multiplex multiple canvases
     const canvasId = `${sampleId}-${createCanvasInstanceSuffix()}`;
 
@@ -102,6 +125,22 @@
 
     type CustomLabelColorMap = Record<string, CustomColor>;
 
+    interface ContextOptions {
+        willReadFrequently?: boolean;
+    }
+
+    const getMainThreadContext = (options?: ContextOptions): CanvasRenderingContext2D | null => {
+        if (!canvasEl || hasOffscreen) {
+            return null;
+        }
+
+        const context = canvasEl.getContext('2d', options) as CanvasRenderingContext2D | null;
+        if (context) {
+            hasMainThreadContext = true;
+        }
+        return context;
+    };
+
     const clampAlpha = (value: number): number => Math.max(0, Math.min(value, 1));
 
     const resolveLabelColor = (
@@ -117,6 +156,23 @@
         const [r, g, b] = rgbaParser(customColor.color);
         const alphaValue = Math.round(clampAlpha(customColor.alpha * colorAlpha) * 255);
         return [r, g, b, alphaValue];
+    };
+
+    const resolveAnnotationColor = (
+        annotation: AnnotationCanvasAnnotation,
+        colorAlpha: number,
+        customLabelColors: CustomLabelColorMap
+    ): [number, number, number, number] => {
+        if (!annotation.color) {
+            return resolveLabelColor(
+                annotation.annotation_label_name || 'label',
+                colorAlpha,
+                customLabelColors
+            );
+        }
+
+        const [r, g, b] = rgbaParser(annotation.color);
+        return [r, g, b, Math.round(clampAlpha(annotation.opacity ?? colorAlpha) * 255)];
     };
 
     const toCloneableRLE = (mask?: ArrayLike<number> | null): number[] => {
@@ -140,13 +196,11 @@
         const boxes: BoxPayload[] = [];
 
         for (const annotation of annotations) {
-            const labelName = annotation.annotation_label_name || 'label';
-
             const rle = toCloneableRLE(annotation.segmentation_mask);
             if (rle.length) {
                 masks.push({
                     rle,
-                    color: resolveLabelColor(labelName, alpha, customLabelColors)
+                    color: resolveAnnotationColor(annotation, alpha, customLabelColors)
                 });
             }
 
@@ -158,7 +212,7 @@
                     y: Math.round(bbox.y),
                     width: Math.round(bbox.width),
                     height: Math.round(bbox.height),
-                    color: resolveLabelColor(labelName, 1, customLabelColors)
+                    color: resolveAnnotationColor(annotation, 1, customLabelColors)
                 });
             }
         }
@@ -166,61 +220,40 @@
         return { masks, boxes };
     };
 
-    const drawBoxes = (
-        ctx: CanvasRenderingContext2D,
-        boxes: BoxPayload[],
-        canvasWidth: number,
-        canvasHeight: number,
-        stroke: number
-    ) => {
-        if (!boxes.length) {
-            return;
-        }
-
-        ctx.save();
-        ctx.lineWidth = stroke;
-        const clamp = (value: number, min: number, max: number) =>
-            Math.min(Math.max(value, min), max);
-
-        for (const box of boxes) {
-            ctx.strokeStyle = rgbaFromBytes(box.color);
-            const x = clamp(box.x, 0, canvasWidth);
-            const y = clamp(box.y, 0, canvasHeight);
-            const wBox = clamp(box.width, 0, canvasWidth - x);
-            const hBox = clamp(box.height, 0, canvasHeight - y);
-
-            if (wBox === 0 || hBox === 0) {
-                continue;
-            }
-
-            ctx.strokeRect(x, y, wBox, hBox);
-        }
-
-        ctx.restore();
-    };
-
     const render = (customLabelColors: CustomLabelColorMap = $customLabelColorsStore) => {
         const payload = buildRenderPayload(customLabelColors);
-        const scaleX = canvasEl && width ? canvasEl.clientWidth / width : 1;
-        const scaleY = canvasEl && height ? canvasEl.clientHeight / height : 1;
+        const geometry: RenderGeometry = {
+            sourceWidth,
+            sourceHeight,
+            outputWidth: canvasWidth,
+            outputHeight: canvasHeight,
+            objectFit,
+            sourceCrop: sourceCrop ? { ...sourceCrop } : undefined
+        };
+
+        // The HTML canvas owns its backing size only until it is transferred. After transfer,
+        // resizing it throws; subsequent OffscreenCanvas sizing happens in the worker.
+        if (canvasEl && !hasOffscreen) {
+            canvasEl.width = canvasWidth;
+            canvasEl.height = canvasHeight;
+        }
 
         if (!workerReady && payload.masks.length === 0) {
             if (!canvasEl) {
                 return;
             }
 
-            const ctx = canvasEl.getContext('2d', { willReadFrequently: true });
+            const ctx = getMainThreadContext({ willReadFrequently: true });
             if (!ctx) {
                 return;
             }
 
-            ctx.clearRect(0, 0, width, height);
+            ctx.clearRect(0, 0, canvasWidth, canvasHeight);
             if (!payload.boxes.length) {
                 return;
             }
 
-            const scale = Math.max(scaleX, scaleY) || 1;
-            drawBoxes(ctx, payload.boxes, width, height, 2 / scale);
+            drawBoxesOnContext(ctx, transformBoxes(geometry, payload.boxes));
             return;
         }
 
@@ -234,18 +267,14 @@
 
         // Clear fallback canvas path to avoid stale pixels before new draw arrives.
         if (!hasOffscreen && canvasEl) {
-            const ctx = canvasEl.getContext('2d');
-            ctx?.clearRect(0, 0, width, height);
+            const ctx = getMainThreadContext();
+            ctx?.clearRect(0, 0, canvasWidth, canvasHeight);
         }
 
-        // Include current CSS scale so the worker can keep stroke widths consistent.
         worker.postMessage({
             type: 'render',
             canvasId,
-            width,
-            height,
-            scaleX,
-            scaleY,
+            ...geometry,
             ...payload
         });
     };
@@ -271,7 +300,7 @@
             stroke?: number;
         };
 
-        const ctx = canvasEl.getContext('2d', { willReadFrequently: true });
+        const ctx = getMainThreadContext({ willReadFrequently: true });
         if (!ctx) {
             return;
         }
@@ -284,26 +313,7 @@
             return;
         }
 
-        ctx.save();
-        ctx.lineWidth = stroke;
-        const clamp = (value: number, min: number, max: number) =>
-            Math.min(Math.max(value, min), max);
-
-        for (const box of boxes) {
-            ctx.strokeStyle = rgbaFromBytes(box.color);
-            const x = clamp(box.x, 0, w);
-            const y = clamp(box.y, 0, h);
-            const wBox = clamp(box.width, 0, w - x);
-            const hBox = clamp(box.height, 0, h - y);
-
-            if (wBox === 0 || hBox === 0) {
-                continue;
-            }
-
-            ctx.strokeRect(x, y, wBox, hBox);
-        }
-
-        ctx.restore();
+        drawBoxesOnContext(ctx, boxes, stroke);
     };
 
     const setupWorker = () => {
@@ -314,14 +324,17 @@
         worker = acquireMaskRendererWorker();
         worker.addEventListener('message', handleWorkerMessage);
 
-        if (canvasEl.transferControlToOffscreen) {
-            // Preferred path: worker draws directly into the canvas through OffscreenCanvas.
-            const offscreen = canvasEl.transferControlToOffscreen();
-            worker.postMessage({ type: 'init', canvasId, canvas: offscreen }, [offscreen]);
-            hasOffscreen = true;
-        } else {
-            // Fallback path: worker sends pixel buffers back and main thread paints them.
-            hasOffscreen = false;
+        if (canvasEl.transferControlToOffscreen && !hasMainThreadContext) {
+            try {
+                // Preferred path: worker draws directly into the canvas through OffscreenCanvas.
+                const offscreen = canvasEl.transferControlToOffscreen();
+                worker.postMessage({ type: 'init', canvasId, canvas: offscreen }, [offscreen]);
+                hasOffscreen = true;
+            } catch {
+                // A browser may reject transfer if any code acquired a context first. Keep the
+                // canvas main-thread-owned and use worker-produced pixel buffers in that case.
+                hasOffscreen = false;
+            }
         }
 
         workerReady = true;
@@ -329,11 +342,6 @@
 
     onMount(() => {
         rgbaParser = createColorParser();
-
-        if (canvasEl && 'ResizeObserver' in window) {
-            resizeObserver = new ResizeObserver(() => render());
-            resizeObserver.observe(canvasEl);
-        }
     });
 
     onDestroy(() => {
@@ -343,7 +351,6 @@
             releaseMaskRendererWorker(worker);
             worker = null;
         }
-        resizeObserver?.disconnect();
     });
 
     $effect(() => {
@@ -352,7 +359,7 @@
     });
 </script>
 
-<canvas bind:this={canvasEl} {width} {height} class={className}></canvas>
+<canvas bind:this={canvasEl} class={className}></canvas>
 
 <style>
     canvas {

--- a/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationCanvas/AnnotationCanvas.test.ts
@@ -61,12 +61,6 @@ class MockWorker {
     }
 }
 
-class MockResizeObserver {
-    observe = vi.fn();
-    unobserve = vi.fn();
-    disconnect = vi.fn();
-}
-
 class MockImageData {
     constructor(
         public data: Uint8ClampedArray,
@@ -110,13 +104,13 @@ describe('AnnotationCanvas', () => {
         });
 
         vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
-        vi.stubGlobal('ResizeObserver', MockResizeObserver as unknown as typeof ResizeObserver);
         vi.stubGlobal('ImageData', MockImageData as unknown as typeof ImageData);
     });
 
     afterEach(() => {
         vi.restoreAllMocks();
         vi.unstubAllGlobals();
+        Reflect.deleteProperty(HTMLCanvasElement.prototype, 'transferControlToOffscreen');
     });
 
     afterEach(async () => {
@@ -128,13 +122,20 @@ describe('AnnotationCanvas', () => {
         const { container } = render(AnnotationCanvas, {
             props: {
                 sampleId: 'sample-object-detection',
-                width: 100,
-                height: 100,
+                sourceWidth: 8192,
+                sourceHeight: 8192,
+                outputWidth: 200,
+                outputHeight: 200,
                 annotations: [
                     {
                         annotation_type: 'object_detection',
                         annotation_label_name: 'car',
-                        object_detection_details: { x: 10.2, y: 20.6, width: 30.4, height: 40.9 }
+                        object_detection_details: {
+                            x: 1024,
+                            y: 2048,
+                            width: 3072,
+                            height: 4096
+                        }
                     }
                 ]
             }
@@ -147,16 +148,49 @@ describe('AnnotationCanvas', () => {
         expect(context).toBeDefined();
 
         expect(MockWorker.instances).toHaveLength(0);
-        expect(context?.clearRect).toHaveBeenCalledWith(0, 0, 100, 100);
-        expect(context?.strokeRect).toHaveBeenCalledWith(10, 21, 30, 41);
+        expect(canvas).toHaveAttribute('width', '200');
+        expect(canvas).toHaveAttribute('height', '200');
+        expect(context?.clearRect).toHaveBeenCalledWith(0, 0, 200, 200);
+        expect(context?.strokeRect).toHaveBeenCalledWith(25, 50, 75, 100);
+    });
+
+    it('keeps source-sized canvas defaults for consumers without output dimensions', async () => {
+        const { container } = render(AnnotationCanvas, {
+            props: {
+                sampleId: 'source-sized-default',
+                sourceWidth: 100,
+                sourceHeight: 80,
+                annotations: [
+                    {
+                        annotation_type: 'object_detection',
+                        annotation_label_name: 'car',
+                        object_detection_details: { x: 10, y: 20, width: 30, height: 40 }
+                    }
+                ]
+            }
+        });
+
+        await tick();
+
+        const canvas = container.querySelector('canvas');
+        expect(canvas).toHaveAttribute('width', '100');
+        expect(canvas).toHaveAttribute('height', '80');
+        expect(canvasContexts.get(canvas as HTMLCanvasElement)?.strokeRect).toHaveBeenCalledWith(
+            10,
+            20,
+            30,
+            40
+        );
     });
 
     it('posts a worker render message when masks are present', async () => {
         render(AnnotationCanvas, {
             props: {
                 sampleId: 'sample-masks',
-                width: 16,
-                height: 8,
+                sourceWidth: 16,
+                sourceHeight: 8,
+                outputWidth: 8,
+                outputHeight: 4,
                 annotations: [
                     {
                         annotation_type: 'segmentation_mask',
@@ -177,15 +211,16 @@ describe('AnnotationCanvas', () => {
         const worker = workersWithRender[0];
         const [canvas] = Array.from(document.querySelectorAll('canvas'));
         const context = canvas ? canvasContexts.get(canvas as HTMLCanvasElement) : undefined;
-        expect(context?.clearRect).toHaveBeenCalledWith(0, 0, 16, 8);
+        expect(context?.clearRect).toHaveBeenCalledWith(0, 0, 8, 4);
         expect(worker.postMessage).toHaveBeenCalledTimes(1);
         expect(worker.postMessage).toHaveBeenCalledWith(
             expect.objectContaining({
                 type: 'render',
-                width: 16,
-                height: 8,
-                scaleX: 0,
-                scaleY: 0,
+                sourceWidth: 16,
+                sourceHeight: 8,
+                outputWidth: 8,
+                outputHeight: 4,
+                objectFit: 'contain',
                 boxes: [],
                 masks: [expect.objectContaining({ rle: [0, 3, 2] })]
             })
@@ -194,7 +229,14 @@ describe('AnnotationCanvas', () => {
 
     it('clears and exits early when there are no drawable annotations', async () => {
         const { container } = render(AnnotationCanvas, {
-            props: { sampleId: 'sample-empty', width: 64, height: 32, annotations: [] }
+            props: {
+                sampleId: 'sample-empty',
+                sourceWidth: 64,
+                sourceHeight: 32,
+                outputWidth: 32,
+                outputHeight: 16,
+                annotations: []
+            }
         });
 
         await tick();
@@ -204,16 +246,264 @@ describe('AnnotationCanvas', () => {
         expect(context).toBeDefined();
 
         expect(MockWorker.instances).toHaveLength(0);
-        expect(context?.clearRect).toHaveBeenCalledWith(0, 0, 64, 32);
+        expect(context?.clearRect).toHaveBeenCalledWith(0, 0, 32, 16);
         expect(context?.strokeRect).not.toHaveBeenCalled();
+    });
+
+    it('re-renders the same bounded canvas when the tile size changes', async () => {
+        const { container, rerender } = render(AnnotationCanvas, {
+            props: {
+                sampleId: 'resized-sample',
+                sourceWidth: 1000,
+                sourceHeight: 1000,
+                outputWidth: 200,
+                outputHeight: 200,
+                annotations: [
+                    {
+                        annotation_type: 'object_detection',
+                        annotation_label_name: 'car',
+                        object_detection_details: { x: 100, y: 100, width: 200, height: 200 }
+                    }
+                ]
+            }
+        });
+        await tick();
+
+        await rerender({
+            sampleId: 'resized-sample',
+            sourceWidth: 1000,
+            sourceHeight: 1000,
+            outputWidth: 300,
+            outputHeight: 300,
+            annotations: [
+                {
+                    annotation_type: 'object_detection',
+                    annotation_label_name: 'car',
+                    object_detection_details: { x: 100, y: 100, width: 200, height: 200 }
+                }
+            ]
+        });
+        await tick();
+
+        const canvases = container.querySelectorAll('canvas');
+        expect(canvases).toHaveLength(1);
+        expect(canvases[0]).toHaveAttribute('width', '300');
+        expect(canvases[0]).toHaveAttribute('height', '300');
+        const context = canvasContexts.get(canvases[0]);
+        expect(context?.strokeRect).toHaveBeenLastCalledWith(30, 30, 60, 60);
+    });
+
+    it('does not resize the HTML canvas after transferring it to OffscreenCanvas', async () => {
+        const transferredCanvases = new WeakSet<HTMLCanvasElement>();
+        const offscreenCanvas = { width: 0, height: 0 } as OffscreenCanvas;
+        const widthDescriptor = Object.getOwnPropertyDescriptor(
+            HTMLCanvasElement.prototype,
+            'width'
+        );
+        const heightDescriptor = Object.getOwnPropertyDescriptor(
+            HTMLCanvasElement.prototype,
+            'height'
+        );
+
+        vi.spyOn(HTMLCanvasElement.prototype, 'width', 'set').mockImplementation(function (
+            this: HTMLCanvasElement,
+            value: number
+        ) {
+            if (transferredCanvases.has(this)) {
+                throw new DOMException('Canvas has already been transferred');
+            }
+            widthDescriptor?.set?.call(this, value);
+        });
+        vi.spyOn(HTMLCanvasElement.prototype, 'height', 'set').mockImplementation(function (
+            this: HTMLCanvasElement,
+            value: number
+        ) {
+            if (transferredCanvases.has(this)) {
+                throw new DOMException('Canvas has already been transferred');
+            }
+            heightDescriptor?.set?.call(this, value);
+        });
+        Object.defineProperty(HTMLCanvasElement.prototype, 'transferControlToOffscreen', {
+            configurable: true,
+            value: vi.fn(function (this: HTMLCanvasElement) {
+                transferredCanvases.add(this);
+                return offscreenCanvas;
+            })
+        });
+
+        const { container, rerender } = render(AnnotationCanvas, {
+            props: {
+                sampleId: 'offscreen-resize',
+                sourceWidth: 16,
+                sourceHeight: 8,
+                outputWidth: 8,
+                outputHeight: 4,
+                annotations: [
+                    {
+                        annotation_type: 'segmentation_mask',
+                        annotation_label_name: 'road',
+                        segmentation_mask: [0, 3, 2]
+                    }
+                ]
+            }
+        });
+        await tick();
+
+        await expect(
+            rerender({
+                sampleId: 'offscreen-resize',
+                sourceWidth: 16,
+                sourceHeight: 8,
+                outputWidth: 12,
+                outputHeight: 6,
+                annotations: [
+                    {
+                        annotation_type: 'segmentation_mask',
+                        annotation_label_name: 'road',
+                        segmentation_mask: [0, 3, 2]
+                    }
+                ]
+            })
+        ).resolves.toBeUndefined();
+        await tick();
+
+        const canvas = container.querySelector('canvas');
+        expect(canvas).toHaveAttribute('width', '8');
+        expect(canvas).toHaveAttribute('height', '4');
+        const renderMessages = MockWorker.instances.flatMap((instance) =>
+            instance.postMessage.mock.calls
+                .map(([message]) => message)
+                .filter((message) => message.type === 'render')
+        );
+        expect(renderMessages.at(-1)).toEqual(
+            expect.objectContaining({ outputWidth: 12, outputHeight: 6 })
+        );
+    });
+
+    it.each([
+        {
+            name: 'an empty canvas',
+            annotations: []
+        },
+        {
+            name: 'a box canvas',
+            annotations: [
+                {
+                    annotation_type: 'object_detection' as const,
+                    annotation_label_name: 'car',
+                    object_detection_details: { x: 1, y: 1, width: 2, height: 2 }
+                }
+            ]
+        }
+    ])('uses the worker fallback when $name later receives a mask', async ({ annotations }) => {
+        const transferControlToOffscreen = vi.fn();
+        Object.defineProperty(HTMLCanvasElement.prototype, 'transferControlToOffscreen', {
+            configurable: true,
+            value: transferControlToOffscreen
+        });
+        const { container, rerender } = render(AnnotationCanvas, {
+            props: {
+                sampleId: 'main-thread-to-mask',
+                sourceWidth: 4,
+                sourceHeight: 4,
+                outputWidth: 4,
+                outputHeight: 4,
+                annotations
+            }
+        });
+        await tick();
+
+        await rerender({
+            sampleId: 'main-thread-to-mask',
+            sourceWidth: 4,
+            sourceHeight: 4,
+            outputWidth: 4,
+            outputHeight: 4,
+            annotations: [
+                {
+                    annotation_type: 'segmentation_mask',
+                    annotation_label_name: 'road',
+                    segmentation_mask: [0, 4, 12]
+                }
+            ]
+        });
+        await tick();
+
+        expect(transferControlToOffscreen).not.toHaveBeenCalled();
+        const worker = MockWorker.instances.find((instance) =>
+            instance.postMessage.mock.calls.some(([message]) => message.type === 'render')
+        );
+        const renderMessage = worker?.postMessage.mock.calls
+            .map(([message]) => message)
+            .find((message) => message.type === 'render');
+        expect(worker).toBeDefined();
+        expect(worker?.postMessage).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'init' }),
+            expect.anything()
+        );
+        expect(worker?.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'render', masks: [expect.anything()] })
+        );
+
+        worker?.dispatchMessage({
+            type: 'image',
+            canvasId: renderMessage.canvasId,
+            width: 4,
+            height: 4,
+            data: new Uint8ClampedArray(4 * 4 * 4),
+            boxes: []
+        });
+        const canvas = container.querySelector('canvas');
+        expect(canvasContexts.get(canvas as HTMLCanvasElement)?.putImageData).toHaveBeenCalledTimes(
+            1
+        );
+    });
+
+    it('falls back to main-thread painting if OffscreenCanvas transfer is rejected', async () => {
+        Object.defineProperty(HTMLCanvasElement.prototype, 'transferControlToOffscreen', {
+            configurable: true,
+            value: vi.fn(() => {
+                throw new DOMException('Canvas has already acquired a rendering context');
+            })
+        });
+
+        expect(() =>
+            render(AnnotationCanvas, {
+                props: {
+                    sampleId: 'rejected-transfer',
+                    sourceWidth: 4,
+                    sourceHeight: 4,
+                    outputWidth: 4,
+                    outputHeight: 4,
+                    annotations: [
+                        {
+                            annotation_type: 'segmentation_mask',
+                            annotation_label_name: 'road',
+                            segmentation_mask: [0, 4, 12]
+                        }
+                    ]
+                }
+            })
+        ).not.toThrow();
+        await tick();
+
+        const worker = MockWorker.instances.find((instance) =>
+            instance.postMessage.mock.calls.some(([message]) => message.type === 'render')
+        );
+        expect(worker).toBeDefined();
+        expect(worker?.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'render', masks: [expect.anything()] })
+        );
     });
 
     it('keeps rendering isolated for two canvases with the same sampleId', async () => {
         const first = render(AnnotationCanvas, {
             props: {
                 sampleId: 'duplicate-sample-id',
-                width: 2,
-                height: 1,
+                sourceWidth: 2,
+                sourceHeight: 1,
+                outputWidth: 2,
+                outputHeight: 1,
                 annotations: [
                     {
                         annotation_type: 'segmentation_mask',
@@ -227,8 +517,10 @@ describe('AnnotationCanvas', () => {
         const second = render(AnnotationCanvas, {
             props: {
                 sampleId: 'duplicate-sample-id',
-                width: 2,
-                height: 1,
+                sourceWidth: 2,
+                sourceHeight: 1,
+                outputWidth: 2,
+                outputHeight: 1,
                 annotations: [
                     {
                         annotation_type: 'segmentation_mask',

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
@@ -22,10 +22,14 @@
 
     const {
         sample,
-        objectFit = 'contain'
+        objectFit = 'contain',
+        outputWidth = sample.width,
+        outputHeight = sample.height
     }: {
         sample: SampleView;
         objectFit?: SampleImageObjectFit;
+        outputWidth?: number;
+        outputHeight?: number;
     } = $props();
 
     const { isHidden } = useHideAnnotations();
@@ -119,8 +123,11 @@
     <div data-testid="sample-annotation-item">
         <AnnotationCanvas
             sampleId={sample.sample_id}
-            width={sample.width}
-            height={sample.height}
+            sourceWidth={sample.width}
+            sourceHeight={sample.height}
+            {outputWidth}
+            {outputHeight}
+            {objectFit}
             annotations={annotationsWithVisuals}
             alpha={0.8}
             className={`pointer-events-none absolute inset-0 z-[1] h-full w-full ${objectFitClass}`}

--- a/lightly_studio_view/src/lib/workers/maskRenderer.testFixtures.ts
+++ b/lightly_studio_view/src/lib/workers/maskRenderer.testFixtures.ts
@@ -1,0 +1,23 @@
+import type { RenderGeometry } from './maskRendererUtils';
+
+export const createRenderGeometry = (overrides: Partial<RenderGeometry> = {}): RenderGeometry => ({
+    sourceWidth: 100,
+    sourceHeight: 100,
+    outputWidth: 200,
+    outputHeight: 200,
+    objectFit: 'contain',
+    ...overrides
+});
+
+export const createWorkerRenderMessage = (overrides: Record<string, unknown> = {}) => ({
+    type: 'render',
+    canvasId: 'canvas-1',
+    sourceWidth: 16,
+    sourceHeight: 8,
+    outputWidth: 8,
+    outputHeight: 4,
+    objectFit: 'contain',
+    masks: [],
+    boxes: [],
+    ...overrides
+});

--- a/lightly_studio_view/src/lib/workers/maskRenderer.worker.test.ts
+++ b/lightly_studio_view/src/lib/workers/maskRenderer.worker.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createWorkerRenderMessage } from './maskRenderer.testFixtures';
+
+class MockImageData {
+    constructor(
+        public data: Uint8ClampedArray,
+        public width: number,
+        public height: number
+    ) {}
+}
+
+describe('maskRenderer worker', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        vi.resetModules();
+    });
+
+    it('resizes the worker-owned OffscreenCanvas when output dimensions change', async () => {
+        const canvas = { width: 0, height: 0 };
+        const context = {
+            canvas,
+            clearRect: vi.fn(),
+            putImageData: vi.fn(),
+            save: vi.fn(),
+            restore: vi.fn(),
+            lineWidth: 1,
+            strokeStyle: '',
+            strokeRect: vi.fn()
+        };
+        const offscreenCanvas = {
+            ...canvas,
+            getContext: vi.fn(() => context)
+        };
+        vi.stubGlobal('ImageData', MockImageData as unknown as typeof ImageData);
+
+        await import('./maskRenderer.worker');
+        self.onmessage?.(
+            new MessageEvent('message', {
+                data: { type: 'init', canvasId: 'canvas-1', canvas: offscreenCanvas }
+            })
+        );
+        self.onmessage?.(
+            new MessageEvent('message', {
+                data: createWorkerRenderMessage()
+            })
+        );
+        self.onmessage?.(
+            new MessageEvent('message', {
+                data: createWorkerRenderMessage({ outputWidth: 12, outputHeight: 6 })
+            })
+        );
+
+        expect(context.canvas).toMatchObject({ width: 12, height: 6 });
+        expect(context.clearRect).toHaveBeenLastCalledWith(0, 0, 12, 6);
+        expect(context.putImageData).toHaveBeenCalledTimes(2);
+    });
+});

--- a/lightly_studio_view/src/lib/workers/maskRenderer.worker.ts
+++ b/lightly_studio_view/src/lib/workers/maskRenderer.worker.ts
@@ -3,32 +3,36 @@
 import {
     type BoundingBoxInput,
     type MaskInput,
-    computeStroke,
     drawBoxesOnContext,
-    renderMasks
+    renderMasks,
+    transformBoxes,
+    type RenderGeometry,
+    type SourceCrop
 } from './maskRendererUtils';
 
-type RenderMessage = {
+interface RenderMessage {
     type: 'render';
     canvasId: string;
-    width: number;
-    height: number;
+    sourceWidth: number;
+    sourceHeight: number;
+    outputWidth: number;
+    outputHeight: number;
+    objectFit: 'contain' | 'cover';
+    sourceCrop?: SourceCrop;
     masks: MaskInput[];
     boxes: BoundingBoxInput[];
-    scaleX?: number;
-    scaleY?: number;
-};
+}
 
-type InitMessage = {
+interface InitMessage {
     type: 'init';
     canvasId: string;
     canvas: OffscreenCanvas;
-};
+}
 
-type DisposeMessage = {
+interface DisposeMessage {
     type: 'dispose';
     canvasId: string;
-};
+}
 
 type WorkerMessage = RenderMessage | InitMessage | DisposeMessage;
 
@@ -37,31 +41,50 @@ const contexts = new Map<string, OffscreenCanvasRenderingContext2D>();
 
 const handleRender = ({
     canvasId,
-    width,
-    height,
+    sourceWidth,
+    sourceHeight,
+    outputWidth,
+    outputHeight,
+    objectFit,
+    sourceCrop,
     masks,
-    boxes,
-    scaleX = 1,
-    scaleY = 1
+    boxes
 }: RenderMessage) => {
-    // Render masks into a pixel buffer and overlay boxes; stroke is scaled to CSS size.
-    const pixelData = renderMasks(width, height, masks);
-    const stroke = computeStroke(scaleX, scaleY);
+    const geometry: RenderGeometry = {
+        sourceWidth,
+        sourceHeight,
+        outputWidth,
+        outputHeight,
+        objectFit,
+        sourceCrop
+    };
+    const pixelData = renderMasks(geometry, masks);
+    const transformedBoxes = transformBoxes(geometry, boxes);
     const ctx = contexts.get(canvasId);
 
     if (ctx) {
         // Offscreen path: paint fully inside worker.
-        const imageData = new ImageData(pixelData, width, height);
-        ctx.canvas.width = width;
-        ctx.canvas.height = height;
-        ctx.clearRect(0, 0, width, height);
+        const imageData = new ImageData(pixelData, outputWidth, outputHeight);
+        ctx.canvas.width = outputWidth;
+        ctx.canvas.height = outputHeight;
+        ctx.clearRect(0, 0, outputWidth, outputHeight);
         ctx.putImageData(imageData, 0, 0);
-        drawBoxesOnContext(ctx, boxes, width, height, stroke);
+        drawBoxesOnContext(ctx, transformedBoxes);
     } else {
         // Fallback path when no OffscreenCanvas context was registered for this canvas id.
-        postMessage({ type: 'image', canvasId, width, height, data: pixelData, boxes, stroke }, [
-            pixelData.buffer
-        ]);
+        // renderMasks deliberately returns an ArrayBuffer-backed view because transferable
+        // payloads cannot use SharedArrayBuffer as their ownership-transfer list entry.
+        postMessage(
+            {
+                type: 'image',
+                canvasId,
+                width: outputWidth,
+                height: outputHeight,
+                data: pixelData,
+                boxes: transformedBoxes
+            },
+            [pixelData.buffer]
+        );
     }
 };
 

--- a/lightly_studio_view/src/lib/workers/maskRendererUtils.test.ts
+++ b/lightly_studio_view/src/lib/workers/maskRendererUtils.test.ts
@@ -1,20 +1,91 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-    computeStroke,
     drawBoxesOnContext,
+    getRenderTransform,
     renderMasks,
+    transformBoxes,
     type BoundingBoxInput
 } from './maskRendererUtils';
+import { createRenderGeometry as geometry } from './maskRenderer.testFixtures';
 
 describe('maskRendererUtils', () => {
-    it('renders masks into RGBA pixels', () => {
-        const color: BoundingBoxInput['color'] = [10, 20, 30, 40];
-        const pixels = renderMasks(2, 2, [{ rle: [1, 3], color }]);
-        const expected = new Uint8ClampedArray([0, 0, 0, 0, ...color, ...color, ...color]);
-        expect(pixels).toEqual(expected);
+    it('renders a large logical mask into only the output-sized RGBA buffer', () => {
+        const pixels = renderMasks(geometry({ sourceWidth: 20_000, sourceHeight: 20_000 }), [
+            { rle: [0, 400_000_000], color: [10, 20, 30, 40] }
+        ]);
+
+        expect(pixels.byteLength).toBe(200 * 200 * 4);
+        expect(pixels.slice(0, 4)).toEqual(new Uint8ClampedArray([10, 20, 30, 40]));
     });
 
-    it('clamps boxes before drawing', () => {
+    it('leaves pixels beyond a partial RLE transparent', () => {
+        const pixels = renderMasks(
+            geometry({ sourceWidth: 4, sourceHeight: 1, outputWidth: 4, outputHeight: 1 }),
+            [{ rle: [0, 2], color: [10, 20, 30, 40] }]
+        );
+
+        expect(pixels).toEqual(
+            new Uint8ClampedArray([10, 20, 30, 40, 10, 20, 30, 40, 0, 0, 0, 0, 0, 0, 0, 0])
+        );
+    });
+
+    it.each([
+        {
+            name: 'contain landscape',
+            input: geometry({ sourceWidth: 200, sourceHeight: 100 }),
+            expected: { scale: 1, offsetX: 0, offsetY: 50 }
+        },
+        {
+            name: 'contain portrait',
+            input: geometry({ sourceWidth: 100, sourceHeight: 200 }),
+            expected: { scale: 1, offsetX: 50, offsetY: 0 }
+        },
+        {
+            name: 'cover landscape',
+            input: geometry({ sourceWidth: 200, sourceHeight: 100, objectFit: 'cover' }),
+            expected: { scale: 2, offsetX: -100, offsetY: 0 }
+        },
+        {
+            name: 'cover portrait',
+            input: geometry({ sourceWidth: 100, sourceHeight: 200, objectFit: 'cover' }),
+            expected: { scale: 2, offsetX: 0, offsetY: -100 }
+        },
+        {
+            name: 'annotation crop',
+            input: geometry({
+                sourceWidth: 1000,
+                sourceHeight: 800,
+                outputWidth: 200,
+                outputHeight: 100,
+                sourceCrop: { x: 100, y: 200, width: 400, height: 200 }
+            }),
+            expected: { scale: 0.5, offsetX: -50, offsetY: -100 }
+        }
+    ])('computes the $name transform', ({ input, expected }) => {
+        expect(getRenderTransform(input)).toMatchObject(expected);
+    });
+
+    it('transforms and clips boxes into output coordinates', () => {
+        const boxes: BoundingBoxInput[] = [
+            { x: -10, y: 10, width: 30, height: 40, color: [0, 0, 0, 255] }
+        ];
+
+        expect(transformBoxes(geometry(), boxes)).toEqual([
+            { x: 0, y: 20, width: 40, height: 80, color: [0, 0, 0, 255] }
+        ]);
+    });
+
+    it('clips boxes to the source crop before applying contain letterboxing', () => {
+        const boxes: BoundingBoxInput[] = [
+            { x: 0, y: 0, width: 100, height: 100, color: [0, 0, 0, 255] }
+        ];
+
+        expect(
+            transformBoxes(geometry({ sourceCrop: { x: 25, y: 25, width: 50, height: 25 } }), boxes)
+        ).toEqual([{ x: 0, y: 50, width: 200, height: 100, color: [0, 0, 0, 255] }]);
+    });
+
+    it('draws transformed boxes with a tile-sized stroke', () => {
         const ctx = {
             save: vi.fn(),
             restore: vi.fn(),
@@ -22,22 +93,14 @@ describe('maskRendererUtils', () => {
             lineWidth: 0,
             strokeStyle: ''
         } as unknown as OffscreenCanvasRenderingContext2D;
-
         const boxes: BoundingBoxInput[] = [
-            { x: -1, y: -1, width: 3, height: 10, color: [0, 0, 0, 255] }
+            { x: 1, y: 2, width: 3, height: 4, color: [0, 0, 0, 255] }
         ];
 
-        drawBoxesOnContext(ctx, boxes, 5, 4, 2);
+        drawBoxesOnContext(ctx, boxes);
 
-        expect(ctx.save).toHaveBeenCalledTimes(1);
-        expect(ctx.restore).toHaveBeenCalledTimes(1);
         expect(ctx.lineWidth).toBe(2);
         expect(ctx.strokeStyle).toBe('rgba(0, 0, 0, 1)');
-        expect(ctx.strokeRect).toHaveBeenCalledWith(0, 0, 3, 4);
-    });
-
-    it('computes stroke inversely to scale', () => {
-        expect(computeStroke(2, 1)).toBeCloseTo(1);
-        expect(computeStroke()).toBeCloseTo(2);
+        expect(ctx.strokeRect).toHaveBeenCalledWith(1, 2, 3, 4);
     });
 });

--- a/lightly_studio_view/src/lib/workers/maskRendererUtils.ts
+++ b/lightly_studio_view/src/lib/workers/maskRendererUtils.ts
@@ -1,85 +1,169 @@
 import { rgbaFromBytes } from '$lib/utils/colorConvert';
 
-export type MaskInput = {
+export interface MaskInput {
     rle: ReadonlyArray<number>;
-    color: [number, number, number, number]; // RGBA 0-255
-};
+    color: [number, number, number, number];
+}
 
-export type BoundingBoxInput = {
+export interface BoundingBoxInput {
     x: number;
     y: number;
     width: number;
     height: number;
-    color: [number, number, number, number]; // RGBA 0-255
+    color: [number, number, number, number];
+}
+
+export interface SourceCrop {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export interface RenderGeometry {
+    sourceWidth: number;
+    sourceHeight: number;
+    outputWidth: number;
+    outputHeight: number;
+    objectFit: 'contain' | 'cover';
+    sourceCrop?: SourceCrop;
+}
+
+export interface RenderTransform {
+    scale: number;
+    offsetX: number;
+    offsetY: number;
+    viewport: SourceCrop;
+}
+
+export const getRenderTransform = ({
+    sourceWidth,
+    sourceHeight,
+    outputWidth,
+    outputHeight,
+    objectFit,
+    sourceCrop
+}: RenderGeometry): RenderTransform => {
+    const viewport = sourceCrop ?? { x: 0, y: 0, width: sourceWidth, height: sourceHeight };
+    const scaleForWidth = outputWidth / viewport.width;
+    const scaleForHeight = outputHeight / viewport.height;
+    const scale =
+        objectFit === 'cover'
+            ? Math.max(scaleForWidth, scaleForHeight)
+            : Math.min(scaleForWidth, scaleForHeight);
+
+    return {
+        scale,
+        offsetX: (outputWidth - viewport.width * scale) / 2 - viewport.x * scale,
+        offsetY: (outputHeight - viewport.height * scale) / 2 - viewport.y * scale,
+        viewport
+    };
 };
 
-export const renderMasks = (width: number, height: number, masks: MaskInput[]) => {
-    const pixelData = new Uint8ClampedArray(width * height * 4);
-    const maxPixels = width * height;
+const findRunIndex = (runEnds: number[], pixelIndex: number): number => {
+    let low = 0;
+    let high = runEnds.length;
+    while (low < high) {
+        const middle = Math.floor((low + high) / 2);
+        if (pixelIndex < runEnds[middle]) high = middle;
+        else low = middle + 1;
+    }
+    return low;
+};
+
+const getRunEnds = (rle: ReadonlyArray<number>): number[] => {
+    const runEnds: number[] = [];
+    let end = 0;
+    for (const run of rle) {
+        end += Math.max(0, Math.floor(Number(run) || 0));
+        runEnds.push(end);
+    }
+    return runEnds;
+};
+
+export const renderMasks = (
+    geometry: RenderGeometry,
+    masks: MaskInput[]
+): Uint8ClampedArray<ArrayBuffer> => {
+    const { sourceWidth, sourceHeight, outputWidth, outputHeight } = geometry;
+    const pixelData = new Uint8ClampedArray(
+        new ArrayBuffer(outputWidth * outputHeight * Uint8ClampedArray.BYTES_PER_ELEMENT * 4)
+    );
+    const { scale, offsetX, offsetY, viewport } = getRenderTransform(geometry);
 
     for (const { rle, color } of masks) {
-        if (!rle?.length) {
-            continue;
-        }
+        const runEnds = getRunEnds(rle);
+        if (runEnds.length === 0) continue;
 
-        // Decode RLE runs directly into RGBA output to avoid allocating an intermediate mask.
-        let pixelIndex = 0;
-        let value = 0;
+        for (let outputY = 0; outputY < outputHeight; outputY++) {
+            const sourceY = Math.floor((outputY + 0.5 - offsetY) / scale);
+            if (
+                sourceY < 0 ||
+                sourceY >= sourceHeight ||
+                sourceY < viewport.y ||
+                sourceY >= viewport.y + viewport.height
+            )
+                continue;
 
-        for (let runIndex = 0; runIndex < rle.length && pixelIndex < maxPixels; runIndex++) {
-            const count = Math.max(0, Math.floor(Number(rle[runIndex]) || 0));
-            const end = Math.min(pixelIndex + count, maxPixels);
+            for (let outputX = 0; outputX < outputWidth; outputX++) {
+                const sourceX = Math.floor((outputX + 0.5 - offsetX) / scale);
+                if (
+                    sourceX < 0 ||
+                    sourceX >= sourceWidth ||
+                    sourceX < viewport.x ||
+                    sourceX >= viewport.x + viewport.width
+                )
+                    continue;
 
-            if (value === 1) {
-                for (let i = pixelIndex; i < end; i++) {
-                    const offset = i * 4;
-                    pixelData[offset] = color[0];
-                    pixelData[offset + 1] = color[1];
-                    pixelData[offset + 2] = color[2];
-                    pixelData[offset + 3] = color[3];
-                }
+                const runIndex = findRunIndex(runEnds, sourceY * sourceWidth + sourceX);
+                if (runIndex >= runEnds.length || runIndex % 2 === 0) continue;
+
+                const offset = (outputY * outputWidth + outputX) * 4;
+                pixelData.set(color, offset);
             }
-
-            pixelIndex = end;
-            value = value === 0 ? 1 : 0;
         }
     }
-
     return pixelData;
 };
 
-export const computeStroke = (scaleX = 1, scaleY = 1) => {
-    const scale = Math.max(scaleX, scaleY) || 1;
-    return 2 / scale;
+export const transformBoxes = (
+    geometry: RenderGeometry,
+    boxes: BoundingBoxInput[]
+): BoundingBoxInput[] => {
+    const { outputWidth, outputHeight } = geometry;
+    const { sourceWidth, sourceHeight } = geometry;
+    const { scale, offsetX, offsetY, viewport } = getRenderTransform(geometry);
+    const viewportLeft = Math.max(0, viewport.x);
+    const viewportTop = Math.max(0, viewport.y);
+    const viewportRight = Math.min(sourceWidth, viewport.x + viewport.width);
+    const viewportBottom = Math.min(sourceHeight, viewport.y + viewport.height);
+
+    return boxes.flatMap((box) => {
+        const sourceLeft = Math.max(viewportLeft, box.x);
+        const sourceTop = Math.max(viewportTop, box.y);
+        const sourceRight = Math.min(viewportRight, box.x + box.width);
+        const sourceBottom = Math.min(viewportBottom, box.y + box.height);
+        const left = Math.max(0, sourceLeft * scale + offsetX);
+        const top = Math.max(0, sourceTop * scale + offsetY);
+        const right = Math.min(outputWidth, sourceRight * scale + offsetX);
+        const bottom = Math.min(outputHeight, sourceBottom * scale + offsetY);
+        if (right <= left || bottom <= top) return [];
+        return [{ ...box, x: left, y: top, width: right - left, height: bottom - top }];
+    });
 };
 
-export const drawBoxesOnContext = (
-    ctx: OffscreenCanvasRenderingContext2D,
-    boxes: BoundingBoxInput[],
-    width: number,
-    height: number,
-    stroke: number
-) => {
-    if (!boxes.length) return;
+type BoxContext = Pick<
+    CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+    'save' | 'restore' | 'lineWidth' | 'strokeStyle' | 'strokeRect'
+>;
 
+export const drawBoxesOnContext = (ctx: BoxContext, boxes: BoundingBoxInput[], stroke = 2) => {
+    if (!boxes.length) return;
     ctx.save();
     ctx.lineWidth = stroke;
-    const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
-
     for (const box of boxes) {
         ctx.strokeStyle = rgbaFromBytes(box.color);
-
-        const x = clamp(box.x, 0, width);
-        const y = clamp(box.y, 0, height);
-        const w = clamp(box.width, 0, width - x);
-        const h = clamp(box.height, 0, height - y);
-
-        if (w === 0 || h === 0) {
-            continue;
-        }
-
-        ctx.strokeRect(x, y, w, h);
+        ctx.strokeRect(box.x, box.y, box.width, box.height);
     }
-
     ctx.restore();
 };


### PR DESCRIPTION
## What has changed and why?

  - Renders annotations at the displayed image size instead of the full original resolution.
  - Correctly handles cropping and “contain” or “cover” image layouts.
  - Reduces memory usage when displaying annotations from large images.
  - Provides the shared foundation required by the next PR.

## How has it been tested?

- new tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Annotation overlays now support custom output sizes, object-fit modes, cropping, and per-annotation colors and opacity.
  * Mask and bounding-box rendering adapts correctly to resized, cropped, and contained or covered images.
  * Rendering falls back smoothly when accelerated canvas transfer is unavailable.

* **Bug Fixes**
  * Improved canvas resizing and annotation positioning across different image dimensions.
  * Fixed rendering transitions and handling of duplicate samples.

* **Tests**
  * Expanded coverage for resizing, cropping, transparency, worker rendering, fallback behavior, and coordinate transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->