### PR TITLE
Support creating captions with a temporal segment

### DIFF
--- a/lightly_studio/src/lightly_studio/models/caption.py
+++ b/lightly_studio/src/lightly_studio/models/caption.py
@@ -1,12 +1,14 @@
 """This module defines the caption model."""
 
 from datetime import datetime, timezone
+from typing import Optional
 from uuid import UUID
 
 from sqlalchemy.orm import Mapped
 from sqlmodel import Field, Relationship, SQLModel
 
 from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.temporal_span import TemporalSpanTable, TemporalSpanView
 
 
 class CaptionTable(SQLModel, table=True):
@@ -33,12 +35,26 @@ class CaptionTable(SQLModel, table=True):
         },
     )
 
+    # Optional temporal bounds for this caption's sample.
+    temporal_span_details: Mapped[Optional["TemporalSpanTable"]] = Relationship(
+        sa_relationship_kwargs={
+            "primaryjoin": "CaptionTable.sample_id == foreign(TemporalSpanTable.sample_id)",
+            "lazy": "selectin",
+            "uselist": False,
+            "viewonly": True,
+        },
+    )
+
 
 class CaptionCreate(SQLModel):
     """Input model for creating captions."""
 
     parent_sample_id: UUID
     text: str
+
+    # Optional temporal bounds for the caption's sample.
+    start_time_s: Optional[float] = None
+    end_time_s: Optional[float] = None
 
 
 class CaptionView(SQLModel):
@@ -47,3 +63,4 @@ class CaptionView(SQLModel):
     parent_sample_id: UUID
     sample_id: UUID
     text: str
+    temporal_span_details: Optional[TemporalSpanView] = None

--- a/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
@@ -10,6 +10,7 @@ from sqlmodel import Session, col, select
 from lightly_studio.models.caption import CaptionCreate, CaptionTable
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.sample import SampleCreate
+from lightly_studio.models.temporal_span import TemporalSpanTable
 from lightly_studio.resolvers import collection_resolver, sample_resolver
 from lightly_studio.utils import batching
 
@@ -49,18 +50,33 @@ def create_many(
         samples=[SampleCreate(collection_id=caption_collection_id) for _ in captions],
     )
 
-    # Bulk create CaptionTable entries using the generated sample_ids.
-    db_captions = [
-        CaptionTable.model_validate(
-            CaptionCreateHelper(
-                parent_sample_id=sample.parent_sample_id,
-                text=sample.text,
-                sample_id=sample_id,
+    # Bulk create CaptionTable entries and their optional temporal spans using the
+    # generated sample_ids.
+    db_captions = []
+    temporal_spans = []
+    for sample_id, caption in zip(sample_ids, captions):
+        db_captions.append(
+            CaptionTable.model_validate(
+                CaptionCreateHelper(
+                    parent_sample_id=caption.parent_sample_id,
+                    text=caption.text,
+                    sample_id=sample_id,
+                )
             )
         )
-        for sample_id, sample in zip(sample_ids, captions)
-    ]
+        temporal_span = _validate_optional_temporal_span(caption=caption)
+        if temporal_span is not None:
+            start_time_s, end_time_s = temporal_span
+            temporal_spans.append(
+                TemporalSpanTable(
+                    sample_id=sample_id,
+                    start_time_s=start_time_s,
+                    end_time_s=end_time_s,
+                )
+            )
+
     session.bulk_save_objects(db_captions)
+    session.bulk_save_objects(temporal_spans)
     session.commit()
     return sample_ids
 
@@ -131,3 +147,31 @@ def delete_caption(
     session.commit()
     session.delete(caption)
     session.commit()
+
+
+def _validate_optional_temporal_span(caption: CaptionCreate) -> tuple[float, float] | None:
+    """Validate the optional temporal span of a caption to create.
+
+    Args:
+        caption: The caption to validate.
+
+    Returns:
+        The validated ``(start_time_s, end_time_s)`` tuple, or ``None`` if the caption has
+        no temporal span.
+
+    Raises:
+        ValueError: If only one of the two bounds is set or the span is invalid.
+    """
+    start_time_s = caption.start_time_s
+    end_time_s = caption.end_time_s
+    if start_time_s is None and end_time_s is None:
+        return None
+
+    if start_time_s is None or end_time_s is None:
+        raise ValueError("Both start_time_s and end_time_s must be provided together.")
+    if start_time_s < 0:
+        raise ValueError("start_time_s must be non-negative.")
+    if start_time_s >= end_time_s:
+        raise ValueError("start_time_s must be less than end_time_s.")
+
+    return (start_time_s, end_time_s)

--- a/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
@@ -6,7 +6,7 @@ import math
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlmodel import Session, col, select
+from sqlmodel import Session, col, delete, select
 
 from lightly_studio.models.caption import CaptionCreate, CaptionTable
 from lightly_studio.models.collection import SampleType
@@ -152,7 +152,8 @@ def delete_caption(
         raise ValueError(f"Caption with ID {sample_id} not found.")
 
     caption = captions[0]
-    session.commit()
+    # Delete the caption's optional temporal span first to avoid leaving an orphaned row.
+    session.exec(delete(TemporalSpanTable).where(col(TemporalSpanTable.sample_id) == sample_id))
     session.delete(caption)
     session.commit()
 

--- a/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from uuid import UUID
 
@@ -42,6 +43,13 @@ def create_many(
     if not captions:
         return []
 
+    # Validate all temporal spans before writing any rows.
+    temporal_spans_by_index = {
+        index: temporal_span
+        for index, caption in enumerate(captions)
+        if (temporal_span := _validate_optional_temporal_span(caption=caption)) is not None
+    }
+
     caption_collection_id = collection_resolver.get_or_create_child_collection(
         session=session, collection_id=parent_collection_id, sample_type=SampleType.CAPTION
     )
@@ -54,7 +62,7 @@ def create_many(
     # generated sample_ids.
     db_captions = []
     temporal_spans = []
-    for sample_id, caption in zip(sample_ids, captions):
+    for index, (sample_id, caption) in enumerate(zip(sample_ids, captions)):
         db_captions.append(
             CaptionTable.model_validate(
                 CaptionCreateHelper(
@@ -64,7 +72,7 @@ def create_many(
                 )
             )
         )
-        temporal_span = _validate_optional_temporal_span(caption=caption)
+        temporal_span = temporal_spans_by_index.get(index)
         if temporal_span is not None:
             start_time_s, end_time_s = temporal_span
             temporal_spans.append(
@@ -169,6 +177,8 @@ def _validate_optional_temporal_span(caption: CaptionCreate) -> tuple[float, flo
 
     if start_time_s is None or end_time_s is None:
         raise ValueError("Both start_time_s and end_time_s must be provided together.")
+    if not math.isfinite(start_time_s) or not math.isfinite(end_time_s):
+        raise ValueError("start_time_s and end_time_s must be finite.")
     if start_time_s < 0:
         raise ValueError("start_time_s must be non-negative.")
     if start_time_s >= end_time_s:

--- a/lightly_studio/tests/resolvers/test_caption_resolver.py
+++ b/lightly_studio/tests/resolvers/test_caption_resolver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from uuid import uuid4
 
 import pytest
@@ -266,6 +267,38 @@ def test_create_many__invalid_temporal_span(db_session: Session) -> None:
                     parent_sample_id=image.sample_id,
                     text="partial span",
                     start_time_s=1.0,
+                ),
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    ("start_time_s", "end_time_s"),
+    [
+        (math.nan, 1.0),
+        (0.0, math.nan),
+        (math.inf, 1.0),
+        (0.0, math.inf),
+        (-math.inf, 1.0),
+        (0.0, -math.inf),
+    ],
+)
+def test_create_many__non_finite_temporal_span(
+    db_session: Session, start_time_s: float, end_time_s: float
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+
+    with pytest.raises(ValueError, match="start_time_s and end_time_s must be finite"):
+        caption_resolver.create_many(
+            session=db_session,
+            parent_collection_id=collection.collection_id,
+            captions=[
+                CaptionCreate(
+                    parent_sample_id=image.sample_id,
+                    text="non-finite span",
+                    start_time_s=start_time_s,
+                    end_time_s=end_time_s,
                 ),
             ],
         )

--- a/lightly_studio/tests/resolvers/test_caption_resolver.py
+++ b/lightly_studio/tests/resolvers/test_caption_resolver.py
@@ -211,6 +211,66 @@ def test_update_text(db_session: Session) -> None:
         )
 
 
+def test_create_many__with_temporal_span(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+
+    created_ids = caption_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        captions=[
+            CaptionCreate(
+                parent_sample_id=image.sample_id,
+                text="with span",
+                start_time_s=1.0,
+                end_time_s=2.5,
+            ),
+            CaptionCreate(
+                parent_sample_id=image.sample_id,
+                text="without span",
+            ),
+        ],
+    )
+    created = caption_resolver.get_by_ids(session=db_session, sample_ids=created_ids)
+
+    assert created[0].temporal_span_details is not None
+    assert created[0].temporal_span_details.start_time_s == 1.0
+    assert created[0].temporal_span_details.end_time_s == 2.5
+    assert created[1].temporal_span_details is None
+
+
+def test_create_many__invalid_temporal_span(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+
+    with pytest.raises(ValueError, match="start_time_s must be less than end_time_s"):
+        caption_resolver.create_many(
+            session=db_session,
+            parent_collection_id=collection.collection_id,
+            captions=[
+                CaptionCreate(
+                    parent_sample_id=image.sample_id,
+                    text="bad span",
+                    start_time_s=2.0,
+                    end_time_s=1.0,
+                ),
+            ],
+        )
+
+    with pytest.raises(ValueError, match="Both start_time_s and end_time_s must be provided"):
+        caption_resolver.create_many(
+            session=db_session,
+            parent_collection_id=collection.collection_id,
+            captions=[
+                CaptionCreate(
+                    parent_sample_id=image.sample_id,
+                    text="partial span",
+                    start_time_s=1.0,
+                ),
+            ],
+        )
+
+
 def test_delete_caption(db_session: Session) -> None:
     collection = create_collection(session=db_session)
 

--- a/lightly_studio/tests/resolvers/test_caption_resolver.py
+++ b/lightly_studio/tests/resolvers/test_caption_resolver.py
@@ -4,10 +4,11 @@ import math
 from uuid import uuid4
 
 import pytest
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 
 from lightly_studio.models.caption import CaptionCreate, CaptionTable
 from lightly_studio.models.collection import SampleType
+from lightly_studio.models.temporal_span import TemporalSpanTable
 from lightly_studio.resolvers import caption_resolver, collection_resolver
 from tests.helpers_resolvers import create_collection, create_image
 
@@ -342,3 +343,29 @@ def test_delete_caption(db_session: Session) -> None:
     wrong_id = uuid4()
     with pytest.raises(ValueError, match=f"Caption with ID {wrong_id} not found."):
         caption_resolver.delete_caption(session=db_session, sample_id=wrong_id)
+
+
+def test_delete_caption__removes_temporal_span(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+
+    caption_ids = caption_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        captions=[
+            CaptionCreate(
+                parent_sample_id=image.sample_id,
+                text="with span",
+                start_time_s=1.0,
+                end_time_s=2.5,
+            ),
+        ],
+    )
+
+    caption_resolver.delete_caption(session=db_session, sample_id=caption_ids[0])
+
+    # The caption's temporal span must not be left orphaned.
+    remaining_spans = db_session.exec(
+        select(TemporalSpanTable).where(col(TemporalSpanTable.sample_id) == caption_ids[0])
+    ).all()
+    assert remaining_spans == []


### PR DESCRIPTION
## What has changed and why?

Add optional temporal bounds to captions so a caption can be created with a time segment.

## How has it been tested?

New tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Captions can include optional start and end times.
  * Caption details display associated temporal-span information when available.
  * Captions without timing data remain supported.
  * Valid timing data is automatically associated with captions.

* **Bug Fixes**
  * Invalid or incomplete time ranges are rejected.
  * Associated timing data is removed when captions are deleted.

* **Tests**
  * Added coverage for valid, invalid, and missing temporal-span scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->