### PR TITLE
move out HistogramToolbar component

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/HistogramToolbar/HistogramToolbar.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/HistogramToolbar/HistogramToolbar.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+    import { Maximize2 as Maximize2Icon } from '@lucide/svelte';
+    import { Button } from '$lib/components';
+    import { Select, type SelectItem } from '$lib/components/Select';
+    import { formatFloat, formatInteger } from '$lib/utils';
+    import type { HistogramData } from '$lib/components/Histogram';
+
+    interface Props {
+        histogram: HistogramData;
+        histogramTotal: number;
+        valueNoun: string;
+        histogramBinCount: number;
+        binCountItems: SelectItem[];
+        onHistogramBinCountChange?: (binCount: number) => void;
+        onExpand: () => void;
+    }
+
+    const {
+        histogram,
+        histogramTotal,
+        valueNoun,
+        histogramBinCount,
+        binCountItems,
+        onHistogramBinCountChange,
+        onExpand
+    }: Props = $props();
+</script>
+
+<div class="mt-2 flex flex-wrap items-center justify-between gap-2">
+    <span
+        class="text-xs text-muted-foreground"
+        data-testid="dataset-distribution-histogram-summary"
+    >
+        {formatInteger(histogramTotal)}
+        {valueNoun} · {histogram.counts.length}
+        {histogram.counts.length === 1 ? 'bin' : 'bins'} · {formatFloat(
+            histogram.binEdges[0]
+        )}–{formatFloat(histogram.binEdges[histogram.binEdges.length - 1])}
+    </span>
+    <div class="flex items-center gap-1">
+        {#if onHistogramBinCountChange}
+            <Select
+                items={binCountItems}
+                value={String(histogramBinCount)}
+                size="xs"
+                class="w-24"
+                testId="dataset-distribution-bin-count"
+                selectProps={{ 'aria-label': 'Histogram bin count' }}
+                onValueChange={(value) => onHistogramBinCountChange(Number(value))}
+            />
+        {/if}
+        <Button
+            variant="ghost"
+            icon={Maximize2Icon}
+            ariaLabel="Expand distribution"
+            buttonProps={{
+                size: 'sm',
+                class: 'h-8 w-8 p-0',
+                onclick: onExpand,
+                'data-testid': 'dataset-distribution-histogram-expand'
+            }}
+        />
+    </div>
+</div>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/HistogramToolbar/HistogramToolbar.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/HistogramToolbar/HistogramToolbar.test.ts
@@ -64,14 +64,6 @@ describe('HistogramToolbar', () => {
         expect(screen.getByTestId('dataset-distribution-bin-count')).toHaveTextContent('50 bins');
     });
 
-    it('hides the bin-count selector when no change handler is provided', () => {
-        render(HistogramToolbar, {
-            props: { ...defaultProps, onHistogramBinCountChange: undefined }
-        });
-
-        expect(screen.queryByTestId('dataset-distribution-bin-count')).not.toBeInTheDocument();
-    });
-
     it('calls onHistogramBinCountChange with the selected count', async () => {
         const onHistogramBinCountChange = vi.fn();
         const user = userEvent.setup();

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/HistogramToolbar/HistogramToolbar.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/HistogramToolbar/HistogramToolbar.test.ts
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import HistogramToolbar from './HistogramToolbar.svelte';
+import type { HistogramData } from '$lib/components/Histogram';
+import { HISTOGRAM_BIN_COUNT_ITEMS } from '../types';
+import type { SelectItem } from '$lib/components/Select';
+
+const histogram: HistogramData = { binEdges: [0, 0.5, 1], counts: [30, 70] };
+
+const binCountItems: SelectItem[] = HISTOGRAM_BIN_COUNT_ITEMS.map((count) => ({
+    value: String(count),
+    label: `${count} bins`
+}));
+
+const defaultProps = {
+    histogram,
+    histogramTotal: 100,
+    valueNoun: 'annotations',
+    histogramBinCount: 20,
+    binCountItems,
+    onHistogramBinCountChange: vi.fn(),
+    onExpand: vi.fn()
+};
+
+describe('HistogramToolbar', () => {
+    beforeAll(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+        Element.prototype.hasPointerCapture = vi.fn(() => false);
+        Element.prototype.setPointerCapture = vi.fn();
+        Element.prototype.releasePointerCapture = vi.fn();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        document.body.style.pointerEvents = '';
+    });
+
+    it('renders the summary with total count, bin count, and range', () => {
+        render(HistogramToolbar, { props: defaultProps });
+
+        expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
+            '100 annotations · 2 bins · 0–1'
+        );
+    });
+
+    it('uses the singular "bin" when there is only one bin', () => {
+        render(HistogramToolbar, {
+            props: {
+                ...defaultProps,
+                histogram: { binEdges: [0, 1], counts: [50] },
+                histogramTotal: 50
+            }
+        });
+
+        expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
+            '1 bin ·'
+        );
+    });
+
+    it('shows the bin-count selector with the applied bin count', () => {
+        render(HistogramToolbar, { props: { ...defaultProps, histogramBinCount: 50 } });
+
+        expect(screen.getByTestId('dataset-distribution-bin-count')).toHaveTextContent('50 bins');
+    });
+
+    it('hides the bin-count selector when no change handler is provided', () => {
+        render(HistogramToolbar, {
+            props: { ...defaultProps, onHistogramBinCountChange: undefined }
+        });
+
+        expect(screen.queryByTestId('dataset-distribution-bin-count')).not.toBeInTheDocument();
+    });
+
+    it('calls onHistogramBinCountChange with the selected count', async () => {
+        const onHistogramBinCountChange = vi.fn();
+        const user = userEvent.setup();
+        render(HistogramToolbar, { props: { ...defaultProps, onHistogramBinCountChange } });
+
+        await user.click(screen.getByTestId('dataset-distribution-bin-count'));
+        const option = await waitFor(() => screen.getByRole('option', { name: '10 bins' }));
+        await user.click(option);
+
+        expect(onHistogramBinCountChange).toHaveBeenCalledWith(10);
+    });
+
+    it('calls onExpand when the expand button is clicked', async () => {
+        const onExpand = vi.fn();
+        const user = userEvent.setup();
+        render(HistogramToolbar, { props: { ...defaultProps, onExpand } });
+
+        await user.click(screen.getByTestId('dataset-distribution-histogram-expand'));
+
+        expect(onExpand).toHaveBeenCalledOnce();
+    });
+
+    it('uses the provided valueNoun in the summary', () => {
+        render(HistogramToolbar, { props: { ...defaultProps, valueNoun: 'samples' } });
+
+        expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
+            '100 samples ·'
+        );
+    });
+});


### PR DESCRIPTION
## What has changed and why?

Part of facteroed out branch of https://github.com/lightly-ai/lightly-studio/pull/1814/changes#diff-ee7de82e1ccc331bae450c6ef08c07cb8274cc46f4b9fb4723ad375ed3b0668f

See details in source branch

## How has it been tested?

Should be enough to pass unit test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a histogram toolbar displaying distribution totals, value labels, bin counts, and bin-edge ranges.
  * Added optional bin-count selection with updated values.
  * Added an expand control for viewing the histogram in an expanded layout.
  * Supports customized value labels and singular/plural bin wording.
  * Provides a clearer summary of dataset distributions and more convenient controls for adjusting histogram detail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->