### PR TITLE
Add caption temporal-span update and API wiring

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/caption.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/caption.py
@@ -26,44 +26,33 @@ class CaptionCreateInput(BaseModel):
     end_time_s: float | None = None
 
 
-class CaptionTemporalSpanUpdateInput(BaseModel):
-    """API interface to update the temporal span of a caption."""
+class CaptionUpdateInput(BaseModel):
+    """API interface to update a caption's text and/or temporal span."""
 
-    start_time_s: float
-    end_time_s: float
+    text: str | None = None
+    start_time_s: float | None = None
+    end_time_s: float | None = None
 
 
 captions_router = APIRouter(prefix="/collections/{collection_id}", tags=["captions"])
 
 
 @captions_router.put("/captions/{sample_id}", response_model=CaptionView)
-def update_caption_text(
+def update_caption(
     session: SessionDep,
     sample_id: Annotated[
         UUID,
         Path(title="Caption ID", description="ID of the caption to update"),
     ],
-    text: Annotated[str, Body()],
+    caption_update: Annotated[CaptionUpdateInput, Body()],
 ) -> CaptionTable:
-    """Update an existing caption in the database."""
-    return caption_resolver.update_text(session=session, sample_id=sample_id, text=text)
-
-
-@captions_router.put("/captions/{sample_id}/temporal_span", response_model=CaptionView)
-def update_caption_temporal_span(
-    session: SessionDep,
-    sample_id: Annotated[
-        UUID,
-        Path(title="Caption ID", description="ID of the caption to update"),
-    ],
-    temporal_span: Annotated[CaptionTemporalSpanUpdateInput, Body()],
-) -> CaptionTable:
-    """Update the temporal span of an existing caption."""
-    return caption_resolver.update_temporal_span(
+    """Update an existing caption's text and/or temporal span."""
+    return caption_resolver.update(
         session=session,
         sample_id=sample_id,
-        start_time_s=temporal_span.start_time_s,
-        end_time_s=temporal_span.end_time_s,
+        text=caption_update.text,
+        start_time_s=caption_update.start_time_s,
+        end_time_s=caption_update.end_time_s,
     )
 
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/caption.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/caption.py
@@ -21,6 +21,17 @@ class CaptionCreateInput(BaseModel):
     parent_sample_id: UUID
     text: str = ""
 
+    # Optional temporal bounds for the caption's sample.
+    start_time_s: float | None = None
+    end_time_s: float | None = None
+
+
+class CaptionTemporalSpanUpdateInput(BaseModel):
+    """API interface to update the temporal span of a caption."""
+
+    start_time_s: float
+    end_time_s: float
+
 
 captions_router = APIRouter(prefix="/collections/{collection_id}", tags=["captions"])
 
@@ -36,6 +47,24 @@ def update_caption_text(
 ) -> CaptionTable:
     """Update an existing caption in the database."""
     return caption_resolver.update_text(session=session, sample_id=sample_id, text=text)
+
+
+@captions_router.put("/captions/{sample_id}/temporal_span", response_model=CaptionView)
+def update_caption_temporal_span(
+    session: SessionDep,
+    sample_id: Annotated[
+        UUID,
+        Path(title="Caption ID", description="ID of the caption to update"),
+    ],
+    temporal_span: Annotated[CaptionTemporalSpanUpdateInput, Body()],
+) -> CaptionTable:
+    """Update the temporal span of an existing caption."""
+    return caption_resolver.update_temporal_span(
+        session=session,
+        sample_id=sample_id,
+        start_time_s=temporal_span.start_time_s,
+        end_time_s=temporal_span.end_time_s,
+    )
 
 
 @captions_router.get("/captions/{sample_id}", response_model=CaptionView)
@@ -75,6 +104,8 @@ def create_caption(
             CaptionCreate(
                 parent_sample_id=create_caption_input.parent_sample_id,
                 text=create_caption_input.text,
+                start_time_s=create_caption_input.start_time_s,
+                end_time_s=create_caption_input.end_time_s,
             ),
         ],
     )

--- a/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
@@ -108,7 +108,7 @@ def update(
     start_time_s: float | None = None,
     end_time_s: float | None = None,
 ) -> CaptionTable:
-    """Update a caption's text and/or temporal span in a single transaction.
+    """Update a caption's text and/or temporal span.
 
     The temporal span is created if it does not exist yet. Both ``start_time_s`` and
     ``end_time_s`` must be provided together to change the span.
@@ -117,8 +117,10 @@ def update(
         session: Database session for executing the operation.
         sample_id: UUID of the caption to update.
         text: New text. Left unchanged when ``None``.
-        start_time_s: New start time in seconds. Left unchanged when ``None``.
-        end_time_s: New end time in seconds. Left unchanged when ``None``.
+        start_time_s: New start time in seconds. Must be provided together with
+            ``end_time_s``; the span is left unchanged only when both are ``None``.
+        end_time_s: New end time in seconds. Must be provided together with
+            ``start_time_s``; the span is left unchanged only when both are ``None``.
 
     Returns:
         The updated caption.

--- a/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
@@ -117,10 +117,8 @@ def update(
         session: Database session for executing the operation.
         sample_id: UUID of the caption to update.
         text: New text. Left unchanged when ``None``.
-        start_time_s: New start time in seconds. Must be provided together with
-            ``end_time_s``; the span is left unchanged only when both are ``None``.
-        end_time_s: New end time in seconds. Must be provided together with
-            ``start_time_s``; the span is left unchanged only when both are ``None``.
+        start_time_s: New start time in seconds. Must be given with ``end_time_s``.
+        end_time_s: New end time in seconds. Must be given with ``start_time_s``.
 
     Returns:
         The updated caption.
@@ -145,18 +143,12 @@ def update(
         if text is not None:
             caption.text = text
         if start_time_s is not None and end_time_s is not None:
-            if caption.temporal_span_details is None:
-                session.add(
-                    TemporalSpanTable(
-                        sample_id=sample_id,
-                        start_time_s=start_time_s,
-                        end_time_s=end_time_s,
-                    )
+            # The span's primary key is the caption's sample_id, so merge upserts the row.
+            session.merge(
+                TemporalSpanTable(
+                    sample_id=sample_id, start_time_s=start_time_s, end_time_s=end_time_s
                 )
-            else:
-                caption.temporal_span_details.start_time_s = start_time_s
-                caption.temporal_span_details.end_time_s = end_time_s
-                session.add(caption.temporal_span_details)
+            )
         session.commit()
         session.refresh(caption)
         return caption
@@ -216,10 +208,6 @@ def _validate_optional_temporal_span(caption: CaptionCreate) -> tuple[float, flo
 
 def _validate_temporal_span_bounds(start_time_s: float, end_time_s: float) -> None:
     """Validate that a temporal span's bounds are finite, non-negative, and ordered.
-
-    Args:
-        start_time_s: Start time in seconds.
-        end_time_s: End time in seconds.
 
     Raises:
         ValueError: If either bound is not finite, the start is negative, or the start is

--- a/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
@@ -134,6 +134,54 @@ def update_text(
         raise
 
 
+def update_temporal_span(
+    session: Session,
+    sample_id: UUID,
+    start_time_s: float,
+    end_time_s: float,
+) -> CaptionTable:
+    """Update the temporal span of a caption, creating it if it does not exist.
+
+    Args:
+        session: Database session for executing the operation.
+        sample_id: UUID of the caption to update.
+        start_time_s: New start time in seconds.
+        end_time_s: New end time in seconds.
+
+    Returns:
+        The updated caption with the new temporal span.
+
+    Raises:
+        ValueError: If the caption is not found or the span is invalid.
+    """
+    _validate_temporal_span_bounds(start_time_s=start_time_s, end_time_s=end_time_s)
+
+    captions = get_by_ids(session=session, sample_ids=[sample_id])
+    if not captions:
+        raise ValueError(f"Caption with ID {sample_id} not found.")
+
+    caption = captions[0]
+    try:
+        if caption.temporal_span_details is None:
+            session.add(
+                TemporalSpanTable(
+                    sample_id=sample_id,
+                    start_time_s=start_time_s,
+                    end_time_s=end_time_s,
+                )
+            )
+        else:
+            caption.temporal_span_details.start_time_s = start_time_s
+            caption.temporal_span_details.end_time_s = end_time_s
+            session.add(caption.temporal_span_details)
+        session.commit()
+        session.refresh(caption)
+        return caption
+    except Exception:
+        session.rollback()
+        raise
+
+
 def delete_caption(
     session: Session,
     sample_id: UUID,
@@ -178,11 +226,25 @@ def _validate_optional_temporal_span(caption: CaptionCreate) -> tuple[float, flo
 
     if start_time_s is None or end_time_s is None:
         raise ValueError("Both start_time_s and end_time_s must be provided together.")
+    _validate_temporal_span_bounds(start_time_s=start_time_s, end_time_s=end_time_s)
+
+    return (start_time_s, end_time_s)
+
+
+def _validate_temporal_span_bounds(start_time_s: float, end_time_s: float) -> None:
+    """Validate that a temporal span's bounds are finite, non-negative, and ordered.
+
+    Args:
+        start_time_s: Start time in seconds.
+        end_time_s: End time in seconds.
+
+    Raises:
+        ValueError: If either bound is not finite, the start is negative, or the start is
+            not strictly less than the end.
+    """
     if not math.isfinite(start_time_s) or not math.isfinite(end_time_s):
         raise ValueError("start_time_s and end_time_s must be finite.")
     if start_time_s < 0:
         raise ValueError("start_time_s must be non-negative.")
     if start_time_s >= end_time_s:
         raise ValueError("start_time_s must be less than end_time_s.")
-
-    return (start_time_s, end_time_s)

--- a/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/caption_resolver.py
@@ -101,60 +101,38 @@ def get_by_ids(session: Session, sample_ids: Sequence[UUID]) -> list[CaptionTabl
     return [caption_map[id_] for id_ in sample_ids if id_ in caption_map]
 
 
-def update_text(
+def update(
     session: Session,
     sample_id: UUID,
-    text: str,
+    text: str | None = None,
+    start_time_s: float | None = None,
+    end_time_s: float | None = None,
 ) -> CaptionTable:
-    """Update the text of a caption.
+    """Update a caption's text and/or temporal span in a single transaction.
+
+    The temporal span is created if it does not exist yet. Both ``start_time_s`` and
+    ``end_time_s`` must be provided together to change the span.
 
     Args:
         session: Database session for executing the operation.
         sample_id: UUID of the caption to update.
-        text: New text.
+        text: New text. Left unchanged when ``None``.
+        start_time_s: New start time in seconds. Left unchanged when ``None``.
+        end_time_s: New end time in seconds. Left unchanged when ``None``.
 
     Returns:
-        The updated caption with the new text.
+        The updated caption.
 
     Raises:
-        ValueError: If the caption is not found.
+        ValueError: If the caption is not found, no fields are provided, or the temporal
+            span is incomplete or invalid.
     """
-    captions = get_by_ids(session, [sample_id])
-    if not captions:
-        raise ValueError(f"Caption with ID {sample_id} not found.")
-
-    caption = captions[0]
-    try:
-        caption.text = text
-        session.commit()
-        session.refresh(caption)
-        return caption
-    except Exception:
-        session.rollback()
-        raise
-
-
-def update_temporal_span(
-    session: Session,
-    sample_id: UUID,
-    start_time_s: float,
-    end_time_s: float,
-) -> CaptionTable:
-    """Update the temporal span of a caption, creating it if it does not exist.
-
-    Args:
-        session: Database session for executing the operation.
-        sample_id: UUID of the caption to update.
-        start_time_s: New start time in seconds.
-        end_time_s: New end time in seconds.
-
-    Returns:
-        The updated caption with the new temporal span.
-
-    Raises:
-        ValueError: If the caption is not found or the span is invalid.
-    """
-    _validate_temporal_span_bounds(start_time_s=start_time_s, end_time_s=end_time_s)
+    if (start_time_s is None) != (end_time_s is None):
+        raise ValueError("Both start_time_s and end_time_s must be provided together.")
+    if text is None and start_time_s is None:
+        raise ValueError("No updates provided for the caption.")
+    if start_time_s is not None and end_time_s is not None:
+        _validate_temporal_span_bounds(start_time_s=start_time_s, end_time_s=end_time_s)
 
     captions = get_by_ids(session=session, sample_ids=[sample_id])
     if not captions:
@@ -162,18 +140,21 @@ def update_temporal_span(
 
     caption = captions[0]
     try:
-        if caption.temporal_span_details is None:
-            session.add(
-                TemporalSpanTable(
-                    sample_id=sample_id,
-                    start_time_s=start_time_s,
-                    end_time_s=end_time_s,
+        if text is not None:
+            caption.text = text
+        if start_time_s is not None and end_time_s is not None:
+            if caption.temporal_span_details is None:
+                session.add(
+                    TemporalSpanTable(
+                        sample_id=sample_id,
+                        start_time_s=start_time_s,
+                        end_time_s=end_time_s,
+                    )
                 )
-            )
-        else:
-            caption.temporal_span_details.start_time_s = start_time_s
-            caption.temporal_span_details.end_time_s = end_time_s
-            session.add(caption.temporal_span_details)
+            else:
+                caption.temporal_span_details.start_time_s = start_time_s
+                caption.temporal_span_details.end_time_s = end_time_s
+                session.add(caption.temporal_span_details)
         session.commit()
         session.refresh(caption)
         return caption

--- a/lightly_studio/tests/api/routes/api/test_caption.py
+++ b/lightly_studio/tests/api/routes/api/test_caption.py
@@ -99,8 +99,7 @@ def test_create_caption(db_session: Session, test_client: TestClient) -> None:
 
 
 def test_create_caption__with_temporal_span(db_session: Session, test_client: TestClient) -> None:
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
+    collection_id = create_collection(session=db_session).collection_id
     sample = create_image(session=db_session, collection_id=collection_id)
     input_data = {
         "parent_sample_id": str(sample.sample_id),
@@ -111,25 +110,20 @@ def test_create_caption__with_temporal_span(db_session: Session, test_client: Te
     response = test_client.post(f"/api/collections/{collection_id!s}/captions", json=input_data)
 
     assert response.status_code == HTTP_STATUS_OK
-    result = response.json()
-    assert result["temporal_span_details"] == {"start_time_s": 1.0, "end_time_s": 2.5}
+    assert response.json()["temporal_span_details"] == {"start_time_s": 1.0, "end_time_s": 2.5}
 
 
-def test_update_caption_text_and_temporal_span(
+def test_update_caption__text_and_temporal_span(
     db_session: Session, test_client: TestClient
 ) -> None:
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
+    collection_id = create_collection(session=db_session).collection_id
     parent_sample = create_image(session=db_session, collection_id=collection_id)
     caption = create_caption(
-        session=db_session,
-        collection_id=collection_id,
-        parent_sample_id=parent_sample.sample_id,
+        session=db_session, collection_id=collection_id, parent_sample_id=parent_sample.sample_id
     )
-    sample_id = caption.sample_id
 
     response = test_client.put(
-        f"/api/collections/{collection_id!s}/captions/{sample_id!s}",
+        f"/api/collections/{collection_id!s}/captions/{caption.sample_id!s}",
         json={"text": "new text", "start_time_s": 1.0, "end_time_s": 2.0},
     )
 

--- a/lightly_studio/tests/api/routes/api/test_caption.py
+++ b/lightly_studio/tests/api/routes/api/test_caption.py
@@ -30,7 +30,7 @@ def test_update_caption_text(db_session: Session, test_client: TestClient) -> No
     new_text = "updated text"
     response = test_client.put(
         f"/api/collections/{collection_id!s}/captions/{sample_id!s}",
-        json=new_text,
+        json={"text": new_text},
     )
 
     # Verify that the response includes the updated caption.
@@ -127,7 +127,7 @@ def test_update_caption_temporal_span(db_session: Session, test_client: TestClie
     sample_id = caption.sample_id
 
     response = test_client.put(
-        f"/api/collections/{collection_id!s}/captions/{sample_id!s}/temporal_span",
+        f"/api/collections/{collection_id!s}/captions/{sample_id!s}",
         json={"start_time_s": 3.0, "end_time_s": 5.0},
     )
 
@@ -141,6 +141,30 @@ def test_update_caption_temporal_span(db_session: Session, test_client: TestClie
     assert updated_caption.temporal_span_details is not None
     assert updated_caption.temporal_span_details.start_time_s == 3.0
     assert updated_caption.temporal_span_details.end_time_s == 5.0
+
+
+def test_update_caption_text_and_temporal_span(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    parent_sample = create_image(session=db_session, collection_id=collection_id)
+    caption = create_caption(
+        session=db_session,
+        collection_id=collection_id,
+        parent_sample_id=parent_sample.sample_id,
+    )
+    sample_id = caption.sample_id
+
+    response = test_client.put(
+        f"/api/collections/{collection_id!s}/captions/{sample_id!s}",
+        json={"text": "new text", "start_time_s": 1.0, "end_time_s": 2.0},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    result = response.json()
+    assert result["text"] == "new text"
+    assert result["temporal_span_details"] == {"start_time_s": 1.0, "end_time_s": 2.0}
 
 
 def test_delete_caption(db_session: Session, test_client: TestClient) -> None:

--- a/lightly_studio/tests/api/routes/api/test_caption.py
+++ b/lightly_studio/tests/api/routes/api/test_caption.py
@@ -115,34 +115,6 @@ def test_create_caption__with_temporal_span(db_session: Session, test_client: Te
     assert result["temporal_span_details"] == {"start_time_s": 1.0, "end_time_s": 2.5}
 
 
-def test_update_caption_temporal_span(db_session: Session, test_client: TestClient) -> None:
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-    parent_sample = create_image(session=db_session, collection_id=collection_id)
-    caption = create_caption(
-        session=db_session,
-        collection_id=collection_id,
-        parent_sample_id=parent_sample.sample_id,
-    )
-    sample_id = caption.sample_id
-
-    response = test_client.put(
-        f"/api/collections/{collection_id!s}/captions/{sample_id!s}",
-        json={"start_time_s": 3.0, "end_time_s": 5.0},
-    )
-
-    assert response.status_code == HTTP_STATUS_OK
-    result = response.json()
-    assert result["sample_id"] == str(sample_id)
-    assert result["temporal_span_details"] == {"start_time_s": 3.0, "end_time_s": 5.0}
-
-    # Verify the span persisted in the database.
-    updated_caption = caption_resolver.get_by_ids(db_session, sample_ids=[sample_id])[0]
-    assert updated_caption.temporal_span_details is not None
-    assert updated_caption.temporal_span_details.start_time_s == 3.0
-    assert updated_caption.temporal_span_details.end_time_s == 5.0
-
-
 def test_update_caption_text_and_temporal_span(
     db_session: Session, test_client: TestClient
 ) -> None:

--- a/lightly_studio/tests/api/routes/api/test_caption.py
+++ b/lightly_studio/tests/api/routes/api/test_caption.py
@@ -98,6 +98,51 @@ def test_create_caption(db_session: Session, test_client: TestClient) -> None:
     assert result["error"] == f"Sample with ID {wrong_sample_id} not found."
 
 
+def test_create_caption__with_temporal_span(db_session: Session, test_client: TestClient) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    sample = create_image(session=db_session, collection_id=collection_id)
+    input_data = {
+        "parent_sample_id": str(sample.sample_id),
+        "text": "captioned segment",
+        "start_time_s": 1.0,
+        "end_time_s": 2.5,
+    }
+    response = test_client.post(f"/api/collections/{collection_id!s}/captions", json=input_data)
+
+    assert response.status_code == HTTP_STATUS_OK
+    result = response.json()
+    assert result["temporal_span_details"] == {"start_time_s": 1.0, "end_time_s": 2.5}
+
+
+def test_update_caption_temporal_span(db_session: Session, test_client: TestClient) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    parent_sample = create_image(session=db_session, collection_id=collection_id)
+    caption = create_caption(
+        session=db_session,
+        collection_id=collection_id,
+        parent_sample_id=parent_sample.sample_id,
+    )
+    sample_id = caption.sample_id
+
+    response = test_client.put(
+        f"/api/collections/{collection_id!s}/captions/{sample_id!s}/temporal_span",
+        json={"start_time_s": 3.0, "end_time_s": 5.0},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    result = response.json()
+    assert result["sample_id"] == str(sample_id)
+    assert result["temporal_span_details"] == {"start_time_s": 3.0, "end_time_s": 5.0}
+
+    # Verify the span persisted in the database.
+    updated_caption = caption_resolver.get_by_ids(db_session, sample_ids=[sample_id])[0]
+    assert updated_caption.temporal_span_details is not None
+    assert updated_caption.temporal_span_details.start_time_s == 3.0
+    assert updated_caption.temporal_span_details.end_time_s == 5.0
+
+
 def test_delete_caption(db_session: Session, test_client: TestClient) -> None:
     # Initialize a collection and add a caption
     collection = create_collection(session=db_session)

--- a/lightly_studio/tests/resolvers/test_caption_resolver.py
+++ b/lightly_studio/tests/resolvers/test_caption_resolver.py
@@ -305,6 +305,73 @@ def test_create_many__non_finite_temporal_span(
         )
 
 
+def test_update_temporal_span__creates_when_missing(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    created_ids = caption_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        captions=[CaptionCreate(parent_sample_id=image.sample_id, text="caption")],
+    )
+
+    updated = caption_resolver.update_temporal_span(
+        session=db_session, sample_id=created_ids[0], start_time_s=1.0, end_time_s=3.0
+    )
+    assert updated.temporal_span_details is not None
+    assert updated.temporal_span_details.start_time_s == 1.0
+    assert updated.temporal_span_details.end_time_s == 3.0
+
+
+def test_update_temporal_span__updates_existing(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    created_ids = caption_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        captions=[
+            CaptionCreate(
+                parent_sample_id=image.sample_id,
+                text="caption",
+                start_time_s=1.0,
+                end_time_s=2.0,
+            )
+        ],
+    )
+
+    updated = caption_resolver.update_temporal_span(
+        session=db_session, sample_id=created_ids[0], start_time_s=4.0, end_time_s=6.0
+    )
+    assert updated.temporal_span_details is not None
+    assert updated.temporal_span_details.start_time_s == 4.0
+    assert updated.temporal_span_details.end_time_s == 6.0
+
+
+def test_update_temporal_span__invalid_and_not_found(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    created_ids = caption_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        captions=[CaptionCreate(parent_sample_id=image.sample_id, text="caption")],
+    )
+
+    with pytest.raises(ValueError, match="start_time_s must be less than end_time_s"):
+        caption_resolver.update_temporal_span(
+            session=db_session, sample_id=created_ids[0], start_time_s=5.0, end_time_s=1.0
+        )
+
+    with pytest.raises(ValueError, match="start_time_s and end_time_s must be finite"):
+        caption_resolver.update_temporal_span(
+            session=db_session, sample_id=created_ids[0], start_time_s=math.inf, end_time_s=1.0
+        )
+
+    wrong_id = uuid4()
+    with pytest.raises(ValueError, match=f"Caption with ID {wrong_id} not found."):
+        caption_resolver.update_temporal_span(
+            session=db_session, sample_id=wrong_id, start_time_s=1.0, end_time_s=2.0
+        )
+
+
 def test_delete_caption(db_session: Session) -> None:
     collection = create_collection(session=db_session)
 

--- a/lightly_studio/tests/resolvers/test_caption_resolver.py
+++ b/lightly_studio/tests/resolvers/test_caption_resolver.py
@@ -328,30 +328,6 @@ def test_update__creates_temporal_span_when_missing(db_session: Session) -> None
     assert updated.temporal_span_details.end_time_s == 3.0
 
 
-def test_update__updates_existing_temporal_span(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    image = create_image(session=db_session, collection_id=collection.collection_id)
-    created_ids = caption_resolver.create_many(
-        session=db_session,
-        parent_collection_id=collection.collection_id,
-        captions=[
-            CaptionCreate(
-                parent_sample_id=image.sample_id,
-                text="caption",
-                start_time_s=1.0,
-                end_time_s=2.0,
-            )
-        ],
-    )
-
-    updated = caption_resolver.update(
-        session=db_session, sample_id=created_ids[0], start_time_s=4.0, end_time_s=6.0
-    )
-    assert updated.temporal_span_details is not None
-    assert updated.temporal_span_details.start_time_s == 4.0
-    assert updated.temporal_span_details.end_time_s == 6.0
-
-
 def test_update__text_and_temporal_span(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=collection.collection_id)

--- a/lightly_studio/tests/resolvers/test_caption_resolver.py
+++ b/lightly_studio/tests/resolvers/test_caption_resolver.py
@@ -327,6 +327,8 @@ def test_update__overwrites_existing_temporal_span(db_session: Session) -> None:
     assert updated.temporal_span_details.end_time_s == 5.0
     # The span is overwritten in place instead of a second row being inserted.
     assert len(db_session.exec(select(TemporalSpanTable)).all()) == 1
+    # Caption text is preserved.
+    assert updated.text == "caption"
 
 
 def test_update__invalid_temporal_span(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/test_caption_resolver.py
+++ b/lightly_studio/tests/resolvers/test_caption_resolver.py
@@ -175,7 +175,7 @@ def test_get_by_id(db_session: Session) -> None:
     assert caption_retrieved[1].sample_id == created_caption_ids[1]
 
 
-def test_update_text(db_session: Session) -> None:
+def test_update__text(db_session: Session) -> None:
     collection = create_collection(session=db_session)
 
     image_a = create_image(
@@ -196,7 +196,7 @@ def test_update_text(db_session: Session) -> None:
     )
 
     # Update the text and double check it got updated
-    caption_updated = caption_resolver.update_text(
+    caption_updated = caption_resolver.update(
         session=db_session, sample_id=created_caption_ids[0], text="Updated text"
     )
     assert caption_updated.text == "Updated text"
@@ -205,12 +205,18 @@ def test_update_text(db_session: Session) -> None:
     )
     assert caption_retrieved[0].text == "Updated text"
 
-    # Try to update non exist caption
-    wrong_id = uuid4()
-    with pytest.raises(ValueError, match=f"Caption with ID {wrong_id} not found."):
-        caption_updated = caption_resolver.update_text(
-            session=db_session, sample_id=wrong_id, text="Updated text"
-        )
+
+def test_update__no_fields(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    created_ids = caption_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        captions=[CaptionCreate(parent_sample_id=image.sample_id, text="caption")],
+    )
+
+    with pytest.raises(ValueError, match="No updates provided for the caption"):
+        caption_resolver.update(session=db_session, sample_id=created_ids[0])
 
 
 def test_create_many__with_temporal_span(db_session: Session) -> None:
@@ -305,7 +311,7 @@ def test_create_many__non_finite_temporal_span(
         )
 
 
-def test_update_temporal_span__creates_when_missing(db_session: Session) -> None:
+def test_update__creates_temporal_span_when_missing(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=collection.collection_id)
     created_ids = caption_resolver.create_many(
@@ -314,7 +320,7 @@ def test_update_temporal_span__creates_when_missing(db_session: Session) -> None
         captions=[CaptionCreate(parent_sample_id=image.sample_id, text="caption")],
     )
 
-    updated = caption_resolver.update_temporal_span(
+    updated = caption_resolver.update(
         session=db_session, sample_id=created_ids[0], start_time_s=1.0, end_time_s=3.0
     )
     assert updated.temporal_span_details is not None
@@ -322,7 +328,7 @@ def test_update_temporal_span__creates_when_missing(db_session: Session) -> None
     assert updated.temporal_span_details.end_time_s == 3.0
 
 
-def test_update_temporal_span__updates_existing(db_session: Session) -> None:
+def test_update__updates_existing_temporal_span(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=collection.collection_id)
     created_ids = caption_resolver.create_many(
@@ -338,7 +344,7 @@ def test_update_temporal_span__updates_existing(db_session: Session) -> None:
         ],
     )
 
-    updated = caption_resolver.update_temporal_span(
+    updated = caption_resolver.update(
         session=db_session, sample_id=created_ids[0], start_time_s=4.0, end_time_s=6.0
     )
     assert updated.temporal_span_details is not None
@@ -346,7 +352,29 @@ def test_update_temporal_span__updates_existing(db_session: Session) -> None:
     assert updated.temporal_span_details.end_time_s == 6.0
 
 
-def test_update_temporal_span__invalid_and_not_found(db_session: Session) -> None:
+def test_update__text_and_temporal_span(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    created_ids = caption_resolver.create_many(
+        session=db_session,
+        parent_collection_id=collection.collection_id,
+        captions=[CaptionCreate(parent_sample_id=image.sample_id, text="caption")],
+    )
+
+    updated = caption_resolver.update(
+        session=db_session,
+        sample_id=created_ids[0],
+        text="new text",
+        start_time_s=1.0,
+        end_time_s=3.0,
+    )
+    assert updated.text == "new text"
+    assert updated.temporal_span_details is not None
+    assert updated.temporal_span_details.start_time_s == 1.0
+    assert updated.temporal_span_details.end_time_s == 3.0
+
+
+def test_update__invalid_temporal_span(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=collection.collection_id)
     created_ids = caption_resolver.create_many(
@@ -356,18 +384,23 @@ def test_update_temporal_span__invalid_and_not_found(db_session: Session) -> Non
     )
 
     with pytest.raises(ValueError, match="start_time_s must be less than end_time_s"):
-        caption_resolver.update_temporal_span(
+        caption_resolver.update(
             session=db_session, sample_id=created_ids[0], start_time_s=5.0, end_time_s=1.0
         )
 
     with pytest.raises(ValueError, match="start_time_s and end_time_s must be finite"):
-        caption_resolver.update_temporal_span(
+        caption_resolver.update(
             session=db_session, sample_id=created_ids[0], start_time_s=math.inf, end_time_s=1.0
         )
 
+    with pytest.raises(ValueError, match="Both start_time_s and end_time_s must be provided"):
+        caption_resolver.update(session=db_session, sample_id=created_ids[0], start_time_s=1.0)
+
+
+def test_update__not_found(db_session: Session) -> None:
     wrong_id = uuid4()
     with pytest.raises(ValueError, match=f"Caption with ID {wrong_id} not found."):
-        caption_resolver.update_temporal_span(
+        caption_resolver.update(
             session=db_session, sample_id=wrong_id, start_time_s=1.0, end_time_s=2.0
         )
 

--- a/lightly_studio/tests/resolvers/test_caption_resolver.py
+++ b/lightly_studio/tests/resolvers/test_caption_resolver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlmodel import Session, col, select
@@ -207,16 +207,10 @@ def test_update__text(db_session: Session) -> None:
 
 
 def test_update__no_fields(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    image = create_image(session=db_session, collection_id=collection.collection_id)
-    created_ids = caption_resolver.create_many(
-        session=db_session,
-        parent_collection_id=collection.collection_id,
-        captions=[CaptionCreate(parent_sample_id=image.sample_id, text="caption")],
-    )
+    sample_id = _create_caption(session=db_session)
 
     with pytest.raises(ValueError, match="No updates provided for the caption"):
-        caption_resolver.update(session=db_session, sample_id=created_ids[0])
+        caption_resolver.update(session=db_session, sample_id=sample_id)
 
 
 def test_create_many__with_temporal_span(db_session: Session) -> None:
@@ -312,65 +306,40 @@ def test_create_many__non_finite_temporal_span(
 
 
 def test_update__creates_temporal_span_when_missing(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    image = create_image(session=db_session, collection_id=collection.collection_id)
-    created_ids = caption_resolver.create_many(
-        session=db_session,
-        parent_collection_id=collection.collection_id,
-        captions=[CaptionCreate(parent_sample_id=image.sample_id, text="caption")],
-    )
+    sample_id = _create_caption(session=db_session)
 
     updated = caption_resolver.update(
-        session=db_session, sample_id=created_ids[0], start_time_s=1.0, end_time_s=3.0
+        session=db_session, sample_id=sample_id, start_time_s=1.0, end_time_s=3.0
     )
     assert updated.temporal_span_details is not None
     assert updated.temporal_span_details.start_time_s == 1.0
     assert updated.temporal_span_details.end_time_s == 3.0
 
 
-def test_update__text_and_temporal_span(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    image = create_image(session=db_session, collection_id=collection.collection_id)
-    created_ids = caption_resolver.create_many(
-        session=db_session,
-        parent_collection_id=collection.collection_id,
-        captions=[CaptionCreate(parent_sample_id=image.sample_id, text="caption")],
-    )
+def test_update__overwrites_existing_temporal_span(db_session: Session) -> None:
+    sample_id = _create_caption(session=db_session, start_time_s=1.0, end_time_s=3.0)
 
     updated = caption_resolver.update(
-        session=db_session,
-        sample_id=created_ids[0],
-        text="new text",
-        start_time_s=1.0,
-        end_time_s=3.0,
+        session=db_session, sample_id=sample_id, start_time_s=4.0, end_time_s=5.0
     )
-    assert updated.text == "new text"
     assert updated.temporal_span_details is not None
-    assert updated.temporal_span_details.start_time_s == 1.0
-    assert updated.temporal_span_details.end_time_s == 3.0
+    assert updated.temporal_span_details.start_time_s == 4.0
+    assert updated.temporal_span_details.end_time_s == 5.0
+    # The span is overwritten in place instead of a second row being inserted.
+    assert len(db_session.exec(select(TemporalSpanTable)).all()) == 1
 
 
 def test_update__invalid_temporal_span(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    image = create_image(session=db_session, collection_id=collection.collection_id)
-    created_ids = caption_resolver.create_many(
-        session=db_session,
-        parent_collection_id=collection.collection_id,
-        captions=[CaptionCreate(parent_sample_id=image.sample_id, text="caption")],
-    )
+    # The bounds share a validator with `create_many`, which covers them exhaustively.
+    sample_id = _create_caption(session=db_session)
 
     with pytest.raises(ValueError, match="start_time_s must be less than end_time_s"):
         caption_resolver.update(
-            session=db_session, sample_id=created_ids[0], start_time_s=5.0, end_time_s=1.0
-        )
-
-    with pytest.raises(ValueError, match="start_time_s and end_time_s must be finite"):
-        caption_resolver.update(
-            session=db_session, sample_id=created_ids[0], start_time_s=math.inf, end_time_s=1.0
+            session=db_session, sample_id=sample_id, start_time_s=5.0, end_time_s=1.0
         )
 
     with pytest.raises(ValueError, match="Both start_time_s and end_time_s must be provided"):
-        caption_resolver.update(session=db_session, sample_id=created_ids[0], start_time_s=1.0)
+        caption_resolver.update(session=db_session, sample_id=sample_id, start_time_s=1.0)
 
 
 def test_update__not_found(db_session: Session) -> None:
@@ -445,3 +414,20 @@ def test_delete_caption__removes_temporal_span(db_session: Session) -> None:
         select(TemporalSpanTable).where(col(TemporalSpanTable.sample_id) == caption_ids[0])
     ).all()
     assert remaining_spans == []
+
+
+def _create_caption(
+    session: Session, start_time_s: float | None = None, end_time_s: float | None = None
+) -> UUID:
+    """Creates a caption in a fresh collection and returns its sample_id."""
+    collection = create_collection(session=session)
+    image = create_image(session=session, collection_id=collection.collection_id)
+    caption = CaptionCreate(
+        parent_sample_id=image.sample_id,
+        text="caption",
+        start_time_s=start_time_s,
+        end_time_s=end_time_s,
+    )
+    return caption_resolver.create_many(
+        session=session, parent_collection_id=collection.collection_id, captions=[caption]
+    )[0]

--- a/lightly_studio_view/src/lib/hooks/useCaption/useCaption.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useCaption/useCaption.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { useCaption } from './useCaption';
+
+const { mutateAsync } = vi.hoisted(() => ({ mutateAsync: vi.fn() }));
+vi.mock('@tanstack/svelte-query', () => ({ createMutation: () => ({ mutateAsync }) }));
+vi.mock('svelte-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+const { toast } = await import('svelte-sonner');
+
+describe('useCaption', () => {
+    it('sends the new text as a structured update body', async () => {
+        const onUpdate = vi.fn();
+        const { updateCaptionText } = useCaption({ sampleId: 'sample-1', onUpdate });
+
+        await updateCaptionText('new text');
+
+        expect(mutateAsync).toHaveBeenCalledWith({
+            path: { sample_id: 'sample-1' },
+            body: { text: 'new text' }
+        });
+        expect(onUpdate).toHaveBeenCalledWith();
+    });
+
+    it('reports a failed update as an error toast', async () => {
+        mutateAsync.mockRejectedValueOnce(new Error('boom'));
+        const { updateCaptionText } = useCaption({ sampleId: 'sample-1' });
+
+        await updateCaptionText('new text');
+
+        expect(toast.error).toHaveBeenCalledWith('Failed to update caption: boom');
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useCaption/useCaption.ts
+++ b/lightly_studio_view/src/lib/hooks/useCaption/useCaption.ts
@@ -1,17 +1,17 @@
-import { type UpdateCaptionTextData } from '$lib/api/lightly_studio_local';
-import { updateCaptionTextMutation } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import { type UpdateCaptionData } from '$lib/api/lightly_studio_local';
+import { updateCaptionMutation } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
 import { createMutation } from '@tanstack/svelte-query';
 import { toast } from 'svelte-sonner';
 
 export const useCaption = ({ sampleId, onUpdate }: { sampleId: string; onUpdate?: () => void }) => {
-    const captionMutation = createMutation(() => updateCaptionTextMutation());
+    const captionMutation = createMutation(() => updateCaptionMutation());
 
     const mutateCaptionText = async (text: string): Promise<void> => {
         await captionMutation.mutateAsync({
             path: {
                 sample_id: sampleId
-            } as UpdateCaptionTextData['path'],
-            body: text
+            } as UpdateCaptionData['path'],
+            body: { text }
         });
     };
 


### PR DESCRIPTION
## What has changed and why?
- The create endpoint forwards start_time_s/end_time_s, and a new  /captions/{sample_id}/temporal_span endpoint updates a caption's span.
- delete_caption removes the caption's span to avoid orphaned rows.

## How has it been tested?

New tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Captions can now include optional start and end timestamps.
  * Caption updates support changing text and temporal boundaries together or independently.
* **Bug Fixes**
  * Added validation to prevent incomplete or incorrectly ordered temporal spans.
  * Improved handling for missing captions and empty update requests.
  * Caption editing now reports update failures more clearly.
* **Tests**
  * Expanded coverage for caption creation, updates, temporal spans, validation, and not-found scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->