### PR TITLE
introduce DatasetDistributionContent component

### DIFF
--- a/lightly_studio/tests/api/test_server.py
+++ b/lightly_studio/tests/api/test_server.py
@@ -87,9 +87,9 @@ def test_server_static_webapp() -> None:
     assert static_file.status_code == HTTP_STATUS_OK
     assert static_file.headers["content-type"] == "image/png"
 
-    static_file = client.get("/_app/env.js")
+    static_file = client.get("/_app/version.json")
     assert static_file.status_code == HTTP_STATUS_OK
-    assert "javascript" in static_file.headers["content-type"]
+    assert "json" in static_file.headers["content-type"]
 
     static_file = client.get("/non-existing-file.png")
     assert static_file.status_code == HTTP_STATUS_NOT_FOUND

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import DistributionChart from '../DistributionChart/DistributionChart.svelte';
+    import type { CategoryCount } from '$lib/components/BarChart';
+    import type { HistogramRange } from '$lib/components/Histogram';
+    import type { useDistributionPanel } from '../useDistributionPanel.svelte';
+
+    interface Props {
+        panel: ReturnType<typeof useDistributionPanel>;
+        onHistogramRangeSelect?: (groupId: string, range: HistogramRange) => void;
+        onBarClick?: (item: CategoryCount) => void;
+        onCategoricalRetry?: () => void;
+    }
+
+    const { panel, onHistogramRangeSelect, onBarClick, onCategoricalRetry }: Props = $props();
+</script>
+
+<DistributionChart
+    activeHistogram={panel.activeHistogram}
+    activeCategorical={panel.activeCategorical}
+    viewConfig={panel.activeViewConfig}
+    visible={panel.visible}
+    totalCount={panel.totalCount}
+    selectedRange={panel.activeHistogramRange}
+    onHistogramRangeSelect={onHistogramRangeSelect
+        ? (range) => onHistogramRangeSelect(panel.activeGroup?.id ?? panel.activeSource.id, range)
+        : undefined}
+    onBarClick={panel.activeCategorical ? panel.handleCategoricalBarClick : onBarClick}
+    {onCategoricalRetry}
+/>

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionContent/DatasetDistributionContent.test.ts
@@ -1,0 +1,186 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import DatasetDistributionContent from './DatasetDistributionContent.svelte';
+import { useDistributionPanel } from '../useDistributionPanel.svelte';
+import type { DistributionSource } from '../types';
+
+const echartsMock = vi.hoisted(() => {
+    let clickHandler: ((params: { dataIndex?: number }) => void) | undefined;
+    const zrHandlers: Record<string, (event: { offsetX: number; offsetY: number }) => void> = {};
+    const instance = {
+        setOption: vi.fn(),
+        resize: vi.fn(),
+        dispose: vi.fn(),
+        on: vi.fn((event: string, handler: (params: { dataIndex?: number }) => void) => {
+            if (event === 'click') clickHandler = handler;
+        }),
+        convertFromPixel: vi.fn((_finder: unknown, offsetX: number) => offsetX / 100),
+        getZr: () => ({
+            on: vi.fn(
+                (event: string, handler: (e: { offsetX: number; offsetY: number }) => void) => {
+                    zrHandlers[event] = handler;
+                }
+            ),
+            off: vi.fn()
+        })
+    };
+    return {
+        init: vi.fn(() => instance),
+        instance,
+        getClickHandler: () => clickHandler,
+        zrHandlers
+    };
+});
+
+vi.mock('echarts/core', () => ({ init: echartsMock.init, use: vi.fn() }));
+vi.mock('echarts/charts', () => ({ BarChart: {}, CustomChart: {} }));
+vi.mock('echarts/components', () => ({ GridComponent: {}, TooltipComponent: {} }));
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as unknown as typeof ResizeObserver;
+}
+
+const renderContent = (sources: DistributionSource[], overrides: Record<string, unknown> = {}) => {
+    const panel = useDistributionPanel(() => ({ sources }));
+    return render(DatasetDistributionContent, { props: { panel, ...overrides } });
+};
+
+describe('DatasetDistributionContent', () => {
+    it('renders a bar chart for bar data', () => {
+        renderContent([{ id: 'classes', label: 'Classes', data: [{ label: 'car', count: 10 }] }]);
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+        expect(screen.queryByTestId('histogram')).not.toBeInTheDocument();
+    });
+
+    it('renders the empty chart state when no data', () => {
+        renderContent([{ id: 'classes', label: 'Classes', data: [] }]);
+        expect(screen.getByTestId('bar-chart-empty')).toBeInTheDocument();
+    });
+
+    it('renders a histogram for a histogram group', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                valueNoun: 'samples',
+                groups: [
+                    {
+                        id: 'confidence',
+                        label: 'confidence',
+                        histogram: { binEdges: [0, 0.5, 1], counts: [30, 70] }
+                    }
+                ]
+            }
+        ];
+        renderContent(sources);
+        expect(screen.getByTestId('histogram')).toBeInTheDocument();
+        expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
+    });
+
+    it('renders a bar chart for categorical data', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        renderContent(sources);
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    });
+
+    it('forwards onBarClick when a bar is clicked', () => {
+        const onBarClick = vi.fn();
+        renderContent([{ id: 'classes', label: 'Classes', data: [{ label: 'car', count: 10 }] }], {
+            onBarClick
+        });
+        echartsMock.getClickHandler()?.({ dataIndex: 0 });
+        expect(onBarClick).toHaveBeenCalledOnce();
+    });
+
+    it('forwards onHistogramRangeSelect with the group id when a histogram range is selected', () => {
+        const onHistogramRangeSelect = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'confidence',
+                        label: 'confidence',
+                        histogram: { binEdges: [0, 0.5, 1], counts: [30, 70] }
+                    }
+                ]
+            }
+        ];
+        renderContent(sources, { onHistogramRangeSelect });
+        echartsMock.zrHandlers.mousedown({ offsetX: 150, offsetY: 10 });
+        window.dispatchEvent(new MouseEvent('mouseup'));
+        expect(onHistogramRangeSelect).toHaveBeenCalledWith('confidence', { min: 0.5, max: 1 });
+    });
+
+    it('shows the loading status when categorical buckets are empty and loading', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: { buckets: [], selectedValues: [], loading: true }
+                    }
+                ]
+            }
+        ];
+        renderContent(sources);
+        expect(screen.getByRole('status')).toHaveTextContent('Loading metadata distribution');
+    });
+
+    it('shows the error alert with retry when categorical buckets are empty and there is an error', async () => {
+        const onCategoricalRetry = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            buckets: [],
+                            selectedValues: ['Zurich'],
+                            error: 'network failure'
+                        }
+                    }
+                ]
+            }
+        ];
+        renderContent(sources, { onCategoricalRetry });
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not load metadata distribution');
+        await fireEvent.click(screen.getByTestId('metadata-categorical-retry'));
+        expect(onCategoricalRetry).toHaveBeenCalledOnce();
+    });
+});

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.stories.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.stories.svelte
@@ -17,7 +17,12 @@
     import { GripVertical } from '@lucide/svelte';
     import { Pane, PaneGroup, PaneResizer } from 'paneforge';
     import { balanced, empty, longLabels, longTail, many80Classes } from '../BarChart/fixtures';
-    import { exampleSources, numericMetadataSources } from './sourceFixtures';
+    import {
+        categoricalMetadataSources,
+        exampleSources,
+        mixedSources,
+        numericMetadataSources
+    } from './sourceFixtures';
 </script>
 
 {#snippet sidePanel(args)}
@@ -49,6 +54,29 @@
 <Story
     name="Multi-source (class / tags / metadata / eval)"
     args={{ sources: exampleSources, title: 'Distribution', onClose: () => {} }}
+    template={sidePanel}
+/>
+
+<!-- Categorical metadata: location_type key with city / suburban / rural / village
+     values. Demonstrates value buckets, a missing-value bucket, and an active
+     filter (city + rural) with dimmed background bars for context. -->
+<Story
+    name="Categorical metadata (location_type)"
+    args={{
+        sources: categoricalMetadataSources,
+        title: 'Distribution',
+        onClose: () => {}
+    }}
+    template={sidePanel}
+/>
+
+<!-- Classes + categorical + numeric in one panel. Switching between sources
+     demonstrates chart-type transitions: bar chart (class labels) →
+     categorical bar chart with active filter (location_type) →
+     histogram (confidence). -->
+<Story
+    name="Mixed (class / categorical / numeric)"
+    args={{ sources: mixedSources, title: 'Distribution', onClose: () => {} }}
     template={sidePanel}
 />
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -13,12 +13,15 @@
     import PanelHeader from './PanelHeader/PanelHeader.svelte';
     import { selectVisibleCounts } from './selectVisibleCounts';
     import {
+        CATEGORICAL_DISTRIBUTION_SORT_LABELS,
         HISTOGRAM_BIN_COUNT_ITEMS,
         type DistributionConfig,
         type DistributionSource,
         type DistributionSourceGroup
     } from './types';
     import { AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
+    import { MetadataCategoricalFilter } from './MetadataCategoricalFilter';
+    import type { CategoricalMetadataValue } from '$lib/services/types';
 
     interface Props {
         /**
@@ -60,6 +63,12 @@
         histogramBinCount?: number;
         /** Called when the user picks a new histogram bin count. */
         onHistogramBinCountChange?: (binCount: number) => void;
+        /** Called when a concrete categorical value or Missing is toggled. */
+        onCategoricalValueToggle?: (groupId: string, value: CategoricalMetadataValue) => void;
+        /** Removes every categorical value selected for the given group. */
+        onCategoricalValuesClear?: (groupId: string) => void;
+        /** Retries a failed categorical distribution request. */
+        onCategoricalRetry?: () => void;
     }
 
     const {
@@ -73,7 +82,10 @@
         initialCountMode = AnnotationCountMode.OBJECTS,
         onHistogramRangeSelect,
         histogramBinCount = 20,
-        onHistogramBinCountChange
+        onHistogramBinCountChange,
+        onCategoricalValueToggle,
+        onCategoricalValuesClear,
+        onCategoricalRetry
     }: Props = $props();
 
     // Normalise to a source list so the rest of the panel has one code path.
@@ -86,7 +98,7 @@
     let selectedGroupId = $state<string | undefined>(undefined);
 
     const groupHasContent = (group: DistributionSourceGroup): boolean =>
-        (group.data?.length ?? 0) > 0 || group.histogram != null;
+        (group.data?.length ?? 0) > 0 || group.histogram != null || group.categorical != null;
 
     const sourceHasContent = (source: DistributionSource): boolean =>
         (source.data?.length ?? 0) > 0 ||
@@ -110,6 +122,37 @@
     // A group/source carrying bins renders as a histogram instead of a bar
     // chart; the categorical controls (sort, top-N, orientation) don't apply.
     const activeHistogram = $derived(activeGroup?.histogram ?? activeSource.histogram ?? null);
+    const activeCategorical = $derived(activeGroup?.categorical ?? null);
+    const categoricalData = $derived<CategoryCount[]>(
+        (activeCategorical?.buckets ?? []).map((bucket) => {
+            // When filteredBuckets is defined (query has returned) look up the
+            // filtered count for this bucket. Absent = 0 (filter removed it entirely).
+            const filteredBucket = activeCategorical?.filteredBuckets?.find(
+                (fb) => fb.id === bucket.id
+            );
+            const filteredCount =
+                activeCategorical?.filteredBuckets !== undefined
+                    ? (filteredBucket?.count ?? 0)
+                    : undefined;
+            return {
+                id: bucket.id,
+                label: bucket.label,
+                count: bucket.count,
+                filteredCount,
+                selectable: bucket.kind !== 'other',
+                pinned: bucket.kind !== 'value',
+                selected:
+                    bucket.kind !== 'other' &&
+                    activeCategorical?.selectedValues.some((value) =>
+                        Object.is(value, bucket.value)
+                    )
+            };
+        })
+    );
+    const displayedData = $derived(activeCategorical ? categoricalData : activeData);
+    const configurationItems = $derived(
+        displayedData.map((item) => ({ value: item.id ?? item.label, label: item.label }))
+    );
     const activeHistogramRange = $derived(activeGroup?.selectedRange ?? activeSource.selectedRange);
     const handleHistogramRangeSelect = (range: HistogramRange) => {
         const groupId = activeGroup?.id ?? activeSource.id;
@@ -131,6 +174,23 @@
         orientation: 'horizontal',
         countMode: untrack(() => initialCountMode)
     });
+    const defaultCategoricalConfig: DistributionConfig = {
+        mode: 'topN',
+        n: 1,
+        sortBy: 'count',
+        manualClasses: [],
+        orientation: 'horizontal',
+        countMode: AnnotationCountMode.SAMPLES
+    };
+    let categoricalConfigs = $state<Record<string, DistributionConfig>>({});
+    const categoricalConfig = $derived<DistributionConfig>(
+        activeGroup
+            ? (categoricalConfigs[activeGroup.id] ?? {
+                  ...defaultCategoricalConfig,
+                  n: Math.max(categoricalData.length, 1)
+              })
+            : defaultCategoricalConfig
+    );
     let configDialogOpen = $state(false);
     let expandOpen = $state(false);
     let histogramExpandOpen = $state(false);
@@ -154,16 +214,44 @@
         (activeSource.groups ?? []).map((group) => ({ value: group.id, label: group.label }))
     );
 
-    const visible = $derived(selectVisibleCounts(activeData, config));
-    const totalCount = $derived(activeData.reduce((sum, item) => sum + item.count, 0));
+    const activeViewConfig = $derived<DistributionConfig>(
+        activeCategorical ? categoricalConfig : config
+    );
+    const visible = $derived(selectVisibleCounts(displayedData, activeViewConfig));
+    const totalCount = $derived(displayedData.reduce((sum, item) => sum + item.count, 0));
+
+    const handleCategoricalBarClick = (item: CategoryCount) => {
+        const bucket = activeCategorical?.buckets.find((candidate) => candidate.id === item.id);
+        if (!bucket || bucket.kind === 'other' || !activeGroup) return;
+        onCategoricalValueToggle?.(activeGroup.id, bucket.value);
+    };
+
+    const setCategoricalConfig = (next: DistributionConfig) => {
+        if (!activeGroup) return;
+        categoricalConfigs = {
+            ...categoricalConfigs,
+            [activeGroup.id]: {
+                ...next,
+                countMode: AnnotationCountMode.SAMPLES
+            }
+        };
+    };
 
     function applyConfig(next: DistributionConfig) {
+        if (activeCategorical) {
+            setCategoricalConfig(next);
+            return;
+        }
         if (next.countMode !== config.countMode) {
             onCountModeChange?.(next.countMode ?? AnnotationCountMode.OBJECTS);
         }
         config = next;
     }
 </script>
+
+{#snippet categoricalEmptyState()}
+    <span>No matching samples for this metadata field.</span>
+{/snippet}
 
 <div
     class="flex h-full min-w-0 flex-1 flex-col rounded-[1vw] bg-card p-4"
@@ -260,22 +348,82 @@
                 />
             </div>
         </div>
-    {:else if activeData.length > 0}
-        <PanelHeader
-            {config}
-            classCount={activeData.length}
-            visibleClassCount={visible.length}
-            totalCount={showTotalCount ? totalCount : undefined}
-            {valueNoun}
-            onConfigure={() => (configDialogOpen = true)}
-            onShowAll={() => (config = { ...config, mode: 'topN', n: activeData.length })}
-            onToggleOrientation={() =>
-                (config = {
-                    ...config,
-                    orientation: config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
-                })}
-            onExpand={() => (expandOpen = true)}
+    {:else if activeCategorical && activeGroup}
+        <MetadataCategoricalFilter
+            buckets={activeCategorical.buckets}
+            selectedValues={activeCategorical.selectedValues}
+            loading={activeCategorical.loading}
+            onToggle={(value) => onCategoricalValueToggle?.(activeGroup.id, value)}
+            onClear={() => onCategoricalValuesClear?.(activeGroup.id)}
         />
+        {#if activeCategorical.loading && activeCategorical.buckets.length > 0}
+            <p class="mt-1 text-xs text-muted-foreground" role="status">Updating values…</p>
+        {/if}
+        {#if activeCategorical.error && activeCategorical.buckets.length > 0}
+            <div
+                class="mt-1 flex items-center justify-between gap-2 text-xs text-destructive"
+                role="alert"
+            >
+                <span>Could not update metadata distribution.</span>
+                {#if onCategoricalRetry}
+                    <button
+                        class="underline max-sm:min-h-11"
+                        type="button"
+                        onclick={onCategoricalRetry}
+                    >
+                        Retry
+                    </button>
+                {/if}
+            </div>
+        {/if}
+        {#if categoricalData.length > 0}
+            <div class="mt-2">
+                <PanelHeader
+                    config={categoricalConfig}
+                    classCount={categoricalData.length}
+                    visibleClassCount={visible.length}
+                    {totalCount}
+                    {valueNoun}
+                    categoryNoun="value"
+                    categoryNounPlural="values"
+                    sortLabels={CATEGORICAL_DISTRIBUTION_SORT_LABELS}
+                    onConfigure={() => (configDialogOpen = true)}
+                    onShowAll={() =>
+                        setCategoricalConfig({
+                            ...categoricalConfig,
+                            mode: 'topN',
+                            n: categoricalData.length
+                        })}
+                    onToggleOrientation={() =>
+                        setCategoricalConfig({
+                            ...categoricalConfig,
+                            orientation:
+                                categoricalConfig.orientation === 'horizontal'
+                                    ? 'vertical'
+                                    : 'horizontal'
+                        })}
+                    onExpand={() => (expandOpen = true)}
+                />
+            </div>
+        {/if}
+    {:else if activeData.length > 0}
+        <div class="mt-2">
+            <PanelHeader
+                {config}
+                classCount={activeData.length}
+                visibleClassCount={visible.length}
+                totalCount={showTotalCount ? totalCount : undefined}
+                {valueNoun}
+                onConfigure={() => (configDialogOpen = true)}
+                onShowAll={() => (config = { ...config, mode: 'topN', n: activeData.length })}
+                onToggleOrientation={() =>
+                    (config = {
+                        ...config,
+                        orientation: config.orientation === 'horizontal' ? 'vertical' : 'horizontal'
+                    })}
+                onExpand={() => (expandOpen = true)}
+            />
+        </div>
     {/if}
     <div
         class="min-h-0 flex-1 overflow-y-auto dark:[color-scheme:dark]"
@@ -290,32 +438,79 @@
                 showAxes
                 onRangeSelect={onHistogramRangeSelect ? handleHistogramRangeSelect : undefined}
             />
+        {:else if activeCategorical?.loading && activeCategorical.buckets.length === 0}
+            <div class="p-8 text-center text-sm text-muted-foreground" role="status">
+                Loading metadata distribution…
+            </div>
+        {:else if activeCategorical?.error && activeCategorical.buckets.length === 0}
+            <div class="space-y-2 p-8 text-center text-sm" role="alert">
+                <p class="text-destructive">Could not load metadata distribution.</p>
+                {#if onCategoricalRetry}
+                    <Button
+                        variant="secondary"
+                        buttonProps={{
+                            size: 'sm',
+                            class: 'max-sm:min-h-11',
+                            onclick: onCategoricalRetry,
+                            'data-testid': 'metadata-categorical-retry'
+                        }}>Retry</Button
+                    >
+                {/if}
+            </div>
         {:else}
+            {#if activeCategorical}
+                <ul class="sr-only" aria-label="Categorical metadata value counts">
+                    {#each activeCategorical.buckets as bucket (bucket.id)}
+                        <li>
+                            {bucket.label}: {bucket.count} samples{bucket.kind === 'other'
+                                ? ', aggregated and not selectable'
+                                : activeCategorical.selectedValues.some((value) =>
+                                        Object.is(value, bucket.value)
+                                    )
+                                  ? ', selected'
+                                  : ''}
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
             <BarChart
                 data={visible}
-                orientation={config.orientation}
+                orientation={activeViewConfig.orientation}
                 maxHeightPx={chartHeight || undefined}
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
-                {onBarClick}
+                onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
+                emptyState={activeCategorical ? categoricalEmptyState : undefined}
+                gridTopPx={4}
             />
         {/if}
     </div>
 </div>
-<DistributionConfigDialog
-    bind:open={configDialogOpen}
-    allClasses={activeData.map((item) => item.label)}
-    {config}
-    onApply={applyConfig}
-/>
-<ExpandDialog
-    bind:open={expandOpen}
-    data={activeData}
-    {config}
-    {valueNoun}
-    onConfigChange={applyConfig}
-    {onBarClick}
-/>
+{#if !activeHistogram}
+    <DistributionConfigDialog
+        bind:open={configDialogOpen}
+        allClasses={displayedData.map((item) => item.label)}
+        items={configurationItems}
+        config={activeViewConfig}
+        showCountMode={!activeCategorical}
+        itemNoun={activeCategorical ? 'value' : 'class'}
+        itemNounPlural={activeCategorical ? 'values' : 'classes'}
+        sortLabels={activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
+        onApply={applyConfig}
+    />
+    <ExpandDialog
+        bind:open={expandOpen}
+        data={displayedData}
+        config={activeViewConfig}
+        {valueNoun}
+        categoryNoun={activeCategorical ? 'value' : 'class'}
+        categoryNounPlural={activeCategorical ? 'values' : 'classes'}
+        sortLabels={activeCategorical ? CATEGORICAL_DISTRIBUTION_SORT_LABELS : undefined}
+        showCountMode={!activeCategorical}
+        onConfigChange={applyConfig}
+        onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
+    />
+{/if}
 {#if activeHistogram}
     <HistogramExpandDialog
         bind:open={histogramExpandOpen}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -8,11 +8,14 @@ import { AnnotationCountMode, AnnotationType } from '$lib/api/lightly_studio_loc
 
 const echartsMock = vi.hoisted(() => {
     const zrHandlers: Record<string, (event: { offsetX: number; offsetY: number }) => void> = {};
+    let clickHandler: ((params: { dataIndex?: number }) => void) | undefined;
     const instance = {
         setOption: vi.fn(),
         resize: vi.fn(),
         dispose: vi.fn(),
-        on: vi.fn(),
+        on: vi.fn((event: string, handler: (params: { dataIndex?: number }) => void) => {
+            if (event === 'click') clickHandler = handler;
+        }),
         // 2 bins across a 200px-wide canvas → 100px per bin index.
         convertFromPixel: vi.fn((_finder: unknown, offsetX: number) => offsetX / 100),
         getZr: () => ({
@@ -22,7 +25,12 @@ const echartsMock = vi.hoisted(() => {
             off: vi.fn()
         })
     };
-    return { init: vi.fn(() => instance), instance, zrHandlers };
+    return {
+        init: vi.fn(() => instance),
+        instance,
+        zrHandlers,
+        getClickHandler: () => clickHandler
+    };
 });
 
 vi.mock('echarts/core', () => ({
@@ -93,8 +101,10 @@ describe('DatasetDistributionPanel', () => {
         // Horizontal default: categories live on the y-axis.
         const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
             yAxis: { data: string[] };
+            grid: { top: number };
         };
         expect(option.yAxis.data).toEqual(['person', 'dog', 'car']);
+        expect(option.grid.top).toBe(4);
     });
 
     it('applies a new top-N from the config dialog', async () => {
@@ -216,6 +226,272 @@ describe('DatasetDistributionPanel', () => {
         expect(screen.getByTestId('histogram')).toBeInTheDocument();
         expect(screen.getByTestId('dataset-distribution-histogram-summary')).toHaveTextContent(
             '100 samples · 2 bins · 0–1'
+        );
+    });
+
+    it('preserves categorical endpoint order and toggles typed buckets but not Other', () => {
+        const onCategoricalValueToggle = vi.fn();
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: ['Missing'],
+                            buckets: [
+                                {
+                                    id: 'literal',
+                                    kind: 'value',
+                                    value: 'Missing',
+                                    label: 'Missing',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 3
+                                },
+                                { id: 'other', kind: 'other', label: 'Other', count: 2 }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources, onCategoricalValueToggle } });
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+            series: [{ data: { itemStyle: { color: string } }[] }];
+            grid: { top: number };
+        };
+        expect(option.yAxis.data).toEqual(['Missing', 'Missing', 'Other']);
+        expect(option.grid.top).toBe(4);
+        // 'Missing' (value) is selected → accent green; the others are dimmed grey.
+        expect(option.series[0].data[0].itemStyle.color).toBe('rgba(59,217,159,0.85)');
+
+        echartsMock.getClickHandler()?.({ dataIndex: 1 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledWith('city', null);
+        echartsMock.getClickHandler()?.({ dataIndex: 2 });
+        expect(onCategoricalValueToggle).toHaveBeenCalledOnce();
+    });
+
+    it('stores categorical orientation per metadata field', async () => {
+        const user = userEvent.setup();
+        const categorical = (label: string) => ({
+            selectedValues: [],
+            buckets: [{ id: label, kind: 'value' as const, value: label, label, count: 1 }]
+        });
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groupLabel: 'Metadata key',
+                groups: [
+                    { id: 'city', label: 'city', categorical: categorical('Zurich') },
+                    { id: 'weather', label: 'weather', categorical: categorical('rainy') }
+                ]
+            },
+            { id: 'classes', label: 'Classes', data: [] }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        const orientationToggle = screen.getByTestId('dataset-distribution-toggle-orientation');
+        await fireEvent.click(orientationToggle);
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        const groupSelect = screen.getByTestId('dataset-distribution-group-select');
+        await user.click(groupSelect);
+        await user.click(await screen.findByRole('option', { name: 'weather' }));
+        expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars');
+
+        await user.click(groupSelect);
+        await user.click(await screen.findByRole('option', { name: 'city' }));
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+    });
+
+    it('configures, reorients, and expands categorical values', async () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                valueNoun: 'samples',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                },
+                                {
+                                    id: 'missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 1
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        expect(screen.getByText(/2 values · sorted by count · 5 samples/)).toBeInTheDocument();
+        const orientationToggle = screen.getByTestId('dataset-distribution-toggle-orientation');
+        expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars');
+
+        await fireEvent.click(orientationToggle);
+        await waitFor(() =>
+            expect(
+                (echartsMock.instance.setOption.mock.lastCall?.[0] as { xAxis: { type: string } })
+                    .xAxis.type
+            ).toBe('category')
+        );
+        expect(orientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        expect(screen.getByText('Configure values')).toBeInTheDocument();
+        expect(screen.queryByTestId('distribution-config-count-mode')).not.toBeInTheDocument();
+        await fireEvent.click(screen.getByText('Cancel'));
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-expand'));
+        expect(screen.getByTestId('dataset-distribution-expanded-configure')).toBeInTheDocument();
+        const expandedOrientationToggle = screen.getByTestId(
+            'dataset-distribution-expanded-toggle-orientation'
+        );
+        expect(expandedOrientationToggle).toHaveAccessibleName('Switch to horizontal bars');
+
+        await fireEvent.click(expandedOrientationToggle);
+        await waitFor(() =>
+            expect(orientationToggle).toHaveAccessibleName('Switch to vertical bars')
+        );
+    });
+
+    it('manually configures colliding categorical labels by stable bucket id', async () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'status',
+                        label: 'status',
+                        categorical: {
+                            selectedValues: [],
+                            buckets: [
+                                {
+                                    id: 'literal-missing',
+                                    kind: 'value',
+                                    value: 'Missing',
+                                    label: 'Missing',
+                                    count: 4
+                                },
+                                {
+                                    id: 'semantic-missing',
+                                    kind: 'missing',
+                                    value: null,
+                                    label: 'Missing',
+                                    count: 3
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ];
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        await fireEvent.click(screen.getByTestId('dataset-distribution-configure'));
+        await fireEvent.click(screen.getByRole('tab', { name: 'Manual' }));
+        const missingOptions = screen.getAllByText('Missing');
+        expect(missingOptions).toHaveLength(2);
+        await fireEvent.click(missingOptions[1]);
+        await fireEvent.click(screen.getByTestId('distribution-config-apply'));
+
+        const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
+            yAxis: { data: string[] };
+            series: [{ data: { value: number }[] }];
+        };
+        expect(option.yAxis.data).toEqual(['Missing']);
+        expect(option.series[0].data[0].value).toBe(3);
+    });
+
+    it('shows categorical loading and retryable error states', async () => {
+        const onCategoricalRetry = vi.fn();
+        const source = (state: { loading?: boolean; error?: string }): DistributionSource[] => [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: { buckets: [], selectedValues: ['Zurich'], ...state }
+                    }
+                ]
+            }
+        ];
+        const view = render(DatasetDistributionPanel, {
+            props: { sources: source({ loading: true }), onCategoricalRetry }
+        });
+        expect(screen.getByRole('status')).toHaveTextContent('Loading metadata distribution');
+
+        await view.rerender({
+            sources: source({ error: 'network failure' }),
+            onCategoricalRetry
+        });
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not load metadata distribution');
+        await fireEvent.click(screen.getByTestId('metadata-categorical-retry'));
+        expect(onCategoricalRetry).toHaveBeenCalledOnce();
+    });
+
+    it('keeps stale categorical bars visible after a refetch error', () => {
+        const sources: DistributionSource[] = [
+            {
+                id: 'metadata',
+                label: 'Metadata',
+                groups: [
+                    {
+                        id: 'city',
+                        label: 'city',
+                        categorical: {
+                            buckets: [
+                                {
+                                    id: 'zurich',
+                                    kind: 'value',
+                                    value: 'Zurich',
+                                    label: 'Zurich',
+                                    count: 4
+                                }
+                            ],
+                            selectedValues: [],
+                            error: 'network failure'
+                        }
+                    }
+                ]
+            }
+        ];
+
+        render(DatasetDistributionPanel, { props: { sources } });
+
+        expect(screen.getByRole('alert')).toHaveTextContent('Could not update');
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+        expect(screen.getByLabelText('Categorical metadata value counts')).toHaveTextContent(
+            'Zurich: 4 samples'
         );
     });
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
@@ -19,9 +19,8 @@
         totalCount?: number;
         /** Noun for the total count summary (e.g. 'annotations', 'samples'). */
         valueNoun?: string;
-        /** Singular label for the distributed categories. */
+        /** Singular/plural labels for the distributed categories. */
         categoryNoun?: string;
-        /** Plural labels for the distributed categories. */
         categoryNounPlural?: string;
         /** Labels for the active sort mode. */
         sortLabels?: Record<keyof typeof DISTRIBUTION_SORT_LABELS, string>;

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.test.ts
@@ -49,6 +49,23 @@ describe('selectVisibleCounts', () => {
         expect(visible.map((item) => item.label)).toEqual(['dog', 'car']);
     });
 
+    it('uses stable ids for manual selections when labels collide', () => {
+        const visible = selectVisibleCounts(
+            [
+                { id: 'literal-missing', label: 'Missing', count: 2 },
+                { id: 'semantic-missing', label: 'Missing', count: 1 }
+            ],
+            {
+                mode: 'manual',
+                n: 1,
+                sortBy: 'count',
+                manualClasses: ['semantic-missing']
+            }
+        );
+
+        expect(visible.map((item) => item.id)).toEqual(['semantic-missing']);
+    });
+
     it('returns nothing when the manual selection is empty', () => {
         const visible = selectVisibleCounts(data, {
             mode: 'manual',
@@ -57,5 +74,18 @@ describe('selectVisibleCounts', () => {
             manualClasses: []
         });
         expect(visible).toEqual([]);
+    });
+
+    it('keeps pinned semantic buckets within a top-N limit', () => {
+        const visible = selectVisibleCounts(
+            [
+                ...data,
+                { label: 'Missing', count: 1, pinned: true },
+                { label: 'Other', count: 2, pinned: true }
+            ],
+            { mode: 'topN', n: 3, sortBy: 'count', manualClasses: [] }
+        );
+
+        expect(visible.map((item) => item.label)).toEqual(['person', 'Other', 'Missing']);
     });
 });

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/selectVisibleCounts.ts
@@ -16,7 +16,16 @@ export function selectVisibleCounts(
             : a.label.localeCompare(b.label)
     );
     if (config.mode === 'manual') {
-        return sorted.filter((item) => config.manualClasses.includes(item.label));
+        return sorted.filter((item) => config.manualClasses.includes(item.id ?? item.label));
     }
-    return sorted.slice(0, Math.max(config.n, 1));
+    const limit = Math.max(config.n, 1);
+    const pinned = sorted.filter((item) => item.pinned);
+    if (pinned.length === 0) return sorted.slice(0, limit);
+
+    const remainingSlots = Math.max(limit - pinned.length, 0);
+    const selected = new Set([
+        ...pinned,
+        ...sorted.filter((item) => !item.pinned).slice(0, remainingSlots)
+    ]);
+    return sorted.filter((item) => selected.has(item));
 }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/sourceFixtures.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/sourceFixtures.ts
@@ -1,4 +1,6 @@
 import type { CategoryCount } from '$lib/components/BarChart';
+import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
+import type { CategoricalMetadataValue } from '$lib/services/types';
 import type { DistributionSource } from './types';
 import { longTail } from '$lib/components/BarChart/fixtures';
 import {
@@ -76,6 +78,40 @@ const evalErrors: CategoryCount[] = counts([
     ['duplicate_pred', 176]
 ]);
 
+function categoricalBuckets(
+    entries: [string | boolean | null, number][]
+): CategoricalMetadataBucket[] {
+    return entries.map(([value, count], i) => {
+        const id = String(i);
+        if (value === null) return { id, kind: 'missing', value: null, label: '(missing)', count };
+        return { id, kind: 'value', value, label: String(value), count };
+    });
+}
+
+/** Location-type metadata: urban / rural classification per sample. */
+const locationTypeBuckets = categoricalBuckets([
+    ['city', 5840],
+    ['suburban', 3210],
+    ['rural', 2470],
+    ['village', 1390],
+    ['town', 980],
+    ['industrial', 540],
+    ['highway', 420],
+    [null, 115]
+]);
+
+/** Same distribution with an active filter on city + rural (foreground bars). */
+const locationTypeFilteredBuckets = categoricalBuckets([
+    ['city', 2910],
+    ['suburban', 3210],
+    ['rural', 1230],
+    ['village', 1390],
+    ['town', 980],
+    ['industrial', 540],
+    ['highway', 420],
+    [null, 115]
+]);
+
 /**
  * A metadata-only source list with a numeric key first, so the histogram
  * rendering is visible immediately. Switching to `weather` demonstrates the
@@ -91,6 +127,64 @@ export const numericMetadataSources: DistributionSource[] = [
             { id: 'confidence', label: 'confidence (numeric)', histogram: numericConfidence },
             { id: 'brightness', label: 'brightness (numeric)', histogram: numericBrightness },
             { id: 'weather', label: 'weather', data: metadataWeather }
+        ]
+    }
+];
+
+/**
+ * Single-source fixture for the categorical metadata story. Shows:
+ * - value / missing bucket kinds
+ * - active filter selection (city + rural) with filtered counts as foreground bars
+ */
+export const categoricalMetadataSources: DistributionSource[] = [
+    {
+        id: 'metadata',
+        label: 'Metadata',
+        groupLabel: 'Metadata key',
+        valueNoun: 'samples',
+        groups: [
+            {
+                id: 'location_type',
+                label: 'location_type',
+                categorical: {
+                    buckets: locationTypeBuckets,
+                    filteredBuckets: locationTypeFilteredBuckets,
+                    selectedValues: ['city', 'rural'] satisfies CategoricalMetadataValue[]
+                }
+            }
+        ]
+    }
+];
+
+/**
+ * All three data kinds in one panel: class labels (bar chart), categorical
+ * metadata with an active filter (location_type), and numeric metadata
+ * (confidence histogram). Useful for reviewing how source-switching feels
+ * when the chart type changes between selections.
+ */
+export const mixedSources: DistributionSource[] = [
+    {
+        id: 'class',
+        label: 'Class labels',
+        data: longTail,
+        valueNoun: 'annotations'
+    },
+    {
+        id: 'metadata',
+        label: 'Metadata',
+        groupLabel: 'Metadata key',
+        valueNoun: 'samples',
+        groups: [
+            {
+                id: 'location_type',
+                label: 'location_type',
+                categorical: {
+                    buckets: locationTypeBuckets,
+                    filteredBuckets: locationTypeFilteredBuckets,
+                    selectedValues: ['city', 'rural'] satisfies CategoricalMetadataValue[]
+                }
+            },
+            { id: 'confidence', label: 'confidence (numeric)', histogram: numericConfidence }
         ]
     }
 ];

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -2,6 +2,7 @@ import type { CategoryCount } from '$lib/components/BarChart';
 import type { ClassSetSelection } from '$lib/components/ClassSetConfig';
 import { type AnnotationCountMode } from '$lib/api/lightly_studio_local/types.gen';
 import type { HistogramData, HistogramRange } from '$lib/components/Histogram';
+import type { CategoricalMetadataBucket } from '$lib/hooks/useCategoricalMetadataDistribution/types';
 import type { CategoricalMetadataValue } from '$lib/services/types';
 
 export type DistributionSortOption = 'count' | 'name';
@@ -63,8 +64,21 @@ export interface DistributionSourceGroup {
      * metadata filter). Bins outside it render dimmed.
      */
     selectedRange?: HistogramRange;
-    /** Categorical distribution rendered as a bar chart with selection state. */
-    categorical?: CategoricalDistribution;
+    /** Controlled categorical distribution and selection state. */
+    categorical?: {
+        buckets: CategoricalMetadataBucket[];
+        /**
+         * Buckets from the same query with all sidebar filters applied.
+         * When provided, each bar shows a grey background at the full `count`
+         * with a coloured foreground at the filtered count, giving context for
+         * how active filters affect the distribution.
+         * Omit (undefined) while the filtered query is still loading.
+         */
+        filteredBuckets?: CategoricalMetadataBucket[];
+        selectedValues: CategoricalMetadataValue[];
+        loading?: boolean;
+        error?: string;
+    };
 }
 
 /**

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -20,14 +20,17 @@
 
     // Instantiate all variants once: this component lives in the layout, which persists
     // when switching between the images/annotations tabs.
+    // svelte-ignore state_referenced_locally
     const imagesFilter = useEmbeddingFilterForImages(
         collectionIdStore,
         setRangeSelectionForCollection
     );
+    // svelte-ignore state_referenced_locally
     const videosFilter = useEmbeddingFilterForVideos(
         collectionIdStore,
         setRangeSelectionForCollection
     );
+    // svelte-ignore state_referenced_locally
     const annotationsFilter = useEmbeddingFilterForAnnotations(
         collectionIdStore,
         setRangeSelectionForCollection

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -20,17 +20,14 @@
 
     // Instantiate all variants once: this component lives in the layout, which persists
     // when switching between the images/annotations tabs.
-    // svelte-ignore state_referenced_locally
     const imagesFilter = useEmbeddingFilterForImages(
         collectionIdStore,
         setRangeSelectionForCollection
     );
-    // svelte-ignore state_referenced_locally
     const videosFilter = useEmbeddingFilterForVideos(
         collectionIdStore,
         setRangeSelectionForCollection
     );
-    // svelte-ignore state_referenced_locally
     const annotationsFilter = useEmbeddingFilterForAnnotations(
         collectionIdStore,
         setRangeSelectionForCollection

--- a/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.test.ts
+++ b/lightly_studio_view/src/lib/components/MetadataFilterChips/useMetadataFilterChips.test.ts
@@ -27,6 +27,7 @@ describe('useMetadataFilterChips', () => {
         storage.updateMetadataBounds({});
         storage.updateMetadataValues({});
         trackEvent.mockClear();
+        storage.updateCategoricalMetadataValues({});
     });
 
     it('provides a chip only for narrowed filters, not for full-range ones', () => {
@@ -168,5 +169,104 @@ describe('useMetadataFilterChips', () => {
             expect(get(storage.metadataValues).confidence).toEqual({ min: 0, max: 1 })
         );
         expect(trackEvent).not.toHaveBeenCalled();
+    });
+
+    describe('categorical metadata', () => {
+        it('shows a chip when categorical values are selected', () => {
+            storage.updateCategoricalMetadataValues({ location_type: ['city', 'rural'] });
+            render(MetadataFilterChips);
+
+            expect(screen.getByTestId('metadata-filter-chip-location_type')).toBeInTheDocument();
+        });
+
+        it('chip subtitle shows the selected values joined by comma', () => {
+            storage.updateCategoricalMetadataValues({ location_type: ['city', 'rural'] });
+            render(MetadataFilterChips);
+
+            expect(screen.getByTestId('metadata-filter-chip-location_type')).toHaveTextContent(
+                'city, rural'
+            );
+        });
+
+        it('chip is checked when values are active', () => {
+            storage.updateCategoricalMetadataValues({ location_type: ['city'] });
+            render(MetadataFilterChips);
+
+            expect(screen.getByRole('checkbox')).toBeChecked();
+        });
+
+        it('does not show a chip when categorical values are empty', () => {
+            storage.updateCategoricalMetadataValues({ location_type: [] });
+            render(MetadataFilterChips);
+
+            expect(
+                screen.queryByTestId('metadata-filter-chip-location_type')
+            ).not.toBeInTheDocument();
+        });
+
+        it('unchecking clears the filter but keeps the chip with the remembered values', async () => {
+            storage.updateCategoricalMetadataValues({ location_type: ['city', 'rural'] });
+            render(MetadataFilterChips);
+
+            screen.getByRole('checkbox').click();
+
+            await waitFor(() =>
+                expect(get(storage.categoricalMetadataValues).location_type).toEqual([])
+            );
+            expect(screen.getByTestId('metadata-filter-chip-location_type')).toHaveTextContent(
+                'city, rural'
+            );
+            expect(screen.getByRole('checkbox')).not.toBeChecked();
+        });
+
+        it('re-checking restores the remembered categorical values', async () => {
+            storage.updateCategoricalMetadataValues({ location_type: ['city', 'rural'] });
+            render(MetadataFilterChips);
+
+            screen.getByRole('checkbox').click();
+            await waitFor(() => expect(screen.getByRole('checkbox')).not.toBeChecked());
+
+            screen.getByRole('checkbox').click();
+
+            await waitFor(() =>
+                expect(get(storage.categoricalMetadataValues).location_type).toEqual([
+                    'city',
+                    'rural'
+                ])
+            );
+            expect(screen.getByRole('checkbox')).toBeChecked();
+        });
+
+        it('clearing removes the chip and the filter', async () => {
+            storage.updateCategoricalMetadataValues({ location_type: ['city'] });
+            render(MetadataFilterChips);
+
+            screen.getByLabelText('Clear location_type').click();
+
+            await waitFor(() =>
+                expect(
+                    screen.queryByTestId('metadata-filter-chip-location_type')
+                ).not.toBeInTheDocument()
+            );
+            expect(get(storage.categoricalMetadataValues).location_type).toBeUndefined();
+        });
+
+        it('formats null as "Missing"', () => {
+            storage.updateCategoricalMetadataValues({ location_type: [null] });
+            render(MetadataFilterChips);
+
+            expect(screen.getByTestId('metadata-filter-chip-location_type')).toHaveTextContent(
+                'Missing'
+            );
+        });
+
+        it('disambiguates null and the string "Missing" when both are selected', () => {
+            storage.updateCategoricalMetadataValues({ location_type: [null, 'Missing'] });
+            render(MetadataFilterChips);
+
+            expect(screen.getByTestId('metadata-filter-chip-location_type')).toHaveTextContent(
+                'Missing (no value), Missing (value)'
+            );
+        });
     });
 });


### PR DESCRIPTION
## What has changed and why?

Introduce component to incapsulate logic to render DatasetDistributionPanel content

## How has it been tested?

It should be enough to passs tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added categorical metadata distributions alongside class and numeric charts.
  * Filter categorical values directly from charts and metadata filter chips.
  * View selected, filtered, missing, and top-ranked values with clear counts.
  * Added support for switching between mixed distribution types and configuring each field independently.
  * Added loading, empty, error, retry, and accessibility states for distribution panels.

* **Bug Fixes**
  * Improved selection accuracy when labels are duplicated.
  * Ensured pinned values remain visible in top-value lists.
  * Clarified singular and plural category labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->