### PR TITLE
Add lightly-studio demo CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Show indexed categorical metadata values in distribution panel
-- Add the `lightly-studio demo` CLI command, which downloads the COCO example dataset and launches the GUI in one step.
+- Add the `lightly-studio quickstart` CLI command, which downloads the COCO example dataset and launches the GUI in one step.
 
 - Export image classification annotations to CSV via the GUI and Python SDK
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Show indexed categorical metadata values in distribution panel
+- Add the `lightly-studio demo` CLI command, which downloads the COCO example dataset and launches the GUI in one step.
 
 - Export image classification annotations to CSV via the GUI and Python SDK
 

--- a/lightly_studio/docs/docs/dataset_setup/image_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/image_dataset.md
@@ -453,7 +453,7 @@ See the [API reference](../api/dataset.md#lightly_studio.ImageDataset) for `add_
 ## Image Dataset in the GUI
 
 !!! tip "Trying LightlyStudio for the first time?"
-    Run `lightly-studio demo` to download the COCO example dataset and open the GUI
+    Run `lightly-studio quickstart` to download the COCO example dataset and open the GUI
     in a single command — no Python script needed.
 
 Launch the GUI from your terminal:

--- a/lightly_studio/docs/docs/dataset_setup/image_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/image_dataset.md
@@ -452,6 +452,10 @@ See the [API reference](../api/dataset.md#lightly_studio.ImageDataset) for `add_
 
 ## Image Dataset in the GUI
 
+!!! tip "Trying LightlyStudio for the first time?"
+    Run `lightly-studio demo` to download the COCO example dataset and open the GUI
+    in a single command — no Python script needed.
+
 Launch the GUI from your terminal:
 
 ```shell

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -48,8 +48,18 @@ pip install lightly-studio
 
 ## Quickstart
 
-The examples below download the required example data the first time you run them. You can also
-directly use your own image, video, or YOLO/COCO dataset.
+Want to try LightlyStudio instantly? Run:
+
+```shell
+lightly-studio demo
+```
+
+This downloads the COCO example dataset on the first run (skipped on subsequent runs), loads it,
+and opens the GUI automatically. Use `--force-download` to re-fetch the dataset, or `--port <N>`
+to serve on a custom port.
+
+The examples below let you load your own data. They download the required example data the first
+time you run them.
 
 === "COCO Object Detection"
 
@@ -142,8 +152,9 @@ directly use your own image, video, or YOLO/COCO dataset.
     1. Click on the printed URL to open the app in your browser.
 
 !!! tip
-    Call `lightly-studio gui` from the command line instead of `ls.start_gui()` in Python
-    to skip reindexing your dataset.
+    - Run `lightly-studio demo` to try LightlyStudio instantly — no Python script needed.
+    - Call `lightly-studio gui` instead of `ls.start_gui()` in Python to skip reindexing
+      an already-loaded dataset.
 
 Ready for a complete, end-to-end workflow? Follow the tutorial
 [Curate a Traffic CCTV Dataset for YOLO Training](tutorials/yolo-traffic-cctv-object-detection.md)

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -58,8 +58,8 @@ This downloads the COCO example dataset on the first run (skipped on subsequent 
 and starts the GUI server. Click the printed URL to open it in your browser. Use
 `--force-download` to re-fetch the dataset, or `--port <N>` to serve on a custom port.
 
-The examples below let you load your own data. They download the required example data the first
-time you run them.
+The examples below use the same example dataset by default, downloaded on the first run. Point
+them at your own image, video, or YOLO/COCO dataset by changing the input path.
 
 === "COCO Object Detection"
 

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -51,7 +51,7 @@ pip install lightly-studio
 Want to try LightlyStudio instantly? Run:
 
 ```shell
-lightly-studio demo
+lightly-studio quickstart
 ```
 
 This downloads the COCO example dataset on the first run (skipped on subsequent runs), loads it,
@@ -152,7 +152,7 @@ time you run them.
     1. Click on the printed URL to open the app in your browser.
 
 !!! tip
-    - Run `lightly-studio demo` to try LightlyStudio instantly — no Python script needed.
+    - Run `lightly-studio quickstart` to try LightlyStudio instantly — no Python script needed.
     - Call `lightly-studio gui` instead of `ls.start_gui()` in Python to skip reindexing
       an already-loaded dataset.
 

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -55,8 +55,8 @@ lightly-studio quickstart
 ```
 
 This downloads the COCO example dataset on the first run (skipped on subsequent runs), loads it,
-and opens the GUI automatically. Use `--force-download` to re-fetch the dataset, or `--port <N>`
-to serve on a custom port.
+and starts the GUI server. Click the printed URL to open it in your browser. Use
+`--force-download` to re-fetch the dataset, or `--port <N>` to serve on a custom port.
 
 The examples below let you load your own data. They download the required example data the first
 time you run them.

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -7,7 +7,9 @@ from importlib import metadata
 import click
 
 import lightly_studio
+from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
 from lightly_studio.database import db_manager
+from lightly_studio.evaluation.image_dataset_evaluate import ObjectDetectionEvaluationConfig
 
 
 @click.group()
@@ -25,18 +27,42 @@ def main() -> None:
     help="Re-download the demo dataset even if already cached.",
 )
 def demo(port: int | None, force_download: bool) -> None:
-    """Launch the GUI preloaded with the COCO demo dataset."""
+    """Launch the GUI preloaded with a COCO object detection evaluation demo dataset."""
     dataset_path = lightly_studio.utils.download_example_dataset(
         download_dir="dataset_examples",
         force_redownload=force_download,
     )
+    images_path = f"{dataset_path}/coco_subset_128_images/images"
+    evaluation_config = ObjectDetectionEvaluationConfig(
+        iou_threshold=0.5,
+        classwise=True,
+    )
+
     db_manager.connect(db_file="demo.db", cleanup_existing=force_download)
     dataset = lightly_studio.ImageDataset.create()
-    dataset.add_samples_from_coco(
+    dataset.add_images_from_path(path=images_path)
+    dataset.add_annotations_from_coco(
         annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
-        images_path=f"{dataset_path}/coco_subset_128_images/images",
-        annotation_type=lightly_studio.AnnotationType.SEGMENTATION_MASK,
+        images_root=images_path,
+        annotation_source="ground_truth",
     )
+    dataset.add_annotations_from_coco(
+        annotations_json=f"{dataset_path}/coco_subset_128_images/predictions_train2017.json",
+        images_root=images_path,
+        annotation_source="predictions",
+    )
+    # Tag a subset of samples to run the evaluation on.
+    dataset.query()[:10].add_tag("evaluated_samples")
+    tagged_evaluation_query = dataset.query().match(
+        ImageSampleField.tags.contains("evaluated_samples")
+    )
+    dataset.evaluate(query=tagged_evaluation_query).object_detection(
+        name="od_evaluation",
+        gt_annotation_source="ground_truth",
+        pred_annotation_source="predictions",
+        config=evaluation_config,
+    )
+
     lightly_studio.start_gui(port=port)
 
 

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -27,7 +27,7 @@ def main() -> None:
     default=False,
     help="Re-download the demo dataset even if already cached.",
 )
-def demo(port: int | None, force_download: bool) -> None:
+def quickstart(port: int | None, force_download: bool) -> None:
     """Launch the GUI preloaded with a COCO object detection evaluation demo dataset."""
     dataset_path = Path(
         lightly_studio.utils.download_example_dataset(
@@ -42,7 +42,7 @@ def demo(port: int | None, force_download: bool) -> None:
         classwise=True,
     )
 
-    db_manager.connect(db_file="demo.db", cleanup_existing=True)
+    db_manager.connect(db_file="quickstart.db", cleanup_existing=True)
     dataset = lightly_studio.ImageDataset.create()
     dataset.add_images_from_path(path=images_path)
     dataset.add_annotations_from_coco(

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -39,7 +39,7 @@ def demo(port: int | None, force_download: bool) -> None:
     )
 
     db_manager.connect(db_file="demo.db", cleanup_existing=force_download)
-    dataset = lightly_studio.ImageDataset.create()
+    dataset = lightly_studio.ImageDataset.load_or_create()
     dataset.add_images_from_path(path=images_path)
     dataset.add_annotations_from_coco(
         annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -67,6 +67,8 @@ def quickstart(port: int | None, force_download: bool) -> None:
         config=evaluation_config,
     )
 
+    # TODO(Gabriel, 08/2026): Open the browser automatically once the server is ready.
+    # See LIG-10436.
     lightly_studio.start_gui(port=port)
 
 

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -26,20 +26,18 @@ def main() -> None:
 )
 def demo(port: int | None, force_download: bool) -> None:
     """Launch the GUI preloaded with the COCO demo dataset."""
-    import lightly_studio as ls
-
-    dataset_path = ls.utils.download_example_dataset(
+    dataset_path = lightly_studio.utils.download_example_dataset(
         download_dir="dataset_examples",
         force_redownload=force_download,
     )
-    db_manager.connect(cleanup_existing=True)
-    dataset = ls.ImageDataset.create()
+    db_manager.connect(db_file="demo.db", cleanup_existing=force_download)
+    dataset = lightly_studio.ImageDataset.create()
     dataset.add_samples_from_coco(
         annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
         images_path=f"{dataset_path}/coco_subset_128_images/images",
-        annotation_type=ls.AnnotationType.SEGMENTATION_MASK,
+        annotation_type=lightly_studio.AnnotationType.SEGMENTATION_MASK,
     )
-    ls.start_gui(port=port)
+    lightly_studio.start_gui(port=port)
 
 
 @main.command()

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import click
 
 import lightly_studio
-from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
 from lightly_studio.database import db_manager
 from lightly_studio.evaluation.image_dataset_evaluate import ObjectDetectionEvaluationConfig
 
@@ -39,7 +38,7 @@ def quickstart(port: int | None, force_download: bool) -> None:
     images_path = coco_dir / "images"
     evaluation_config = ObjectDetectionEvaluationConfig(
         iou_threshold=0.5,
-        classwise=True,
+        classwise=False,
     )
 
     db_manager.connect(db_file="quickstart.db", cleanup_existing=True)
@@ -55,12 +54,9 @@ def quickstart(port: int | None, force_download: bool) -> None:
         images_root=images_path,
         annotation_source="predictions",
     )
-    # Tag a subset of samples to run the evaluation on.
-    dataset.query()[:10].add_tag("evaluated_samples")
-    tagged_evaluation_query = dataset.query().match(
-        ImageSampleField.tags.contains("evaluated_samples")
-    )
-    dataset.evaluate(query=tagged_evaluation_query).object_detection(
+    # Tag a subset of samples to demonstrate tags in the GUI.
+    dataset.query()[:10].add_tag("sample_subset")
+    dataset.evaluate().object_detection(
         name="od_evaluation",
         gt_annotation_source="ground_truth",
         pred_annotation_source="predictions",

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from importlib import metadata
+from pathlib import Path
 
 import click
 
@@ -28,26 +29,29 @@ def main() -> None:
 )
 def demo(port: int | None, force_download: bool) -> None:
     """Launch the GUI preloaded with a COCO object detection evaluation demo dataset."""
-    dataset_path = lightly_studio.utils.download_example_dataset(
-        download_dir="dataset_examples",
-        force_redownload=force_download,
+    dataset_path = Path(
+        lightly_studio.utils.download_example_dataset(
+            download_dir="dataset_examples",
+            force_redownload=force_download,
+        )
     )
-    images_path = f"{dataset_path}/coco_subset_128_images/images"
+    coco_dir = dataset_path / "coco_subset_128_images"
+    images_path = coco_dir / "images"
     evaluation_config = ObjectDetectionEvaluationConfig(
         iou_threshold=0.5,
         classwise=True,
     )
 
-    db_manager.connect(db_file="demo.db", cleanup_existing=force_download)
-    dataset = lightly_studio.ImageDataset.load_or_create()
+    db_manager.connect(db_file="demo.db", cleanup_existing=True)
+    dataset = lightly_studio.ImageDataset.create()
     dataset.add_images_from_path(path=images_path)
     dataset.add_annotations_from_coco(
-        annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
+        annotations_json=coco_dir / "instances_train2017.json",
         images_root=images_path,
         annotation_source="ground_truth",
     )
     dataset.add_annotations_from_coco(
-        annotations_json=f"{dataset_path}/coco_subset_128_images/predictions_train2017.json",
+        annotations_json=coco_dir / "predictions_train2017.json",
         images_root=images_path,
         annotation_source="predictions",
     )

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -17,6 +17,32 @@ def main() -> None:
 
 
 @main.command()
+@click.option("--port", default=None, type=int, help="Port to bind the server to.")
+@click.option(
+    "--force-download",
+    is_flag=True,
+    default=False,
+    help="Re-download the demo dataset even if already cached.",
+)
+def demo(port: int | None, force_download: bool) -> None:
+    """Launch the GUI preloaded with the COCO demo dataset."""
+    import lightly_studio as ls
+
+    dataset_path = ls.utils.download_example_dataset(
+        download_dir="dataset_examples",
+        force_redownload=force_download,
+    )
+    db_manager.connect(cleanup_existing=True)
+    dataset = ls.ImageDataset.create()
+    dataset.add_samples_from_coco(
+        annotations_json=f"{dataset_path}/coco_subset_128_images/instances_train2017.json",
+        images_path=f"{dataset_path}/coco_subset_128_images/images",
+        annotation_type=ls.AnnotationType.SEGMENTATION_MASK,
+    )
+    ls.start_gui(port=port)
+
+
+@main.command()
 @click.option("--host", default=None, type=str, help="Host to bind the server to.")
 @click.option("--port", default=None, type=int, help="Port to bind the server to.")
 @click.option(

--- a/lightly_studio/tests/test_cli.py
+++ b/lightly_studio/tests/test_cli.py
@@ -15,7 +15,7 @@ import lightly_studio
 from lightly_studio import cli
 from lightly_studio.database import db_manager
 from lightly_studio.models.evaluation_run import EvaluationTaskType
-from lightly_studio.resolvers import evaluation_run_resolver
+from lightly_studio.resolvers import annotation_resolver, evaluation_run_resolver
 
 
 @pytest.fixture(autouse=True)
@@ -121,19 +121,20 @@ def _mock_demo_dependencies(mocker: MockerFixture) -> tuple[Any, Any, Any, Any]:
     mock_connect = mocker.patch.object(db_manager, "connect")
     mock_dataset = mocker.MagicMock()
     mock_create = mocker.patch.object(
-        lightly_studio.ImageDataset, "load_or_create", return_value=mock_dataset
+        lightly_studio.ImageDataset, "create", return_value=mock_dataset
     )
     mock_start_gui = mocker.patch.object(lightly_studio, "start_gui")
     return mock_download, mock_connect, mock_create, mock_start_gui
 
 
 def test_demo(mocker: MockerFixture) -> None:
-    mock_download, mock_connect, _, mock_start_gui = _mock_demo_dependencies(mocker)
+    mock_download, mock_connect, mock_create, mock_start_gui = _mock_demo_dependencies(mocker)
     runner = CliRunner()
     result = runner.invoke(cli=cli.main, args=["demo"])
     assert result.exit_code == 0
     mock_download.assert_called_once_with(download_dir="dataset_examples", force_redownload=False)
-    mock_connect.assert_called_once_with(db_file="demo.db", cleanup_existing=False)
+    mock_connect.assert_called_once_with(db_file="demo.db", cleanup_existing=True)
+    mock_create.assert_called_once_with()
     mock_start_gui.assert_called_once_with(port=None)
 
 
@@ -217,3 +218,43 @@ def test_demo__runs_real_evaluation_pipeline(
     assert len(evaluation_runs) == 1
     assert evaluation_runs[0].name == "od_evaluation"
     assert evaluation_runs[0].task_type == EvaluationTaskType.OBJECT_DETECTION
+
+
+def test_demo__second_run_without_force_download_does_not_duplicate_or_crash(
+    mocker: MockerFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test for a bug where demo crashed on a second run.
+
+    Previously demo.db was only wiped for --force-download, so a second run duplicated
+    annotations and then crashed with an IntegrityError on the evaluation run insert.
+    """
+    monkeypatch.chdir(tmp_path)
+    dataset_dir = _build_demo_dataset_dir(tmp_path)
+    mocker.patch.object(
+        lightly_studio.utils, "download_example_dataset", return_value=str(dataset_dir)
+    )
+    mocker.patch.object(lightly_studio, "start_gui")
+
+    runner = CliRunner()
+    assert runner.invoke(cli=cli.main, args=["demo"]).exit_code == 0
+    # Each `lightly-studio demo` invocation is normally its own process, starting with no
+    # engine set. Close the engine here to reproduce that between the two invokes below.
+    db_manager.close()
+    result_second = runner.invoke(cli=cli.main, args=["demo"])
+    assert result_second.exit_code == 0, result_second.output
+
+    dataset = lightly_studio.ImageDataset.load()
+    assert len(dataset.query().to_list()) == 3
+
+    evaluation_runs = evaluation_run_resolver.get_all_by_dataset_id(
+        session=dataset.session, dataset_id=dataset.dataset_id
+    )
+    assert len(evaluation_runs) == 1
+
+    ground_truth = annotation_resolver.get_all_by_collection_name(
+        session=dataset.session,
+        collection_name="ground_truth",
+        parent_collection_id=dataset.collection_id,
+    )
+    # 3 fixture images x 1 annotation each in _coco_dict_with — must stay at 3, not double to 6.
+    assert len(ground_truth.annotations) == 3

--- a/lightly_studio/tests/test_cli.py
+++ b/lightly_studio/tests/test_cli.py
@@ -114,7 +114,7 @@ def test_gui__with_empty_db_file__complains_about_missing_dataset(
     assert "No datasets found" in str(result.exception)
 
 
-def _mock_demo_dependencies(mocker: MockerFixture) -> tuple[Any, Any, Any, Any]:
+def _mock_quickstart_dependencies(mocker: MockerFixture) -> tuple[Any, Any, Any, Any]:
     mock_download = mocker.patch.object(
         lightly_studio.utils, "download_example_dataset", return_value="/dataset_examples"
     )
@@ -127,30 +127,30 @@ def _mock_demo_dependencies(mocker: MockerFixture) -> tuple[Any, Any, Any, Any]:
     return mock_download, mock_connect, mock_create, mock_start_gui
 
 
-def test_demo(mocker: MockerFixture) -> None:
-    mock_download, mock_connect, mock_create, mock_start_gui = _mock_demo_dependencies(mocker)
+def test_quickstart(mocker: MockerFixture) -> None:
+    mock_download, mock_connect, mock_create, mock_start_gui = _mock_quickstart_dependencies(mocker)
     runner = CliRunner()
-    result = runner.invoke(cli=cli.main, args=["demo"])
+    result = runner.invoke(cli=cli.main, args=["quickstart"])
     assert result.exit_code == 0
     mock_download.assert_called_once_with(download_dir="dataset_examples", force_redownload=False)
-    mock_connect.assert_called_once_with(db_file="demo.db", cleanup_existing=True)
+    mock_connect.assert_called_once_with(db_file="quickstart.db", cleanup_existing=True)
     mock_create.assert_called_once_with()
     mock_start_gui.assert_called_once_with(port=None)
 
 
-def test_demo__with_force_download(mocker: MockerFixture) -> None:
-    mock_download, mock_connect, _, _ = _mock_demo_dependencies(mocker)
+def test_quickstart__with_force_download(mocker: MockerFixture) -> None:
+    mock_download, mock_connect, _, _ = _mock_quickstart_dependencies(mocker)
     runner = CliRunner()
-    result = runner.invoke(cli=cli.main, args=["demo", "--force-download"])
+    result = runner.invoke(cli=cli.main, args=["quickstart", "--force-download"])
     assert result.exit_code == 0
     mock_download.assert_called_once_with(download_dir="dataset_examples", force_redownload=True)
-    mock_connect.assert_called_once_with(db_file="demo.db", cleanup_existing=True)
+    mock_connect.assert_called_once_with(db_file="quickstart.db", cleanup_existing=True)
 
 
-def test_demo__with_port(mocker: MockerFixture) -> None:
-    _, _, _, mock_start_gui = _mock_demo_dependencies(mocker)
+def test_quickstart__with_port(mocker: MockerFixture) -> None:
+    _, _, _, mock_start_gui = _mock_quickstart_dependencies(mocker)
     runner = CliRunner()
-    result = runner.invoke(cli=cli.main, args=["demo", "--port", "9999"])
+    result = runner.invoke(cli=cli.main, args=["quickstart", "--port", "9999"])
     assert result.exit_code == 0
     mock_start_gui.assert_called_once_with(port=9999)
 
@@ -176,7 +176,7 @@ def _coco_dict_with(file_names: list[str]) -> dict[str, Any]:
     }
 
 
-def _build_demo_dataset_dir(root: Path) -> Path:
+def _build_quickstart_dataset_dir(root: Path) -> Path:
     """Build a fixture dataset with the same layout as the real demo dataset."""
     dataset_dir = root / "dataset_examples"
     images_dir = dataset_dir / "coco_subset_128_images" / "images"
@@ -190,24 +190,24 @@ def _build_demo_dataset_dir(root: Path) -> Path:
     return dataset_dir
 
 
-def test_demo__runs_real_evaluation_pipeline(
+def test_quickstart__runs_real_evaluation_pipeline(
     mocker: MockerFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Loads real images, real COCO annotations, and persists a real evaluation run.
 
-    Runs against its own isolated 'demo.db', without any network access.
+    Runs against its own isolated 'quickstart.db', without any network access.
     """
     monkeypatch.chdir(tmp_path)
-    dataset_dir = _build_demo_dataset_dir(tmp_path)
+    dataset_dir = _build_quickstart_dataset_dir(tmp_path)
     mocker.patch.object(
         lightly_studio.utils, "download_example_dataset", return_value=str(dataset_dir)
     )
     mocker.patch.object(lightly_studio, "start_gui")
 
     runner = CliRunner()
-    result = runner.invoke(cli=cli.main, args=["demo"])
+    result = runner.invoke(cli=cli.main, args=["quickstart"])
     assert result.exit_code == 0, result.output
-    assert (tmp_path / "demo.db").exists()
+    assert (tmp_path / "quickstart.db").exists()
 
     dataset = lightly_studio.ImageDataset.load()
     assert len(dataset.query().to_list()) == 3
@@ -220,27 +220,27 @@ def test_demo__runs_real_evaluation_pipeline(
     assert evaluation_runs[0].task_type == EvaluationTaskType.OBJECT_DETECTION
 
 
-def test_demo__second_run_without_force_download_does_not_duplicate_or_crash(
+def test_quickstart__second_run_without_force_download_does_not_duplicate_or_crash(
     mocker: MockerFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Regression test for a bug where demo crashed on a second run.
+    """Regression test for a bug where quickstart crashed on a second run.
 
-    Previously demo.db was only wiped for --force-download, so a second run duplicated
+    Previously quickstart.db was only wiped for --force-download, so a second run duplicated
     annotations and then crashed with an IntegrityError on the evaluation run insert.
     """
     monkeypatch.chdir(tmp_path)
-    dataset_dir = _build_demo_dataset_dir(tmp_path)
+    dataset_dir = _build_quickstart_dataset_dir(tmp_path)
     mocker.patch.object(
         lightly_studio.utils, "download_example_dataset", return_value=str(dataset_dir)
     )
     mocker.patch.object(lightly_studio, "start_gui")
 
     runner = CliRunner()
-    assert runner.invoke(cli=cli.main, args=["demo"]).exit_code == 0
-    # Each `lightly-studio demo` invocation is normally its own process, starting with no
+    assert runner.invoke(cli=cli.main, args=["quickstart"]).exit_code == 0
+    # Each `lightly-studio quickstart` invocation is normally its own process, starting with no
     # engine set. Close the engine here to reproduce that between the two invokes below.
     db_manager.close()
-    result_second = runner.invoke(cli=cli.main, args=["demo"])
+    result_second = runner.invoke(cli=cli.main, args=["quickstart"])
     assert result_second.exit_code == 0, result_second.output
 
     dataset = lightly_studio.ImageDataset.load()

--- a/lightly_studio/tests/test_cli.py
+++ b/lightly_studio/tests/test_cli.py
@@ -34,8 +34,8 @@ def test_main__version_option() -> None:
 
 
 def test_gui(mocker: MockerFixture) -> None:
-    mock_connect = mocker.patch.object(db_manager, "connect")
-    mock_start_gui = mocker.patch.object(lightly_studio, "start_gui")
+    mock_connect = mocker.patch.object(db_manager, attribute="connect")
+    mock_start_gui = mocker.patch.object(lightly_studio, attribute="start_gui")
     runner = CliRunner()
     result = runner.invoke(cli=cli.main, args=["gui"])
     assert result.exit_code == 0
@@ -44,8 +44,8 @@ def test_gui(mocker: MockerFixture) -> None:
 
 
 def test_gui__with_host_port(mocker: MockerFixture) -> None:
-    mock_connect = mocker.patch.object(db_manager, "connect")
-    mock_start_gui = mocker.patch.object(lightly_studio, "start_gui")
+    mock_connect = mocker.patch.object(db_manager, attribute="connect")
+    mock_start_gui = mocker.patch.object(lightly_studio, attribute="start_gui")
     runner = CliRunner()
     result = runner.invoke(cli=cli.main, args=["gui", "--host", "0.0.0.0", "--port", "9999"])
     assert result.exit_code == 0
@@ -54,8 +54,8 @@ def test_gui__with_host_port(mocker: MockerFixture) -> None:
 
 
 def test_gui__with_db_file(mocker: MockerFixture) -> None:
-    mock_connect = mocker.patch.object(db_manager, "connect")
-    mock_start_gui = mocker.patch.object(lightly_studio, "start_gui")
+    mock_connect = mocker.patch.object(db_manager, attribute="connect")
+    mock_start_gui = mocker.patch.object(lightly_studio, attribute="start_gui")
     runner = CliRunner()
     result = runner.invoke(cli=cli.main, args=["gui", "--db-file", "my_duck.db"])
     assert result.exit_code == 0
@@ -64,8 +64,8 @@ def test_gui__with_db_file(mocker: MockerFixture) -> None:
 
 
 def test_gui__with_db_url(mocker: MockerFixture) -> None:
-    mock_connect = mocker.patch.object(db_manager, "connect")
-    mock_start_gui = mocker.patch.object(lightly_studio, "start_gui")
+    mock_connect = mocker.patch.object(db_manager, attribute="connect")
+    mock_start_gui = mocker.patch.object(lightly_studio, attribute="start_gui")
     runner = CliRunner()
     result = runner.invoke(cli=cli.main, args=["gui", "--db-url", "postgresql://localhost/mydb"])
     assert result.exit_code == 0
@@ -76,8 +76,8 @@ def test_gui__with_db_url(mocker: MockerFixture) -> None:
 
 
 def test_gui__with_db_file_and_db_url(mocker: MockerFixture) -> None:
-    mocker.patch.object(db_manager, "connect")
-    mocker.patch.object(lightly_studio, "start_gui")
+    mocker.patch.object(db_manager, attribute="connect")
+    mocker.patch.object(lightly_studio, attribute="start_gui")
     runner = CliRunner()
     result = runner.invoke(
         cli=cli.main,
@@ -114,19 +114,6 @@ def test_gui__with_empty_db_file__complains_about_missing_dataset(
     assert "No datasets found" in str(result.exception)
 
 
-def _mock_quickstart_dependencies(mocker: MockerFixture) -> tuple[Any, Any, Any, Any]:
-    mock_download = mocker.patch.object(
-        lightly_studio.utils, "download_example_dataset", return_value="/dataset_examples"
-    )
-    mock_connect = mocker.patch.object(db_manager, "connect")
-    mock_dataset = mocker.MagicMock()
-    mock_create = mocker.patch.object(
-        lightly_studio.ImageDataset, "create", return_value=mock_dataset
-    )
-    mock_start_gui = mocker.patch.object(lightly_studio, "start_gui")
-    return mock_download, mock_connect, mock_create, mock_start_gui
-
-
 def test_quickstart(mocker: MockerFixture) -> None:
     mock_download, mock_connect, mock_create, mock_start_gui = _mock_quickstart_dependencies(mocker)
     runner = CliRunner()
@@ -155,41 +142,6 @@ def test_quickstart__with_port(mocker: MockerFixture) -> None:
     mock_start_gui.assert_called_once_with(port=9999)
 
 
-def _coco_dict_with(file_names: list[str]) -> dict[str, Any]:
-    return {
-        "images": [
-            {"id": i + 1, "file_name": fn, "width": 10, "height": 10}
-            for i, fn in enumerate(file_names)
-        ],
-        "annotations": [
-            {
-                "id": i + 1,
-                "image_id": i + 1,
-                "category_id": 1,
-                "bbox": [1, 1, 2, 2],
-                "area": 4,
-                "iscrowd": 0,
-            }
-            for i in range(len(file_names))
-        ],
-        "categories": [{"id": 1, "name": "cat"}],
-    }
-
-
-def _build_quickstart_dataset_dir(root: Path) -> Path:
-    """Build a fixture dataset with the same layout as the real demo dataset."""
-    dataset_dir = root / "dataset_examples"
-    images_dir = dataset_dir / "coco_subset_128_images" / "images"
-    images_dir.mkdir(parents=True)
-    file_names = [f"image{i}.jpg" for i in range(3)]
-    for file_name in file_names:
-        Image.new("RGB", (10, 10)).save(images_dir / file_name)
-    coco_dir = dataset_dir / "coco_subset_128_images"
-    (coco_dir / "instances_train2017.json").write_text(json.dumps(_coco_dict_with(file_names)))
-    (coco_dir / "predictions_train2017.json").write_text(json.dumps(_coco_dict_with(file_names)))
-    return dataset_dir
-
-
 def test_quickstart__runs_real_evaluation_pipeline(
     mocker: MockerFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -200,9 +152,9 @@ def test_quickstart__runs_real_evaluation_pipeline(
     monkeypatch.chdir(tmp_path)
     dataset_dir = _build_quickstart_dataset_dir(tmp_path)
     mocker.patch.object(
-        lightly_studio.utils, "download_example_dataset", return_value=str(dataset_dir)
+        lightly_studio.utils, attribute="download_example_dataset", return_value=str(dataset_dir)
     )
-    mocker.patch.object(lightly_studio, "start_gui")
+    mocker.patch.object(lightly_studio, attribute="start_gui")
 
     runner = CliRunner()
     result = runner.invoke(cli=cli.main, args=["quickstart"])
@@ -231,9 +183,9 @@ def test_quickstart__second_run_without_force_download_does_not_duplicate_or_cra
     monkeypatch.chdir(tmp_path)
     dataset_dir = _build_quickstart_dataset_dir(tmp_path)
     mocker.patch.object(
-        lightly_studio.utils, "download_example_dataset", return_value=str(dataset_dir)
+        lightly_studio.utils, attribute="download_example_dataset", return_value=str(dataset_dir)
     )
-    mocker.patch.object(lightly_studio, "start_gui")
+    mocker.patch.object(lightly_studio, attribute="start_gui")
 
     runner = CliRunner()
     assert runner.invoke(cli=cli.main, args=["quickstart"]).exit_code == 0
@@ -258,3 +210,51 @@ def test_quickstart__second_run_without_force_download_does_not_duplicate_or_cra
     )
     # 3 fixture images x 1 annotation each in _coco_dict_with — must stay at 3, not double to 6.
     assert len(ground_truth.annotations) == 3
+
+
+def _mock_quickstart_dependencies(mocker: MockerFixture) -> tuple[Any, Any, Any, Any]:
+    mock_download = mocker.patch.object(
+        lightly_studio.utils, attribute="download_example_dataset", return_value="/dataset_examples"
+    )
+    mock_connect = mocker.patch.object(db_manager, attribute="connect")
+    mock_dataset = mocker.MagicMock()
+    mock_create = mocker.patch.object(
+        lightly_studio.ImageDataset, attribute="create", return_value=mock_dataset
+    )
+    mock_start_gui = mocker.patch.object(lightly_studio, attribute="start_gui")
+    return mock_download, mock_connect, mock_create, mock_start_gui
+
+
+def _coco_dict_with(file_names: list[str]) -> dict[str, Any]:
+    return {
+        "images": [
+            {"id": i + 1, "file_name": fn, "width": 10, "height": 10}
+            for i, fn in enumerate(file_names)
+        ],
+        "annotations": [
+            {
+                "id": i + 1,
+                "image_id": i + 1,
+                "category_id": 1,
+                "bbox": [1, 1, 2, 2],
+                "area": 4,
+                "iscrowd": 0,
+            }
+            for i in range(len(file_names))
+        ],
+        "categories": [{"id": 1, "name": "cat"}],
+    }
+
+
+def _build_quickstart_dataset_dir(root: Path) -> Path:
+    """Build a fixture dataset with the same layout as the real demo dataset."""
+    dataset_dir = root / "dataset_examples"
+    images_dir = dataset_dir / "coco_subset_128_images" / "images"
+    images_dir.mkdir(parents=True)
+    file_names = ["image0.jpg", "image1.jpg", "image2.jpg"]
+    for file_name in file_names:
+        Image.new("RGB", (10, 10)).save(images_dir / file_name)
+    coco_dir = dataset_dir / "coco_subset_128_images"
+    (coco_dir / "instances_train2017.json").write_text(json.dumps(_coco_dict_with(file_names)))
+    (coco_dir / "predictions_train2017.json").write_text(json.dumps(_coco_dict_with(file_names)))
+    return dataset_dir

--- a/lightly_studio/tests/test_cli.py
+++ b/lightly_studio/tests/test_cli.py
@@ -121,7 +121,7 @@ def _mock_demo_dependencies(mocker: MockerFixture) -> tuple[Any, Any, Any, Any]:
     mock_connect = mocker.patch.object(db_manager, "connect")
     mock_dataset = mocker.MagicMock()
     mock_create = mocker.patch.object(
-        lightly_studio.ImageDataset, "create", return_value=mock_dataset
+        lightly_studio.ImageDataset, "load_or_create", return_value=mock_dataset
     )
     mock_start_gui = mocker.patch.object(lightly_studio, "start_gui")
     return mock_download, mock_connect, mock_create, mock_start_gui

--- a/lightly_studio/tests/test_cli.py
+++ b/lightly_studio/tests/test_cli.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 
 import pytest
 from click.testing import CliRunner
+from PIL import Image
 from pytest_mock import MockerFixture
 
 import lightly_studio
 from lightly_studio import cli
 from lightly_studio.database import db_manager
+from lightly_studio.models.evaluation_run import EvaluationTaskType
+from lightly_studio.resolvers import evaluation_run_resolver
 
 
 @pytest.fixture(autouse=True)
@@ -107,3 +112,108 @@ def test_gui__with_empty_db_file__complains_about_missing_dataset(
     assert result.exit_code != 0
     assert isinstance(result.exception, ValueError)
     assert "No datasets found" in str(result.exception)
+
+
+def _mock_demo_dependencies(mocker: MockerFixture) -> tuple[Any, Any, Any, Any]:
+    mock_download = mocker.patch.object(
+        lightly_studio.utils, "download_example_dataset", return_value="/dataset_examples"
+    )
+    mock_connect = mocker.patch.object(db_manager, "connect")
+    mock_dataset = mocker.MagicMock()
+    mock_create = mocker.patch.object(
+        lightly_studio.ImageDataset, "create", return_value=mock_dataset
+    )
+    mock_start_gui = mocker.patch.object(lightly_studio, "start_gui")
+    return mock_download, mock_connect, mock_create, mock_start_gui
+
+
+def test_demo(mocker: MockerFixture) -> None:
+    mock_download, mock_connect, _, mock_start_gui = _mock_demo_dependencies(mocker)
+    runner = CliRunner()
+    result = runner.invoke(cli=cli.main, args=["demo"])
+    assert result.exit_code == 0
+    mock_download.assert_called_once_with(download_dir="dataset_examples", force_redownload=False)
+    mock_connect.assert_called_once_with(db_file="demo.db", cleanup_existing=False)
+    mock_start_gui.assert_called_once_with(port=None)
+
+
+def test_demo__with_force_download(mocker: MockerFixture) -> None:
+    mock_download, mock_connect, _, _ = _mock_demo_dependencies(mocker)
+    runner = CliRunner()
+    result = runner.invoke(cli=cli.main, args=["demo", "--force-download"])
+    assert result.exit_code == 0
+    mock_download.assert_called_once_with(download_dir="dataset_examples", force_redownload=True)
+    mock_connect.assert_called_once_with(db_file="demo.db", cleanup_existing=True)
+
+
+def test_demo__with_port(mocker: MockerFixture) -> None:
+    _, _, _, mock_start_gui = _mock_demo_dependencies(mocker)
+    runner = CliRunner()
+    result = runner.invoke(cli=cli.main, args=["demo", "--port", "9999"])
+    assert result.exit_code == 0
+    mock_start_gui.assert_called_once_with(port=9999)
+
+
+def _coco_dict_with(file_names: list[str]) -> dict[str, Any]:
+    return {
+        "images": [
+            {"id": i + 1, "file_name": fn, "width": 10, "height": 10}
+            for i, fn in enumerate(file_names)
+        ],
+        "annotations": [
+            {
+                "id": i + 1,
+                "image_id": i + 1,
+                "category_id": 1,
+                "bbox": [1, 1, 2, 2],
+                "area": 4,
+                "iscrowd": 0,
+            }
+            for i in range(len(file_names))
+        ],
+        "categories": [{"id": 1, "name": "cat"}],
+    }
+
+
+def _build_demo_dataset_dir(root: Path) -> Path:
+    """Build a fixture dataset with the same layout as the real demo dataset."""
+    dataset_dir = root / "dataset_examples"
+    images_dir = dataset_dir / "coco_subset_128_images" / "images"
+    images_dir.mkdir(parents=True)
+    file_names = [f"image{i}.jpg" for i in range(3)]
+    for file_name in file_names:
+        Image.new("RGB", (10, 10)).save(images_dir / file_name)
+    coco_dir = dataset_dir / "coco_subset_128_images"
+    (coco_dir / "instances_train2017.json").write_text(json.dumps(_coco_dict_with(file_names)))
+    (coco_dir / "predictions_train2017.json").write_text(json.dumps(_coco_dict_with(file_names)))
+    return dataset_dir
+
+
+def test_demo__runs_real_evaluation_pipeline(
+    mocker: MockerFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Loads real images, real COCO annotations, and persists a real evaluation run.
+
+    Runs against its own isolated 'demo.db', without any network access.
+    """
+    monkeypatch.chdir(tmp_path)
+    dataset_dir = _build_demo_dataset_dir(tmp_path)
+    mocker.patch.object(
+        lightly_studio.utils, "download_example_dataset", return_value=str(dataset_dir)
+    )
+    mocker.patch.object(lightly_studio, "start_gui")
+
+    runner = CliRunner()
+    result = runner.invoke(cli=cli.main, args=["demo"])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "demo.db").exists()
+
+    dataset = lightly_studio.ImageDataset.load()
+    assert len(dataset.query().to_list()) == 3
+
+    evaluation_runs = evaluation_run_resolver.get_all_by_dataset_id(
+        session=dataset.session, dataset_id=dataset.dataset_id
+    )
+    assert len(evaluation_runs) == 1
+    assert evaluation_runs[0].name == "od_evaluation"
+    assert evaluation_runs[0].task_type == EvaluationTaskType.OBJECT_DETECTION


### PR DESCRIPTION
## What has changed and why?

Adds a `lightly-studio demo` CLI command. It downloads the COCO example dataset (if not cached), builds an object detection evaluation, and starts the GUI in one step. No Python script is necessary.

## How has it been tested?

Ran `lightly-studio demo` locally. It downloaded the dataset, loaded images and annotations, ran the evaluation, and started the GUI on the default port. Ran it again with `--force-download` and with `--port` to confirm both options work. The command uses its own `demo.db` file, so it does not touch a user's configured database.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the `lightly-studio demo` command to download a COCO example dataset and launch the GUI in one step.
  * Added options to select a custom port or force a fresh dataset download.
  * The demo includes example annotations and object-detection evaluation results.

* **Documentation**
  * Updated quickstart and image dataset setup guides with demo instructions.
  * Clarified how to open existing datasets without reindexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->