### PR TITLE
docs: clarify frontend dev env vars and backend startup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,9 @@ For this to work, the backend must already be serving on <http://localhost:8001>
 `.env.local` needs to point at it:
 
 ```shell
+# where the backend serves sample images/videos from
 PUBLIC_SAMPLES_URL=http://localhost:8001/images
+# base URL the frontend uses to call the backend API
 PUBLIC_LIGHTLY_STUDIO_API_URL=http://localhost:8001/
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,8 @@ The documentation source is in [docs/docs](./lightly_studio/docs/docs). The docu
 written in Markdown and built with MkDocs using the Material theme. For more information regarding
 formatting, see:
 
-- https://squidfunk.github.io/mkdocs-material/reference/ — Material theme syntax (admonitions, tabs, icons)
-- https://www.mkdocs.org/user-guide/writing-your-docs/ — base MkDocs Markdown and page structure
+- https://squidfunk.github.io/mkdocs-material/reference/
+- https://www.mkdocs.org/user-guide/writing-your-docs/
 
 
 ## Development Environment Setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,8 @@ The documentation source is in [docs/docs](./lightly_studio/docs/docs). The docu
 written in Markdown and built with MkDocs using the Material theme. For more information regarding
 formatting, see:
 
-- https://squidfunk.github.io/mkdocs-material/reference/
-- https://www.mkdocs.org/user-guide/writing-your-docs/
+- https://squidfunk.github.io/mkdocs-material/reference/ — Material theme syntax (admonitions, tabs, icons)
+- https://www.mkdocs.org/user-guide/writing-your-docs/ — base MkDocs Markdown and page structure
 
 
 ## Development Environment Setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,16 @@ cp .env.example .env.local
 npm run dev
 ```
 
+For this to work, the backend must already be serving on <http://localhost:8001> — either via
+`make start` (or `make start-example`), or by running any script directly with
+`uv run src/lightly_studio/examples/<script>.py` (see [Run Examples](#run-examples)). Either way,
+`.env.local` needs to point at it:
+
+```
+PUBLIC_SAMPLES_URL=http://localhost:8001/images
+PUBLIC_LIGHTLY_STUDIO_API_URL=http://localhost:8001/
+```
+
 ### Exploring the Makefile
 
 There are three Makefiles: one in `lightly_studio` for the backend, build, e2e and migration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ For this to work, the backend must already be serving on <http://localhost:8001>
 `uv run src/lightly_studio/examples/<script>.py` (see [Run Examples](#run-examples)). Either way,
 `.env.local` needs to point at it:
 
-```
+```shell
 PUBLIC_SAMPLES_URL=http://localhost:8001/images
 PUBLIC_LIGHTLY_STUDIO_API_URL=http://localhost:8001/
 ```


### PR DESCRIPTION
## What has changed and why?

Documents the env vars (`PUBLIC_SAMPLES_URL`, `PUBLIC_LIGHTLY_STUDIO_API_URL`) needed in `.env.local` for `npm run dev` to talk to the backend, and points out that any example script can serve the backend via `uv run src/lightly_studio/examples/<script>.py` instead of `make start`.

## How has it been tested?

Docs-only change, read through for accuracy against the existing setup steps.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added instructions for enabling frontend hot reloading during local development.
  * Documented supported backend startup commands and required `.env.local` configuration.
  * Clarified that the backend should run on port 8001.
  * Included sample local API URLs to help developers configure and verify their development environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->