### PR TITLE
Fix: speedup embedding plot coloring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Annotation class names no longer overflow in class selection.
 - Autofocus lets users create their first annotation faster.
 - Opening a DuckDB database that another lightly_studio process already has open now raises a clear error instead of a raw DuckDB traceback.
+- Coloring the 2D embedding plot by annotations or metadata now loads faster, especially for large datasets.
 
 ### Security
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/annotations.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_coloring/annotations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from uuid import UUID
 
 from sqlmodel import Session
@@ -40,23 +39,11 @@ def build_annotation_color_maps(
         is a mapping from color ID to a human-readable string.
     """
     names = annotation_label_resolver.names_by_ids(session=session, ids=annotation_label_ids)
-    annotations = annotation_resolver.get_all_by_parent_sample_ids(
-        session=session, parent_sample_ids=sample_ids
+    sample_to_labels = annotation_resolver.get_label_ids_by_sample_ids(
+        session=session,
+        sample_ids=sample_ids,
+        annotation_label_ids=annotation_label_ids,
     )
-
-    # Build a lookup: parent_sample_id → set of annotation_label_ids.
-    sample_to_labels: dict[UUID, set[UUID]] = defaultdict(set)
-    requested = set(annotation_label_ids)
-    for ann in annotations:
-        if ann.annotation_label_id in requested:
-            sample_to_labels[ann.parent_sample_id].add(ann.annotation_label_id)
-
-    # When the colored samples are annotations themselves (annotation collection),
-    # each sample carries its own label rather than labels of child annotations.
-    own_annotations = annotation_resolver.get_by_ids(session=session, annotation_ids=sample_ids)
-    for ann in own_annotations:
-        if ann.annotation_label_id in requested:
-            sample_to_labels[ann.sample_id].add(ann.annotation_label_id)
 
     ordered_label_ids = coloring_helpers.order_values_by_frequency(
         sample_to_values=sample_to_labels,

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
@@ -34,6 +34,9 @@ from lightly_studio.resolvers.annotation_resolver.get_by_id import get_by_id, ge
 from lightly_studio.resolvers.annotation_resolver.get_by_id_with_payload import (
     get_by_id_with_payload,
 )
+from lightly_studio.resolvers.annotation_resolver.get_label_ids_by_sample_ids import (
+    get_label_ids_by_sample_ids,
+)
 from lightly_studio.resolvers.annotation_resolver.get_sample_ids import (
     build_sample_ids_query,
     get_sample_ids,
@@ -71,6 +74,7 @@ __all__ = [
     "get_by_id",
     "get_by_id_with_payload",
     "get_by_ids",
+    "get_label_ids_by_sample_ids",
     "get_sample_ids",
     "get_unembedded_annotation_ids",
     "update_annotation_label",

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_label_ids_by_sample_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_label_ids_by_sample_ids.py
@@ -1,0 +1,58 @@
+"""Get annotation label IDs associated with samples."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import or_
+from sqlmodel import Session, col, select
+
+from lightly_studio.database import db_array
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+
+
+def get_label_ids_by_sample_ids(
+    session: Session,
+    sample_ids: Sequence[UUID],
+    annotation_label_ids: Sequence[UUID],
+) -> dict[UUID, set[UUID]]:
+    """Return selected annotation labels associated with each requested sample.
+
+    A plotted parent sample is associated with labels from its child annotations.
+    A plotted annotation sample is associated with its own label.
+    """
+    if not sample_ids or not annotation_label_ids:
+        return {}
+
+    requested_sample_ids = set(sample_ids)
+    rows = session.exec(
+        select(
+            AnnotationBaseTable.sample_id,
+            AnnotationBaseTable.parent_sample_id,
+            AnnotationBaseTable.annotation_label_id,
+        )
+        .where(
+            db_array.in_array(
+                column=col(AnnotationBaseTable.annotation_label_id),
+                values=annotation_label_ids,
+            )
+        )
+        .where(
+            or_(
+                db_array.in_array(
+                    column=col(AnnotationBaseTable.parent_sample_id), values=sample_ids
+                ),
+                db_array.in_array(column=col(AnnotationBaseTable.sample_id), values=sample_ids),
+            )
+        )
+    ).all()
+
+    sample_to_labels: dict[UUID, set[UUID]] = defaultdict(set)
+    for annotation_id, parent_sample_id, annotation_label_id in rows:
+        if parent_sample_id in requested_sample_ids:
+            sample_to_labels[parent_sample_id].add(annotation_label_id)
+        if annotation_id in requested_sample_ids:
+            sample_to_labels[annotation_id].add(annotation_label_id)
+    return dict(sample_to_labels)

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_values_for_key.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_values_for_key.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from uuid import UUID
 
@@ -31,13 +32,14 @@ def get_metadata_values_for_key(
             - The schema type for `key`, or `None` if the key is not present in
               the collection schema.
     """
-    schema_type_expr = db_json.json_extract(
+    schema_type_expr = db_json.json_extract_string(
         column=SampleMetadataTable.metadata_schema,
         field=key,
     )
+    value_expr = db_json.json_extract_string(column=SampleMetadataTable.data, field=key)
 
     rows = session.exec(
-        select(SampleMetadataTable)
+        select(SampleMetadataTable.sample_id, value_expr, schema_type_expr)
         .select_from(SampleTable)
         .join(
             SampleMetadataTable,
@@ -53,16 +55,30 @@ def get_metadata_values_for_key(
 
     sample_to_value: dict[UUID, Any] = {}
     metadata_type: str | None = None
-    for row in rows:
-        row_metadata_type = row.metadata_schema[key]
+    for sample_id, value, row_metadata_type in rows:
         if metadata_type is None:
             metadata_type = row_metadata_type
         elif metadata_type != row_metadata_type:
             raise ValueError(
                 f"Metadata field '{key}': value does not match schema type {metadata_type!r}."
             )
-        value = row.data.get(key)
         if value is not None:
-            sample_to_value[row.sample_id] = value
+            sample_to_value[sample_id] = _parse_value(value=value, metadata_type=row_metadata_type)
 
     return sample_to_value, metadata_type
+
+
+def _parse_value(value: str, metadata_type: str) -> Any:
+    """Parse a scalar JSON extraction result according to its stored schema."""
+    if metadata_type == "string":
+        return value
+    if metadata_type == "boolean":
+        return value.lower() == "true"
+    if metadata_type == "integer":
+        return int(value)
+    if metadata_type == "float":
+        return float(value)
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value

--- a/lightly_studio/tests/metadata/test_get_metadata_values_for_key.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_values_for_key.py
@@ -75,6 +75,58 @@ def test_get_metadata_values_for_key__missing_key(
     assert metadata_type is None
 
 
+def test_get_metadata_values_for_key__omits_null_value(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    sample = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/sample.png",
+    ).sample
+    sample["nullable"] = None
+
+    result, metadata_type = metadata_resolver.get_metadata_values_for_key(
+        session=db_session,
+        collection_id=collection.collection_id,
+        key="nullable",
+    )
+
+    assert result == {}
+    assert metadata_type == "null"
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("enabled", True),
+        ("count", 42),
+        ("score", 1.5),
+        ("items", [1, "two"]),
+        ("details", {"nested": "value"}),
+        ("key.with.dots", "literal key"),
+    ],
+)
+def test_get_metadata_values_for_key__preserves_value_types_and_literal_keys(
+    db_session: Session,
+    key: str,
+    value: object,
+) -> None:
+    collection = create_collection(session=db_session)
+    sample = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/sample.png",
+    ).sample
+    sample[key] = value
+
+    result, _ = metadata_resolver.get_metadata_values_for_key(
+        session=db_session,
+        collection_id=collection.collection_id,
+        key=key,
+    )
+
+    assert result == {sample.sample_id: value}
+
+
 def test_get_metadata_values_for_key__inconsistent_schema_types(
     db_session: Session,
 ) -> None:

--- a/lightly_studio/tests/resolvers/annotations/test_get_label_ids_by_sample_ids.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_label_ids_by_sample_ids.py
@@ -1,0 +1,94 @@
+"""Tests for retrieving annotation labels associated with samples."""
+
+from uuid import UUID
+
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.resolvers import annotation_resolver
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
+
+
+def test_get_label_ids_by_sample_ids__returns_parent_and_own_labels(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/image.png",
+    )
+    unrelated_image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/unrelated.png",
+    )
+    selected_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="selected",
+    )
+    unselected_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="unselected",
+    )
+    selected_annotation = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=selected_label.annotation_label_id,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=selected_label.annotation_label_id,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=unselected_label.annotation_label_id,
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=unrelated_image.sample_id,
+        annotation_label_id=selected_label.annotation_label_id,
+    )
+
+    result = annotation_resolver.get_label_ids_by_sample_ids(
+        session=db_session,
+        sample_ids=[image.sample_id, selected_annotation.sample_id],
+        annotation_label_ids=[selected_label.annotation_label_id],
+    )
+
+    assert result == {
+        image.sample_id: {selected_label.annotation_label_id},
+        selected_annotation.sample_id: {selected_label.annotation_label_id},
+    }
+
+
+@pytest.mark.parametrize(
+    ("sample_ids", "annotation_label_ids"),
+    [([], [UUID(int=1)]), ([UUID(int=1)], [])],
+)
+def test_get_label_ids_by_sample_ids__empty_input(
+    db_session: Session,
+    sample_ids: list[UUID],
+    annotation_label_ids: list[UUID],
+) -> None:
+    assert (
+        annotation_resolver.get_label_ids_by_sample_ids(
+            session=db_session,
+            sample_ids=sample_ids,
+            annotation_label_ids=annotation_label_ids,
+        )
+        == {}
+    )


### PR DESCRIPTION
## What has changed and why?

  - Loading a colored embedding plot was slow because the backend retrieved much more annotation and metadata information than the plot needed.
  - Annotation coloring now retrieves only the selected class IDs instead of loading complete annotation objects.
  - Metadata coloring now retrieves only the selected metadata field instead of every metadata field for each sample.
  - Plot behavior and the public API remain unchanged.
  - On a representative local dataset, the annotation lookup was about four times faster.
  - Added tests to ensure annotation and metadata colors still behave as before.

Quantitative comparison of before and after this PR. Values are seconds it took to load the embedding plot (end to end) on the images or the annotations view.

|             | Before | After |
|-------------|--------|-------|
| Images      | 2.9s   | 1.35s |
| Annotations | 5.28s  | 3.43s |

## How has it been tested?

- Manual testing + new tests

In the video here you see the speedup of annotations and metadata vs tags:

https://github.com/user-attachments/assets/b220f91e-9f4d-4a97-83c6-5e1c3e3df32a



## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [X] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster loading when coloring 2D embedding plots by annotations or metadata, especially for large datasets.

* **Bug Fixes**
  * Improved handling of annotation labels across related samples.
  * Preserved metadata values and types for nulls, booleans, numbers, lists, dictionaries, and dotted keys.

* **Tests**
  * Added coverage for annotation filtering and metadata value handling, including empty inputs and duplicate annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->