### PR TITLE
introduce dataset splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Split a dataset into named subsets (e.g. train/val/test) by proportion, from the UI or via `DatasetQuery.random_split` in the Python SDK.
+
 ### Changed
 
 ### Deprecated

--- a/lightly_studio/src/lightly_studio/api/app.py
+++ b/lightly_studio/src/lightly_studio/api/app.py
@@ -26,6 +26,7 @@ from lightly_studio.api.routes.api import (
     caption,
     classifier,
     collection,
+    collection_split,
     collection_tag,
     embeddings2d,
     enterprise,
@@ -137,6 +138,7 @@ api_router = APIRouter(prefix="/api", tags=["api"])
 
 api_router.include_router(collection.collection_router)
 api_router.include_router(collection_tag.tag_router)
+api_router.include_router(collection_split.split_router)
 api_router.include_router(export.export_router)
 api_router.include_router(image.image_router)
 api_router.include_router(sample.sample_router)

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_split.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_split.py
@@ -31,7 +31,9 @@ class SplitCreateBody(BaseModel):
     is omitted, the whole collection is split.
     """
 
-    sizes: dict[str, float] = Field(description="Split name to percentage, summing to 100.")
+    sizes: dict[str, float] = Field(
+        description="Split name to relative parts (each positive; need not sum to any total)."
+    )
     filter: GridFilter | None = None
     seed: int | None = Field(default=None, description="Optional seed for a reproducible split.")
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_split.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_split.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field
 from sqlmodel import Session, col, select
+from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.api.routes.api.status import (
@@ -83,12 +84,21 @@ def create_split(
     return SplitResultView(splits=splits, seed=result.seed)
 
 
+def build_selected_sample_ids_query(
+    collection_id: UUID, grid_filter: GridFilter | None
+) -> SelectOfScalar[UUID]:
+    """Build the query selecting the sample ids of the current selection.
+
+    Uses the filter when given, otherwise selects the whole collection.
+    """
+    if grid_filter is not None:
+        return grid_filter.build_sample_ids_query(collection_id=collection_id)
+    return select(SampleTable.sample_id).where(col(SampleTable.collection_id) == collection_id)
+
+
 def _resolve_sample_ids(
     session: Session, collection_id: UUID, grid_filter: GridFilter | None
 ) -> list[UUID]:
     """Resolve the input sample ids, using the filter or the whole collection."""
-    if grid_filter is not None:
-        query = grid_filter.build_sample_ids_query(collection_id=collection_id)
-    else:
-        query = select(SampleTable.sample_id).where(col(SampleTable.collection_id) == collection_id)
+    query = build_selected_sample_ids_query(collection_id=collection_id, grid_filter=grid_filter)
     return [sample_id for sample_id in session.exec(query).all() if sample_id is not None]

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_split.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_split.py
@@ -1,0 +1,94 @@
+"""This module contains the API routes for splitting a collection into tags."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+from pydantic import BaseModel, Field
+from sqlmodel import Session, col, select
+
+from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
+from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_CREATED,
+    HTTP_STATUS_UNPROCESSABLE_ENTITY,
+)
+from lightly_studio.core.dataset_query import random_split
+from lightly_studio.database.db_manager import SessionDep
+from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers.grid_filter import GridFilter
+
+split_router = APIRouter()
+
+
+class SplitCreateBody(BaseModel):
+    """Body for splitting a collection into named split tags.
+
+    ``filter`` reuses the same grid filter payload the images grid sends. When it
+    is omitted, the whole collection is split.
+    """
+
+    sizes: dict[str, float] = Field(description="Split name to percentage, summing to 100.")
+    filter: GridFilter | None = None
+    seed: int | None = Field(default=None, description="Optional seed for a reproducible split.")
+
+
+class SplitCountView(BaseModel):
+    """The number of samples assigned to a single split."""
+
+    name: str
+    count: int
+
+
+class SplitResultView(BaseModel):
+    """Response model summarizing a completed split."""
+
+    splits: list[SplitCountView]
+    seed: int
+
+
+@split_router.post(
+    "/collections/{collection_id}/splits",
+    response_model=SplitResultView,
+    status_code=HTTP_STATUS_CREATED,
+)
+def create_split(
+    session: SessionDep,
+    collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(get_and_validate_collection_id),
+    ],
+    body: SplitCreateBody,
+) -> SplitResultView:
+    """Randomly split the collection (or a filtered subset) into named split tags."""
+    collection_id = collection.collection_id
+    sample_ids = _resolve_sample_ids(
+        session=session, collection_id=collection_id, grid_filter=body.filter
+    )
+    try:
+        result = random_split.random_split(
+            session=session,
+            collection_id=collection_id,
+            sample_ids=sample_ids,
+            sizes=body.sizes,
+            seed=body.seed,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=HTTP_STATUS_UNPROCESSABLE_ENTITY, detail=str(e)) from e
+
+    splits = [SplitCountView(name=name, count=count) for name, count in result.counts.items()]
+    return SplitResultView(splits=splits, seed=result.seed)
+
+
+def _resolve_sample_ids(
+    session: Session, collection_id: UUID, grid_filter: GridFilter | None
+) -> list[UUID]:
+    """Resolve the input sample ids, using the filter or the whole collection."""
+    if grid_filter is not None:
+        query = grid_filter.build_sample_ids_query(collection_id=collection_id)
+    else:
+        query = select(SampleTable.sample_id).where(col(SampleTable.collection_id) == collection_id)
+    return [sample_id for sample_id in session.exec(query).all() if sample_id is not None]

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field
 
+from lightly_studio.api.routes.api import collection_split
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_CONFLICT,
@@ -239,6 +240,57 @@ def add_samples_to_tag_by_filter(
         session=session, tag_id=tag_id, sample_ids_query=sample_ids_query
     )
     return True
+
+
+class TagSelectionOverlapBody(BaseModel):
+    """Body for reporting which tags overlap a filtered selection.
+
+    ``filter`` reuses the same grid filter payload the images grid sends. When it
+    is ``null``, the whole collection is used as the selection.
+    """
+
+    filter: GridFilter | None = None
+
+
+class TagOverlapCountView(BaseModel):
+    """The number of selected samples carrying a single tag."""
+
+    name: str
+    count: int
+
+
+class TagSelectionOverlapView(BaseModel):
+    """Response model listing sample tags overlapping a selection, with counts."""
+
+    tags: list[TagOverlapCountView]
+
+
+@tag_router.post(
+    "/collections/{collection_id}/tags/selection-overlap",
+    response_model=TagSelectionOverlapView,
+)
+def get_tag_selection_overlap(
+    session: SessionDep,
+    collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(get_and_validate_collection_id),
+    ],
+    body: TagSelectionOverlapBody,
+) -> TagSelectionOverlapView:
+    """Report which sample tags overlap a selection, with per-tag counts.
+
+    Only ``kind='sample'`` tags carrying at least one selected sample are
+    returned. Used to warn before a dataset split overwrites existing tags.
+    """
+    sample_ids_query = collection_split.build_selected_sample_ids_query(
+        collection_id=collection.collection_id, grid_filter=body.filter
+    )
+    overlap = tag_resolver.get_selection_tag_overlap(
+        session=session, sample_ids_query=sample_ids_query
+    )
+    tags = [TagOverlapCountView(name=name, count=count) for name, count in overlap]
+    return TagSelectionOverlapView(tags=tags)
 
 
 @tag_router.delete(

--- a/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/dataset_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from typing import Generic, cast
 from uuid import UUID
 
@@ -11,9 +11,11 @@ from sqlmodel import Session, col, select
 from sqlmodel.sql.expression import SelectOfScalar
 from typing_extensions import Self, TypeVar
 
+from lightly_studio.core.dataset_query import random_split
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
 from lightly_studio.core.dataset_query.match_expression import MatchExpression
 from lightly_studio.core.dataset_query.order_by import OrderByExpression, OrderByField
+from lightly_studio.core.dataset_query.random_split import SplitResult
 from lightly_studio.core.image.image_sample import ImageSample
 from lightly_studio.core.sample import Sample
 from lightly_studio.models.collection import CollectionTable, SampleType
@@ -108,6 +110,13 @@ class DatasetQuery(Generic[T]):
     The filtered set can also be used to add a tag to all matching samples.
     ```python
     query.add_tag('my_tag')
+    ```
+
+    ## Splitting the matching samples into named tags
+    The filtered set can be split into named splits (e.g. train/val/test) by
+    proportion. Each split becomes a sample tag.
+    ```python
+    query.random_split({"train": 80, "val": 10, "test": 10}, seed=42)
     ```
 
     ## Selecting a subset of samples using sampling
@@ -386,6 +395,39 @@ class DatasetQuery(Generic[T]):
         # Use resolver to bulk assign tag (handles validation and edge cases)
         tag_resolver.add_sample_ids_to_tag_id(
             session=self.session, tag_id=tag.tag_id, sample_ids=sample_ids
+        )
+
+    def random_split(self, sizes: Mapping[str, float], seed: int | None = None) -> SplitResult:
+        """Randomly split the samples matched by this query into named tags.
+
+        Assigns the matched samples to named splits (e.g. ``train`` / ``val`` /
+        ``test``) at random, in the given proportions. Each split name becomes a
+        sample tag and every matched sample is linked to exactly one split tag.
+        Re-running removes the target split tags from the matched samples first,
+        overwriting any previous assignment.
+
+        ```python
+        result = dataset.query().random_split(
+            {"train": 80, "val": 10, "test": 10}, seed=42
+        )
+        ```
+
+        Args:
+            sizes: Mapping of split name to percentage. Values must all be
+                positive and sum to 100 (within a small tolerance).
+            seed: Seed for the deterministic shuffle. A random seed is chosen
+                when ``None``; the effective seed is reported in the result.
+
+        Returns:
+            A :class:`SplitResult` with the per-split counts and effective seed.
+        """
+        sample_ids = [sample.sample_id for sample in self]
+        return random_split.random_split(
+            session=self.session,
+            collection_id=self.dataset.collection_id,
+            sample_ids=sample_ids,
+            sizes=sizes,
+            seed=seed,
         )
 
     def sampling(self) -> Sampling:

--- a/lightly_studio/src/lightly_studio/core/dataset_query/random_split.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/random_split.py
@@ -1,7 +1,7 @@
 """Random, proportional splitting of samples into named tags.
 
 A split assigns a set of input samples to named groups (e.g. ``train`` / ``val`` /
-``test``) at random, in proportions given as percentages. Splits are stored as
+``test``) at random, in proportions given as relative parts. Splits are stored as
 ordinary sample tags: each split name becomes a tag, and every input sample is
 linked to exactly one of the split tags. Re-running a split first removes the
 target split tags from the input samples, so the assignment is overwritten rather
@@ -18,10 +18,6 @@ from uuid import UUID
 from sqlmodel import Session
 
 from lightly_studio.resolvers import tag_resolver
-
-# Percentages are allowed to sum to 100 up to this absolute tolerance to account
-# for floating point representation of user-provided values.
-_SUM_TOLERANCE = 1e-6
 
 # Upper bound for a randomly chosen seed. Matches the range accepted by
 # ``random.Random`` and keeps the value comfortably within a 32-bit integer.
@@ -56,8 +52,8 @@ def random_split(
         session: Database session used to read and write tags.
         collection_id: Collection the split tags belong to.
         sample_ids: The input samples to partition.
-        sizes: Mapping of split name to percentage. Values must all be positive
-            and sum to 100 (within a small tolerance).
+        sizes: Mapping of split name to relative parts. Values must all be
+            positive; they need not sum to any particular total.
         seed: Seed for the deterministic shuffle. A random seed is chosen when
             ``None``; the effective seed is always reported in the result.
 
@@ -65,8 +61,8 @@ def random_split(
         A :class:`SplitResult` with the per-split counts and the effective seed.
 
     Raises:
-        ValueError: If ``sizes`` is empty, contains a non-positive value, has an
-            empty split name, or does not sum to 100.
+        ValueError: If ``sizes`` is empty, contains a non-positive value, or has
+            an empty split name.
     """
     validate_sizes(sizes)
     effective_seed = seed if seed is not None else random.randrange(_MAX_SEED)
@@ -87,11 +83,11 @@ def validate_sizes(sizes: Mapping[str, float]) -> None:
     """Validate split sizes.
 
     Args:
-        sizes: Mapping of split name to percentage.
+        sizes: Mapping of split name to relative parts.
 
     Raises:
-        ValueError: If ``sizes`` is empty, has an empty split name, contains a
-            non-positive value, or does not sum to 100 within tolerance.
+        ValueError: If ``sizes`` is empty, has an empty split name, or contains a
+            non-positive value.
     """
     if not sizes:
         raise ValueError("sizes must not be empty.")
@@ -101,10 +97,6 @@ def validate_sizes(sizes: Mapping[str, float]) -> None:
             raise ValueError("Split names must be non-empty.")
         if value <= 0:
             raise ValueError(f"Split size for '{name}' must be greater than 0, got {value}.")
-
-    total = sum(sizes.values())
-    if abs(total - 100) > _SUM_TOLERANCE:
-        raise ValueError(f"Split sizes must sum to 100, got {total}.")
 
 
 def partition_counts(total: int, sizes: Mapping[str, float]) -> dict[str, int]:
@@ -116,7 +108,7 @@ def partition_counts(total: int, sizes: Mapping[str, float]) -> dict[str, int]:
 
     Args:
         total: The number of items to distribute.
-        sizes: Mapping of split name to percentage.
+        sizes: Mapping of split name to relative parts.
 
     Returns:
         Mapping of split name to count, ordered the same as ``sizes`` and summing

--- a/lightly_studio/src/lightly_studio/core/dataset_query/random_split.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/random_split.py
@@ -1,0 +1,169 @@
+"""Random, proportional splitting of samples into named tags.
+
+A split assigns a set of input samples to named groups (e.g. ``train`` / ``val`` /
+``test``) at random, in proportions given as percentages. Splits are stored as
+ordinary sample tags: each split name becomes a tag, and every input sample is
+linked to exactly one of the split tags. Re-running a split first removes the
+target split tags from the input samples, so the assignment is overwritten rather
+than accumulated.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.resolvers import tag_resolver
+
+# Percentages are allowed to sum to 100 up to this absolute tolerance to account
+# for floating point representation of user-provided values.
+_SUM_TOLERANCE = 1e-6
+
+# Upper bound for a randomly chosen seed. Matches the range accepted by
+# ``random.Random`` and keeps the value comfortably within a 32-bit integer.
+_MAX_SEED = 2**32 - 1
+
+
+@dataclass(frozen=True)
+class SplitResult:
+    """Summary of a completed split.
+
+    Attributes:
+        counts: Number of samples assigned to each split, keyed by split name and
+            ordered the same as the input ``sizes``.
+        seed: The seed that was used for the random assignment. Equal to the
+            provided seed, or the randomly chosen one when no seed was given.
+    """
+
+    counts: dict[str, int]
+    seed: int
+
+
+def random_split(
+    session: Session,
+    collection_id: UUID,
+    sample_ids: Sequence[UUID],
+    sizes: Mapping[str, float],
+    seed: int | None = None,
+) -> SplitResult:
+    """Randomly assign ``sample_ids`` to named split tags by proportion.
+
+    Args:
+        session: Database session used to read and write tags.
+        collection_id: Collection the split tags belong to.
+        sample_ids: The input samples to partition.
+        sizes: Mapping of split name to percentage. Values must all be positive
+            and sum to 100 (within a small tolerance).
+        seed: Seed for the deterministic shuffle. A random seed is chosen when
+            ``None``; the effective seed is always reported in the result.
+
+    Returns:
+        A :class:`SplitResult` with the per-split counts and the effective seed.
+
+    Raises:
+        ValueError: If ``sizes`` is empty, contains a non-positive value, has an
+            empty split name, or does not sum to 100.
+    """
+    validate_sizes(sizes)
+    effective_seed = seed if seed is not None else random.randrange(_MAX_SEED)
+
+    # Empty input set: report the split names with zero counts without touching
+    # any tags.
+    if not sample_ids:
+        return SplitResult(counts=dict.fromkeys(sizes, 0), seed=effective_seed)
+
+    assignment = _assign_sample_ids(sample_ids=sample_ids, sizes=sizes, seed=effective_seed)
+    _write_splits(session=session, collection_id=collection_id, assignment=assignment)
+
+    counts = {name: len(ids) for name, ids in assignment.items()}
+    return SplitResult(counts=counts, seed=effective_seed)
+
+
+def validate_sizes(sizes: Mapping[str, float]) -> None:
+    """Validate split sizes.
+
+    Args:
+        sizes: Mapping of split name to percentage.
+
+    Raises:
+        ValueError: If ``sizes`` is empty, has an empty split name, contains a
+            non-positive value, or does not sum to 100 within tolerance.
+    """
+    if not sizes:
+        raise ValueError("sizes must not be empty.")
+
+    for name, value in sizes.items():
+        if not name.strip():
+            raise ValueError("Split names must be non-empty.")
+        if value <= 0:
+            raise ValueError(f"Split size for '{name}' must be greater than 0, got {value}.")
+
+    total = sum(sizes.values())
+    if abs(total - 100) > _SUM_TOLERANCE:
+        raise ValueError(f"Split sizes must sum to 100, got {total}.")
+
+
+def partition_counts(total: int, sizes: Mapping[str, float]) -> dict[str, int]:
+    """Split ``total`` into per-split counts using the largest-remainder method.
+
+    Each split gets the floor of its exact proportional share, then the leftover
+    units are handed out one at a time to the splits with the largest fractional
+    remainder. This guarantees the counts sum exactly to ``total``.
+
+    Args:
+        total: The number of items to distribute.
+        sizes: Mapping of split name to percentage.
+
+    Returns:
+        Mapping of split name to count, ordered the same as ``sizes`` and summing
+        to ``total``.
+    """
+    size_sum = sum(sizes.values())
+    exact_shares = {name: total * value / size_sum for name, value in sizes.items()}
+    counts = {name: int(share) for name, share in exact_shares.items()}
+
+    leftover = total - sum(counts.values())
+    by_remainder = sorted(sizes, key=lambda name: exact_shares[name] - counts[name], reverse=True)
+    for name in by_remainder[:leftover]:
+        counts[name] += 1
+    return counts
+
+
+def _assign_sample_ids(
+    sample_ids: Sequence[UUID], sizes: Mapping[str, float], seed: int
+) -> dict[str, list[UUID]]:
+    """Shuffle the input ids deterministically and slice them per split."""
+    shuffled = list(sample_ids)
+    random.Random(seed).shuffle(shuffled)
+
+    counts = partition_counts(total=len(shuffled), sizes=sizes)
+    assignment: dict[str, list[UUID]] = {}
+    start = 0
+    for name, count in counts.items():
+        assignment[name] = shuffled[start : start + count]
+        start += count
+    return assignment
+
+
+def _write_splits(
+    session: Session, collection_id: UUID, assignment: Mapping[str, list[UUID]]
+) -> None:
+    """Overwrite the split tags with the given assignment.
+
+    For each split tag, the tag is first removed from the entire input set and
+    then linked to only its assigned samples, so re-running replaces the previous
+    assignment instead of accumulating.
+    """
+    input_sample_ids = [sample_id for ids in assignment.values() for sample_id in ids]
+    for name, ids in assignment.items():
+        tag = tag_resolver.get_or_create_sample_tag_by_name(
+            session=session, collection_id=collection_id, tag_name=name
+        )
+        tag_resolver.remove_sample_ids_from_tag_id(
+            session=session, tag_id=tag.tag_id, sample_ids=input_sample_ids
+        )
+        tag_resolver.add_sample_ids_to_tag_id(session=session, tag_id=tag.tag_id, sample_ids=ids)

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 import sqlmodel
-from sqlalchemy import literal
+from sqlalchemy import func, literal
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, col, select
 from sqlmodel.sql.expression import SelectOfScalar
@@ -273,6 +273,33 @@ def get_tags_by_sample(
         assert tag_id is not None
         result.setdefault(sample_id, set()).add(tag_id)
     return result
+
+
+def get_selection_tag_overlap(
+    session: Session,
+    sample_ids_query: SelectOfScalar[UUID],
+) -> list[tuple[str, int]]:
+    """Return the sample-kind tags overlapping a selection, with counts.
+
+    ``sample_ids_query`` must select a single ``sample_id`` column describing the
+    selection. Only ``kind='sample'`` tags that link at least one selected sample
+    are returned; ``count`` is the number of selected samples carrying the tag.
+    Results are ordered by tag name for determinism, computed in a single grouped
+    query with the selection applied as a subquery.
+
+    Returns:
+        A list of ``(tag_name, count)`` tuples ordered by ``tag_name`` ascending.
+    """
+    stmt = (
+        select(TagTable.name, func.count(col(SampleTagLinkTable.sample_id)))
+        .select_from(SampleTagLinkTable)
+        .join(TagTable, col(TagTable.tag_id) == col(SampleTagLinkTable.tag_id))
+        .where(col(SampleTagLinkTable.sample_id).in_(sample_ids_query))
+        .where(col(TagTable.kind) == "sample")
+        .group_by(col(TagTable.name))
+        .order_by(col(TagTable.name).asc())
+    )
+    return [(name, int(count)) for name, count in session.exec(stmt).all()]
 
 
 def get_or_create_sample_tag_by_name(

--- a/lightly_studio/tests/api/routes/api/test_collection_split.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_split.py
@@ -99,7 +99,7 @@ def test_create_split__invalid_sizes_returns_422(
 
     response = test_client.post(
         f"/api/collections/{collection_id}/splits",
-        json={"sizes": {"train": 80, "val": 10}},
+        json={"sizes": {"train": 8, "val": 0}},
     )
 
     assert response.status_code == HTTP_STATUS_UNPROCESSABLE_ENTITY

--- a/lightly_studio/tests/api/routes/api/test_collection_split.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_split.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, col, select
+
+from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_CREATED,
+    HTTP_STATUS_UNPROCESSABLE_ENTITY,
+)
+from lightly_studio.models.sample import SampleTagLinkTable
+from lightly_studio.resolvers import tag_resolver
+from tests.helpers_resolvers import ImageStub, create_collection, create_image, create_images
+
+
+def test_create_split__no_filter_splits_whole_collection(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    create_images(
+        db_session=db_session,
+        collection_id=collection_id,
+        images=[ImageStub(path=f"s{i}.png") for i in range(10)],
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/splits",
+        json={"sizes": {"train": 80, "val": 10, "test": 10}, "seed": 42},
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    body = response.json()
+    assert body["seed"] == 42
+    counts = {split["name"]: split["count"] for split in body["splits"]}
+    assert counts == {"train": 8, "val": 1, "test": 1}
+
+
+def test_create_split__with_filter_splits_only_matching(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="wide.png", width=1920
+    )
+    create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="narrow.png", width=10
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/splits",
+        json={
+            "sizes": {"train": 50, "val": 50},
+            "filter": {"filter_type": "image", "width": {"min": 100}},
+            "seed": 1,
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    counts = {split["name"]: split["count"] for split in response.json()["splits"]}
+    assert sum(counts.values()) == 1
+
+
+def test_create_split__split_tags_are_created_and_linked(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection_id,
+        images=[ImageStub(path=f"s{i}.png") for i in range(4)],
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/splits",
+        json={"sizes": {"train": 50, "val": 50}, "seed": 3},
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    train_tag = tag_resolver.get_by_name(
+        session=db_session, tag_name="train", collection_id=collection_id
+    )
+    val_tag = tag_resolver.get_by_name(
+        session=db_session, tag_name="val", collection_id=collection_id
+    )
+    assert train_tag is not None
+    assert val_tag is not None
+    all_split_ids = _tagged_sample_ids(
+        session=db_session, tag_id=train_tag.tag_id
+    ) | _tagged_sample_ids(session=db_session, tag_id=val_tag.tag_id)
+    assert all_split_ids == {image.sample_id for image in images}
+
+
+def test_create_split__invalid_sizes_returns_422(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    create_image(session=db_session, collection_id=collection_id, file_path_abs="s.png")
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/splits",
+        json={"sizes": {"train": 80, "val": 10}},
+    )
+
+    assert response.status_code == HTTP_STATUS_UNPROCESSABLE_ENTITY
+
+
+def _tagged_sample_ids(session: Session, tag_id: UUID) -> set[UUID]:
+    linked = session.exec(
+        select(SampleTagLinkTable.sample_id).where(col(SampleTagLinkTable.tag_id) == tag_id)
+    ).all()
+    return {sample_id for sample_id in linked if sample_id is not None}

--- a/lightly_studio/tests/api/routes/api/test_collection_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_tag.py
@@ -9,10 +9,11 @@ from sqlmodel import Session, col, select
 from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_CREATED,
     HTTP_STATUS_NOT_FOUND,
+    HTTP_STATUS_OK,
 )
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.sample import SampleTagLinkTable
-from lightly_studio.resolvers import collection_resolver
+from lightly_studio.resolvers import collection_resolver, tag_resolver
 from tests.helpers_resolvers import (
     ImageStub,
     create_annotation,
@@ -139,6 +140,144 @@ def test_add_samples_by_filter__wrong_collection_returns_404(
     )
 
     assert response.status_code == HTTP_STATUS_NOT_FOUND
+
+
+def test_selection_overlap__no_filter_uses_whole_collection(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection_id,
+        images=[ImageStub(path=f"s{i}.png") for i in range(3)],
+    )
+    tag = create_tag(session=db_session, collection_id=collection_id, tag_name="train")
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=tag.tag_id,
+        sample_ids=[image.sample_id for image in images[:2]],
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/tags/selection-overlap",
+        json={"filter": None},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {"tags": [{"name": "train", "count": 2}]}
+
+
+def test_selection_overlap__with_filter_counts_only_matching(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    wide = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="wide.png", width=1920
+    )
+    narrow = create_image(
+        session=db_session, collection_id=collection_id, file_path_abs="narrow.png", width=10
+    )
+    tag = create_tag(session=db_session, collection_id=collection_id, tag_name="train")
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=tag.tag_id,
+        sample_ids=[wide.sample_id, narrow.sample_id],
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/tags/selection-overlap",
+        json={"filter": {"filter_type": "image", "width": {"min": 100}}},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    # Only the wide image matches the filter, so the tag overlaps a single sample.
+    assert response.json() == {"tags": [{"name": "train", "count": 1}]}
+
+
+def test_selection_overlap__excludes_tags_with_zero_overlap(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection_id,
+        images=[ImageStub(path="s0.png"), ImageStub(path="s1.png")],
+    )
+    overlapping = create_tag(session=db_session, collection_id=collection_id, tag_name="train")
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session, tag_id=overlapping.tag_id, sample_ids=[images[0].sample_id]
+    )
+    # A tag with no linked samples must not appear in the response.
+    create_tag(session=db_session, collection_id=collection_id, tag_name="unused")
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/tags/selection-overlap",
+        json={"filter": None},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {"tags": [{"name": "train", "count": 1}]}
+
+
+def test_selection_overlap__returns_only_sample_kind_tags(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    image = create_image(session=db_session, collection_id=collection_id, file_path_abs="s.png")
+    sample_tag = create_tag(
+        session=db_session, collection_id=collection_id, tag_name="sample_tag", kind="sample"
+    )
+    annotation_tag = create_tag(
+        session=db_session,
+        collection_id=collection_id,
+        tag_name="annotation_tag",
+        kind="annotation",
+    )
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session, tag_id=sample_tag.tag_id, sample_ids=[image.sample_id]
+    )
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session, tag_id=annotation_tag.tag_id, sample_ids=[image.sample_id]
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/tags/selection-overlap",
+        json={"filter": None},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {"tags": [{"name": "sample_tag", "count": 1}]}
+
+
+def test_selection_overlap__multiple_tags_ordered_by_name(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = create_collection(session=db_session).collection_id
+    images = create_images(
+        db_session=db_session,
+        collection_id=collection_id,
+        images=[ImageStub(path=f"s{i}.png") for i in range(3)],
+    )
+    tag_val = create_tag(session=db_session, collection_id=collection_id, tag_name="val")
+    tag_train = create_tag(session=db_session, collection_id=collection_id, tag_name="train")
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=tag_train.tag_id,
+        sample_ids=[image.sample_id for image in images],
+    )
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session, tag_id=tag_val.tag_id, sample_ids=[images[0].sample_id]
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/tags/selection-overlap",
+        json={"filter": None},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {
+        "tags": [{"name": "train", "count": 3}, {"name": "val", "count": 1}]
+    }
 
 
 def _tagged_sample_ids(session: Session, tag_id: UUID) -> set[UUID]:

--- a/lightly_studio/tests/core/dataset_query/test_dataset_query__random_split.py
+++ b/lightly_studio/tests/core/dataset_query/test_dataset_query__random_split.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from lightly_studio.core.dataset_query.dataset_query import DatasetQuery
+from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
+from lightly_studio.resolvers import tag_resolver
+from tests.helpers_resolvers import ImageStub, create_collection, create_images
+
+
+class TestDatasetQueryRandomSplit:
+    def test_random_split__no_filter_splits_whole_collection(self, db_session: Session) -> None:
+        dataset = create_collection(session=db_session)
+        create_images(
+            db_session=db_session,
+            collection_id=dataset.collection_id,
+            images=[ImageStub(path=f"s{i}.png") for i in range(10)],
+        )
+
+        query = DatasetQuery(dataset=dataset, session=db_session)
+        result = query.random_split({"train": 80, "val": 10, "test": 10}, seed=42)
+
+        assert result.counts == {"train": 8, "val": 1, "test": 1}
+        assert result.seed == 42
+
+    def test_random_split__with_filter_splits_only_matching(self, db_session: Session) -> None:
+        dataset = create_collection(session=db_session)
+        # Five wide images match the filter, five narrow ones do not.
+        create_images(
+            db_session=db_session,
+            collection_id=dataset.collection_id,
+            images=[ImageStub(path=f"wide{i}.png", width=1920) for i in range(5)],
+        )
+        create_images(
+            db_session=db_session,
+            collection_id=dataset.collection_id,
+            images=[ImageStub(path=f"narrow{i}.png", width=10) for i in range(5)],
+        )
+
+        query = DatasetQuery(dataset=dataset, session=db_session)
+        query.match(ImageSampleField.width > 100)
+        result = query.random_split({"train": 60, "val": 40}, seed=1)
+
+        assert result.counts == {"train": 3, "val": 2}
+        assert sum(result.counts.values()) == 5
+
+    def test_random_split__random_seed_is_returned(self, db_session: Session) -> None:
+        dataset = create_collection(session=db_session)
+        create_images(
+            db_session=db_session,
+            collection_id=dataset.collection_id,
+            images=[ImageStub(path=f"s{i}.png") for i in range(4)],
+        )
+
+        query = DatasetQuery(dataset=dataset, session=db_session)
+        result = query.random_split({"train": 50, "val": 50})
+
+        # A seed was chosen and the split tags were created.
+        assert isinstance(result.seed, int)
+        train_tag = tag_resolver.get_by_name(
+            session=db_session, tag_name="train", collection_id=dataset.collection_id
+        )
+        assert train_tag is not None

--- a/lightly_studio/tests/core/dataset_query/test_random_split.py
+++ b/lightly_studio/tests/core/dataset_query/test_random_split.py
@@ -26,13 +26,10 @@ class TestValidateSizes:
         with pytest.raises(ValueError, match="non-empty"):
             random_split.validate_sizes({"  ": 100})
 
-    def test_validate_sizes__does_not_sum_to_100(self) -> None:
-        with pytest.raises(ValueError, match="sum to 100"):
-            random_split.validate_sizes({"train": 80, "val": 10})
-
-    def test_validate_sizes__float_tolerance(self) -> None:
-        # Three thirds should be accepted despite floating point imprecision.
-        random_split.validate_sizes({"a": 100 / 3, "b": 100 / 3, "c": 100 / 3})
+    def test_validate_sizes__parts_need_not_sum_to_100(self) -> None:
+        # Sizes are relative parts, so any positive totals are accepted.
+        random_split.validate_sizes({"train": 8, "val": 1, "test": 1})
+        random_split.validate_sizes({"train": 3, "val": 1})
 
 
 class TestPartitionCounts:
@@ -55,6 +52,11 @@ class TestPartitionCounts:
     def test_partition_counts__zero_total(self) -> None:
         counts = random_split.partition_counts(total=0, sizes={"train": 80, "val": 20})
         assert counts == {"train": 0, "val": 0}
+
+    def test_partition_counts__unnormalized_parts(self) -> None:
+        # Parts are normalized by their sum, so 8/1/1 matches 80/10/10.
+        counts = random_split.partition_counts(total=1000, sizes={"train": 8, "val": 1, "test": 1})
+        assert counts == {"train": 800, "val": 100, "test": 100}
 
 
 class TestRandomSplit:
@@ -176,12 +178,12 @@ class TestRandomSplit:
 
     def test_random_split__invalid_sizes_raises(self, db_session: Session) -> None:
         collection = create_collection(session=db_session)
-        with pytest.raises(ValueError, match="sum to 100"):
+        with pytest.raises(ValueError, match="greater than 0"):
             random_split.random_split(
                 session=db_session,
                 collection_id=collection.collection_id,
                 sample_ids=[],
-                sizes={"train": 80},
+                sizes={"train": 8, "val": 0},
             )
 
 

--- a/lightly_studio/tests/core/dataset_query/test_random_split.py
+++ b/lightly_studio/tests/core/dataset_query/test_random_split.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.core.dataset_query import random_split
+from lightly_studio.resolvers import tag_resolver
+from tests.helpers_resolvers import ImageStub, create_collection, create_images
+
+
+class TestValidateSizes:
+    def test_validate_sizes__valid(self) -> None:
+        random_split.validate_sizes({"train": 80, "val": 10, "test": 10})
+
+    def test_validate_sizes__empty(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            random_split.validate_sizes({})
+
+    def test_validate_sizes__non_positive(self) -> None:
+        with pytest.raises(ValueError, match="greater than 0"):
+            random_split.validate_sizes({"train": 100, "val": 0})
+
+    def test_validate_sizes__empty_name(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            random_split.validate_sizes({"  ": 100})
+
+    def test_validate_sizes__does_not_sum_to_100(self) -> None:
+        with pytest.raises(ValueError, match="sum to 100"):
+            random_split.validate_sizes({"train": 80, "val": 10})
+
+    def test_validate_sizes__float_tolerance(self) -> None:
+        # Three thirds should be accepted despite floating point imprecision.
+        random_split.validate_sizes({"a": 100 / 3, "b": 100 / 3, "c": 100 / 3})
+
+
+class TestPartitionCounts:
+    def test_partition_counts__exact(self) -> None:
+        counts = random_split.partition_counts(
+            total=1000, sizes={"train": 80, "val": 10, "test": 10}
+        )
+        assert counts == {"train": 800, "val": 100, "test": 100}
+
+    def test_partition_counts__largest_remainder(self) -> None:
+        # Exact shares are 2.8 / 2.8 / 1.4; the two units of leftover go to the
+        # largest remainders (train and val), never to test.
+        counts = random_split.partition_counts(total=7, sizes={"train": 40, "val": 40, "test": 20})
+        assert counts == {"train": 3, "val": 3, "test": 1}
+
+    def test_partition_counts__sums_to_total(self) -> None:
+        counts = random_split.partition_counts(total=17, sizes={"a": 33, "b": 33, "c": 34})
+        assert sum(counts.values()) == 17
+
+    def test_partition_counts__zero_total(self) -> None:
+        counts = random_split.partition_counts(total=0, sizes={"train": 80, "val": 20})
+        assert counts == {"train": 0, "val": 0}
+
+
+class TestRandomSplit:
+    def test_random_split__assigns_each_sample_once(self, db_session: Session) -> None:
+        collection = create_collection(session=db_session)
+        images = create_images(
+            db_session=db_session,
+            collection_id=collection.collection_id,
+            images=[ImageStub(path=f"s{i}.png") for i in range(10)],
+        )
+        sample_ids = [image.sample_id for image in images]
+
+        result = random_split.random_split(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_ids=sample_ids,
+            sizes={"train": 80, "val": 10, "test": 10},
+            seed=42,
+        )
+
+        assert result.counts == {"train": 8, "val": 1, "test": 1}
+        assert result.seed == 42
+        # Every input sample is tagged with exactly one split.
+        tagged = _split_tag_names_by_sample(
+            session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
+        )
+        assert all(len(names) == 1 for names in tagged.values())
+
+    def test_random_split__is_deterministic_for_seed(self, db_session: Session) -> None:
+        collection = create_collection(session=db_session)
+        images = create_images(
+            db_session=db_session,
+            collection_id=collection.collection_id,
+            images=[ImageStub(path=f"s{i}.png") for i in range(10)],
+        )
+        sample_ids = [image.sample_id for image in images]
+
+        first = _run_and_read_train(
+            session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
+        )
+        second = _run_and_read_train(
+            session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
+        )
+        assert first == second
+
+    def test_random_split__overwrites_previous_assignment(self, db_session: Session) -> None:
+        collection = create_collection(session=db_session)
+        images = create_images(
+            db_session=db_session,
+            collection_id=collection.collection_id,
+            images=[ImageStub(path=f"s{i}.png") for i in range(10)],
+        )
+        sample_ids = [image.sample_id for image in images]
+
+        random_split.random_split(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_ids=sample_ids,
+            sizes={"train": 50, "val": 50},
+            seed=1,
+        )
+        random_split.random_split(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_ids=sample_ids,
+            sizes={"train": 50, "val": 50},
+            seed=2,
+        )
+
+        # After a re-run each sample is still tagged with exactly one split.
+        tagged = _split_tag_names_by_sample(
+            session=db_session, collection_id=collection.collection_id, sample_ids=sample_ids
+        )
+        assert all(len(names) == 1 for names in tagged.values())
+
+    def test_random_split__empty_input_is_noop(self, db_session: Session) -> None:
+        collection = create_collection(session=db_session)
+
+        result = random_split.random_split(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_ids=[],
+            sizes={"train": 80, "val": 20},
+            seed=7,
+        )
+
+        assert result.counts == {"train": 0, "val": 0}
+        # No tags are created for an empty input set.
+        assert (
+            tag_resolver.get_by_name(
+                session=db_session, tag_name="train", collection_id=collection.collection_id
+            )
+            is None
+        )
+
+    def test_random_split__zero_count_split_creates_empty_tag(self, db_session: Session) -> None:
+        collection = create_collection(session=db_session)
+        images = create_images(
+            db_session=db_session,
+            collection_id=collection.collection_id,
+            images=[ImageStub(path="s0.png")],
+        )
+        sample_ids = [image.sample_id for image in images]
+
+        result = random_split.random_split(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_ids=sample_ids,
+            sizes={"train": 90, "val": 10},
+            seed=1,
+        )
+
+        assert result.counts == {"train": 1, "val": 0}
+        # The empty split still exists as a tag.
+        val_tag = tag_resolver.get_by_name(
+            session=db_session, tag_name="val", collection_id=collection.collection_id
+        )
+        assert val_tag is not None
+
+    def test_random_split__invalid_sizes_raises(self, db_session: Session) -> None:
+        collection = create_collection(session=db_session)
+        with pytest.raises(ValueError, match="sum to 100"):
+            random_split.random_split(
+                session=db_session,
+                collection_id=collection.collection_id,
+                sample_ids=[],
+                sizes={"train": 80},
+            )
+
+
+def _run_and_read_train(session: Session, collection_id: UUID, sample_ids: list[UUID]) -> set[UUID]:
+    random_split.random_split(
+        session=session,
+        collection_id=collection_id,
+        sample_ids=sample_ids,
+        sizes={"train": 60, "val": 40},
+        seed=123,
+    )
+    tag = tag_resolver.get_by_name(session=session, tag_name="train", collection_id=collection_id)
+    assert tag is not None
+    return set(tag_resolver.get_tags_by_sample(session=session, tag_ids=[tag.tag_id]).keys())
+
+
+def _split_tag_names_by_sample(
+    session: Session, collection_id: UUID, sample_ids: list[UUID]
+) -> dict[UUID, set[str]]:
+    """Return, for each input sample, the set of split tag names linked to it."""
+    tag_ids = []
+    for name in ("train", "val", "test"):
+        tag = tag_resolver.get_by_name(session=session, tag_name=name, collection_id=collection_id)
+        if tag is not None:
+            tag_ids.append(tag.tag_id)
+    names_by_id = tag_resolver.get_names_by_ids(session=session, tag_ids=tag_ids)
+    tags_by_sample = tag_resolver.get_tags_by_sample(session=session, tag_ids=tag_ids)
+    return {
+        sample_id: {names_by_id[tag_id] for tag_id in tags_by_sample.get(sample_id, set())}
+        for sample_id in sample_ids
+    }

--- a/lightly_studio/tests/resolvers/test_tag_resolver.py
+++ b/lightly_studio/tests/resolvers/test_tag_resolver.py
@@ -334,6 +334,61 @@ def test_get_tags_by_sample__no_memberships(db_session: Session) -> None:
     assert result == {}
 
 
+def test_get_selection_tag_overlap(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    cid = collection.collection_id
+
+    img_a = create_image(session=db_session, collection_id=cid, file_path_abs="a.png")
+    img_b = create_image(session=db_session, collection_id=cid, file_path_abs="b.png")
+    img_c = create_image(session=db_session, collection_id=cid, file_path_abs="c.png")
+
+    tag_train = create_tag(session=db_session, collection_id=cid, tag_name="train", kind="sample")
+    tag_val = create_tag(session=db_session, collection_id=cid, tag_name="val", kind="sample")
+    tag_annotation = create_tag(
+        session=db_session, collection_id=cid, tag_name="ann", kind="annotation"
+    )
+    # A tag with no linked samples must be excluded from the overlap.
+    create_tag(session=db_session, collection_id=cid, tag_name="unused", kind="sample")
+
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=tag_train.tag_id,
+        sample_ids=[img_a.sample_id, img_b.sample_id, img_c.sample_id],
+    )
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session, tag_id=tag_val.tag_id, sample_ids=[img_a.sample_id]
+    )
+    # Annotation-kind tags must not appear in the result.
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session, tag_id=tag_annotation.tag_id, sample_ids=[img_a.sample_id]
+    )
+
+    # Select only two of the three samples.
+    query = select(SampleTable.sample_id).where(
+        col(SampleTable.sample_id).in_([img_a.sample_id, img_b.sample_id])
+    )
+    result = tag_resolver.get_selection_tag_overlap(session=db_session, sample_ids_query=query)
+
+    # Ordered by name; counts reflect only the selected samples.
+    assert result == [("train", 2), ("val", 1)]
+
+
+def test_get_selection_tag_overlap__empty_selection(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    cid = collection.collection_id
+    tag = create_tag(session=db_session, collection_id=cid, tag_name="train", kind="sample")
+    image = create_image(session=db_session, collection_id=cid, file_path_abs="a.png")
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session, tag_id=tag.tag_id, sample_ids=[image.sample_id]
+    )
+
+    # A selection matching no samples yields no overlap.
+    query = select(SampleTable.sample_id).where(col(SampleTable.sample_id).in_([uuid4()]))
+    result = tag_resolver.get_selection_tag_overlap(session=db_session, sample_ids_query=query)
+
+    assert result == []
+
+
 def test_get_or_create_sample_tag_by_name(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id

--- a/lightly_studio_view/src/lib/components/Header/Menu.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Menu.svelte
@@ -3,6 +3,7 @@
     import { Select, type SelectItem } from '$lib/components/Select';
     import { useClassifiersMenu } from '$lib/hooks/useClassifiers/useClassifiersMenu';
     import { useSamplingDialog } from '$lib/hooks/useSamplingDialog/useSamplingDialog';
+    import { useSplitDialog } from '$lib/hooks/useSplitDialog/useSplitDialog';
     import { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
     import { useSettingsDialog } from '$lib/hooks/useSettingsDialog/useSettingsDialog';
     import { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
@@ -13,7 +14,8 @@
         Download as DownloadIcon,
         Settings as SettingsIcon,
         BrainCircuit as BrainCircuitIcon,
-        WandSparkles as WandSparklesIcon
+        WandSparkles as WandSparklesIcon,
+        SplitSquareHorizontal as SplitSquareHorizontalIcon
     } from '@lucide/svelte';
 
     import type { CollectionView } from '$lib/api/lightly_studio_local';
@@ -36,6 +38,7 @@
 
     const { openClassifiersMenu } = useClassifiersMenu();
     const { openSamplingDialog } = useSamplingDialog();
+    const { openSplitDialog } = useSplitDialog();
     const { filteredSampleCount } = useGlobalStorage();
     const { openExportDialog } = useExportDialog();
     const { openSettingsDialog } = useSettingsDialog();
@@ -77,6 +80,16 @@
                         collection_id: page.params.collection_id!,
                         filtered_sample_count: get(filteredSampleCount)
                     })
+            });
+        }
+
+        if (hasSampling && isEditor) {
+            items.push({
+                value: 'menu-split',
+                label: 'Split dataset',
+                icon: SplitSquareHorizontalIcon,
+                testId: 'menu-split',
+                onSelect: openSplitDialog
             });
         }
 

--- a/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
+++ b/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { ExportSamples, SamplingCombinationDialog } from '$lib/components';
+    import { ExportSamples, SamplingCombinationDialog, SplitDialog } from '$lib/components';
     import { ClassifiersMenu } from '$lib/components/FewShotClassifier';
     import { SettingsDialog } from '$lib/components/Settings';
     import OperatorsMenu from '$lib/components/Operator/OperatorsMenu.svelte';
@@ -31,6 +31,7 @@
 
 {#if hasSelection}
     <SamplingCombinationDialog />
+    <SplitDialog />
 {/if}
 
 {#if isImageCollection || isVideoCollection}

--- a/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.svelte
+++ b/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.svelte
@@ -34,11 +34,11 @@
         rows,
         errorMessage,
         isValid,
-        previewCounts,
+        preview,
         addRow,
         removeRow,
         updateName,
-        updatePercentage,
+        updateParts,
         reset,
         getSizes
     } = useSplitForm({ filteredSampleCount });
@@ -124,14 +124,15 @@
                         Randomly assign the
                         <strong class="font-semibold text-primary">{$filteredSampleCount}</strong>
                         {isFiltered ? 'filtered' : ''}
-                        {$filteredSampleCount === 1 ? 'sample' : 'samples'} to named split tags.
+                        {$filteredSampleCount === 1 ? 'sample' : 'samples'} to named split tags. Sizes
+                        are relative parts — the share and sample count are shown alongside.
                     </Dialog.Description>
                 </Dialog.Header>
 
                 <div class="grid max-h-[60vh] gap-4 overflow-y-auto p-2 py-4">
                     <div class="grid gap-2">
                         {#each $rows as row (row.id)}
-                            {@const count = $previewCounts[row.name] ?? 0}
+                            {@const info = $preview[row.id] ?? { percentage: 0, count: 0 }}
                             <div class="flex items-center gap-2">
                                 <Input
                                     type="text"
@@ -141,25 +142,23 @@
                                     oninput={(e) => updateName(row.id, e.currentTarget.value)}
                                     data-testid="split-name-input"
                                 />
-                                <div class="flex items-center gap-1">
-                                    <Input
-                                        type="number"
-                                        class="w-20"
-                                        min="0"
-                                        max="100"
-                                        value={row.percentage}
-                                        oninput={(e) =>
-                                            updatePercentage(row.id, e.currentTarget.valueAsNumber)}
-                                        data-testid="split-percentage-input"
-                                    />
-                                    <span class="text-xs text-muted-foreground">%</span>
-                                </div>
+                                <Input
+                                    type="number"
+                                    class="w-16"
+                                    min="1"
+                                    step="1"
+                                    value={row.parts}
+                                    oninput={(e) =>
+                                        updateParts(row.id, e.currentTarget.valueAsNumber)}
+                                    aria-label={`Parts for ${row.name || 'split'}`}
+                                    data-testid="split-parts-input"
+                                />
                                 <span
-                                    class="w-24 text-right text-xs text-muted-foreground"
-                                    data-testid="split-count-preview"
+                                    class="shrink-0 whitespace-nowrap text-right text-xs text-muted-foreground"
+                                    data-testid="split-preview"
                                 >
-                                    {count}
-                                    {count === 1 ? 'sample' : 'samples'}
+                                    {info.percentage}% · {info.count}
+                                    {info.count === 1 ? 'sample' : 'samples'}
                                 </span>
                                 <Button
                                     variant="ghost"

--- a/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.svelte
+++ b/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+    import { page } from '$app/state';
+    import { get, derived } from 'svelte/store';
+    import { Plus, Trash2, ChevronDown } from '@lucide/svelte';
+    import { Button } from '$lib/components/ui/button';
+    import { Input } from '$lib/components/ui/input';
+    import { Label } from '$lib/components/ui/label';
+    import * as Dialog from '$lib/components/ui/dialog';
+    import * as Collapsible from '$lib/components/ui/collapsible';
+    import { useGlobalStorage } from '$lib/hooks';
+    import { useTags } from '$lib/hooks/useTags/useTags';
+    import { useSplitDialog } from '$lib/hooks/useSplitDialog/useSplitDialog';
+    import { useCreateSplit } from '$lib/hooks/useCreateSplit/useCreateSplit';
+    import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
+    import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
+    import type { SplitCreateBody } from '$lib/api/lightly_studio_local/types.gen';
+    import { useSplitForm } from './useSplitForm';
+
+    const collectionId = $derived(page.params.collection_id!);
+    const isVideoCollection = $derived(
+        page.data.collection?.sample_type === 'video' ||
+            page.data.collection?.sample_type === 'video_frame'
+    );
+
+    const { isSplitDialogOpen, closeSplitDialog } = useSplitDialog();
+    const { filteredSampleCount } = useGlobalStorage();
+    const { tags, loadTags, setTagSelected } = useTags({
+        collection_id: page.params.collection_id!,
+        kind: ['sample']
+    });
+    const { imageFilter } = useImageFilters();
+    const { videoFilter } = useVideoFilters();
+
+    const existingTagNames = derived(tags, ($tags) => $tags.map((tag) => tag.name));
+    const {
+        rows,
+        percentageSum,
+        errorMessage,
+        isValid,
+        previewCounts,
+        overwrittenTagNames,
+        addRow,
+        removeRow,
+        updateName,
+        updatePercentage,
+        reset,
+        getSizes
+    } = useSplitForm({ filteredSampleCount, existingTagNames });
+
+    const { isSubmitting, submit } = useCreateSplit({
+        tags,
+        setTagSelected,
+        loadTags,
+        closeSplitDialog
+    });
+
+    let showAdvanced = $state(false);
+    let seed = $state<number | null>(null);
+    let confirmingOverwrite = $state(false);
+
+    function buildFilter(): SplitCreateBody['filter'] {
+        if (isVideoCollection) {
+            const f = get(videoFilter);
+            return f ? { ...f, filter_type: 'video' } : null;
+        }
+        const f = get(imageFilter);
+        return f ? { ...f, filter_type: 'image' } : null;
+    }
+
+    const isFiltered = $derived(buildFilter() !== null);
+
+    async function handleSubmit(event: Event) {
+        event.preventDefault();
+        if (!$isValid || $isSubmitting) return;
+        if ($overwrittenTagNames.length > 0 && !confirmingOverwrite) {
+            confirmingOverwrite = true;
+            return;
+        }
+        const success = await submit({
+            collectionId,
+            sizes: getSizes(),
+            filter: buildFilter(),
+            seed
+        });
+        if (success) {
+            reset();
+            seed = null;
+            confirmingOverwrite = false;
+        }
+    }
+</script>
+
+<Dialog.Root
+    open={$isSplitDialogOpen}
+    onOpenChange={(open) => (open ? undefined : closeSplitDialog())}
+>
+    <Dialog.Portal>
+        <Dialog.Overlay />
+        <Dialog.Content class="border-border bg-background sm:max-w-[520px]">
+            <form onsubmit={handleSubmit}>
+                <Dialog.Header>
+                    <Dialog.Title class="text-foreground">Split dataset</Dialog.Title>
+                    <Dialog.Description class="text-foreground">
+                        Randomly assign the
+                        <strong class="font-semibold text-primary">{$filteredSampleCount}</strong>
+                        {isFiltered ? 'filtered' : ''}
+                        {$filteredSampleCount === 1 ? 'sample' : 'samples'} to named split tags.
+                    </Dialog.Description>
+                </Dialog.Header>
+
+                <div class="grid max-h-[60vh] gap-4 overflow-y-auto p-2 py-4">
+                    <div class="grid gap-2">
+                        {#each $rows as row (row.id)}
+                            <div class="flex items-center gap-2">
+                                <Input
+                                    type="text"
+                                    class="flex-1"
+                                    placeholder="Split name"
+                                    value={row.name}
+                                    oninput={(e) => updateName(row.id, e.currentTarget.value)}
+                                    data-testid="split-name-input"
+                                />
+                                <Input
+                                    type="number"
+                                    class="w-20"
+                                    min="0"
+                                    max="100"
+                                    value={row.percentage}
+                                    oninput={(e) =>
+                                        updatePercentage(row.id, e.currentTarget.valueAsNumber)}
+                                    data-testid="split-percentage-input"
+                                />
+                                <span class="w-10 text-xs text-muted-foreground">%</span>
+                                <span
+                                    class="w-16 text-right text-xs text-muted-foreground"
+                                    data-testid="split-count-preview"
+                                >
+                                    {$previewCounts[row.name] ?? 0}
+                                </span>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    type="button"
+                                    disabled={$rows.length <= 1}
+                                    onclick={() => removeRow(row.id)}
+                                    aria-label="Remove split"
+                                >
+                                    <Trash2 class="size-4" />
+                                </Button>
+                            </div>
+                        {/each}
+                    </div>
+
+                    <div class="flex items-center justify-between">
+                        <Button variant="outline" size="sm" type="button" onclick={addRow}>
+                            <Plus class="mr-1 size-4" /> Add split
+                        </Button>
+                        <span class="text-xs text-muted-foreground">Total: {$percentageSum}%</span>
+                    </div>
+
+                    <Collapsible.Root bind:open={showAdvanced}>
+                        <Collapsible.Trigger
+                            class="flex items-center gap-1 text-sm text-muted-foreground"
+                        >
+                            <ChevronDown class="size-4" /> Advanced
+                        </Collapsible.Trigger>
+                        <Collapsible.Content class="pt-2">
+                            <div class="grid gap-2">
+                                <Label for="split-seed" class="text-foreground"
+                                    >Seed (optional)</Label
+                                >
+                                <Input
+                                    id="split-seed"
+                                    type="number"
+                                    placeholder="Random"
+                                    value={seed ?? ''}
+                                    oninput={(e) =>
+                                        (seed = Number.isFinite(e.currentTarget.valueAsNumber)
+                                            ? e.currentTarget.valueAsNumber
+                                            : null)}
+                                    data-testid="split-seed-input"
+                                />
+                            </div>
+                        </Collapsible.Content>
+                    </Collapsible.Root>
+
+                    {#if $errorMessage}
+                        <p class="text-sm text-destructive-text" data-testid="split-error">
+                            {$errorMessage}
+                        </p>
+                    {/if}
+
+                    {#if confirmingOverwrite && $overwrittenTagNames.length > 0}
+                        <p
+                            class="text-sm text-destructive-text"
+                            data-testid="split-overwrite-warning"
+                        >
+                            This will clear and reassign the existing
+                            {$overwrittenTagNames.join(', ')}
+                            {$overwrittenTagNames.length === 1 ? 'tag' : 'tags'}. Confirm to
+                            continue.
+                        </p>
+                    {/if}
+                </div>
+
+                <Dialog.Footer class="mt-4">
+                    <Button
+                        variant="outline"
+                        type="button"
+                        onclick={closeSplitDialog}
+                        disabled={$isSubmitting}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        type="submit"
+                        disabled={!$isValid || $isSubmitting}
+                        data-testid="split-submit"
+                    >
+                        {#if $isSubmitting}
+                            Splitting...
+                        {:else if confirmingOverwrite && $overwrittenTagNames.length > 0}
+                            Overwrite &amp; split
+                        {:else}
+                            Split
+                        {/if}
+                    </Button>
+                </Dialog.Footer>
+            </form>
+        </Dialog.Content>
+    </Dialog.Portal>
+</Dialog.Root>

--- a/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.svelte
+++ b/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
     import { page } from '$app/state';
-    import { get, derived } from 'svelte/store';
-    import { Plus, Trash2, ChevronDown } from '@lucide/svelte';
+    import { Plus, Trash2 } from '@lucide/svelte';
     import { Button } from '$lib/components/ui/button';
     import { Input } from '$lib/components/ui/input';
-    import { Label } from '$lib/components/ui/label';
     import * as Dialog from '$lib/components/ui/dialog';
-    import * as Collapsible from '$lib/components/ui/collapsible';
     import { useGlobalStorage } from '$lib/hooks';
     import { useTags } from '$lib/hooks/useTags/useTags';
     import { useSplitDialog } from '$lib/hooks/useSplitDialog/useSplitDialog';
     import { useCreateSplit } from '$lib/hooks/useCreateSplit/useCreateSplit';
+    import { useSelectionTagOverlap } from '$lib/hooks/useSelectionTagOverlap/useSelectionTagOverlap.svelte';
     import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
     import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
     import type { SplitCreateBody } from '$lib/api/lightly_studio_local/types.gen';
     import { useSplitForm } from './useSplitForm';
+    import { formatClearedMessage, formatCreatedMessage } from './splitDialogMessages';
 
     const collectionId = $derived(page.params.collection_id!);
     const isVideoCollection = $derived(
@@ -31,21 +30,18 @@
     const { imageFilter } = useImageFilters();
     const { videoFilter } = useVideoFilters();
 
-    const existingTagNames = derived(tags, ($tags) => $tags.map((tag) => tag.name));
     const {
         rows,
-        percentageSum,
         errorMessage,
         isValid,
         previewCounts,
-        overwrittenTagNames,
         addRow,
         removeRow,
         updateName,
         updatePercentage,
         reset,
         getSizes
-    } = useSplitForm({ filteredSampleCount, existingTagNames });
+    } = useSplitForm({ filteredSampleCount });
 
     const { isSubmitting, submit } = useCreateSplit({
         tags,
@@ -54,37 +50,61 @@
         closeSplitDialog
     });
 
-    let showAdvanced = $state(false);
-    let seed = $state<number | null>(null);
     let confirmingOverwrite = $state(false);
 
-    function buildFilter(): SplitCreateBody['filter'] {
+    const currentFilter = $derived.by((): SplitCreateBody['filter'] => {
         if (isVideoCollection) {
-            const f = get(videoFilter);
-            return f ? { ...f, filter_type: 'video' } : null;
+            return $videoFilter ? { ...$videoFilter, filter_type: 'video' } : null;
         }
-        const f = get(imageFilter);
-        return f ? { ...f, filter_type: 'image' } : null;
-    }
+        return $imageFilter ? { ...$imageFilter, filter_type: 'image' } : null;
+    });
 
-    const isFiltered = $derived(buildFilter() !== null);
+    const isFiltered = $derived(currentFilter !== null);
+
+    // Overlap of the current filtered selection with existing sample tags, so we
+    // can warn about which target splits will be cleared before submitting.
+    const overlapQuery = useSelectionTagOverlap(() => ({
+        collectionId,
+        filter: currentFilter,
+        enabled: $isSplitDialogOpen
+    }));
+
+    const overlapCounts = $derived.by(() => {
+        const counts = new Map<string, number>();
+        for (const tag of overlapQuery.data?.tags ?? []) counts.set(tag.name, tag.count);
+        return counts;
+    });
+
+    const targetNames = $derived($rows.map((row) => row.name.trim()).filter((name) => name.length));
+
+    // Target splits already carrying selected samples — these get overwritten.
+    const clearedTags = $derived(
+        targetNames
+            .filter((name) => (overlapCounts.get(name) ?? 0) > 0)
+            .map((name) => ({ name, count: overlapCounts.get(name)! }))
+    );
+
+    // Target splits that do not yet exist as sample tags in the collection.
+    const existingTagNames = $derived(new Set($tags.map((tag) => tag.name)));
+    const createdNames = $derived(targetNames.filter((name) => !existingTagNames.has(name)));
+
+    const clearedMessage = $derived(formatClearedMessage(clearedTags));
+    const createdMessage = $derived(formatCreatedMessage(createdNames));
 
     async function handleSubmit(event: Event) {
         event.preventDefault();
-        if (!$isValid || $isSubmitting) return;
-        if ($overwrittenTagNames.length > 0 && !confirmingOverwrite) {
+        if (!$isValid || $isSubmitting || overlapQuery.isLoading) return;
+        if (clearedTags.length > 0 && !confirmingOverwrite) {
             confirmingOverwrite = true;
             return;
         }
         const success = await submit({
             collectionId,
             sizes: getSizes(),
-            filter: buildFilter(),
-            seed
+            filter: currentFilter
         });
         if (success) {
             reset();
-            seed = null;
             confirmingOverwrite = false;
         }
     }
@@ -111,6 +131,7 @@
                 <div class="grid max-h-[60vh] gap-4 overflow-y-auto p-2 py-4">
                     <div class="grid gap-2">
                         {#each $rows as row (row.id)}
+                            {@const count = $previewCounts[row.name] ?? 0}
                             <div class="flex items-center gap-2">
                                 <Input
                                     type="text"
@@ -120,22 +141,25 @@
                                     oninput={(e) => updateName(row.id, e.currentTarget.value)}
                                     data-testid="split-name-input"
                                 />
-                                <Input
-                                    type="number"
-                                    class="w-20"
-                                    min="0"
-                                    max="100"
-                                    value={row.percentage}
-                                    oninput={(e) =>
-                                        updatePercentage(row.id, e.currentTarget.valueAsNumber)}
-                                    data-testid="split-percentage-input"
-                                />
-                                <span class="w-10 text-xs text-muted-foreground">%</span>
+                                <div class="flex items-center gap-1">
+                                    <Input
+                                        type="number"
+                                        class="w-20"
+                                        min="0"
+                                        max="100"
+                                        value={row.percentage}
+                                        oninput={(e) =>
+                                            updatePercentage(row.id, e.currentTarget.valueAsNumber)}
+                                        data-testid="split-percentage-input"
+                                    />
+                                    <span class="text-xs text-muted-foreground">%</span>
+                                </div>
                                 <span
-                                    class="w-16 text-right text-xs text-muted-foreground"
+                                    class="w-24 text-right text-xs text-muted-foreground"
                                     data-testid="split-count-preview"
                                 >
-                                    {$previewCounts[row.name] ?? 0}
+                                    {count}
+                                    {count === 1 ? 'sample' : 'samples'}
                                 </span>
                                 <Button
                                     variant="ghost"
@@ -155,34 +179,7 @@
                         <Button variant="outline" size="sm" type="button" onclick={addRow}>
                             <Plus class="mr-1 size-4" /> Add split
                         </Button>
-                        <span class="text-xs text-muted-foreground">Total: {$percentageSum}%</span>
                     </div>
-
-                    <Collapsible.Root bind:open={showAdvanced}>
-                        <Collapsible.Trigger
-                            class="flex items-center gap-1 text-sm text-muted-foreground"
-                        >
-                            <ChevronDown class="size-4" /> Advanced
-                        </Collapsible.Trigger>
-                        <Collapsible.Content class="pt-2">
-                            <div class="grid gap-2">
-                                <Label for="split-seed" class="text-foreground"
-                                    >Seed (optional)</Label
-                                >
-                                <Input
-                                    id="split-seed"
-                                    type="number"
-                                    placeholder="Random"
-                                    value={seed ?? ''}
-                                    oninput={(e) =>
-                                        (seed = Number.isFinite(e.currentTarget.valueAsNumber)
-                                            ? e.currentTarget.valueAsNumber
-                                            : null)}
-                                    data-testid="split-seed-input"
-                                />
-                            </div>
-                        </Collapsible.Content>
-                    </Collapsible.Root>
 
                     {#if $errorMessage}
                         <p class="text-sm text-destructive-text" data-testid="split-error">
@@ -190,15 +187,18 @@
                         </p>
                     {/if}
 
-                    {#if confirmingOverwrite && $overwrittenTagNames.length > 0}
+                    {#if !overlapQuery.isLoading && clearedMessage}
                         <p
                             class="text-sm text-destructive-text"
-                            data-testid="split-overwrite-warning"
+                            data-testid="split-cleared-warning"
                         >
-                            This will clear and reassign the existing
-                            {$overwrittenTagNames.join(', ')}
-                            {$overwrittenTagNames.length === 1 ? 'tag' : 'tags'}. Confirm to
-                            continue.
+                            {clearedMessage}
+                        </p>
+                    {/if}
+
+                    {#if createdMessage}
+                        <p class="text-sm text-muted-foreground" data-testid="split-created-info">
+                            {createdMessage}
                         </p>
                     {/if}
                 </div>
@@ -219,7 +219,7 @@
                     >
                         {#if $isSubmitting}
                             Splitting...
-                        {:else if confirmingOverwrite && $overwrittenTagNames.length > 0}
+                        {:else if confirmingOverwrite && clearedTags.length > 0}
                             Overwrite &amp; split
                         {:else}
                             Split

--- a/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.test.ts
@@ -83,11 +83,11 @@ describe('SplitDialog', () => {
         const names = screen.getAllByTestId('split-name-input') as HTMLInputElement[];
         expect(names.map((input) => input.value)).toEqual(['train', 'val', 'test']);
 
-        const previews = screen.getAllByTestId('split-count-preview');
+        const previews = screen.getAllByTestId('split-preview');
         expect(previews.map((el) => el.textContent?.replace(/\s+/g, ' ').trim())).toEqual([
-            '800 samples',
-            '100 samples',
-            '100 samples'
+            '80% · 800 samples',
+            '10% · 100 samples',
+            '10% · 100 samples'
         ]);
     });
 
@@ -106,7 +106,7 @@ describe('SplitDialog', () => {
 
         expect(submitMock).toHaveBeenCalledWith({
             collectionId: 'test-collection-id',
-            sizes: { train: 80, val: 10, test: 10 },
+            sizes: { train: 8, val: 1, test: 1 },
             filter: null
         });
     });

--- a/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.test.ts
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { readable, writable, type Writable } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SplitDialog from './SplitDialog.svelte';
+
+const pageMock = vi.hoisted(() => ({
+    params: { collection_id: 'test-collection-id' },
+    data: { collection: { sample_type: 'image' as string } }
+}));
+
+vi.mock('$app/state', () => ({ page: pageMock }));
+
+type MockTag = { tag_id: string; name: string; kind: 'sample' };
+let tagsStore: Writable<MockTag[]>;
+
+vi.mock('$lib/hooks/useTags/useTags', () => ({
+    useTags: () => ({
+        tags: tagsStore,
+        loadTags: vi.fn().mockResolvedValue(undefined),
+        setTagSelected: vi.fn()
+    })
+}));
+
+vi.mock('$lib/hooks/useSplitDialog/useSplitDialog', () => ({
+    useSplitDialog: () => ({
+        isSplitDialogOpen: readable(true),
+        openSplitDialog: vi.fn(),
+        closeSplitDialog: vi.fn()
+    })
+}));
+
+const submitMock = vi.fn();
+let isSubmittingStore: Writable<boolean>;
+
+vi.mock('$lib/hooks/useCreateSplit/useCreateSplit', () => ({
+    useCreateSplit: () => ({ isSubmitting: isSubmittingStore, submit: submitMock })
+}));
+
+let imageFilterStore: Writable<Record<string, unknown> | null>;
+let videoFilterStore: Writable<Record<string, unknown> | null>;
+let filteredSampleCountStore: Writable<number>;
+
+vi.mock('$lib/hooks/useImageFilters/useImageFilters', () => ({
+    useImageFilters: () => ({ imageFilter: imageFilterStore })
+}));
+
+vi.mock('$lib/hooks/useVideoFilters/useVideoFilters', () => ({
+    useVideoFilters: () => ({ videoFilter: videoFilterStore })
+}));
+
+vi.mock('$lib/hooks/useGlobalStorage', () => ({
+    useGlobalStorage: () => ({ filteredSampleCount: filteredSampleCountStore })
+}));
+
+describe('SplitDialog', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        pageMock.data.collection.sample_type = 'image';
+        tagsStore = writable([]);
+        isSubmittingStore = writable(false);
+        imageFilterStore = writable(null);
+        videoFilterStore = writable(null);
+        filteredSampleCountStore = writable(1000);
+        submitMock.mockResolvedValue(true);
+    });
+
+    it('renders the default train/val/test rows with previewed counts', () => {
+        render(SplitDialog);
+
+        const names = screen.getAllByTestId('split-name-input') as HTMLInputElement[];
+        expect(names.map((input) => input.value)).toEqual(['train', 'val', 'test']);
+
+        const previews = screen.getAllByTestId('split-count-preview');
+        expect(previews.map((el) => el.textContent?.trim())).toEqual(['800', '100', '100']);
+    });
+
+    it('submits the split sizes when valid', async () => {
+        render(SplitDialog);
+
+        await fireEvent.submit(screen.getByTestId('split-submit').closest('form')!);
+
+        expect(submitMock).toHaveBeenCalledWith({
+            collectionId: 'test-collection-id',
+            sizes: { train: 80, val: 10, test: 10 },
+            filter: null,
+            seed: null
+        });
+    });
+
+    it('requires confirmation before overwriting existing split tags', async () => {
+        tagsStore.set([{ tag_id: 't-train', name: 'train', kind: 'sample' }]);
+        render(SplitDialog);
+
+        await fireEvent.submit(screen.getByTestId('split-submit').closest('form')!);
+
+        // First submit only surfaces the overwrite warning, without calling submit.
+        expect(submitMock).not.toHaveBeenCalled();
+        expect(screen.getByTestId('split-overwrite-warning')).toBeInTheDocument();
+
+        await fireEvent.submit(screen.getByTestId('split-submit').closest('form')!);
+        expect(submitMock).toHaveBeenCalledOnce();
+    });
+});

--- a/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/SplitDialog.test.ts
@@ -36,6 +36,18 @@ vi.mock('$lib/hooks/useCreateSplit/useCreateSplit', () => ({
     useCreateSplit: () => ({ isSubmitting: isSubmittingStore, submit: submitMock })
 }));
 
+let overlapData: { tags: { name: string; count: number }[] };
+
+vi.mock('$lib/hooks/useSelectionTagOverlap/useSelectionTagOverlap.svelte', () => ({
+    useSelectionTagOverlap: () => ({
+        get data() {
+            return overlapData;
+        },
+        isLoading: false,
+        isSuccess: true
+    })
+}));
+
 let imageFilterStore: Writable<Record<string, unknown> | null>;
 let videoFilterStore: Writable<Record<string, unknown> | null>;
 let filteredSampleCountStore: Writable<number>;
@@ -61,17 +73,30 @@ describe('SplitDialog', () => {
         imageFilterStore = writable(null);
         videoFilterStore = writable(null);
         filteredSampleCountStore = writable(1000);
+        overlapData = { tags: [] };
         submitMock.mockResolvedValue(true);
     });
 
-    it('renders the default train/val/test rows with previewed counts', () => {
+    it('renders the default train/val/test rows with previewed sample counts', () => {
         render(SplitDialog);
 
         const names = screen.getAllByTestId('split-name-input') as HTMLInputElement[];
         expect(names.map((input) => input.value)).toEqual(['train', 'val', 'test']);
 
         const previews = screen.getAllByTestId('split-count-preview');
-        expect(previews.map((el) => el.textContent?.trim())).toEqual(['800', '100', '100']);
+        expect(previews.map((el) => el.textContent?.replace(/\s+/g, ' ').trim())).toEqual([
+            '800 samples',
+            '100 samples',
+            '100 samples'
+        ]);
+    });
+
+    it('informs which target splits will be created', () => {
+        render(SplitDialog);
+
+        expect(screen.getByTestId('split-created-info').textContent).toContain(
+            'train, val and test will be created.'
+        );
     });
 
     it('submits the split sizes when valid', async () => {
@@ -82,20 +107,22 @@ describe('SplitDialog', () => {
         expect(submitMock).toHaveBeenCalledWith({
             collectionId: 'test-collection-id',
             sizes: { train: 80, val: 10, test: 10 },
-            filter: null,
-            seed: null
+            filter: null
         });
     });
 
-    it('requires confirmation before overwriting existing split tags', async () => {
+    it('warns and requires confirmation before clearing tags that overlap the selection', async () => {
         tagsStore.set([{ tag_id: 't-train', name: 'train', kind: 'sample' }]);
+        overlapData = { tags: [{ name: 'train', count: 120 }] };
         render(SplitDialog);
 
-        await fireEvent.submit(screen.getByTestId('split-submit').closest('form')!);
+        expect(screen.getByTestId('split-cleared-warning').textContent).toContain(
+            'train (120 samples) will be cleared and reassigned.'
+        );
 
-        // First submit only surfaces the overwrite warning, without calling submit.
+        // First submit only arms the overwrite confirmation, without calling submit.
+        await fireEvent.submit(screen.getByTestId('split-submit').closest('form')!);
         expect(submitMock).not.toHaveBeenCalled();
-        expect(screen.getByTestId('split-overwrite-warning')).toBeInTheDocument();
 
         await fireEvent.submit(screen.getByTestId('split-submit').closest('form')!);
         expect(submitMock).toHaveBeenCalledOnce();

--- a/lightly_studio_view/src/lib/components/SplitDialog/partitionCounts.test.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/partitionCounts.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { partitionCounts } from './partitionCounts';
+
+describe('partitionCounts', () => {
+    it('splits exactly when shares are whole numbers', () => {
+        expect(partitionCounts(1000, { train: 80, val: 10, test: 10 })).toEqual({
+            train: 800,
+            val: 100,
+            test: 100
+        });
+    });
+
+    it('assigns leftover units by largest remainder', () => {
+        // Exact shares 2.8 / 2.8 / 1.4: the two leftover units go to train and val.
+        expect(partitionCounts(7, { train: 40, val: 40, test: 20 })).toEqual({
+            train: 3,
+            val: 3,
+            test: 1
+        });
+    });
+
+    it('always sums to the total', () => {
+        const counts = partitionCounts(17, { a: 33, b: 33, c: 34 });
+        const sum = Object.values(counts).reduce((acc, value) => acc + value, 0);
+        expect(sum).toBe(17);
+    });
+
+    it('returns zeros for an empty input set', () => {
+        expect(partitionCounts(0, { train: 80, val: 20 })).toEqual({ train: 0, val: 0 });
+    });
+});

--- a/lightly_studio_view/src/lib/components/SplitDialog/partitionCounts.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/partitionCounts.ts
@@ -1,0 +1,31 @@
+/**
+ * Split `total` into per-split counts using the largest-remainder method.
+ *
+ * Mirrors the backend `partition_counts` so the previewed counts match what the
+ * server will actually assign. Each split gets the floor of its exact
+ * proportional share, then the leftover units go to the splits with the largest
+ * fractional remainder, guaranteeing the counts sum exactly to `total`.
+ */
+export function partitionCounts(
+    total: number,
+    sizes: Record<string, number>
+): Record<string, number> {
+    const names = Object.keys(sizes);
+    const sizeSum = names.reduce((sum, name) => sum + sizes[name], 0);
+    if (sizeSum <= 0 || total <= 0) {
+        return Object.fromEntries(names.map((name) => [name, 0]));
+    }
+
+    const exactShares = names.map((name) => (total * sizes[name]) / sizeSum);
+    const counts = exactShares.map((share) => Math.floor(share));
+    const leftover = total - counts.reduce((sum, count) => sum + count, 0);
+
+    const orderByRemainder = names
+        .map((_, index) => index)
+        .sort((a, b) => exactShares[b] - counts[b] - (exactShares[a] - counts[a]));
+    for (let i = 0; i < leftover; i++) {
+        counts[orderByRemainder[i]] += 1;
+    }
+
+    return Object.fromEntries(names.map((name, index) => [name, counts[index]]));
+}

--- a/lightly_studio_view/src/lib/components/SplitDialog/splitDialogMessages.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/splitDialogMessages.ts
@@ -1,0 +1,27 @@
+export interface ClearedTag {
+    name: string;
+    count: number;
+}
+
+function pluralizeSamples(count: number): string {
+    return `${count} ${count === 1 ? 'sample' : 'samples'}`;
+}
+
+// Joins items into a natural-language list: "a", "a and b", "a, b and c".
+function joinNatural(items: string[]): string {
+    if (items.length <= 1) return items.join('');
+    return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
+}
+
+// e.g. "train (120 samples) and val (30 samples) will be cleared and reassigned."
+export function formatClearedMessage(tags: ClearedTag[]): string {
+    if (tags.length === 0) return '';
+    const parts = tags.map((tag) => `${tag.name} (${pluralizeSamples(tag.count)})`);
+    return `${joinNatural(parts)} will be cleared and reassigned.`;
+}
+
+// e.g. "test will be created." / "test and holdout will be created."
+export function formatCreatedMessage(names: string[]): string {
+    if (names.length === 0) return '';
+    return `${joinNatural(names)} will be created.`;
+}

--- a/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.test.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.test.ts
@@ -1,0 +1,58 @@
+import { get, writable } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+import { useSplitForm } from './useSplitForm';
+
+function setup(sampleCount = 100, existingNames: string[] = []) {
+    const filteredSampleCount = writable(sampleCount);
+    const existingTagNames = writable(existingNames);
+    const form = useSplitForm({ filteredSampleCount, existingTagNames });
+    return { form, filteredSampleCount, existingTagNames };
+}
+
+describe('useSplitForm', () => {
+    it('starts valid with the default train/val/test rows', () => {
+        const { form } = setup();
+        expect(get(form.percentageSum)).toBe(100);
+        expect(get(form.isValid)).toBe(true);
+        expect(get(form.errorMessage)).toBeNull();
+    });
+
+    it('flags an error when percentages do not sum to 100', () => {
+        const { form } = setup();
+        const rows = get(form.rows);
+        form.updatePercentage(rows[0].id, 50);
+        expect(get(form.isValid)).toBe(false);
+        expect(get(form.errorMessage)).toContain('sum to 100');
+    });
+
+    it('flags duplicate split names', () => {
+        const { form } = setup();
+        const rows = get(form.rows);
+        form.updateName(rows[1].id, 'train');
+        expect(get(form.errorMessage)).toContain('unique');
+    });
+
+    it('adds and removes rows', () => {
+        const { form } = setup();
+        form.addRow();
+        expect(get(form.rows)).toHaveLength(4);
+        const rows = get(form.rows);
+        form.removeRow(rows[3].id);
+        expect(get(form.rows)).toHaveLength(3);
+    });
+
+    it('previews per-split counts against the filtered set', () => {
+        const { form } = setup(1000);
+        expect(get(form.previewCounts)).toEqual({ train: 800, val: 100, test: 100 });
+    });
+
+    it('reports which target splits already exist as tags', () => {
+        const { form } = setup(100, ['train', 'other']);
+        expect(get(form.overwrittenTagNames)).toEqual(['train']);
+    });
+
+    it('exposes trimmed sizes for submission', () => {
+        const { form } = setup();
+        expect(form.getSizes()).toEqual({ train: 80, val: 10, test: 10 });
+    });
+});

--- a/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.test.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.test.ts
@@ -8,49 +8,40 @@ function setup(sampleCount = 100) {
     return { form, filteredSampleCount };
 }
 
-function sumOf(rows: { percentage: number }[]): number {
-    return rows.reduce((sum, row) => sum + row.percentage, 0);
-}
-
 describe('useSplitForm', () => {
-    it('starts valid with the default train/val/test rows summing to 100', () => {
+    it('starts valid with the default train/val/test rows in 8:1:1 parts', () => {
         const { form } = setup();
-        expect(sumOf(get(form.rows))).toBe(100);
+        expect(get(form.rows).map((row) => row.parts)).toEqual([8, 1, 1]);
         expect(get(form.isValid)).toBe(true);
         expect(get(form.errorMessage)).toBeNull();
     });
 
-    it('absorbs an edit into the next row so the total stays 100', () => {
-        const { form } = setup();
-        const [train, val, test] = get(form.rows);
-        // train 80 -> 70 pushes +10 into val (10 -> 20); test untouched.
-        form.updatePercentage(train.id, 70);
-        const rows = get(form.rows);
-        expect(rows.map((row) => row.percentage)).toEqual([70, 20, 10]);
-        expect(sumOf(rows)).toBe(100);
-        expect(val.id).toBe(rows[1].id);
-        expect(test.id).toBe(rows[2].id);
-    });
-
-    it('clamps an edit so the next row never goes below 0', () => {
+    it('edits a row without touching the others', () => {
         const { form } = setup();
         const [train] = get(form.rows);
-        // val only has 10 to give, so train tops out at 90.
-        form.updatePercentage(train.id, 95);
-        const rows = get(form.rows);
-        expect(rows.map((row) => row.percentage)).toEqual([90, 0, 10]);
-        expect(sumOf(rows)).toBe(100);
+        form.updateParts(train.id, 3);
+        expect(get(form.rows).map((row) => row.parts)).toEqual([3, 1, 1]);
+        expect(get(form.isValid)).toBe(true);
     });
 
-    it('wraps the absorbed delta from the last row into the first', () => {
-        const { form } = setup();
+    it('derives percentage and sample count from the relative parts', () => {
+        const { form } = setup(1000);
+        const preview = get(form.preview);
         const rows = get(form.rows);
-        const test = rows[2];
-        // Editing the last row pushes the delta into the first (train).
-        form.updatePercentage(test.id, 30);
-        const updated = get(form.rows);
-        expect(updated.map((row) => row.percentage)).toEqual([60, 10, 30]);
-        expect(sumOf(updated)).toBe(100);
+        expect(preview[rows[0].id]).toEqual({ percentage: 80, count: 800 });
+        expect(preview[rows[1].id]).toEqual({ percentage: 10, count: 100 });
+        expect(preview[rows[2].id]).toEqual({ percentage: 10, count: 100 });
+    });
+
+    it('recomputes the preview when parts change', () => {
+        const { form } = setup(100);
+        const rows = get(form.rows);
+        // 1:1:1 -> even thirds; largest-remainder hands the leftover to the first.
+        form.updateParts(rows[0].id, 1);
+        const preview = get(form.preview);
+        expect(preview[rows[0].id]).toEqual({ percentage: 33, count: 34 });
+        expect(preview[rows[1].id]).toEqual({ percentage: 33, count: 33 });
+        expect(preview[rows[2].id]).toEqual({ percentage: 33, count: 33 });
     });
 
     it('flags duplicate split names', () => {
@@ -60,52 +51,32 @@ describe('useSplitForm', () => {
         expect(get(form.errorMessage)).toContain('unique');
     });
 
-    it('flags a split with a non-positive percentage', () => {
+    it('flags a split with non-positive parts', () => {
         const { form } = setup();
         const [train] = get(form.rows);
-        form.updatePercentage(train.id, 90); // drives val to 0
-        expect(get(form.errorMessage)).toContain('greater than 0');
+        form.updateParts(train.id, 0);
+        expect(get(form.errorMessage)).toContain('at least 1 part');
     });
 
-    it('adds a row by carving its share out of the last row, keeping the total 100', () => {
+    it('adds a row with a default of one part', () => {
         const { form } = setup();
         form.addRow();
         const rows = get(form.rows);
         expect(rows).toHaveLength(4);
-        // test 10 -> 5, new row gets 5.
-        expect(rows[2].percentage).toBe(5);
-        expect(rows[3].percentage).toBe(5);
-        expect(sumOf(rows)).toBe(100);
+        expect(rows[3].parts).toBe(1);
     });
 
-    it('removes a row by donating its share to the next row, keeping the total 100', () => {
+    it('removes a row without redistributing parts', () => {
         const { form } = setup();
         const val = get(form.rows)[1];
         form.removeRow(val.id);
         const rows = get(form.rows);
         expect(rows.map((row) => row.name)).toEqual(['train', 'test']);
-        // val's 10 goes to the following row (test): 10 -> 20.
-        expect(rows.map((row) => row.percentage)).toEqual([80, 20]);
-        expect(sumOf(rows)).toBe(100);
-    });
-
-    it('wraps a removed last row donation into the first row', () => {
-        const { form } = setup();
-        const test = get(form.rows)[2];
-        form.removeRow(test.id);
-        const rows = get(form.rows);
-        expect(rows.map((row) => row.name)).toEqual(['train', 'val']);
-        expect(rows.map((row) => row.percentage)).toEqual([90, 10]);
-        expect(sumOf(rows)).toBe(100);
-    });
-
-    it('previews per-split counts against the filtered set', () => {
-        const { form } = setup(1000);
-        expect(get(form.previewCounts)).toEqual({ train: 800, val: 100, test: 100 });
+        expect(rows.map((row) => row.parts)).toEqual([8, 1]);
     });
 
     it('exposes trimmed sizes for submission', () => {
         const { form } = setup();
-        expect(form.getSizes()).toEqual({ train: 80, val: 10, test: 10 });
+        expect(form.getSizes()).toEqual({ train: 8, val: 1, test: 1 });
     });
 });

--- a/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.test.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.test.ts
@@ -2,27 +2,55 @@ import { get, writable } from 'svelte/store';
 import { describe, expect, it } from 'vitest';
 import { useSplitForm } from './useSplitForm';
 
-function setup(sampleCount = 100, existingNames: string[] = []) {
+function setup(sampleCount = 100) {
     const filteredSampleCount = writable(sampleCount);
-    const existingTagNames = writable(existingNames);
-    const form = useSplitForm({ filteredSampleCount, existingTagNames });
-    return { form, filteredSampleCount, existingTagNames };
+    const form = useSplitForm({ filteredSampleCount });
+    return { form, filteredSampleCount };
+}
+
+function sumOf(rows: { percentage: number }[]): number {
+    return rows.reduce((sum, row) => sum + row.percentage, 0);
 }
 
 describe('useSplitForm', () => {
-    it('starts valid with the default train/val/test rows', () => {
+    it('starts valid with the default train/val/test rows summing to 100', () => {
         const { form } = setup();
-        expect(get(form.percentageSum)).toBe(100);
+        expect(sumOf(get(form.rows))).toBe(100);
         expect(get(form.isValid)).toBe(true);
         expect(get(form.errorMessage)).toBeNull();
     });
 
-    it('flags an error when percentages do not sum to 100', () => {
+    it('absorbs an edit into the next row so the total stays 100', () => {
+        const { form } = setup();
+        const [train, val, test] = get(form.rows);
+        // train 80 -> 70 pushes +10 into val (10 -> 20); test untouched.
+        form.updatePercentage(train.id, 70);
+        const rows = get(form.rows);
+        expect(rows.map((row) => row.percentage)).toEqual([70, 20, 10]);
+        expect(sumOf(rows)).toBe(100);
+        expect(val.id).toBe(rows[1].id);
+        expect(test.id).toBe(rows[2].id);
+    });
+
+    it('clamps an edit so the next row never goes below 0', () => {
+        const { form } = setup();
+        const [train] = get(form.rows);
+        // val only has 10 to give, so train tops out at 90.
+        form.updatePercentage(train.id, 95);
+        const rows = get(form.rows);
+        expect(rows.map((row) => row.percentage)).toEqual([90, 0, 10]);
+        expect(sumOf(rows)).toBe(100);
+    });
+
+    it('wraps the absorbed delta from the last row into the first', () => {
         const { form } = setup();
         const rows = get(form.rows);
-        form.updatePercentage(rows[0].id, 50);
-        expect(get(form.isValid)).toBe(false);
-        expect(get(form.errorMessage)).toContain('sum to 100');
+        const test = rows[2];
+        // Editing the last row pushes the delta into the first (train).
+        form.updatePercentage(test.id, 30);
+        const updated = get(form.rows);
+        expect(updated.map((row) => row.percentage)).toEqual([60, 10, 30]);
+        expect(sumOf(updated)).toBe(100);
     });
 
     it('flags duplicate split names', () => {
@@ -32,23 +60,48 @@ describe('useSplitForm', () => {
         expect(get(form.errorMessage)).toContain('unique');
     });
 
-    it('adds and removes rows', () => {
+    it('flags a split with a non-positive percentage', () => {
+        const { form } = setup();
+        const [train] = get(form.rows);
+        form.updatePercentage(train.id, 90); // drives val to 0
+        expect(get(form.errorMessage)).toContain('greater than 0');
+    });
+
+    it('adds a row by carving its share out of the last row, keeping the total 100', () => {
         const { form } = setup();
         form.addRow();
-        expect(get(form.rows)).toHaveLength(4);
         const rows = get(form.rows);
-        form.removeRow(rows[3].id);
-        expect(get(form.rows)).toHaveLength(3);
+        expect(rows).toHaveLength(4);
+        // test 10 -> 5, new row gets 5.
+        expect(rows[2].percentage).toBe(5);
+        expect(rows[3].percentage).toBe(5);
+        expect(sumOf(rows)).toBe(100);
+    });
+
+    it('removes a row by donating its share to the next row, keeping the total 100', () => {
+        const { form } = setup();
+        const val = get(form.rows)[1];
+        form.removeRow(val.id);
+        const rows = get(form.rows);
+        expect(rows.map((row) => row.name)).toEqual(['train', 'test']);
+        // val's 10 goes to the following row (test): 10 -> 20.
+        expect(rows.map((row) => row.percentage)).toEqual([80, 20]);
+        expect(sumOf(rows)).toBe(100);
+    });
+
+    it('wraps a removed last row donation into the first row', () => {
+        const { form } = setup();
+        const test = get(form.rows)[2];
+        form.removeRow(test.id);
+        const rows = get(form.rows);
+        expect(rows.map((row) => row.name)).toEqual(['train', 'val']);
+        expect(rows.map((row) => row.percentage)).toEqual([90, 10]);
+        expect(sumOf(rows)).toBe(100);
     });
 
     it('previews per-split counts against the filtered set', () => {
         const { form } = setup(1000);
         expect(get(form.previewCounts)).toEqual({ train: 800, val: 100, test: 100 });
-    });
-
-    it('reports which target splits already exist as tags', () => {
-        const { form } = setup(100, ['train', 'other']);
-        expect(get(form.overwrittenTagNames)).toEqual(['train']);
     });
 
     it('exposes trimmed sizes for submission', () => {

--- a/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.ts
@@ -1,0 +1,110 @@
+import { derived, get, writable, type Readable } from 'svelte/store';
+import { partitionCounts } from './partitionCounts';
+
+export interface SplitRow {
+    id: string;
+    name: string;
+    percentage: number;
+}
+
+interface UseSplitFormParams {
+    filteredSampleCount: Readable<number>;
+    existingTagNames: Readable<string[]>;
+}
+
+// Percentages are integers in the UI, so an exact sum of 100 is required.
+const REQUIRED_SUM = 100;
+
+const DEFAULT_ROWS: SplitRow[] = [
+    { id: 'train', name: 'train', percentage: 80 },
+    { id: 'val', name: 'val', percentage: 10 },
+    { id: 'test', name: 'test', percentage: 10 }
+];
+
+export function useSplitForm({ filteredSampleCount, existingTagNames }: UseSplitFormParams) {
+    const rows = writable<SplitRow[]>(cloneDefaultRows());
+
+    const percentageSum = derived(rows, ($rows) =>
+        $rows.reduce((sum, row) => sum + (Number.isFinite(row.percentage) ? row.percentage : 0), 0)
+    );
+
+    const errorMessage = derived([rows, percentageSum], ([$rows, $sum]) =>
+        computeErrorMessage($rows, $sum)
+    );
+
+    const isValid = derived(errorMessage, ($error) => $error === null);
+
+    // Per-split counts previewed against the current filtered set, using the same
+    // largest-remainder method as the backend so the numbers match the result.
+    const previewCounts = derived([rows, filteredSampleCount], ([$rows, $count]) =>
+        partitionCounts(
+            $count,
+            Object.fromEntries($rows.map((row) => [row.name, Math.max(row.percentage, 0)]))
+        )
+    );
+
+    // Names of target splits that already exist as tags, so the caller can warn
+    // that they will be cleared and reassigned.
+    const overwrittenTagNames = derived([rows, existingTagNames], ([$rows, $existing]) => {
+        const existingSet = new Set($existing);
+        return $rows.map((row) => row.name).filter((name) => existingSet.has(name));
+    });
+
+    function addRow(): void {
+        rows.update(($rows) => [...$rows, { id: crypto.randomUUID(), name: '', percentage: 0 }]);
+    }
+
+    function removeRow(id: string): void {
+        rows.update(($rows) => $rows.filter((row) => row.id !== id));
+    }
+
+    function updateName(id: string, name: string): void {
+        rows.update(($rows) => $rows.map((row) => (row.id === id ? { ...row, name } : row)));
+    }
+
+    function updatePercentage(id: string, percentage: number): void {
+        const safe = Number.isFinite(percentage) ? percentage : 0;
+        rows.update(($rows) =>
+            $rows.map((row) => (row.id === id ? { ...row, percentage: safe } : row))
+        );
+    }
+
+    function reset(): void {
+        rows.set(cloneDefaultRows());
+    }
+
+    function getSizes(): Record<string, number> {
+        return Object.fromEntries(get(rows).map((row) => [row.name.trim(), row.percentage]));
+    }
+
+    return {
+        rows,
+        percentageSum,
+        errorMessage,
+        isValid,
+        previewCounts,
+        overwrittenTagNames,
+        addRow,
+        removeRow,
+        updateName,
+        updatePercentage,
+        reset,
+        getSizes
+    };
+}
+
+function cloneDefaultRows(): SplitRow[] {
+    return DEFAULT_ROWS.map((row) => ({ ...row }));
+}
+
+function computeErrorMessage(rows: SplitRow[], sum: number): string | null {
+    if (rows.length === 0) return 'Add at least one split.';
+
+    const names = rows.map((row) => row.name.trim());
+    if (names.some((name) => name.length === 0)) return 'Every split needs a name.';
+    if (new Set(names).size !== names.length) return 'Split names must be unique.';
+    if (rows.some((row) => row.percentage <= 0)) return 'Every percentage must be greater than 0.';
+    if (sum !== REQUIRED_SUM) return `Percentages must sum to 100 (currently ${sum}).`;
+
+    return null;
+}

--- a/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.ts
@@ -4,20 +4,24 @@ import { partitionCounts } from './partitionCounts';
 export interface SplitRow {
     id: string;
     name: string;
+    parts: number;
+}
+
+export interface SplitPreview {
     percentage: number;
+    count: number;
 }
 
 interface UseSplitFormParams {
     filteredSampleCount: Readable<number>;
 }
 
-// Percentages are integers that always sum to exactly 100.
-const REQUIRED_SUM = 100;
-
+// Splits are sized by relative parts (e.g. 8 : 1 : 1), so they never need to
+// sum to any particular total.
 const DEFAULT_ROWS: SplitRow[] = [
-    { id: 'train', name: 'train', percentage: 80 },
-    { id: 'val', name: 'val', percentage: 10 },
-    { id: 'test', name: 'test', percentage: 10 }
+    { id: 'train', name: 'train', parts: 8 },
+    { id: 'val', name: 'val', parts: 1 },
+    { id: 'test', name: 'test', parts: 1 }
 ];
 
 export function useSplitForm({ filteredSampleCount }: UseSplitFormParams) {
@@ -27,51 +31,41 @@ export function useSplitForm({ filteredSampleCount }: UseSplitFormParams) {
 
     const isValid = derived(errorMessage, ($error) => $error === null);
 
-    // Per-split counts previewed against the current filtered set, using the same
-    // largest-remainder method as the backend so the numbers match the result.
-    const previewCounts = derived([rows, filteredSampleCount], ([$rows, $count]) =>
-        partitionCounts(
-            $count,
-            Object.fromEntries($rows.map((row) => [row.name, Math.max(row.percentage, 0)]))
-        )
-    );
+    // Per-row percentage and sample count, keyed by row id so temporary empty or
+    // duplicate names never collide. Counts use the same largest-remainder method
+    // as the backend so the preview matches the actual result.
+    const preview = derived([rows, filteredSampleCount], ([$rows, $count]) => {
+        const partsById = Object.fromEntries($rows.map((row) => [row.id, Math.max(row.parts, 0)]));
+        const partsSum = $rows.reduce((sum, row) => sum + Math.max(row.parts, 0), 0);
+        const counts = partitionCounts($count, partsById);
+
+        return Object.fromEntries(
+            $rows.map((row): [string, SplitPreview] => [
+                row.id,
+                {
+                    percentage:
+                        partsSum > 0 ? Math.round((Math.max(row.parts, 0) / partsSum) * 100) : 0,
+                    count: counts[row.id] ?? 0
+                }
+            ])
+        );
+    });
 
     function addRow(): void {
-        // Carve the new row's share out of the current last row so the total
-        // stays at 100.
-        rows.update(($rows) => {
-            const last = $rows[$rows.length - 1];
-            const take = last ? Math.floor(last.percentage / 2) : 0;
-            const next = $rows.map((row, index) =>
-                index === $rows.length - 1 ? { ...row, percentage: row.percentage - take } : row
-            );
-            return [...next, { id: crypto.randomUUID(), name: '', percentage: take }];
-        });
+        rows.update(($rows) => [...$rows, { id: crypto.randomUUID(), name: '', parts: 1 }]);
     }
 
     function removeRow(id: string): void {
-        // Hand the removed row's share to the following row (wrapping to the
-        // first) so the total stays at 100.
-        rows.update(($rows) => {
-            const index = $rows.findIndex((row) => row.id === id);
-            if (index === -1 || $rows.length <= 1) return $rows;
-
-            const donated = $rows[index].percentage;
-            const recipientId = $rows[(index + 1) % $rows.length].id;
-            return $rows
-                .filter((row) => row.id !== id)
-                .map((row) =>
-                    row.id === recipientId ? { ...row, percentage: row.percentage + donated } : row
-                );
-        });
+        rows.update(($rows) => $rows.filter((row) => row.id !== id));
     }
 
     function updateName(id: string, name: string): void {
         rows.update(($rows) => $rows.map((row) => (row.id === id ? { ...row, name } : row)));
     }
 
-    function updatePercentage(id: string, percentage: number): void {
-        rows.update(($rows) => rebalanceOnEdit($rows, id, percentage));
+    function updateParts(id: string, parts: number): void {
+        const safe = Number.isFinite(parts) ? parts : 0;
+        rows.update(($rows) => $rows.map((row) => (row.id === id ? { ...row, parts: safe } : row)));
     }
 
     function reset(): void {
@@ -79,46 +73,21 @@ export function useSplitForm({ filteredSampleCount }: UseSplitFormParams) {
     }
 
     function getSizes(): Record<string, number> {
-        return Object.fromEntries(get(rows).map((row) => [row.name.trim(), row.percentage]));
+        return Object.fromEntries(get(rows).map((row) => [row.name.trim(), row.parts]));
     }
 
     return {
         rows,
         errorMessage,
         isValid,
-        previewCounts,
+        preview,
         addRow,
         removeRow,
         updateName,
-        updatePercentage,
+        updateParts,
         reset,
         getSizes
     };
-}
-
-// Applies an edit to row `id`, absorbing the delta into the NEXT row (wrapping
-// to the first). The edited value is clamped so the neighbour stays within
-// [0, 100], which keeps the visible percentages summing to exactly 100.
-function rebalanceOnEdit(rows: SplitRow[], id: string, percentage: number): SplitRow[] {
-    const index = rows.findIndex((row) => row.id === id);
-    if (index === -1) return rows;
-
-    const neighbourIndex = (index + 1) % rows.length;
-    // A single row can only ever be 100; nothing to rebalance against.
-    if (neighbourIndex === index) return rows;
-
-    const safe = Number.isFinite(percentage) ? percentage : 0;
-    const current = rows[index].percentage;
-    const neighbour = rows[neighbourIndex].percentage;
-    const lower = Math.max(0, current + neighbour - REQUIRED_SUM);
-    const upper = Math.min(REQUIRED_SUM, current + neighbour);
-    const clamped = Math.min(Math.max(safe, lower), upper);
-
-    return rows.map((row, i) => {
-        if (i === index) return { ...row, percentage: clamped };
-        if (i === neighbourIndex) return { ...row, percentage: current + neighbour - clamped };
-        return row;
-    });
 }
 
 function cloneDefaultRows(): SplitRow[] {
@@ -131,7 +100,7 @@ function computeErrorMessage(rows: SplitRow[]): string | null {
     const names = rows.map((row) => row.name.trim());
     if (names.some((name) => name.length === 0)) return 'Every split needs a name.';
     if (new Set(names).size !== names.length) return 'Split names must be unique.';
-    if (rows.some((row) => row.percentage <= 0)) return 'Every percentage must be greater than 0.';
+    if (rows.some((row) => row.parts <= 0)) return 'Every split needs at least 1 part.';
 
     return null;
 }

--- a/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.ts
+++ b/lightly_studio_view/src/lib/components/SplitDialog/useSplitForm.ts
@@ -9,10 +9,9 @@ export interface SplitRow {
 
 interface UseSplitFormParams {
     filteredSampleCount: Readable<number>;
-    existingTagNames: Readable<string[]>;
 }
 
-// Percentages are integers in the UI, so an exact sum of 100 is required.
+// Percentages are integers that always sum to exactly 100.
 const REQUIRED_SUM = 100;
 
 const DEFAULT_ROWS: SplitRow[] = [
@@ -21,16 +20,10 @@ const DEFAULT_ROWS: SplitRow[] = [
     { id: 'test', name: 'test', percentage: 10 }
 ];
 
-export function useSplitForm({ filteredSampleCount, existingTagNames }: UseSplitFormParams) {
+export function useSplitForm({ filteredSampleCount }: UseSplitFormParams) {
     const rows = writable<SplitRow[]>(cloneDefaultRows());
 
-    const percentageSum = derived(rows, ($rows) =>
-        $rows.reduce((sum, row) => sum + (Number.isFinite(row.percentage) ? row.percentage : 0), 0)
-    );
-
-    const errorMessage = derived([rows, percentageSum], ([$rows, $sum]) =>
-        computeErrorMessage($rows, $sum)
-    );
+    const errorMessage = derived(rows, ($rows) => computeErrorMessage($rows));
 
     const isValid = derived(errorMessage, ($error) => $error === null);
 
@@ -43,19 +36,34 @@ export function useSplitForm({ filteredSampleCount, existingTagNames }: UseSplit
         )
     );
 
-    // Names of target splits that already exist as tags, so the caller can warn
-    // that they will be cleared and reassigned.
-    const overwrittenTagNames = derived([rows, existingTagNames], ([$rows, $existing]) => {
-        const existingSet = new Set($existing);
-        return $rows.map((row) => row.name).filter((name) => existingSet.has(name));
-    });
-
     function addRow(): void {
-        rows.update(($rows) => [...$rows, { id: crypto.randomUUID(), name: '', percentage: 0 }]);
+        // Carve the new row's share out of the current last row so the total
+        // stays at 100.
+        rows.update(($rows) => {
+            const last = $rows[$rows.length - 1];
+            const take = last ? Math.floor(last.percentage / 2) : 0;
+            const next = $rows.map((row, index) =>
+                index === $rows.length - 1 ? { ...row, percentage: row.percentage - take } : row
+            );
+            return [...next, { id: crypto.randomUUID(), name: '', percentage: take }];
+        });
     }
 
     function removeRow(id: string): void {
-        rows.update(($rows) => $rows.filter((row) => row.id !== id));
+        // Hand the removed row's share to the following row (wrapping to the
+        // first) so the total stays at 100.
+        rows.update(($rows) => {
+            const index = $rows.findIndex((row) => row.id === id);
+            if (index === -1 || $rows.length <= 1) return $rows;
+
+            const donated = $rows[index].percentage;
+            const recipientId = $rows[(index + 1) % $rows.length].id;
+            return $rows
+                .filter((row) => row.id !== id)
+                .map((row) =>
+                    row.id === recipientId ? { ...row, percentage: row.percentage + donated } : row
+                );
+        });
     }
 
     function updateName(id: string, name: string): void {
@@ -63,10 +71,7 @@ export function useSplitForm({ filteredSampleCount, existingTagNames }: UseSplit
     }
 
     function updatePercentage(id: string, percentage: number): void {
-        const safe = Number.isFinite(percentage) ? percentage : 0;
-        rows.update(($rows) =>
-            $rows.map((row) => (row.id === id ? { ...row, percentage: safe } : row))
-        );
+        rows.update(($rows) => rebalanceOnEdit($rows, id, percentage));
     }
 
     function reset(): void {
@@ -79,11 +84,9 @@ export function useSplitForm({ filteredSampleCount, existingTagNames }: UseSplit
 
     return {
         rows,
-        percentageSum,
         errorMessage,
         isValid,
         previewCounts,
-        overwrittenTagNames,
         addRow,
         removeRow,
         updateName,
@@ -93,18 +96,42 @@ export function useSplitForm({ filteredSampleCount, existingTagNames }: UseSplit
     };
 }
 
+// Applies an edit to row `id`, absorbing the delta into the NEXT row (wrapping
+// to the first). The edited value is clamped so the neighbour stays within
+// [0, 100], which keeps the visible percentages summing to exactly 100.
+function rebalanceOnEdit(rows: SplitRow[], id: string, percentage: number): SplitRow[] {
+    const index = rows.findIndex((row) => row.id === id);
+    if (index === -1) return rows;
+
+    const neighbourIndex = (index + 1) % rows.length;
+    // A single row can only ever be 100; nothing to rebalance against.
+    if (neighbourIndex === index) return rows;
+
+    const safe = Number.isFinite(percentage) ? percentage : 0;
+    const current = rows[index].percentage;
+    const neighbour = rows[neighbourIndex].percentage;
+    const lower = Math.max(0, current + neighbour - REQUIRED_SUM);
+    const upper = Math.min(REQUIRED_SUM, current + neighbour);
+    const clamped = Math.min(Math.max(safe, lower), upper);
+
+    return rows.map((row, i) => {
+        if (i === index) return { ...row, percentage: clamped };
+        if (i === neighbourIndex) return { ...row, percentage: current + neighbour - clamped };
+        return row;
+    });
+}
+
 function cloneDefaultRows(): SplitRow[] {
     return DEFAULT_ROWS.map((row) => ({ ...row }));
 }
 
-function computeErrorMessage(rows: SplitRow[], sum: number): string | null {
+function computeErrorMessage(rows: SplitRow[]): string | null {
     if (rows.length === 0) return 'Add at least one split.';
 
     const names = rows.map((row) => row.name.trim());
     if (names.some((name) => name.length === 0)) return 'Every split needs a name.';
     if (new Set(names).size !== names.length) return 'Split names must be unique.';
     if (rows.some((row) => row.percentage <= 0)) return 'Every percentage must be greater than 0.';
-    if (sum !== REQUIRED_SUM) return `Percentages must sum to 100 (currently ${sum}).`;
 
     return null;
 }

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -70,4 +70,5 @@ export { default as CollectionSearchImage } from '$lib/components/CollectionSear
 export { default as CollectionSearchInput } from '$lib/components/CollectionSearch/SearchInput/CollectionSearchInput.svelte';
 export { default as OrderBy } from '$lib/components/OrderBy/OrderBy.svelte';
 export { default as SamplingCombinationDialog } from '$lib/components/Sampling/SamplingCombinationDialog.svelte';
+export { default as SplitDialog } from '$lib/components/SplitDialog/SplitDialog.svelte';
 export { default as MetadataFilterChips } from '$lib/components/MetadataFilterChips/MetadataFilterChips.svelte';

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -39,6 +39,8 @@ export { useAnnotation } from '$lib/hooks/useAnnotation/useAnnotation';
 export { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
 export { useSegmentationMaskPreview } from '$lib/hooks/useSegmentationMaskPreview';
 export { useCreateSampling } from '$lib/hooks/useCreateSampling/useCreateSampling';
+export { useCreateSplit } from '$lib/hooks/useCreateSplit/useCreateSplit';
+export { useSplitDialog } from '$lib/hooks/useSplitDialog/useSplitDialog';
 export { useColorPicker } from '$lib/hooks/useColorPicker/useColorPicker.svelte';
 export { useSubmitCombinationSelection } from '$lib/hooks/useSubmitCombinationSelection/useSubmitCombinationSelection';
 export { usePostHog } from '$lib/hooks/usePostHog';

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -40,6 +40,7 @@ export { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotatio
 export { useSegmentationMaskPreview } from '$lib/hooks/useSegmentationMaskPreview';
 export { useCreateSampling } from '$lib/hooks/useCreateSampling/useCreateSampling';
 export { useCreateSplit } from '$lib/hooks/useCreateSplit/useCreateSplit';
+export { useSelectionTagOverlap } from '$lib/hooks/useSelectionTagOverlap/useSelectionTagOverlap.svelte';
 export { useSplitDialog } from '$lib/hooks/useSplitDialog/useSplitDialog';
 export { useColorPicker } from '$lib/hooks/useColorPicker/useColorPicker.svelte';
 export { useSubmitCombinationSelection } from '$lib/hooks/useSubmitCombinationSelection/useSubmitCombinationSelection';

--- a/lightly_studio_view/src/lib/hooks/useCreateSplit/index.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSplit/index.ts
@@ -1,0 +1,1 @@
+export { useCreateSplit } from './useCreateSplit';

--- a/lightly_studio_view/src/lib/hooks/useCreateSplit/useCreateSplit.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSplit/useCreateSplit.test.ts
@@ -1,0 +1,85 @@
+import { createSplit } from '$lib/api/lightly_studio_local/sdk.gen';
+import { writable } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCreateSplit } from './useCreateSplit';
+
+vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
+    createSplit: vi.fn()
+}));
+
+vi.mock('svelte-sonner', () => ({
+    toast: { error: vi.fn(), success: vi.fn() }
+}));
+
+const { toast } = await import('svelte-sonner');
+
+describe('useCreateSplit', () => {
+    const now = new Date();
+    const tags = writable([
+        {
+            tag_id: 't-train',
+            name: 'train',
+            kind: 'sample' as const,
+            created_at: now,
+            updated_at: now
+        },
+        { tag_id: 't-val', name: 'val', kind: 'sample' as const, created_at: now, updated_at: now }
+    ]);
+    const defaultParams = {
+        tags,
+        setTagSelected: vi.fn(),
+        loadTags: vi.fn().mockResolvedValue(undefined),
+        closeSplitDialog: vi.fn()
+    };
+    const submitInput = {
+        collectionId: 'col-1',
+        sizes: { train: 80, val: 20 },
+        filter: null,
+        seed: 42
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('posts the split, toasts the summary, and selects the new tags', async () => {
+        vi.mocked(createSplit).mockResolvedValue({
+            data: {
+                splits: [
+                    { name: 'train', count: 8 },
+                    { name: 'val', count: 2 }
+                ],
+                seed: 42
+            },
+            error: null
+        } as never);
+
+        const { submit } = useCreateSplit(defaultParams);
+        const success = await submit(submitInput);
+
+        expect(success).toBe(true);
+        expect(createSplit).toHaveBeenCalledWith({
+            path: { collection_id: 'col-1' },
+            body: { sizes: { train: 80, val: 20 }, filter: undefined, seed: 42 }
+        });
+        expect(toast.success).toHaveBeenCalled();
+        expect(defaultParams.loadTags).toHaveBeenCalled();
+        expect(defaultParams.setTagSelected).toHaveBeenCalledWith('t-train', true);
+        expect(defaultParams.setTagSelected).toHaveBeenCalledWith('t-val', true);
+        expect(defaultParams.closeSplitDialog).toHaveBeenCalled();
+    });
+
+    it('toasts an error and keeps the dialog open on failure', async () => {
+        vi.mocked(createSplit).mockResolvedValue({
+            data: undefined,
+            error: { error: 'boom' }
+        } as never);
+
+        const { submit } = useCreateSplit(defaultParams);
+        const success = await submit(submitInput);
+
+        expect(success).toBe(false);
+        expect(toast.error).toHaveBeenCalled();
+        expect(defaultParams.closeSplitDialog).not.toHaveBeenCalled();
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useCreateSplit/useCreateSplit.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSplit/useCreateSplit.test.ts
@@ -34,8 +34,7 @@ describe('useCreateSplit', () => {
     const submitInput = {
         collectionId: 'col-1',
         sizes: { train: 80, val: 20 },
-        filter: null,
-        seed: 42
+        filter: null
     };
 
     beforeEach(() => {
@@ -60,7 +59,7 @@ describe('useCreateSplit', () => {
         expect(success).toBe(true);
         expect(createSplit).toHaveBeenCalledWith({
             path: { collection_id: 'col-1' },
-            body: { sizes: { train: 80, val: 20 }, filter: undefined, seed: 42 }
+            body: { sizes: { train: 80, val: 20 }, filter: undefined }
         });
         expect(toast.success).toHaveBeenCalled();
         expect(defaultParams.loadTags).toHaveBeenCalled();

--- a/lightly_studio_view/src/lib/hooks/useCreateSplit/useCreateSplit.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSplit/useCreateSplit.ts
@@ -1,0 +1,85 @@
+import { get, readonly, writable, type Readable } from 'svelte/store';
+import { toast } from 'svelte-sonner';
+import { createSplit } from '$lib/api/lightly_studio_local/sdk.gen';
+import type { SplitCreateBody } from '$lib/api/lightly_studio_local/types.gen';
+import type { TagView } from '$lib/services/types';
+
+type SplitError = { error: string };
+
+function extractError(error: unknown, fallback: string): string {
+    return (error as SplitError)?.error || fallback;
+}
+
+interface UseCreateSplitParams {
+    tags: Readable<TagView[]>;
+    setTagSelected: (tagId: string, isSelected: boolean) => void;
+    loadTags: () => Promise<void>;
+    closeSplitDialog: () => void;
+}
+
+interface SubmitParams {
+    collectionId: string;
+    sizes: SplitCreateBody['sizes'];
+    filter: SplitCreateBody['filter'];
+    seed: number | null;
+}
+
+export function useCreateSplit(params: UseCreateSplitParams) {
+    const _isSubmitting = writable(false);
+
+    async function submit(submitParams: SubmitParams): Promise<boolean> {
+        if (get(_isSubmitting)) return false;
+        const { collectionId, sizes, filter, seed } = submitParams;
+        _isSubmitting.set(true);
+
+        try {
+            const response = await createSplit({
+                path: { collection_id: collectionId },
+                body: { sizes, filter: filter ?? undefined, seed: seed ?? undefined }
+            });
+
+            if (response.error || !response.data) {
+                toast.error(extractError(response.error, 'Failed to split dataset'));
+                return false;
+            }
+
+            const summary = response.data.splits
+                .map((split) => `${split.name}: ${split.count}`)
+                .join(', ');
+            toast.success(`Dataset split (seed ${response.data.seed}) — ${summary}`);
+
+            await params.loadTags();
+            selectSplitTags(
+                get(params.tags),
+                response.data.splits.map((split) => split.name),
+                params.setTagSelected
+            );
+            params.closeSplitDialog();
+            return true;
+        } catch (error) {
+            // API functions return { data, error } and don't throw, so this only
+            // fires for unexpected runtime bugs in the hook itself.
+            console.error('Unexpected error in useCreateSplit.submit:', error);
+            toast.error('Failed to split dataset: ' + (error as Error).message);
+            return false;
+        } finally {
+            _isSubmitting.set(false);
+        }
+    }
+
+    return {
+        isSubmitting: readonly(_isSubmitting),
+        submit
+    };
+}
+
+function selectSplitTags(
+    tags: TagView[],
+    splitNames: string[],
+    setTagSelected: (tagId: string, isSelected: boolean) => void
+): void {
+    for (const name of splitNames) {
+        const tag = tags.find((candidate) => candidate.name === name);
+        if (tag) setTagSelected(tag.tag_id, true);
+    }
+}

--- a/lightly_studio_view/src/lib/hooks/useCreateSplit/useCreateSplit.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateSplit/useCreateSplit.ts
@@ -21,7 +21,6 @@ interface SubmitParams {
     collectionId: string;
     sizes: SplitCreateBody['sizes'];
     filter: SplitCreateBody['filter'];
-    seed: number | null;
 }
 
 export function useCreateSplit(params: UseCreateSplitParams) {
@@ -29,13 +28,14 @@ export function useCreateSplit(params: UseCreateSplitParams) {
 
     async function submit(submitParams: SubmitParams): Promise<boolean> {
         if (get(_isSubmitting)) return false;
-        const { collectionId, sizes, filter, seed } = submitParams;
+        const { collectionId, sizes, filter } = submitParams;
         _isSubmitting.set(true);
 
         try {
+            // Omitting seed lets the backend pick a random seed for each split.
             const response = await createSplit({
                 path: { collection_id: collectionId },
-                body: { sizes, filter: filter ?? undefined, seed: seed ?? undefined }
+                body: { sizes, filter: filter ?? undefined }
             });
 
             if (response.error || !response.data) {

--- a/lightly_studio_view/src/lib/hooks/useSelectionTagOverlap/useSelectionTagOverlap.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useSelectionTagOverlap/useSelectionTagOverlap.svelte.ts
@@ -1,0 +1,36 @@
+import { createQuery } from '@tanstack/svelte-query';
+import type { TagSelectionOverlapBody } from '$lib/api/lightly_studio_local/types.gen';
+import { getTagSelectionOverlapOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import { getTagSelectionOverlap } from '$lib/api/lightly_studio_local/sdk.gen';
+
+// Reports, per sample tag, how many of the currently selected samples already
+// carry it. Used by the split dialog to warn which tags will be overwritten.
+export const useSelectionTagOverlap = (
+    getParams: () => {
+        collectionId: string;
+        filter: TagSelectionOverlapBody['filter'];
+        /** Set to false to prevent the query from fetching. Default: true. */
+        enabled?: boolean;
+    }
+) => {
+    return createQuery(() => {
+        const { collectionId, filter, enabled } = getParams();
+        const requestOptions = {
+            path: { collection_id: collectionId },
+            body: { filter: filter ?? null }
+        };
+
+        return {
+            ...getTagSelectionOverlapOptions(requestOptions),
+            queryFn: async ({ signal }: { signal: AbortSignal }) => {
+                const { data } = await getTagSelectionOverlap({
+                    ...requestOptions,
+                    signal,
+                    throwOnError: true
+                });
+                return data;
+            },
+            ...(enabled !== undefined ? { enabled } : {})
+        };
+    });
+};

--- a/lightly_studio_view/src/lib/hooks/useSplitDialog/index.ts
+++ b/lightly_studio_view/src/lib/hooks/useSplitDialog/index.ts
@@ -1,0 +1,1 @@
+export { useSplitDialog } from './useSplitDialog';

--- a/lightly_studio_view/src/lib/hooks/useSplitDialog/useSplitDialog.ts
+++ b/lightly_studio_view/src/lib/hooks/useSplitDialog/useSplitDialog.ts
@@ -1,0 +1,16 @@
+import { writable } from 'svelte/store';
+
+// Module-level store so every invocation of useSplitDialog() (e.g. the trigger in
+// the menu and the dialog component itself) shares the same open state.
+const isSplitDialogOpen = writable(false);
+
+export function useSplitDialog() {
+    const openSplitDialog = () => isSplitDialogOpen.set(true);
+    const closeSplitDialog = () => isSplitDialogOpen.set(false);
+
+    return {
+        isSplitDialogOpen,
+        openSplitDialog,
+        closeSplitDialog
+    };
+}


### PR DESCRIPTION
## What has changed and why?

Adds the ability to split a dataset into named subsets (e.g. train/val/test) by proportion.

- **UI:** a "Split dataset" dialog to name splits and set percentages (summing to 100), with an optional seed. Operates on the current filtered view and reports per-split counts.
- **Python SDK:** `DatasetQuery.random_split({"train": 80, "val": 10, "test": 10}, seed=...)`, composing with `match`/`slice`.

Splits are stored as ordinary sample tags — no new table or migration. One core implementation backs both the API route and the SDK method. Re-running clears and reassigns the target splits.

## How has it been tested?

New unit tests for the core algorithm, the API route, the SDK method, and the frontend dialog/hooks. Backend (pytest) and frontend (vitest) suites and static checks pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)