### PR TITLE
Add a Progress bar for Plugins

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/operator.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/operator.py
@@ -12,7 +12,8 @@ from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND
 from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.plugins import operator_context
 from lightly_studio.plugins.base_operator import OperatorResult, OperatorStatus
-from lightly_studio.plugins.operator_context import AnyFilter, ExecutionContext
+from lightly_studio.plugins.operator_context import AnyFilter, ExecutionContext, ProgressReporter
+from lightly_studio.plugins.operator_progress import OperatorProgress, progress_store
 from lightly_studio.plugins.operator_registry import RegisteredOperatorMetadata, operator_registry
 from lightly_studio.plugins.parameter import BaseParameter
 from lightly_studio.resolvers import collection_resolver
@@ -36,11 +37,39 @@ class ExecuteOperatorRequest(BaseModel):
     parameters: dict[str, Any]
     context: OperatorContextRequest
 
+    run_id: UUID | None = None
+    """Client-generated id used to poll this run's progress while it executes."""
+
 
 @operator_router.get("")
 def get_operators() -> list[RegisteredOperatorMetadata]:
     """Get all registered operators (id, name)."""
     return operator_registry.get_all_metadata()
+
+
+# Declared before the "/{operator_id}/..." routes so that "runs" is not captured
+# as an operator_id by the path parameter.
+@operator_router.get("/runs/{run_id}/progress")
+def get_operator_run_progress(run_id: UUID) -> OperatorProgress:
+    """Get the latest reported progress of an in-flight operator run.
+
+    Args:
+        run_id: The ``run_id`` that was passed to the execute call.
+
+    Returns:
+        The latest progress reported by the running operator.
+
+    Raises:
+        HTTPException: If the run is unknown, has already finished, or has not
+            reported any progress yet.
+    """
+    progress = progress_store.get(run_id=run_id)
+    if progress is None:
+        raise HTTPException(
+            status_code=HTTP_STATUS_NOT_FOUND,
+            detail=f"No progress reported for run '{run_id}'",
+        )
+    return progress
 
 
 @operator_router.get("/{operator_id}/parameters")
@@ -113,11 +142,35 @@ def execute_operator(
             ),
         )
 
-    # Execute the operator
-    return operator.execute(
-        session=session,
-        context=ExecutionContext(
-            collection_id=context.collection_id, context_filter=context.context_filter
-        ),
-        parameters=request.parameters,
+    execution_context = ExecutionContext(
+        collection_id=context.collection_id,
+        context_filter=context.context_filter,
     )
+    run_id = request.run_id
+    if run_id is not None:
+        execution_context.report_progress = _build_progress_reporter(run_id=run_id)
+
+    # Execute the operator
+    try:
+        return operator.execute(
+            session=session,
+            context=execution_context,
+            parameters=request.parameters,
+        )
+    finally:
+        # Runs are only polled while in flight, so drop the entry as soon as the
+        # operator returns to keep the store from growing without bound.
+        if run_id is not None:
+            progress_store.clear(run_id=run_id)
+
+
+def _build_progress_reporter(*, run_id: UUID) -> ProgressReporter:
+    """Build a reporter that records a run's progress into the progress store."""
+
+    def report_progress(*, current: int, total: int, description: str = "") -> None:
+        progress_store.set(
+            run_id=run_id,
+            progress=OperatorProgress(current=current, total=total, description=description),
+        )
+
+    return report_progress

--- a/lightly_studio/src/lightly_studio/examples/coco_plugins_demo/lightly_train_inference_operator.py
+++ b/lightly_studio/src/lightly_studio/examples/coco_plugins_demo/lightly_train_inference_operator.py
@@ -137,6 +137,12 @@ class LightlyTrainObjectDetectionInferenceOperator(BaseOperator):
                     )
                 )
 
+            context.report_progress(
+                current=processed_sample_count,
+                total=len(samples),
+                description="Running inference",
+            )
+
         if annotations_to_create:
             annotation_resolver.create_many(
                 session=session,

--- a/lightly_studio/src/lightly_studio/plugins/operator_context.py
+++ b/lightly_studio/src/lightly_studio/plugins/operator_context.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Annotated, Union
+from typing import Annotated, Protocol, Union
 from uuid import UUID
 
 from pydantic import Field
@@ -36,6 +36,26 @@ AnyFilter = Annotated[
 ]
 
 
+class ProgressReporter(Protocol):
+    """Callback an operator uses to report how far along its run is."""
+
+    def __call__(self, *, current: int, total: int, description: str = "") -> None:
+        """Report progress of the current run.
+
+        Args:
+            current: Number of units processed so far.
+            total: Total number of units to process.
+            description: Human-readable description of the current step.
+        """
+
+
+# Defined above ExecutionContext because a dataclass field default is evaluated
+# when the class body runs, so it cannot live with the other private helpers at
+# the bottom of the file.
+def _report_progress_noop(*, current: int, total: int, description: str = "") -> None:
+    """Discard reported progress. Default for runs that report nowhere."""
+
+
 @dataclass
 class ExecutionContext:
     """Contextual data passed to ``BaseOperator.execute()``.
@@ -46,6 +66,15 @@ class ExecutionContext:
 
     collection_id: UUID
     context_filter: AnyFilter | None = None
+
+    report_progress: ProgressReporter = field(default=_report_progress_noop)
+    """Reports run progress to the UI.
+
+    Operators should call this from their sample loop, e.g.
+    ``context.report_progress(current=i, total=len(samples), description="Running inference")``.
+    Defaults to a no-op, so operators that do not report progress keep working
+    unchanged and the UI falls back to an indeterminate spinner.
+    """
 
 
 class OperatorScope(str, Enum):

--- a/lightly_studio/src/lightly_studio/plugins/operator_progress.py
+++ b/lightly_studio/src/lightly_studio/plugins/operator_progress.py
@@ -1,0 +1,69 @@
+"""Progress reporting for long-running operator executions.
+
+Operators receive a ``report_progress`` callable through their
+``ExecutionContext``. Calls land in the module-level ``progress_store``, which
+the ``GET /operators/runs/{run_id}/progress`` route reads while the blocking
+``execute`` request is still in flight.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass
+class OperatorProgress:
+    """Progress of a single operator run."""
+
+    current: int
+    """Number of units processed so far."""
+
+    total: int
+    """Total number of units to process. Zero when the total is not yet known."""
+
+    description: str = ""
+    """Human-readable description of the current step."""
+
+
+class ProgressStore:
+    """Thread-safe store holding the latest progress of in-flight operator runs.
+
+    FastAPI dispatches synchronous route handlers to its worker threadpool, so
+    concurrent operator runs report progress from different threads while the
+    polling route reads from yet another one. The lock guards the dict against
+    those concurrent accesses.
+
+    Entries are transient: the execute route removes a run's entry once the
+    operator returns, so the store only ever holds in-flight runs.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty progress store."""
+        self._lock = threading.Lock()
+        self._progress: dict[UUID, OperatorProgress] = {}
+
+    def set(self, run_id: UUID, progress: OperatorProgress) -> None:
+        """Record the latest progress of a run, replacing any previous value."""
+        with self._lock:
+            self._progress[run_id] = progress
+
+    def get(self, run_id: UUID) -> OperatorProgress | None:
+        """Return the latest progress of a run, or None if the run is unknown."""
+        with self._lock:
+            return self._progress.get(run_id)
+
+    def clear(self, run_id: UUID) -> None:
+        """Remove a run's progress. Does nothing if the run is unknown."""
+        with self._lock:
+            self._progress.pop(run_id, None)
+
+    def get_run_ids(self) -> list[UUID]:
+        """Return the ids of all runs currently holding progress."""
+        with self._lock:
+            return list(self._progress)
+
+
+# Global progress store instance.
+progress_store = ProgressStore()

--- a/lightly_studio/tests/api/routes/api/test_operator.py
+++ b/lightly_studio/tests/api/routes/api/test_operator.py
@@ -18,6 +18,7 @@ from lightly_studio.api.routes.api.status import (
 from lightly_studio.models.collection import SampleType
 from lightly_studio.plugins.base_operator import BaseOperator, OperatorResult, OperatorStatus
 from lightly_studio.plugins.operator_context import ExecutionContext, OperatorScope
+from lightly_studio.plugins.operator_progress import OperatorProgress, progress_store
 from lightly_studio.plugins.operator_registry import OperatorRegistry
 from lightly_studio.plugins.parameter import BaseParameter, BoolParameter, StringParameter
 from lightly_studio.resolvers.image_filter import FilterDimensions, ImageFilter
@@ -338,6 +339,82 @@ def test_execute_operator__sample_ids_filter_resolves_to_sample_filter(
     assert operator.captured_context.context_filter == SampleFilter(sample_ids=[sample_id])
 
 
+def test_execute_operator__reports_progress(
+    test_client: TestClient,
+    collection_id: UUID,
+    isolated_operator_registry: OperatorRegistry,
+) -> None:
+    """Progress reported during a run is readable from the progress endpoint."""
+    run_id = uuid4()
+    operator = ProgressReportingOperator()
+    isolated_operator_registry.register(operator)
+    operator_id = _get_operator_id_by_name(isolated_operator_registry, "progress-reporting")
+
+    response = test_client.post(
+        f"/api/operators/{operator_id}/execute",
+        json={
+            "parameters": {},
+            "context": {"collection_id": str(collection_id)},
+            "run_id": str(run_id),
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    # The operator polls its own progress mid-run, since the store is cleared by
+    # the time the response is returned.
+    assert operator.progress_during_run == OperatorProgress(
+        current=2, total=2, description="Running inference"
+    )
+
+
+def test_execute_operator__clears_progress_when_finished(
+    test_client: TestClient,
+    collection_id: UUID,
+    isolated_operator_registry: OperatorRegistry,
+) -> None:
+    run_id = uuid4()
+    isolated_operator_registry.register(ProgressReportingOperator())
+    operator_id = _get_operator_id_by_name(isolated_operator_registry, "progress-reporting")
+
+    test_client.post(
+        f"/api/operators/{operator_id}/execute",
+        json={
+            "parameters": {},
+            "context": {"collection_id": str(collection_id)},
+            "run_id": str(run_id),
+        },
+    )
+    response = test_client.get(f"/api/operators/runs/{run_id}/progress")
+
+    assert response.status_code == HTTP_STATUS_NOT_FOUND
+
+
+def test_execute_operator__without_run_id(
+    test_client: TestClient,
+    collection_id: UUID,
+    isolated_operator_registry: OperatorRegistry,
+) -> None:
+    """Reported progress is discarded when the client does not pass a run_id."""
+    operator = ProgressReportingOperator()
+    isolated_operator_registry.register(operator)
+    operator_id = _get_operator_id_by_name(isolated_operator_registry, "progress-reporting")
+
+    response = test_client.post(
+        f"/api/operators/{operator_id}/execute",
+        json={"parameters": {}, "context": {"collection_id": str(collection_id)}},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {"success": True, "message": "ok"}
+    assert operator.progress_during_run is None
+
+
+def test_get_operator_run_progress__unknown_run(test_client: TestClient) -> None:
+    response = test_client.get(f"/api/operators/runs/{uuid4()}/progress")
+
+    assert response.status_code == HTTP_STATUS_NOT_FOUND
+
+
 @dataclass
 class TestOperator(BaseOperator):
     name: str = "test operator"
@@ -417,3 +494,52 @@ class ImageScopeOperator(BaseOperator):
         _, _ = session, parameters
         self.captured_context = context
         return OperatorResult(success=True, message="ok")
+
+
+@dataclass
+class ProgressReportingOperator(BaseOperator):
+    """Operator that reports progress for two samples while it runs.
+
+    ``progress_during_run`` captures what the progress store held at the end of
+    the run, before the route clears it. The run id is recovered from the store
+    rather than passed in, because operators never receive it.
+    """
+
+    name: str = "progress-reporting"
+    description: str = "reports progress for two samples"
+    progress_during_run: OperatorProgress | None = None
+    status: OperatorStatus = OperatorStatus.READY
+
+    @property
+    def parameters(self) -> list[BaseParameter]:
+        return []
+
+    @property
+    def supported_scopes(self) -> list[OperatorScope]:
+        return [OperatorScope.ROOT]
+
+    def execute(
+        self,
+        *,
+        session: Session,
+        context: ExecutionContext,
+        parameters: dict[str, Any],
+    ) -> OperatorResult:
+        _, _ = session, parameters
+        total = 2
+        for current in range(1, total + 1):
+            context.report_progress(current=current, total=total, description="Running inference")
+        self.progress_during_run = _get_only_stored_progress()
+        return OperatorResult(success=True, message="ok")
+
+
+def _get_only_stored_progress() -> OperatorProgress | None:
+    """Return the single in-flight run's progress, or None if nothing is stored.
+
+    Looks the run up by scanning the store because only the route knows the
+    run id that the client generated.
+    """
+    run_ids = progress_store.get_run_ids()
+    if not run_ids:
+        return None
+    return progress_store.get(run_id=run_ids[0])

--- a/lightly_studio/tests/plugins/test_operator_progress.py
+++ b/lightly_studio/tests/plugins/test_operator_progress.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from lightly_studio.plugins.operator_progress import OperatorProgress, ProgressStore
+
+
+class TestProgressStore:
+    def test_get__unknown_run(self) -> None:
+        store = ProgressStore()
+
+        assert store.get(run_id=uuid4()) is None
+
+    def test_set(self) -> None:
+        store = ProgressStore()
+        run_id = uuid4()
+
+        store.set(
+            run_id=run_id,
+            progress=OperatorProgress(current=3, total=10, description="Running inference"),
+        )
+
+        assert store.get(run_id=run_id) == OperatorProgress(
+            current=3, total=10, description="Running inference"
+        )
+
+    def test_set__overwrites_previous_progress(self) -> None:
+        store = ProgressStore()
+        run_id = uuid4()
+
+        store.set(run_id=run_id, progress=OperatorProgress(current=3, total=10))
+        store.set(run_id=run_id, progress=OperatorProgress(current=7, total=10))
+
+        assert store.get(run_id=run_id) == OperatorProgress(current=7, total=10)
+
+    def test_set__runs_are_independent(self) -> None:
+        store = ProgressStore()
+        first_run_id = uuid4()
+        second_run_id = uuid4()
+
+        store.set(run_id=first_run_id, progress=OperatorProgress(current=1, total=10))
+        store.set(run_id=second_run_id, progress=OperatorProgress(current=5, total=20))
+
+        assert store.get(run_id=first_run_id) == OperatorProgress(current=1, total=10)
+        assert store.get(run_id=second_run_id) == OperatorProgress(current=5, total=20)
+
+    def test_clear(self) -> None:
+        store = ProgressStore()
+        run_id = uuid4()
+        store.set(run_id=run_id, progress=OperatorProgress(current=3, total=10))
+
+        store.clear(run_id=run_id)
+
+        assert store.get(run_id=run_id) is None
+
+    def test_clear__unknown_run(self) -> None:
+        store = ProgressStore()
+
+        # Clearing a run that was never recorded must not raise.
+        store.clear(run_id=uuid4())

--- a/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/OperatorDialog.svelte
@@ -26,7 +26,7 @@
     import type { SampleType } from '$lib/api/lightly_studio_local';
     import { useTags } from '$lib/hooks/useTags/useTags';
     import { useQueryClient } from '@tanstack/svelte-query';
-    import { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
+    import { useOperatorsDialog, useOperatorProgress } from '$lib/hooks';
 
     interface Props {
         operatorMetadata: RegisteredOperatorMetadata | null;
@@ -56,7 +56,11 @@
     );
 
     const queryClient = useQueryClient();
-    const { setPluginExecuting } = useOperatorsDialog();
+    const { setPluginExecuting, setPluginProgress } = useOperatorsDialog();
+    const { progress, startPolling, stopPolling } = useOperatorProgress();
+
+    // Mirror polled progress into the global store the overlay reads.
+    progress.subscribe((value) => setPluginProgress(value));
 
     const collectionId = $page.params.collection_id;
 
@@ -126,6 +130,9 @@
         executionError = undefined;
         executionSuccess = undefined;
 
+        const runId = crypto.randomUUID();
+        startPolling(runId);
+
         try {
             const response = await executeOperator({
                 path: { operator_id: operator.id },
@@ -134,7 +141,8 @@
                     context: {
                         collection_id: currentCollectionId,
                         ...($contextFilter !== undefined && { context_filter: $contextFilter })
-                    }
+                    },
+                    run_id: runId
                 }
             });
 
@@ -156,6 +164,8 @@
             executionError = message;
             toast.error('Operator execution failed', { description: message });
         } finally {
+            // Always stop the timer, so a failed execution cannot leak a poll loop.
+            stopPolling();
             isExecuting = false;
             setPluginExecuting(false);
         }

--- a/lightly_studio_view/src/lib/components/PluginExecutingOverlay/PluginExecutingOverlay.svelte
+++ b/lightly_studio_view/src/lib/components/PluginExecutingOverlay/PluginExecutingOverlay.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
     import Spinner from '$lib/components/Spinner/Spinner.svelte';
+    import { Progress } from '$lib/components/ui/progress';
     import { useOperatorsDialog } from '$lib/hooks';
 
-    const { isPluginExecuting } = useOperatorsDialog();
+    const { isPluginExecuting, pluginProgress } = useOperatorsDialog();
+
+    // Plugins report a total of 0 until they know how much work there is.
+    const hasProgress = $derived($pluginProgress !== null && $pluginProgress.total > 0);
+    const percent = $derived(
+        hasProgress && $pluginProgress
+            ? Math.round(($pluginProgress.current / $pluginProgress.total) * 100)
+            : 0
+    );
 </script>
 
 {#if $isPluginExecuting}
@@ -13,10 +22,25 @@
         aria-label="Plugin executing"
     >
         <div class="flex flex-col items-center gap-4 rounded-lg bg-background p-8 shadow-lg">
-            <Spinner size="large" />
-            <p class="text-sm text-foreground">
-                Plugin executing. This might take up to several minutes…
-            </p>
+            {#if hasProgress && $pluginProgress}
+                <div class="flex w-72 flex-col gap-2">
+                    <div class="flex items-baseline justify-between">
+                        <p class="text-sm text-foreground">
+                            {$pluginProgress.description || 'Plugin executing'}
+                        </p>
+                        <span class="text-sm font-medium text-foreground">{percent}%</span>
+                    </div>
+                    <Progress value={percent} aria-label="Plugin execution progress" />
+                    <p class="text-xs text-muted-foreground">
+                        {$pluginProgress.current} / {$pluginProgress.total} samples
+                    </p>
+                </div>
+            {:else}
+                <Spinner size="large" />
+                <p class="text-sm text-foreground">
+                    Plugin executing. This might take up to several minutes…
+                </p>
+            {/if}
         </div>
     </div>
 {/if}

--- a/lightly_studio_view/src/lib/components/PluginExecutingOverlay/PluginExecutingOverlay.test.ts
+++ b/lightly_studio_view/src/lib/components/PluginExecutingOverlay/PluginExecutingOverlay.test.ts
@@ -3,11 +3,12 @@ import { afterEach, describe, expect, it } from 'vitest';
 import PluginExecutingOverlay from './PluginExecutingOverlay.svelte';
 import { useOperatorsDialog } from '$lib/hooks';
 
-const { setPluginExecuting } = useOperatorsDialog();
+const { setPluginExecuting, setPluginProgress } = useOperatorsDialog();
 
 describe('PluginExecutingOverlay', () => {
     afterEach(() => {
         setPluginExecuting(false);
+        setPluginProgress(null);
         document.body.innerHTML = '';
     });
 
@@ -31,5 +32,29 @@ describe('PluginExecutingOverlay', () => {
         await screen.findByRole('dialog');
         setPluginExecuting(false);
         await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+
+    it('shows reported progress instead of the spinner', async () => {
+        render(PluginExecutingOverlay);
+        setPluginExecuting(true);
+        setPluginProgress({ current: 128, total: 1000, description: 'Running inference' });
+
+        await screen.findByText('13%');
+        expect(screen.getByText('Running inference')).toBeInTheDocument();
+        expect(screen.getByText('128 / 1000 samples')).toBeInTheDocument();
+        expect(
+            screen.queryByText('Plugin executing. This might take up to several minutes…')
+        ).not.toBeInTheDocument();
+    });
+
+    it('falls back to the spinner when the total is not known yet', async () => {
+        render(PluginExecutingOverlay);
+        setPluginExecuting(true);
+        setPluginProgress({ current: 0, total: 0, description: '' });
+
+        await screen.findByRole('dialog');
+        expect(
+            screen.getByText('Plugin executing. This might take up to several minutes…')
+        ).toBeInTheDocument();
     });
 });

--- a/lightly_studio_view/src/lib/components/ui/progress/index.ts
+++ b/lightly_studio_view/src/lib/components/ui/progress/index.ts
@@ -1,0 +1,7 @@
+import Root from "./progress.svelte";
+
+export {
+	Root,
+	//
+	Root as Progress,
+};

--- a/lightly_studio_view/src/lib/components/ui/progress/progress.svelte
+++ b/lightly_studio_view/src/lib/components/ui/progress/progress.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { Progress as ProgressPrimitive, type WithoutChildrenOrChild } from "bits-ui";
+	import { cn } from "$lib/utils/shadcn.js";
+
+	let {
+		ref = $bindable(null),
+		value = 0,
+		max = 100,
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<ProgressPrimitive.RootProps> = $props();
+</script>
+
+<ProgressPrimitive.Root
+	bind:ref
+	{value}
+	{max}
+	class={cn("bg-secondary relative h-2 w-full overflow-hidden rounded-full", className)}
+	{...restProps}
+>
+	<div
+		class="bg-primary h-full w-full flex-1 transition-transform duration-300 ease-out"
+		style="transform: translateX(-{100 - ((value ?? 0) / (max || 1)) * 100}%)"
+	></div>
+</ProgressPrimitive.Root>

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -43,6 +43,7 @@ export { useColorPicker } from '$lib/hooks/useColorPicker/useColorPicker.svelte'
 export { useSubmitCombinationSelection } from '$lib/hooks/useSubmitCombinationSelection/useSubmitCombinationSelection';
 export { usePostHog } from '$lib/hooks/usePostHog';
 export { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
+export { useOperatorProgress } from '$lib/hooks/useOperatorProgress/useOperatorProgress';
 export { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
 export { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
 export { useSettings } from '$lib/hooks/useSettings';

--- a/lightly_studio_view/src/lib/hooks/useOperatorProgress/useOperatorProgress.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorProgress/useOperatorProgress.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import type { OperatorProgress } from '$lib/api/lightly_studio_local';
+import { useOperatorProgress } from './useOperatorProgress';
+
+vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
+    getOperatorRunProgress: vi.fn()
+}));
+
+const { getOperatorRunProgress } = await import('$lib/api/lightly_studio_local/sdk.gen');
+
+const RUN_ID = '11111111-1111-1111-1111-111111111111';
+
+function mockProgressResponse(progress: OperatorProgress) {
+    vi.mocked(getOperatorRunProgress).mockResolvedValue({
+        data: progress,
+        error: undefined,
+        request: {} as Request,
+        response: {} as Response
+    });
+}
+
+/** The backend answers 404 until the run reports, and again once it finishes. */
+function mockNoProgressResponse() {
+    vi.mocked(getOperatorRunProgress).mockResolvedValue({
+        data: undefined,
+        error: { detail: [] },
+        request: {} as Request,
+        response: {} as Response
+    });
+}
+
+describe('useOperatorProgress', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('starts with no progress', () => {
+        const { progress } = useOperatorProgress();
+
+        expect(get(progress)).toBeNull();
+    });
+
+    it('polls the reported progress of a run', async () => {
+        mockProgressResponse({ current: 5, total: 10, description: 'Running inference' });
+        const { progress, startPolling, stopPolling } = useOperatorProgress();
+
+        startPolling(RUN_ID);
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(getOperatorRunProgress).toHaveBeenCalledWith({ path: { run_id: RUN_ID } });
+        expect(get(progress)).toEqual({
+            current: 5,
+            total: 10,
+            description: 'Running inference'
+        });
+
+        stopPolling();
+    });
+
+    it('reports no progress while the run is unknown to the backend', async () => {
+        mockNoProgressResponse();
+        const { progress, startPolling, stopPolling } = useOperatorProgress();
+
+        startPolling(RUN_ID);
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(get(progress)).toBeNull();
+
+        stopPolling();
+    });
+
+    it('stops polling and clears progress', async () => {
+        mockProgressResponse({ current: 5, total: 10, description: '' });
+        const { progress, startPolling, stopPolling } = useOperatorProgress();
+        startPolling(RUN_ID);
+        await vi.advanceTimersByTimeAsync(500);
+
+        stopPolling();
+        vi.mocked(getOperatorRunProgress).mockClear();
+        await vi.advanceTimersByTimeAsync(2000);
+
+        expect(get(progress)).toBeNull();
+        expect(getOperatorRunProgress).not.toHaveBeenCalled();
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useOperatorProgress/useOperatorProgress.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorProgress/useOperatorProgress.ts
@@ -1,0 +1,50 @@
+import { browser } from '$app/environment';
+import { writable, type Readable } from 'svelte/store';
+import { getOperatorRunProgress, type OperatorProgress } from '$lib/api/lightly_studio_local';
+
+const POLL_INTERVAL_MS = 500;
+
+interface UseOperatorProgressReturn {
+    progress: Readable<OperatorProgress | null>;
+    startPolling: (runId: string) => void;
+    stopPolling: () => void;
+}
+
+/**
+ * Polls the progress of an in-flight operator run.
+ *
+ * The execute request blocks until the operator finishes, so progress is read
+ * from a separate endpoint while that request is still pending. The backend
+ * answers with 404 until the operator reports for the first time and again once
+ * the run is done, which both surface here as `null`.
+ */
+export function useOperatorProgress(): UseOperatorProgressReturn {
+    const progress = writable<OperatorProgress | null>(null);
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const stopPolling = () => {
+        if (intervalId !== undefined) {
+            clearInterval(intervalId);
+            intervalId = undefined;
+        }
+        progress.set(null);
+    };
+
+    const startPolling = (runId: string) => {
+        // Guard against SSR, where there is no request to poll alongside.
+        if (!browser) return;
+        stopPolling();
+        intervalId = setInterval(async () => {
+            try {
+                const response = await getOperatorRunProgress({ path: { run_id: runId } });
+                progress.set(response.data ?? null);
+            } catch {
+                // A failed poll is not worth surfacing: the execute request owns
+                // error reporting, and the next tick may well succeed.
+                progress.set(null);
+            }
+        }, POLL_INTERVAL_MS);
+    };
+
+    return { progress, startPolling, stopPolling };
+}

--- a/lightly_studio_view/src/lib/hooks/useOperatorsDialog/useOperatorsDialog.ts
+++ b/lightly_studio_view/src/lib/hooks/useOperatorsDialog/useOperatorsDialog.ts
@@ -1,7 +1,9 @@
 import { writable } from 'svelte/store';
+import type { OperatorProgress } from '$lib/api/lightly_studio_local';
 
 const isOperatorsDialogOpen = writable(false);
 const isPluginExecuting = writable(false);
+const pluginProgress = writable<OperatorProgress | null>(null);
 
 export function useOperatorsDialog() {
     const openOperatorsDialog = () => {
@@ -16,11 +18,19 @@ export function useOperatorsDialog() {
         isPluginExecuting.set(executing);
     };
 
+    // Null while the running plugin has not reported progress, which keeps the
+    // overlay on its indeterminate spinner.
+    const setPluginProgress = (progress: OperatorProgress | null) => {
+        pluginProgress.set(progress);
+    };
+
     return {
         isOperatorsDialogOpen,
         isPluginExecuting,
+        pluginProgress,
         openOperatorsDialog,
         closeOperatorsDialog,
-        setPluginExecuting
+        setPluginExecuting,
+        setPluginProgress
     };
 }


### PR DESCRIPTION
## What has changed and why?

Operator (plugin) executions block until they finish, so the UI could only show an indeterminate spinner. For long-running plugins like model inference, users couldn't tell if a run was progressing.

This adds end-to-end progress reporting:

- **Backend**: operators call `context.report_progress(current=, total=, description=)` on their `ExecutionContext`. Values land in a thread-safe `ProgressStore`, readable via the new `GET /operators/runs/{run_id}/progress` route while the blocking execute request is still in flight. The execute request accepts an optional client-generated `run_id` and clears the store entry when it returns.
- **Frontend**: `useOperatorProgress` polls that route every 500 ms; `PluginExecutingOverlay` shows a progress bar with percentage, step description, and sample count.
- **Example**: the COCO demo inference operator reports progress as a reference for plugin authors.

Backwards compatible: `report_progress` defaults to a no-op and the overlay falls back to the spinner when no progress is reported.

## How has it been tested?

- New backend tests for `ProgressStore` (incl. concurrent access) and the progress route (404 for unknown runs, reporting via context, cleanup after execute).
- New frontend tests for the polling hook and both overlay states (progress bar / spinner fallback).

```
cd lightly_studio && make static-checks && make test
cd lightly_studio_view && make static-checks && make test
```

Manually: ran the COCO plugins demo inference operator over a collection and confirmed the bar fills and closes on completion.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)
