### PR TITLE
Add an empty Embeddings docs page under Concepts

### DIFF
--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -1,0 +1,3 @@
+# Embeddings
+
+TODO(Michal)

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -196,6 +196,10 @@ to explore embeddings, remove near-duplicates, auto-label, and train a model —
 
     [![Metadata](https://storage.googleapis.com/lightly-public/studio/docs_cards/metadata.png)](concepts_and_tools/metadata.md)
 
+-   **[Embeddings](concepts_and_tools/embeddings.md)**
+
+    [![Embeddings](https://storage.googleapis.com/lightly-public/studio/docs_cards/embeddings.png)](concepts_and_tools/embeddings.md)
+
 </div>
 
 ### Tools

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - Tags: concepts_and_tools/tags.md
       - Captions: concepts_and_tools/captions.md
       - Metadata: concepts_and_tools/metadata.md
+      - Embeddings: concepts_and_tools/embeddings.md
     - Tools:
       - Search and Filter: concepts_and_tools/search_and_filter.md
       - Dataset Distributions: concepts_and_tools/dataset_distributions.md


### PR DESCRIPTION
## What has changed and why?

Adds a placeholder Embeddings page to the docs under **Concepts**, wired into
the nav and shown as a card on the docs landing page. Content is a stub for now.

## How has it been tested?

Local docs build.

<img width="826" height="664" alt="Screenshot 2026-08-05 at 14 37 52" src="https://github.com/user-attachments/assets/9ad3c323-1fed-4a9b-ba69-2a287fe6147f" />
<img width="1298" height="555" alt="Screenshot 2026-08-05 at 14 38 06" src="https://github.com/user-attachments/assets/28c719b8-26ff-49e2-a7de-9c11d17eb234" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Embeddings page to the documentation.
  * Added Embeddings to the Concepts overview with a dedicated card and link.
  * Included Embeddings in the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->