### PR TITLE
Add: example for loading precomputed embeddings

### DIFF
--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -1,0 +1,3 @@
+# Embeddings
+
+TODO(Michal)

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -196,6 +196,10 @@ to explore embeddings, remove near-duplicates, auto-label, and train a model —
 
     [![Metadata](https://storage.googleapis.com/lightly-public/studio/docs_cards/metadata.png)](concepts_and_tools/metadata.md)
 
+-   **[Embeddings](concepts_and_tools/embeddings.md)**
+
+    [![Embeddings](https://storage.googleapis.com/lightly-public/studio/docs_cards/embeddings.png)](concepts_and_tools/embeddings.md)
+
 </div>
 
 ### Tools

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - Tags: concepts_and_tools/tags.md
       - Captions: concepts_and_tools/captions.md
       - Metadata: concepts_and_tools/metadata.md
+      - Embeddings: concepts_and_tools/embeddings.md
     - Tools:
       - Search and Filter: concepts_and_tools/search_and_filter.md
       - Dataset Distributions: concepts_and_tools/dataset_distributions.md

--- a/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
+++ b/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
@@ -29,8 +29,12 @@ def create_mock_embeddings(dataset_path: Path) -> dict[str, NDArray[np.float32]]
 
     The embeddings are mocked here, a real implementation would read them from a file.
     """
+    # Key by the same absolute posix path the backend stores as file_path_abs, so
+    # the lookup in embed_images matches. A relative key here would never match.
     filepaths = sorted(
-        str(path) for path in dataset_path.rglob("*") if path.suffix.lower() in IMAGE_SUFFIXES
+        path.absolute().as_posix()
+        for path in dataset_path.rglob("*")
+        if path.suffix.lower() in IMAGE_SUFFIXES
     )
     rng = np.random.default_rng(seed=0)
     return {filepath: rng.random(EMBEDDING_DIMENSION, dtype=np.float32) for filepath in filepaths}

--- a/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
+++ b/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
@@ -1,0 +1,130 @@
+"""Example of how to load precomputed embeddings.
+
+Implement a class inheriting from ls.ImageEmbeddingGenerator. For image datasets,
+only `get_embedding_model_input` and `embed_images` functions are necessary.
+Register the generator with `ls.set_default_embedding_model`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import numpy as np
+from environs import Env
+from numpy.typing import NDArray
+from PIL import Image
+
+import lightly_studio as ls
+from lightly_studio.database import db_manager
+from lightly_studio.dataset.embedding_result import EmbeddingResult
+from lightly_studio.models.embedding_model import EmbeddingModelCreate
+
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+EMBEDDING_DIMENSION = 64
+
+
+def create_mock_embeddings(dataset_path: Path) -> dict[str, NDArray[np.float32]]:
+    """Return a dictionary that maps each filepath to a random vector.
+
+    The embeddings are mocked here, a real implementation would read them from a file.
+    """
+    filepaths = sorted(
+        str(path) for path in dataset_path.rglob("*") if path.suffix.lower() in IMAGE_SUFFIXES
+    )
+    rng = np.random.default_rng(seed=0)
+    return {filepath: rng.random(EMBEDDING_DIMENSION, dtype=np.float32) for filepath in filepaths}
+
+
+class LoadExistingEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
+    """A generator that loads precomputed embeddings by filepath."""
+
+    def __init__(self, embeddings_by_filepath: dict[str, NDArray[np.float32]]) -> None:
+        """Store the precomputed vectors.
+
+        Args:
+            embeddings_by_filepath: Precomputed embedding vector for each filepath.
+        """
+        self._embeddings_by_filepath = embeddings_by_filepath
+
+    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+        """Describe the model so it can be recorded in the database."""
+        return EmbeddingModelCreate(
+            name="Precomputed Embeddings",
+            embedding_model_hash="precomputed",
+            embedding_dimension=EMBEDDING_DIMENSION,
+            collection_id=collection_id,
+        )
+
+    def embed_text(self, text: str) -> list[float]:
+        """Not supported: there is no text encoder for precomputed vectors."""
+        raise NotImplementedError(
+            "LoadExistingEmbeddingsGenerator has no text encoder; text search is "
+            "unavailable. Supply an encoder that shares the precomputed space to "
+            "enable it."
+        )
+
+    def embed_images(self, filepaths: list[str], show_progress: bool = True) -> EmbeddingResult:
+        """Look up the precomputed vector for each filepath.
+
+        This method returns one row for each filepath that has a stored vector.
+        It uses kept_indices to skip a filepath that has no vector.
+        """
+        _ = show_progress  # No progress bar. This step is a lookup, not a model run.
+        rows: list[NDArray[np.float32]] = []
+        kept_indices: list[int] = []
+        for index, filepath in enumerate(filepaths):
+            embedding = self._embeddings_by_filepath.get(filepath)
+            if embedding is None:
+                continue
+            rows.append(embedding)
+            kept_indices.append(index)
+
+        embeddings = (
+            np.stack(rows) if rows else np.empty((0, EMBEDDING_DIMENSION), dtype=np.float32)
+        )
+        return EmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
+
+    def embed_image_crops(
+        self, image_crops: list[ls.ImageCrop], show_progress: bool = True
+    ) -> EmbeddingResult:
+        """Not supported: crops have no precomputed vectors."""
+        raise NotImplementedError(
+            "LoadExistingEmbeddingsGenerator only serves precomputed whole-image "
+            "embeddings; object-level (crop) embeddings are unavailable."
+        )
+
+    def embed_pil_images(
+        self, images: list[Image.Image], show_progress: bool = True
+    ) -> NDArray[np.float32]:
+        """Not supported: in-memory images have no precomputed vectors."""
+        raise NotImplementedError(
+            "LoadExistingEmbeddingsGenerator only serves precomputed vectors keyed "
+            "by filepath; in-memory PIL images cannot be looked up."
+        )
+
+
+# Read environment variables
+env = Env()
+env.read_env()
+
+# Remove any existing database
+db_manager.connect(cleanup_existing=True)
+
+# Get the path to the dataset directory
+dataset_path = env.path("EXAMPLES_DATASET_PATH")
+
+# Load the precomputed embeddings. Here they are mocked. In a real setup, load
+# your own vectors keyed by filepath.
+embeddings_by_filepath = create_mock_embeddings(dataset_path=dataset_path)
+
+# Register the generator BEFORE you create the dataset. It overrides the model
+# from LIGHTLY_STUDIO_EMBEDDINGS_MODEL_TYPE for every collection.
+ls.set_default_embedding_model(LoadExistingEmbeddingsGenerator(embeddings_by_filepath))
+
+# Create a dataset from a path. The images reuse the precomputed embeddings
+# instead of new ones.
+dataset = ls.ImageDataset.create()
+dataset.add_images_from_path(path=str(dataset_path))
+
+ls.start_gui()

--- a/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
+++ b/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
@@ -3,6 +3,9 @@
 Implement a class inheriting from ls.ImageEmbeddingGenerator. For image datasets,
 only `get_embedding_model_input` and `embed_images` functions are necessary.
 Register the generator with `ls.set_default_embedding_model`.
+
+For video datasets, implement ls.VideoEmbeddingGenerator as well to override the
+video model.
 """
 
 from __future__ import annotations
@@ -27,7 +30,9 @@ EMBEDDING_DIMENSION = 64
 def create_mock_embeddings(dataset_path: Path) -> dict[str, NDArray[np.float32]]:
     """Return a dictionary that maps each filepath to a random vector.
 
-    The embeddings are mocked here, a real implementation would read them from a file.
+    The returned dictionary is conceptually just `filepath -> vector`, for example
+    `{"/data/images/cat.jpg": [0.1, 0.2, ...]}`. The embeddings are mocked here, a
+    real implementation would read them from a file.
     """
     # Key by the same absolute posix path the backend stores as file_path_abs, so
     # the lookup in embed_images matches. A relative key here would never match.
@@ -126,8 +131,7 @@ embeddings_by_filepath = create_mock_embeddings(dataset_path=dataset_path)
 # from LIGHTLY_STUDIO_EMBEDDINGS_MODEL_TYPE for every collection.
 ls.set_default_embedding_model(LoadExistingEmbeddingsGenerator(embeddings_by_filepath))
 
-# Create a dataset from a path. The images reuse the precomputed embeddings
-# instead of new ones.
+# Create a dataset from a path. The embedding generator is invoked here.
 dataset = ls.ImageDataset.create()
 dataset.add_images_from_path(path=str(dataset_path))
 


### PR DESCRIPTION
## What has changed and why?

Adds an example showing how to feed precomputed embeddings into LightlyStudio. It implements an `ImageEmbeddingGenerator` that looks up stored vectors by filepath and registers it via `set_default_embedding_model`, so a dataset reuses existing vectors instead of computing new ones.

## How has it been tested?

Ran the example locally against a sample dataset.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)
