### PR TITLE
Frontend, Part 3: Add Storybook stories and a runnable table parameter example

### DIFF
--- a/lightly_studio/src/lightly_studio/examples/example_table_parameter.py
+++ b/lightly_studio/src/lightly_studio/examples/example_table_parameter.py
@@ -1,0 +1,107 @@
+"""Example of an operator with a table parameter.
+
+A `TableParameter` accepts a variable number of rows sharing the same columns. Each column is a
+built-in parameter, so it carries its own type, description, default and required flag. The GUI
+renders one cell per column, typed after that column, and the operator receives the rows as a
+`list[dict[str, Any]]` keyed by column name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from environs import Env
+from sqlmodel import Session
+
+import lightly_studio as ls
+from lightly_studio.database import db_manager
+from lightly_studio.plugins.base_operator import BaseOperator, OperatorResult
+from lightly_studio.plugins.operator_context import ExecutionContext, OperatorScope
+from lightly_studio.plugins.operator_registry import operator_registry
+from lightly_studio.plugins.parameter import (
+    BaseParameter,
+    BoolParameter,
+    FloatParameter,
+    StringParameter,
+    TableParameter,
+)
+
+PROMPTS = "prompts"
+
+
+@dataclass
+class PromptTableOperator(BaseOperator):
+    """Operator that collects prompts and their settings through a table parameter."""
+
+    name: str = "Prompt Table"
+    description: str = "Collects a table of segmentation prompts and their settings."
+
+    @property
+    def parameters(self) -> list[BaseParameter]:
+        """Return the list of parameters this operator expects."""
+        return [
+            TableParameter(
+                name=PROMPTS,
+                description="Prompts to segment with and how to filter their masks.",
+                # More columns than the dialog fits, so the table scrolls horizontally.
+                columns=[
+                    StringParameter(name="prompt", description="What to segment."),
+                    StringParameter(
+                        name="label", description="Label for the masks.", default="pedestrian"
+                    ),
+                    FloatParameter(
+                        name="threshold", description="Minimum confidence.", default=0.5
+                    ),
+                    BoolParameter(name="enabled", description="Run this prompt.", default=True),
+                ],
+                # A row must hold every declared column, so the default fills all four in.
+                default=[
+                    {"prompt": "person", "label": "pedestrian", "threshold": 0.5, "enabled": True}
+                ],
+            ),
+        ]
+
+    @property
+    def supported_scopes(self) -> list[OperatorScope]:
+        """Return the list of scopes this operator can be triggered from."""
+        return [OperatorScope.ROOT]
+
+    def execute(
+        self,
+        *,
+        session: Session,  # noqa: ARG002
+        context: ExecutionContext,  # noqa: ARG002
+        parameters: dict[str, Any],
+    ) -> OperatorResult:
+        """Report the prompts that were entered in the GUI.
+
+        Args:
+            session: Database session.
+            context: Execution context containing collection_id and optional filter.
+            parameters: Parameters passed to the operator.
+
+        Returns:
+            An OperatorResult listing the received rows.
+        """
+        # Parameters reach the operator unvalidated, so check the shape before reading cells.
+        rows = parameters.get(PROMPTS)
+        if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+            return OperatorResult(success=False, message="Expected a table of prompts.")
+        if not rows:
+            return OperatorResult(success=False, message="No prompts provided.")
+
+        summary = ", ".join(f"{row.get('prompt')} -> {row.get('label')}" for row in rows)
+        return OperatorResult(success=True, message=f"Received {len(rows)} prompt(s): {summary}")
+
+
+env = Env()
+env.read_env()
+
+db_manager.connect(cleanup_existing=True)
+operator_registry.register(operator=PromptTableOperator())
+
+dataset = ls.ImageDataset.create()
+dataset.add_images_from_path(path=env.path("EXAMPLES_DATASET_PATH"))
+
+ls.start_gui()

--- a/lightly_studio_view/src/lib/components/Operator/ParameterTable/ParameterTable.stories.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/ParameterTable/ParameterTable.stories.svelte
@@ -1,0 +1,82 @@
+<script module lang="ts">
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import { fn } from 'storybook/test';
+    import ParameterTable from './ParameterTable.svelte';
+
+    const { Story } = defineMeta({
+        title: 'Components/Operator/ParameterTable',
+        component: ParameterTable,
+        tags: ['autodocs'],
+        parameters: { layout: 'centered' },
+        args: {
+            name: 'prompts',
+            required: true,
+            isMissing: false,
+            description: 'Prompt to segment with and the label to assign to the masks.',
+            onUpdate: fn()
+        }
+    });
+</script>
+
+<script lang="ts">
+    import { column } from '../fixtures';
+    import { promptColumns, promptRows, wideColumns, wideRows } from './storyFixtures';
+</script>
+
+<!-- The table fills whatever width it is given, so every story renders at the width it would have in
+     the operator dialog: max-w-md (28rem) less the dialog's own p-6. Without this the stories size to
+     their content and the scrolling ones never overflow. -->
+{#snippet dialogWidth(args)}
+    <div class="w-[25rem]">
+        <ParameterTable {...args} />
+    </div>
+{/snippet}
+
+<Story name="Empty" args={{ value: [], columns: promptColumns }} template={dialogWidth} />
+
+<Story
+    name="With rows"
+    args={{ value: promptRows.slice(0, 2), columns: promptColumns }}
+    template={dialogWidth}
+/>
+
+<Story
+    name="Incomplete row (invalid)"
+    args={{ value: [{ prompt: '', label: 'pedestrian' }], columns: promptColumns, isMissing: true }}
+    template={dialogWidth}
+/>
+
+<!-- The header stays pinned to the top of the box while the rows scroll. -->
+<Story
+    name="Many rows (scrolling)"
+    args={{ value: promptRows, columns: promptColumns }}
+    template={dialogWidth}
+/>
+
+<!-- Columns stop shrinking at 9rem, so past two of them the table scrolls sideways rather than
+     squeezing the cells. A `float` column renders a number input and a `bool` column a checkbox. -->
+<Story
+    name="Many columns (horizontal scroll)"
+    args={{ value: wideRows.slice(0, 2), columns: wideColumns }}
+    template={dialogWidth}
+/>
+
+<!-- Both axes at once: the header stays pinned to the top, the remove button to the right, and the
+     corner where the two meet stays covered. -->
+<Story
+    name="Many columns and rows (both scrollbars)"
+    args={{ value: wideRows, columns: wideColumns }}
+    template={dialogWidth}
+/>
+
+<Story
+    name="Single column"
+    args={{
+        name: 'classes',
+        value: [{ class: 'person' }, { class: 'car' }],
+        columns: [column({ name: 'class', description: 'Class to keep.' })],
+        required: false,
+        description: undefined
+    }}
+    template={dialogWidth}
+/>

--- a/lightly_studio_view/src/lib/components/Operator/ParameterTable/ParameterTable.svelte
+++ b/lightly_studio_view/src/lib/components/Operator/ParameterTable/ParameterTable.svelte
@@ -198,8 +198,8 @@
     {#if isMissing}
         <p class="text-sm text-destructive-text">
             {required && rows.length === 0
-                ? 'Add at least one row and fill in every highlighted cell.'
-                : 'Fill in every highlighted cell.'}
+                ? 'Add at least one row and fill in every empty cell.'
+                : 'Fill in every empty cell.'}
         </p>
     {/if}
 </div>

--- a/lightly_studio_view/src/lib/components/Operator/ParameterTable/ParameterTable.test.ts
+++ b/lightly_studio_view/src/lib/components/Operator/ParameterTable/ParameterTable.test.ts
@@ -132,7 +132,7 @@ describe('ParameterTable', () => {
         });
 
         expect(
-            screen.getByText('Add at least one row and fill in every highlighted cell.')
+            screen.getByText('Add at least one row and fill in every empty cell.')
         ).toBeInTheDocument();
     });
 
@@ -149,7 +149,7 @@ describe('ParameterTable', () => {
             }
         });
 
-        expect(screen.getByText('Fill in every highlighted cell.')).toBeInTheDocument();
+        expect(screen.getByText('Fill in every empty cell.')).toBeInTheDocument();
         expect(screen.getByTestId('parameter-table-prompts-prompt-0')).toBeInvalid();
     });
 

--- a/lightly_studio_view/src/lib/components/Operator/ParameterTable/storyFixtures.ts
+++ b/lightly_studio_view/src/lib/components/Operator/ParameterTable/storyFixtures.ts
@@ -1,0 +1,36 @@
+import type { OperatorParameterColumn } from '$lib/hooks';
+import { column } from '../fixtures';
+import type { ParameterTableRow } from '../parameterTypeConfig';
+
+/** The two `str` columns a segmentation operator declares. `column()` already covers `prompt`. */
+export const promptColumns: OperatorParameterColumn[] = [
+    column({ description: 'What to segment in the image.' }),
+    column({ name: 'label', description: 'Label for the masks.', required: false })
+];
+
+/** Every cell type, and more columns than the dialog fits, so the table scrolls sideways. */
+export const wideColumns: OperatorParameterColumn[] = [
+    ...promptColumns,
+    column({ name: 'limit', paramType: 'int', default: 5, required: false }),
+    column({ name: 'threshold', paramType: 'float', default: 0.5, required: false }),
+    column({ name: 'enabled', paramType: 'bool', default: true, required: false })
+];
+
+/** Seven rows: past the four the table shows before it starts scrolling vertically. */
+export const promptRows: ParameterTableRow[] = [
+    { prompt: 'person', label: 'pedestrian' },
+    { prompt: 'car', label: 'vehicle' },
+    { prompt: 'dog', label: 'animal' },
+    { prompt: 'tree', label: 'plant' },
+    { prompt: 'bicycle', label: 'vehicle' },
+    { prompt: 'traffic light', label: 'signal' },
+    { prompt: 'building', label: 'structure' }
+];
+
+/** The same rows with a cell for every `wideColumns` column, so no cell reads as missing. */
+export const wideRows: ParameterTableRow[] = promptRows.map((row, index) => ({
+    ...row,
+    limit: index + 1,
+    threshold: 0.5,
+    enabled: index % 2 === 0
+}));


### PR DESCRIPTION
## What has changed and why?

Frontend Part 3 of the table parameter stack, on top of Part 2 (#1802). Stories and an
example only — no production code changes.

- `ParameterTable.stories.svelte` — seven stories. Four cover the scroll states unit tests
  can't assert on: the header stays pinned while rows scroll, the remove button while columns
  scroll, and the corner where they meet. The rest cover empty, populated, invalid and
  single-column. Columns come from the shared `column()` fixture; shared args live in
  `defineMeta`.
- `examples/example_table_parameter.py` — a runnable operator with a four-column table
  (`str`, `float`, `bool`) that echoes submitted rows back to the GUI, so the feature can be
  exercised end to end.

## How has it been tested?

Static and unit checks:

```bash
cd lightly_studio && make static-checks
cd lightly_studio_view && make static-checks && make test
```

- Frontend: `svelte-check` 0 errors / 0 warnings, 2528 tests pass across 329 files.
- Backend: `ruff` and `mypy` clean on the example.
- Storybook builds and registers all seven stories (`npm run build-storybook`).

The example's `TableParameter` definition and its `execute` body were exercised directly
against `plugins/parameter.py`: the default row constructs without error and covers every
declared column, and malformed table values (non-list, list of non-dicts, `None`, empty)
each return an unsuccessful `OperatorResult` rather than raising.

Not yet run end to end against a real dataset — importing `lightly_studio` needs a built
`dist_lightly_studio_view_app`, which isn't present in my working copy. To run it:

```bash
cd lightly_studio
EXAMPLES_DATASET_PATH=/path/to/your/dataset \
  uv run src/lightly_studio/examples/example_table_parameter.py
```

Note: `cd lightly_studio && make static-checks` fails locally on 10 pre-existing mypy errors
(missing `s3fs`/`gcsfs` stubs). Identical on a clean `main` checkout, so unrelated to this PR.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an example operator that accepts and validates multiple table-based parameters, including prompts, labels, thresholds, and enabled states.
  * Added a runnable example that loads a dataset and launches the graphical interface.

* **Bug Fixes**
  * Updated table validation messages to clearly identify empty cells and required rows.

* **Tests**
  * Added interactive stories covering empty, populated, invalid, single-column, and scrolling table layouts.
  * Added reusable sample data for narrow and wide parameter tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->