### PR TITLE
introduce classes dialog

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation_label.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation_label.py
@@ -5,18 +5,23 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Path
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Path, Response
+from pydantic import BaseModel, StringConstraints
+from sqlalchemy.exc import IntegrityError
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_CONFLICT,
     HTTP_STATUS_CREATED,
     HTTP_STATUS_NOT_FOUND,
+    HTTP_STATUS_OK,
 )
 from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.annotation_label import (
+    AnnotationLabelBatchCreateRequest,
     AnnotationLabelCreate,
     AnnotationLabelTable,
+    AnnotationLabelWithCountView,
 )
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.resolvers import annotation_label_resolver
@@ -27,7 +32,10 @@ annotations_label_router = APIRouter()
 class AnnotationLabelCreateRequest(BaseModel):
     """Request model for creating or updating an annotation label."""
 
-    annotation_label_name: str
+    annotation_label_name: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, min_length=1, max_length=255),
+    ]
 
 
 @annotations_label_router.post(
@@ -44,14 +52,29 @@ def create_annotation_label(
     ],
 ) -> AnnotationLabelTable:
     """Create a new annotation label in the database."""
-    # TODO(Michal, 12/2025): Use a different model for label creation from the frontend.
-    return annotation_label_resolver.create(
+    if annotation_label_resolver.get_by_label_name(
         session=session,
-        label=AnnotationLabelCreate(
-            dataset_id=collection.dataset_id,
-            annotation_label_name=input_label.annotation_label_name,
-        ),
-    )
+        dataset_id=collection.dataset_id,
+        label_name=input_label.annotation_label_name,
+    ):
+        raise HTTPException(
+            status_code=HTTP_STATUS_CONFLICT,
+            detail="Annotation class name already in use",
+        )
+    try:
+        return annotation_label_resolver.create(
+            session=session,
+            label=AnnotationLabelCreate(
+                dataset_id=collection.dataset_id,
+                annotation_label_name=input_label.annotation_label_name,
+            ),
+        )
+    except IntegrityError as error:
+        session.rollback()
+        raise HTTPException(
+            status_code=HTTP_STATUS_CONFLICT,
+            detail="Annotation class name already in use",
+        ) from error
 
 
 @annotations_label_router.get("/collections/{collection_id}/annotation_labels")
@@ -65,6 +88,57 @@ def read_annotation_labels(
 ) -> list[AnnotationLabelTable]:
     """Retrieve a list of annotation labels from the database."""
     return annotation_label_resolver.get_all(session=session, dataset_id=collection.dataset_id)
+
+
+@annotations_label_router.get("/collections/{collection_id}/annotation_labels/with_counts")
+def read_annotation_labels_with_counts(
+    session: SessionDep,
+    collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(get_and_validate_collection_id),
+    ],
+) -> list[AnnotationLabelWithCountView]:
+    """Retrieve annotation labels and their annotation counts."""
+    return annotation_label_resolver.get_all_with_counts(
+        session=session,
+        dataset_id=collection.dataset_id,
+    )
+
+
+@annotations_label_router.post(
+    "/collections/{collection_id}/annotation_labels/batch",
+    status_code=HTTP_STATUS_CREATED,
+)
+def create_annotation_labels_batch(
+    input_labels: AnnotationLabelBatchCreateRequest,
+    session: SessionDep,
+    response: Response,
+    collection: Annotated[
+        CollectionTable,
+        Path(title="collection Id"),
+        Depends(get_and_validate_collection_id),
+    ],
+) -> list[AnnotationLabelWithCountView]:
+    """Create multiple annotation labels, skipping duplicate names."""
+    created_labels = annotation_label_resolver.create_batch(
+        session=session,
+        dataset_id=collection.dataset_id,
+        label_names=input_labels.annotation_label_names,
+    )
+    if not created_labels:
+        response.status_code = HTTP_STATUS_OK
+        return []
+    return [
+        AnnotationLabelWithCountView(
+            annotation_label_id=label.annotation_label_id,
+            dataset_id=label.dataset_id,
+            annotation_label_name=label.annotation_label_name,
+            created_at=label.created_at,
+            annotation_count=0,
+        )
+        for label in created_labels
+    ]
 
 
 @annotations_label_router.get("/annotation_labels/{label_id}")

--- a/lightly_studio/src/lightly_studio/examples/example.py
+++ b/lightly_studio/src/lightly_studio/examples/example.py
@@ -1,13 +1,9 @@
-"""Example of how to load videos with annotations in YouTube-VIS format."""
-
-from __future__ import annotations
+"""Example of how to load samples from path with the dataset class."""
 
 from environs import Env
 
 import lightly_studio as ls
-from lightly_studio.core.video.video_dataset import VideoDataset
 from lightly_studio.database import db_manager
-from lightly_studio.models.annotation.annotation_base import AnnotationType
 
 # Read environment variables
 env = Env()
@@ -17,16 +13,13 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH")
-annotations_path = env.path("EXAMPLES_VIDEO_YVIS_JSON_PATH")
+dataset_path = env.path("EXAMPLES_DATASET_PATH")
 
 # Create a Dataset from a path
-dataset = VideoDataset.create()
-dataset.add_videos_from_youtube_vis(
-    annotations_json=annotations_path,
-    videos_path=dataset_path,
-    annotation_type=AnnotationType.SEGMENTATION_MASK,
-)
+dataset = ls.ImageDataset.create()
+dataset.add_images_from_path(path=dataset_path)
 
-# Start the GUI
+for sample in dataset:
+    print(sample)
+
 ls.start_gui()

--- a/lightly_studio/src/lightly_studio/examples/example.py
+++ b/lightly_studio/src/lightly_studio/examples/example.py
@@ -1,9 +1,13 @@
-"""Example of how to load samples from path with the dataset class."""
+"""Example of how to load videos with annotations in YouTube-VIS format."""
+
+from __future__ import annotations
 
 from environs import Env
 
 import lightly_studio as ls
+from lightly_studio.core.video.video_dataset import VideoDataset
 from lightly_studio.database import db_manager
+from lightly_studio.models.annotation.annotation_base import AnnotationType
 
 # Read environment variables
 env = Env()
@@ -13,13 +17,16 @@ env.read_env()
 db_manager.connect(cleanup_existing=True)
 
 # Define the path to the dataset directory
-dataset_path = env.path("EXAMPLES_DATASET_PATH")
+dataset_path = env.path("EXAMPLES_VIDEO_DATASET_PATH")
+annotations_path = env.path("EXAMPLES_VIDEO_YVIS_JSON_PATH")
 
 # Create a Dataset from a path
-dataset = ls.ImageDataset.create()
-dataset.add_images_from_path(path=dataset_path)
+dataset = VideoDataset.create()
+dataset.add_videos_from_youtube_vis(
+    annotations_json=annotations_path,
+    videos_path=dataset_path,
+    annotation_type=AnnotationType.SEGMENTATION_MASK,
+)
 
-for sample in dataset:
-    print(sample)
-
+# Start the GUI
 ls.start_gui()

--- a/lightly_studio/src/lightly_studio/models/annotation_label.py
+++ b/lightly_studio/src/lightly_studio/models/annotation_label.py
@@ -1,8 +1,10 @@
 """This module defines the AnnotationLabel model for the application."""
 
 from datetime import datetime, timezone
+from typing import Annotated
 from uuid import UUID, uuid4
 
+from pydantic import StringConstraints
 from sqlalchemy.orm import Mapped
 from sqlmodel import Field, Relationship, SQLModel, UniqueConstraint
 
@@ -28,6 +30,19 @@ class AnnotationLabelView(AnnotationLabelBase):
     """Model used when retrieving an annotation label."""
 
     annotation_label_id: UUID
+
+
+class AnnotationLabelWithCountView(AnnotationLabelView):
+    """Model used when retrieving an annotation label with its annotation count."""
+
+    created_at: str
+    annotation_count: int
+
+
+class AnnotationLabelBatchCreateRequest(SQLModel):
+    """Model used when creating multiple annotation labels."""
+
+    annotation_label_names: list[Annotated[str, StringConstraints(max_length=255)]]
 
 
 class AnnotationLabelTable(AnnotationLabelBase, table=True):

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/__init__.py
@@ -1,11 +1,13 @@
 """Handler for database operations related to annotation labels."""
 
 from .create import create
+from .create_batch import create_batch
 from .delete import delete
 from .get_all import (
     get_all,
     get_all_sorted_alphabetically,
 )
+from .get_all_with_counts import get_all_with_counts
 from .get_by_id import get_by_id
 from .get_by_ids import get_by_ids
 from .get_by_label_name import get_by_label_name
@@ -14,9 +16,11 @@ from .update import update
 
 __all__ = [
     "create",
+    "create_batch",
     "delete",
     "get_all",
     "get_all_sorted_alphabetically",
+    "get_all_with_counts",
     "get_by_id",
     "get_by_ids",
     "get_by_label_name",

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/create_batch.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/create_batch.py
@@ -13,8 +13,7 @@ from lightly_studio.models.annotation_label import (
     AnnotationLabelTable,
 )
 
-from .create import create
-from .get_by_label_name import get_by_label_name
+from . import create, get_by_label_name
 
 
 def create_batch(
@@ -35,10 +34,12 @@ def create_batch(
     normalized_names = list(dict.fromkeys(name.strip() for name in label_names if name.strip()))
     created_labels: list[AnnotationLabelTable] = []
     for name in normalized_names:
-        if get_by_label_name(session=session, dataset_id=dataset_id, label_name=name):
+        if get_by_label_name.get_by_label_name(
+            session=session, dataset_id=dataset_id, label_name=name
+        ):
             continue
         try:
-            created_label = create(
+            created_label = create.create(
                 session=session,
                 label=AnnotationLabelCreate(
                     dataset_id=dataset_id,

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/create_batch.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/create_batch.py
@@ -13,7 +13,8 @@ from lightly_studio.models.annotation_label import (
     AnnotationLabelTable,
 )
 
-from . import create, get_by_label_name
+from .create import create
+from .get_by_label_name import get_by_label_name
 
 
 def create_batch(
@@ -34,12 +35,10 @@ def create_batch(
     normalized_names = list(dict.fromkeys(name.strip() for name in label_names if name.strip()))
     created_labels: list[AnnotationLabelTable] = []
     for name in normalized_names:
-        if get_by_label_name.get_by_label_name(
-            session=session, dataset_id=dataset_id, label_name=name
-        ):
+        if get_by_label_name(session=session, dataset_id=dataset_id, label_name=name):
             continue
         try:
-            created_label = create.create(
+            created_label = create(
                 session=session,
                 label=AnnotationLabelCreate(
                     dataset_id=dataset_id,

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/create_batch.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/create_batch.py
@@ -1,0 +1,52 @@
+"""Create multiple annotation labels functionality."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session
+
+from lightly_studio.models.annotation_label import (
+    AnnotationLabelCreate,
+    AnnotationLabelTable,
+)
+
+from .create import create
+from .get_by_label_name import get_by_label_name
+
+
+def create_batch(
+    session: Session,
+    dataset_id: UUID,
+    label_names: Sequence[str],
+) -> list[AnnotationLabelTable]:
+    """Create multiple unique annotation labels, skipping existing names.
+
+    Args:
+        session: The database session.
+        dataset_id: The dataset to create the annotation labels in.
+        label_names: Annotation label names to create.
+
+    Returns:
+        The newly created annotation labels.
+    """
+    normalized_names = list(dict.fromkeys(name.strip() for name in label_names if name.strip()))
+    created_labels: list[AnnotationLabelTable] = []
+    for name in normalized_names:
+        if get_by_label_name(session=session, dataset_id=dataset_id, label_name=name):
+            continue
+        try:
+            created_label = create(
+                session=session,
+                label=AnnotationLabelCreate(
+                    dataset_id=dataset_id,
+                    annotation_label_name=name,
+                ),
+            )
+        except IntegrityError:
+            session.rollback()
+            continue
+        created_labels.append(created_label)
+    return created_labels

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/get_all_with_counts.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_label_resolver/get_all_with_counts.py
@@ -1,0 +1,57 @@
+"""Get annotation labels with annotation counts functionality."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session, col, func, select
+
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation_label import (
+    AnnotationLabelTable,
+    AnnotationLabelWithCountView,
+)
+
+
+def get_all_with_counts(
+    session: Session,
+    dataset_id: UUID,
+) -> list[AnnotationLabelWithCountView]:
+    """Retrieve all annotation labels and their annotation counts.
+
+    Args:
+        session: The database session.
+        dataset_id: The dataset ID to which the labels belong.
+
+    Returns:
+        Annotation labels ordered by creation time, including zero-count labels.
+    """
+    rows = session.exec(
+        select(
+            AnnotationLabelTable,
+            func.count(col(AnnotationBaseTable.sample_id)).label("annotation_count"),
+        )
+        .outerjoin(
+            AnnotationBaseTable,
+            col(AnnotationBaseTable.annotation_label_id)
+            == col(AnnotationLabelTable.annotation_label_id),
+        )
+        .where(AnnotationLabelTable.dataset_id == dataset_id)
+        .group_by(
+            col(AnnotationLabelTable.annotation_label_id),
+            col(AnnotationLabelTable.dataset_id),
+            col(AnnotationLabelTable.annotation_label_name),
+            col(AnnotationLabelTable.created_at),
+        )
+        .order_by(col(AnnotationLabelTable.created_at).asc())
+    ).all()
+    return [
+        AnnotationLabelWithCountView(
+            annotation_label_id=label.annotation_label_id,
+            dataset_id=label.dataset_id,
+            annotation_label_name=label.annotation_label_name,
+            created_at=label.created_at,
+            annotation_count=count,
+        )
+        for label, count in rows
+    ]

--- a/lightly_studio/tests/api/routes/api/test_annotation_label.py
+++ b/lightly_studio/tests/api/routes/api/test_annotation_label.py
@@ -4,12 +4,19 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_CONFLICT,
     HTTP_STATUS_CREATED,
     HTTP_STATUS_NOT_FOUND,
     HTTP_STATUS_OK,
+    HTTP_STATUS_UNPROCESSABLE_ENTITY,
 )
 from lightly_studio.resolvers import annotation_label_resolver
-from tests.helpers_resolvers import create_annotation_label, create_collection
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
 
 
 def test_create_annotation_label(db_session: Session, test_client: TestClient) -> None:
@@ -31,6 +38,25 @@ def test_create_annotation_label(db_session: Session, test_client: TestClient) -
     assert all_labels[0].annotation_label_name == "cat"
 
 
+def test_create_annotation_label__duplicate(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="cat",
+    )
+
+    result = test_client.post(
+        f"/api/collections/{collection.collection_id!s}/annotation_labels",
+        json={"annotation_label_name": "cat"},
+    )
+
+    assert result.status_code == HTTP_STATUS_CONFLICT
+
+
 def test_get_annotation_labels(db_session: Session, test_client: TestClient) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
@@ -42,6 +68,88 @@ def test_get_annotation_labels(db_session: Session, test_client: TestClient) -> 
     assert len(labels_result.json()) == 1
     label = labels_result.json()[0]
     assert label["annotation_label_name"] == "cat"
+
+
+def test_get_annotation_labels_with_counts(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="cat",
+    )
+    image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/tmp/api-count.png",
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+
+    result = test_client.get(
+        f"/api/collections/{collection.collection_id!s}/annotation_labels/with_counts"
+    )
+
+    assert result.status_code == HTTP_STATUS_OK
+    assert result.json()[0]["annotation_count"] == 1
+
+
+def test_create_annotation_labels_batch(db_session: Session, test_client: TestClient) -> None:
+    collection = create_collection(session=db_session)
+    create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="cat",
+    )
+
+    result = test_client.post(
+        f"/api/collections/{collection.collection_id!s}/annotation_labels/batch",
+        json={"annotation_label_names": ["cat", " dog ", "", "bird", "dog"]},
+    )
+
+    assert result.status_code == HTTP_STATUS_CREATED
+    assert [label["annotation_label_name"] for label in result.json()] == ["dog", "bird"]
+    assert all(label["annotation_count"] == 0 for label in result.json())
+
+
+def test_create_annotation_labels_batch__all_exist(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+    create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="cat",
+    )
+
+    result = test_client.post(
+        f"/api/collections/{collection.collection_id!s}/annotation_labels/batch",
+        json={"annotation_label_names": ["cat"]},
+    )
+
+    assert result.status_code == HTTP_STATUS_OK
+    assert result.json() == []
+
+
+def test_create_annotation_labels_batch__name_too_long(
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    collection = create_collection(session=db_session)
+
+    result = test_client.post(
+        f"/api/collections/{collection.collection_id!s}/annotation_labels/batch",
+        json={"annotation_label_names": ["a" * 256]},
+    )
+
+    assert result.status_code == HTTP_STATUS_UNPROCESSABLE_ENTITY
 
 
 def test_get_annotation_label(db_session: Session, test_client: TestClient) -> None:

--- a/lightly_studio/tests/resolvers/annotation_label_resolver/test_create_batch.py
+++ b/lightly_studio/tests/resolvers/annotation_label_resolver/test_create_batch.py
@@ -1,0 +1,39 @@
+"""Tests for batch annotation label creation."""
+
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from lightly_studio.resolvers import annotation_label_resolver
+from tests.helpers_resolvers import create_annotation_label, create_collection
+
+
+def test_create_batch__normalizes_and_deduplicates(db_session: Session) -> None:
+    """Create normalized unique names and skip blank values."""
+    collection = create_collection(session=db_session)
+
+    result = annotation_label_resolver.create_batch(
+        session=db_session,
+        dataset_id=collection.dataset_id,
+        label_names=[" cat ", "", "dog", "cat", "  "],
+    )
+
+    assert [label.annotation_label_name for label in result] == ["cat", "dog"]
+
+
+def test_create_batch__skips_existing_labels(db_session: Session) -> None:
+    """Return only newly created labels when a requested name already exists."""
+    collection = create_collection(session=db_session)
+    create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="cat",
+    )
+
+    result = annotation_label_resolver.create_batch(
+        session=db_session,
+        dataset_id=collection.dataset_id,
+        label_names=["cat", "dog"],
+    )
+
+    assert [label.annotation_label_name for label in result] == ["dog"]

--- a/lightly_studio/tests/resolvers/annotation_label_resolver/test_get_all_with_counts.py
+++ b/lightly_studio/tests/resolvers/annotation_label_resolver/test_get_all_with_counts.py
@@ -1,0 +1,61 @@
+"""Tests for annotation labels with annotation counts."""
+
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from lightly_studio.resolvers import annotation_label_resolver
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
+
+
+def test_get_all_with_counts(db_session: Session) -> None:
+    """Return zero-count and used annotation labels in creation order."""
+    collection = create_collection(session=db_session)
+    cat = create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="cat",
+    )
+    create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    image = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/tmp/counts.png",
+    )
+    create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=cat.annotation_label_id,
+    )
+
+    result = annotation_label_resolver.get_all_with_counts(
+        session=db_session,
+        dataset_id=collection.dataset_id,
+    )
+
+    assert [(label.annotation_label_name, label.annotation_count) for label in result] == [
+        ("cat", 1),
+        ("dog", 0),
+    ]
+
+
+def test_get_all_with_counts__no_labels(db_session: Session) -> None:
+    """Return an empty list when the dataset has no annotation labels."""
+    collection = create_collection(session=db_session)
+
+    result = annotation_label_resolver.get_all_with_counts(
+        session=db_session,
+        dataset_id=collection.dataset_id,
+    )
+
+    assert result == []

--- a/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationMetadata/AnnotationMetadataLabel/AnnotationMetadataLabel.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationDetails/AnnotationDetailsPanel/AnnotationMetadata/AnnotationMetadataLabel/AnnotationMetadataLabel.svelte
@@ -56,7 +56,8 @@
             {items}
             selectedItem={items.find((i) => i.value === value?.value)}
             name="annotation-label"
-            placeholder="Select or create a class"
+            placeholder="Select a class"
+            allowCreate={false}
             className="w-full min-w-0"
             contentClassName="w-full min-w-0"
             onSelect={(item) => {
@@ -81,7 +82,7 @@
             }}
         >
             {#snippet notFound({ inputValue })}
-                <LabelNotFound label={inputValue} />
+                <LabelNotFound label={inputValue} allowCreate={false} />
             {/snippet}
         </SelectList>
     </div>

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/SelectedAnnotations.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/SelectedAnnotations/SelectedAnnotations.svelte
@@ -35,14 +35,15 @@
                     <SelectList
                         {items}
                         name="annotation-label"
-                        placeholder="Select or create a class"
+                        placeholder="Select a class"
                         label="Select a class"
+                        allowCreate={false}
                         {onSelect}
                         {isLoading}
                         {disabled}
                     >
                         {#snippet notFound({ inputValue })}
-                            <LabelNotFound label={inputValue} />
+                            <LabelNotFound label={inputValue} allowCreate={false} />
                         {/snippet}
                     </SelectList>
                 </div>

--- a/lightly_studio_view/src/lib/components/ClassesDialog/AddClassesForm.svelte
+++ b/lightly_studio_view/src/lib/components/ClassesDialog/AddClassesForm.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+    import { Button } from '$lib/components/ui/button';
+    import { Input } from '$lib/components/ui/input';
+    import { LoaderCircle, Plus } from '@lucide/svelte';
+
+    let {
+        existingNames,
+        onAdd,
+        onValueChange
+    }: {
+        existingNames: string[];
+        onAdd: (names: string[]) => Promise<void>;
+        onValueChange?: (value: string) => void;
+    } = $props();
+
+    let value = $state('');
+    let isAdding = $state(false);
+    let message = $state('');
+    const parsedNames = $derived([
+        ...new Set(
+            value
+                .split(',')
+                .map((name) => name.trim())
+                .filter(Boolean)
+        )
+    ]);
+    const disabled = $derived(parsedNames.length === 0 || isAdding);
+
+    async function handleSubmit(event: SubmitEvent) {
+        event.preventDefault();
+        const existing = new Set(existingNames.map((name) => name.toLowerCase()));
+        const duplicates = parsedNames.filter((name) => existing.has(name.toLowerCase()));
+        const names = parsedNames.filter((name) => !existing.has(name.toLowerCase()));
+        if (!names.length) {
+            message = 'All classes already exist.';
+            return;
+        }
+        isAdding = true;
+        message = duplicates.length ? `Already exist: ${duplicates.join(', ')}.` : '';
+        try {
+            await onAdd(names);
+            value = '';
+            onValueChange?.('');
+        } catch {
+            message = 'Failed to add classes. Please try again.';
+        } finally {
+            isAdding = false;
+        }
+    }
+</script>
+
+<form class="space-y-2" onsubmit={handleSubmit}>
+    <div class="flex gap-2">
+        <Input
+            bind:value
+            aria-label="Class names"
+            placeholder="e.g. dogs, cats, people"
+            disabled={isAdding}
+            oninput={() => onValueChange?.(value)}
+        />
+        <Button type="submit" {disabled}>
+            {#if isAdding}<LoaderCircle class="animate-spin" />{:else}<Plus />{/if}
+            {isAdding ? 'Adding...' : 'Add'}
+        </Button>
+    </div>
+    {#if message}<p class="text-sm text-muted-foreground" role="status">{message}</p>{/if}
+</form>

--- a/lightly_studio_view/src/lib/components/ClassesDialog/AddClassesForm.svelte
+++ b/lightly_studio_view/src/lib/components/ClassesDialog/AddClassesForm.svelte
@@ -56,7 +56,7 @@
             aria-label="Class names"
             placeholder="e.g. dogs, cats, people"
             disabled={isAdding}
-            oninput={() => onValueChange?.(value)}
+            oninput={(e) => onValueChange?.((e.currentTarget as HTMLInputElement).value)}
         />
         <Button type="submit" {disabled}>
             {#if isAdding}<LoaderCircle class="animate-spin" />{:else}<Plus />{/if}

--- a/lightly_studio_view/src/lib/components/ClassesDialog/ClassesDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ClassesDialog/ClassesDialog.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+    import * as Dialog from '$lib/components/ui/dialog';
+    import { useClasses } from '$lib/hooks/useClasses/useClasses.svelte';
+    import { useClassesDialog } from '$lib/hooks/useClassesDialog/useClassesDialog';
+    import AddClassesForm from './AddClassesForm.svelte';
+    import ClassesDialogTable from './ClassesDialogTable.svelte';
+
+    let { collectionId }: { collectionId: string } = $props();
+    const { isClassesDialogOpen, openClassesDialog, closeClassesDialog } = useClassesDialog();
+    const { query, addClasses } = useClasses(() => ({
+        collectionId,
+        enabled: $isClassesDialogOpen
+    }));
+    const skeletonRows = [0, 1, 2];
+
+    let searchTerm = $state('');
+    const filteredLabels = $derived.by(() => {
+        const term = searchTerm.trim().toLowerCase();
+        const labels = query.data ?? [];
+        if (!term || term.includes(',')) return labels;
+        return labels.filter((l) => l.annotation_label_name.toLowerCase().includes(term));
+    });
+
+    function setOpen(open: boolean) {
+        if (open) {
+            openClassesDialog();
+        } else {
+            closeClassesDialog();
+            searchTerm = '';
+        }
+    }
+</script>
+
+<Dialog.Root open={$isClassesDialogOpen} onOpenChange={setOpen}>
+    <Dialog.Content class="border-border bg-background sm:max-w-[620px]">
+        <Dialog.Header>
+            <Dialog.Title>Classes</Dialog.Title>
+            <Dialog.Description>
+                Define the annotation classes available during labeling.
+            </Dialog.Description>
+        </Dialog.Header>
+
+        <AddClassesForm
+            existingNames={(query.data ?? []).map((label) => label.annotation_label_name)}
+            onAdd={addClasses}
+            onValueChange={(v) => (searchTerm = v)}
+        />
+
+        {#if query.isPending}
+            <div class="space-y-2 py-4" aria-label="Loading classes">
+                {#each skeletonRows as row (row)}
+                    <div class="h-10 animate-pulse rounded bg-muted"></div>
+                {/each}
+            </div>
+        {:else if query.isError}
+            <p class="py-6 text-center text-sm text-destructive" role="alert">
+                Failed to load classes. Please try again.
+            </p>
+        {:else}
+            <ClassesDialogTable labels={filteredLabels} />
+        {/if}
+    </Dialog.Content>
+</Dialog.Root>

--- a/lightly_studio_view/src/lib/components/ClassesDialog/ClassesDialog.svelte
+++ b/lightly_studio_view/src/lib/components/ClassesDialog/ClassesDialog.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import * as Dialog from '$lib/components/ui/dialog';
-    import { useClasses } from '$lib/hooks/useClasses/useClasses.svelte';
-    import { useClassesDialog } from '$lib/hooks/useClassesDialog/useClassesDialog';
+    import { useClasses, useClassesDialog } from '$lib/hooks';
     import AddClassesForm from './AddClassesForm.svelte';
     import ClassesDialogTable from './ClassesDialogTable.svelte';
 

--- a/lightly_studio_view/src/lib/components/ClassesDialog/ClassesDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/ClassesDialog/ClassesDialog.test.ts
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useClassesDialog } from '$lib/hooks/useClassesDialog/useClassesDialog';
+import { useClasses } from '$lib/hooks/useClasses/useClasses.svelte';
+import ClassesDialog from './ClassesDialog.svelte';
+
+vi.mock('$lib/hooks/useClasses/useClasses.svelte', () => ({ useClasses: vi.fn() }));
+
+const cat = {
+    annotation_label_id: 'cat-id',
+    dataset_id: 'dataset-id',
+    annotation_label_name: 'cat',
+    created_at: '2026-01-01',
+    annotation_count: 3
+};
+const addClasses = vi.fn();
+const { openClassesDialog, closeClassesDialog } = useClassesDialog();
+
+function renderDialog(labels = [cat]) {
+    vi.mocked(useClasses).mockReturnValue({
+        query: { data: labels, isPending: false, isError: false },
+        addClasses
+    } as unknown as ReturnType<typeof useClasses>);
+    render(ClassesDialog, { props: { collectionId: 'collection-id' } });
+    openClassesDialog();
+}
+
+describe('ClassesDialog', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        addClasses.mockResolvedValue(undefined);
+        closeClassesDialog();
+    });
+
+    afterEach(() => {
+        closeClassesDialog();
+        document.body.innerHTML = '';
+    });
+
+    it('adds normalized comma-separated class names and renders counts', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        expect(await screen.findByText('cat')).toBeInTheDocument();
+        expect(screen.getByText('3')).toBeInTheDocument();
+        await user.type(screen.getByLabelText('Class names'), ' dog, , bird, dog ');
+        await user.click(screen.getByRole('button', { name: 'Add' }));
+
+        await waitFor(() => expect(addClasses).toHaveBeenCalledWith(['dog', 'bird']));
+    });
+
+    it('filters existing classes before adding and reports them', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+        await screen.findByText('cat');
+
+        await user.type(screen.getByLabelText('Class names'), 'CAT, dog');
+        await user.click(screen.getByRole('button', { name: 'Add' }));
+
+        await waitFor(() => expect(addClasses).toHaveBeenCalledWith(['dog']));
+        expect(screen.getByRole('status')).toHaveTextContent('Already exist: CAT.');
+    });
+
+    it('does not submit when every class already exists', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+        await screen.findByText('cat');
+
+        await user.type(screen.getByLabelText('Class names'), 'cat');
+        await user.click(screen.getByRole('button', { name: 'Add' }));
+
+        expect(addClasses).not.toHaveBeenCalled();
+        expect(screen.getByRole('status')).toHaveTextContent('All classes already exist.');
+    });
+});

--- a/lightly_studio_view/src/lib/components/ClassesDialog/ClassesDialogRow.svelte
+++ b/lightly_studio_view/src/lib/components/ClassesDialog/ClassesDialogRow.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import type { AnnotationLabelWithCountView } from '$lib/api/lightly_studio_local';
+    import AnnotationColorLegend from '$lib/components/AnnotationColorLegend/AnnotationColorLegend.svelte';
+
+    let { label }: { label: AnnotationLabelWithCountView } = $props();
+</script>
+
+<tr>
+    <td class="w-16 py-2 pl-3">
+        <AnnotationColorLegend
+            labelName={label.annotation_label_name}
+            className="size-4"
+            selected={false}
+        />
+    </td>
+    <td class="max-w-0 truncate py-2" title={label.annotation_label_name}>
+        {label.annotation_label_name}
+    </td>
+    <td class="w-20 py-2 text-center tabular-nums">{label.annotation_count}</td>
+</tr>

--- a/lightly_studio_view/src/lib/components/ClassesDialog/ClassesDialogTable.svelte
+++ b/lightly_studio_view/src/lib/components/ClassesDialog/ClassesDialogTable.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import type { AnnotationLabelWithCountView } from '$lib/api/lightly_studio_local';
+    import ClassesDialogRow from './ClassesDialogRow.svelte';
+
+    let { labels }: { labels: AnnotationLabelWithCountView[] } = $props();
+</script>
+
+{#if labels.length}
+    <div class="max-h-[50vh] overflow-y-auto dark:[color-scheme:dark]">
+        <table class="w-full table-fixed text-sm">
+            <thead class="sticky top-0 bg-background text-muted-foreground">
+                <tr>
+                    <th scope="col" class="w-16 py-2 text-left">Color</th>
+                    <th scope="col" class="py-2 text-left">Class</th>
+                    <th scope="col" class="w-20 py-2 text-center">Counts</th>
+                </tr>
+            </thead>
+            <tbody>
+                {#each labels as label (label.annotation_label_id)}
+                    <ClassesDialogRow {label} />
+                {/each}
+            </tbody>
+        </table>
+    </div>
+{:else}
+    <p class="py-8 text-center text-sm text-muted-foreground">
+        No classes yet. Add your first class above.
+    </p>
+{/if}

--- a/lightly_studio_view/src/lib/components/FrameAnnotationsPanel/FrameAnnotationsPanel.svelte
+++ b/lightly_studio_view/src/lib/components/FrameAnnotationsPanel/FrameAnnotationsPanel.svelte
@@ -69,21 +69,22 @@
                 </div>
                 {#if addAnnotationEnabled}
                     <label class="flex w-full flex-col gap-3 text-muted-foreground">
-                        <div class="text-sm">Select or create a class for a new annotation.</div>
+                        <div class="text-sm">Select a class for a new annotation.</div>
                         <SelectList
                             {items}
                             selectedItem={items.find((i) => i.value === addAnnotationLabel?.value)}
                             name="annotation-label"
-                            label="Choose or create a class"
+                            label="Choose a class"
                             className="w-full"
                             contentClassName="w-full"
-                            placeholder="Select or create a class"
+                            placeholder="Select a class"
+                            allowCreate={false}
                             onSelect={(item) => {
                                 addAnnotationLabel = item;
                             }}
                         >
                             {#snippet notFound({ inputValue })}
-                                <LabelNotFound label={inputValue} />
+                                <LabelNotFound label={inputValue} allowCreate={false} />
                             {/snippet}
                         </SelectList>
                     </label>

--- a/lightly_studio_view/src/lib/components/Header/Menu.svelte
+++ b/lightly_studio_view/src/lib/components/Header/Menu.svelte
@@ -6,6 +6,7 @@
     import { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
     import { useSettingsDialog } from '$lib/hooks/useSettingsDialog/useSettingsDialog';
     import { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
+    import { useClassesDialog } from '$lib/hooks/useClassesDialog/useClassesDialog';
     import { get } from 'svelte/store';
     import { useGlobalStorage } from '$lib/hooks';
     import {
@@ -13,7 +14,8 @@
         Download as DownloadIcon,
         Settings as SettingsIcon,
         BrainCircuit as BrainCircuitIcon,
-        WandSparkles as WandSparklesIcon
+        WandSparkles as WandSparklesIcon,
+        Tags as TagsIcon
     } from '@lucide/svelte';
 
     import type { CollectionView } from '$lib/api/lightly_studio_local';
@@ -40,6 +42,7 @@
     const { openExportDialog } = useExportDialog();
     const { openSettingsDialog } = useSettingsDialog();
     const { openOperatorsDialog } = useOperatorsDialog();
+    const { openClassesDialog } = useClassesDialog();
 
     type MenuAction = SelectItem & { onSelect: () => void };
 
@@ -89,6 +92,14 @@
                 onSelect: openOperatorsDialog
             });
         }
+
+        items.push({
+            value: 'menu-classes',
+            label: 'Classes',
+            icon: TagsIcon,
+            testId: 'menu-classes',
+            onSelect: openClassesDialog
+        });
 
         if (hasExport) {
             items.push({

--- a/lightly_studio_view/src/lib/components/Header/Menu.test.ts
+++ b/lightly_studio_view/src/lib/components/Header/Menu.test.ts
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { describe, expect, it, vi } from 'vitest';
+import type { CollectionView } from '$lib/api/lightly_studio_local';
+import Menu from './Menu.svelte';
+
+vi.mock('$lib/components/Select', async () => ({
+    Select: (await import('./MenuTestSelect.svelte')).default
+}));
+vi.mock('$lib/hooks', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('$lib/hooks')>()),
+    useGlobalStorage: () => ({ filteredSampleCount: writable(0) })
+}));
+vi.mock('$lib/hooks/useClassifiers/useClassifiersMenu', () => ({
+    useClassifiersMenu: () => ({ openClassifiersMenu: vi.fn() })
+}));
+vi.mock('$lib/hooks/useSamplingDialog/useSamplingDialog', () => ({
+    useSamplingDialog: () => ({ openSamplingDialog: vi.fn() })
+}));
+vi.mock('$lib/hooks/useExportDialog/useExportDialog', () => ({
+    useExportDialog: () => ({ openExportDialog: vi.fn() })
+}));
+vi.mock('$lib/hooks/useSettingsDialog/useSettingsDialog', () => ({
+    useSettingsDialog: () => ({ openSettingsDialog: vi.fn() })
+}));
+vi.mock('$lib/hooks/useOperatorsDialog/useOperatorsDialog', () => ({
+    useOperatorsDialog: () => ({ openOperatorsDialog: vi.fn() })
+}));
+vi.mock('$lib/hooks/useClassesDialog/useClassesDialog', () => ({
+    useClassesDialog: () => ({ openClassesDialog: vi.fn() })
+}));
+
+const collection = {
+    collection_id: 'collection-id',
+    name: 'Collection',
+    sample_type: 'image',
+    created_at: new Date(),
+    updated_at: new Date()
+} as CollectionView;
+
+describe('Menu', () => {
+    it('shows Classes for viewers', () => {
+        render(Menu, {
+            props: {
+                collection,
+                user: { username: 'viewer', email: 'viewer@test.com', role: 'viewer' }
+            }
+        });
+
+        expect(screen.getByTestId('menu-classes')).toHaveTextContent('Classes');
+    });
+});

--- a/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
+++ b/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
@@ -4,6 +4,7 @@
     import { SettingsDialog } from '$lib/components/Settings';
     import OperatorsMenu from '$lib/components/Operator/OperatorsMenu.svelte';
     import type { CollectionView } from '$lib/api/lightly_studio_local';
+    import ClassesDialog from '$lib/components/ClassesDialog/ClassesDialog.svelte';
 
     let {
         isImages = false,
@@ -38,4 +39,5 @@
 {/if}
 
 <OperatorsMenu />
+<ClassesDialog collectionId={collection.collection_id} />
 <SettingsDialog />

--- a/lightly_studio_view/src/lib/components/Header/MenuTestSelect.svelte
+++ b/lightly_studio_view/src/lib/components/Header/MenuTestSelect.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    import type { SelectItem } from '$lib/components/Select';
+
+    let {
+        items = [],
+        onValueChange
+    }: { items?: SelectItem[]; onValueChange?: (value: string) => void } = $props();
+</script>
+
+{#each items as item (item.value)}
+    <button data-testid={item.testId} onclick={() => onValueChange?.(item.value)}>
+        {item.label}
+    </button>
+{/each}

--- a/lightly_studio_view/src/lib/components/LabelNotFound/LabelNotFound.svelte
+++ b/lightly_studio_view/src/lib/components/LabelNotFound/LabelNotFound.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-    const { label }: { label: string } = $props();
+    const { label, allowCreate = true }: { label: string; allowCreate?: boolean } = $props();
 </script>
 
-{#if label.length > 0}
+{#if !allowCreate}
+    <div class="text-md m-2">No matching class. Add classes via the Classes menu.</div>
+{:else if label.length > 0}
     <div class="text-md m-2">
         Press Enter to create a new <span class="font-semibold">"{label}"</span> annotation class.
     </div>

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -17,7 +17,6 @@
     } from '../SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.helpers';
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
     import { useCreateAnnotation } from '$lib/hooks/useCreateAnnotation/useCreateAnnotation';
-    import { useCreateLabel } from '$lib/hooks/useCreateLabel/useCreateLabel';
     import { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
     import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
     import { useUpdateAnnotationsMutation } from '$lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation';
@@ -44,7 +43,6 @@
     const annotationLabels = useAnnotationLabels(() => ({ collectionId }));
     const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => collectionId });
     const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => collectionId });
-    const { createLabel } = useCreateLabel({ getCollectionId: () => collectionId });
     const { updateAnnotations } = useUpdateAnnotationsMutation({
         getCollectionId: () => collectionId
     });
@@ -121,15 +119,13 @@
     const createClassificationAnnotation = async (labelName: string) => {
         if (!annotationLabels.data) return false;
 
-        let label = annotationLabels.data.find(
+        const label = annotationLabels.data.find(
             (labelItem) => labelItem.annotation_label_name === labelName
         );
 
         if (!label) {
-            label = await createLabel({
-                dataset_id: datasetId,
-                annotation_label_name: labelName
-            });
+            toast.error('This class no longer exists. Choose another class.');
+            return false;
         }
 
         try {
@@ -243,7 +239,8 @@
                                 (i) => i.value === getLabelValue(annotation)?.value
                             )}
                             name="classification-label"
-                            placeholder="Select or create a class"
+                            placeholder="Select a class"
+                            allowCreate={false}
                             className="w-full min-w-0"
                             contentClassName="w-full min-w-0"
                             onSelect={async (item) => {
@@ -251,7 +248,7 @@
                             }}
                         >
                             {#snippet notFound({ inputValue })}
-                                <LabelNotFound label={inputValue} />
+                                <LabelNotFound label={inputValue} allowCreate={false} />
                             {/snippet}
                         </SelectList>
                     {:else}
@@ -334,7 +331,8 @@
                                 <SelectList
                                     {items}
                                     name="classification-label"
-                                    placeholder="Select or create a class"
+                                    placeholder="Select a class"
+                                    allowCreate={false}
                                     className="w-full min-w-0"
                                     contentClassName="w-full min-w-0"
                                     onSelect={async (item) => {
@@ -347,7 +345,7 @@
                                     }}
                                 >
                                     {#snippet notFound({ inputValue })}
-                                        <LabelNotFound label={inputValue} />
+                                        <LabelNotFound label={inputValue} allowCreate={false} />
                                     {/snippet}
                                 </SelectList>
                             </span>

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
@@ -160,7 +160,8 @@
                                         {items}
                                         selectedItem={items.find((i) => i.value === value?.value)}
                                         name="annotation-label"
-                                        placeholder="Select or create a class"
+                                        placeholder="Select a class"
+                                        allowCreate={false}
                                         className="w-full min-w-0"
                                         contentClassName="w-full min-w-0"
                                         onSelect={async (item) => {
@@ -188,7 +189,7 @@
                                         }}
                                     >
                                         {#snippet notFound({ inputValue })}
-                                            <LabelNotFound label={inputValue} />
+                                            <LabelNotFound label={inputValue} allowCreate={false} />
                                         {/snippet}
                                     </SelectList>
                                 </div>

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleObjectDetectionRect/SampleObjectDetectionRect.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleObjectDetectionRect/SampleObjectDetectionRect.svelte
@@ -2,7 +2,6 @@
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
     import { useSelectClassDialog } from '$lib/hooks/useSelectClassDialog/useSelectClassDialog';
     import { useCreateAnnotation } from '$lib/hooks/useCreateAnnotation/useCreateAnnotation';
-    import { useCreateLabel } from '$lib/hooks/useCreateLabel/useCreateLabel';
     import type { BoundingBox } from '$lib/types';
     import { drag, type D3DragEvent } from 'd3-drag';
     import SampleAnnotationRect from '../SampleAnnotationRect/SampleAnnotationRect.svelte';
@@ -64,7 +63,6 @@
         handleCancel: handleClassDialogCancel
     } = useSelectClassDialog();
 
-    const { createLabel } = useCreateLabel({ getCollectionId: () => collectionId });
     const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => collectionId });
     const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => collectionId });
     const { addReversibleAction, updateLastAnnotationLabel } = useGlobalStorage();
@@ -200,16 +198,13 @@
                 updateLastAnnotationLabel(collectionId, selectedLabelName);
             }
 
-            let label = labels.data?.find(
+            const label = labels.data?.find(
                 (label) => label.annotation_label_name === selectedLabelName
             );
 
-            // Create label if it does not exist yet
             if (!label) {
-                label = await createLabel({
-                    dataset_id: datasetId,
-                    annotation_label_name: selectedLabelName
-                });
+                toast.error('This class no longer exists. Choose another class.');
+                return;
             }
 
             const newAnnotation = await createAnnotation({

--- a/lightly_studio_view/src/lib/components/SelectClassDialog/SelectClassDialog.svelte
+++ b/lightly_studio_view/src/lib/components/SelectClassDialog/SelectClassDialog.svelte
@@ -58,9 +58,7 @@
     <Dialog.Content class="max-w-sm">
         <Dialog.Header>
             <Dialog.Title>Select a Class</Dialog.Title>
-            <Dialog.Description>
-                Choose an existing class or type a new one to create it.
-            </Dialog.Description>
+            <Dialog.Description>Choose an existing annotation class.</Dialog.Description>
         </Dialog.Header>
 
         <div class="min-w-0 space-y-1 py-2">
@@ -68,7 +66,8 @@
                 bind:selectedItem
                 {items}
                 label="Select a class..."
-                placeholder="Search or create a class..."
+                placeholder="Search classes..."
+                allowCreate={false}
                 className="w-full"
                 autoOpen
                 autoFocus

--- a/lightly_studio_view/src/lib/components/SelectClassDialog/SelectClassDialog.test.ts
+++ b/lightly_studio_view/src/lib/components/SelectClassDialog/SelectClassDialog.test.ts
@@ -42,9 +42,7 @@ describe('SelectClassDialog', () => {
         renderDialog();
 
         expect(screen.getByText('Select a Class')).toBeInTheDocument();
-        expect(
-            screen.getByText('Choose an existing class or type a new one to create it.')
-        ).toBeInTheDocument();
+        expect(screen.getByText('Choose an existing annotation class.')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
     });
@@ -71,7 +69,7 @@ describe('SelectClassDialog', () => {
         expect(onCancel).not.toHaveBeenCalled();
     });
 
-    it('confirms a newly typed class name when Enter is pressed', async () => {
+    it('does not confirm a newly typed class name when Enter is pressed', async () => {
         const user = userEvent.setup();
         const { onConfirm } = renderDialog();
         const input = await screen.findByTestId('select-list-input');
@@ -80,8 +78,7 @@ describe('SelectClassDialog', () => {
 
         await user.type(input, 'fish{Enter}');
 
-        expect(onConfirm).toHaveBeenCalledTimes(1);
-        expect(onConfirm).toHaveBeenCalledWith('fish');
+        expect(onConfirm).not.toHaveBeenCalled();
     });
 
     it('confirms the keyboard-highlighted class instead of the filter text', async () => {
@@ -112,18 +109,14 @@ describe('SelectClassDialog', () => {
         expect(onConfirm).not.toHaveBeenCalled();
     });
 
-    it('selects a newly typed class name before explicit mouse confirmation', async () => {
+    it('does not offer a create option for a newly typed class name', async () => {
         const user = userEvent.setup();
         const { onConfirm } = renderDialog();
 
         await user.type(await screen.findByTestId('select-list-input'), 'fish');
-        await user.click(screen.getByRole('option', { name: /Create:\s*fish/i }));
 
-        const confirmButton = screen.getByRole('button', { name: 'Confirm' });
-        await waitFor(() => expect(confirmButton).toBeEnabled());
-        await user.click(confirmButton);
-
-        expect(onConfirm).toHaveBeenCalledWith('fish');
+        expect(screen.queryByRole('option', { name: /Create:\s*fish/i })).not.toBeInTheDocument();
+        expect(onConfirm).not.toHaveBeenCalled();
     });
 
     it('does not render an annotation source selector', () => {

--- a/lightly_studio_view/src/lib/components/SelectList/SelectList.svelte
+++ b/lightly_studio_view/src/lib/components/SelectList/SelectList.svelte
@@ -42,6 +42,7 @@
         autoFocus = false,
         disabled = false,
         isLoading = false,
+        allowCreate = true,
         onKeyboardConfirm
     }: {
         placeholder?: string;
@@ -57,6 +58,7 @@
         onSelect?: (item: ListItem) => void;
         disabled?: boolean;
         isLoading?: boolean;
+        allowCreate?: boolean;
         onKeyboardConfirm?: (item: ListItem) => void;
     } = $props();
 
@@ -100,7 +102,7 @@
 
     const handleKeyDown = (event: KeyboardEvent) => {
         if (event.key !== 'Enter' || !onKeyboardConfirm) {
-            if (event.key === 'Enter' && !highlightedValue && inputValue) {
+            if (event.key === 'Enter' && allowCreate && !highlightedValue && inputValue) {
                 createNewItem(inputValue);
                 event.preventDefault();
                 event.stopPropagation();
@@ -118,8 +120,9 @@
             const existingItem = items.find(
                 (item) => item.value.toLowerCase() === inputValue.toLowerCase()
             );
-            const item = existingItem ?? { value: inputValue, label: inputValue };
+            if (!existingItem && !allowCreate) return;
 
+            const item = existingItem ?? { value: inputValue, label: inputValue };
             if (!existingItem) items.push(item);
 
             confirmWithKeyboard(item);
@@ -201,7 +204,7 @@
                         </Command.Item>
                     {/each}
                 </Command.Group>
-                {#if inputValue.trim()}
+                {#if allowCreate && inputValue.trim()}
                     <div class="border-t">
                         <Command.Item
                             value="__create__"

--- a/lightly_studio_view/src/lib/components/SelectList/SelectList.test.ts
+++ b/lightly_studio_view/src/lib/components/SelectList/SelectList.test.ts
@@ -69,6 +69,20 @@ describe('SelectList', () => {
         expect(screen.getByText('nonexistent')).toBeInTheDocument();
     });
 
+    it('does not offer or create new items when creation is disabled', async () => {
+        const user = userEvent.setup();
+        const onSelect = vi.fn();
+        render(SelectList, {
+            props: { items: [...mockItems], onSelect, allowCreate: false }
+        });
+
+        await user.click(screen.getByTestId('select-list-trigger'));
+        await user.type(screen.getByTestId('select-list-input'), 'nonexistent{Enter}');
+
+        expect(screen.queryByText('Create:')).not.toBeInTheDocument();
+        expect(onSelect).not.toHaveBeenCalled();
+    });
+
     it('renders all items in the list', async () => {
         const user = userEvent.setup();
         render(SelectList, {

--- a/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
+++ b/lightly_studio_view/src/lib/components/VideoDetails/VideoDetails.svelte
@@ -24,7 +24,6 @@
     import { useUpdateAnnotationsMutation } from '$lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation';
     import { useAnnotationLabels } from '$lib/hooks/useAnnotationLabels/useAnnotationLabels';
     import { useCreateAnnotation } from '$lib/hooks/useCreateAnnotation/useCreateAnnotation';
-    import { useCreateLabel } from '$lib/hooks/useCreateLabel/useCreateLabel';
     import { useSelectClassDialog } from '$lib/hooks/useSelectClassDialog/useSelectClassDialog';
     import { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
     import { onMount, untrack } from 'svelte';
@@ -59,7 +58,6 @@
         getCollectionId: () => eventCollectionId
     });
     const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => eventCollectionId });
-    const { createLabel } = useCreateLabel({ getCollectionId: () => eventCollectionId });
     const { deleteAnnotation } = useDeleteAnnotation({ getCollectionId: () => eventCollectionId });
     const annotationLabels = useAnnotationLabels(() => ({ collectionId: eventCollectionId }));
 
@@ -99,14 +97,12 @@
         if (!result?.label) return;
 
         try {
-            let label = annotationLabels.data?.find(
+            const label = annotationLabels.data?.find(
                 (item) => item.annotation_label_name === result.label
             );
             if (!label) {
-                label = await createLabel({
-                    dataset_id: datasetId,
-                    annotation_label_name: result.label
-                });
+                toast.error('This class no longer exists. Choose another class.');
+                return;
             }
 
             await createAnnotation({

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -46,6 +46,7 @@ export { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDi
 export { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnnotation';
 export { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
 export { useSettings } from '$lib/hooks/useSettings';
+export { useClassesDialog } from '$lib/hooks/useClassesDialog/useClassesDialog';
 export { useTrackSampleInspected } from '$lib/hooks/useTrackSampleInspected';
 export { useAnnotationClassVisibility } from '$lib/hooks/useAnnotationClassVisibility/useAnnotationClassVisibility';
 export {

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -47,6 +47,7 @@ export { useDeleteAnnotation } from '$lib/hooks/useDeleteAnnotation/useDeleteAnn
 export { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
 export { useSettings } from '$lib/hooks/useSettings';
 export { useClassesDialog } from '$lib/hooks/useClassesDialog/useClassesDialog';
+export { useClasses } from '$lib/hooks/useClasses/useClasses.svelte';
 export { useTrackSampleInspected } from '$lib/hooks/useTrackSampleInspected';
 export { useAnnotationClassVisibility } from '$lib/hooks/useAnnotationClassVisibility/useAnnotationClassVisibility';
 export {

--- a/lightly_studio_view/src/lib/hooks/useClasses/useClasses.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useClasses/useClasses.svelte.ts
@@ -1,6 +1,7 @@
 import {
     createAnnotationLabelsBatchMutation,
-    readAnnotationLabelsWithCountsOptions
+    readAnnotationLabelsWithCountsOptions,
+    readAnnotationLabelsWithCountsQueryKey
 } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
 import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 
@@ -14,7 +15,12 @@ export function useClasses(getParams: () => { collectionId: string; enabled: boo
     }));
     const addMutation = createMutation(() => createAnnotationLabelsBatchMutation());
 
-    const refresh = () => client.invalidateQueries();
+    const refresh = () =>
+        client.invalidateQueries({
+            queryKey: readAnnotationLabelsWithCountsQueryKey({
+                path: { collection_id: getParams().collectionId }
+            })
+        });
     const addClasses = async (names: string[]) => {
         await addMutation.mutateAsync({
             path: { collection_id: getParams().collectionId },

--- a/lightly_studio_view/src/lib/hooks/useClasses/useClasses.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useClasses/useClasses.svelte.ts
@@ -1,0 +1,27 @@
+import {
+    createAnnotationLabelsBatchMutation,
+    readAnnotationLabelsWithCountsOptions
+} from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
+
+export function useClasses(getParams: () => { collectionId: string; enabled: boolean }) {
+    const client = useQueryClient();
+    const query = createQuery(() => ({
+        ...readAnnotationLabelsWithCountsOptions({
+            path: { collection_id: getParams().collectionId }
+        }),
+        enabled: getParams().enabled
+    }));
+    const addMutation = createMutation(() => createAnnotationLabelsBatchMutation());
+
+    const refresh = () => client.invalidateQueries();
+    const addClasses = async (names: string[]) => {
+        await addMutation.mutateAsync({
+            path: { collection_id: getParams().collectionId },
+            body: { annotation_label_names: names }
+        });
+        await refresh();
+    };
+
+    return { query, addClasses };
+}

--- a/lightly_studio_view/src/lib/hooks/useClassesDialog/useClassesDialog.ts
+++ b/lightly_studio_view/src/lib/hooks/useClassesDialog/useClassesDialog.ts
@@ -1,0 +1,10 @@
+import { writable } from 'svelte/store';
+
+const isClassesDialogOpen = writable(false);
+
+export function useClassesDialog() {
+    const openClassesDialog = () => isClassesDialogOpen.set(true);
+    const closeClassesDialog = () => isClassesDialogOpen.set(false);
+
+    return { isClassesDialogOpen, openClassesDialog, closeClassesDialog };
+}

--- a/lightly_studio_view/src/lib/hooks/useCreateLabel/useCreateLabel.ts
+++ b/lightly_studio_view/src/lib/hooks/useCreateLabel/useCreateLabel.ts
@@ -1,5 +1,5 @@
 import {
-    type AnnotationLabelCreate,
+    type AnnotationLabelCreateRequest,
     type CreateAnnotationLabelResponse
 } from '$lib/api/lightly_studio_local';
 import { createAnnotationLabelMutation } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
@@ -8,7 +8,7 @@ import { createMutation } from '@tanstack/svelte-query';
 export const useCreateLabel = ({ getCollectionId }: { getCollectionId: () => string }) => {
     const mutation = createMutation(() => createAnnotationLabelMutation());
 
-    const createLabel = (inputs: AnnotationLabelCreate) =>
+    const createLabel = (inputs: AnnotationLabelCreateRequest) =>
         new Promise<CreateAnnotationLabelResponse>((resolve, reject) => {
             mutation.mutate(
                 {

--- a/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.test.ts
@@ -344,7 +344,9 @@ describe('useSegmentationMaskBrush', () => {
             requestLabel
         });
 
-        await finishBrush(mask, null, []);
+        await finishBrush(mask, null, [
+            { annotation_label_id: 'car-label-id', annotation_label_name: 'car' }
+        ]);
 
         expect(annotationLabelContext.annotationLabel).toBe('car');
         // The label choice is persisted to the session store, keyed by collection id.
@@ -380,7 +382,7 @@ describe('useSegmentationMaskBrush', () => {
         );
     });
 
-    it('creates a new label with the selected name when label does not exist yet', async () => {
+    it('does not create an annotation when the selected class no longer exists', async () => {
         const refetch = vi.fn();
 
         annotationLabelContext.annotationLabel = 'car';
@@ -396,13 +398,12 @@ describe('useSegmentationMaskBrush', () => {
 
         await finishBrush(mask, null, []);
 
-        expect(createLabel).toHaveBeenCalledWith({
-            dataset_id: datasetId,
-            annotation_label_name: 'car'
-        });
-
-        expect(createAnnotation).toHaveBeenCalled();
-        expect(refetch).toHaveBeenCalled();
+        expect(createLabel).not.toHaveBeenCalled();
+        expect(createAnnotation).not.toHaveBeenCalled();
+        expect(refetch).not.toHaveBeenCalled();
+        expect(toast.error).toHaveBeenCalledWith(
+            'This class no longer exists. Choose another class.'
+        );
     });
 
     it('adds a create-annotation undo action to the stack when a new annotation is created with a brush stroke', async () => {

--- a/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.ts
+++ b/lightly_studio_view/src/lib/hooks/useSegmentationMaskBrush.ts
@@ -5,7 +5,6 @@ import {
 } from '$lib/components/SampleAnnotation/utils';
 import { useAnnotationLabelContext } from '$lib/contexts/SampleDetailsAnnotation.svelte';
 import { useCreateAnnotation } from '$lib/hooks/useCreateAnnotation/useCreateAnnotation';
-import { useCreateLabel } from '$lib/hooks/useCreateLabel/useCreateLabel';
 import { addAnnotationUpdateToUndoStack } from '$lib/services/addAnnotationUpdateToUndoStack';
 import type { BoundingBox } from '$lib/types';
 import { toast } from 'svelte-sonner';
@@ -17,7 +16,6 @@ import { restoreOverriddenSegmentationAnnotationsForUndo } from '$lib/services/r
 
 export function useSegmentationMaskBrush({
     collectionId,
-    datasetId,
     sampleId,
     sample,
     annotations = [],
@@ -40,7 +38,6 @@ export function useSegmentationMaskBrush({
      *  the chosen class, or null if the user cancelled. */
     requestLabel?: () => Promise<{ label: string } | null>;
 }) {
-    const { createLabel } = useCreateLabel({ getCollectionId: () => collectionId });
     const { createAnnotation } = useCreateAnnotation({ getCollectionId: () => collectionId });
     const { addReversibleAction, updateLastAnnotationLabel } = useGlobalStorage();
     const {
@@ -157,13 +154,11 @@ export function useSegmentationMaskBrush({
             }
         }
 
-        let label = labels?.find((l) => l.annotation_label_name === annotationLabelName);
+        const label = labels?.find((l) => l.annotation_label_name === annotationLabelName);
 
         if (!label) {
-            label = await createLabel({
-                dataset_id: datasetId,
-                annotation_label_name: annotationLabelName!
-            });
+            toast.error('This class no longer exists. Choose another class.');
+            return;
         }
 
         const newAnnotation = await createAnnotation({


### PR DESCRIPTION
## What has changed and why?

Introduces a "Classes" dialog that lets users view and add annotation classes (labels) for a dataset, accessible from the main header menu.


https://github.com/user-attachments/assets/17e472cd-7db4-4891-8dda-b38182d6d646


## How has it been tested?

Unit tests + manual tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
