### PR TITLE
Export filtering: integrate format-specific export tabs

### DIFF
--- a/lightly_studio_view/e2e/general/export-annotations.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/export-annotations.e2e-test.ts
@@ -12,14 +12,8 @@ test.describe('Export Annotations', () => {
         await page.getByRole('option', { name: 'Image Classifications (CSV)' }).click();
 
         const downloadButton = page.getByTestId('submit-button-classifications');
-        await expect(downloadButton).toHaveAttribute(
-            'href',
-            /\/api\/collections\/.*\/export\/annotations\?ts=\d+&export_format=classification_csv/
-        );
-        await downloadButton.evaluate((el: HTMLAnchorElement) => el.removeAttribute('target'));
-
         const [download] = await Promise.all([
-            page.waitForEvent('download'),
+            page.context().waitForEvent('download'),
             downloadButton.click()
         ]);
 

--- a/lightly_studio_view/e2e/general/export-annotations.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/export-annotations.e2e-test.ts
@@ -14,19 +14,10 @@ test.describe('Export Annotations', () => {
         // Switch to the correct export type
         await page.getByTestId('export-type-select').click();
         await page.getByRole('option', { name: 'Image Object Detections (COCO)' }).click();
-        await expect(page.getByTestId('submit-button-annotations-coco')).toHaveAttribute(
-            'href',
-            /\/api\/collections\/.*\/export\/annotations\?ts=\d+/
-        );
 
-        // Remove target to avoid popup and keep navigation in the same page context
-        await page
-            .getByTestId('submit-button-annotations-coco')
-            .evaluate((el: HTMLAnchorElement) => el.removeAttribute('target'));
-
-        // Click and wait for the download event deterministically
+        // Click and wait for the download triggered via window.open in a popup
         const [download] = await Promise.all([
-            page.waitForEvent('download'),
+            page.context().waitForEvent('download'),
             page.getByTestId('submit-button-annotations-coco').click()
         ]);
 
@@ -76,19 +67,10 @@ test.describe('Export Annotations', () => {
         // Switch to the YOLO export type
         await page.getByTestId('export-type-select').click();
         await page.getByRole('option', { name: 'Image Object Detections (YOLO)' }).click();
-        await expect(page.getByTestId('submit-button-annotations-yolo')).toHaveAttribute(
-            'href',
-            /\/api\/collections\/.*\/export\/annotations\?ts=\d+&export_format=object_detection_yolo/
-        );
 
-        // Remove target to avoid popup and keep navigation in the same page context
-        await page
-            .getByTestId('submit-button-annotations-yolo')
-            .evaluate((el: HTMLAnchorElement) => el.removeAttribute('target'));
-
-        // Click and wait for the download event deterministically
+        // Click and wait for the download triggered via window.open in a popup
         const [download] = await Promise.all([
-            page.waitForEvent('download'),
+            page.context().waitForEvent('download'),
             page.getByTestId('submit-button-annotations-yolo').click()
         ]);
 

--- a/lightly_studio_view/e2e/general/export-captions.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/export-captions.e2e-test.ts
@@ -30,19 +30,10 @@ test.describe('Export Captions', () => {
         // Switch to the correct export type
         await page.getByTestId('export-type-select').click();
         await page.getByRole('option', { name: 'Image Captions' }).click();
-        await expect(page.getByTestId('submit-button-captions')).toHaveAttribute(
-            'href',
-            /\/api\/collections\/.*\/export\/captions\?ts=\d+/
-        );
 
-        // Remove target to avoid popup and keep navigation in the same page context
-        await page
-            .getByTestId('submit-button-captions')
-            .evaluate((el: HTMLAnchorElement) => el.removeAttribute('target'));
-
-        // Click and wait for the download event deterministically
+        // Click and wait for the download triggered via window.open in a popup
         const [download] = await Promise.all([
-            page.waitForEvent('download'),
+            page.context().waitForEvent('download'),
             page.getByTestId('submit-button-captions').click()
         ]);
 

--- a/lightly_studio_view/e2e/general/export-segmentation-masks.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/export-segmentation-masks.e2e-test.ts
@@ -14,19 +14,10 @@ test.describe('Export Segmentation Masks', () => {
         // Switch to the correct export type
         await page.getByTestId('export-type-select').click();
         await page.getByRole('option', { name: 'Image Segmentation Mask (COCO)' }).click();
-        await expect(page.getByTestId('submit-button-instance-segmentations')).toHaveAttribute(
-            'href',
-            /\/api\/collections\/.*\/export\/annotations\?ts=\d+&export_format=segmentation_mask_coco/
-        );
 
-        // Remove target to avoid popup and keep navigation in the same page context
-        await page
-            .getByTestId('submit-button-instance-segmentations')
-            .evaluate((el: HTMLAnchorElement) => el.removeAttribute('target'));
-
-        // Click and wait for the download event deterministically
+        // Click and wait for the download triggered via window.open in a popup
         const [download] = await Promise.all([
-            page.waitForEvent('download'),
+            page.context().waitForEvent('download'),
             page.getByTestId('submit-button-instance-segmentations').click()
         ]);
 

--- a/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
+++ b/lightly_studio_view/src/lib/components/EmbeddingSelectionFilterItem/EmbeddingSelectionFilterItem.svelte
@@ -22,19 +22,19 @@
     // when switching between the images/annotations tabs. collectionIdStore is a Svelte
     // store (Readable<string>) consumed via get() inside the hooks, so it is not a stale
     // capture — the svelte-ignore suppresses a false-positive state_referenced_locally warning.
-    // eslint-disable-next-line svelte/no-unused-svelte-ignore
+
     // svelte-ignore state_referenced_locally
     const imagesFilter = useEmbeddingFilterForImages(
         collectionIdStore,
         setRangeSelectionForCollection
     );
-    // eslint-disable-next-line svelte/no-unused-svelte-ignore
+
     // svelte-ignore state_referenced_locally
     const videosFilter = useEmbeddingFilterForVideos(
         collectionIdStore,
         setRangeSelectionForCollection
     );
-    // eslint-disable-next-line svelte/no-unused-svelte-ignore
+
     // svelte-ignore state_referenced_locally
     const annotationsFilter = useEmbeddingFilterForAnnotations(
         collectionIdStore,

--- a/lightly_studio_view/src/lib/components/ExportSamples/CaptionsTab/CaptionsTab.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/CaptionsTab/CaptionsTab.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
     import { page } from '$app/state';
     import { exportCollectionCaptionsPrepare } from '$lib/api/lightly_studio_local';
-    import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
+    import { useImageFilters } from '$lib/hooks';
     import { PUBLIC_LIGHTLY_STUDIO_API_URL } from '$env/static/public';
     import { useExportDownload } from '../useExportDownload/useExportDownload';
     import ExportDownloadButton from '../ExportDownloadButton/ExportDownloadButton.svelte';
+
+    interface Props {
+        onDownloadClick?: () => void;
+    }
+
+    let { onDownloadClick }: Props = $props();
 
     const collectionId = page.params.collection_id!;
     const { imageFilter } = useImageFilters();
@@ -29,7 +35,10 @@
     <ExportDownloadButton
         isLoading={$isLoading}
         errorMessage={$errorMessage}
-        onclick={handleDownload}
+        onclick={() => {
+            onDownloadClick?.();
+            handleDownload();
+        }}
         testId="submit-button-captions"
     />
 </div>

--- a/lightly_studio_view/src/lib/components/ExportSamples/CaptionsTab/CaptionsTab.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/CaptionsTab/CaptionsTab.test.ts
@@ -14,7 +14,7 @@ vi.mock('$lib/api/lightly_studio_local', () => ({
 }));
 
 const imageFilterStore = writable(null);
-vi.mock('$lib/hooks/useImageFilters/useImageFilters', () => ({
+vi.mock('$lib/hooks', () => ({
     useImageFilters: () => ({ imageFilter: imageFilterStore })
 }));
 

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -28,6 +28,7 @@
 
     let exportType = $state<
         | 'samples'
+        | 'classifications'
         | 'object_detections_coco'
         | 'object_detections_yolo'
         | 'segmentation'
@@ -149,6 +150,18 @@
 
                     <Tabs.Content value="samples" class="pt-0">
                         <SamplesTab
+                            onDownloadClick={() =>
+                                tracking.handleAnnotationDownloadClick(exportType)}
+                        />
+                    </Tabs.Content>
+
+                    <Tabs.Content value="classifications" class="pt-0">
+                        <AnnotationsTab
+                            exportFormat={ExportFormat.CLASSIFICATION_CSV}
+                            description="The classification annotations will be exported in CSV format."
+                            {annotationSources}
+                            bind:selectedAnnotationCollectionId
+                            testId="submit-button-classifications"
                             onDownloadClick={() =>
                                 tracking.handleAnnotationDownloadClick(exportType)}
                         />

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -1,38 +1,44 @@
 <script lang="ts">
     import { page } from '$app/state';
     import FormField from '$lib/components/FormField/FormField.svelte';
-    import { Checkbox } from '$lib/components';
-    import { Button } from '$lib/components/ui';
-    import {
-        Select,
-        SelectMenuItem,
-        SelectMenuGroup,
-        SelectMenuGroupHeading
-    } from '$lib/components/Select';
+    import { Select, SelectMenuItem } from '$lib/components/Select';
     import * as Tabs from '$lib/components/ui/tabs/index.js';
-    import { useTags } from '$lib/hooks/useTags/useTags';
-    import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
-    import AnnotationSourceSelect from '$lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte';
-    import type { ExportFilter } from '$lib/services/types';
-    import { exportCollection } from '$lib/services/exportCollection';
-    import { useExportSamplesCount } from './useExportSamplesCount/useExportSamplesCount.svelte';
-    import { useExportTracking } from './useExportTracking/useExportTracking';
-    import { PUBLIC_LIGHTLY_STUDIO_API_URL } from '$env/static/public';
     import * as Dialog from '$lib/components/ui/dialog';
-    import { Loader2 } from '@lucide/svelte';
-    import * as Alert from '$lib/components/ui/alert/index.js';
-    import { fade } from 'svelte/transition';
-    import { useExportDialog } from '$lib/hooks';
-    import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
+    import { ExportFormat } from '$lib/api/lightly_studio_local';
+    import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
+    import { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
+    import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+    import { useExportTracking } from './useExportTracking/useExportTracking';
+    import SamplesTab from './SamplesTab/SamplesTab.svelte';
+    import AnnotationsTab from './AnnotationsTab/AnnotationsTab.svelte';
+    import CaptionsTab from './CaptionsTab/CaptionsTab.svelte';
+    import YoutubeVisTab from './YoutubeVisTab/YoutubeVisTab.svelte';
 
     const { isExportDialogOpen, openExportDialog, closeExportDialog } = useExportDialog();
-    const { imageFilter } = useImageFilters();
+    const { filteredSampleCount } = useGlobalStorage();
+    const sampleCountLabel = $derived(
+        `${$filteredSampleCount} ${$filteredSampleCount === 1 ? 'sample' : 'samples'}`
+    );
 
-    let collectionId = page.params.collection_id!;
+    const isVideoCollection = $derived(
+        page.data.collection?.sample_type === 'video' ||
+            page.data.collection?.sample_type === 'video_frame'
+    );
 
+    const collectionId = page.params.collection_id!;
     const tracking = useExportTracking({ collectionId });
 
-    let prevIsDialogOpen = false;
+    let exportType = $state<
+        | 'samples'
+        | 'object_detections_coco'
+        | 'object_detections_yolo'
+        | 'segmentation'
+        | 'captions'
+        | 'youtube_vis_segmentation'
+        | 'semantic_segmentations'
+    >('samples');
+
+    let prevIsDialogOpen = $state(false);
     $effect(() => {
         const isOpen = $isExportDialogOpen;
         if (isOpen) {
@@ -45,20 +51,6 @@
         prevIsDialogOpen = isOpen;
     });
 
-    const isVideoCollection = $derived(
-        page.data.collection?.sample_type === 'video' ||
-            page.data.collection?.sample_type === 'video_frame'
-    );
-
-    let exportType = $state<
-        | 'samples'
-        | 'object_detections_coco'
-        | 'object_detections_yolo'
-        | 'segmentation'
-        | 'captions'
-        | 'youtube_vis_segmentation'
-        | 'semantic_segmentations'
-    >('samples');
     const exportTypeLabels: Record<typeof exportType, string> = {
         samples: 'Image Filenames',
         object_detections_coco: 'Image Object Detections (COCO)',
@@ -68,141 +60,12 @@
         captions: 'Image Captions',
         youtube_vis_segmentation: 'YouTube-VIS Video Segmentation Masks'
     };
-    const exportTypeTriggerContent = $derived(exportTypeLabels[exportType]);
 
-    //
-    // Annotation source selection
-    //
     const annotationCollectionsQuery = useAnnotationCollections(() => ({ collectionId }));
     const annotationSources = $derived(
         (annotationCollectionsQuery.data ?? []).map((c) => ({ id: c.collection_id, name: c.name }))
     );
     let selectedAnnotationCollectionId = $state<string | undefined>(undefined);
-
-    const effectiveAnnotationCollectionId = $derived(
-        selectedAnnotationCollectionId ?? annotationSources[0]?.id
-    );
-    const annotationCollectionParam = $derived(
-        effectiveAnnotationCollectionId
-            ? `&annotation_collection_id=${effectiveAnnotationCollectionId}`
-            : ''
-    );
-
-    //
-    // Sample export
-    //
-
-    let isSelectionInverted = $state(false);
-    let tagIdToExport = $state('');
-    const { tags } = useTags({ collection_id: collectionId });
-
-    const tagNameToExport = $derived($tags.find((f) => f.tag_id === tagIdToExport)?.name ?? null);
-    const triggerContent = $derived(
-        tagNameToExport ?? 'Select a tag to export its samples (required)'
-    );
-
-    // Enable info panel if there are selected samples or annotations or tag is selected
-    const isInfoEnabled = $derived(exportType === 'samples' ? !!tagIdToExport : false);
-
-    const filter = $derived.by(() => {
-        const filter: ExportFilter = {};
-        // Only "Samples" export mode supports filtering by selected samples.
-        if (exportType === 'samples' && tagIdToExport) {
-            filter.tag_ids = [tagIdToExport];
-        }
-        return filter;
-    });
-
-    const includeFilter = $derived(
-        !isSelectionInverted && Object.keys(filter).length > 0 ? filter : undefined
-    );
-    const excludeFilter = $derived(
-        isSelectionInverted && Object.keys(filter).length > 0 ? filter : undefined
-    );
-
-    const {
-        count,
-        isLoading,
-        error: statError
-    } = useExportSamplesCount(() => ({
-        collection_id: collectionId,
-        includeFilter,
-        excludeFilter,
-        collectionFilter: $imageFilter
-    }));
-
-    let errorMessage = $derived.by(() => {
-        return $statError ? $statError : '';
-    });
-
-    // Disable submit button if neither a tag nor a collection filter is set
-    const isSubmitDisabled = $derived.by(() => {
-        if (exportType === 'samples') {
-            if (!tagIdToExport) {
-                return true;
-            }
-        }
-        return !!errorMessage;
-    });
-
-    const handleExport = async () => {
-        const sampleCount = $count;
-        tracking.trackExportDownloadClicked({ exportType, tagNameToExport, sampleCount });
-
-        const response = await exportCollection({
-            collection_id: collectionId,
-            includeFilter,
-            excludeFilter,
-            collectionFilter: $imageFilter
-        });
-
-        tracking.trackExportTriggered({
-            exportType,
-            tagNameToExport,
-            sampleCount,
-            success: !response.error
-        });
-
-        if (response.error) {
-            errorMessage = `Export failed: ${response.error}`;
-        }
-    };
-
-    //
-    // COCO object detection export
-    //
-    const exportObjectDetectionCocoURL = $derived(
-        `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/annotations?ts=${Date.now()}&export_format=object_detection_coco${annotationCollectionParam}`
-    );
-
-    //
-    // YOLO object detection export
-    //
-    const exportObjectDetectionYoloURL = $derived(
-        `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/annotations?ts=${Date.now()}&export_format=object_detection_yolo${annotationCollectionParam}`
-    );
-
-    //
-    // Segmentation mask export
-    //
-    const exportSegmentationMaskURL = $derived(
-        `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/annotations?ts=${Date.now()}&export_format=segmentation_mask_coco${annotationCollectionParam}`
-    );
-
-    //
-    // YouTube-VIS video Segmentation mask export
-    //
-    const exportYoutubeVisSegmentationMaskURL = `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/youtube-vis?ts=${Date.now()}&export_format=youtube_vis_segmentation`;
-    // Semantic segmentation export
-    //
-    const exportPascalVocURL = $derived(
-        `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/annotations?ts=${Date.now()}&export_format=pascal_voc${annotationCollectionParam}`
-    );
-
-    //
-    // Caption export
-    //
-    const exportCaptionsURL = `${PUBLIC_LIGHTLY_STUDIO_API_URL}api/collections/${collectionId}/export/captions?ts=${Date.now()}`;
 </script>
 
 <Dialog.Root
@@ -220,17 +83,17 @@
             <Dialog.Header>
                 <Dialog.Title class="text-foreground">Collection Export</Dialog.Title>
             </Dialog.Header>
-            <Dialog.Description class="text-muted-foreground">
-                Choose the export type:
+            <Dialog.Description class="text-foreground">
+                Export <strong class="font-semibold text-primary">{sampleCountLabel}</strong> currently
+                matching your filters.
             </Dialog.Description>
 
             <div class="grid flex-1 gap-4 overflow-y-auto px-1">
                 <Tabs.Root bind:value={exportType} class="w-full">
-                    <!-- TODO(lukas 3/2026): Consider constructing this by iterating over exportTypeLabels-->
                     <FormField label="Export Type">
                         <Select
                             value={exportType}
-                            triggerLabel={exportTypeTriggerContent}
+                            triggerLabel={exportTypeLabels[exportType]}
                             class="w-full"
                             testId="export-type-select"
                             onOpenChange={(open) =>
@@ -245,8 +108,9 @@
                                     <SelectMenuItem
                                         value="youtube_vis_segmentation"
                                         label="YouTube-VIS Video Segmentation Masks"
-                                        >YouTube-VIS Video Segmentation Masks</SelectMenuItem
                                     >
+                                        YouTube-VIS Video Segmentation Masks
+                                    </SelectMenuItem>
                                 {:else}
                                     <SelectMenuItem value="samples" label="Image Filenames"
                                         >Image Filenames</SelectMenuItem
@@ -279,258 +143,76 @@
                         </Select>
                     </FormField>
 
-                    <!-- Samples tab -->
-
-                    <Tabs.Content value="samples" class="pt-2">
-                        <FormField label="Tag">
-                            <Select
-                                value={tagIdToExport}
-                                triggerLabel={triggerContent}
-                                class="w-full"
-                                onValueChange={(v) => (tagIdToExport = v)}
-                            >
-                                {#snippet children()}
-                                    <SelectMenuGroup>
-                                        <SelectMenuGroupHeading
-                                            >Annotation tags</SelectMenuGroupHeading
-                                        >
-                                        {#if $tags.filter((tag) => tag.kind === 'annotation').length === 0}
-                                            <div
-                                                class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
-                                            >
-                                                no tags available
-                                            </div>
-                                        {/if}
-                                        {#each $tags.filter((tag) => tag.kind === 'annotation') as annotationTag}
-                                            <SelectMenuItem
-                                                value={annotationTag.tag_id}
-                                                label={annotationTag.name}
-                                                >{annotationTag.name}</SelectMenuItem
-                                            >
-                                        {/each}
-                                        <SelectMenuGroupHeading>Sample tags</SelectMenuGroupHeading>
-                                        {#if $tags.filter((tag) => tag.kind === 'sample').length === 0}
-                                            <div
-                                                class="py-1.5 pl-8 pr-2 text-sm italic text-muted-foreground"
-                                            >
-                                                no tags available
-                                            </div>
-                                        {/if}
-                                        {#each $tags.filter((tag) => tag.kind === 'sample') as sampleTag}
-                                            <SelectMenuItem
-                                                value={sampleTag.tag_id}
-                                                label={sampleTag.name}
-                                                >{sampleTag.name}</SelectMenuItem
-                                            >
-                                        {/each}
-                                    </SelectMenuGroup>
-                                {/snippet}
-                            </Select>
-                        </FormField>
-
-                        <div class="my-4">
-                            <Checkbox
-                                name="inverse-selection"
-                                label="Inverse selection"
-                                isChecked={isSelectionInverted}
-                                onCheckedChange={() => (isSelectionInverted = !isSelectionInverted)}
-                                helperText="Inverse selection will export all samples that are not selected"
-                                disabled={isSubmitDisabled}
-                            />
-                        </div>
-
-                        {#if isInfoEnabled}
-                            <div class="my-4 rounded-lg bg-muted p-4">
-                                <h4 class="font-medium">Summary</h4>
-                                <div class="mt-2 text-sm text-muted-foreground">
-                                    <p>Samples to export: <strong>{$count}</strong></p>
-                                </div>
-                            </div>
-                        {/if}
-
-                        {#if errorMessage}
-                            <div transition:fade>
-                                <Alert.Root
-                                    variant="destructive"
-                                    class="border text-foreground"
-                                    data-testid={errorMessage
-                                        ? 'alert-destructive'
-                                        : 'alert-success'}
-                                >
-                                    <div class="flex items-center gap-2">
-                                        <span class="text-destructive-foreground"
-                                            >{errorMessage}</span
-                                        >
-                                    </div>
-                                </Alert.Root>
-                            </div>
-                        {/if}
-
-                        <Button
-                            class="relative my-4 w-full"
-                            disabled={isSubmitDisabled || $isLoading}
-                            onclick={handleExport}
-                            data-testid="submit-button-samples"
-                        >
-                            Download
-                            {#if $isLoading}
-                                <div
-                                    class="absolute inset-0 flex items-center justify-center backdrop-blur-sm"
-                                    data-testid="loading-spinner"
-                                >
-                                    <Loader2 class="animate-spin" />
-                                </div>
-                            {/if}
-                        </Button>
+                    <Tabs.Content value="samples" class="pt-0">
+                        <SamplesTab
+                            onDownloadClick={() =>
+                                tracking.handleAnnotationDownloadClick(exportType)}
+                        />
                     </Tabs.Content>
 
-                    <!-- Object Detections (COCO) tab -->
-                    <Tabs.Content value="object_detections_coco" class="pt-2">
-                        <p class="text-sm text-muted-foreground">
-                            The object detection annotations will be exported in COCO format.
-                        </p>
-
-                        {#if annotationSources.length > 1}
-                            <div class="mt-6">
-                                <FormField label="Annotation Source">
-                                    <AnnotationSourceSelect
-                                        sourceOptions={annotationSources}
-                                        placeholder="Only annotations from the selected source will be exported"
-                                        bind:selectedSource={selectedAnnotationCollectionId}
-                                    />
-                                </FormField>
-                            </div>
-                        {/if}
-
-                        <Button
-                            class="relative my-4 w-full"
-                            href={exportObjectDetectionCocoURL}
-                            target="_blank"
-                            data-testid="submit-button-annotations-coco"
-                            onclick={() => tracking.handleAnnotationDownloadClick(exportType)}
-                        >
-                            Download
-                        </Button>
+                    <Tabs.Content value="object_detections_coco" class="pt-0">
+                        <AnnotationsTab
+                            exportFormat={ExportFormat.OBJECT_DETECTION_COCO}
+                            description="The object detection annotations will be exported in COCO format."
+                            {annotationSources}
+                            bind:selectedAnnotationCollectionId
+                            testId="submit-button-annotations-coco"
+                            onDownloadClick={() =>
+                                tracking.handleAnnotationDownloadClick(exportType)}
+                        />
                     </Tabs.Content>
 
-                    <!-- Object Detections (YOLO) tab -->
-                    <Tabs.Content value="object_detections_yolo" class="pt-2">
-                        <p class="text-sm text-muted-foreground">
-                            The object detection annotations will be exported in YOLO format.
-                        </p>
-
-                        {#if annotationSources.length > 1}
-                            <div class="mt-3">
-                                <FormField label="Annotation Source">
-                                    <AnnotationSourceSelect
-                                        sourceOptions={annotationSources}
-                                        bind:selectedSource={selectedAnnotationCollectionId}
-                                    />
-                                </FormField>
-                            </div>
-                        {/if}
-
-                        <Button
-                            class="relative my-4 w-full"
-                            href={exportObjectDetectionYoloURL}
-                            target="_blank"
-                            data-testid="submit-button-annotations-yolo"
-                            onclick={() => tracking.handleAnnotationDownloadClick(exportType)}
-                        >
-                            Download
-                        </Button>
+                    <Tabs.Content value="object_detections_yolo" class="pt-0">
+                        <AnnotationsTab
+                            exportFormat={ExportFormat.OBJECT_DETECTION_YOLO}
+                            description="The object detection annotations will be exported in YOLO format."
+                            {annotationSources}
+                            bind:selectedAnnotationCollectionId
+                            testId="submit-button-annotations-yolo"
+                            onDownloadClick={() =>
+                                tracking.handleAnnotationDownloadClick(exportType)}
+                        />
                     </Tabs.Content>
 
-                    <Tabs.Content value="segmentation" class="pt-2">
-                        <p class="text-sm text-muted-foreground">
-                            The segmentation masks will be exported in COCO format.
-                        </p>
+                    <Tabs.Content value="segmentation" class="pt-0">
+                        <AnnotationsTab
+                            exportFormat={ExportFormat.SEGMENTATION_MASK_COCO}
+                            description="The segmentation masks will be exported in COCO format."
+                            {annotationSources}
+                            bind:selectedAnnotationCollectionId
+                            testId="submit-button-instance-segmentations"
+                            onDownloadClick={() =>
+                                tracking.handleAnnotationDownloadClick(exportType)}
+                        />
+                    </Tabs.Content>
 
-                        {#if annotationSources.length > 1}
-                            <div class="mt-6">
-                                <FormField label="Annotation Source">
-                                    <AnnotationSourceSelect
-                                        sourceOptions={annotationSources}
-                                        placeholder="Select an annotation collection to export from (required)"
-                                        bind:selectedSource={selectedAnnotationCollectionId}
-                                    />
-                                </FormField>
-                            </div>
-                        {/if}
+                    <Tabs.Content value="semantic_segmentations" class="pt-0">
+                        <AnnotationsTab
+                            exportFormat={ExportFormat.PASCAL_VOC}
+                            description="The semantic segmentations will be exported in PASCAL VOC format."
+                            {annotationSources}
+                            bind:selectedAnnotationCollectionId
+                            testId="submit-button-semantic-segmentations"
+                            onDownloadClick={() =>
+                                tracking.handleAnnotationDownloadClick(exportType)}
+                        />
+                    </Tabs.Content>
 
-                        <Button
-                            class="relative my-4 w-full"
-                            href={exportSegmentationMaskURL}
-                            target="_blank"
-                            data-testid="submit-button-instance-segmentations"
-                            onclick={() => tracking.handleAnnotationDownloadClick(exportType)}
-                        >
-                            Download
-                        </Button>
+                    <Tabs.Content value="captions" class="pt-0">
+                        <CaptionsTab
+                            onDownloadClick={() =>
+                                tracking.handleAnnotationDownloadClick(exportType)}
+                        />
                     </Tabs.Content>
 
                     {#if isVideoCollection}
-                        <Tabs.Content value="youtube_vis_segmentation" class="pt-2">
-                            <p class="text-sm text-muted-foreground">
-                                The video segmentation masks will be exported in YouTube-VIS format.
-                            </p>
-
-                            <Button
-                                class="relative my-4 w-full"
-                                href={exportYoutubeVisSegmentationMaskURL}
-                                target="_blank"
-                                data-testid="submit-button-youtube-vis-instance-segmentations"
-                                onclick={() => tracking.handleAnnotationDownloadClick(exportType)}
-                            >
-                                Download
-                            </Button>
+                        <Tabs.Content value="youtube_vis_segmentation" class="pt-0">
+                            <YoutubeVisTab
+                                onDownloadClick={() =>
+                                    tracking.handleAnnotationDownloadClick(exportType)}
+                            />
                         </Tabs.Content>
                     {/if}
-                    <Tabs.Content value="semantic_segmentations" class="pt-2">
-                        <p class="text-sm text-muted-foreground">
-                            The semantic segmentations will be exported in PASCAL VOC format.
-                        </p>
-
-                        {#if annotationSources.length > 1}
-                            <div class="mt-6">
-                                <FormField label="Annotation Source">
-                                    <AnnotationSourceSelect
-                                        sourceOptions={annotationSources}
-                                        placeholder="Select an annotation collection to export from (required)"
-                                        bind:selectedSource={selectedAnnotationCollectionId}
-                                    />
-                                </FormField>
-                            </div>
-                        {/if}
-
-                        <Button
-                            class="relative my-4 w-full"
-                            href={exportPascalVocURL}
-                            target="_blank"
-                            data-testid="submit-button-semantic-segmentations"
-                            onclick={() => tracking.handleAnnotationDownloadClick(exportType)}
-                        >
-                            Download
-                        </Button>
-                    </Tabs.Content>
-
-                    <!-- Captions tab -->
-
-                    <Tabs.Content value="captions" class="pt-2">
-                        <p class="text-sm text-muted-foreground">
-                            The captions will be exported in COCO format.
-                        </p>
-
-                        <Button
-                            class="relative my-4 w-full"
-                            href={exportCaptionsURL}
-                            target="_blank"
-                            data-testid="submit-button-captions"
-                            onclick={() => tracking.handleAnnotationDownloadClick(exportType)}
-                        >
-                            Download
-                        </Button>
-                    </Tabs.Content>
                 </Tabs.Root>
             </div>
         </Dialog.Content>

--- a/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/ExportSamples.svelte
@@ -5,9 +5,7 @@
     import * as Tabs from '$lib/components/ui/tabs/index.js';
     import * as Dialog from '$lib/components/ui/dialog';
     import { ExportFormat } from '$lib/api/lightly_studio_local';
-    import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
-    import { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
-    import { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+    import { useAnnotationCollections, useExportDialog, useGlobalStorage } from '$lib/hooks';
     import { useExportTracking } from './useExportTracking/useExportTracking';
     import SamplesTab from './SamplesTab/SamplesTab.svelte';
     import AnnotationsTab from './AnnotationsTab/AnnotationsTab.svelte';

--- a/lightly_studio_view/src/lib/components/ExportSamples/SamplesTab/SamplesTab.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/SamplesTab/SamplesTab.svelte
@@ -16,6 +16,12 @@
     import type { ExportFilter } from '$lib/services/types';
     import { PUBLIC_LIGHTLY_STUDIO_API_URL } from '$env/static/public';
 
+    interface Props {
+        onDownloadClick?: () => void;
+    }
+
+    let { onDownloadClick }: Props = $props();
+
     const collectionId = page.params.collection_id!;
     const { imageFilter } = useImageFilters();
     const { tags } = useTags({ collection_id: collectionId });
@@ -133,7 +139,10 @@
         isLoading={$exportIsLoading || $countIsLoading}
         disabled={isSubmitDisabled}
         errorMessage={$statError ?? $errorMessage}
-        onclick={handleExport}
+        onclick={() => {
+            onDownloadClick?.();
+            handleExport();
+        }}
         testId="submit-button-samples"
     />
 </div>

--- a/lightly_studio_view/src/lib/components/ExportSamples/SamplesTab/SamplesTab.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/SamplesTab/SamplesTab.test.ts
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { writable } from 'svelte/store';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import SamplesTab from './SamplesTab.svelte';
@@ -66,5 +67,20 @@ describe('SamplesTab', () => {
         expect(
             screen.getByText(/Inverse selection will export all samples that are not selected/)
         ).toBeInTheDocument();
+    });
+
+    it('calls onDownloadClick when the download button is clicked', async () => {
+        tagsStore = writable([{ tag_id: 'tag-1', name: 'My Tag', kind: 'sample' }]);
+        const onDownloadClick = vi.fn();
+        render(SamplesTab, { props: { onDownloadClick } });
+
+        const user = userEvent.setup();
+        await user.click(screen.getByText('Select a tag to export its samples (required)'));
+        const option = await waitFor(() => screen.getByRole('option', { name: 'My Tag' }));
+        await user.click(option);
+        await waitFor(() => expect(screen.getByTestId('submit-button-samples')).not.toBeDisabled());
+        await fireEvent.click(screen.getByTestId('submit-button-samples'));
+
+        expect(onDownloadClick).toHaveBeenCalledOnce();
     });
 });

--- a/lightly_studio_view/src/lib/components/ExportSamples/YoutubeVisTab/YoutubeVisTab.svelte
+++ b/lightly_studio_view/src/lib/components/ExportSamples/YoutubeVisTab/YoutubeVisTab.svelte
@@ -4,7 +4,13 @@
     import { PUBLIC_LIGHTLY_STUDIO_API_URL } from '$env/static/public';
     import { useExportDownload } from '../useExportDownload/useExportDownload';
     import ExportDownloadButton from '../ExportDownloadButton/ExportDownloadButton.svelte';
-    import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
+    import { useVideoFilters } from '$lib/hooks';
+
+    interface Props {
+        onDownloadClick?: () => void;
+    }
+
+    let { onDownloadClick }: Props = $props();
 
     const collectionId = page.params.collection_id!;
     const { videoFilter } = useVideoFilters();
@@ -29,7 +35,10 @@
     <ExportDownloadButton
         isLoading={$isLoading}
         errorMessage={$errorMessage}
-        onclick={handleDownload}
+        onclick={() => {
+            onDownloadClick?.();
+            handleDownload();
+        }}
         testId="submit-button-youtube-vis-instance-segmentations"
     />
 </div>

--- a/lightly_studio_view/src/lib/components/ExportSamples/YoutubeVisTab/YoutubeVisTab.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/YoutubeVisTab/YoutubeVisTab.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { writable } from 'svelte/store';
 import type { VideoFilter } from '$lib/api/lightly_studio_local/types.gen';
 import YoutubeVisTab from './YoutubeVisTab.svelte';
-import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
+import { useVideoFilters } from '$lib/hooks';
 
 const pageMock = vi.hoisted(() => ({ params: { collection_id: 'test-collection' } }));
 vi.mock('$app/state', () => ({ page: pageMock }));
@@ -15,7 +15,7 @@ vi.mock('$lib/api/lightly_studio_local', () => ({
     exportCollectionYoutubeVisPrepare: mocks.exportCollectionYoutubeVisPrepare
 }));
 
-vi.mock('$lib/hooks/useVideoFilters/useVideoFilters', () => ({
+vi.mock('$lib/hooks', () => ({
     useVideoFilters: vi.fn()
 }));
 
@@ -48,11 +48,11 @@ describe('YoutubeVisTab', () => {
         await fireEvent.click(
             screen.getByTestId('submit-button-youtube-vis-instance-segmentations')
         );
-        expect(mocks.exportCollectionYoutubeVisPrepare).toHaveBeenCalledWith({
-            path: { collection_id: 'test-collection' },
-            body: { video_filter: null }
-        });
         await waitFor(() => {
+            expect(mocks.exportCollectionYoutubeVisPrepare).toHaveBeenCalledWith({
+                path: { collection_id: 'test-collection' },
+                body: { video_filter: null }
+            });
             expect(openSpy).toHaveBeenCalledWith(
                 expect.stringContaining('/export/download/key123'),
                 '_blank'

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -53,6 +53,7 @@ export {
     useImageAnnotationCountsQueryKey
 } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
 export { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
+export { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
 export {
     createOperatorFromMetadata,
     type Operator,


### PR DESCRIPTION
## What has changed and why?

Replace the inline collection export implementations with dedicated tabs for samples, annotations, captions, and YouTube-VIS exports.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refined the export dialog with dedicated tabs for samples, annotations, captions, and YouTube-VIS.
  * Added download tracking across export tabs.
  * Improved filtered sample counts and shared filter handling while preserving video-specific behavior.

* **Bug Fixes**
  * Improved exporting filtered samples after tag selection.
  * Made downloads more reliable when opened in a new window.

* **Tests**
  * Expanded coverage for download callbacks, tag selection, and asynchronous export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->