### PR TITLE
Wait for the Postgres database, not just the postmaster

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -232,7 +232,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U lightly -d lightly_studio"
+          --health-cmd "pg_isready -h 127.0.0.1 -U lightly -d lightly_studio"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -121,16 +121,18 @@ start-postgres: stop-postgres
 		-p $(POSTGRES_PORT):5432 \
 		$(POSTGRES_IMAGE)
 	@echo "Waiting for PostgreSQL to be ready..."
-# Query $(POSTGRES_DB) instead of using pg_isready: pg_isready only pings the postmaster and
-# reports success even while the entrypoint's temporary bootstrap server is still creating the
-# database, which lets callers connect before $(POSTGRES_DB) exists.
+# Probe over TCP (-h 127.0.0.1) with a real query against $(POSTGRES_DB). Both details matter:
+# pg_isready only pings the postmaster and reports success even when the database is missing, and
+# the entrypoint's temporary bootstrap server -- which creates $(POSTGRES_DB), then runs the init
+# scripts and shuts down again -- listens on the Unix socket only. A socket probe therefore
+# answers from that short-lived server, so callers reach $(POSTGRES_URL) before the real server
+# accepts TCP connections.
 ifeq ($(OS),Windows_NT)
-	@powershell -Command "$$remaining = $(POSTGRES_STARTUP_TIMEOUT_SECONDS); while ($$remaining -gt 0) { docker exec $(POSTGRES_CONTAINER_NAME) psql -U $(POSTGRES_USER) -d $(POSTGRES_DB) -c 'SELECT 1' *> $$null; if ($$LASTEXITCODE -eq 0) { exit 0 }; Start-Sleep -Seconds 1; $$remaining-- }; Write-Host 'PostgreSQL did not become ready within $(POSTGRES_STARTUP_TIMEOUT_SECONDS) seconds'; docker logs $(POSTGRES_CONTAINER_NAME); exit 1"
+	@powershell -Command "$$deadline = (Get-Date).AddSeconds($(POSTGRES_STARTUP_TIMEOUT_SECONDS)); while ($$true) { docker exec -e PGPASSWORD=$(POSTGRES_PASSWORD) $(POSTGRES_CONTAINER_NAME) psql -h 127.0.0.1 -U $(POSTGRES_USER) -d $(POSTGRES_DB) -c 'SELECT 1' *> $$null; if ($$LASTEXITCODE -eq 0) { break }; if ((Get-Date) -ge $$deadline) { Write-Host 'PostgreSQL did not become ready within $(POSTGRES_STARTUP_TIMEOUT_SECONDS) seconds'; docker logs $(POSTGRES_CONTAINER_NAME); exit 1 }; Start-Sleep -Seconds 1 }"
 else
-	@remaining=$(POSTGRES_STARTUP_TIMEOUT_SECONDS); \
-	until docker exec $(POSTGRES_CONTAINER_NAME) psql -U $(POSTGRES_USER) -d $(POSTGRES_DB) -c 'SELECT 1' > /dev/null 2>&1; do \
-		remaining=$$((remaining - 1)); \
-		if [ $$remaining -le 0 ]; then \
+	@deadline=$$(($$(date +%s) + $(POSTGRES_STARTUP_TIMEOUT_SECONDS))); \
+	until docker exec -e PGPASSWORD=$(POSTGRES_PASSWORD) $(POSTGRES_CONTAINER_NAME) psql -h 127.0.0.1 -U $(POSTGRES_USER) -d $(POSTGRES_DB) -c 'SELECT 1' > /dev/null 2>&1; do \
+		if [ $$(date +%s) -ge $$deadline ]; then \
 			echo "PostgreSQL did not become ready within $(POSTGRES_STARTUP_TIMEOUT_SECONDS) seconds"; \
 			docker logs $(POSTGRES_CONTAINER_NAME); \
 			exit 1; \

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -7,6 +7,7 @@ POSTGRES_DB := lightly_studio
 POSTGRES_IMAGE := pgvector/pgvector:0.8.1-pg18-bookworm
 POSTGRES_SHM_SIZE ?= 2g
 POSTGRES_URL ?= postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@localhost:$(POSTGRES_PORT)/$(POSTGRES_DB)
+POSTGRES_STARTUP_TIMEOUT_SECONDS ?= 60
 
 .PHONY: install-uv
 install-uv:
@@ -119,11 +120,21 @@ start-postgres: stop-postgres
 		-e POSTGRES_DB=$(POSTGRES_DB) \
 		-p $(POSTGRES_PORT):5432 \
 		$(POSTGRES_IMAGE)
-ifeq ($(OS),Windows_NT)
-	@powershell -Command "Start-Sleep -Seconds 3"
-else
 	@echo "Waiting for PostgreSQL to be ready..."
-	@until docker exec $(POSTGRES_CONTAINER_NAME) pg_isready -U $(POSTGRES_USER) -d $(POSTGRES_DB) > /dev/null 2>&1; do \
+# Query $(POSTGRES_DB) instead of using pg_isready: pg_isready only pings the postmaster and
+# reports success even while the entrypoint's temporary bootstrap server is still creating the
+# database, which lets callers connect before $(POSTGRES_DB) exists.
+ifeq ($(OS),Windows_NT)
+	@powershell -Command "$$remaining = $(POSTGRES_STARTUP_TIMEOUT_SECONDS); while ($$remaining -gt 0) { docker exec $(POSTGRES_CONTAINER_NAME) psql -U $(POSTGRES_USER) -d $(POSTGRES_DB) -c 'SELECT 1' *> $$null; if ($$LASTEXITCODE -eq 0) { exit 0 }; Start-Sleep -Seconds 1; $$remaining-- }; Write-Host 'PostgreSQL did not become ready within $(POSTGRES_STARTUP_TIMEOUT_SECONDS) seconds'; docker logs $(POSTGRES_CONTAINER_NAME); exit 1"
+else
+	@remaining=$(POSTGRES_STARTUP_TIMEOUT_SECONDS); \
+	until docker exec $(POSTGRES_CONTAINER_NAME) psql -U $(POSTGRES_USER) -d $(POSTGRES_DB) -c 'SELECT 1' > /dev/null 2>&1; do \
+		remaining=$$((remaining - 1)); \
+		if [ $$remaining -le 0 ]; then \
+			echo "PostgreSQL did not become ready within $(POSTGRES_STARTUP_TIMEOUT_SECONDS) seconds"; \
+			docker logs $(POSTGRES_CONTAINER_NAME); \
+			exit 1; \
+		fi; \
 		sleep 1; \
 	done
 endif


### PR DESCRIPTION
## What has changed and why?

`Backend (3.14, Postgres)` failed on an unrelated PR ([run 31087210327](https://github.com/lightly-ai/lightly-studio/actions/runs/31087210327/job/92569559312)) during `make migration-check-postgresql`:

```
09:02:02.026  Waiting for PostgreSQL to be ready...
09:02:03.166  PostgreSQL is ready on port 5433      <- 1.1s after docker run
09:02:03.356  psql: error: ... FATAL: database "lightly_studio" does not exist
```

`start-postgres` gated on `pg_isready` over the container's Unix socket, which is unsound twice over. `pg_isready` only pings the postmaster — a server answering `FATAL: database ... does not exist` still counts as `PQPING_OK`, so `-d lightly_studio` bought nothing. And the socket is where the *bootstrap* server lives: the entrypoint boots a temporary server with `listen_addresses=''` to run `initdb`, create `POSTGRES_DB`, and run the init scripts, then shuts it down and restarts for real. A socket probe answers from that short-lived server, so "ready" can fire while nothing is listening on the TCP port `POSTGRES_URL` points at.

The gate therefore exited mid-init and the next command raced ahead. Flaky, and likelier on a cold image pull (13s in that run) or a loaded runner.

Changes:

- Probe `SELECT 1` against `$(POSTGRES_DB)` over `-h 127.0.0.1`. The bootstrap server can't answer TCP, so only the real server satisfies the gate. TCP needs authentication, hence `PGPASSWORD`.
- Bound the wait by a `date +%s` deadline rather than a retry counter — each probe's round trip isn't free, so counting iterations doesn't bound seconds. On timeout it dumps `docker logs` and exits 1 instead of spinning.
- The Windows branch previously slept a flat 3 seconds, the same race; it now runs the same bounded probe.
- Same `-h 127.0.0.1` on the e2e Postgres service health check, which had the identical socket flaw.

This affects every target depending on `start-postgres`, including `make test-postgres` and the `migration-*-postgresql` targets.

Not done here: no `timeout(1)` wrapper around the probe — it isn't present on macOS, so it would break local dev to guard a wedged-daemon case where the build is doomed anyway. The workflow sets no `timeout-minutes`, so a hang burns GitHub's 360-minute default; better fixed at the job level in a separate PR, where it covers every hang.

## How has it been tested?

- `make -n start-postgres` expands as intended.
- The loop was exercised against a stub `docker`: succeeds after N failed probes; on timeout prints the message, dumps logs, exits 1. With a deliberately slow 2s probe and a 4s timeout it exits at 6s (deadline plus one in-flight probe), where the retry-counter version ran ~12s.
- Docker is unavailable on my machine, so the real container start and the PowerShell branch are untested locally — CI covers the former.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)