### PR TITLE
Rename test_and_release.yml to unit_test.yml

### DIFF
--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         # Never pushes — keep the git token out of the checkout. The later toolchain steps
-        # expose GCP secrets to PR code (same posture as test_and_release.yml); fork PRs get
+        # expose GCP secrets to PR code (same posture as unit_test.yml); fork PRs get
         # no secrets, so their toolchain-dependent guardrails error instead of emitting a verdict.
         with:
           persist-credentials: false

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -40,7 +40,7 @@ jobs:
             # List paths in `lightly_studio/` to exclude triggering on docs.
             # E2E tests and examples are included for static checks.
             backend:
-              - '.github/workflows/test_and_release.yml'
+              - '.github/workflows/unit_test.yml'
               - 'lightly_studio/src/**'
               - 'lightly_studio/tests/**'
               - 'lightly_studio/e2e-tests/**'
@@ -52,14 +52,14 @@ jobs:
               - 'lightly_studio/Makefile'
               - 'lightly_studio/alembic.ini'
             frontend:
-              - '.github/workflows/test_and_release.yml'
+              - '.github/workflows/unit_test.yml'
               - 'lightly_studio_view/**'
             docs:
-              - '.github/workflows/test_and_release.yml'
+              - '.github/workflows/unit_test.yml'
               - 'lightly_studio/docs/**'
             # Self-contained Node package (guardrails + bot); Node-only toolchain.
             fast_track:
-              - '.github/workflows/test_and_release.yml'
+              - '.github/workflows/unit_test.yml'
               - 'fast_track/**'
 
   check-python:


### PR DESCRIPTION
## What has changed and why?

The workflow releases nothing — no `release:` trigger, no tag filter, and all eight jobs are checks. `unit_test.yml` matches its own `name: Unit Test` (what the Actions UI shows) and pairs with `end2end_test.yml`.

Also updates the four `detect` path filters that listed the old filename — stale entries there would silently stop the workflow triggering on its own changes — and a mention in a `fast_track_guardrails.yml` comment.

Required checks are job names (`CI Success Check`), so the ruleset is unaffected. Run history under the old name is orphaned, as with any workflow rename.

## How has it been tested?

Both touched files parse; `name: Unit Test`, all eight job names, and the four filter entries verified after the rename. CI on this PR exercises the renamed workflow end to end.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to reference the current unit test workflow.
  * Ensured workflow changes trigger the appropriate backend, frontend, documentation, and fast-track validations.
  * Updated related workflow comments for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->