### PR TITLE
Add: custom embedding model serving for hosted Studio (LIG-10428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Export image classification annotations to CSV via Python SDK
 
+- Python SDK: Keep text and image search working for datasets indexed with a custom embedding model, by pointing LightlyStudio at an HTTP service serving that model with the new `serving_url` parameter of `set_default_embedding_model`.
+
 ### Changed
 
 ### Deprecated
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Autofocus lets users create their first annotation faster.
 - Opening a DuckDB database that another lightly_studio process already has open now raises a clear error instead of a raw DuckDB traceback.
 - Coloring the 2D embedding plot by annotations or metadata now loads faster, especially for large datasets.
+- Opening a collection no longer records the default embedding model against it, which previously overwrote the record of which model produced its stored embeddings and hid search for datasets indexed with a custom model.
 
 ### Security
 

--- a/lightly_studio/docs/docs/enterprise/custom_embedding_model.md
+++ b/lightly_studio/docs/docs/enterprise/custom_embedding_model.md
@@ -1,0 +1,199 @@
+# Custom Embedding Models
+
+LightlyStudio computes embeddings for your samples during indexing and uses them for text
+search, image search, similarity, and sampling. If you index with your own embedding model,
+those embeddings live in the database and everything that only *reads* them keeps working.
+
+Search is different. Typing a query embeds that query, which needs a live copy of your model.
+On a hosted LightlyStudio instance your model is not present, so LightlyStudio needs somewhere
+to send query text and query images.
+
+The answer is an **embedding service**: a small HTTP endpoint you run on your own network that
+serves the same model you indexed with. The browser calls it directly.
+
+```
+                    ┌──────────────────────┐
+   your browser ───►│ hosted LightlyStudio │  filters, ranking, stored vectors
+        │           └──────────────────────┘
+        │  query text / query image
+        ▼
+  ┌───────────────────────┐
+  │ your embedding service│  your network, your weights
+  └───────────────────────┘
+```
+
+Your model and your queries never reach Lightly's infrastructure, and Lightly's servers never
+connect to your network. The browser hands the resulting vector to LightlyStudio, which uses it
+to rank the stored embeddings.
+
+## Registering a service
+
+Pass `serving_url` when you register your model. The URL is stored next to the record of which
+model produced the embeddings, so the two cannot drift apart:
+
+```python
+import lightly_studio as ls
+
+ls.set_default_embedding_model(
+    MyEmbeddingGenerator(),
+    serving_url="https://gpu-box.corp.example:8123",
+)
+
+dataset = ls.ImageDataset.create()
+dataset.add_images_from_path(path="/data/images")
+```
+
+To change the URL later without re-indexing, `PUT` the new one. This is keyed on the model, so
+one call covers every collection indexed with it:
+
+```bash
+curl -X PUT https://studio.corp.example/api/embedding_models/my-model-v1/serving_url \
+  -H 'Content-Type: application/json' \
+  -d '{"serving_url": "https://new-gpu-box.corp.example:8123"}'
+```
+
+Send `{"serving_url": null}` to stop serving the model.
+
+## The wire contract
+
+Your service must answer three requests. A complete, runnable implementation is in
+`lightly_studio/examples/example_embedding_service.py` — copy it and replace the model.
+
+### `GET /info`
+
+Called once when a collection is opened, so LightlyStudio knows what your model can do before
+it draws the search bar.
+
+```json
+{
+  "contract_version": "1",
+  "model_id": "my-model-v1",
+  "embedding_dimension": 512,
+  "supports_text": true,
+  "supports_image": true,
+  "normalized": false
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `contract_version` | Always `"1"` today. |
+| `model_id` | Must equal the `embedding_model_hash` your indexing code declares. See [Model identity](#model-identity). |
+| `embedding_dimension` | Length of the vectors you return. |
+| `supports_text` | `false` for a model with no text tower. Hides the text search box instead of offering one that always fails. |
+| `supports_image` | `false` for a model that cannot embed images. |
+| `normalized` | Whether your vectors are unit length. |
+
+A missing `supports_*` flag is read as `false`.
+
+### `POST /embed/text`
+
+```
+Content-Type: application/json
+
+{"text": "a red car at night"}
+```
+
+Returns the vector as a JSON array: `[0.013, -0.221, ...]`.
+
+### `POST /embed/image`
+
+A `multipart/form-data` body with the image in a field named `image`. Returns a vector in the
+same format.
+
+Your service owns all preprocessing — resizing, cropping, normalization. LightlyStudio sends the
+raw file exactly as the user supplied it.
+
+## Model identity
+
+`model_id` is a string **you** declare, not a digest of your weights. The rule is:
+
+> Change `model_id` whenever your model starts producing different vectors.
+
+LightlyStudio compares the `model_id` your service reports against the identifier recorded when
+the collection was indexed. If they differ, search is disabled with an explicit message. It never
+falls back to the built-in model: a built-in query vector compared against your embeddings
+produces a confidently ordered list of unrelated results, with no error — and because 512 is a
+common width, a dimension check would not catch it either.
+
+The flip side is that this is trust-based. If you retrain and forget to bump `model_id`, search
+returns quietly wrong results. The most reliable pattern is to have one source of truth — fetch
+the id from the service itself when you index:
+
+```python
+import httpx
+
+SERVING_URL = "https://gpu-box.corp.example:8123"
+model_id = httpx.get(f"{SERVING_URL}/info").json()["model_id"]
+```
+
+## Requirements
+
+**One model per process.** The URL is keyed on model identity, so three models means three
+processes on three ports.
+
+**HTTPS.** Hosted LightlyStudio is served over HTTPS, and browsers block plain-`http` requests
+from an HTTPS page as mixed content. Your service needs a TLS certificate the browser trusts.
+`http://` is accepted only for `localhost`, which browsers treat as a secure context.
+LightlyStudio rejects a non-loopback `http://` URL when you save it, rather than letting it fail
+later during a search.
+
+**CORS.** The browser sends a cross-origin request, so your service must return
+`Access-Control-Allow-Origin` for your LightlyStudio origin and answer the `OPTIONS` preflight.
+
+**Private Network Access.** If your service is on a private address (`10.x`, `192.168.x`,
+`172.16–31.x`) and LightlyStudio is on a public origin, Chrome sends a preflight carrying
+`Access-Control-Request-Private-Network: true` and requires
+`Access-Control-Allow-Private-Network: true` in the response. The example service does this.
+
+**Reachable from each user's machine.** The browser makes the call, not the LightlyStudio
+backend. A user on a VPN that does not route to the service will see search fail while a
+colleague on the LAN sees it work.
+
+Search is submit-triggered, so your service sees roughly one request per deliberate search.
+
+## Security
+
+**No authentication in v1.** An open port inside your own network is your security policy to
+set. The contract reserves an `Authorization` header for a future token so adding one will not
+require a protocol change.
+
+**CORS is not authentication.** It stops other *websites* from reading your service's responses
+in a browser. It does not stop `curl` from anything already on the network.
+
+**Model extraction is not preventable.** Anyone who can run searches can collect
+query/vector pairs. No scheme at this layer changes that.
+
+**The serving URL is a sensitive setting.** Whoever writes it redirects every user's queries and
+uploaded images to a host of their choosing — and because Lightly's servers are not in the path,
+there is no trace of it on them. Restricting the update endpoint to administrators is not
+implemented yet; treat write access to it as equivalent to intercepting search traffic.
+
+## Troubleshooting
+
+**"Could not reach the embedding service"** — Open the service URL directly in the same browser.
+If that works but search does not, it is CORS or Private Network Access. Check the browser
+console for the blocked preflight and confirm your service returns both
+`Access-Control-Allow-Origin` and, for a private address,
+`Access-Control-Allow-Private-Network`.
+
+To reproduce a private-network block deliberately: serve the example service on a LAN address
+over HTTPS, open a hosted LightlyStudio instance, and watch the Network tab for the `OPTIONS`
+request to `/info`. A preflight that fails with a private-network error means the header is
+missing or the browser policy has tightened further.
+
+**"the service serves model X, but this collection was indexed with Y"** — The running service
+is not the model that produced the stored embeddings. Either point the URL at the right service,
+or re-index.
+
+**Search works for you but not a colleague** — Their machine cannot reach the service. This is a
+network path problem, not a LightlyStudio one.
+
+## Limitations
+
+- **Browser required.** There is no headless path; the Python API cannot run a text search
+  against a custom model.
+- **Video collections are not supported.** Video embeddings are hard-wired to the built-in
+  model.
+- **Your downtime looks like ours.** If the service is down, search is unavailable in
+  LightlyStudio.

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Security and Architecture: enterprise/security.md
       - On-Premise Deployment: enterprise/on-premise.md
       - Local Storage: enterprise/local_storage.md
+      - Custom Embedding Models: enterprise/custom_embedding_model.md
     - Cloud Storage:
       - enterprise/cloud_storage/index.md
       - AWS S3: enterprise/cloud_storage/aws.md

--- a/lightly_studio/src/lightly_studio/api/app.py
+++ b/lightly_studio/src/lightly_studio/api/app.py
@@ -27,6 +27,7 @@ from lightly_studio.api.routes.api import (
     classifier,
     collection,
     collection_tag,
+    embedding_model,
     embeddings2d,
     enterprise,
     evaluation,
@@ -147,6 +148,7 @@ api_router.include_router(text_embedding.text_embedding_router)
 api_router.include_router(image_embedding.image_embedding_router)
 api_router.include_router(settings.settings_router)
 api_router.include_router(classifier.classifier_router)
+api_router.include_router(embedding_model.embedding_model_router)
 api_router.include_router(embeddings2d.embeddings2d_router)
 api_router.include_router(features.features_router)
 api_router.include_router(evaluation.evaluation_router)

--- a/lightly_studio/src/lightly_studio/api/db_tables.py
+++ b/lightly_studio/src/lightly_studio/api/db_tables.py
@@ -22,6 +22,9 @@ from lightly_studio.models.dataset import (
 from lightly_studio.models.embedding_model import (
     EmbeddingModelTable,  # noqa: F401, required for SQLModel to work properly
 )
+from lightly_studio.models.embedding_model_service import (
+    EmbeddingModelServiceTable,  # noqa: F401, required for SQLModel to work properly
+)
 from lightly_studio.models.image import (
     ImageTable,  # noqa: F401, required for SQLModel to work properly
 )

--- a/lightly_studio/src/lightly_studio/api/routes/api/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embedding_model.py
@@ -1,0 +1,127 @@
+"""This module contains the API routes for embedding models and their serving endpoints.
+
+A collection's embedding model may live outside this process: customers who index with
+their own model run it behind an HTTP service on their own network, and the browser calls
+that service directly for search queries. These routes expose which model a collection was
+embedded with and where it is served from.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+from pydantic import BaseModel
+
+from lightly_studio.api.routes.api import collection
+from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_BAD_REQUEST,
+    HTTP_STATUS_NOT_FOUND,
+)
+from lightly_studio.database.db_manager import SessionDep
+from lightly_studio.models.collection import CollectionTable
+from lightly_studio.resolvers import embedding_model_resolver, embedding_model_service_resolver
+
+embedding_model_router = APIRouter()
+
+
+class EmbeddingModelView(BaseModel):
+    """The model a collection's stored embeddings were produced with.
+
+    Attributes:
+        embedding_model_hash: A customer-declared identifier, not a digest of the
+            weights. The rule is to bump it whenever the output vectors change.
+        serving_url: Where a live copy of the model is served for search queries, or
+            None when the model runs inside this process. The browser calls it directly,
+            so this host must be reachable from the user's machine.
+    """
+
+    embedding_model_id: UUID
+    name: str
+    embedding_model_hash: str
+    embedding_dimension: int
+    serving_url: str | None
+
+
+class UpdateServingUrlRequest(BaseModel):
+    """Request body for pointing a model at an embedding service.
+
+    Attributes:
+        serving_url: Base URL of the service, or None to stop serving the model.
+    """
+
+    serving_url: str | None
+
+
+@embedding_model_router.get("/collections/{collection_id}/embedding_model")
+def read_embedding_model(
+    session: SessionDep,
+    collection_row: Annotated[
+        CollectionTable,
+        Path(title="Collection Id"),
+        Depends(collection.get_and_validate_collection_id),
+    ],
+) -> EmbeddingModelView | None:
+    """Return the collection's embedding model, or None if it has none."""
+    embedding_model = embedding_model_resolver.get_default_by_collection_id(
+        session=session, collection_id=collection_row.collection_id
+    )
+    if embedding_model is None:
+        return None
+
+    service = embedding_model_service_resolver.get_by_model_hash(
+        session=session, embedding_model_hash=embedding_model.embedding_model_hash
+    )
+    return EmbeddingModelView(
+        embedding_model_id=embedding_model.embedding_model_id,
+        name=embedding_model.name,
+        embedding_model_hash=embedding_model.embedding_model_hash,
+        embedding_dimension=embedding_model.embedding_dimension,
+        serving_url=service.serving_url if service is not None else None,
+    )
+
+
+@embedding_model_router.put("/embedding_models/{embedding_model_hash}/serving_url")
+def update_embedding_model_serving_url(
+    session: SessionDep,
+    embedding_model_hash: Annotated[str, Path(title="Embedding model hash")],
+    request: UpdateServingUrlRequest,
+) -> UpdateServingUrlRequest:
+    """Point a model at an embedding service, or clear its URL.
+
+    Keyed on the model hash rather than a collection, so one update covers every
+    collection embedded with that model.
+
+    TODO(Jonas, 08/2026): Restrict this to admins. Whoever sets a serving URL redirects
+    every user's queries and uploaded images to a host of their choosing, and the request
+    never touches our servers, so there is no trace of it here. Authentication is
+    terminated by a proxy outside this repository, so the check cannot be written yet.
+    """
+    if not embedding_model_resolver.exists_by_model_hash(
+        session=session, embedding_model_hash=embedding_model_hash
+    ):
+        raise HTTPException(
+            status_code=HTTP_STATUS_NOT_FOUND,
+            detail=(
+                f"No collection was embedded with model '{embedding_model_hash}'. Index with "
+                f"the model before pointing Lightly Studio at a service for it."
+            ),
+        )
+
+    if request.serving_url is None:
+        embedding_model_service_resolver.delete_by_model_hash(
+            session=session, embedding_model_hash=embedding_model_hash
+        )
+        return UpdateServingUrlRequest(serving_url=None)
+
+    try:
+        service = embedding_model_service_resolver.set_serving_url(
+            session=session,
+            embedding_model_hash=embedding_model_hash,
+            serving_url=request.serving_url,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=HTTP_STATUS_BAD_REQUEST, detail=f"{exc}") from None
+
+    return UpdateServingUrlRequest(serving_url=service.serving_url)

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -12,7 +12,7 @@ from PIL import Image
 from sqlmodel import Session
 from tqdm import tqdm
 
-from lightly_studio.dataset import env
+from lightly_studio.dataset import embedding_service, env
 from lightly_studio.dataset.embedding_generator import (
     EmbeddingGenerator,
     ImageEmbeddingGenerator,
@@ -25,6 +25,7 @@ from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
     embedding_model_resolver,
+    embedding_model_service_resolver,
     image_resolver,
     sample_embedding_resolver,
     video_resolver,
@@ -68,7 +69,9 @@ class EmbeddingManagerProvider:
         return cls._instance
 
 
-def set_default_embedding_model(embedding_generator: EmbeddingGenerator) -> None:
+def set_default_embedding_model(
+    embedding_generator: EmbeddingGenerator, serving_url: str | None = None
+) -> None:
     """Register a custom embedding model that overrides the env-var default.
 
     Call this before ingesting a dataset (e.g. before ImageDataset.load_or_create)
@@ -77,15 +80,22 @@ def set_default_embedding_model(embedding_generator: EmbeddingGenerator) -> None
 
     Note: the registration lives in-process only. When re-launching the GUI via the
     `lightly-studio gui` CLI without re-running this call, embeddings computed with the
-    custom model remain, but text search falls back to the env-var default model and
-    will not match them.
+    custom model remain, and text search is disabled rather than answered by a different
+    model. Pass `serving_url` to keep search working in that case.
 
     Args:
         embedding_generator: A generator implementing ImageEmbeddingGenerator and/or
             VideoEmbeddingGenerator.
+        serving_url: Base URL of an HTTP service that serves this same model for search
+            queries, e.g. `https://gpu-box.corp.example:8123`. The browser calls it
+            directly, so it must be reachable from the user's machine, not from the
+            LightlyStudio backend. See docs/enterprise/custom_embedding_model.md.
+
+    Raises:
+        ValueError: If serving_url is not a valid embedding service URL.
     """
     EmbeddingManagerProvider.get_embedding_manager().set_default_embedding_model(
-        embedding_generator=embedding_generator
+        embedding_generator=embedding_generator, serving_url=serving_url
     )
 
 
@@ -109,8 +119,12 @@ class EmbeddingManager:
         # Keyed by generator sample type (IMAGE or VIDEO) and consulted before
         # loading a generator from the environment.
         self._override_generators: dict[SampleType, EmbeddingGenerator] = {}
+        # Serving URLs declared alongside those generators, keyed by sample type.
+        self._override_serving_urls: dict[SampleType, str] = {}
 
-    def set_default_embedding_model(self, embedding_generator: EmbeddingGenerator) -> None:
+    def set_default_embedding_model(
+        self, embedding_generator: EmbeddingGenerator, serving_url: str | None = None
+    ) -> None:
         """Register a generator that overrides the env-var default for all collections.
 
         The generator's sample-type slot(s) are inferred from the protocols it
@@ -121,19 +135,30 @@ class EmbeddingManager:
 
         Args:
             embedding_generator: The generator to use instead of the env-var default.
+            serving_url: Base URL of an HTTP service serving this same model for search
+                queries. Persisted when the model is registered for a collection.
 
         Raises:
             TypeError: If the generator implements neither the image nor the video
                 embedding protocol.
+            ValueError: If serving_url is not a valid embedding service URL.
         """
+        validated_url = embedding_service.validate_serving_url(serving_url) if serving_url else None
+
         matched = False
         if isinstance(embedding_generator, ImageEmbeddingGenerator):
-            self._override_generators[SampleType.IMAGE] = embedding_generator
-            self._sample_type_to_model_id.pop(SampleType.IMAGE, None)
+            self._register_override(
+                sample_type=SampleType.IMAGE,
+                embedding_generator=embedding_generator,
+                serving_url=validated_url,
+            )
             matched = True
         if isinstance(embedding_generator, VideoEmbeddingGenerator):
-            self._override_generators[SampleType.VIDEO] = embedding_generator
-            self._sample_type_to_model_id.pop(SampleType.VIDEO, None)
+            self._register_override(
+                sample_type=SampleType.VIDEO,
+                embedding_generator=embedding_generator,
+                serving_url=validated_url,
+            )
             matched = True
         if not matched:
             raise TypeError(
@@ -162,6 +187,10 @@ class EmbeddingManager:
 
         Returns:
             The created EmbeddingModel.
+
+        Raises:
+            ValueError: If a serving URL was declared for a generator that does not
+                declare an embedding_model_hash.
         """
         # Get or create embedding model record in the database.
         db_model = embedding_model_resolver.get_or_create(
@@ -171,6 +200,22 @@ class EmbeddingManager:
             ),
         )
         model_id = db_model.embedding_model_id
+
+        # Write the serving URL next to the model row so the record of "what produced
+        # these vectors" and "where do I get more" cannot drift apart.
+        serving_url = self._get_declared_serving_url(embedding_generator)
+        if serving_url is not None:
+            if not db_model.embedding_model_hash:
+                raise ValueError(
+                    "A serving URL is keyed on the model identity, so the generator must "
+                    "return a non-empty embedding_model_hash from "
+                    "get_embedding_model_input()."
+                )
+            embedding_model_service_resolver.set_serving_url(
+                session=session,
+                embedding_model_hash=db_model.embedding_model_hash,
+                serving_url=serving_url,
+            )
 
         # Store the model in our dictionary
         self._models[model_id] = embedding_generator
@@ -442,7 +487,8 @@ class EmbeddingManager:
             collection_id: Collection identifier the model should belong to.
 
         Returns:
-            UUID of the default embedding model or None if the model cannot be loaded.
+            UUID of the default embedding model, or None if no generator matching the
+            collection's stored embeddings can be loaded.
         """
         # Return the existing default model ID if available.
         if collection_id in self._collection_id_to_default_model_id:
@@ -471,6 +517,11 @@ class EmbeddingManager:
         if embedding_generator is None:
             return None
 
+        if not _matches_stored_model(
+            session=session, collection_id=collection_id, embedding_generator=embedding_generator
+        ):
+            return None
+
         # Register the embedding model and set it as default.
         embedding_model = self.register_embedding_model(
             session=session,
@@ -482,6 +533,27 @@ class EmbeddingManager:
         self._sample_type_to_model_id[generator_sample_type] = embedding_model.embedding_model_id
 
         return embedding_model.embedding_model_id
+
+    def _register_override(
+        self,
+        sample_type: SampleType,
+        embedding_generator: EmbeddingGenerator,
+        serving_url: str | None,
+    ) -> None:
+        """Fill one sample-type override slot and forget any model loaded for it."""
+        self._override_generators[sample_type] = embedding_generator
+        self._sample_type_to_model_id.pop(sample_type, None)
+        if serving_url is None:
+            self._override_serving_urls.pop(sample_type, None)
+        else:
+            self._override_serving_urls[sample_type] = serving_url
+
+    def _get_declared_serving_url(self, embedding_generator: EmbeddingGenerator) -> str | None:
+        """Return the serving URL declared for this generator, if any."""
+        for sample_type, override in self._override_generators.items():
+            if override is embedding_generator:
+                return self._override_serving_urls.get(sample_type)
+        return None
 
     def _get_default_or_validate(
         self, collection_id: UUID, embedding_model_id: UUID | None
@@ -554,6 +626,37 @@ def _store_embeddings(
             progress.update(len(sample_embeddings))
 
     session.commit()
+
+
+def _matches_stored_model(
+    session: Session, collection_id: UUID, embedding_generator: EmbeddingGenerator
+) -> bool:
+    """Check that the generator produced the collection's already-stored embeddings.
+
+    Returns True when the collection has no embedding model yet, so a fresh collection
+    can register one. Returns False when the collection was embedded by a different
+    model: registering the generator then would attribute the stored vectors to it and
+    let search compare query vectors against a different embedding space.
+    """
+    stored_model = embedding_model_resolver.get_default_by_collection_id(
+        session=session, collection_id=collection_id
+    )
+    if stored_model is None:
+        return True
+
+    generator_hash = embedding_generator.get_embedding_model_input(
+        collection_id=collection_id
+    ).embedding_model_hash
+    if stored_model.embedding_model_hash == generator_hash:
+        return True
+
+    logger.warning(
+        f"Collection {collection_id} was embedded with model "
+        f"'{stored_model.name}' (hash '{stored_model.embedding_model_hash}'), which is not "
+        f"loaded. Embedding is disabled for this collection to avoid mixing embedding spaces. "
+        f"Register the matching model with set_default_embedding_model()."
+    )
+    return False
 
 
 def _load_embedding_generator_from_env(sample_type: SampleType) -> EmbeddingGenerator | None:

--- a/lightly_studio/src/lightly_studio/dataset/embedding_service.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_service.py
@@ -1,0 +1,53 @@
+"""Contract helpers for customer-hosted embedding services.
+
+An embedding service is an HTTP endpoint the customer runs on their own network that
+implements the embedding wire contract (see ``docs/enterprise/custom_embedding_model.md``). The
+browser calls it directly; the Lightly Studio backend only stores where it lives.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse
+
+# Hostnames the browser treats as a secure context, so plain http is allowed for them.
+_LOOPBACK_HOST_NAMES = frozenset({"localhost"})
+
+
+def validate_serving_url(serving_url: str) -> str:
+    """Validate and normalize the URL an embedding service is reachable at.
+
+    Hosted Studio is served over HTTPS, so the browser blocks plain-http requests as
+    mixed content. Rejecting them here surfaces the problem when an admin saves the URL
+    instead of as an inscrutable error during a search.
+
+    Args:
+        serving_url: Base URL of the embedding service, e.g. ``https://gpu-box:8123``.
+
+    Returns:
+        The URL without a trailing slash.
+
+    Raises:
+        ValueError: If the URL has no host, or uses a scheme other than https on a
+            non-loopback host.
+    """
+    parsed = urlparse(serving_url)
+    if not parsed.hostname:
+        raise ValueError(f"Embedding service URL '{serving_url}' has no host.")
+
+    if parsed.scheme != "https" and not _is_loopback_host(parsed.hostname):
+        raise ValueError(
+            f"Embedding service URL '{serving_url}' must use https. Plain http is only "
+            f"allowed for loopback hosts, because the browser blocks mixed content."
+        )
+
+    return serving_url.rstrip("/")
+
+
+def _is_loopback_host(hostname: str) -> bool:
+    if hostname in _LOOPBACK_HOST_NAMES:
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False

--- a/lightly_studio/src/lightly_studio/dataset/embedding_utils.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_utils.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 from sqlmodel import Session
 
-from lightly_studio.dataset.embedding_manager import EmbeddingManagerProvider
 from lightly_studio.resolvers import (
     sample_embedding_resolver,
 )
@@ -13,6 +12,9 @@ from lightly_studio.resolvers import (
 def collection_has_embeddings(session: Session, collection_id: UUID) -> bool:
     """Check if there are any embeddings available for the given collection.
 
+    Model-free on purpose: resolving the collection's default model would register one,
+    overwriting the record of what actually produced the stored vectors.
+
     Args:
         session: Database session for resolver operations.
         collection_id: The ID of the collection to check for embeddings.
@@ -20,18 +22,6 @@ def collection_has_embeddings(session: Session, collection_id: UUID) -> bool:
     Returns:
         True if embeddings exist for the collection, False otherwise.
     """
-    embedding_manager = EmbeddingManagerProvider.get_embedding_manager()
-    model_id = embedding_manager.load_or_get_default_model(
-        session=session,
-        collection_id=collection_id,
-    )
-    if model_id is None:
-        # No default embedding model loaded for this collection.
-        return False
-
-    return (
-        sample_embedding_resolver.get_embedding_count(
-            session=session, collection_id=collection_id, embedding_model_id=model_id
-        )
-        > 0
+    return sample_embedding_resolver.has_any_embeddings(
+        session=session, collection_id=collection_id
     )

--- a/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
@@ -30,6 +30,10 @@ from lightly_studio.models.embedding_model import EmbeddingModelCreate
 from lightly_studio.vendor import mobileclip
 
 MODEL_NAME = "mobileclip_s0"
+# Identifies the embedding space, not the weights file. Bump it whenever the model starts
+# producing different vectors. An embedding service serving this model must report the same
+# string as its model_id, otherwise LightlyStudio disables search.
+MODEL_ID = MODEL_NAME
 MOBILECLIP_DOWNLOAD_URL = (
     f"https://docs-assets.developer.apple.com/ml-research/datasets/mobileclip/{MODEL_NAME}.pt"
 )
@@ -64,17 +68,16 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
         )
         self._model = self._model.to(self._device)
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
-        self._model_hash = file_utils.get_file_xxhash(model_path)
 
     def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
         """Describe the model so it can be recorded in the database.
 
-        The name shows up in the GUI and the hash lets Lightly Studio detect when
-        the same model has been used before.
+        The name shows up in the GUI and the hash identifies the embedding space, so
+        Lightly Studio can tell when the same model has been used before.
         """
         return EmbeddingModelCreate(
             name="Custom Embedding Model",
-            embedding_model_hash=self._model_hash,
+            embedding_model_hash=MODEL_ID,
             embedding_dimension=EMBEDDING_DIMENSION,
             collection_id=collection_id,
         )

--- a/lightly_studio/src/lightly_studio/examples/example_embedding_service.py
+++ b/lightly_studio/src/lightly_studio/examples/example_embedding_service.py
@@ -1,0 +1,194 @@
+"""Reference implementation of the LightlyStudio embedding service contract.
+
+Run this on your own network to keep text and image search working for a dataset that
+was indexed with your own embedding model. The browser calls this service directly, so
+it never sends your model or your queries to Lightly.
+
+The model below is MobileCLIP, to keep the example runnable. Replace the three
+`_embed_*` bodies with your own model and set MODEL_ID to a string you bump whenever the
+output vectors change.
+
+Run it with:
+
+    uv run uvicorn lightly_studio.examples.example_embedding_service:app --port 8123
+
+Then register the URL when you index, or set it later in the GUI:
+
+    ls.set_default_embedding_model(
+        MyGenerator(), serving_url="http://localhost:8123"
+    )
+
+The endpoints are:
+
+    GET  /info         -> capabilities and model identity
+    POST /embed/text   -> {"text": "..."}         -> [0.1, ...]
+    POST /embed/image  -> multipart file "image"  -> [0.1, ...]
+"""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Awaitable, Callable
+from typing import Annotated
+
+import torch
+from fastapi import FastAPI, File, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from PIL import Image
+from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from lightly_studio.dataset import file_utils
+from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
+from lightly_studio.vendor import mobileclip
+
+# Bump this whenever the model produces different vectors. It must match the
+# embedding_model_hash your indexing generator declares, otherwise LightlyStudio disables
+# search rather than compare vectors from two different embedding spaces.
+MODEL_ID = "mobileclip_s0"
+
+# Origins allowed to call this service. Set this to the LightlyStudio URL your users open.
+# CORS is not authentication: it stops other websites from reading responses in a browser,
+# it does not stop anything on this network from calling the service directly.
+ALLOWED_ORIGINS = ["*"]
+
+CONTRACT_VERSION = "1"
+EMBEDDING_DIMENSION = 512
+_MOBILECLIP_MODEL_NAME = "mobileclip_s0"
+_MOBILECLIP_DOWNLOAD_URL = (
+    f"https://docs-assets.developer.apple.com/ml-research/datasets/mobileclip/"
+    f"{_MOBILECLIP_MODEL_NAME}.pt"
+)
+
+
+class ServiceInfo(BaseModel):
+    """What this service can do, fetched once before the search bar renders.
+
+    Attributes:
+        contract_version: Version of the wire contract this service speaks.
+        model_id: Must equal the embedding_model_hash the stored vectors were indexed with.
+        embedding_dimension: Length of the returned vectors.
+        supports_text: False for a model with no text tower, which hides the text search box.
+        supports_image: False for a model that cannot embed images.
+        normalized: Whether returned vectors are unit length.
+    """
+
+    contract_version: str
+    model_id: str
+    embedding_dimension: int
+    supports_text: bool
+    supports_image: bool
+    normalized: bool
+
+
+class EmbedTextRequest(BaseModel):
+    """Request body for text embedding."""
+
+    text: str
+
+
+class PrivateNetworkAccessMiddleware(BaseHTTPMiddleware):
+    """Answer Chrome's private-network preflight.
+
+    An HTTPS page on a public origin calling a host on a private network triggers a
+    preflight that Chrome only accepts if the response carries this header. Without it the
+    browser blocks the request before this service ever sees the real call.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        """Add the private-network header to preflight responses."""
+        response = await call_next(request)
+        if request.headers.get("Access-Control-Request-Private-Network") == "true":
+            response.headers["Access-Control-Allow-Private-Network"] = "true"
+        return response
+
+
+app = FastAPI(title="LightlyStudio embedding service")
+
+# CORSMiddleware is added first so that it ends up inside the private-network middleware,
+# which needs to add its header to the preflight response CORSMiddleware produces.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
+    max_age=3600,
+)
+app.add_middleware(PrivateNetworkAccessMiddleware)
+
+
+@app.get("/info")
+def read_info() -> ServiceInfo:
+    """Report the model identity and capabilities."""
+    return ServiceInfo(
+        contract_version=CONTRACT_VERSION,
+        model_id=MODEL_ID,
+        embedding_dimension=EMBEDDING_DIMENSION,
+        supports_text=True,
+        supports_image=True,
+        # MobileCLIP does not normalize its outputs. PerceptionEncoder does.
+        normalized=False,
+    )
+
+
+@app.post("/embed/text")
+def embed_text(request: EmbedTextRequest) -> list[float]:
+    """Embed a search query into the same space as the indexed images."""
+    model = _get_model()
+    tokenized = model.tokenizer([request.text]).to(model.device)
+    with torch.no_grad():
+        embedding = model.model.encode_text(tokenized)[0]  # type: ignore[operator]
+    embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
+    return embedding_list
+
+
+@app.post("/embed/image")
+def embed_image(
+    image: Annotated[UploadFile, File(description="The image to embed.")],
+) -> list[float]:
+    """Embed a query image. This service owns all preprocessing."""
+    model = _get_model()
+    pil_image = Image.open(io.BytesIO(image.file.read())).convert("RGB")
+    image_tensor = model.preprocess(pil_image).unsqueeze(0).to(model.device)
+    with torch.no_grad():
+        embedding = model.model.encode_image(image_tensor)[0]  # type: ignore[operator]
+    embedding_list: list[float] = embedding.cpu().numpy().flatten().tolist()
+    return embedding_list
+
+
+class _MobileCLIP:
+    """MobileCLIP weights, tokenizer and preprocessing, loaded once."""
+
+    def __init__(self) -> None:
+        """Download the checkpoint if needed and move the model onto the best device."""
+        checkpoint_path = LIGHTLY_STUDIO_MODEL_CACHE_DIR / f"{_MOBILECLIP_MODEL_NAME}.pt"
+        file_utils.download_file_if_does_not_exist(
+            url=_MOBILECLIP_DOWNLOAD_URL, local_filename=checkpoint_path
+        )
+        self.model, _, self.preprocess = mobileclip.create_model_and_transforms(
+            model_name=_MOBILECLIP_MODEL_NAME, pretrained=str(checkpoint_path)
+        )
+        self.device = torch.device(
+            "cuda"
+            if torch.cuda.is_available()
+            else "mps"
+            if torch.backends.mps.is_available()
+            else "cpu"
+        )
+        self.model = self.model.to(self.device)
+        self.tokenizer = mobileclip.get_tokenizer(model_name=_MOBILECLIP_MODEL_NAME)
+
+
+_model: _MobileCLIP | None = None
+
+
+def _get_model() -> _MobileCLIP:
+    """Load the model on first use so startup does not block on the download."""
+    global _model  # noqa: PLW0603 one model per process, one port per model.
+    if _model is None:
+        _model = _MobileCLIP()
+    return _model

--- a/lightly_studio/src/lightly_studio/examples/example_embedding_service_pna_check.html
+++ b/lightly_studio/src/lightly_studio/examples/example_embedding_service_pna_check.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<!--
+  Private Network Access check for the LightlyStudio embedding service contract.
+
+  Answers one question: can a page on a public HTTPS origin reach an embedding service on a
+  private network address, or does the browser block it? This is the single assumption the
+  browser-calls-the-service design rests on, so test it before building on top.
+
+  It deliberately tests nothing else. Give the service a PUBLIC DNS name whose A record points at
+  its PRIVATE address (e.g. embed.corp.example -> 192.168.1.20) with a real certificate issued via
+  a DNS-01 challenge. That satisfies HTTPS and name resolution, leaving Private Network Access as
+  the only variable. A self-signed or mkcert certificate also works, but only on machines with the
+  local CA installed, which is not how a customer's setup looks.
+
+  How to run:
+
+    1. Start the service on the private host:
+         uv run uvicorn lightly_studio.examples.example_embedding_service:app \
+           --host 0.0.0.0 --port 8123 --ssl-certfile cert.pem --ssl-keyfile key.pem
+
+    2. Serve THIS file from a public HTTPS origin. Any static host works; it must not be
+       localhost, because a page on localhost is in the same address space as the service and
+       the browser sends no private-network preflight at all.
+
+    3. Open it in Chrome, with DevTools -> Network open, and enter the service URL.
+
+  What to look for in the Network tab:
+
+    - An OPTIONS request to /info that precedes the GET. Its request headers must include
+      `Access-Control-Request-Private-Network: true`. If that header is absent, Chrome did not
+      classify the target as private and this check proves nothing - confirm the hostname really
+      resolves to a private address.
+    - The OPTIONS response must carry `Access-Control-Allow-Private-Network: true`. The example
+      service sends it.
+    - PASS means the whole approach is viable. A blocked preflight means it is not, and no amount
+      of work on the LightlyStudio side changes that.
+
+  Do not reach for --unsafely-treat-insecure-origin-as-secure or chrome://flags to force a pass.
+  Those change the answer without changing what a customer will experience.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Embedding service — Private Network Access check</title>
+    <style>
+      body {
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        max-width: 44rem;
+        margin: 3rem auto;
+        padding: 0 1.5rem;
+        line-height: 1.5;
+      }
+      input {
+        width: 100%;
+        padding: 0.6rem;
+        font-family: ui-monospace, monospace;
+        font-size: 1rem;
+        box-sizing: border-box;
+      }
+      button {
+        padding: 0.6rem 1.2rem;
+        font: inherit;
+        margin-top: 0.75rem;
+        cursor: pointer;
+      }
+      pre {
+        background: #f4f4f5;
+        padding: 1rem;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        border-radius: 4px;
+      }
+      .pass {
+        color: #15803d;
+        font-weight: 600;
+      }
+      .fail {
+        color: #b91c1c;
+        font-weight: 600;
+      }
+      .origin {
+        font-family: ui-monospace, monospace;
+        font-size: 0.9rem;
+        color: #52525b;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Private Network Access check</h1>
+    <p>
+      Calls <code>GET /info</code> on an embedding service exactly the way the
+      LightlyStudio frontend does, so a failure here is a failure there.
+    </p>
+    <p class="origin">This page is served from: <span id="origin"></span></p>
+
+    <label for="url"><strong>Embedding service base URL</strong></label>
+    <input
+      id="url"
+      value="https://embed.corp.example:8123"
+      spellcheck="false"
+    />
+    <button id="run">Probe /info</button>
+
+    <h2>Result</h2>
+    <pre id="out">Not run yet.</pre>
+
+    <script>
+      const out = document.getElementById("out");
+      document.getElementById("origin").textContent = window.location.origin;
+
+      if (window.location.protocol !== "https:") {
+        out.innerHTML =
+          '<span class="fail">This page is not on HTTPS.</span>\n\n' +
+          "Serve it from a public HTTPS origin. On http:// or localhost the browser " +
+          "does not send a private-network preflight, so the check would pass " +
+          "regardless and tell you nothing.";
+      }
+
+      document.getElementById("run").addEventListener("click", async () => {
+        const base = document
+          .getElementById("url")
+          .value.trim()
+          .replace(/\/+$/, "");
+        const target = `${base}/info`;
+        out.textContent = `Requesting ${target} ...`;
+
+        // Same 3s budget the frontend probe uses.
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 3000);
+        const started = performance.now();
+        try {
+          const response = await fetch(target, {
+            method: "GET",
+            mode: "cors",
+            signal: controller.signal,
+          });
+          const elapsed = Math.round(performance.now() - started);
+          const body = await response.text();
+          out.innerHTML =
+            `<span class="pass">PASS — the browser allowed the request.</span>\n\n` +
+            `${response.status} ${response.statusText} in ${elapsed}ms\n\n${body}\n\n` +
+            `Now confirm in the Network tab that an OPTIONS preflight carried\n` +
+            `Access-Control-Request-Private-Network: true. Without that header the\n` +
+            `target was not treated as private and this result proves nothing.`;
+        } catch (error) {
+          const elapsed = Math.round(performance.now() - started);
+          const blocked = error instanceof TypeError;
+          out.innerHTML =
+            `<span class="fail">FAIL — ${error.name}: ${error.message}</span>\n\n` +
+            `after ${elapsed}ms\n\n` +
+            (blocked
+              ? `An opaque TypeError is what a blocked request looks like: the page\n` +
+                `never sees the response. Open the Network tab and read the OPTIONS\n` +
+                `request to tell the causes apart:\n\n` +
+                `  - preflight missing Access-Control-Allow-Private-Network\n` +
+                `      -> Private Network Access blocked it. This is the finding.\n` +
+                `  - preflight missing Access-Control-Allow-Origin\n` +
+                `      -> plain CORS misconfiguration, not a PNA result.\n` +
+                `  - certificate or mixed-content error in the Console\n` +
+                `      -> TLS problem. Fix it and re-run; PNA is untested until then.\n` +
+                `  - no request at all\n` +
+                `      -> DNS or routing. The host is not reachable from this machine.`
+              : `The request was not blocked by the browser; the service itself failed.`);
+        } finally {
+          clearTimeout(timer);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/lightly_studio/src/lightly_studio/migrations/versions/1786032000_b7c1d2e3f4a5_add_embedding_model_service.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1786032000_b7c1d2e3f4a5_add_embedding_model_service.py
@@ -1,0 +1,48 @@
+"""add-embedding-model-service.
+
+Revision ID: b7c1d2e3f4a5
+Revises: e8f9a0b1c2d3
+Create Date: 2026-08-06 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlmodel.sql.sqltypes import AutoString
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c1d2e3f4a5"
+down_revision: Union[str, Sequence[str], None] = "e8f9a0b1c2d3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "embedding_model_service",
+        sa.Column("embedding_model_hash", sa.VARCHAR(length=128), nullable=False),
+        sa.Column("serving_url", AutoString(), nullable=False),
+        sa.Column("embedding_model_service_id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("embedding_model_service_id"),
+    )
+    op.create_index(
+        op.f("ix_embedding_model_service_embedding_model_hash"),
+        "embedding_model_service",
+        ["embedding_model_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        op.f("ix_embedding_model_service_embedding_model_hash"),
+        table_name="embedding_model_service",
+    )
+    op.drop_table("embedding_model_service")

--- a/lightly_studio/src/lightly_studio/models/embedding_model_service.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model_service.py
@@ -1,0 +1,37 @@
+"""This module defines the EmbeddingModelService model for the application."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from sqlmodel import VARCHAR, Column, Field, SQLModel
+
+
+class EmbeddingModelServiceBase(SQLModel):
+    """Base class for the EmbeddingModelService.
+
+    Attributes:
+        embedding_model_hash: Identifies the model the service serves. Matches
+            ``embedding_model.embedding_model_hash``.
+        serving_url: Base URL the browser calls to embed text and images.
+    """
+
+    embedding_model_hash: str = Field(
+        sa_column=Column(VARCHAR(128), unique=True, index=True, nullable=False)
+    )
+    serving_url: str
+
+
+class EmbeddingModelServiceTable(EmbeddingModelServiceBase, table=True):
+    """Where the model behind an ``embedding_model_hash`` is served from.
+
+    Keyed by model identity rather than by collection: the same model used across ten
+    collections has ten ``embedding_model`` rows but one service row, so a hostname
+    change is a single update.
+    """
+
+    __tablename__ = "embedding_model_service"
+    embedding_model_service_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -95,6 +95,18 @@ def get_by_model_hash(
     return session.exec(query).one_or_none()
 
 
+def exists_by_model_hash(session: Session, embedding_model_hash: str) -> bool:
+    """Check whether any collection was embedded with the model of the given hash."""
+    return (
+        session.exec(
+            select(EmbeddingModelTable.embedding_model_id)
+            .where(EmbeddingModelTable.embedding_model_hash == embedding_model_hash)
+            .limit(1)
+        ).first()
+        is not None
+    )
+
+
 def get_by_name(
     session: Session, collection_id: UUID, embedding_model_name: str | None
 ) -> EmbeddingModelTable:

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_service_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_service_resolver.py
@@ -1,0 +1,65 @@
+"""Handler for database operations related to embedding model services."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlmodel import Session, select
+
+from lightly_studio.dataset import embedding_service
+from lightly_studio.models.embedding_model_service import EmbeddingModelServiceTable
+
+
+def get_by_model_hash(
+    session: Session, embedding_model_hash: str
+) -> EmbeddingModelServiceTable | None:
+    """Retrieve the service serving the model with the given hash."""
+    return session.exec(
+        select(EmbeddingModelServiceTable).where(
+            EmbeddingModelServiceTable.embedding_model_hash == embedding_model_hash
+        )
+    ).one_or_none()
+
+
+def set_serving_url(
+    session: Session, embedding_model_hash: str, serving_url: str
+) -> EmbeddingModelServiceTable:
+    """Point the given model at ``serving_url``, replacing any previous URL.
+
+    Args:
+        session: The database session.
+        embedding_model_hash: Identifies the model the service serves.
+        serving_url: Base URL of the embedding service.
+
+    Returns:
+        The stored service row.
+
+    Raises:
+        ValueError: If ``serving_url`` is not a valid embedding service URL.
+    """
+    validated_url = embedding_service.validate_serving_url(serving_url)
+
+    service = get_by_model_hash(session=session, embedding_model_hash=embedding_model_hash)
+    if service is None:
+        service = EmbeddingModelServiceTable(
+            embedding_model_hash=embedding_model_hash, serving_url=validated_url
+        )
+    else:
+        service.serving_url = validated_url
+        service.updated_at = datetime.now(timezone.utc)
+
+    session.add(service)
+    session.commit()
+    session.refresh(service)
+    return service
+
+
+def delete_by_model_hash(session: Session, embedding_model_hash: str) -> bool:
+    """Delete the service for the given model hash. Returns False if there was none."""
+    service = get_by_model_hash(session=session, embedding_model_hash=embedding_model_hash)
+    if service is None:
+        return False
+
+    session.delete(service)
+    session.commit()
+    return True

--- a/lightly_studio/src/lightly_studio/resolvers/sample_embedding_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_embedding_resolver.py
@@ -225,6 +225,28 @@ def get_embedding_count(session: Session, collection_id: UUID, embedding_model_i
     return session.exec(query).one()
 
 
+def has_any_embeddings(session: Session, collection_id: UUID) -> bool:
+    """Check whether the collection has at least one sample embedding.
+
+    Deliberately model-free: the caller only wants to know whether embeddings exist,
+    and resolving a model would register one as a side effect.
+
+    Args:
+        session: The database session.
+        collection_id: The collection ID to filter by.
+
+    Returns:
+        True if any sample in the collection has an embedding.
+    """
+    query = (
+        select(SampleEmbeddingTable.sample_id)
+        .join(SampleTable, col(SampleEmbeddingTable.sample_id) == col(SampleTable.sample_id))
+        .where(SampleTable.collection_id == collection_id)
+        .limit(1)
+    )
+    return session.exec(query).first() is not None
+
+
 def _read_embedding_rows_binary(
     session: Session, sql: str, params: Sequence[Any] | Mapping[str, Any]
 ) -> list[SampleEmbeddingRow]:

--- a/lightly_studio/tests/api/routes/api/test_collection.py
+++ b/lightly_studio/tests/api/routes/api/test_collection.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
-from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.api.routes.api.status import (
@@ -14,8 +13,8 @@ from lightly_studio.api.routes.api.status import (
     HTTP_STATUS_NOT_FOUND,
     HTTP_STATUS_OK,
 )
-from lightly_studio.dataset.embedding_manager import EmbeddingManager
 from lightly_studio.models.collection import SampleType
+from lightly_studio.resolvers import embedding_model_resolver
 from tests.helpers_resolvers import (
     ImageStub,
     create_collection,
@@ -215,22 +214,16 @@ def test_read_collections_overview(test_client: TestClient, db_session: Session)
 def test_has_embeddings(
     test_client: TestClient,
     db_session: Session,
-    mocker: MockerFixture,
 ) -> None:
     col_id = create_collection(session=db_session).collection_id
     embedding_model_id = create_embedding_model(
         session=db_session, collection_id=col_id
     ).embedding_model_id
-    mock_get_model = mocker.patch.object(
-        EmbeddingManager, "load_or_get_default_model", return_value=embedding_model_id
-    )
 
     # Initially, the collection has no embeddings.
     response = test_client.get(f"/api/collections/{col_id!s}/has_embeddings")
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() is False
-    mock_get_model.assert_called_once_with(session=db_session, collection_id=col_id)
-    mock_get_model.reset_mock()
 
     # Add an embedding to the collection.
     create_samples_with_embeddings(
@@ -244,7 +237,26 @@ def test_has_embeddings(
     response = test_client.get(f"/api/collections/{col_id!s}/has_embeddings")
     assert response.status_code == HTTP_STATUS_OK
     assert response.json() is True
-    mock_get_model.assert_called_once_with(session=db_session, collection_id=col_id)
+
+
+def test_has_embeddings__does_not_register_a_model(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    """Opening a collection must not write an embedding-model row.
+
+    The row records what produced the stored vectors. Registering the built-in default
+    here would attribute custom-model embeddings to it and silently hide search.
+    """
+    col_id = create_collection(session=db_session).collection_id
+
+    response = test_client.get(f"/api/collections/{col_id!s}/has_embeddings")
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert (
+        embedding_model_resolver.get_all_by_collection_id(session=db_session, collection_id=col_id)
+        == []
+    )
 
 
 @pytest.mark.postgres_only  # Deep copying is enterprise-only (PostgreSQL-backed).

--- a/lightly_studio/tests/api/routes/api/test_embedding_model.py
+++ b/lightly_studio/tests/api/routes/api/test_embedding_model.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_BAD_REQUEST,
+    HTTP_STATUS_NOT_FOUND,
+    HTTP_STATUS_OK,
+)
+from lightly_studio.resolvers import embedding_model_service_resolver
+from tests import helpers_resolvers
+
+
+def test_read_embedding_model(db_session: Session, test_client: TestClient) -> None:
+    collection_id = helpers_resolvers.create_collection(session=db_session).collection_id
+    embedding_model = helpers_resolvers.create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_name="customer-model",
+        embedding_model_hash="customer-model-v1",
+    )
+
+    response = test_client.get(f"/api/collections/{collection_id}/embedding_model")
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() == {
+        "embedding_model_id": str(embedding_model.embedding_model_id),
+        "name": "customer-model",
+        "embedding_model_hash": "customer-model-v1",
+        "embedding_dimension": 128,
+        "serving_url": None,
+    }
+
+
+def test_read_embedding_model__with_serving_url(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = helpers_resolvers.create_collection(session=db_session).collection_id
+    helpers_resolvers.create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_hash="customer-model-v1",
+    )
+    embedding_model_service_resolver.set_serving_url(
+        session=db_session,
+        embedding_model_hash="customer-model-v1",
+        serving_url="https://embeddings.corp.example",
+    )
+
+    response = test_client.get(f"/api/collections/{collection_id}/embedding_model")
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json()["serving_url"] == "https://embeddings.corp.example"
+
+
+def test_read_embedding_model__no_model(db_session: Session, test_client: TestClient) -> None:
+    """A collection without embeddings reports no model rather than erroring."""
+    collection_id = helpers_resolvers.create_collection(session=db_session).collection_id
+
+    response = test_client.get(f"/api/collections/{collection_id}/embedding_model")
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json() is None
+
+
+def test_read_embedding_model__unknown_collection(test_client: TestClient) -> None:
+    response = test_client.get(f"/api/collections/{uuid4()}/embedding_model")
+
+    assert response.status_code == HTTP_STATUS_NOT_FOUND
+
+
+def test_update_embedding_model_serving_url(db_session: Session, test_client: TestClient) -> None:
+    collection_id = helpers_resolvers.create_collection(session=db_session).collection_id
+    helpers_resolvers.create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_hash="customer-model-v1",
+    )
+
+    response = test_client.put(
+        "/api/embedding_models/customer-model-v1/serving_url",
+        json={"serving_url": "https://embeddings.corp.example"},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json()["serving_url"] == "https://embeddings.corp.example"
+    stored = embedding_model_service_resolver.get_by_model_hash(
+        session=db_session, embedding_model_hash="customer-model-v1"
+    )
+    assert stored is not None
+    assert stored.serving_url == "https://embeddings.corp.example"
+
+
+def test_update_embedding_model_serving_url__clears(
+    db_session: Session, test_client: TestClient
+) -> None:
+    collection_id = helpers_resolvers.create_collection(session=db_session).collection_id
+    helpers_resolvers.create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_hash="customer-model-v1",
+    )
+    embedding_model_service_resolver.set_serving_url(
+        session=db_session,
+        embedding_model_hash="customer-model-v1",
+        serving_url="https://embeddings.corp.example",
+    )
+
+    response = test_client.put(
+        "/api/embedding_models/customer-model-v1/serving_url",
+        json={"serving_url": None},
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    assert response.json()["serving_url"] is None
+    assert (
+        embedding_model_service_resolver.get_by_model_hash(
+            session=db_session, embedding_model_hash="customer-model-v1"
+        )
+        is None
+    )
+
+
+def test_update_embedding_model_serving_url__rejects_insecure_url(
+    db_session: Session, test_client: TestClient
+) -> None:
+    """Mixed content is caught here rather than as an opaque failure during a search."""
+    collection_id = helpers_resolvers.create_collection(session=db_session).collection_id
+    helpers_resolvers.create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_hash="customer-model-v1",
+    )
+
+    response = test_client.put(
+        "/api/embedding_models/customer-model-v1/serving_url",
+        json={"serving_url": "http://192.168.1.20:8123"},
+    )
+
+    assert response.status_code == HTTP_STATUS_BAD_REQUEST
+
+
+def test_update_embedding_model_serving_url__unknown_model(test_client: TestClient) -> None:
+    """Refuse to store a URL for a model no collection was embedded with."""
+    response = test_client.put(
+        "/api/embedding_models/never-indexed/serving_url",
+        json={"serving_url": "https://embeddings.corp.example"},
+    )
+
+    assert response.status_code == HTTP_STATUS_NOT_FOUND

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -30,6 +30,7 @@ from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import (
     collection_resolver,
     embedding_model_resolver,
+    embedding_model_service_resolver,
     sample_embedding_resolver,
 )
 from tests.helpers_resolvers import (
@@ -571,6 +572,70 @@ def test_load_or_get_default_model__cant_load(
     assert model_id is None
 
 
+def test_load_or_get_default_model__existing_row_from_another_model(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """A collection embedded by a model we cannot load reports no default model.
+
+    Registering the env default here would attribute the stored vectors to the wrong
+    model and let search compare query vectors against a different embedding space.
+    """
+    collection = create_collection(session=db_session)
+    embedding_model_resolver.create(
+        session=db_session,
+        embedding_model=EmbeddingModelCreate(
+            name="customer-model",
+            embedding_model_hash="customer-model-v1",
+            embedding_dimension=512,
+            collection_id=collection.collection_id,
+        ),
+    )
+    manager = EmbeddingManager()
+    mocker.patch.object(
+        embedding_manager,
+        "_load_embedding_generator_from_env",
+        return_value=RandomEmbeddingGenerator(),
+    )
+
+    model_id = manager.load_or_get_default_model(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert model_id is None
+    # No second row was written for the collection.
+    models = embedding_model_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    )
+    assert [model.embedding_model_hash for model in models] == ["customer-model-v1"]
+
+
+def test_load_or_get_default_model__existing_row_from_same_model(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """A collection embedded by the loadable default reuses its existing row."""
+    collection = create_collection(session=db_session)
+    generator = RandomEmbeddingGenerator()
+    existing = embedding_model_resolver.create(
+        session=db_session,
+        embedding_model=generator.get_embedding_model_input(collection_id=collection.collection_id),
+    )
+    manager = EmbeddingManager()
+    mocker.patch.object(
+        embedding_manager,
+        "_load_embedding_generator_from_env",
+        return_value=generator,
+    )
+
+    model_id = manager.load_or_get_default_model(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert model_id == existing.embedding_model_id
+    assert manager._models[existing.embedding_model_id] is generator
+
+
 def test_set_default_embedding_model_overrides_env(
     db_session: Session,
     mocker: MockerFixture,
@@ -591,6 +656,68 @@ def test_set_default_embedding_model_overrides_env(
     assert manager._models[model_id] is override
     # The env loader is never consulted when an override is registered.
     mock_load.assert_not_called()
+
+
+def test_set_default_embedding_model__persists_serving_url(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """The serving URL is written where the model row is written, so the two cannot drift."""
+    collection = create_collection(session=db_session)
+    manager = EmbeddingManager()
+    mocker.patch.object(embedding_manager, "_load_embedding_generator_from_env")
+
+    manager.set_default_embedding_model(
+        embedding_generator=RandomEmbeddingGenerator(),
+        serving_url="https://embeddings.corp.example/",
+    )
+    manager.load_or_get_default_model(session=db_session, collection_id=collection.collection_id)
+
+    service = embedding_model_service_resolver.get_by_model_hash(
+        session=db_session, embedding_model_hash="random_model"
+    )
+    assert service is not None
+    assert service.serving_url == "https://embeddings.corp.example"
+
+
+def test_set_default_embedding_model__rejects_invalid_serving_url() -> None:
+    """The URL is checked at the call site, not first seen during a search."""
+    manager = EmbeddingManager()
+
+    with pytest.raises(ValueError, match="must use https"):
+        manager.set_default_embedding_model(
+            embedding_generator=RandomEmbeddingGenerator(),
+            serving_url="http://192.168.1.20:8123",
+        )
+
+
+def test_register_embedding_model__serving_url_without_model_hash(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A serving URL is keyed on the model hash, so the generator must declare one."""
+
+    class UnnamedGenerator(RandomEmbeddingGenerator):
+        def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+            return EmbeddingModelCreate(
+                name="Unnamed",
+                embedding_model_hash="",
+                embedding_dimension=3,
+                collection_id=collection_id,
+            )
+
+    manager = EmbeddingManager()
+    generator = UnnamedGenerator()
+    manager.set_default_embedding_model(
+        embedding_generator=generator, serving_url="https://embeddings.corp.example"
+    )
+
+    with pytest.raises(ValueError, match="embedding_model_hash"):
+        manager.register_embedding_model(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_generator=generator,
+        )
 
 
 def test_set_default_embedding_model_fills_both_slots() -> None:

--- a/lightly_studio/tests/dataset/test_embedding_service.py
+++ b/lightly_studio/tests/dataset/test_embedding_service.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from lightly_studio.dataset import embedding_service
+
+
+def test_validate_serving_url() -> None:
+    assert embedding_service.validate_serving_url("https://embeddings.corp.example") == (
+        "https://embeddings.corp.example"
+    )
+
+
+def test_validate_serving_url__strips_trailing_slash() -> None:
+    assert embedding_service.validate_serving_url("https://embeddings.corp.example/") == (
+        "https://embeddings.corp.example"
+    )
+
+
+@pytest.mark.parametrize(
+    "serving_url",
+    [
+        "http://localhost:8123",
+        "http://127.0.0.1:8123",
+        "http://[::1]:8123",
+    ],
+)
+def test_validate_serving_url__plain_http_on_loopback(serving_url: str) -> None:
+    """Loopback is exempt: the browser treats it as a secure context."""
+    assert embedding_service.validate_serving_url(serving_url) == serving_url
+
+
+def test_validate_serving_url__plain_http_on_lan_host() -> None:
+    """A hosted Studio page is served over HTTPS, so plain http is blocked as mixed content."""
+    with pytest.raises(ValueError, match="must use https"):
+        embedding_service.validate_serving_url("http://192.168.1.20:8123")
+
+
+def test_validate_serving_url__unsupported_scheme() -> None:
+    with pytest.raises(ValueError, match="must use https"):
+        embedding_service.validate_serving_url("ftp://embeddings.corp.example")
+
+
+def test_validate_serving_url__missing_host() -> None:
+    with pytest.raises(ValueError, match="host"):
+        embedding_service.validate_serving_url("https://")

--- a/lightly_studio/tests/dataset/test_embedding_utils.py
+++ b/lightly_studio/tests/dataset/test_embedding_utils.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.dataset import embedding_utils
-from lightly_studio.dataset.embedding_manager import EmbeddingManager
+from lightly_studio.resolvers import embedding_model_resolver
 from tests.helpers_resolvers import (
     ImageStub,
     create_collection,
@@ -13,25 +12,17 @@ from tests.helpers_resolvers import (
 )
 
 
-def test_collection_has_embeddings(db_session: Session, mocker: MockerFixture) -> None:
+def test_collection_has_embeddings(db_session: Session) -> None:
     col_id = create_collection(session=db_session).collection_id
     embedding_model_id = create_embedding_model(
         session=db_session, collection_id=col_id
     ).embedding_model_id
-    mock_get_model = mocker.patch.object(
-        EmbeddingManager, "load_or_get_default_model", return_value=embedding_model_id
-    )
 
     # Initially, the collection has no embeddings.
     assert not embedding_utils.collection_has_embeddings(
         session=db_session,
         collection_id=col_id,
     )
-    mock_get_model.assert_called_once_with(
-        session=db_session,
-        collection_id=col_id,
-    )
-    mock_get_model.reset_mock()
 
     # Add an embedding to the collection.
     create_samples_with_embeddings(
@@ -46,7 +37,39 @@ def test_collection_has_embeddings(db_session: Session, mocker: MockerFixture) -
         session=db_session,
         collection_id=col_id,
     )
-    mock_get_model.assert_called_once_with(
+
+
+def test_collection_has_embeddings__does_not_register_a_model(db_session: Session) -> None:
+    """Reading the flag must never write an embedding-model row.
+
+    The collection's embedding-model row records what produced the stored vectors.
+    Registering a model here would attribute custom-model embeddings to the built-in
+    default and silently hide search.
+    """
+    col_id = create_collection(session=db_session).collection_id
+
+    assert not embedding_utils.collection_has_embeddings(session=db_session, collection_id=col_id)
+
+    assert (
+        embedding_model_resolver.get_all_by_collection_id(session=db_session, collection_id=col_id)
+        == []
+    )
+
+
+def test_collection_has_embeddings__custom_model(db_session: Session) -> None:
+    """Embeddings from a model that is not loaded in-process still count."""
+    col_id = create_collection(session=db_session).collection_id
+    custom_model_id = create_embedding_model(
         session=db_session,
         collection_id=col_id,
+        embedding_model_name="customer-model",
+        embedding_model_hash="customer-model-v1",
+    ).embedding_model_id
+    create_samples_with_embeddings(
+        session=db_session,
+        collection_id=col_id,
+        embedding_model_id=custom_model_id,
+        images_and_embeddings=[(ImageStub(), [0.1, 0.2, 0.3])],
     )
+
+    assert embedding_utils.collection_has_embeddings(session=db_session, collection_id=col_id)

--- a/lightly_studio/tests/resolvers/test_embedding_model_service_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_service_resolver.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from lightly_studio.resolvers import embedding_model_service_resolver
+
+
+def test_get_by_model_hash__missing(db_session: Session) -> None:
+    assert (
+        embedding_model_service_resolver.get_by_model_hash(
+            session=db_session, embedding_model_hash="customer-model-v1"
+        )
+        is None
+    )
+
+
+def test_set_serving_url(db_session: Session) -> None:
+    service = embedding_model_service_resolver.set_serving_url(
+        session=db_session,
+        embedding_model_hash="customer-model-v1",
+        serving_url="https://embeddings.corp.example",
+    )
+
+    assert service.serving_url == "https://embeddings.corp.example"
+    stored = embedding_model_service_resolver.get_by_model_hash(
+        session=db_session, embedding_model_hash="customer-model-v1"
+    )
+    assert stored is not None
+    assert stored.embedding_model_service_id == service.embedding_model_service_id
+
+
+def test_set_serving_url__updates_existing(db_session: Session) -> None:
+    """A hostname change is one update, not a new row per collection using the model."""
+    created = embedding_model_service_resolver.set_serving_url(
+        session=db_session,
+        embedding_model_hash="customer-model-v1",
+        serving_url="https://old.corp.example",
+    )
+
+    updated = embedding_model_service_resolver.set_serving_url(
+        session=db_session,
+        embedding_model_hash="customer-model-v1",
+        serving_url="https://new.corp.example",
+    )
+
+    assert updated.embedding_model_service_id == created.embedding_model_service_id
+    assert updated.serving_url == "https://new.corp.example"
+
+
+def test_set_serving_url__rejects_insecure_url(db_session: Session) -> None:
+    try:
+        embedding_model_service_resolver.set_serving_url(
+            session=db_session,
+            embedding_model_hash="customer-model-v1",
+            serving_url="http://192.168.1.20:8123",
+        )
+        raise AssertionError("Expected a ValueError for a non-loopback http URL.")
+    except ValueError:
+        pass
+
+    assert (
+        embedding_model_service_resolver.get_by_model_hash(
+            session=db_session, embedding_model_hash="customer-model-v1"
+        )
+        is None
+    )
+
+
+def test_delete_by_model_hash(db_session: Session) -> None:
+    embedding_model_service_resolver.set_serving_url(
+        session=db_session,
+        embedding_model_hash="customer-model-v1",
+        serving_url="https://embeddings.corp.example",
+    )
+
+    assert embedding_model_service_resolver.delete_by_model_hash(
+        session=db_session, embedding_model_hash="customer-model-v1"
+    )
+    assert (
+        embedding_model_service_resolver.get_by_model_hash(
+            session=db_session, embedding_model_hash="customer-model-v1"
+        )
+        is None
+    )
+
+
+def test_delete_by_model_hash__missing(db_session: Session) -> None:
+    assert not embedding_model_service_resolver.delete_by_model_hash(
+        session=db_session, embedding_model_hash="customer-model-v1"
+    )

--- a/lightly_studio_view/src/lib/api/embeddingService/embeddingServiceClient.test.ts
+++ b/lightly_studio_view/src/lib/api/embeddingService/embeddingServiceClient.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    embedImageViaService,
+    embedTextViaService,
+    fetchServiceInfo
+} from './embeddingServiceClient';
+
+const validInfo = {
+    contract_version: '1',
+    model_id: 'customer-model-v1',
+    embedding_dimension: 512,
+    supports_text: true,
+    supports_image: true,
+    normalized: false
+};
+
+function mockJsonResponse(body: unknown, ok = true, status = 200) {
+    return { ok, status, json: async () => body } as Response;
+}
+
+/** A fetch mock whose recorded calls keep the `(url, init)` argument types. */
+function mockFetch(body: unknown, ok = true, status = 200) {
+    return vi.fn<(url: string, init: RequestInit) => Promise<Response>>(async () =>
+        mockJsonResponse(body, ok, status)
+    );
+}
+
+describe('fetchServiceInfo', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the reported identity and capabilities', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => mockJsonResponse(validInfo))
+        );
+
+        const info = await fetchServiceInfo({ servingUrl: 'https://gpu-box:8123' });
+
+        expect(info).toEqual({
+            contractVersion: '1',
+            modelId: 'customer-model-v1',
+            embeddingDimension: 512,
+            supportsText: true,
+            supportsImage: true,
+            normalized: false
+        });
+    });
+
+    it('requests /info on the given base url without a double slash', async () => {
+        const fetchMock = mockFetch(validInfo);
+        vi.stubGlobal('fetch', fetchMock);
+
+        await fetchServiceInfo({ servingUrl: 'https://gpu-box:8123/' });
+
+        expect(fetchMock.mock.calls[0][0]).toBe('https://gpu-box:8123/info');
+    });
+
+    it('treats missing capability flags as unsupported', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () =>
+                mockJsonResponse({ model_id: 'customer-model-v1', embedding_dimension: 512 })
+            )
+        );
+
+        const info = await fetchServiceInfo({ servingUrl: 'https://gpu-box:8123' });
+
+        expect(info.supportsText).toBe(false);
+        expect(info.supportsImage).toBe(false);
+    });
+
+    it('rejects a response without a model_id', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => mockJsonResponse({ embedding_dimension: 512 }))
+        );
+
+        await expect(fetchServiceInfo({ servingUrl: 'https://gpu-box:8123' })).rejects.toThrow(
+            /model_id/
+        );
+    });
+
+    it('reports a non-ok status', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => mockJsonResponse(null, false, 503))
+        );
+
+        await expect(fetchServiceInfo({ servingUrl: 'https://gpu-box:8123' })).rejects.toThrow(
+            /503/
+        );
+    });
+
+    it('explains a blocked request rather than repeating "Failed to fetch"', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => {
+                throw new TypeError('Failed to fetch');
+            })
+        );
+
+        await expect(fetchServiceInfo({ servingUrl: 'http://192.168.1.20:8123' })).rejects.toThrow(
+            /blocked the request/
+        );
+    });
+
+    it('times out an unresponsive service', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn((_url: string, init: RequestInit) => {
+                return new Promise((_resolve, reject) => {
+                    init.signal?.addEventListener('abort', () => {
+                        const error = new Error('aborted');
+                        error.name = 'AbortError';
+                        reject(error);
+                    });
+                });
+            })
+        );
+
+        await expect(
+            fetchServiceInfo({ servingUrl: 'https://gpu-box:8123', timeoutMs: 5 })
+        ).rejects.toThrow(/did not respond/);
+    });
+});
+
+describe('embedTextViaService', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('posts the query and returns the vector', async () => {
+        const fetchMock = mockFetch([0.1, 0.2, 0.3]);
+        vi.stubGlobal('fetch', fetchMock);
+
+        const vector = await embedTextViaService({
+            servingUrl: 'https://gpu-box:8123',
+            text: 'a red car'
+        });
+
+        expect(vector).toEqual([0.1, 0.2, 0.3]);
+        expect(fetchMock.mock.calls[0][0]).toBe('https://gpu-box:8123/embed/text');
+        expect(fetchMock.mock.calls[0][1].body).toBe(JSON.stringify({ text: 'a red car' }));
+    });
+
+    it('rejects a body that is not a vector', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => mockJsonResponse({ embedding: [0.1] }))
+        );
+
+        await expect(
+            embedTextViaService({ servingUrl: 'https://gpu-box:8123', text: 'a red car' })
+        ).rejects.toThrow(/vector of numbers/);
+    });
+
+    it('rejects a vector containing non-finite values', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => mockJsonResponse([0.1, null, 0.3]))
+        );
+
+        await expect(
+            embedTextViaService({ servingUrl: 'https://gpu-box:8123', text: 'a red car' })
+        ).rejects.toThrow(/vector of numbers/);
+    });
+});
+
+describe('embedImageViaService', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('posts the file as multipart under the "image" field', async () => {
+        const fetchMock = mockFetch([0.4, 0.5]);
+        vi.stubGlobal('fetch', fetchMock);
+        const file = new File(['bytes'], 'query.jpg', { type: 'image/jpeg' });
+
+        const vector = await embedImageViaService({ servingUrl: 'https://gpu-box:8123', file });
+
+        expect(vector).toEqual([0.4, 0.5]);
+        expect(fetchMock.mock.calls[0][0]).toBe('https://gpu-box:8123/embed/image');
+        const form = fetchMock.mock.calls[0][1].body as FormData;
+        expect((form.get('image') as File).name).toBe('query.jpg');
+    });
+});

--- a/lightly_studio_view/src/lib/api/embeddingService/embeddingServiceClient.ts
+++ b/lightly_studio_view/src/lib/api/embeddingService/embeddingServiceClient.ts
@@ -1,0 +1,159 @@
+/**
+ * Client for a customer-hosted embedding service.
+ *
+ * The service runs on the customer's own network and serves the model their dataset was
+ * indexed with. The browser calls it directly, so its vectors never pass through the
+ * LightlyStudio backend and its weights never leave the customer's network.
+ */
+
+/** Timeout for the capability probe. Long enough for a cold service, short enough not to stall. */
+const PROBE_TIMEOUT_MS = 3000;
+
+/** Timeout for an embedding request, which may queue behind a model warm-up. */
+const EMBED_TIMEOUT_MS = 30000;
+
+interface ServiceInfo {
+    contractVersion: string;
+    modelId: string;
+    embeddingDimension: number;
+    supportsText: boolean;
+    supportsImage: boolean;
+    normalized: boolean;
+}
+
+/**
+ * Fetch the service's model identity and capabilities.
+ *
+ * @throws If the service is unreachable, times out, or answers with a body that does not
+ * match the contract.
+ */
+export async function fetchServiceInfo({
+    servingUrl,
+    timeoutMs = PROBE_TIMEOUT_MS
+}: {
+    servingUrl: string;
+    timeoutMs?: number;
+}): Promise<ServiceInfo> {
+    const body = await requestJson({
+        url: `${trimUrl(servingUrl)}/info`,
+        init: { method: 'GET' },
+        timeoutMs
+    });
+    return parseServiceInfo(body);
+}
+
+/** Embed a text query. Returns the raw vector the service produced. */
+export async function embedTextViaService({
+    servingUrl,
+    text
+}: {
+    servingUrl: string;
+    text: string;
+}): Promise<number[]> {
+    const body = await requestJson({
+        url: `${trimUrl(servingUrl)}/embed/text`,
+        init: {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text })
+        },
+        timeoutMs: EMBED_TIMEOUT_MS
+    });
+    return parseEmbedding(body);
+}
+
+/** Embed a query image. The service owns all preprocessing. */
+export async function embedImageViaService({
+    servingUrl,
+    file
+}: {
+    servingUrl: string;
+    file: File;
+}): Promise<number[]> {
+    const form = new FormData();
+    form.append('image', file, file.name);
+    const body = await requestJson({
+        url: `${trimUrl(servingUrl)}/embed/image`,
+        init: { method: 'POST', body: form },
+        timeoutMs: EMBED_TIMEOUT_MS
+    });
+    return parseEmbedding(body);
+}
+
+function trimUrl(servingUrl: string): string {
+    return servingUrl.replace(/\/+$/, '');
+}
+
+async function requestJson({
+    url,
+    init,
+    timeoutMs
+}: {
+    url: string;
+    init: RequestInit;
+    timeoutMs: number;
+}): Promise<unknown> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const response = await fetch(url, { ...init, signal: controller.signal, mode: 'cors' });
+        if (!response.ok) {
+            throw new Error(`The embedding service at ${url} answered ${response.status}.`);
+        }
+        return await response.json();
+    } catch (error) {
+        // A blocked cross-origin or private-network request surfaces as an opaque
+        // TypeError, so name the likely cause rather than repeating "Failed to fetch".
+        if (error instanceof Error && error.name === 'AbortError') {
+            throw new Error(
+                `The embedding service at ${url} did not respond within ${timeoutMs}ms.`
+            );
+        }
+        if (error instanceof TypeError) {
+            throw new Error(
+                `Could not reach the embedding service at ${url}. It may be down, or the browser ` +
+                    `may have blocked the request because the service is not served over HTTPS or ` +
+                    `does not allow this origin.`
+            );
+        }
+        throw error;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+function parseServiceInfo(body: unknown): ServiceInfo {
+    if (typeof body !== 'object' || body === null) {
+        throw new Error('The embedding service did not return a /info object.');
+    }
+    const info = body as Record<string, unknown>;
+    const modelId = info.model_id;
+    const embeddingDimension = info.embedding_dimension;
+    if (typeof modelId !== 'string' || modelId === '') {
+        throw new Error('The embedding service did not report a model_id.');
+    }
+    if (typeof embeddingDimension !== 'number' || !Number.isFinite(embeddingDimension)) {
+        throw new Error(`The embedding service reported no embedding_dimension for '${modelId}'.`);
+    }
+    return {
+        contractVersion: typeof info.contract_version === 'string' ? info.contract_version : '',
+        modelId,
+        embeddingDimension,
+        // Absent capability flags default to unsupported: offering a search box that always
+        // errors is worse than hiding one the model could have served.
+        supportsText: info.supports_text === true,
+        supportsImage: info.supports_image === true,
+        normalized: info.normalized === true
+    };
+}
+
+function parseEmbedding(body: unknown): number[] {
+    if (
+        !Array.isArray(body) ||
+        body.length === 0 ||
+        !body.every((value) => typeof value === 'number' && Number.isFinite(value))
+    ) {
+        throw new Error('The embedding service did not return a vector of numbers.');
+    }
+    return body as number[];
+}

--- a/lightly_studio_view/src/lib/hooks/useEmbeddingService/useEmbeddingService.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useEmbeddingService/useEmbeddingService.svelte.ts
@@ -1,0 +1,117 @@
+import { readEmbeddingModelOptions } from '$lib/api/lightly_studio_local/@tanstack/svelte-query.gen';
+import { fetchServiceInfo } from '$lib/api/embeddingService/embeddingServiceClient';
+import { createQuery } from '@tanstack/svelte-query';
+
+/**
+ * `builtin` — the model runs inside the LightlyStudio backend, which embeds queries.
+ * `probing` — a customer-hosted service is configured and is being contacted.
+ * `ready` — the service answered and serves the model this collection was indexed with.
+ * `unreachable` — the service did not answer.
+ * `model-mismatch` — the service serves a different model than the stored vectors.
+ */
+type Status = 'builtin' | 'probing' | 'ready' | 'unreachable' | 'model-mismatch';
+
+interface Params {
+    /** Returns the collection whose embedding model should be resolved. */
+    getCollectionId: () => string;
+}
+
+/**
+ * Resolve where search queries for a collection must be embedded.
+ *
+ * A collection indexed with a customer's own model has no live model in the hosted
+ * backend, so queries are embedded by an HTTP service on the customer's network that the
+ * browser calls directly. This hook finds that service and reports whether it can serve
+ * the collection, so search is either correct or visibly unavailable — it never falls
+ * back to the built-in model, whose vectors would produce a confidently ordered list of
+ * garbage against custom-model embeddings.
+ */
+export function useEmbeddingService({ getCollectionId }: Params) {
+    const modelQuery = createQuery(() => ({
+        ...readEmbeddingModelOptions({ path: { collection_id: getCollectionId() } }),
+        // A collection's model does not change while it is open.
+        staleTime: Infinity
+    }));
+
+    const servingUrl = $derived(modelQuery.data?.serving_url ?? undefined);
+    const expectedModelId = $derived(modelQuery.data?.embedding_model_hash);
+
+    const probeQuery = createQuery(() => ({
+        // Keyed on the model identity as well as the host, so two collections sharing a
+        // model share one probe result.
+        queryKey: ['embeddingService', servingUrl, expectedModelId],
+        queryFn: () => fetchServiceInfo({ servingUrl: servingUrl as string }),
+        enabled: servingUrl !== undefined,
+        staleTime: Infinity,
+        // The probe is the failure signal, so surface it rather than retrying behind a spinner.
+        retry: false
+    }));
+
+    const status: Status = $derived.by(() => {
+        if (servingUrl === undefined) return 'builtin';
+        if (probeQuery.isError) return 'unreachable';
+        if (!probeQuery.isSuccess) return 'probing';
+        if (probeQuery.data.modelId !== expectedModelId) return 'model-mismatch';
+        return 'ready';
+    });
+
+    const info = $derived(probeQuery.isSuccess ? probeQuery.data : undefined);
+
+    return {
+        /** Base URL to embed queries against, or undefined to use the LightlyStudio backend. */
+        get servingUrl() {
+            return servingUrl;
+        },
+        get status() {
+            return status;
+        },
+        get canSearchText() {
+            if (status === 'builtin') return true;
+            return status === 'ready' && info?.supportsText === true;
+        },
+        get canSearchImage() {
+            if (status === 'builtin') return true;
+            return status === 'ready' && info?.supportsImage === true;
+        },
+        /** User-facing explanation when search is unavailable, else undefined. */
+        get textDisabledReason() {
+            return disabledReason({ status, servingUrl, expectedModelId, info, modality: 'text' });
+        },
+        get imageDisabledReason() {
+            return disabledReason({ status, servingUrl, expectedModelId, info, modality: 'image' });
+        },
+        /** Contact the service again, so a restarted box recovers without a page reload. */
+        reprobe() {
+            if (servingUrl !== undefined) void probeQuery.refetch();
+        }
+    };
+}
+
+function disabledReason({
+    status,
+    servingUrl,
+    expectedModelId,
+    info,
+    modality
+}: {
+    status: Status;
+    servingUrl: string | undefined;
+    expectedModelId: string | undefined;
+    info: Awaited<ReturnType<typeof fetchServiceInfo>> | undefined;
+    modality: 'text' | 'image';
+}): string | undefined {
+    if (status === 'builtin' || status === 'probing') return undefined;
+    if (status === 'unreachable') {
+        return `Search is unavailable: the embedding service at ${servingUrl} did not respond. Check that it is running and reachable from this machine.`;
+    }
+    if (status === 'model-mismatch') {
+        return `Search is unavailable: the service at ${servingUrl} serves model '${info?.modelId}', but this collection was indexed with '${expectedModelId}'. Searching would compare vectors from two different embedding spaces.`;
+    }
+    if (modality === 'text' && info?.supportsText !== true) {
+        return `This collection's embedding model cannot embed text. Search by image instead.`;
+    }
+    if (modality === 'image' && info?.supportsImage !== true) {
+        return `This collection's embedding model cannot embed images. Search by text instead.`;
+    }
+    return undefined;
+}

--- a/lightly_studio_view/src/lib/hooks/useImageUpload/useImageUpload.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageUpload/useImageUpload.ts
@@ -17,6 +17,14 @@ type UseImageUploadParams = {
     onSuccess: (result: UploadSuccessResult) => void;
     /** Maximum accepted upload size in MB. Defaults to `50`. */
     maxSizeMb?: number;
+    /**
+     * Returns an embedder to use instead of the LightlyStudio backend, or `undefined` to
+     * use the backend. Consulted per upload, because whether a collection has a
+     * customer-hosted embedding service is resolved after this hook is created.
+     */
+    getEmbed?: () =>
+        | ((params: { file: File; collectionId: string }) => Promise<number[]>)
+        | undefined;
 };
 
 type UseImageUploadReturn = {
@@ -39,7 +47,8 @@ export function useImageUpload({
     getCollectionId,
     onError,
     onSuccess,
-    maxSizeMb = 50
+    maxSizeMb = 50,
+    getEmbed
 }: UseImageUploadParams): UseImageUploadReturn {
     const mutation = createMutation(() => embedImageFromFileMutation());
 
@@ -87,26 +96,29 @@ export function useImageUpload({
                 throw new Error('Collection ID is not available');
             }
 
-            const embedding = await new Promise<number[]>((resolve, reject) => {
-                mutation.mutate(
-                    {
-                        path: {
-                            collection_id: collectionId
-                        },
-                        body: {
-                            file
-                        }
-                    },
-                    {
-                        onSuccess: (data) => {
-                            resolve(data);
-                        },
-                        onError: (error) => {
-                            reject(error);
-                        }
-                    }
-                );
-            });
+            const embedViaService = getEmbed?.();
+            const embedding = embedViaService
+                ? await embedViaService({ file, collectionId })
+                : await new Promise<number[]>((resolve, reject) => {
+                      mutation.mutate(
+                          {
+                              path: {
+                                  collection_id: collectionId
+                              },
+                              body: {
+                                  file
+                              }
+                          },
+                          {
+                              onSuccess: (data) => {
+                                  resolve(data);
+                              },
+                              onError: (error) => {
+                                  reject(error);
+                              }
+                          }
+                      );
+                  });
 
             setPreview(file.name, URL.createObjectURL(file));
             onSuccess({ fileName: file.name, embedding, collectionId });

--- a/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.test.ts
@@ -31,6 +31,8 @@ const mocks = vi.hoisted(() => {
         clearImage: vi.fn(),
         setPreview: vi.fn(),
         embedText: vi.fn(),
+        embedTextViaService: vi.fn(),
+        embedImageViaService: vi.fn(),
         imageName: createStore<string | undefined>(undefined),
         previewUrl: createStore<string | undefined>(undefined),
         isUploading: createStore(false),
@@ -56,6 +58,11 @@ vi.mock('$lib/hooks/useImageUpload/useImageUpload', () => ({
             setPreview: mocks.setPreview
         };
     }
+}));
+
+vi.mock('$lib/api/embeddingService/embeddingServiceClient', () => ({
+    embedTextViaService: mocks.embedTextViaService,
+    embedImageViaService: mocks.embedImageViaService
 }));
 
 vi.mock('$lib/hooks/useTextEmbedding/useTextEmbedding', () => ({
@@ -211,5 +218,143 @@ describe('useSearchEmbedding', () => {
 
         expect(get(embedding)).toBeUndefined();
         expect(mocks.clearImage).toHaveBeenCalled();
+    });
+
+    describe('with a customer-hosted embedding service', () => {
+        const readyService = () => ({
+            servingUrl: 'https://gpu-box:8123',
+            status: 'ready' as const,
+            canSearchText: true,
+            canSearchImage: true,
+            textDisabledReason: undefined,
+            imageDisabledReason: undefined,
+            reprobe: vi.fn()
+        });
+
+        it('embeds text against the service instead of the backend', async () => {
+            mocks.embedTextViaService.mockResolvedValue([7, 8, 9]);
+            useSearchEmbedding({
+                getCollectionId: () => 'collection-id',
+                embedding,
+                service: readyService()
+            });
+
+            const opts = mocks.useTextEmbeddingOptions as {
+                getEmbed: () => ((p: { text: string }) => Promise<number[]>) | undefined;
+            };
+            const embed = opts.getEmbed();
+            expect(embed).toBeDefined();
+            await expect(embed!({ text: 'a red car' })).resolves.toEqual([7, 8, 9]);
+            expect(mocks.embedTextViaService).toHaveBeenCalledWith({
+                servingUrl: 'https://gpu-box:8123',
+                text: 'a red car'
+            });
+        });
+
+        it('embeds images against the service instead of the backend', async () => {
+            mocks.embedImageViaService.mockResolvedValue([1, 1, 1]);
+            const file = new File(['x'], 'query.png', { type: 'image/png' });
+            useSearchEmbedding({
+                getCollectionId: () => 'collection-id',
+                embedding,
+                service: readyService()
+            });
+
+            const opts = mocks.useImageUploadOptions as {
+                getEmbed: () => ((p: { file: File }) => Promise<number[]>) | undefined;
+            };
+            await expect(opts.getEmbed()!({ file })).resolves.toEqual([1, 1, 1]);
+            expect(mocks.embedImageViaService).toHaveBeenCalledWith({
+                servingUrl: 'https://gpu-box:8123',
+                file
+            });
+        });
+
+        it('uses the backend when the collection has no service', () => {
+            useSearchEmbedding({
+                getCollectionId: () => 'collection-id',
+                embedding,
+                service: { ...readyService(), servingUrl: undefined, status: 'builtin' }
+            });
+
+            const textOpts = mocks.useTextEmbeddingOptions as { getEmbed: () => unknown };
+            const imageOpts = mocks.useImageUploadOptions as { getEmbed: () => unknown };
+            expect(textOpts.getEmbed()).toBeUndefined();
+            expect(imageOpts.getEmbed()).toBeUndefined();
+        });
+
+        it('refuses a text search instead of falling back to the built-in model', async () => {
+            const service = {
+                ...readyService(),
+                status: 'model-mismatch' as const,
+                canSearchText: false,
+                textDisabledReason: 'Search is unavailable: wrong model.'
+            };
+            const search = useSearchEmbedding({
+                getCollectionId: () => 'collection-id',
+                embedding,
+                service
+            });
+
+            await search.setText('a red car');
+
+            expect(mocks.embedText).not.toHaveBeenCalled();
+            expect(mocks.toastError).toHaveBeenCalledWith('Error', {
+                description: 'Search is unavailable: wrong model.'
+            });
+        });
+
+        it('still clears the search when the query is emptied on a disabled service', async () => {
+            embedding.set({ queryText: 'foo', embedding: [1] });
+            const search = useSearchEmbedding({
+                getCollectionId: () => 'collection-id',
+                embedding,
+                service: {
+                    ...readyService(),
+                    status: 'unreachable' as const,
+                    canSearchText: false,
+                    textDisabledReason: 'Search is unavailable: no response.'
+                }
+            });
+
+            await search.setText('   ');
+
+            expect(get(embedding)).toBeUndefined();
+            expect(mocks.toastError).not.toHaveBeenCalled();
+        });
+
+        it('refuses an image search when the model cannot embed images', async () => {
+            const file = new File(['x'], 'query.png', { type: 'image/png' });
+            const search = useSearchEmbedding({
+                getCollectionId: () => 'collection-id',
+                embedding,
+                service: {
+                    ...readyService(),
+                    canSearchImage: false,
+                    imageDisabledReason: 'This model cannot embed images.'
+                }
+            });
+
+            await search.setImage(file);
+
+            expect(mocks.upload).not.toHaveBeenCalled();
+            expect(mocks.toastError).toHaveBeenCalledWith('Error', {
+                description: 'This model cannot embed images.'
+            });
+        });
+
+        it('re-probes the service when a search fails', () => {
+            const service = readyService();
+            useSearchEmbedding({
+                getCollectionId: () => 'collection-id',
+                embedding,
+                service
+            });
+
+            const opts = mocks.useTextEmbeddingOptions as EmbedOptions;
+            opts.onError('boom');
+
+            expect(service.reprobe).toHaveBeenCalled();
+        });
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
+++ b/lightly_studio_view/src/lib/hooks/useSearchEmbedding/useSearchEmbedding.ts
@@ -2,6 +2,11 @@ import { useImageUpload } from '$lib/hooks/useImageUpload/useImageUpload';
 import { useTextEmbedding } from '$lib/hooks/useTextEmbedding/useTextEmbedding';
 import type { TextEmbedding } from '$lib/hooks/useGlobalStorage';
 import { usePostHog } from '$lib/hooks';
+import type { useEmbeddingService } from '$lib/hooks/useEmbeddingService/useEmbeddingService.svelte';
+import {
+    embedImageViaService,
+    embedTextViaService
+} from '$lib/api/embeddingService/embeddingServiceClient';
 import { toast } from 'svelte-sonner';
 import { derived, readonly, type Readable, type Writable } from 'svelte/store';
 
@@ -20,6 +25,11 @@ interface Params {
     getCollectionId: () => string;
     /** External writable that receives the resulting embedding. */
     embedding: Writable<TextEmbedding | undefined>;
+    /**
+     * Routes queries to a customer-hosted embedding service for collections indexed with a
+     * model the backend does not run. Omit to always embed via the backend.
+     */
+    service?: ReturnType<typeof useEmbeddingService>;
 }
 
 interface Return {
@@ -45,16 +55,23 @@ interface Return {
     onError: (message: string) => void;
 }
 
-export function useSearchEmbedding({ getCollectionId, embedding }: Params): Return {
+export function useSearchEmbedding({ getCollectionId, embedding, service }: Params): Return {
     const { trackEvent } = usePostHog();
 
     const onError = (message: string) => {
         toast.error('Error', { description: message });
+        // Contact the service again so a restarted box recovers without a page reload.
+        service?.reprobe();
     };
 
     const upload = useImageUpload({
         getCollectionId,
         onError,
+        getEmbed: () => {
+            const servingUrl = service?.servingUrl;
+            if (!servingUrl) return undefined;
+            return ({ file }) => embedImageViaService({ servingUrl, file });
+        },
         onSuccess: ({ fileName, embedding: vector, collectionId }) => {
             embedding.set({ queryText: fileName, embedding: vector });
             trackEvent('search_executed', {
@@ -67,6 +84,11 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
     const text = useTextEmbedding({
         getCollectionId,
         onError,
+        getEmbed: () => {
+            const servingUrl = service?.servingUrl;
+            if (!servingUrl) return undefined;
+            return ({ text: query }) => embedTextViaService({ servingUrl, text: query });
+        },
         onSuccess: ({ queryText, embedding: vector, collectionId }) => {
             embedding.set({ queryText, embedding: vector });
             trackEvent('search_executed', {
@@ -89,6 +111,11 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
 
     const setText = async (input: string) => {
         upload.clear();
+        // Refuse rather than let the request reach the built-in model. See useEmbeddingService.
+        if (input.trim() && service?.textDisabledReason) {
+            onError(service.textDisabledReason);
+            return;
+        }
         if (!input.trim()) {
             embedding.set(undefined);
         } else {
@@ -103,6 +130,10 @@ export function useSearchEmbedding({ getCollectionId, embedding }: Params): Retu
     };
 
     const setImage = async (file: File) => {
+        if (service?.imageDisabledReason) {
+            onError(service.imageDisabledReason);
+            return;
+        }
         trackEvent('search_initiated', {
             collection_id: getCollectionId(),
             search_type: 'image'

--- a/lightly_studio_view/src/lib/hooks/useTextEmbedding/useTextEmbedding.ts
+++ b/lightly_studio_view/src/lib/hooks/useTextEmbedding/useTextEmbedding.ts
@@ -14,6 +14,14 @@ type UseTextEmbeddingParams = {
     onError: (message: string) => void;
     /** Called after successful embedding with trimmed query text and embedding vector. */
     onSuccess: (result: EmbedSuccessResult) => void;
+    /**
+     * Returns an embedder to use instead of the LightlyStudio backend, or `undefined` to
+     * use the backend. Consulted per request, because whether a collection has a
+     * customer-hosted embedding service is resolved after this hook is created.
+     */
+    getEmbed?: () =>
+        | ((params: { text: string; collectionId: string }) => Promise<number[]>)
+        | undefined;
 };
 
 type UseTextEmbeddingReturn = {
@@ -27,7 +35,8 @@ type UseTextEmbeddingReturn = {
 export function useTextEmbedding({
     getCollectionId,
     onError,
-    onSuccess
+    onSuccess,
+    getEmbed
 }: UseTextEmbeddingParams): UseTextEmbeddingReturn {
     const isEmbedding = writable(false);
     let latestRequestId = 0;
@@ -42,17 +51,12 @@ export function useTextEmbedding({
         pendingRequests += 1;
         isEmbedding.set(true);
         try {
-            const { data, error } = await embedText({
-                path: { collection_id: collectionId },
-                query: { query_text: trimmed, embedding_model_id: null }
-            });
+            const embedViaService = getEmbed?.();
+            const vector = embedViaService
+                ? await embedViaService({ text: trimmed, collectionId })
+                : await embedViaBackend({ text: trimmed, collectionId });
             if (requestId !== latestRequestId) return;
-            if (error) {
-                const errObj = error as { error?: unknown; message?: string };
-                throw new Error(String(errObj.error ?? errObj.message ?? 'Failed to embed text'));
-            }
-            if (!data) throw new Error('Failed to embed text');
-            onSuccess({ queryText: trimmed, embedding: data, collectionId });
+            onSuccess({ queryText: trimmed, embedding: vector, collectionId });
         } catch (err) {
             if (requestId !== latestRequestId) return;
             const message = err instanceof Error ? err.message : 'Failed to embed text';
@@ -64,4 +68,23 @@ export function useTextEmbedding({
     };
 
     return { isEmbedding, embed };
+}
+
+async function embedViaBackend({
+    text,
+    collectionId
+}: {
+    text: string;
+    collectionId: string;
+}): Promise<number[]> {
+    const { data, error } = await embedText({
+        path: { collection_id: collectionId },
+        query: { query_text: text, embedding_model_id: null }
+    });
+    if (error) {
+        const errObj = error as { error?: unknown; message?: string };
+        throw new Error(String(errObj.error ?? errObj.message ?? 'Failed to embed text'));
+    }
+    if (!data) throw new Error('Failed to embed text');
+    return data;
 }

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -85,6 +85,7 @@
     import { GRID_IMAGE_SEARCH_DROP_EVENT, type GridItemDragData } from '$lib/components/GridItem';
     import { readAnnotationEmbedding } from '$lib/api/lightly_studio_local/sdk.gen';
     import { useSearchEmbedding } from '$lib/hooks/useSearchEmbedding/useSearchEmbedding';
+    import { useEmbeddingService } from '$lib/hooks/useEmbeddingService/useEmbeddingService.svelte';
     import { useEvaluationRuns } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
     import { clearAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
     import { isPanelVisible } from './panelVisibility';
@@ -165,9 +166,15 @@
     // Instantiate once (not `$derived`) so the active search survives collection changes: the image
     // and annotation tabs are separate collections, and re-creating the hook per collection would
     // reset the preview chip. `collectionId` is read lazily via the getter when a request fires.
+    // Resolves whether this collection's queries must be embedded by a service on the
+    // customer's network instead of by the backend. Probed on collection open so
+    // capabilities are known before the search bar renders.
+    const embeddingService = useEmbeddingService({ getCollectionId: () => collectionId });
+
     const search = useSearchEmbedding({
         getCollectionId: () => collectionId,
-        embedding: textEmbedding
+        embedding: textEmbedding,
+        service: embeddingService
     });
     const searchImage = search.image;
     const searchPending = search.isPending;

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -164,6 +164,17 @@ vi.mock('$lib/hooks/useSearchEmbedding/useSearchEmbedding', () => ({
         onError: vi.fn()
     }))
 }));
+vi.mock('$lib/hooks/useEmbeddingService/useEmbeddingService.svelte', () => ({
+    useEmbeddingService: vi.fn(() => ({
+        servingUrl: undefined,
+        status: 'builtin',
+        canSearchText: true,
+        canSearchImage: true,
+        textDisabledReason: undefined,
+        imageDisabledReason: undefined,
+        reprobe: vi.fn()
+    }))
+}));
 vi.mock('$lib/hooks/useEvaluationRuns/useEvaluationRuns', () => ({
     useEvaluationRuns: vi.fn(() => ({ data: undefined, isLoading: false, error: null }))
 }));


### PR DESCRIPTION
## What has changed and why?

Prototype for [LIG-10428](https://linear.app/lightly/issue/LIG-10428/figure-out-custom-embedding-model-hosted), implementing the [decision record](https://linear.app/lightly/document/decision-record-custom-embedding-models-on-hosted-studio-d3daa5d97237).

Customers who index with their own embedding model write vectors straight to the DB. Everything that reads those vectors works, but **search does not**: embedding a query needs a live model, and a hosted instance has none. The chosen approach is that the customer serves the model over HTTP on their own network and the browser calls it directly — our backend is never in the path, so weights and queries never reach our infrastructure.

- **`embedding_model_service` table** keyed on `embedding_model_hash` rather than collection, so a hostname change is one update instead of one per collection (D-8). Plus its Alembic revision.
- **`serving_url` on `set_default_embedding_model`**, persisted where the model row is written so "what produced these vectors" and "where do I get more" cannot drift apart (D-9). An endpoint changes it without re-indexing.
- **Frontend probes `/info` on collection open**, routes text and image queries to the service, and disables search on model mismatch or timeout, re-probing when a search fails (D-12, D-13). It never falls back to the built-in model — those query vectors against custom-model embeddings return a confidently ordered list of unrelated results with no error, and dimensions often match so a dimension check would not catch it.
- **Write-on-read fix (D-18)**, the blocking prerequisite: `GET /has_embeddings` registered the env-default model and overwrote the record of what produced the stored vectors, silently hiding search on custom-model collections. `collection_has_embeddings` is now model-free, and `load_or_get_default_model` refuses to register a generator that does not match the collection's stored model.
- **Reference service** implementing the contract, a **standalone page** for answering the open Private Network Access question, and **customer-facing docs**.

### Notes for reviewers

**Size.** Above the 100-line target because a vertical slice needs the table, the write path, the read path and the frontend together — a partial slice is not demoable and cannot answer the open question the issue exists to settle. Roughly half the diff is tests and docs. The D-18 fix is separable and is the one part with blast radius beyond this feature; happy to split it out if preferred.

**Admin gating is deliberately absent.** D-16 calls for it, but auth is terminated by a proxy outside this repo and D-17 (whether that proxy distinguishes admins) is unresolved, so a real check cannot be written here. Left as a `TODO` on the endpoint rather than a placeholder dependency that would look like a gate without being one. Whoever can write a serving URL can redirect every user's queries to a host they control, with no trace on our servers.

**Open questions this does not close.** D-5 (Private Network Access) needs a browser against a real hosted origin — see below. D-20 stands: video collections are hard-wired to PerceptionEncoder and are documented as unsupported.

**Trust-based identity (D-11).** `embedding_model_hash` is a customer-declared string, not a digest. A forgotten version bump yields silently wrong results; accepted and documented.

## How has it been tested?

**Automated.** Backend `make static-checks` and `make test` (1879 passed). Frontend `make static-checks` and `npm run test:unit` (2505 passed). New coverage: URL validation, the service resolver, both endpoints, the D-18 behaviour in `embedding_manager` and `embedding_utils`, the contract client, and search routing/refusal in `useSearchEmbedding`.

**Contract round trip verified numerically.** The reference service returns vectors bit-identical (max abs diff `0.0`, text and image) to the in-process `MobileCLIPEmbeddingGenerator` used for indexing, so going over HTTP preserves the embedding space.

**Alembic revision is hand-written** — Docker was unavailable locally. Its DDL was verified to match `SQLModel.metadata` exactly, but `make migration-check-postgresql` has **not** been run. Please run it before merge.

**Not yet run: the browser.** `useEmbeddingService` has no direct unit test (it is a runes hook needing a component harness plus a `QueryClient`); it is covered indirectly through `useSearchEmbedding`. Manual verification planned:

1. Local: default model regression, then a custom model with `serving_url="http://localhost:8123"`, then the negative case — a custom-model collection reopened with no service must *disable* search, not return results.
2. Hosted: Studio on EC2 over **HTTPS** (mandatory — private-network requests from an `http://` public origin are blocked outright with no header opt-in, which looks identical to a PNA failure and would produce a false negative on D-5), with the model served locally.

`example_embedding_service_pna_check.html` isolates D-5 from CORS and TLS so a failure has one interpretation.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
