### PR TITLE
Add: Document python interface to add video classifications and

### DIFF
--- a/lightly_studio/docs/docs/concepts_and_tools/annotations.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/annotations.md
@@ -70,9 +70,55 @@ sample.add_annotation(
     CreateClassification(
         class_name="cat",
         confidence=0.95,  # optional
-    )
+    ),
+    annotation_source="model-v1",
 )
 ```
+
+Model predictions can be added as multi-label classifications by passing all predictions for a
+sample at once:
+
+```python
+from lightly_studio.core.annotation import CreateClassification
+
+predictions = {
+    "/data/cat.jpg": [("cat", 0.95), ("indoor", 0.81)],
+    "/data/dog.jpg": [("dog", 0.91)],
+}
+
+for sample in dataset:
+    sample_predictions = predictions.get(sample.file_path_abs, [])
+    if not sample_predictions:
+        continue
+    sample.add_annotations(
+        annotations=[
+            CreateClassification(class_name=class_name, confidence=confidence)
+            for class_name, confidence in sample_predictions
+        ],
+        annotation_source="model-v1",
+    )
+```
+
+Calling `add_annotation(...)` or `add_annotations(...)` again appends annotations to the selected
+annotation source.
+
+The same API attaches classifications directly to whole video samples:
+
+```python
+from lightly_studio import VideoDataset
+from lightly_studio.core.annotation import CreateClassification
+
+dataset = VideoDataset.load()
+video = next(iter(dataset))
+video.add_annotation(
+    CreateClassification(class_name="sports", confidence=0.92),
+    annotation_source="model-v1",
+)
+```
+
+Whole-video classifications can be exported with
+`dataset.export().to_csv_classifications("classifications.csv")`. Classifications with temporal
+spans represent events within a video and are not included in this export.
 
 ### Object Detection
 

--- a/lightly_studio/tests/core/video/test_video_sample.py
+++ b/lightly_studio/tests/core/video/test_video_sample.py
@@ -1,5 +1,7 @@
+import pytest
 from sqlmodel import Session
 
+from lightly_studio.core.annotation import ClassificationAnnotation, CreateClassification
 from lightly_studio.core.video.video_sample import VideoSample
 from lightly_studio.models.collection import SampleType
 from tests.helpers_resolvers import create_collection
@@ -24,3 +26,25 @@ class TestImageSample:
         assert sample.collection_id == collection.collection_id
         assert sample.file_path_abs == "/path/to/sample1.mp4"
         assert sample.sample_id == video_table.sample_id
+
+
+def test_add_annotation_classification(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_table = create_video(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/path/to/sample.mp4"),
+    )
+    video = VideoSample(inner=video_table)
+
+    video.add_annotation(
+        CreateClassification(class_name="cat", confidence=0.75),
+        annotation_source="model-v1",
+    )
+
+    assert len(video.annotations) == 1
+    annotation = video.annotations[0]
+    assert isinstance(annotation, ClassificationAnnotation)
+    assert annotation.class_name == "cat"
+    assert annotation.confidence == pytest.approx(0.75)
+    assert annotation.annotation_source == "model-v1"


### PR DESCRIPTION
## What has changed and why?

- Adds better docs around how to add multi-label and video classifications via Python SDK
- Adds a simple test for adding video classifications via Python

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated classification examples to specify annotation sources and add multiple model predictions per image.
  * Documented how repeated annotations are appended to a selected source.
  * Added whole-video classification examples and clarified CSV export behavior for video classifications.

* **Tests**
  * Added coverage for creating video classification annotations with class, confidence, and source details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->