### PR TITLE
Open the browser automatically when quickstart starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `lightly-studio quickstart` now opens your browser automatically once the GUI server is ready. Pass `--no-browser` to skip that.
+
 ### Deprecated
 
 ### Removed

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -54,9 +54,8 @@ Want to try LightlyStudio instantly? Run:
 lightly-studio quickstart
 ```
 
-This downloads the COCO example dataset on the first run (skipped on subsequent runs), loads it,
-and starts the GUI server. Click the printed URL to open it in your browser. Use
-`--force-download` to re-fetch the dataset, or `--port <N>` to serve on a custom port.
+This downloads the COCO example dataset, loads it, and opens the GUI in your browser. Run
+`lightly-studio quickstart --help` for the available options.
 
 The examples below use the same example dataset by default, downloaded on the first run. Point
 them at your own image, video, or YOLO/COCO dataset by changing the input path.

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -26,7 +26,13 @@ def main() -> None:
     default=False,
     help="Re-download the demo dataset even if already cached.",
 )
-def quickstart(port: int | None, force_download: bool) -> None:
+@click.option(
+    "--no-browser",
+    is_flag=True,
+    default=False,
+    help="Do not open a browser automatically once the GUI server is ready.",
+)
+def quickstart(port: int | None, force_download: bool, no_browser: bool) -> None:
     """Launch the GUI preloaded with a COCO object detection evaluation demo dataset."""
     dataset_path = Path(
         lightly_studio.utils.download_example_dataset(
@@ -63,9 +69,7 @@ def quickstart(port: int | None, force_download: bool) -> None:
         config=evaluation_config,
     )
 
-    # TODO(Gabriel, 08/2026): Open the browser automatically once the server is ready.
-    # See LIG-10436.
-    lightly_studio.start_gui(port=port)
+    lightly_studio.start_gui(port=port, open_browser=not no_browser)
 
 
 @main.command()

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -33,15 +33,42 @@ def main() -> None:
     help="Do not open a browser automatically once the GUI server is ready.",
 )
 def quickstart(port: int | None, force_download: bool, no_browser: bool) -> None:
-    """Launch the GUI preloaded with a COCO object detection evaluation demo dataset.
+    """Launch the GUI preloaded with a COCO object detection evaluation demo dataset."""
+    dataset_path = Path(
+        lightly_studio.utils.download_example_dataset(
+            download_dir="dataset_examples",
+            force_redownload=force_download,
+        )
+    )
+    coco_dir = dataset_path / "coco_subset_128_images"
+    images_path = coco_dir / "images"
+    evaluation_config = ObjectDetectionEvaluationConfig(
+        iou_threshold=0.5,
+        classwise=False,
+    )
 
-    Recreates ./quickstart.db in the current directory on every run, overwriting
-    any existing file with that name.
-    """
-    coco_dir, images_path = _download_quickstart_dataset(force_download=force_download)
     db_manager.connect(db_file="quickstart.db", cleanup_existing=True)
-    dataset = _load_quickstart_dataset(coco_dir=coco_dir, images_path=images_path)
-    _evaluate_quickstart_dataset(dataset=dataset)
+    dataset = lightly_studio.ImageDataset.create()
+    dataset.add_images_from_path(path=images_path)
+    dataset.add_annotations_from_coco(
+        annotations_json=coco_dir / "instances_train2017.json",
+        images_root=images_path,
+        annotation_source="ground_truth",
+    )
+    dataset.add_annotations_from_coco(
+        annotations_json=coco_dir / "predictions_train2017.json",
+        images_root=images_path,
+        annotation_source="predictions",
+    )
+    # Tag a subset of samples to demonstrate tags in the GUI.
+    dataset.query()[:10].add_tag("sample_subset")
+    dataset.evaluate().object_detection(
+        name="od_evaluation",
+        gt_annotation_source="ground_truth",
+        pred_annotation_source="predictions",
+        config=evaluation_config,
+    )
+
     lightly_studio.start_gui(port=port, open_browser=not no_browser)
 
 
@@ -73,48 +100,3 @@ def gui(
         raise click.UsageError("Options '--db-file' and '--db-url' are mutually exclusive.")
     db_manager.connect(db_file=db_file, db_url=db_url, must_exist=True)
     lightly_studio.start_gui(host=host, port=port)
-
-
-def _download_quickstart_dataset(force_download: bool) -> tuple[Path, Path]:
-    """Download the demo COCO dataset and return (coco_dir, images_path)."""
-    dataset_path = Path(
-        lightly_studio.utils.download_example_dataset(
-            download_dir="dataset_examples",
-            force_redownload=force_download,
-        )
-    )
-    coco_dir = dataset_path / "coco_subset_128_images"
-    return coco_dir, coco_dir / "images"
-
-
-def _load_quickstart_dataset(coco_dir: Path, images_path: Path) -> lightly_studio.ImageDataset:
-    """Create the quickstart dataset and import its ground-truth and prediction annotations."""
-    dataset = lightly_studio.ImageDataset.create()
-    dataset.add_images_from_path(path=images_path)
-    dataset.add_annotations_from_coco(
-        annotations_json=coco_dir / "instances_train2017.json",
-        images_root=images_path,
-        annotation_source="ground_truth",
-    )
-    dataset.add_annotations_from_coco(
-        annotations_json=coco_dir / "predictions_train2017.json",
-        images_root=images_path,
-        annotation_source="predictions",
-    )
-    # Tag a subset of samples to demonstrate tags in the GUI.
-    dataset.query()[:10].add_tag("sample_subset")
-    return dataset
-
-
-def _evaluate_quickstart_dataset(dataset: lightly_studio.ImageDataset) -> None:
-    """Run the object-detection evaluation used to showcase the evaluation GUI."""
-    evaluation_config = ObjectDetectionEvaluationConfig(
-        iou_threshold=0.5,
-        classwise=False,
-    )
-    dataset.evaluate().object_detection(
-        name="od_evaluation",
-        gt_annotation_source="ground_truth",
-        pred_annotation_source="predictions",
-        config=evaluation_config,
-    )

--- a/lightly_studio/src/lightly_studio/cli.py
+++ b/lightly_studio/src/lightly_studio/cli.py
@@ -33,42 +33,15 @@ def main() -> None:
     help="Do not open a browser automatically once the GUI server is ready.",
 )
 def quickstart(port: int | None, force_download: bool, no_browser: bool) -> None:
-    """Launch the GUI preloaded with a COCO object detection evaluation demo dataset."""
-    dataset_path = Path(
-        lightly_studio.utils.download_example_dataset(
-            download_dir="dataset_examples",
-            force_redownload=force_download,
-        )
-    )
-    coco_dir = dataset_path / "coco_subset_128_images"
-    images_path = coco_dir / "images"
-    evaluation_config = ObjectDetectionEvaluationConfig(
-        iou_threshold=0.5,
-        classwise=False,
-    )
+    """Launch the GUI preloaded with a COCO object detection evaluation demo dataset.
 
+    Recreates ./quickstart.db in the current directory on every run, overwriting
+    any existing file with that name.
+    """
+    coco_dir, images_path = _download_quickstart_dataset(force_download=force_download)
     db_manager.connect(db_file="quickstart.db", cleanup_existing=True)
-    dataset = lightly_studio.ImageDataset.create()
-    dataset.add_images_from_path(path=images_path)
-    dataset.add_annotations_from_coco(
-        annotations_json=coco_dir / "instances_train2017.json",
-        images_root=images_path,
-        annotation_source="ground_truth",
-    )
-    dataset.add_annotations_from_coco(
-        annotations_json=coco_dir / "predictions_train2017.json",
-        images_root=images_path,
-        annotation_source="predictions",
-    )
-    # Tag a subset of samples to demonstrate tags in the GUI.
-    dataset.query()[:10].add_tag("sample_subset")
-    dataset.evaluate().object_detection(
-        name="od_evaluation",
-        gt_annotation_source="ground_truth",
-        pred_annotation_source="predictions",
-        config=evaluation_config,
-    )
-
+    dataset = _load_quickstart_dataset(coco_dir=coco_dir, images_path=images_path)
+    _evaluate_quickstart_dataset(dataset=dataset)
     lightly_studio.start_gui(port=port, open_browser=not no_browser)
 
 
@@ -100,3 +73,48 @@ def gui(
         raise click.UsageError("Options '--db-file' and '--db-url' are mutually exclusive.")
     db_manager.connect(db_file=db_file, db_url=db_url, must_exist=True)
     lightly_studio.start_gui(host=host, port=port)
+
+
+def _download_quickstart_dataset(force_download: bool) -> tuple[Path, Path]:
+    """Download the demo COCO dataset and return (coco_dir, images_path)."""
+    dataset_path = Path(
+        lightly_studio.utils.download_example_dataset(
+            download_dir="dataset_examples",
+            force_redownload=force_download,
+        )
+    )
+    coco_dir = dataset_path / "coco_subset_128_images"
+    return coco_dir, coco_dir / "images"
+
+
+def _load_quickstart_dataset(coco_dir: Path, images_path: Path) -> lightly_studio.ImageDataset:
+    """Create the quickstart dataset and import its ground-truth and prediction annotations."""
+    dataset = lightly_studio.ImageDataset.create()
+    dataset.add_images_from_path(path=images_path)
+    dataset.add_annotations_from_coco(
+        annotations_json=coco_dir / "instances_train2017.json",
+        images_root=images_path,
+        annotation_source="ground_truth",
+    )
+    dataset.add_annotations_from_coco(
+        annotations_json=coco_dir / "predictions_train2017.json",
+        images_root=images_path,
+        annotation_source="predictions",
+    )
+    # Tag a subset of samples to demonstrate tags in the GUI.
+    dataset.query()[:10].add_tag("sample_subset")
+    return dataset
+
+
+def _evaluate_quickstart_dataset(dataset: lightly_studio.ImageDataset) -> None:
+    """Run the object-detection evaluation used to showcase the evaluation GUI."""
+    evaluation_config = ObjectDetectionEvaluationConfig(
+        iou_threshold=0.5,
+        classwise=False,
+    )
+    dataset.evaluate().object_detection(
+        name="od_evaluation",
+        gt_annotation_source="ground_truth",
+        pred_annotation_source="predictions",
+        config=evaluation_config,
+    )

--- a/lightly_studio/src/lightly_studio/core/start_gui.py
+++ b/lightly_studio/src/lightly_studio/core/start_gui.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+import time
+import webbrowser
 from dataclasses import dataclass
 
 import uvicorn
@@ -19,6 +21,7 @@ logger = logging.getLogger(__name__)
 def start_gui(
     host: str | None = None,
     port: int | None = None,
+    open_browser: bool = False,
 ) -> Server:
     """Launch the web interface for the loaded dataset.
 
@@ -27,6 +30,7 @@ def start_gui(
     Args:
         host: Host to bind the server to. Falls back to LIGHTLY_STUDIO_HOST env var.
         port: Port to bind the server to. Falls back to LIGHTLY_STUDIO_PORT env var.
+        open_browser: Whether to open the URL in a browser once the server is ready.
 
     Returns:
         The Server instance.
@@ -38,8 +42,26 @@ def start_gui(
 
     logger.info(f"Open the LightlyStudio GUI under: {server.url}")
 
+    if open_browser:
+        threading.Thread(
+            target=_open_browser_when_ready,
+            args=(uvicorn_server, server.url),
+            daemon=True,
+            name="lightly-studio-browser-opener",
+        ).start()
+
     _run_uvicorn_server(uvicorn_server)
     return server
+
+
+def _open_browser_when_ready(uvicorn_server: uvicorn.Server, url: str) -> None:
+    """Open the browser at url once the uvicorn server starts accepting connections."""
+    while not uvicorn_server.started:
+        time.sleep(0.1)
+    try:
+        webbrowser.open(url)
+    except webbrowser.Error:
+        logger.debug("No runnable browser found; skipping auto-open.", exc_info=True)
 
 
 @dataclass

--- a/lightly_studio/src/lightly_studio/core/start_gui.py
+++ b/lightly_studio/src/lightly_studio/core/start_gui.py
@@ -56,8 +56,10 @@ def start_gui(
 
 def _open_browser_when_ready(uvicorn_server: uvicorn.Server, url: str) -> None:
     """Open the browser at url once the uvicorn server starts accepting connections."""
-    while not uvicorn_server.started:
+    while not uvicorn_server.started and not uvicorn_server.should_exit:
         time.sleep(0.1)
+    if not uvicorn_server.started:
+        return
     try:
         webbrowser.open(url)
     except webbrowser.Error:

--- a/lightly_studio/tests/core/test_start_gui.py
+++ b/lightly_studio/tests/core/test_start_gui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 import webbrowser
 from collections.abc import Generator
 from pathlib import Path
@@ -25,13 +26,18 @@ class FakeUvicornServer:
         self,
         stop_event: threading.Event,
         respect_should_exit: bool = False,
+        never_starts: bool = False,
     ) -> None:
         self.started = False
         self.should_exit = False
         self.stop_event = stop_event
         self._respect_should_exit = respect_should_exit
+        self._never_starts = never_starts
 
     def run(self) -> None:
+        if self._never_starts:
+            self.should_exit = True
+            return
         self.started = True
         if self._respect_should_exit:
             while not self.should_exit:
@@ -125,6 +131,33 @@ def test_start_gui__opens_browser_when_ready(
     start_gui(open_browser=True)
 
     mock_open.assert_called_once_with("http://127.0.0.1:8001")
+
+
+def test_start_gui__stops_polling_when_startup_aborts(
+    mocker: MockerFixture,
+    patch_collection: None,  # noqa: ARG001
+    tmp_path: Path,
+) -> None:
+    """Test that the browser-opener thread exits without opening a browser.
+
+    Covers the case where server startup aborts before becoming ready.
+    """
+    image_path = tmp_path / "sample.jpg"
+    Image.new("RGB", (10, 10)).save(image_path)
+
+    dataset = ImageDataset.create("test_dataset")
+    dataset.add_images_from_path(path=tmp_path)
+
+    stop_event = threading.Event()
+    fake_server = FakeUvicornServer(stop_event=stop_event, never_starts=True)
+    mock_server = mocker.patch.object(start_gui_module, "Server")
+    mock_server.return_value.create_uvicorn_server.return_value = fake_server
+    mock_open = mocker.patch.object(webbrowser, "open")
+
+    start_gui(open_browser=True)
+    time.sleep(0.2)  # let the daemon opener thread observe should_exit
+
+    mock_open.assert_not_called()
 
 
 def test_start_gui__does_not_open_browser_by_default(

--- a/lightly_studio/tests/core/test_start_gui.py
+++ b/lightly_studio/tests/core/test_start_gui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import webbrowser
 from collections.abc import Generator
 from pathlib import Path
 
@@ -99,6 +100,55 @@ def test_start_gui__with_explicit_host_port(
     start_gui(host="0.0.0.0", port=9999)
 
     mock_server.assert_called_once_with(host="0.0.0.0", port=9999)
+
+
+def test_start_gui__opens_browser_when_ready(
+    mocker: MockerFixture,
+    patch_collection: None,  # noqa: ARG001
+    tmp_path: Path,
+) -> None:
+    """Test that start_gui opens the browser once the server is ready, when requested."""
+    image_path = tmp_path / "sample.jpg"
+    Image.new("RGB", (10, 10)).save(image_path)
+
+    dataset = ImageDataset.create("test_dataset")
+    dataset.add_images_from_path(path=tmp_path)
+
+    stop_event = threading.Event()
+    fake_server = FakeUvicornServer(stop_event=stop_event)
+    mock_server = mocker.patch.object(start_gui_module, "Server")
+    mock_server.return_value.create_uvicorn_server.return_value = fake_server
+    mock_server.return_value.url = "http://127.0.0.1:8001"
+    mock_open = mocker.patch.object(webbrowser, "open")
+
+    threading.Timer(interval=0.3, function=stop_event.set).start()
+    start_gui(open_browser=True)
+
+    mock_open.assert_called_once_with("http://127.0.0.1:8001")
+
+
+def test_start_gui__does_not_open_browser_by_default(
+    mocker: MockerFixture,
+    patch_collection: None,  # noqa: ARG001
+    tmp_path: Path,
+) -> None:
+    """Test that start_gui does not open the browser unless open_browser is True."""
+    image_path = tmp_path / "sample.jpg"
+    Image.new("RGB", (10, 10)).save(image_path)
+
+    dataset = ImageDataset.create("test_dataset")
+    dataset.add_images_from_path(path=tmp_path)
+
+    stop_event = threading.Event()
+    fake_server = FakeUvicornServer(stop_event=stop_event)
+    mock_server = mocker.patch.object(start_gui_module, "Server")
+    mock_server.return_value.create_uvicorn_server.return_value = fake_server
+    mock_open = mocker.patch.object(webbrowser, "open")
+
+    threading.Timer(interval=0.3, function=stop_event.set).start()
+    start_gui()
+
+    mock_open.assert_not_called()
 
 
 def test_start_gui__no_datasets(

--- a/lightly_studio/tests/test_cli.py
+++ b/lightly_studio/tests/test_cli.py
@@ -122,7 +122,7 @@ def test_quickstart(mocker: MockerFixture) -> None:
     mock_download.assert_called_once_with(download_dir="dataset_examples", force_redownload=False)
     mock_connect.assert_called_once_with(db_file="quickstart.db", cleanup_existing=True)
     mock_create.assert_called_once_with()
-    mock_start_gui.assert_called_once_with(port=None)
+    mock_start_gui.assert_called_once_with(port=None, open_browser=True)
 
 
 def test_quickstart__with_force_download(mocker: MockerFixture) -> None:
@@ -139,7 +139,15 @@ def test_quickstart__with_port(mocker: MockerFixture) -> None:
     runner = CliRunner()
     result = runner.invoke(cli=cli.main, args=["quickstart", "--port", "9999"])
     assert result.exit_code == 0
-    mock_start_gui.assert_called_once_with(port=9999)
+    mock_start_gui.assert_called_once_with(port=9999, open_browser=True)
+
+
+def test_quickstart__with_no_browser(mocker: MockerFixture) -> None:
+    _, _, _, mock_start_gui = _mock_quickstart_dependencies(mocker)
+    runner = CliRunner()
+    result = runner.invoke(cli=cli.main, args=["quickstart", "--no-browser"])
+    assert result.exit_code == 0
+    mock_start_gui.assert_called_once_with(port=None, open_browser=False)
 
 
 def test_quickstart__runs_real_evaluation_pipeline(


### PR DESCRIPTION
## What has changed and why?

`lightly-studio quickstart` now opens the GUI in your browser automatically once the server is ready. Before this change, you had to copy the printed URL and open it yourself. Pass `--no-browser` to skip this and keep the old behavior.

## How has it been tested?

Added unit tests for `start_gui(open_browser=...)` and the new `--no-browser` CLI flag. Ran `make test` and `make static-checks` in `lightly_studio`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `lightly-studio quickstart` command with a COCO object-detection demo dataset, evaluation, and GUI launch.
  * The GUI now opens automatically in a browser when ready.
  * Added options to select a port, force dataset downloads, disable browser opening, and view help.

* **Documentation**
  * Updated quickstart documentation and the unreleased changelog with the new behavior and options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->