### PR TITLE
Allow choosing the MobileCLIP model size for image embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Python SDK: `MobileCLIPEmbeddingGenerator` now accepts a `model_name` parameter to pick a bigger MobileCLIP variant (`mobileclip_s1`, `mobileclip_s2`, `mobileclip_b`) for higher-quality image embeddings.
+
 ### Changed
 
 ### Deprecated

--- a/lightly_studio/docs/docs/dataset_setup/image_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/image_dataset.md
@@ -37,6 +37,34 @@ To skip embedding, pass `embed=False` to the method.
 The method supports additional arguments, e.g. you can pass `tag_depth=1` to add the image parent
 folder name as a tag to each sample. See the [API reference](../api/dataset.md#lightly_studio.ImageDataset.add_images_from_path) for full details.
 
+### Using a Bigger Embedding Model
+
+Images are embedded with `mobileclip_s0` by default, the smallest MobileCLIP variant.
+For higher-quality embeddings (e.g. for retrieval), pick a bigger one before creating
+the dataset:
+
+```python title="Use a bigger MobileCLIP model"
+import lightly_studio as ls
+
+ls.set_default_embedding_model(
+    ls.MobileCLIPEmbeddingGenerator(model_name="mobileclip_s2")
+)
+
+dataset = ls.ImageDataset.create()
+dataset.add_images_from_path(path="...")
+```
+
+Valid names, from smallest to largest: `mobileclip_s0`, `mobileclip_s1`,
+`mobileclip_s2`, `mobileclip_b`. Bigger models mean a bigger download and slower
+embedding; pass `max_batch_size=...` to `MobileCLIPEmbeddingGenerator` to lower
+memory use if needed.
+
+`set_default_embedding_model` must be called before the dataset's first
+`add_images_from_path` call in that process — it has no effect afterwards. Pick one
+model per dataset: re-indexing an existing collection with a different model later
+requires passing `embedding_model_name` explicitly to similarity/typicality calls, or
+starting a fresh dataset.
+
 ### From an Annotation Format
 
 `ImageDataset` class exposes methods to load images with annotations from a number of

--- a/lightly_studio/src/lightly_studio/__init__.py
+++ b/lightly_studio/src/lightly_studio/__init__.py
@@ -44,6 +44,7 @@ __all__ = [
     "ImageCrop",
     "ImageDataset",
     "ImageEmbeddingGenerator",
+    "MobileCLIPEmbeddingGenerator",
     "SampleType",
     "VideoDataset",
     "VideoEmbeddingGenerator",
@@ -56,3 +57,16 @@ __all__ = [
     "start_gui_background",
     "stop_gui_background",
 ]
+
+
+def __getattr__(name: str) -> object:
+    # Loaded lazily so `import lightly_studio` does not pull in torch/torchvision
+    # unless a caller actually reaches for a concrete embedding backend, matching
+    # the lazy-import convention in dataset/embedding_manager.py.
+    if name == "MobileCLIPEmbeddingGenerator":
+        from lightly_studio.dataset.mobileclip_embedding_generator import (  # noqa: PLC0415
+            MobileCLIPEmbeddingGenerator,
+        )
+
+        return MobileCLIPEmbeddingGenerator
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -80,6 +80,17 @@ def set_default_embedding_model(embedding_generator: EmbeddingGenerator) -> None
     custom model remain, but text search falls back to the env-var default model and
     will not match them.
 
+    Note: calling this after a collection has already loaded its default model in
+    this process is a no-op for that collection — the cached default is returned
+    before this override is ever consulted. Call it once, before the first
+    add_images_from_path (or equivalent) call for that sample type.
+
+    Note: re-indexing an existing collection with a different model registers a
+    second embedding model for it. Anything that resolves "the" model without an
+    explicit name (e.g. compute_similarity_metadata, compute_typicality_metadata)
+    then raises ValueError instead of guessing which one to use — pass
+    embedding_model_name explicitly, or start a fresh dataset when switching models.
+
     Args:
         embedding_generator: A generator implementing ImageEmbeddingGenerator and/or
             VideoEmbeddingGenerator.

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from pathlib import Path
 from uuid import UUID
 
@@ -19,26 +21,48 @@ from .embedding_generator import ImageCrop, ImageEmbeddingGenerator
 from .embedding_result import EmbeddingResult
 from .image_embedding import EmbeddingContext
 
-MODEL_NAME = "mobileclip_s0"
-MOBILECLIP_DOWNLOAD_URL = (
-    f"https://docs-assets.developer.apple.com/ml-research/datasets/mobileclip/{MODEL_NAME}.pt"
-)
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_NAME = "mobileclip_s0"
+MOBILECLIP_CONFIGS_DIR = Path(mobileclip.__file__).parent / "configs"
 MAX_BATCH_SIZE: int = 128
-EMBEDDING_DIMENSION: int = 512
+# Embedding dimension of the default model. Kept as a module constant for callers
+# (e.g. tests) that need a stand-in dimension without instantiating the generator.
+EMBEDDING_DIMENSION: int = json.loads(
+    (MOBILECLIP_CONFIGS_DIR / f"{DEFAULT_MODEL_NAME}.json").read_text()
+)["embed_dim"]
 
 
 class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
     """MobileCLIP embedding model."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        model_name: str = DEFAULT_MODEL_NAME,
+        max_batch_size: int | None = None,
+    ) -> None:
         """Initialize the MobileCLIP embedding model.
 
         This method loads the MobileCLIP model and its tokenizer. The model
         checkpoint is downloaded and cached locally for future use.
+
+        Args:
+            model_name: Which MobileCLIP variant to load. One of ``mobileclip_s0``
+                (default, smallest), ``mobileclip_s1``, ``mobileclip_s2``, or
+                ``mobileclip_b`` (largest).
+            max_batch_size: Number of images embedded per forward pass. Defaults to
+                128; lower it if a bigger model runs out of memory.
+
+        Raises:
+            ValueError: If model_name is not a supported MobileCLIP variant.
         """
-        model_path = _get_cached_mobileclip_checkpoint()
+        self._model_name = model_name
+        self._max_batch_size = max_batch_size or MAX_BATCH_SIZE
+        self._embedding_dimension = _read_embedding_dimension(model_name)
+
+        model_path = _get_cached_mobileclip_checkpoint(model_name)
         self._model, _, self._preprocess = mobileclip.create_model_and_transforms(
-            model_name=MODEL_NAME, pretrained=str(model_path)
+            model_name=model_name, pretrained=str(model_path)
         )
 
         # Auto select device: CUDA > MPS (Apple Silicon) > CPU
@@ -50,8 +74,9 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             else "cpu"
         )
         self._model = self._model.to(self._device)
-        self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
+        self._tokenizer = mobileclip.get_tokenizer(model_name=model_name)
         self._model_hash = file_utils.get_file_xxhash(model_path)
+        logger.info(f"Loaded MobileCLIP embedding model '{self._model_name}'.")
 
     def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
@@ -63,9 +88,9 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             An EmbeddingModelCreate instance with the model details.
         """
         return EmbeddingModelCreate(
-            name=MODEL_NAME,
+            name=self._model_name,
             embedding_model_hash=self._model_hash,
-            embedding_dimension=EMBEDDING_DIMENSION,
+            embedding_dimension=self._embedding_dimension,
             collection_id=collection_id,
         )
 
@@ -143,8 +168,8 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
     def _embedding_context(self) -> EmbeddingContext:
         """Build the model-specific configuration for batched image embedding."""
         return EmbeddingContext(
-            embedding_dimension=EMBEDDING_DIMENSION,
-            max_batch_size=MAX_BATCH_SIZE,
+            embedding_dimension=self._embedding_dimension,
+            max_batch_size=self._max_batch_size,
             device=self._device,
             preprocess=self._preprocess,
             encode_batch=lambda images_tensor: (
@@ -155,10 +180,32 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
         )
 
 
-def _get_cached_mobileclip_checkpoint() -> Path:
-    file_path = LIGHTLY_STUDIO_MODEL_CACHE_DIR / f"{MODEL_NAME}.pt"
+def _read_embedding_dimension(model_name: str) -> int:
+    """Read embed_dim from the vendored config for model_name.
+
+    Also serves as the model_name validation step, run before the checkpoint
+    download so an unsupported name fails with a clear error instead of a 404.
+
+    Raises:
+        ValueError: If model_name is not a supported MobileCLIP variant.
+    """
+    config_path = MOBILECLIP_CONFIGS_DIR / f"{model_name}.json"
+    if not config_path.exists():
+        valid_names = sorted(path.stem for path in MOBILECLIP_CONFIGS_DIR.glob("*.json"))
+        raise ValueError(
+            f"Unsupported model name: {model_name!r}. Choose one of: {', '.join(valid_names)}."
+        )
+    config = json.loads(config_path.read_text())
+    return int(config["embed_dim"])
+
+
+def _get_cached_mobileclip_checkpoint(model_name: str) -> Path:
+    file_path = LIGHTLY_STUDIO_MODEL_CACHE_DIR / f"{model_name}.pt"
+    download_url = (
+        f"https://docs-assets.developer.apple.com/ml-research/datasets/mobileclip/{model_name}.pt"
+    )
     file_utils.download_file_if_does_not_exist(
-        url=MOBILECLIP_DOWNLOAD_URL,
+        url=download_url,
         local_filename=file_path,
     )
     return file_path

--- a/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import json
 import uuid
 from pathlib import Path
 
 import numpy as np
+import pytest
 import torch
 from PIL import Image
 
 from lightly_studio.dataset.embedding_generator import ImageCrop
 from lightly_studio.dataset.mobileclip_embedding_generator import (
+    MOBILECLIP_CONFIGS_DIR,
     MobileCLIPEmbeddingGenerator,
 )
 
@@ -25,6 +28,36 @@ class TestMobileCLIPEmbeddingGenerator:
         assert embedding_model_input.embedding_dimension == 512
         assert embedding_model_input.collection_id == collection_id
         assert embedding_model_input.embedding_model_hash != ""
+
+    def test_get_embedding_model_input__custom_model_name(self) -> None:
+        mobileclip = MobileCLIPEmbeddingGenerator(model_name="mobileclip_s1")
+        collection_id = uuid.uuid4()
+        embedding_model_input = mobileclip.get_embedding_model_input(collection_id=collection_id)
+
+        assert embedding_model_input.name == "mobileclip_s1"
+        assert embedding_model_input.embedding_dimension == 512
+        assert embedding_model_input.collection_id == collection_id
+
+    def test_init__unsupported_model_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported model name"):
+            MobileCLIPEmbeddingGenerator(model_name="mobileclip_xl")
+
+    def test_vendored_configs__all_embed_dims_are_512(self) -> None:
+        """Guards EMBEDDING_DIMENSION and the per-instance derived dimension.
+
+        No network access: reads the vendored config JSON files directly instead of
+        constructing a generator (which would download a checkpoint per variant).
+        """
+        config_paths = sorted(MOBILECLIP_CONFIGS_DIR.glob("*.json"))
+        assert {path.stem for path in config_paths} == {
+            "mobileclip_s0",
+            "mobileclip_s1",
+            "mobileclip_s2",
+            "mobileclip_b",
+        }
+        for path in config_paths:
+            config = json.loads(path.read_text())
+            assert config["embed_dim"] == 512
 
     def test_embed_text(self) -> None:
         text = "a cat"


### PR DESCRIPTION
## What has changed and why?

Image embeddings used a single hardcoded model, `mobileclip_s0`, the smallest and weakest MobileCLIP variant. This change lets a caller pick a bigger model when retrieval needs higher-quality embeddings.

`MobileCLIPEmbeddingGenerator` now accepts a `model_name` parameter (`mobileclip_s0`, `mobileclip_s1`, `mobileclip_s2`, or `mobileclip_b`) and a `max_batch_size` parameter. `lightly_studio` exports the class, so a caller can register a bigger model with `set_default_embedding_model` before dataset creation. The export is lazy: `import lightly_studio` still does not load torch until the class is used.

The embedding dimension now comes from the vendored model config file, not a hardcoded constant. An unsupported model name now raises a clear error before any download attempt, instead of failing with a confusing 404.

Docs for image datasets show how to pick a bigger model.

Video embeddings (PerceptionEncoder) are a separate follow-up, not part of this change.

## How has it been tested?

- Added tests: construct the generator with a non-default model, reject an invalid model name, and check that every vendored config reports the same embedding dimension (no network access needed for that last one).
- `make static-checks` and the full backend test suite pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting larger MobileCLIP embedding models.
  * Added configurable batch size to help manage memory usage.
  * Exposed `MobileCLIPEmbeddingGenerator` through the public SDK.
  * Added validation with clear errors for unsupported model names.

* **Documentation**
  * Documented available models, download and performance considerations, batch-size configuration, and default-model behavior.
  * Added an unreleased changelog entry.

* **Tests**
  * Added coverage for custom models, invalid model names, and embedding dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->