### PR TITLE
Fix: lazy load classifier menu and query editor

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -49,7 +49,8 @@ jobs:
             'lightly_studio_view/src/**/*',
             'lightly_studio_view/public/**/*',
             'lightly_studio_view/package.json',
-            'lightly_studio_view/package-lock.json'
+            'lightly_studio_view/package-lock.json',
+            'lightly_studio_view/vite.config.ts'
           ) }}" >> $GITHUB_OUTPUT
 
       - name: Cache build

--- a/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
+++ b/lightly_studio_view/src/lib/components/Header/MenuDialogHost.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-    import { ExportSamples, SamplingCombinationDialog } from '$lib/components';
-    import { ClassifiersMenu } from '$lib/components/FewShotClassifier';
-    import { SettingsDialog } from '$lib/components/Settings';
-    import OperatorsMenu from '$lib/components/Operator/OperatorsMenu.svelte';
     import type { CollectionView } from '$lib/api/lightly_studio_local';
+    import { useClassifiersMenu } from '$lib/hooks/useClassifiers/useClassifiersMenu';
+    import { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
+    import { useOperatorsDialog } from '$lib/hooks/useOperatorsDialog/useOperatorsDialog';
+    import { useSamplingDialog } from '$lib/hooks/useSamplingDialog/useSamplingDialog';
+    import { useSettingsDialog } from '$lib/hooks/useSettingsDialog/useSettingsDialog';
 
     let {
         isImages = false,
@@ -23,19 +24,49 @@
     const isVideoCollection = $derived(
         collection.sample_type == 'video' || collection.sample_type == 'video_frame'
     );
+
+    const { isDialogOpen: isClassifiersDialogOpen } = useClassifiersMenu();
+    const { isSamplingDialogOpen } = useSamplingDialog();
+    const { isExportDialogOpen } = useExportDialog();
+    const { isOperatorsDialogOpen } = useOperatorsDialog();
+    const { isSettingsDialogOpen } = useSettingsDialog();
+
+    let hasClassifierFlowLoaded = $state(false);
+    let hasOperatorsMenuLoaded = $state(false);
+
+    $effect(() => {
+        if ($isClassifiersDialogOpen) hasClassifierFlowLoaded = true;
+        if ($isOperatorsDialogOpen) hasOperatorsMenuLoaded = true;
+    });
 </script>
 
-{#if hasClassifier}
-    <ClassifiersMenu />
+<!-- These menus own subsequent dialog state, so keep them mounted after their first open. -->
+{#if hasClassifier && hasClassifierFlowLoaded}
+    {#await import('$lib/components/FewShotClassifier/ClassifiersMenu.svelte') then { default: ClassifiersMenu }}
+        <ClassifiersMenu />
+    {/await}
 {/if}
 
-{#if hasSelection}
-    <SamplingCombinationDialog />
+{#if hasSelection && $isSamplingDialogOpen}
+    {#await import('$lib/components/Sampling/SamplingCombinationDialog.svelte') then { default: SamplingCombinationDialog }}
+        <SamplingCombinationDialog />
+    {/await}
 {/if}
 
-{#if isImageCollection || isVideoCollection}
-    <ExportSamples />
+{#if (isImageCollection || isVideoCollection) && $isExportDialogOpen}
+    {#await import('$lib/components/ExportSamples/ExportSamples.svelte') then { default: ExportSamples }}
+        <ExportSamples />
+    {/await}
 {/if}
 
-<OperatorsMenu />
-<SettingsDialog />
+{#if hasOperatorsMenuLoaded}
+    {#await import('$lib/components/Operator/OperatorsMenu.svelte') then { default: OperatorsMenu }}
+        <OperatorsMenu />
+    {/await}
+{/if}
+
+{#if $isSettingsDialogOpen}
+    {#await import('$lib/components/Settings/SettingsDialog.svelte') then { default: SettingsDialog }}
+        <SettingsDialog />
+    {/await}
+{/if}

--- a/lightly_studio_view/src/lib/components/Header/MenuDialogHost.test.ts
+++ b/lightly_studio_view/src/lib/components/Header/MenuDialogHost.test.ts
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CollectionView } from '$lib/api/lightly_studio_local';
+import { useSettingsDialog } from '$lib/hooks/useSettingsDialog/useSettingsDialog';
+import MenuDialogHost from './MenuDialogHost.svelte';
+
+vi.mock('$lib/components/Settings/SettingsDialog.svelte', async () => ({
+    default: (await import('./MenuDialogHostStub.test.svelte')).default
+}));
+
+const collection: CollectionView = {
+    collection_id: 'collection-id',
+    dataset_id: 'dataset-id',
+    name: 'Collection',
+    sample_type: 'group',
+    created_at: new Date('2026-01-01'),
+    updated_at: new Date('2026-01-01')
+};
+
+const settingsDialog = useSettingsDialog();
+
+describe('MenuDialogHost', () => {
+    afterEach(settingsDialog.closeSettingsDialog);
+
+    it('loads a dialog only when it is opened', async () => {
+        render(MenuDialogHost, { props: { collection } });
+        expect(screen.queryByTestId('lazy-menu-dialog')).not.toBeInTheDocument();
+
+        settingsDialog.openSettingsDialog();
+
+        expect(await screen.findByTestId('lazy-menu-dialog')).toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/lib/components/Header/MenuDialogHostStub.test.svelte
+++ b/lightly_studio_view/src/lib/components/Header/MenuDialogHostStub.test.svelte
@@ -1,0 +1,1 @@
+<div data-testid="lazy-menu-dialog"></div>

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -31,9 +31,6 @@ export { default as SelectableBox } from '$lib/components/SelectableBox/Selectab
 export { SettingsDialog } from '$lib/components/Settings/';
 export { default as TagsMenu } from '$lib/components/TagsMenu/TagsMenu.svelte';
 export { default as UserInfo } from '$lib/components/UserInfo/index.svelte';
-export { default as ClassifiersMenu } from '$lib/components/FewShotClassifier/ClassifiersMenu.svelte';
-export { default as CreateClassifierDialog } from '$lib/components/FewShotClassifier/CreateClassifierDialog.svelte';
-export { default as RefineClassifierDialog } from '$lib/components/FewShotClassifier/RefineClassifierDialog.svelte';
 export { default as ZoomableContainer } from '$lib/components/ZoomableContainer/ZoomableContainer.svelte';
 export { default as Spinner } from '$lib/components/Spinner/Spinner.svelte';
 export { default as Segment } from '$lib/components/Segment/Segment.svelte';

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -13,7 +13,6 @@
         TagsMenu
     } from '$lib/components';
     import { Tooltip } from '$lib/components/ui/tooltip';
-    import QueryEditorPanel from '$lib/components/QueryEditorPanel/QueryEditorPanel.svelte';
     import { SidePanelTabs } from '$lib/components';
     import Separator from '$lib/components/ui/separator/separator.svelte';
     import { GripVertical, PanelLeftClose, SlidersHorizontal } from '@lucide/svelte';
@@ -87,6 +86,8 @@
     import { useSearchEmbedding } from '$lib/hooks/useSearchEmbedding/useSearchEmbedding';
     import { useEvaluationRuns } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
     import { clearAnnotationPlotSelection } from '$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations';
+    import { useCreateClassifiersPanel } from '$lib/hooks/useClassifiers/useCreateClassifiersPanel';
+    import { useRefineClassifiersPanel } from '$lib/hooks/useClassifiers/useRefineClassifiersPanel';
     import { isPanelVisible } from './panelVisibility';
     const { data, children } = $props();
     const {
@@ -95,6 +96,8 @@
     } = $derived(data);
 
     const { trackEvent } = usePostHog();
+    const { isCreateClassifiersPanelOpen } = useCreateClassifiersPanel();
+    const { isRefineClassifiersPanelOpen } = useRefineClassifiersPanel();
 
     // The dataset ID actually contains the collection ID.
     const datasetId = $derived(page.params.dataset_id!);
@@ -912,7 +915,9 @@
                                     {/key}
                                 {/await}
                             {:else if $activePanel === 'queryEditor' && isImages}
-                                <QueryEditorPanel onClose={() => setActivePanel('none')} />
+                                {#await import('$lib/components/QueryEditorPanel/QueryEditorPanel.svelte') then { default: QueryEditorPanel }}
+                                    <QueryEditorPanel onClose={() => setActivePanel('none')} />
+                                {/await}
                             {:else if distributionPanelVisible}
                                 {#await import('$lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte') then { default: DatasetDistributionPanel }}
                                     {#key collectionId}
@@ -956,10 +961,12 @@
                     />
                 </div>
             {/if}
-            {#if hasEmbeddings}
+            {#if hasEmbeddings && $isCreateClassifiersPanelOpen}
                 {#await import('$lib/components/FewShotClassifier/CreateClassifierDialog.svelte') then { default: CreateClassifierDialog }}
                     <CreateClassifierDialog />
                 {/await}
+            {/if}
+            {#if hasEmbeddings && $isRefineClassifiersPanelOpen}
                 {#await import('$lib/components/FewShotClassifier/RefineClassifierDialog.svelte') then { default: RefineClassifierDialog }}
                     <RefineClassifierDialog />
                 {/await}

--- a/lightly_studio_view/vite.config.ts
+++ b/lightly_studio_view/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
         rollupOptions: {
             output: {
                 manualChunks(id) {
+                    // Keep the preload helper in the base vendor chunk to avoid circular initialization.
+                    if (id.includes('vite/preload-helper')) {
+                        return 'vendor';
+                    }
                     // Split embedding-atlas into its own chunk
                     if (id.includes('node_modules/embedding-atlas')) {
                         return 'vendor-embedding-atlas';


### PR DESCRIPTION
## What has changed and why?

- Lazy-load the query editor and menu dialogs, including their related data requests, only when opened.
- This reduces JavaScript and background work during the initial grid load, improving startup performance.

## How has it been tested?

- Updated tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved menu and dialog loading by loading components only when opened.
  * Reduced unnecessary initial loading across settings, sampling, export, query editor, and classifier workflows.
* **User Experience**
  * Classifier and operator dialogs preserve their state when reopened.
  * Existing collection and embedding availability requirements remain enforced.
* **Bug Fixes**
  * Added coverage to verify dialogs remain hidden until activated.
  * Improved build reliability when configuration changes are introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->