### PR TITLE
Fix: relax image performance test threshold

### DIFF
--- a/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/images-performance.e2e-test.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const PERFORMANCE_LIMITS = {
-    maxRenderTimeMs: 6000,
+    maxRenderTimeMs: 6500,
     maxMemoryUsageMb: 256
 };
 const MEASUREMENT_ITERATIONS = 3;


### PR DESCRIPTION
- Increase the image render-time limit from 6 seconds to 6.5 seconds.
- Reduce flaky failures when CI performance is slightly slower than usual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the image rendering performance threshold to allow completion within 6.5 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->