### PR TITLE
docs: give index.md quickstart its own top-level section

### DIFF
--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -42,7 +42,7 @@ pip install lightly-studio
         pip install lightly-studio
         ```
 
-## Quickstart
+## Try it in 60 seconds
 
 Want to try LightlyStudio instantly? Run:
 
@@ -52,6 +52,8 @@ lightly-studio quickstart
 
 This downloads the COCO example dataset, loads it, and opens the GUI in your browser. Run
 `lightly-studio quickstart --help` for the available options.
+
+## Quickstart
 
 The examples below use the same example dataset by default, downloaded on the first run. Point
 them at your own image, video, or YOLO/COCO dataset by changing the input path.
@@ -147,9 +149,8 @@ them at your own image, video, or YOLO/COCO dataset by changing the input path.
     1. Click on the printed URL to open the app in your browser.
 
 !!! tip
-    - Run `lightly-studio quickstart` to try LightlyStudio instantly — no Python script needed.
-    - Call `lightly-studio gui` instead of `ls.start_gui()` in Python to skip reindexing
-      an already-loaded dataset.
+    Call `lightly-studio gui` instead of `ls.start_gui()` in Python to skip reindexing
+    an already-loaded dataset.
 
 Ready for a complete, end-to-end workflow? Follow the tutorial
 [Curate a Traffic CCTV Dataset for YOLO Training](tutorials/yolo-traffic-cctv-object-detection.md)


### PR DESCRIPTION
## What changed and why?

Restyles the `lightly-studio quickstart` blurb (added in #1850) into its own "Try it in 60 seconds" section in `index.md`, separate from the per-dataset-type Quickstart walkthrough below it. Matches the structure planned for README's quickstart section, coming in a follow-up PR once the CLI ships.

Also trims the now-redundant `lightly-studio quickstart` bullet from the tip box further down — the command has its own section now.

Stacked on #1873 (hero gif).

## How was this tested?

Read through the rendered section order. No content removed, only moved and re-headed.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the quickstart section to “Try it in 60 seconds.”
  * Added a dedicated “Quickstart” heading for Python examples.
  * Removed the command-line quickstart tip while retaining the GUI command guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->