### PR TITLE
(merge after release) docs: add quickstart CLI section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ lightly-studio quickstart
 - **Your own videos:** see the [Video Dataset guide](https://docs.lightly.ai/studio/dataset_setup/video_dataset/).
 - **No install:** [open the quickstart in Colab](https://colab.research.google.com/github/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/examples/example_notebook.ipynb)
 - **A guided walkthrough:** read the [Tutorials](#-tutorials) below. [Curate a Traffic CCTV Dataset for YOLO Training](https://docs.lightly.ai/studio/tutorials/yolo-traffic-cctv-object-detection/) goes from raw images to a trained model.
-- Runs on **Python 3.9 to 3.14** on Windows, Linux, and macOS. Use Python 3.10 for plugin compatibility, for example [SAM autolabeling](https://docs.lightly.ai/studio/concepts_and_tools/plugins/).
+- Runs on **Python 3.9 to 3.14** on Windows, Linux, and macOS. Use Python 3.10 for plugin compatibility, for example [SAM autolabeling](https://docs.lightly.ai/studio/concepts_and_tools/plugins/#example-lightlystudio-sam3-plugin).
 
 ## Workflows
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ lightly-studio quickstart
 
 The first run downloads the example dataset. Then open the URL the command prints.
 
-- **Local only:** all data stays on your machine. LightlyStudio uploads nothing.
+- **Local only:** your images and datasets never leave your machine.
 - **Your own images:** one Python call indexes them, then start the server. See the [Image Dataset guide](https://docs.lightly.ai/studio/dataset_setup/image_dataset/).
 - **Your own videos:** see the [Video Dataset guide](https://docs.lightly.ai/studio/dataset_setup/video_dataset/).
-- **No install:** [open the quickstart in Colab](https://colab.research.google.com/github/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/examples/example_notebook.ipynb). The flow is the same.
+- **No install:** [open the quickstart in Colab](https://colab.research.google.com/github/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/examples/example_notebook.ipynb)
 - **A guided walkthrough:** read the [Tutorials](#-tutorials) below. [Curate a Traffic CCTV Dataset for YOLO Training](https://docs.lightly.ai/studio/tutorials/yolo-traffic-cctv-object-detection/) goes from raw images to a trained model.
 - Runs on **Python 3.9 to 3.14** on Windows, Linux, and macOS. Use Python 3.10 for plugin compatibility, for example SAM autolabeling.
 

--- a/README.md
+++ b/README.md
@@ -37,21 +37,19 @@
 
 ## 🚀 Try it in 60 seconds
 
-LightlyStudio runs on your computer and opens in your browser. One command downloads an example dataset with images, annotations, and evaluation results — no account needed.
+LightlyStudio runs on your computer and opens in your browser. The following command downloads an example dataset with images, annotations, and evaluation results — no account needed.
 
 ```bash
 pip install lightly-studio
 lightly-studio quickstart
 ```
 
-The first run downloads the example dataset. Then open the URL the command prints.
-
 - **Local only:** your images and datasets never leave your machine.
 - **Your own images:** one Python call indexes them, then start the server. See the [Image Dataset guide](https://docs.lightly.ai/studio/dataset_setup/image_dataset/).
 - **Your own videos:** see the [Video Dataset guide](https://docs.lightly.ai/studio/dataset_setup/video_dataset/).
 - **No install:** [open the quickstart in Colab](https://colab.research.google.com/github/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/examples/example_notebook.ipynb)
 - **A guided walkthrough:** read the [Tutorials](#-tutorials) below. [Curate a Traffic CCTV Dataset for YOLO Training](https://docs.lightly.ai/studio/tutorials/yolo-traffic-cctv-object-detection/) goes from raw images to a trained model.
-- Runs on **Python 3.9 to 3.14** on Windows, Linux, and macOS. Use Python 3.10 for plugin compatibility, for example SAM autolabeling.
+- Runs on **Python 3.9 to 3.14** on Windows, Linux, and macOS. Use Python 3.10 for plugin compatibility, for example [SAM autolabeling](https://docs.lightly.ai/studio/concepts_and_tools/plugins/).
 
 ## Workflows
 
@@ -98,7 +96,7 @@ The first run downloads the example dataset. Then open the URL the command print
   </tr>
 </table>
 
-## 🚀 Example workflows
+## Example workflows
 
 Get started with one of these example workflows:
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,23 @@
 <p align="center">The embedding plot shows how images relate to each other, with a preview on hover. A lasso selection filters the grid to one cluster. A search for "coffee" finds a match, and the annotation editor opens to label it.</p>
 <p align="center"><strong>⚡ Works smoothly with 2M+ images, embeddings included, on a single MacBook (M1, 16GB RAM).</strong></p>
 
-## 💻 Installation
+## 🚀 Try it in 60 seconds
 
-Runs on **Python 3.9 to 3.14** on Windows, Linux and MacOS. We recommend **Python 3.10** for the best compatibility with plugins such as SAM autolabeling.
+LightlyStudio runs on your computer and opens in your browser. One command downloads an example dataset with images, annotations, and evaluation results — no account needed.
 
-```shell
+```bash
 pip install lightly-studio
+lightly-studio quickstart
 ```
+
+The first run downloads the example dataset. Then open the URL the command prints.
+
+- **Local only:** all data stays on your machine. LightlyStudio uploads nothing.
+- **Your own images:** one Python call indexes them, then start the server. See the [Image Dataset guide](https://docs.lightly.ai/studio/dataset_setup/image_dataset/).
+- **Your own videos:** see the [Video Dataset guide](https://docs.lightly.ai/studio/dataset_setup/video_dataset/).
+- **No install:** [open the quickstart in Colab](https://colab.research.google.com/github/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/examples/example_notebook.ipynb). The flow is the same.
+- **A guided walkthrough:** read the [Tutorials](#-tutorials) below. [Curate a Traffic CCTV Dataset for YOLO Training](https://docs.lightly.ai/studio/tutorials/yolo-traffic-cctv-object-detection/) goes from raw images to a trained model.
+- Runs on **Python 3.9 to 3.14** on Windows, Linux, and macOS. Use Python 3.10 for plugin compatibility, for example SAM autolabeling.
 
 ## Workflows
 
@@ -88,16 +98,7 @@ pip install lightly-studio
   </tr>
 </table>
 
-## 🚀 Quickstart
-
-LightlyStudio is a browser app that runs on your own computer. Use it in two simple steps:
-
-1. Load your data into the local database with a Python script.
-2. Start the server and explore the data in your browser.
-
-Prefer a guided, end-to-end walkthrough? Follow the tutorial
-[Curate a Traffic CCTV Dataset for YOLO Training](https://docs.lightly.ai/studio/tutorials/yolo-traffic-cctv-object-detection/) — from raw images to a trained model.
-Or try LightlyStudio without installing anything: [open the example notebook in Colab](https://colab.research.google.com/github/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/examples/example_notebook.ipynb).
+## 🚀 Example workflows
 
 Get started with one of these example workflows:
 


### PR DESCRIPTION
## What changed and why?

Adds the "Try it in 60 seconds" section to README, built around `lightly-studio quickstart` (#1850). Replaces the manual Installation and two-step Quickstart sections, and renames the example-workflows heading from "Quickstart" to "Example workflows" to avoid a duplicate.

**Do not merge until `lightly-studio quickstart` is released to PyPI.** It's merged to `main`, but CHANGELOG still has it under `[Unreleased]` and pyproject.toml is still at 1.0.4 — merging early ships a command that doesn't work yet.

Stacked on #1889 → #1873.

## How was this tested?

Compared against the CLI's actual behavior in `cli.py` — downloads the COCO dataset, loads it, runs an evaluation, starts the GUI — to keep the bullets accurate.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced separate installation and quickstart sections with a streamlined 60-second quickstart.
  * Added guidance for local usage, image and video imports, Colab access, tutorials, and supported Python and platform versions.
  * Reorganized the previous quickstart content under an “Example workflows” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->