### PR TITLE
Extract OrderByControl from OrderBy

### DIFF
--- a/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderBy.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-    import { SortDirection } from '$lib/api/lightly_studio_local';
     import { useOrderBy } from '$lib/hooks/useOrderBy/useOrderBy';
     import { useGlobalStorage, usePostHog } from '$lib/hooks';
-    import { Select, type SelectItem } from '$lib/components/Select';
-    import { Button } from '$lib/components/ui/button';
-    import { Tooltip } from '$lib/components/ui/tooltip';
-    import { ArrowDown, ArrowUp } from '@lucide/svelte';
+    import { type SelectItem } from '$lib/components/Select';
+    import OrderByControl from './OrderByControl.svelte';
 
     interface Props {
         collectionId: string;
@@ -57,47 +54,16 @@
         const field = $allSortFields[Number(value)];
         if (field) handleFieldClick(field);
     };
-
-    const directionTooltip = $derived(
-        $selectedDirection === SortDirection.DESC ? 'Sort descending' : 'Sort ascending'
-    );
 </script>
 
-<div class="flex items-center gap-1">
-    <Tooltip content="Sort items by attribute" position="top" triggerClass="inline-flex">
-        <Select
-            items={sortItems}
-            value={selectValue}
-            triggerLabel={$selectedLabel ?? undefined}
-            allowDeselect
-            onValueChange={handleValueChange}
-            onOpenChange={(open) => {
-                if (open) trackEvent('sort_by_opened', { collection_id: collectionId });
-            }}
-            disabled={isSimilaritySearchActive}
-            placeholder="Sort by"
-            size="xs"
-            variant="ghost"
-            class="w-[100px] min-w-20"
-            testId="sort-by-trigger"
-        />
-    </Tooltip>
-
-    <Tooltip content={directionTooltip} position="top">
-        <Button
-            variant="ghost"
-            size="icon"
-            disabled={!$selectedLabel || isSimilaritySearchActive}
-            onclick={toggleDirection}
-            class="size-auto p-0 hover:bg-transparent [&>svg]:text-foreground [&>svg]:hover:text-muted-foreground"
-            data-testid="sort-direction-button"
-            aria-label={directionTooltip}
-        >
-            {#if $selectedDirection === SortDirection.DESC}
-                <ArrowDown class="size-4" />
-            {:else}
-                <ArrowUp class="size-4" />
-            {/if}
-        </Button>
-    </Tooltip>
-</div>
+<OrderByControl
+    items={sortItems}
+    selectedValue={selectValue}
+    triggerLabel={$selectedLabel ?? undefined}
+    direction={$selectedDirection}
+    disabled={isSimilaritySearchActive}
+    allowDeselect
+    onValueChange={handleValueChange}
+    onOpen={() => trackEvent('sort_by_opened', { collection_id: collectionId })}
+    onToggleDirection={toggleDirection}
+/>

--- a/lightly_studio_view/src/lib/components/OrderBy/OrderByControl.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/OrderByControl.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+    import { SortDirection } from '$lib/api/lightly_studio_local';
+    import { Select, type SelectItem } from '$lib/components/Select';
+    import { Button } from '$lib/components/ui/button';
+    import { Tooltip } from '$lib/components/ui/tooltip';
+    import { ArrowDown, ArrowUp } from '@lucide/svelte';
+
+    interface Props {
+        items: SelectItem[];
+        /** Value of the selected item, empty when nothing is sorted on. */
+        selectedValue: string;
+        /** Fixed trigger label, shown instead of the selected item's label. */
+        triggerLabel?: string;
+        direction: SortDirection;
+        disabled?: boolean;
+        allowDeselect?: boolean;
+        onValueChange: (value: string) => void;
+        onOpen: () => void;
+        onToggleDirection: () => void;
+    }
+
+    const {
+        items,
+        selectedValue,
+        triggerLabel,
+        direction,
+        disabled = false,
+        allowDeselect = false,
+        onValueChange,
+        onOpen,
+        onToggleDirection
+    }: Props = $props();
+
+    const directionTooltip = $derived(
+        direction === SortDirection.DESC ? 'Sort descending' : 'Sort ascending'
+    );
+</script>
+
+<div class="flex items-center gap-1">
+    <Tooltip content="Sort items by attribute" position="top" triggerClass="inline-flex">
+        <Select
+            {items}
+            value={selectedValue}
+            {triggerLabel}
+            {allowDeselect}
+            {onValueChange}
+            onOpenChange={(open) => {
+                if (open) onOpen();
+            }}
+            {disabled}
+            placeholder="Sort by"
+            size="xs"
+            variant="ghost"
+            class="w-[100px] min-w-20"
+            testId="sort-by-trigger"
+        />
+    </Tooltip>
+
+    <Tooltip content={directionTooltip} position="top">
+        <Button
+            variant="ghost"
+            size="icon"
+            disabled={!triggerLabel || disabled}
+            onclick={onToggleDirection}
+            class="size-auto p-0 hover:bg-transparent [&>svg]:text-foreground [&>svg]:hover:text-muted-foreground"
+            data-testid="sort-direction-button"
+            aria-label={directionTooltip}
+        >
+            {#if direction === SortDirection.DESC}
+                <ArrowDown class="size-4" />
+            {:else}
+                <ArrowUp class="size-4" />
+            {/if}
+        </Button>
+    </Tooltip>
+</div>


### PR DESCRIPTION
Part 1 of 8

## What has changed and why?

`OrderBy.svelte` mixed its data fetching and selection state with the markup of the control
itself. This moves the markup into a new `OrderByControl.svelte` taking `items`,
`selectedValue`, `triggerLabel`, `direction`, `disabled`, `allowDeselect`, `onValueChange`,
`onOpen` and `onToggleDirection`. `OrderBy.svelte` keeps its logic and renders the control.

Pure refactor, no behaviour change. It prepares a second consumer, `AnnotationOrderBy`, which
adds sorting to the annotations grid later in this stack.

## How has it been tested?

No new tests — that is the point. The 29 existing `OrderBy.test.ts` tests pass unchanged, which
is what proves the extraction did not alter behaviour.

`cd lightly_studio_view && npm run static-checks && npm run test:unit -- --run`: `svelte-check`
0 errors, 2528 tests passing.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable sorting control with selectable sort criteria.
  * Added support for toggling sort direction and clearing the selected sort.
  * Added tooltips and directional icons for clearer sorting controls.
  * Sorting controls can now be disabled when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->