### PR TITLE
Add order-by expression for per-annotation evaluation metrics

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
@@ -271,19 +271,16 @@ class OrderByEvaluationMetricField(OrderByExpression):
 class OrderByAnnotationEvaluationMetricField(OrderByExpression):
     """Order annotations by a per-annotation metric from EvaluationAnnotationMetricTable.
 
-    A single LEFT OUTER JOIN is added, so annotations the run never covered still appear
-    in results. Three states must stay distinguishable:
+    A LEFT OUTER JOIN keeps annotations the run did not cover. The sort value depends on
+    the joined row:
 
-    - Matched pair: a metric value exists, order by it.
-    - Unmatched annotation (false positive / false negative): a row exists but carries no
-      metric name or value. A completely missed box genuinely has zero overlap, so it
-      orders as ``0.0``.
-    - Annotation absent from the run, because evaluation covered a subset of samples:
-      no row at all, genuinely unknown, orders as ``NULL``.
+    - Row with a value: order by that value.
+    - Row without a value (unmatched annotation, i.e. false positive or false negative):
+      order as ``0.0``, because it has no overlap.
+    - No row (the run did not cover this annotation): order as ``NULL``.
 
-    Distinguishing the last two is why the ordering value is keyed on whether the joined
-    row exists rather than coalescing the value itself. Nulls are placed last in both
-    directions so un-evaluated annotations never crowd out the top of the review queue.
+    Nulls sort last in both directions, so un-evaluated annotations stay out of the top
+    of the review queue.
 
     Args:
         evaluation_run_id: ID of the evaluation run holding the metric.

--- a/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Any, cast
+from uuid import UUID
 
 import sqlalchemy
-from sqlalchemy import ColumnElement, and_
+from sqlalchemy import ColumnElement, and_, case, func, nullslast, or_
 from sqlalchemy import Select as SQLAlchemySelect
 from sqlalchemy.engine import Row
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import Mapped, aliased
 from sqlmodel import col
 from sqlmodel.sql.expression import SelectOfScalar
 from typing_extensions import Self, TypeVar
@@ -17,6 +18,10 @@ from typing_extensions import Self, TypeVar
 from lightly_studio.core.dataset_query.field import Field
 from lightly_studio.database import db_json
 from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.evaluation_annotation_metric import (
+    EvaluationAnnotationMetricTable,
+    EvaluationAnnotationSide,
+)
 from lightly_studio.models.evaluation_run import EvaluationRunTable
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricTable
 from lightly_studio.models.image import ImageTable
@@ -259,6 +264,88 @@ class OrderByEvaluationMetricField(OrderByExpression):
                 col(self._metric_alias.sample_id) == col(ImageTable.sample_id),
                 col(self._metric_alias.evaluation_run_id) == col(self._run_alias.id),
                 col(self._metric_alias.metric_name) == self.metric_name,
+            ),
+        )
+
+
+class OrderByAnnotationEvaluationMetricField(OrderByExpression):
+    """Order annotations by a per-annotation metric from EvaluationAnnotationMetricTable.
+
+    A single LEFT OUTER JOIN is added, so annotations the run never covered still appear
+    in results. Three states must stay distinguishable:
+
+    - Matched pair: a metric value exists, order by it.
+    - Unmatched annotation (false positive / false negative): a row exists but carries no
+      metric name or value. A completely missed box genuinely has zero overlap, so it
+      orders as ``0.0``.
+    - Annotation absent from the run, because evaluation covered a subset of samples:
+      no row at all, genuinely unknown, orders as ``NULL``.
+
+    Distinguishing the last two is why the ordering value is keyed on whether the joined
+    row exists rather than coalescing the value itself. Nulls are placed last in both
+    directions so un-evaluated annotations never crowd out the top of the review queue.
+
+    Args:
+        evaluation_run_id: ID of the evaluation run holding the metric.
+        metric_name: Name of the metric to order by, as stored.
+        side: Which side of the run's pairing the browsed annotation source is. Selects
+            the column the join matches the annotation ID against.
+        annotation_id_column: Column holding the annotation's sample ID. Passed in
+            because the grid query is rooted on the annotation table while adjacency
+            orders over a filtered subquery.
+    """
+
+    def __init__(
+        self,
+        *,
+        evaluation_run_id: UUID,
+        metric_name: str,
+        side: EvaluationAnnotationSide,
+        annotation_id_column: ColumnElement[Any] | Mapped[Any],
+    ) -> None:
+        """Initialize with the run, metric, pairing side and annotation ID column."""
+        super().__init__()
+        self.evaluation_run_id = evaluation_run_id
+        self.metric_name = metric_name
+        self.side = side
+        self.annotation_id_column = annotation_id_column
+        # Per-instance alias so this join cannot collide with a filter join on the same table.
+        self._metric_alias = aliased(EvaluationAnnotationMetricTable)
+
+    def to_column_elements(self) -> list[ColumnElement[Any]]:
+        """Return the sort keys with direction applied and nulls placed last."""
+        return [nullslast(element) for element in super().to_column_elements()]
+
+    def _order_value_expression(self) -> ColumnElement[Any]:
+        """Return the metric value, zero when the row is unmatched, null when absent."""
+        return case(
+            (
+                col(self._metric_alias.id).is_not(None),
+                func.coalesce(col(self._metric_alias.value), 0.0),
+            ),
+            else_=None,
+        )
+
+    def apply_joins(self, query: SelectT) -> SelectT:
+        """Left-outer-join the aliased annotation metric table on the pairing side.
+
+        The predicate matches the requested metric name or a null one, so a run writing
+        several metrics per annotation cannot multiply grid rows and corrupt the count.
+        """
+        if self.side == EvaluationAnnotationSide.GROUND_TRUTH:
+            side_column = col(self._metric_alias.gt_annotation_id)
+        else:
+            side_column = col(self._metric_alias.pred_annotation_id)
+
+        return query.outerjoin(
+            self._metric_alias,
+            and_(
+                side_column == self.annotation_id_column,
+                col(self._metric_alias.evaluation_run_id) == self.evaluation_run_id,
+                or_(
+                    col(self._metric_alias.metric_name) == self.metric_name,
+                    col(self._metric_alias.metric_name).is_(None),
+                ),
             ),
         )
 

--- a/lightly_studio/src/lightly_studio/models/evaluation_annotation_metric.py
+++ b/lightly_studio/src/lightly_studio/models/evaluation_annotation_metric.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel
 from sqlmodel import Field, SQLModel
 
 from lightly_studio.models.evaluation_run import EvaluationTaskType
+
+
+class EvaluationAnnotationSide(str, Enum):
+    """Which side of an evaluation run's pairing an annotation source is."""
+
+    GROUND_TRUTH = "ground_truth"
+    PREDICTION = "prediction"
 
 
 class EvaluationAnnotationMetricTable(SQLModel, table=True):

--- a/lightly_studio/tests/core/dataset_query/test_order_by.py
+++ b/lightly_studio/tests/core/dataset_query/test_order_by.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
+import uuid
+
 from duckdb_engine import Dialect as DuckDBDialect
-from sqlmodel import select
+from sqlmodel import col, select
 
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
 from lightly_studio.core.dataset_query.order_by import (
     ORDER_VALUE_LABEL,
+    OrderByAnnotationEvaluationMetricField,
     OrderByEvaluationMetricField,
     OrderByField,
     OrderByMetadataField,
 )
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationSide
 from lightly_studio.models.image import ImageTable
 
 
@@ -234,3 +239,66 @@ class TestOrderByEvaluationMetricField:
         sql = str(col_element.compile(compile_kwargs={"literal_binds": True})).lower()
         assert "evaluation_sample_metric_1.value asc" in sql
         assert "join" not in sql
+
+
+class TestOrderByAnnotationEvaluationMetricField:
+    dialect = DuckDBDialect()
+
+    def test_apply__ground_truth_side(self) -> None:
+        """Test the join, the metric name guard and the default ascending order."""
+        order_by = OrderByAnnotationEvaluationMetricField(
+            evaluation_run_id=uuid.uuid4(),
+            metric_name="iou",
+            side=EvaluationAnnotationSide.GROUND_TRUTH,
+            annotation_id_column=col(AnnotationBaseTable.sample_id),
+        )
+
+        returned_query = order_by.apply(select(AnnotationBaseTable))
+
+        sql = str(
+            returned_query.compile(dialect=self.dialect, compile_kwargs={"literal_binds": True})
+        ).lower()
+        assert sql.count("left outer join evaluation_annotation_metric") == 1
+        assert "evaluation_annotation_metric_1.gt_annotation_id = annotation_base.sample_id" in sql
+        assert "pred_annotation_id" not in sql
+        assert (
+            "(evaluation_annotation_metric_1.metric_name = 'iou' "
+            "or evaluation_annotation_metric_1.metric_name is null)" in sql
+        )
+        assert "order by case when" in sql
+        assert "end asc nulls last" in sql
+
+    def test_apply__prediction_side(self) -> None:
+        """Test that the join is keyed on pred_annotation_id for predictions."""
+        order_by = OrderByAnnotationEvaluationMetricField(
+            evaluation_run_id=uuid.uuid4(),
+            metric_name="iou",
+            side=EvaluationAnnotationSide.PREDICTION,
+            annotation_id_column=col(AnnotationBaseTable.sample_id),
+        )
+
+        returned_query = order_by.apply(select(AnnotationBaseTable))
+
+        sql = str(
+            returned_query.compile(dialect=self.dialect, compile_kwargs={"literal_binds": True})
+        ).lower()
+        assert (
+            "evaluation_annotation_metric_1.pred_annotation_id = annotation_base.sample_id" in sql
+        )
+        assert "gt_annotation_id" not in sql
+
+    def test_apply__descending(self) -> None:
+        """Test that descending ordering also places nulls last."""
+        order_by = OrderByAnnotationEvaluationMetricField(
+            evaluation_run_id=uuid.uuid4(),
+            metric_name="iou",
+            side=EvaluationAnnotationSide.GROUND_TRUTH,
+            annotation_id_column=col(AnnotationBaseTable.sample_id),
+        ).desc()
+
+        returned_query = order_by.apply(select(AnnotationBaseTable))
+
+        sql = str(
+            returned_query.compile(dialect=self.dialect, compile_kwargs={"literal_binds": True})
+        ).lower()
+        assert "end desc nulls last" in sql


### PR DESCRIPTION
## What has changed and why?

The annotations grid must sort by a per-annotation evaluation metric, for example IoU. This PR
adds the sort expression only. Nothing calls it yet. Part 4 translates the request into this
class. Part 5 applies it to the grid.

`OrderByAnnotationEvaluationMetricField` sorts annotations by a metric in
`EvaluationAnnotationMetricTable`. It adds one left outer join. The new
`EvaluationAnnotationSide` enum tells the join which side of the run's pairing to use: the
ground truth side or the prediction side.

The sort keeps three states apart:

| State of the annotation | Sort value | Why |
| --- | --- | --- |
| The run matched it to a pair | the metric value | The value is known. |
| The run did not match it (false positive or false negative) | `0.0` | A box that the run missed has no overlap. |
| The run did not cover it | `NULL`, sorted last | The value is unknown. Un-evaluated annotations must not fill the top of the review queue. |

The sort value keys on the presence of the joined row, not on the value in it. This is what
keeps the last two states apart.

## How has it been tested?

3 new tests in `tests/core/dataset_query/test_order_by.py`. They follow the
`TestOrderByEvaluationMetricField` pattern in the same file: compile the query against
`DuckDBDialect` with `literal_binds`, then assert on the SQL string. No fixtures. No database.


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added sorting by annotation evaluation metrics for ground-truth and prediction annotations.
  * Supports ascending and descending order while consistently placing missing or unmatched metric values last.
  * Added explicit options for selecting the ground-truth or prediction annotation side.

* **Bug Fixes**
  * Improved handling of missing, unmatched, and null metric values during metric-based sorting.
  * Ensured consistent ordering when annotations lack corresponding evaluation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
