### PR TITLE
Add annotation sort request model and side resolution

### DIFF
--- a/lightly_studio/src/lightly_studio/models/annotation_sort.py
+++ b/lightly_studio/src/lightly_studio/models/annotation_sort.py
@@ -1,9 +1,4 @@
-"""Sorting models for annotation grids.
-
-Kept separate from the image sort union in ``models.sort``: that union's members bind to
-image-specific joins that are invalid against an annotation-rooted query, so sharing it
-would let the API accept requests it cannot serve.
-"""
+"""Sorting models for annotation grids."""
 
 from __future__ import annotations
 

--- a/lightly_studio/src/lightly_studio/models/annotation_sort.py
+++ b/lightly_studio/src/lightly_studio/models/annotation_sort.py
@@ -1,0 +1,34 @@
+"""Sorting models for annotation grids.
+
+Kept separate from the image sort union in ``models.sort``: that union's members bind to
+image-specific joins that are invalid against an annotation-rooted query, so sharing it
+would let the API accept requests it cannot serve.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from lightly_studio.models.sort_direction import SortDirection
+
+
+class AnnotationEvaluationMetricSortExpr(BaseModel):
+    """A sorting expression for a per-annotation evaluation metric.
+
+    Attributes:
+        source: Always ``"annotation_evaluation_metric"``.
+        evaluation_run_id: ID of the evaluation run holding the metric.
+        metric_name: Metric name as stored, e.g. ``"iou"`` or ``"disagreement"``. The
+            direction carries the polarity, which differs by task type.
+        direction: The sort direction, either ascending or descending.
+    """
+
+    # TODO(Jonas, 08/2026): Promote to a discriminated union when a second annotation
+    # sort field lands.
+    source: Literal["annotation_evaluation_metric"] = "annotation_evaluation_metric"
+    evaluation_run_id: UUID
+    metric_name: str
+    direction: SortDirection

--- a/lightly_studio/src/lightly_studio/resolvers/annotations/annotation_metric_sort.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotations/annotation_metric_sort.py
@@ -1,0 +1,99 @@
+"""Translate an annotation sort expression into an order by expression.
+
+The client names only a run and a metric. Which side of the run's ground-truth/prediction
+pairing the metric attaches to is resolved here by comparing the browsed annotation source
+against the run's two sources, so the feature works identically for reviewing labels and
+for reviewing predictions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import ColumnElement
+from sqlalchemy.orm import Mapped
+from sqlmodel import Session
+
+from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluationMetricField
+from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationSide
+from lightly_studio.models.evaluation_run import EvaluationRunTable
+from lightly_studio.resolvers import evaluation_run_resolver
+
+
+class EvaluationRunNotFoundError(Exception):
+    """Raised when the sort expression names an evaluation run that does not exist."""
+
+
+class AnnotationSourceNotInEvaluationRunError(Exception):
+    """Raised when the browsed annotation source is neither side of the run's pairing."""
+
+
+def sort_expr_to_order_by(
+    session: Session,
+    annotation_collection_id: UUID,
+    sort_expr: AnnotationEvaluationMetricSortExpr,
+    annotation_id_column: ColumnElement[Any] | Mapped[Any],
+) -> OrderByAnnotationEvaluationMetricField:
+    """Translate an annotation sort expression to an order by expression.
+
+    Args:
+        session: Database session.
+        annotation_collection_id: The browsed annotation source.
+        sort_expr: The sort expression from the API request.
+        annotation_id_column: Column holding the annotation's sample ID in the query the
+            ordering is applied to.
+
+    Returns:
+        An order by expression ready to be applied to an annotation query.
+
+    Raises:
+        EvaluationRunNotFoundError: If the named evaluation run does not exist.
+        AnnotationSourceNotInEvaluationRunError: If the browsed annotation source is
+            neither side of the run's pairing.
+    """
+    run = evaluation_run_resolver.get_by_id(
+        session=session, evaluation_id=sort_expr.evaluation_run_id
+    )
+    if run is None:
+        raise EvaluationRunNotFoundError(
+            f"Evaluation run {sort_expr.evaluation_run_id} does not exist."
+        )
+
+    side = resolve_side(run=run, annotation_collection_id=annotation_collection_id)
+    if side is None:
+        raise AnnotationSourceNotInEvaluationRunError(
+            f"Evaluation run {run.id} involves neither side of annotation source "
+            f"{annotation_collection_id}."
+        )
+
+    order_by = OrderByAnnotationEvaluationMetricField(
+        evaluation_run_id=run.id,
+        metric_name=sort_expr.metric_name,
+        side=side,
+        annotation_id_column=annotation_id_column,
+    )
+    if sort_expr.direction == "desc":
+        order_by.desc()
+    return order_by
+
+
+def resolve_side(
+    run: EvaluationRunTable,
+    annotation_collection_id: UUID,
+) -> EvaluationAnnotationSide | None:
+    """Resolve which side of the run's pairing an annotation source is.
+
+    Args:
+        run: The evaluation run.
+        annotation_collection_id: The browsed annotation source.
+
+    Returns:
+        The matching side, or None if the source is neither side of the pairing.
+    """
+    if annotation_collection_id == run.gt_annotation_collection_id:
+        return EvaluationAnnotationSide.GROUND_TRUTH
+    if annotation_collection_id == run.pred_annotation_collection_id:
+        return EvaluationAnnotationSide.PREDICTION
+    return None

--- a/lightly_studio/src/lightly_studio/resolvers/annotations/annotation_metric_sort.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotations/annotation_metric_sort.py
@@ -1,10 +1,4 @@
-"""Translate an annotation sort expression into an order by expression.
-
-The client names only a run and a metric. Which side of the run's ground-truth/prediction
-pairing the metric attaches to is resolved here by comparing the browsed annotation source
-against the run's two sources, so the feature works identically for reviewing labels and
-for reviewing predictions.
-"""
+"""Translate an annotation sort expression into an order by expression."""
 
 from __future__ import annotations
 
@@ -20,14 +14,6 @@ from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSort
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationSide
 from lightly_studio.models.evaluation_run import EvaluationRunTable
 from lightly_studio.resolvers import evaluation_run_resolver
-
-
-class EvaluationRunNotFoundError(Exception):
-    """Raised when the sort expression names an evaluation run that does not exist."""
-
-
-class AnnotationSourceNotInEvaluationRunError(Exception):
-    """Raised when the browsed annotation source is neither side of the run's pairing."""
 
 
 def sort_expr_to_order_by(
@@ -49,21 +35,18 @@ def sort_expr_to_order_by(
         An order by expression ready to be applied to an annotation query.
 
     Raises:
-        EvaluationRunNotFoundError: If the named evaluation run does not exist.
-        AnnotationSourceNotInEvaluationRunError: If the browsed annotation source is
-            neither side of the run's pairing.
+        ValueError: If the named evaluation run does not exist, or if the browsed
+            annotation source is neither side of the run's pairing.
     """
     run = evaluation_run_resolver.get_by_id(
         session=session, evaluation_id=sort_expr.evaluation_run_id
     )
     if run is None:
-        raise EvaluationRunNotFoundError(
-            f"Evaluation run {sort_expr.evaluation_run_id} does not exist."
-        )
+        raise ValueError(f"Evaluation run with ID {sort_expr.evaluation_run_id} not found.")
 
     side = resolve_side(run=run, annotation_collection_id=annotation_collection_id)
     if side is None:
-        raise AnnotationSourceNotInEvaluationRunError(
+        raise ValueError(
             f"Evaluation run {run.id} involves neither side of annotation source "
             f"{annotation_collection_id}."
         )

--- a/lightly_studio/tests/resolvers/annotations/test_annotation_metric_sort.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotation_metric_sort.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel import Session, col
+
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationSide
+from lightly_studio.models.evaluation_run import EvaluationRunTable, EvaluationTaskType
+from lightly_studio.models.sort_direction import SortDirection
+from lightly_studio.resolvers.annotations import annotation_metric_sort
+from tests.resolvers.evaluation_sample_metric_resolver import helpers as evaluation_run_helpers
+
+
+def _unpersisted_run(
+    *, gt_annotation_collection_id: UUID, pred_annotation_collection_id: UUID
+) -> EvaluationRunTable:
+    return EvaluationRunTable(
+        name="test_run",
+        gt_annotation_collection_id=gt_annotation_collection_id,
+        pred_annotation_collection_id=pred_annotation_collection_id,
+        dataset_id=uuid4(),
+        task_type=EvaluationTaskType.OBJECT_DETECTION,
+    )
+
+
+def test_sort_expr_to_order_by__unknown_run_raises(db_session: Session) -> None:
+    sort_expr = AnnotationEvaluationMetricSortExpr(
+        evaluation_run_id=uuid4(),
+        metric_name="iou",
+        direction=SortDirection.asc,
+    )
+
+    with pytest.raises(annotation_metric_sort.EvaluationRunNotFoundError):
+        annotation_metric_sort.sort_expr_to_order_by(
+            session=db_session,
+            annotation_collection_id=uuid4(),
+            sort_expr=sort_expr,
+            annotation_id_column=col(AnnotationBaseTable.sample_id),
+        )
+
+
+def test_sort_expr_to_order_by__source_not_in_run_raises(db_session: Session) -> None:
+    run = evaluation_run_helpers.create_run(session=db_session)
+    sort_expr = AnnotationEvaluationMetricSortExpr(
+        evaluation_run_id=run.id,
+        metric_name="iou",
+        direction=SortDirection.asc,
+    )
+
+    with pytest.raises(annotation_metric_sort.AnnotationSourceNotInEvaluationRunError):
+        annotation_metric_sort.sort_expr_to_order_by(
+            session=db_session,
+            annotation_collection_id=uuid4(),
+            sort_expr=sort_expr,
+            annotation_id_column=col(AnnotationBaseTable.sample_id),
+        )
+
+
+def test_sort_expr_to_order_by__descending(db_session: Session) -> None:
+    run = evaluation_run_helpers.create_run(session=db_session)
+    sort_expr = AnnotationEvaluationMetricSortExpr(
+        evaluation_run_id=run.id,
+        metric_name="iou",
+        direction=SortDirection.desc,
+    )
+
+    order_by = annotation_metric_sort.sort_expr_to_order_by(
+        session=db_session,
+        annotation_collection_id=run.gt_annotation_collection_id,
+        sort_expr=sort_expr,
+        annotation_id_column=col(AnnotationBaseTable.sample_id),
+    )
+
+    assert order_by.ascending is False
+
+
+def test_resolve_side__ground_truth_source() -> None:
+    gt_id, pred_id = uuid4(), uuid4()
+    run = _unpersisted_run(gt_annotation_collection_id=gt_id, pred_annotation_collection_id=pred_id)
+
+    side = annotation_metric_sort.resolve_side(run=run, annotation_collection_id=gt_id)
+
+    assert side == EvaluationAnnotationSide.GROUND_TRUTH
+
+
+def test_resolve_side__prediction_source() -> None:
+    gt_id, pred_id = uuid4(), uuid4()
+    run = _unpersisted_run(gt_annotation_collection_id=gt_id, pred_annotation_collection_id=pred_id)
+
+    side = annotation_metric_sort.resolve_side(run=run, annotation_collection_id=pred_id)
+
+    assert side == EvaluationAnnotationSide.PREDICTION
+
+
+def test_resolve_side__neither_source() -> None:
+    run = _unpersisted_run(
+        gt_annotation_collection_id=uuid4(), pred_annotation_collection_id=uuid4()
+    )
+
+    side = annotation_metric_sort.resolve_side(run=run, annotation_collection_id=uuid4())
+
+    assert side is None

--- a/lightly_studio/tests/resolvers/annotations/test_annotation_metric_sort.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotation_metric_sort.py
@@ -14,18 +14,6 @@ from lightly_studio.resolvers.annotations import annotation_metric_sort
 from tests.resolvers.evaluation_sample_metric_resolver import helpers as evaluation_run_helpers
 
 
-def _unpersisted_run(
-    *, gt_annotation_collection_id: UUID, pred_annotation_collection_id: UUID
-) -> EvaluationRunTable:
-    return EvaluationRunTable(
-        name="test_run",
-        gt_annotation_collection_id=gt_annotation_collection_id,
-        pred_annotation_collection_id=pred_annotation_collection_id,
-        dataset_id=uuid4(),
-        task_type=EvaluationTaskType.OBJECT_DETECTION,
-    )
-
-
 def test_sort_expr_to_order_by__unknown_run_raises(db_session: Session) -> None:
     sort_expr = AnnotationEvaluationMetricSortExpr(
         evaluation_run_id=uuid4(),
@@ -33,7 +21,7 @@ def test_sort_expr_to_order_by__unknown_run_raises(db_session: Session) -> None:
         direction=SortDirection.asc,
     )
 
-    with pytest.raises(annotation_metric_sort.EvaluationRunNotFoundError):
+    with pytest.raises(ValueError, match="not found"):
         annotation_metric_sort.sort_expr_to_order_by(
             session=db_session,
             annotation_collection_id=uuid4(),
@@ -50,7 +38,7 @@ def test_sort_expr_to_order_by__source_not_in_run_raises(db_session: Session) ->
         direction=SortDirection.asc,
     )
 
-    with pytest.raises(annotation_metric_sort.AnnotationSourceNotInEvaluationRunError):
+    with pytest.raises(ValueError, match="neither side"):
         annotation_metric_sort.sort_expr_to_order_by(
             session=db_session,
             annotation_collection_id=uuid4(),
@@ -103,3 +91,15 @@ def test_resolve_side__neither_source() -> None:
     side = annotation_metric_sort.resolve_side(run=run, annotation_collection_id=uuid4())
 
     assert side is None
+
+
+def _unpersisted_run(
+    *, gt_annotation_collection_id: UUID, pred_annotation_collection_id: UUID
+) -> EvaluationRunTable:
+    return EvaluationRunTable(
+        name="test_run",
+        gt_annotation_collection_id=gt_annotation_collection_id,
+        pred_annotation_collection_id=pred_annotation_collection_id,
+        dataset_id=uuid4(),
+        task_type=EvaluationTaskType.OBJECT_DETECTION,
+    )

--- a/lightly_studio/tests/resolvers/annotations/test_annotation_metric_sort.py
+++ b/lightly_studio/tests/resolvers/annotations/test_annotation_metric_sort.py
@@ -47,6 +47,25 @@ def test_sort_expr_to_order_by__source_not_in_run_raises(db_session: Session) ->
         )
 
 
+def test_sort_expr_to_order_by__ascending(db_session: Session) -> None:
+    run = evaluation_run_helpers.create_run(session=db_session)
+    sort_expr = AnnotationEvaluationMetricSortExpr(
+        evaluation_run_id=run.id,
+        metric_name="iou",
+        direction=SortDirection.asc,
+    )
+
+    order_by = annotation_metric_sort.sort_expr_to_order_by(
+        session=db_session,
+        annotation_collection_id=run.pred_annotation_collection_id,
+        sort_expr=sort_expr,
+        annotation_id_column=col(AnnotationBaseTable.sample_id),
+    )
+
+    assert order_by.ascending is True
+    assert order_by.side == EvaluationAnnotationSide.PREDICTION
+
+
 def test_sort_expr_to_order_by__descending(db_session: Session) -> None:
     run = evaluation_run_helpers.create_run(session=db_session)
     sort_expr = AnnotationEvaluationMetricSortExpr(


### PR DESCRIPTION
## What has changed and why?

Adds `AnnotationEvaluationMetricSortExpr`, the request model for sorting annotations by an
evaluation metric, and `sort_expr_to_order_by`, which turns it into an order-by expression.

The client sends only a run and a metric. This code works out which side of the run the metric
belongs to, by matching the browsed annotation source against the run's ground-truth and
prediction sources. So the same request works for labels and for predictions.

It is kept out of the image sort union in `models.sort`, because those members need
image-specific joins that do not work on an annotation query.

Nothing calls this yet. Part 5 connects it to the annotations endpoint.

## How has it been tested?

6 new tests in `tests/resolvers/annotations/test_annotation_metric_sort.py`, covering both sides
of the run, an unknown run, a source in neither side, and descending order.

`cd lightly_studio && make static-checks && make test`: ruff clean, 1785 passing.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sorting annotations by evaluation metrics.
  * Users can select a metric, evaluation run, annotation source, and ascending or descending order.
  * Supports sorting metrics from both ground-truth and prediction annotations.

* **Bug Fixes**
  * Improved validation for unknown evaluation runs and annotation sources.
  * Prevented sorting when the selected annotation source is not associated with the evaluation run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->