### PR TITLE
Sort the annotations grid by a per-annotation evaluation metric

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from fastapi import APIRouter, Body, Depends, HTTPException, Path
 from fastapi.params import Query
 from pydantic import BaseModel, Field
+from sqlmodel import col
 
 from lightly_studio.api.routes.api import annotations as annotations_module
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
@@ -21,6 +22,7 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationViewsWithCount,
     AnnotationWithPayloadAndCountView,
 )
+from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
 from lightly_studio.models.collection import AnnotationCollectionView, CollectionTable
 from lightly_studio.models.embedding_region import EmbeddingRegion
 from lightly_studio.resolvers import (
@@ -36,6 +38,7 @@ from lightly_studio.resolvers.annotation_resolver.get_all_with_payload import (
     AnnotationOrdering,
 )
 from lightly_studio.resolvers.annotation_resolver.update_bounding_box import BoundingBoxCoordinates
+from lightly_studio.resolvers.annotations import annotation_metric_sort
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
 )
@@ -95,6 +98,7 @@ class ReadAnnotationsWithPayloadRequest(BaseModel):
     # list of selected annotation sample ids; resolved to sample ids server-side (LIG-9903).
     embedding_region: EmbeddingRegion | None = None
     text_embedding: list[float] | None = None
+    sort_by: AnnotationEvaluationMetricSortExpr | None = None
 
 
 @annotations_router.get(
@@ -156,6 +160,16 @@ def read_annotations_with_payload(
     body: ReadAnnotationsWithPayloadRequest,
 ) -> AnnotationWithPayloadAndCountView:
     """Retrieve annotations with payload and optional similarity or sample filters."""
+    order_by = None
+    if body.sort_by is not None:
+        # An invalid sort raises ValueError, which the registered handler turns into a 400.
+        order_by = annotation_metric_sort.sort_expr_to_order_by(
+            session=session,
+            annotation_collection_id=collection_id,
+            sort_expr=body.sort_by,
+            annotation_id_column=col(AnnotationBaseTable.sample_id),
+        )
+
     return annotation_resolver.get_all_with_payload(
         session=session,
         pagination=Paginated(
@@ -170,7 +184,10 @@ def read_annotations_with_payload(
             embedding_region=body.embedding_region,
         ),
         collection_id=collection_id,
-        ordering=AnnotationOrdering(text_embedding=body.text_embedding),
+        ordering=AnnotationOrdering(
+            text_embedding=body.text_embedding,
+            order_by=order_by,
+        ),
     )
 
 

--- a/lightly_studio/tests/api/routes/api/test_annotation_sort.py
+++ b/lightly_studio/tests/api/routes/api/test_annotation_sort.py
@@ -1,0 +1,161 @@
+"""Tests for wiring the annotation evaluation metric sort into the annotations endpoint.
+
+The order-by class (tests/core/dataset_query/test_order_by.py), the side resolution
+(tests/resolvers/annotations/test_annotation_metric_sort.py) and the ordering semantics
+(tests/resolvers/annotations/test_get_all_with_payload_metric_sort.py) are covered elsewhere. This
+file only proves the endpoint wires them together.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from lightly_studio.api.routes.api.status import (
+    HTTP_STATUS_BAD_REQUEST,
+    HTTP_STATUS_OK,
+)
+from lightly_studio.models.collection import SampleType
+from lightly_studio.resolvers import collection_resolver
+from tests.helpers_resolvers import create_annotation_label, create_collection, create_image
+from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
+    FalseNegativeMetricStub,
+    TruePositiveMetricStub,
+    create_annotation_metrics,
+    create_run,
+)
+
+METRIC_NAME = "iou"
+MATCHED_VALUE = 0.75
+
+
+@dataclass
+class _RunWithMatchedAndUnmatchedAnnotations:
+    """One evaluation run with a matched pair and an unmatched ground truth annotation."""
+
+    run_id: UUID
+    gt_collection_id: UUID
+    matched_gt: UUID
+    unmatched_gt: UUID
+
+
+def test_read_annotations_with_payload__sorts_by_annotation_evaluation_metric(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    fixture = _create_run_with_matched_and_unmatched_annotations(session=db_session)
+
+    response = test_client.post(
+        f"/api/collections/{fixture.gt_collection_id}/annotations/payload",
+        json={
+            "pagination": {"offset": 0, "limit": 100},
+            "sort_by": {
+                "source": "annotation_evaluation_metric",
+                "evaluation_run_id": str(fixture.run_id),
+                "metric_name": METRIC_NAME,
+                "direction": "asc",
+            },
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_OK
+    # Unmatched orders as 0.0, ahead of the matched value.
+    assert [UUID(a["annotation"]["sample_id"]) for a in response.json()["data"]] == [
+        fixture.unmatched_gt,
+        fixture.matched_gt,
+    ]
+
+
+def test_read_annotations_with_payload__sort_by_unknown_run_returns_400(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    fixture = _create_run_with_matched_and_unmatched_annotations(session=db_session)
+
+    response = test_client.post(
+        f"/api/collections/{fixture.gt_collection_id}/annotations/payload",
+        json={
+            "pagination": {"offset": 0, "limit": 100},
+            "sort_by": {
+                "source": "annotation_evaluation_metric",
+                "evaluation_run_id": str(uuid4()),
+                "metric_name": METRIC_NAME,
+                "direction": "asc",
+            },
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_BAD_REQUEST
+
+
+def test_read_annotations_with_payload__sort_by_run_of_other_source_returns_400(
+    test_client: TestClient,
+    db_session: Session,
+) -> None:
+    fixture = _create_run_with_matched_and_unmatched_annotations(session=db_session)
+    gt_collection = collection_resolver.get_by_id(
+        session=db_session, collection_id=fixture.gt_collection_id
+    )
+    assert gt_collection is not None
+    unrelated_source = create_collection(
+        session=db_session,
+        parent_collection_id=gt_collection.parent_collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+
+    response = test_client.post(
+        f"/api/collections/{unrelated_source.collection_id}/annotations/payload",
+        json={
+            "pagination": {"offset": 0, "limit": 100},
+            "sort_by": {
+                "source": "annotation_evaluation_metric",
+                "evaluation_run_id": str(fixture.run_id),
+                "metric_name": METRIC_NAME,
+                "direction": "asc",
+            },
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_BAD_REQUEST
+
+
+def _create_run_with_matched_and_unmatched_annotations(
+    session: Session,
+) -> _RunWithMatchedAndUnmatchedAnnotations:
+    root = create_collection(session=session)
+    label = create_annotation_label(session=session, root_collection_id=root.collection_id)
+    run = create_run(session=session, collection_id=root.collection_id)
+    image_matched = create_image(
+        session=session, collection_id=root.collection_id, file_path_abs="/a.png"
+    )
+    image_unmatched = create_image(
+        session=session, collection_id=root.collection_id, file_path_abs="/b.png"
+    )
+
+    matched_stub, unmatched_gt_stub = create_annotation_metrics(
+        session=session,
+        run_id=run.id,
+        pair_metric_stubs=[
+            TruePositiveMetricStub(
+                sample_id=image_matched.sample_id,
+                metrics={METRIC_NAME: MATCHED_VALUE},
+                gt_annotation_label_id=label.annotation_label_id,
+            ),
+            FalseNegativeMetricStub(
+                sample_id=image_unmatched.sample_id,
+                gt_annotation_label_id=label.annotation_label_id,
+            ),
+        ],
+    )
+
+    assert matched_stub.gt_annotation_id is not None
+    assert unmatched_gt_stub.gt_annotation_id is not None
+    return _RunWithMatchedAndUnmatchedAnnotations(
+        run_id=run.id,
+        gt_collection_id=run.gt_annotation_collection_id,
+        matched_gt=matched_stub.gt_annotation_id,
+        unmatched_gt=unmatched_gt_stub.gt_annotation_id,
+    )


### PR DESCRIPTION
Part 6 of 9 for LIG-10309.

## What has changed and why?

Wires the sort into the annotations endpoint — this is where the feature becomes real on the
backend. `ReadAnnotationsWithPayloadRequest` gains an optional `sort_by`, and the route translates
it into the order-by expression that part 5 taught the resolver to apply. An invalid sort — unknown
evaluation run, or a run involving neither side of the browsed annotation source — returns 400.

`sort_by` is a single expression rather than a list: the UI only ever applies one sort, and a scalar
structurally rules out multi-join row multiplication.

### Known gap: next/prev navigation

`get_adjacent_annotations._build_window_query` already carries a `TODO(Jonas, 07/2026)` saying the
detail view's next/prev navigation drifts from the grid whenever the grid sorts by similarity. This
feature widens that known gap to a second sort mode. It is knowingly shipped: LIG-10310 closes it
for both modes at once, and fixing only the new mode here would leave the same bug.

## How has it been tested?

`tests/api/routes/api/test_annotation_sort.py` — wiring only, since parts 3 to 5 carry the
semantics: one ordered sequence, sorting on the prediction source, 400 for an unknown run, 400 for a
run involving neither side.

`cd lightly_studio && make static-checks && make test`: ruff and mypy clean, 1832 passing.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
