### PR TITLE
Hold the annotation sort selection and send it with the grid query

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.svelte
@@ -9,6 +9,7 @@
     import { onDestroy, onMount } from 'svelte';
     import { page } from '$app/state';
     import { useAnnotationsInfinite } from '$lib/hooks/useAnnotationsInfinite/useAnnotationsInfinite';
+    import { useAnnotationSortBy } from '$lib/hooks';
     import { afterNavigate, goto } from '$app/navigation';
     import SelectedAnnotations from './SelectedAnnotations/SelectedAnnotations.svelte';
     import { useScrollRestoration } from '$lib/hooks/useScrollRestoration/useScrollRestoration';
@@ -31,6 +32,8 @@
 
     const { selectedAnnotationFilterIdsArray: selectedAnnotationFilterIds } =
         useSelectedAnnotationsFilter();
+
+    const { sortByFor } = useAnnotationSortBy();
 
     // Use the collection_id for tags - tags should use the specific collection, not root
     const { tagsSelected } = $derived(
@@ -99,7 +102,9 @@
         // Embedding plot lasso selection narrows the grid to annotations inside the region.
         embedding_region: plotSelectedRegion ?? undefined,
         // Embedding text search reorders the grid by similarity (shared with images tab).
-        text_embedding: searchEmbedding?.embedding ?? undefined
+        text_embedding: searchEmbedding?.embedding ?? undefined,
+        // Similarity ordering keeps precedence, so the two are never sent together.
+        sort_by: searchEmbedding ? undefined : ($sortByFor(collection_id) ?? undefined)
     });
 
     const {
@@ -116,7 +121,8 @@
         $selectedAnnotationFilterIds.join(',') +
             Array.from($tagsSelected).join(',') +
             (plotSelectedRegion ? JSON.stringify(plotSelectedRegion) : '') +
-            (searchEmbedding ? `search:${searchEmbedding.queryText}` : '')
+            (searchEmbedding ? `search:${searchEmbedding.queryText}` : '') +
+            (queryParams.sort_by ? `sort:${JSON.stringify(queryParams.sort_by)}` : '')
     );
 
     const filterHash = $derived(infiniteLoaderIdentifier);

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationsGrid.test.ts
@@ -5,14 +5,23 @@ import { type Writable } from 'svelte/store';
 import {
     AnnotationType,
     SampleType,
+    type AnnotationEvaluationMetricSortExpr,
     type AnnotationView,
     type AnnotationWithPayloadView,
     type ImageAnnotationView
 } from '$lib/api/lightly_studio_local';
 import AnnotationsGrid from './AnnotationsGrid.svelte';
 
+const SORT_BY: AnnotationEvaluationMetricSortExpr = {
+    source: 'annotation_evaluation_metric',
+    evaluation_run_id: 'run-1',
+    metric_name: 'iou',
+    direction: 'asc'
+};
+
 const mocks = vi.hoisted(() => ({
     annotationsData: [] as AnnotationWithPayloadView[],
+    sortedAnnotationsData: [] as AnnotationWithPayloadView[],
     updateAnnotations: vi.fn(),
     updateAnnotationsRaw: vi.fn(),
     refresh: vi.fn(),
@@ -25,7 +34,9 @@ const mocks = vi.hoisted(() => ({
     addReversibleAction: vi.fn(),
     clearReversibleActions: vi.fn(),
     textEmbeddingStore: null as unknown as Writable<undefined>,
-    isEditingModeStore: null as unknown as Writable<boolean>
+    isEditingModeStore: null as unknown as Writable<boolean>,
+    hasEmbeddings: false,
+    sortBy: null as AnnotationEvaluationMetricSortExpr | null
 }));
 
 vi.mock('$app/navigation', () => ({
@@ -101,14 +112,29 @@ vi.mock('$lib/hooks/useEmbeddingFilter/useEmbeddingFilterForAnnotations', async 
 });
 
 vi.mock('$lib/hooks/useHasEmbeddings/useHasEmbeddings', () => ({
-    useHasEmbeddings: vi.fn(() => ({ data: null }))
+    useHasEmbeddings: vi.fn(() => ({ data: mocks.hasEmbeddings ? true : null }))
 }));
 
+vi.mock('$lib/hooks/useAnnotationSortBy/useAnnotationSortBy', async () => {
+    const { derived, writable } = await import('svelte/store');
+    return {
+        useAnnotationSortBy: vi.fn(() => ({
+            sortByFor: derived(writable(null), () => () => mocks.sortBy)
+        }))
+    };
+});
+
+// Stands in for the backend: answers with the sorted page only when the grid sends sort_by.
+function pageFor(params: { sort_by?: unknown }) {
+    const data = params.sort_by ? mocks.sortedAnnotationsData : mocks.annotationsData;
+    return { data, total_count: data.length };
+}
+
 vi.mock('$lib/hooks/useAnnotationsInfinite/useAnnotationsInfinite', () => ({
-    useAnnotationsInfinite: vi.fn(() => ({
+    useAnnotationsInfinite: vi.fn((getParams: () => { sort_by?: unknown }) => ({
         annotations: {
             data: {
-                pages: [{ data: mocks.annotationsData, total_count: mocks.annotationsData.length }]
+                pages: [pageFor(getParams())]
             },
             isSuccess: true,
             isFetched: true,
@@ -218,9 +244,44 @@ describe('AnnotationsGrid', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mocks.annotationsData = [];
+        mocks.sortedAnnotationsData = [];
         mocks.getCollectionVersion.mockResolvedValue('v1');
         mocks.pickedAnnotationIds.set({});
         mocks.isEditingModeStore.set(false);
+        mocks.hasEmbeddings = false;
+        mocks.textEmbeddingStore.set(undefined);
+        mocks.sortBy = null;
+    });
+
+    function renderWithSortSelection() {
+        mocks.sortBy = SORT_BY;
+        mocks.annotationsData = [buildClassificationAnnotation('cls-1')];
+        mocks.sortedAnnotationsData = [buildClassificationAnnotation('cls-2')];
+
+        renderGrid();
+
+        return screen.getAllByTestId('mock-classification-grid-item');
+    }
+
+    it('renders the sorted page when a sort is selected', () => {
+        const tiles = renderWithSortSelection();
+
+        expect(tiles[0]).toHaveAttribute('data-annotation-id', 'cls-2');
+        // The reset key restarts the loader and the scroll position on a new sort.
+        expect(screen.getByTestId('mock-grid-scroll-reset-key')).toHaveTextContent('sort:');
+    });
+
+    it('renders the unsorted page while a similarity search is active', () => {
+        mocks.hasEmbeddings = true;
+        mocks.textEmbeddingStore.set({
+            embedding: [0.1, 0.2],
+            queryText: 'a cat'
+        } as unknown as undefined);
+
+        const tiles = renderWithSortSelection();
+
+        expect(tiles[0]).toHaveAttribute('data-annotation-id', 'cls-1');
+        expect(screen.getByTestId('mock-grid-scroll-reset-key')).not.toHaveTextContent('sort:');
     });
 
     it('renders two separate tiles for two classification annotations', () => {

--- a/lightly_studio_view/src/lib/components/Grid/Grid.mock.svelte
+++ b/lightly_studio_view/src/lib/components/Grid/Grid.mock.svelte
@@ -9,9 +9,10 @@
         [key: string]: unknown;
     }
 
-    let { itemCount, gridItem, footerItem }: Props = $props();
+    let { itemCount, gridItem, footerItem, scrollResetKey }: Props = $props();
 </script>
 
+<span data-testid="mock-grid-scroll-reset-key">{scrollResetKey}</span>
 {#each Array.from({ length: itemCount }, (_, i) => i) as index}
     {@render gridItem({ index, style: '', width: 200, height: 150 })}
 {/each}

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -48,6 +48,7 @@ export { useExportDialog } from '$lib/hooks/useExportDialog/useExportDialog';
 export { useSettings } from '$lib/hooks/useSettings';
 export { useTrackSampleInspected } from '$lib/hooks/useTrackSampleInspected';
 export { useAnnotationClassVisibility } from '$lib/hooks/useAnnotationClassVisibility/useAnnotationClassVisibility';
+export { useAnnotationSortBy } from '$lib/hooks/useAnnotationSortBy/useAnnotationSortBy';
 export { useInvalidateAnnotationGridQueries } from '$lib/hooks/useInvalidateAnnotationGridQueries';
 export {
     useImageAnnotationCounts,

--- a/lightly_studio_view/src/lib/hooks/useAnnotationSortBy/useAnnotationSortBy.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationSortBy/useAnnotationSortBy.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import type { AnnotationEvaluationMetricSortExpr } from '$lib/api/lightly_studio_local';
+import { useAnnotationSortBy } from './useAnnotationSortBy';
+
+const SORT_BY: AnnotationEvaluationMetricSortExpr = {
+    source: 'annotation_evaluation_metric',
+    evaluation_run_id: 'run-1',
+    metric_name: 'iou',
+    direction: 'asc'
+};
+
+describe('useAnnotationSortBy', () => {
+    beforeEach(() => {
+        // The store is module-level, so reset it between tests.
+        useAnnotationSortBy().setSortBy('any-source', null);
+    });
+
+    it('defaults to no sort', () => {
+        const { getSortBy } = useAnnotationSortBy();
+
+        expect(getSortBy('source-1')).toBeNull();
+    });
+
+    it('returns the expression set for a source', () => {
+        const { setSortBy, getSortBy } = useAnnotationSortBy();
+
+        setSortBy('source-1', SORT_BY);
+
+        expect(getSortBy('source-1')).toEqual(SORT_BY);
+    });
+
+    it('clears the sort when set to null', () => {
+        const { setSortBy, getSortBy } = useAnnotationSortBy();
+        setSortBy('source-1', SORT_BY);
+
+        setSortBy('source-1', null);
+
+        expect(getSortBy('source-1')).toBeNull();
+    });
+
+    it('exposes the selection reactively through sortByFor', () => {
+        const { setSortBy, sortByFor } = useAnnotationSortBy();
+
+        setSortBy('source-1', SORT_BY);
+
+        expect(get(sortByFor)('source-1')).toEqual(SORT_BY);
+        expect(get(sortByFor)('source-2')).toBeNull();
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useAnnotationSortBy/useAnnotationSortBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationSortBy/useAnnotationSortBy.ts
@@ -1,0 +1,41 @@
+import { derived, get, writable, type Readable } from 'svelte/store';
+import type { AnnotationEvaluationMetricSortExpr } from '$lib/api/lightly_studio_local';
+
+interface AnnotationSortSelection {
+    collectionId: string;
+    expr: AnnotationEvaluationMetricSortExpr;
+}
+
+// Module-level so the grid, its header and its query read one selection. Not persisted.
+const selection = writable<AnnotationSortSelection | null>(null);
+
+interface UseAnnotationSortByReturn {
+    /**
+     * Reads the expression for an annotation source, reactively. Null for any other source, so
+     * switching sources drops the sort instead of carrying a run ID it cannot resolve.
+     */
+    sortByFor: Readable<(collectionId: string) => AnnotationEvaluationMetricSortExpr | null>;
+    getSortBy: (collectionId: string) => AnnotationEvaluationMetricSortExpr | null;
+    setSortBy: (collectionId: string, expr: AnnotationEvaluationMetricSortExpr | null) => void;
+}
+
+export function useAnnotationSortBy(): UseAnnotationSortByReturn {
+    const sortByFor = derived(
+        selection,
+        ($selection) =>
+            (collectionId: string): AnnotationEvaluationMetricSortExpr | null =>
+                $selection?.collectionId === collectionId ? $selection.expr : null
+    );
+
+    const getSortBy = (collectionId: string): AnnotationEvaluationMetricSortExpr | null =>
+        get(sortByFor)(collectionId);
+
+    const setSortBy = (
+        collectionId: string,
+        expr: AnnotationEvaluationMetricSortExpr | null
+    ): void => {
+        selection.set(expr ? { collectionId, expr } : null);
+    };
+
+    return { sortByFor, getSortBy, setSortBy };
+}

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AnnotationEvaluationMetricSortExpr } from '$lib/api/lightly_studio_local';
 import { createAnnotationsInfiniteOptions } from './createAnnotationsInfiniteOptions';
+
+const SORT_BY: AnnotationEvaluationMetricSortExpr = {
+    source: 'annotation_evaluation_metric',
+    evaluation_run_id: 'run-1',
+    metric_name: 'iou',
+    direction: 'asc'
+};
 
 type Options = ReturnType<typeof createAnnotationsInfiniteOptions>;
 type QueryFnContext = { pageParam: number; signal: AbortSignal };
@@ -65,6 +73,18 @@ describe('createAnnotationsInfiniteOptions', () => {
             const options2 = createAnnotationsInfiniteOptions({
                 collection_id: 'col-1',
                 sample_ids: ['s2']
+            });
+            expect(options1.queryKey).not.toEqual(options2.queryKey);
+        });
+
+        it('produces different keys for different sort_by values', () => {
+            const options1 = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                sort_by: SORT_BY
+            });
+            const options2 = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                sort_by: { ...SORT_BY, direction: 'desc' }
             });
             expect(options1.queryKey).not.toEqual(options2.queryKey);
         });
@@ -163,6 +183,21 @@ describe('createAnnotationsInfiniteOptions', () => {
             expect(readAnnotationsWithPayloadMock).toHaveBeenCalledWith(
                 expect.objectContaining({
                     body: expect.objectContaining({ embedding_region })
+                })
+            );
+        });
+
+        it('passes sort_by to readAnnotationsWithPayload body', async () => {
+            const options = createAnnotationsInfiniteOptions({
+                collection_id: 'col-1',
+                sort_by: SORT_BY
+            });
+
+            await callQueryFn(options, { pageParam: 0, signal: new AbortController().signal });
+
+            expect(readAnnotationsWithPayloadMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.objectContaining({ sort_by: SORT_BY })
                 })
             );
         });

--- a/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationsInfinite/createAnnotationsInfiniteOptions.ts
@@ -20,7 +20,9 @@ export const createAnnotationsInfiniteOptions = (params: AnnotationsInfinitePara
             tag_ids: params.tag_ids,
             sample_ids: params.sample_ids,
             embedding_region: params.embedding_region,
-            text_embedding: params.text_embedding
+            text_embedding: params.text_embedding,
+            // In the key, not only the body: without it cached pages serve and nothing reorders.
+            sort_by: params.sort_by
         }
     ];
 
@@ -41,7 +43,8 @@ export const createAnnotationsInfiniteOptions = (params: AnnotationsInfinitePara
                     tag_ids: params.tag_ids,
                     sample_ids: params.sample_ids,
                     embedding_region: params.embedding_region,
-                    text_embedding: params.text_embedding
+                    text_embedding: params.text_embedding,
+                    sort_by: params.sort_by
                 },
                 signal,
                 throwOnError: true


### PR DESCRIPTION
## What has changed and why?

Adds the frontend state holding the annotations grid's sort selection, and sends it with the grid
query.

`useAnnotationSortBy` is a module-level store scoped by annotation source, so the grid, its header
and its query all read one selection, and reading it for a different source returns null. Scoping
makes carrying a run ID into a source that cannot resolve it unrepresentable, rather than relying
on a reset call at every navigation path. It is deliberately not persisted to the URL or storage.

`sort_by` goes into **both** the TanStack query key and the request body. Omitting it from the key
serves cached pages, and the grid silently refuses to reorder — no error, just a grid that ignores
you.

`AnnotationsGrid` suppresses the sort while a similarity search is active, because similarity
ordering keeps precedence and the backend rejects the two together.

**This PR adds state nothing sets yet.** The menu that calls `setSortBy` lands in part 8.

## How has it been tested?

8 new tests: the store returns null when read for a different annotation source and round-trips for
the same one; a changed `sort_by` produces a different query key and reaches the request body; and
the grid renders the sorted page unless a similarity search suppresses the sort. The grid tests
assert the rendered page, with the query hook's test double answering with the sorted page only
when the grid actually sends `sort_by`.

`cd lightly_studio_view && npm run static-checks && npm run test:unit -- --run`: `svelte-check`
0 errors, 2568 tests passing. Fast Track guardrails pass locally, including 100% coverage on the
changed frontend lines.

The generated API client is a gitignored build artefact, so nothing generated is committed here;
it needs part 5's schema to typecheck.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added annotation sorting support to grid views.
  * Sort selections are retained separately for each annotation source.
  * Sorting is applied to annotation requests and cached results.

* **Bug Fixes**
  * Sorting is automatically disabled during active similarity searches, preserving relevant results.

* **Tests**
  * Added coverage for sorting behavior, source changes, cleared selections, caching, and request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->