### PR TITLE
Add the annotations grid sort menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Report anonymous usage data on app launch. Set `LIGHTLY_STUDIO_ANALYTICS_ENABLED=false` to opt out.
+- Sort the annotations grid by a per-annotation evaluation metric, such as IoU.
 
 ### Changed
 

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { CollectionSearch, GridHeader, OrderBy } from '$lib/components';
+    import { AnnotationOrderBy, CollectionSearch, GridHeader, OrderBy } from '$lib/components';
     import GridHeaderSelectAllButton from '$lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte';
 
     type SearchImage = { name: string; previewUrl: string };
@@ -9,6 +9,7 @@
         canSelectAll: boolean;
         isSelectionActive: boolean;
         isImages: boolean;
+        isAnnotations: boolean;
         hasMediaWithEmbeddings: boolean;
         collectionDatasetId: string;
         onSelectAll: () => Promise<void>;
@@ -28,6 +29,7 @@
         canSelectAll,
         isSelectionActive,
         isImages,
+        isAnnotations,
         hasMediaWithEmbeddings,
         onSelectAll,
         onDeselectAll,
@@ -57,6 +59,8 @@
     {#snippet auxControls()}
         {#if isImages}
             <OrderBy {collectionId} datasetId={collectionDatasetId} />
+        {:else if isAnnotations}
+            <AnnotationOrderBy {collectionId} />
         {/if}
     {/snippet}
     {#if hasMediaWithEmbeddings}

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -43,6 +43,7 @@ const defaultProps = {
     canSelectAll: false,
     isSelectionActive: false,
     isImages: false,
+    isAnnotations: false,
     hasMediaWithEmbeddings: false,
     collectionDatasetId: 'dataset-1',
     onSelectAll: vi.fn().mockResolvedValue(undefined),

--- a/lightly_studio_view/src/lib/components/OrderBy/AnnotationOrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/AnnotationOrderBy.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+    import { useAnnotationOrderBy } from '$lib/hooks/useAnnotationOrderBy/useAnnotationOrderBy.svelte';
+    import { useGlobalStorage, usePostHog } from '$lib/hooks';
+    import { type SelectItem } from '$lib/components/Select';
+    import OrderByControl from './OrderByControl.svelte';
+
+    interface Props {
+        /** The browsed annotation source. */
+        collectionId: string;
+    }
+
+    const { collectionId }: Props = $props();
+
+    const { textEmbedding } = useGlobalStorage();
+    const { trackEvent } = usePostHog();
+    // Similarity ordering keeps precedence over metric sorting, so the control is disabled
+    // while a text or drag-to-search is active. The selection survives clearing the search.
+    const isSimilaritySearchActive = $derived(!!$textEmbedding);
+
+    const {
+        allSortFields,
+        selectedDirection,
+        selectedIndex,
+        handleFieldClick,
+        toggleDirection,
+        dispose
+    } = useAnnotationOrderBy({ collectionId: () => collectionId });
+
+    $effect(() => {
+        return () => dispose();
+    });
+
+    const selectValue = $derived($selectedIndex >= 0 ? String($selectedIndex) : '');
+
+    const sortItems = $derived<SelectItem[]>(
+        $allSortFields.map((field, i) => ({
+            value: String(i),
+            label: field.label,
+            testId: `sort-field-${field.evaluation_run_id}-${field.metric_name}`
+        }))
+    );
+
+    const handleValueChange = (value: string) => {
+        if (value === '') {
+            if ($selectedIndex >= 0) handleFieldClick($allSortFields[$selectedIndex]);
+            return;
+        }
+        const field = $allSortFields[Number(value)];
+        if (field) handleFieldClick(field);
+    };
+</script>
+
+<OrderByControl
+    items={sortItems}
+    selectedValue={selectValue}
+    triggerLabel={$allSortFields[$selectedIndex]?.label}
+    direction={$selectedDirection}
+    disabled={isSimilaritySearchActive}
+    allowDeselect
+    onValueChange={handleValueChange}
+    onOpen={() => trackEvent('sort_by_opened', { collection_id: collectionId })}
+    onToggleDirection={toggleDirection}
+/>

--- a/lightly_studio_view/src/lib/components/OrderBy/AnnotationOrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/AnnotationOrderBy.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
-    import { useAnnotationOrderBy } from '$lib/hooks/useAnnotationOrderBy/useAnnotationOrderBy.svelte';
-    import { useGlobalStorage, usePostHog } from '$lib/hooks';
+    import {
+        useAnnotationOrderBy,
+        useGlobalStorage,
+        useHasEmbeddings,
+        usePostHog
+    } from '$lib/hooks';
     import { type SelectItem } from '$lib/components/Select';
     import OrderByControl from './OrderByControl.svelte';
 
@@ -13,9 +17,12 @@
 
     const { textEmbedding } = useGlobalStorage();
     const { trackEvent } = usePostHog();
-    // Similarity ordering keeps precedence over metric sorting, so the control is disabled
-    // while a text or drag-to-search is active. The selection survives clearing the search.
-    const isSimilaritySearchActive = $derived(!!$textEmbedding);
+    const hasEmbeddingsQuery = useHasEmbeddings(() => ({ collectionId }));
+    // Similarity ordering keeps precedence over metric sorting, so the control is disabled while
+    // a search applies to this source. A search started elsewhere persists but cannot be applied
+    // to a source without embeddings, and the grid keeps sorting there. The selection survives
+    // clearing the search.
+    const isSimilaritySearchActive = $derived(!!$textEmbedding && !!hasEmbeddingsQuery.data);
 
     const {
         allSortFields,

--- a/lightly_studio_view/src/lib/components/OrderBy/AnnotationOrderBy.test.ts
+++ b/lightly_studio_view/src/lib/components/OrderBy/AnnotationOrderBy.test.ts
@@ -17,22 +17,28 @@ const RUN: EvaluationRunAnnotationMetricsInfoView = {
 const mocks = vi.hoisted(() => ({
     trackEvent: vi.fn(),
     metricsProxy: { data: null as unknown[] | null, dataUpdatedAt: 0 },
+    hasEmbeddingsProxy: { data: true as boolean | undefined },
     textEmbeddingValue: undefined as TextEmbedding | undefined
 }));
 
-vi.mock('$lib/hooks', async (importOriginal) => ({
-    ...(await importOriginal<typeof import('$lib/hooks')>()),
-    usePostHog: () => ({ trackEvent: mocks.trackEvent }),
-    useGlobalStorage: () => ({ textEmbedding: readable(mocks.textEmbeddingValue) })
+// Mocked at the source modules rather than at the `$lib/hooks` barrel, so both the component and
+// the hook it uses see the mocks when importing through the barrel.
+vi.mock('$lib/hooks/usePostHog', () => ({
+    usePostHog: () => ({ trackEvent: mocks.trackEvent })
 }));
 
 vi.mock('$lib/hooks/useGlobalStorage', () => ({
     useGlobalStorage: () => ({ textEmbedding: readable(mocks.textEmbeddingValue) })
 }));
 
-vi.mock('$lib/hooks/useAnnotationEvaluationMetricsInfo/useAnnotationEvaluationMetricsInfo', () => ({
-    useAnnotationEvaluationMetricsInfo: () => mocks.metricsProxy
+vi.mock('$lib/hooks/useHasEmbeddings/useHasEmbeddings', () => ({
+    useHasEmbeddings: () => mocks.hasEmbeddingsProxy
 }));
+
+vi.mock(
+    '$lib/hooks/useAnnotationEvaluationMetricsInfo/useAnnotationEvaluationMetricsInfo.svelte',
+    () => ({ useAnnotationEvaluationMetricsInfo: () => mocks.metricsProxy })
+);
 
 const COLLECTION_ID = 'source-1';
 
@@ -48,6 +54,7 @@ describe('AnnotationOrderBy', () => {
         vi.clearAllMocks();
         mocks.metricsProxy.data = [RUN];
         mocks.metricsProxy.dataUpdatedAt = 0;
+        mocks.hasEmbeddingsProxy.data = true;
         mocks.textEmbeddingValue = undefined;
         useAnnotationSortBy().setSortBy(COLLECTION_ID, null);
     });
@@ -110,6 +117,14 @@ describe('AnnotationOrderBy', () => {
         expect(screen.getByTestId('sort-direction-button')).toBeDisabled();
     });
 
+    it('stays enabled when the source has no embeddings to search', () => {
+        mocks.textEmbeddingValue = { queryText: 'cat', embedding: [0.1] } as TextEmbedding;
+        mocks.hasEmbeddingsProxy.data = false;
+        render(AnnotationOrderBy, { props: { collectionId: COLLECTION_ID } });
+
+        expect(screen.getByTestId('sort-by-trigger')).toBeEnabled();
+    });
+
     it('fires grid_sorted analytics with the same shape as image sorting', async () => {
         const user = userEvent.setup();
         render(AnnotationOrderBy, { props: { collectionId: COLLECTION_ID } });
@@ -120,7 +135,7 @@ describe('AnnotationOrderBy', () => {
         expect(mocks.trackEvent).toHaveBeenCalledWith('grid_sorted', {
             collection_id: COLLECTION_ID,
             sort_source: 'annotation_evaluation_metric',
-            field_name: 'iou',
+            field_name: 'detection eval.iou',
             direction: 'asc'
         });
     });

--- a/lightly_studio_view/src/lib/components/OrderBy/AnnotationOrderBy.test.ts
+++ b/lightly_studio_view/src/lib/components/OrderBy/AnnotationOrderBy.test.ts
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { readable } from 'svelte/store';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EvaluationRunAnnotationMetricsInfoView } from '$lib/api/lightly_studio_local/types.gen';
+import type { TextEmbedding } from '$lib/hooks/useGlobalStorage';
+import { useAnnotationSortBy } from '$lib/hooks/useAnnotationSortBy/useAnnotationSortBy';
+import AnnotationOrderBy from './AnnotationOrderBy.svelte';
+
+const RUN: EvaluationRunAnnotationMetricsInfoView = {
+    run_id: 'run-1',
+    run_name: 'detection eval',
+    task_type: 'object_detection',
+    metrics: [{ metric_name: 'iou' }]
+};
+
+const mocks = vi.hoisted(() => ({
+    trackEvent: vi.fn(),
+    metricsProxy: { data: null as unknown[] | null, dataUpdatedAt: 0 },
+    textEmbeddingValue: undefined as TextEmbedding | undefined
+}));
+
+vi.mock('$lib/hooks', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('$lib/hooks')>()),
+    usePostHog: () => ({ trackEvent: mocks.trackEvent }),
+    useGlobalStorage: () => ({ textEmbedding: readable(mocks.textEmbeddingValue) })
+}));
+
+vi.mock('$lib/hooks/useGlobalStorage', () => ({
+    useGlobalStorage: () => ({ textEmbedding: readable(mocks.textEmbeddingValue) })
+}));
+
+vi.mock('$lib/hooks/useAnnotationEvaluationMetricsInfo/useAnnotationEvaluationMetricsInfo', () => ({
+    useAnnotationEvaluationMetricsInfo: () => mocks.metricsProxy
+}));
+
+const COLLECTION_ID = 'source-1';
+
+describe('AnnotationOrderBy', () => {
+    beforeAll(() => {
+        Element.prototype.hasPointerCapture = vi.fn(() => false);
+        Element.prototype.setPointerCapture = vi.fn();
+        Element.prototype.releasePointerCapture = vi.fn();
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.metricsProxy.data = [RUN];
+        mocks.metricsProxy.dataUpdatedAt = 0;
+        mocks.textEmbeddingValue = undefined;
+        useAnnotationSortBy().setSortBy(COLLECTION_ID, null);
+    });
+
+    it('renders one entry per run and metric', async () => {
+        const user = userEvent.setup();
+        render(AnnotationOrderBy, { props: { collectionId: COLLECTION_ID } });
+
+        await user.click(screen.getByTestId('sort-by-trigger'));
+
+        expect(screen.getByTestId('sort-field-run-1-iou')).toHaveTextContent('detection eval.iou');
+    });
+
+    it('renders when the source has no evaluation runs', async () => {
+        const user = userEvent.setup();
+        mocks.metricsProxy.data = [];
+        render(AnnotationOrderBy, { props: { collectionId: COLLECTION_ID } });
+
+        await user.click(screen.getByTestId('sort-by-trigger'));
+
+        expect(screen.queryByTestId('sort-field-run-1-iou')).not.toBeInTheDocument();
+    });
+
+    it('produces the annotation sort expression for the picked option', async () => {
+        const user = userEvent.setup();
+        render(AnnotationOrderBy, { props: { collectionId: COLLECTION_ID } });
+
+        await user.click(screen.getByTestId('sort-by-trigger'));
+        await user.click(screen.getByTestId('sort-field-run-1-iou'));
+
+        expect(useAnnotationSortBy().getSortBy(COLLECTION_ID)).toEqual({
+            source: 'annotation_evaluation_metric',
+            evaluation_run_id: 'run-1',
+            metric_name: 'iou',
+            direction: 'asc'
+        });
+    });
+
+    it('deselects the field when clicking the already selected item', async () => {
+        const user = userEvent.setup();
+        useAnnotationSortBy().setSortBy(COLLECTION_ID, {
+            source: 'annotation_evaluation_metric',
+            evaluation_run_id: 'run-1',
+            metric_name: 'iou',
+            direction: 'asc'
+        });
+        render(AnnotationOrderBy, { props: { collectionId: COLLECTION_ID } });
+
+        await user.click(screen.getByTestId('sort-by-trigger'));
+        await user.click(screen.getByTestId('sort-field-run-1-iou'));
+
+        expect(useAnnotationSortBy().getSortBy(COLLECTION_ID)).toBeNull();
+    });
+
+    it('is disabled during similarity search', () => {
+        mocks.textEmbeddingValue = { queryText: 'cat', embedding: [0.1] } as TextEmbedding;
+        render(AnnotationOrderBy, { props: { collectionId: COLLECTION_ID } });
+
+        expect(screen.getByTestId('sort-by-trigger')).toBeDisabled();
+        expect(screen.getByTestId('sort-direction-button')).toBeDisabled();
+    });
+
+    it('fires grid_sorted analytics with the same shape as image sorting', async () => {
+        const user = userEvent.setup();
+        render(AnnotationOrderBy, { props: { collectionId: COLLECTION_ID } });
+
+        await user.click(screen.getByTestId('sort-by-trigger'));
+        await user.click(screen.getByTestId('sort-field-run-1-iou'));
+
+        expect(mocks.trackEvent).toHaveBeenCalledWith('grid_sorted', {
+            collection_id: COLLECTION_ID,
+            sort_source: 'annotation_evaluation_metric',
+            field_name: 'iou',
+            direction: 'asc'
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -67,6 +67,7 @@ export { default as CollectionSearch } from '$lib/components/CollectionSearch/Co
 export { default as CollectionSearchImage } from '$lib/components/CollectionSearch/CollectionSearchImage/CollectionSearchImage.svelte';
 export { default as CollectionSearchInput } from '$lib/components/CollectionSearch/SearchInput/CollectionSearchInput.svelte';
 export { default as OrderBy } from '$lib/components/OrderBy/OrderBy.svelte';
+export { default as AnnotationOrderBy } from '$lib/components/OrderBy/AnnotationOrderBy.svelte';
 export { default as SamplingCombinationDialog } from '$lib/components/Sampling/SamplingCombinationDialog.svelte';
 export { default as MetadataFilterChips } from '$lib/components/MetadataFilterChips/MetadataFilterChips.svelte';
 export { default as FormField } from '$lib/components/FormField/FormField.svelte';

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -2,6 +2,7 @@ export { useVideoFrames } from '$lib/hooks/useVideoFrames/useVideoFrames';
 export { useVideoFrameAnnotations } from '$lib/hooks/useVideoFrameAnnotations/useVideoFrameAnnotations';
 export { useSamplesInfinite } from '$lib/hooks/useSamplesInfinite/useSamplesInfinite.svelte';
 export { useGlobalStorage } from '$lib/hooks/useGlobalStorage';
+export { useHasEmbeddings } from '$lib/hooks/useHasEmbeddings/useHasEmbeddings';
 export { useGroupsInfinite } from '$lib/hooks/useGroupsInfinite/useGroupsInfinite.svelte';
 export { useFrames } from '$lib/hooks/useFrames/useFrames.svelte';
 export { useTags } from '$lib/hooks/useTags/useTags';

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -845,6 +845,7 @@
                                 {canSelectAll}
                                 isSelectionActive={$selectedCount > 0}
                                 {isImages}
+                                {isAnnotations}
                                 {hasMediaWithEmbeddings}
                                 collectionDatasetId={collection.dataset_id}
                                 onSelectAll={selectAllHandle.handleSelectAll}


### PR DESCRIPTION
## What has changed and why?

The feature becomes visible. `AnnotationOrderBy` renders in the grid header when browsing
annotations, letting users order the annotations grid by a per-annotation evaluation metric such
as IoU — so the worst matches can be reviewed first.

It reuses the `OrderByControl` extracted in part 1 and clears the sort by deselecting the active
entry, the same `allowDeselect` idiom the images control uses, rather than introducing a second
idiom for the same control.

The control is disabled while a similarity search applies to the browsed source, because
similarity ordering keeps precedence — the same condition the grid uses to override the sort. A
search started on the images tab persists across a switch to a source without embeddings, where
the grid ignores it, so the control stays usable there. The selection survives clearing the
search.

## How has it been tested?

7 tests in `AnnotationOrderBy.test.ts`: one entry renders per run and metric, the control renders
with no evaluation runs, picking an entry produces the correct sort expression, deselecting clears
the sort, `grid_sorted` fires with the image-sorting shape, the control is disabled during
similarity search, and it stays enabled when the source has no embeddings to search.

`cd lightly_studio_view && npm run static-checks && npm run test:unit -- --run`: `svelte-check`
0 errors, 2585 tests passing.

Full stack re-validated on the final rebase onto `main`: backend 1801 passing with ruff clean,
frontend 2585 passing with `svelte-check` 0 errors.

> **TODO before review:** screenshot / recording of the sort menu, per the PR guidelines' UI
> requirement.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sorting controls to annotation grids.
  - Sort annotations by evaluation metrics, such as IoU.
  - Select, remove, and reverse sorting criteria.
  - Sorting is unavailable while similarity search is active.

- **Documentation**
  - Added an Unreleased changelog entry describing annotation metric sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->