### PR TITLE
Migrate SampleDetailsClassificationSegment to shared Button component

### DIFF
--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -94,11 +94,18 @@
         })
     );
 
+    // Ids of classifications with a delete request in flight, so repeated clicks cannot
+    // issue concurrent deletes or push the same annotation onto the undo stack twice.
+    let deletingAnnotationIds = $state<string[]>([]);
+
     const handleDeleteAnnotation = async (annotationId: string) => {
         if (!annotationLabels.data) return;
 
         const annotation = annotations?.find((a) => a.sample_id === annotationId);
         if (!annotation) return;
+
+        if (deletingAnnotationIds.includes(annotationId)) return;
+        deletingAnnotationIds = [...deletingAnnotationIds, annotationId];
 
         try {
             addAnnotationDeleteToUndoStack({
@@ -115,6 +122,8 @@
         } catch (error) {
             toast.error('Failed to delete classification. Please try again.');
             console.error('Error deleting classification:', error);
+        } finally {
+            deletingAnnotationIds = deletingAnnotationIds.filter((id) => id !== annotationId);
         }
     };
 
@@ -278,8 +287,9 @@
                 <Button
                     icon={Trash2}
                     ariaLabel="Delete classification"
+                    isPending={deletingAnnotationIds.includes(annotation.sample_id)}
                     buttonProps={{
-                        size: 'icon',
+                        class: 'size-7 p-0',
                         onclick: (e) => {
                             e.stopPropagation();
                             handleDeleteAnnotation(annotation.sample_id);
@@ -358,8 +368,7 @@
                                 icon={Trash2}
                                 ariaLabel="Remove classification draft"
                                 buttonProps={{
-                                    size: 'icon',
-                                    class: 'text-muted-foreground',
+                                    class: 'size-7 p-0 text-muted-foreground',
                                     onclick: (e) => {
                                         e.stopPropagation();
                                         removeDraftClassification(draftId);
@@ -371,6 +380,7 @@
                 {/each}
                 <Button
                     variant="ghost"
+                    ariaLabel="Add classification"
                     buttonProps={{
                         type: 'button',
                         class: 'mb-2 h-8 justify-center rounded-sm bg-card px-2 py-0 text-base font-normal text-diffuse-foreground hover:bg-primary hover:text-primary-foreground',

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -279,6 +279,7 @@
                     icon={Trash2}
                     ariaLabel="Delete classification"
                     buttonProps={{
+                        size: 'icon',
                         onclick: (e) => {
                             e.stopPropagation();
                             handleDeleteAnnotation(annotation.sample_id);
@@ -353,10 +354,16 @@
                             </span>
                         </span>
                         <div class="flex shrink-0 items-center gap-3">
-                            <Trash2
-                                class="size-6 text-muted-foreground"
-                                onclick={() => {
-                                    removeDraftClassification(draftId);
+                            <Button
+                                icon={Trash2}
+                                ariaLabel="Remove classification draft"
+                                buttonProps={{
+                                    size: 'icon',
+                                    class: 'text-muted-foreground',
+                                    onclick: (e) => {
+                                        e.stopPropagation();
+                                        removeDraftClassification(draftId);
+                                    }
                                 }}
                             />
                         </div>
@@ -366,7 +373,7 @@
                     variant="ghost"
                     buttonProps={{
                         type: 'button',
-                        class: 'mb-2 h-8 justify-center rounded-sm bg-card px-2 py-0 text-diffuse-foreground hover:bg-primary hover:text-primary-foreground',
+                        class: 'mb-2 h-8 justify-center rounded-sm bg-card px-2 py-0 text-base font-normal text-diffuse-foreground hover:bg-primary hover:text-primary-foreground',
                         onclick: addDraftClassification,
                         'data-testid': 'add-classification-button'
                     }}

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     // TODO (Mihnea, 06/2026): Refactor this component, as it is way past the 100-line guideline.
     import { AnnotationType, type AnnotationView } from '$lib/api/lightly_studio_local';
-    import { SampleDetailsAnnotationSourceGroup, Segment } from '$lib/components';
+    import { Button, SampleDetailsAnnotationSourceGroup, Segment } from '$lib/components';
     import LabelNotFound from '$lib/components/LabelNotFound/LabelNotFound.svelte';
     import SelectList from '$lib/components/SelectList/SelectList.svelte';
     import { getSelectionItems } from '$lib/components/SelectList/getSelectionItems';
@@ -275,16 +275,16 @@
         </span>
         <div class="flex shrink-0 items-center gap-3">
             {#if $isEditingMode}
-                <button
-                    type="button"
-                    aria-label="Delete classification"
-                    onclick={(e) => {
-                        e.stopPropagation();
-                        handleDeleteAnnotation(annotation.sample_id);
+                <Button
+                    icon={Trash2}
+                    ariaLabel="Delete classification"
+                    buttonProps={{
+                        onclick: (e) => {
+                            e.stopPropagation();
+                            handleDeleteAnnotation(annotation.sample_id);
+                        }
                     }}
-                >
-                    <Trash2 class="size-6" />
-                </button>
+                />
             {/if}
         </div>
     </div>
@@ -362,14 +362,17 @@
                         </div>
                     </div>
                 {/each}
-                <button
-                    type="button"
-                    class="mb-2 flex h-8 items-center justify-center rounded-sm bg-card px-2 py-0 text-diffuse-foreground transition-colors hover:bg-primary hover:text-primary-foreground"
-                    onclick={addDraftClassification}
-                    data-testid="add-classification-button"
+                <Button
+                    variant="ghost"
+                    buttonProps={{
+                        type: 'button',
+                        class: 'mb-2 h-8 justify-center rounded-sm bg-card px-2 py-0 text-diffuse-foreground hover:bg-primary hover:text-primary-foreground',
+                        onclick: addDraftClassification,
+                        'data-testid': 'add-classification-button'
+                    }}
                 >
                     +
-                </button>
+                </Button>
             {/if}
         </div>
     </div>

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -142,6 +142,9 @@ const defaultProps = {
     refetch: vi.fn()
 };
 
+const catLabel = { annotation_label_id: 'label-cat', annotation_label_name: 'cat' };
+const dogLabel = { annotation_label_id: 'label-dog', annotation_label_name: 'dog' };
+
 describe('SampleDetailsClassificationSegment', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -149,17 +152,50 @@ describe('SampleDetailsClassificationSegment', () => {
         mocks.selectedCollectionIds = [];
         mocks.lastCreatedAnnotationId = null;
         mocks.annotationLabels = [];
-        mocks.deleteAnnotation.mockReset();
-        mocks.deleteAnnotation.mockResolvedValue(undefined);
-        mocks.createAnnotation.mockReset();
-        mocks.createAnnotation.mockResolvedValue({ sample_id: 'created-1' });
+        mocks.deleteAnnotation.mockReset().mockResolvedValue(undefined);
+        mocks.createAnnotation.mockReset().mockResolvedValue({ sample_id: 'created-1' });
         mocks.createLabel.mockReset();
-        mocks.updateAnnotations.mockReset();
-        mocks.updateAnnotations.mockResolvedValue(undefined);
+        mocks.updateAnnotations.mockReset().mockResolvedValue(undefined);
         mocks.addReversibleAction.mockReset();
         mocks.isEditingMode.set(false);
         mocks.enforceColoringByClassStore.set(false);
+        // The component logs the caught error alongside the toast on every failure path.
+        vi.spyOn(console, 'error').mockImplementation(() => {});
     });
+
+    // One saved 'cat' classification, in edit mode.
+    const renderEditableRow = (labels = [catLabel]) => {
+        const user = userEvent.setup();
+        mocks.isEditingMode.set(true);
+        mocks.collections = [groundTruthSource];
+        mocks.annotationLabels = labels;
+
+        render(SampleDetailsClassificationSegment, {
+            props: {
+                ...defaultProps,
+                annotations: [createClassification('c1', groundTruthSource.collection_id, 'cat')]
+            }
+        });
+
+        return user;
+    };
+
+    // Empty segment in edit mode, with a draft row added and its class dropdown open.
+    const openDraftRow = async () => {
+        const user = userEvent.setup();
+        mocks.isEditingMode.set(true);
+        mocks.collections = [groundTruthSource];
+        mocks.annotationLabels = [catLabel];
+
+        render(SampleDetailsClassificationSegment, { props: defaultProps });
+
+        await user.click(screen.getByRole('button', { name: 'Add classification' }));
+        await user.click(screen.getByTestId('select-list-trigger'));
+
+        return user;
+    };
+
+    const deleteButton = () => screen.getByRole('button', { name: 'Delete classification' });
 
     it('renders a flat list without source groups for a single source', () => {
         mocks.collections = [groundTruthSource];
@@ -357,96 +393,42 @@ describe('SampleDetailsClassificationSegment', () => {
     });
 
     describe('deleting a classification', () => {
-        const renderEditableRow = () => {
-            mocks.isEditingMode.set(true);
-            mocks.collections = [groundTruthSource];
-            mocks.annotationLabels = [
-                { annotation_label_id: 'label-cat', annotation_label_name: 'cat' }
-            ];
-            const annotations = [
-                createClassification('c1', groundTruthSource.collection_id, 'cat')
-            ];
-
-            render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
-
-            return screen.getByRole('button', { name: 'Delete classification' });
-        };
-
         it('deletes once and stacks one undo action when clicked twice mid-flight', async () => {
-            const user = userEvent.setup();
-            let resolveDelete: () => void = () => {};
-            mocks.deleteAnnotation.mockImplementation(
-                () =>
-                    new Promise<void>((resolve) => {
-                        resolveDelete = resolve;
-                    })
+            let resolveDelete = () => {};
+            mocks.deleteAnnotation.mockReturnValue(
+                new Promise<void>((resolve) => {
+                    resolveDelete = resolve;
+                })
             );
+            const user = renderEditableRow();
 
-            const deleteButton = renderEditableRow();
-
-            await user.click(deleteButton);
-            await user.click(deleteButton);
+            await user.click(deleteButton());
+            await user.click(deleteButton());
 
             expect(mocks.deleteAnnotation).toHaveBeenCalledTimes(1);
             expect(mocks.deleteAnnotation).toHaveBeenCalledWith('c1', 'classification');
             expect(mocks.addReversibleAction).toHaveBeenCalledTimes(1);
+            expect(deleteButton()).toBeDisabled();
 
             resolveDelete();
+            await waitFor(() => expect(deleteButton()).not.toBeDisabled());
         });
 
-        it('disables the button while the delete is in flight and re-enables it after', async () => {
-            const user = userEvent.setup();
-            let resolveDelete: () => void = () => {};
-            mocks.deleteAnnotation.mockImplementation(
-                () =>
-                    new Promise<void>((resolve) => {
-                        resolveDelete = resolve;
-                    })
-            );
-
-            const deleteButton = renderEditableRow();
-
-            await user.click(deleteButton);
-            expect(deleteButton).toBeDisabled();
-            expect(screen.getByTestId('button-progress')).toBeInTheDocument();
-
-            resolveDelete();
-
-            await waitFor(() => expect(deleteButton).not.toBeDisabled());
-            expect(screen.queryByTestId('button-progress')).not.toBeInTheDocument();
-        });
-
-        it('re-enables the button when the delete fails', async () => {
-            const user = userEvent.setup();
-            vi.spyOn(console, 'error').mockImplementation(() => {});
+        it('allows another attempt once a failed delete settles', async () => {
             mocks.deleteAnnotation.mockRejectedValue(new Error('network down'));
+            const user = renderEditableRow();
 
-            const deleteButton = renderEditableRow();
+            await user.click(deleteButton());
+            await waitFor(() => expect(toast.error).toHaveBeenCalled());
+            await user.click(deleteButton());
 
-            await user.click(deleteButton);
-
-            await waitFor(() => expect(deleteButton).not.toBeDisabled());
-            expect(mocks.deleteAnnotation).toHaveBeenCalledTimes(1);
+            expect(mocks.deleteAnnotation).toHaveBeenCalledTimes(2);
         });
     });
 
     describe('creating a classification', () => {
-        const openDraftRow = async (user: ReturnType<typeof userEvent.setup>) => {
-            mocks.isEditingMode.set(true);
-            mocks.collections = [groundTruthSource];
-            mocks.annotationLabels = [
-                { annotation_label_id: 'label-cat', annotation_label_name: 'cat' }
-            ];
-
-            render(SampleDetailsClassificationSegment, { props: defaultProps });
-
-            await user.click(screen.getByRole('button', { name: 'Add classification' }));
-            await user.click(screen.getByTestId('select-list-trigger'));
-        };
-
         it('creates the annotation and drops the draft row when an existing class is picked', async () => {
-            const user = userEvent.setup();
-            await openDraftRow(user);
+            const user = await openDraftRow();
 
             await user.click(screen.getByRole('option', { name: 'cat' }));
 
@@ -458,7 +440,6 @@ describe('SampleDetailsClassificationSegment', () => {
                     annotation_collection_name: undefined
                 })
             );
-            expect(mocks.createLabel).not.toHaveBeenCalled();
             // The sample had no classifications, so the root collection counts need a refresh.
             expect(mocks.refetchRootCollection).toHaveBeenCalled();
             expect(mocks.addReversibleAction).toHaveBeenCalledTimes(1);
@@ -466,12 +447,11 @@ describe('SampleDetailsClassificationSegment', () => {
         });
 
         it('creates the class first when the typed name is new', async () => {
-            const user = userEvent.setup();
             mocks.createLabel.mockResolvedValue({
                 annotation_label_id: 'label-otter',
                 annotation_label_name: 'otter'
             });
-            await openDraftRow(user);
+            const user = await openDraftRow();
 
             await user.type(screen.getByTestId('select-list-input'), 'otter{Enter}');
 
@@ -487,14 +467,7 @@ describe('SampleDetailsClassificationSegment', () => {
         });
 
         it('drops the draft row when its trash button is clicked', async () => {
-            const user = userEvent.setup();
-            mocks.isEditingMode.set(true);
-            mocks.collections = [groundTruthSource];
-
-            render(SampleDetailsClassificationSegment, { props: defaultProps });
-
-            await user.click(screen.getByRole('button', { name: 'Add classification' }));
-            expect(screen.getByRole('combobox')).toBeInTheDocument();
+            const user = await openDraftRow();
 
             await user.click(screen.getByRole('button', { name: 'Remove classification draft' }));
 
@@ -503,36 +476,19 @@ describe('SampleDetailsClassificationSegment', () => {
         });
 
         it('keeps the draft row when the create fails', async () => {
-            const user = userEvent.setup();
-            vi.spyOn(console, 'error').mockImplementation(() => {});
             mocks.createAnnotation.mockRejectedValue(new Error('network down'));
-            await openDraftRow(user);
+            const user = await openDraftRow();
 
             await user.click(screen.getByRole('option', { name: 'cat' }));
 
-            await waitFor(() => expect(mocks.createAnnotation).toHaveBeenCalled());
+            await waitFor(() => expect(toast.error).toHaveBeenCalled());
             expect(screen.getByRole('combobox')).toBeInTheDocument();
         });
     });
 
     describe('changing a classification label', () => {
-        const renderEditableRow = () => {
-            mocks.isEditingMode.set(true);
-            mocks.collections = [groundTruthSource];
-            mocks.annotationLabels = [
-                { annotation_label_id: 'label-cat', annotation_label_name: 'cat' },
-                { annotation_label_id: 'label-dog', annotation_label_name: 'dog' }
-            ];
-            const annotations = [
-                createClassification('c1', groundTruthSource.collection_id, 'cat')
-            ];
-
-            render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
-        };
-
         it('shows the current class on the trigger and updates on selection', async () => {
-            const user = userEvent.setup();
-            renderEditableRow();
+            const user = renderEditableRow([catLabel, dogLabel]);
 
             expect(screen.getByTestId('select-list-trigger')).toHaveTextContent('cat');
 
@@ -553,10 +509,8 @@ describe('SampleDetailsClassificationSegment', () => {
         });
 
         it('reports an error when the update fails', async () => {
-            const user = userEvent.setup();
-            vi.spyOn(console, 'error').mockImplementation(() => {});
             mocks.updateAnnotations.mockRejectedValue(new Error('network down'));
-            renderEditableRow();
+            const user = renderEditableRow([catLabel, dogLabel]);
 
             await user.click(screen.getByTestId('select-list-trigger'));
             await user.click(screen.getByRole('option', { name: 'dog' }));

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -1,6 +1,7 @@
 import type { AnnotationView } from '$lib/api/lightly_studio_local';
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import { toast } from 'svelte-sonner';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import SampleDetailsClassificationSegment from './SampleDetailsClassificationSegment.svelte';
 
@@ -8,6 +9,13 @@ const mocks = vi.hoisted(() => ({
     collections: [] as { collection_id: string; name: string }[],
     selectedCollectionIds: [] as string[],
     lastCreatedAnnotationId: null as string | null,
+    annotationLabels: [] as { annotation_label_id: string; annotation_label_name: string }[],
+    deleteAnnotation: vi.fn(),
+    createAnnotation: vi.fn(),
+    createLabel: vi.fn(),
+    updateAnnotations: vi.fn(),
+    refetchRootCollection: vi.fn(),
+    addReversibleAction: vi.fn(),
     isEditingMode: undefined as unknown as { set: (value: boolean) => void },
     enforceColoringByClassStore: undefined as unknown as { set: (value: boolean) => void }
 }));
@@ -39,7 +47,7 @@ vi.mock('$lib/hooks/useGlobalStorage', async () => {
     return {
         useGlobalStorage: () => ({
             isEditingMode,
-            addReversibleAction: vi.fn()
+            addReversibleAction: mocks.addReversibleAction
         })
     };
 });
@@ -69,27 +77,27 @@ vi.mock('$lib/contexts/SampleDetailsAnnotation.svelte', () => ({
 }));
 
 vi.mock('$lib/hooks/useAnnotationLabels/useAnnotationLabels', () => ({
-    useAnnotationLabels: vi.fn(() => ({ data: [] }))
+    useAnnotationLabels: vi.fn(() => ({ data: mocks.annotationLabels }))
 }));
 
 vi.mock('$lib/hooks/useCreateAnnotation/useCreateAnnotation', () => ({
-    useCreateAnnotation: vi.fn(() => ({ createAnnotation: vi.fn() }))
+    useCreateAnnotation: vi.fn(() => ({ createAnnotation: mocks.createAnnotation }))
 }));
 
 vi.mock('$lib/hooks/useDeleteAnnotation/useDeleteAnnotation', () => ({
-    useDeleteAnnotation: vi.fn(() => ({ deleteAnnotation: vi.fn() }))
+    useDeleteAnnotation: vi.fn(() => ({ deleteAnnotation: mocks.deleteAnnotation }))
 }));
 
 vi.mock('$lib/hooks/useCreateLabel/useCreateLabel', () => ({
-    useCreateLabel: vi.fn(() => ({ createLabel: vi.fn() }))
+    useCreateLabel: vi.fn(() => ({ createLabel: mocks.createLabel }))
 }));
 
 vi.mock('$lib/hooks/useUpdateAnnotationsMutation/useUpdateAnnotationsMutation', () => ({
-    useUpdateAnnotationsMutation: vi.fn(() => ({ updateAnnotations: vi.fn() }))
+    useUpdateAnnotationsMutation: vi.fn(() => ({ updateAnnotations: mocks.updateAnnotations }))
 }));
 
 vi.mock('$lib/hooks/useCollection/useCollection', () => ({
-    useCollectionWithChildren: vi.fn(() => ({ refetch: vi.fn() }))
+    useCollectionWithChildren: vi.fn(() => ({ refetch: mocks.refetchRootCollection }))
 }));
 
 vi.mock('svelte-sonner', () => ({
@@ -140,6 +148,15 @@ describe('SampleDetailsClassificationSegment', () => {
         mocks.collections = [];
         mocks.selectedCollectionIds = [];
         mocks.lastCreatedAnnotationId = null;
+        mocks.annotationLabels = [];
+        mocks.deleteAnnotation.mockReset();
+        mocks.deleteAnnotation.mockResolvedValue(undefined);
+        mocks.createAnnotation.mockReset();
+        mocks.createAnnotation.mockResolvedValue({ sample_id: 'created-1' });
+        mocks.createLabel.mockReset();
+        mocks.updateAnnotations.mockReset();
+        mocks.updateAnnotations.mockResolvedValue(undefined);
+        mocks.addReversibleAction.mockReset();
         mocks.isEditingMode.set(false);
         mocks.enforceColoringByClassStore.set(false);
     });
@@ -328,5 +345,223 @@ describe('SampleDetailsClassificationSegment', () => {
         await user.click(screen.getByTestId('add-classification-button'));
         expect(screen.getAllByRole('combobox')).toHaveLength(4);
         expect(screen.getAllByTestId('add-classification-button')).toHaveLength(1);
+    });
+
+    it('names the add button for screen readers instead of leaving it as "+"', () => {
+        mocks.isEditingMode.set(true);
+        mocks.collections = [groundTruthSource];
+
+        render(SampleDetailsClassificationSegment, { props: defaultProps });
+
+        expect(screen.getByRole('button', { name: 'Add classification' })).toBeInTheDocument();
+    });
+
+    describe('deleting a classification', () => {
+        const renderEditableRow = () => {
+            mocks.isEditingMode.set(true);
+            mocks.collections = [groundTruthSource];
+            mocks.annotationLabels = [
+                { annotation_label_id: 'label-cat', annotation_label_name: 'cat' }
+            ];
+            const annotations = [
+                createClassification('c1', groundTruthSource.collection_id, 'cat')
+            ];
+
+            render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+
+            return screen.getByRole('button', { name: 'Delete classification' });
+        };
+
+        it('deletes once and stacks one undo action when clicked twice mid-flight', async () => {
+            const user = userEvent.setup();
+            let resolveDelete: () => void = () => {};
+            mocks.deleteAnnotation.mockImplementation(
+                () =>
+                    new Promise<void>((resolve) => {
+                        resolveDelete = resolve;
+                    })
+            );
+
+            const deleteButton = renderEditableRow();
+
+            await user.click(deleteButton);
+            await user.click(deleteButton);
+
+            expect(mocks.deleteAnnotation).toHaveBeenCalledTimes(1);
+            expect(mocks.deleteAnnotation).toHaveBeenCalledWith('c1', 'classification');
+            expect(mocks.addReversibleAction).toHaveBeenCalledTimes(1);
+
+            resolveDelete();
+        });
+
+        it('disables the button while the delete is in flight and re-enables it after', async () => {
+            const user = userEvent.setup();
+            let resolveDelete: () => void = () => {};
+            mocks.deleteAnnotation.mockImplementation(
+                () =>
+                    new Promise<void>((resolve) => {
+                        resolveDelete = resolve;
+                    })
+            );
+
+            const deleteButton = renderEditableRow();
+
+            await user.click(deleteButton);
+            expect(deleteButton).toBeDisabled();
+            expect(screen.getByTestId('button-progress')).toBeInTheDocument();
+
+            resolveDelete();
+
+            await waitFor(() => expect(deleteButton).not.toBeDisabled());
+            expect(screen.queryByTestId('button-progress')).not.toBeInTheDocument();
+        });
+
+        it('re-enables the button when the delete fails', async () => {
+            const user = userEvent.setup();
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+            mocks.deleteAnnotation.mockRejectedValue(new Error('network down'));
+
+            const deleteButton = renderEditableRow();
+
+            await user.click(deleteButton);
+
+            await waitFor(() => expect(deleteButton).not.toBeDisabled());
+            expect(mocks.deleteAnnotation).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('creating a classification', () => {
+        const openDraftRow = async (user: ReturnType<typeof userEvent.setup>) => {
+            mocks.isEditingMode.set(true);
+            mocks.collections = [groundTruthSource];
+            mocks.annotationLabels = [
+                { annotation_label_id: 'label-cat', annotation_label_name: 'cat' }
+            ];
+
+            render(SampleDetailsClassificationSegment, { props: defaultProps });
+
+            await user.click(screen.getByRole('button', { name: 'Add classification' }));
+            await user.click(screen.getByTestId('select-list-trigger'));
+        };
+
+        it('creates the annotation and drops the draft row when an existing class is picked', async () => {
+            const user = userEvent.setup();
+            await openDraftRow(user);
+
+            await user.click(screen.getByRole('option', { name: 'cat' }));
+
+            await waitFor(() =>
+                expect(mocks.createAnnotation).toHaveBeenCalledWith({
+                    parent_sample_id: 'sample-1',
+                    annotation_type: 'classification',
+                    annotation_label_id: 'label-cat',
+                    annotation_collection_name: undefined
+                })
+            );
+            expect(mocks.createLabel).not.toHaveBeenCalled();
+            // The sample had no classifications, so the root collection counts need a refresh.
+            expect(mocks.refetchRootCollection).toHaveBeenCalled();
+            expect(mocks.addReversibleAction).toHaveBeenCalledTimes(1);
+            await waitFor(() => expect(screen.queryByRole('combobox')).not.toBeInTheDocument());
+        });
+
+        it('creates the class first when the typed name is new', async () => {
+            const user = userEvent.setup();
+            mocks.createLabel.mockResolvedValue({
+                annotation_label_id: 'label-otter',
+                annotation_label_name: 'otter'
+            });
+            await openDraftRow(user);
+
+            await user.type(screen.getByTestId('select-list-input'), 'otter{Enter}');
+
+            await waitFor(() =>
+                expect(mocks.createLabel).toHaveBeenCalledWith({
+                    dataset_id: 'dataset-1',
+                    annotation_label_name: 'otter'
+                })
+            );
+            expect(mocks.createAnnotation).toHaveBeenCalledWith(
+                expect.objectContaining({ annotation_label_id: 'label-otter' })
+            );
+        });
+
+        it('drops the draft row when its trash button is clicked', async () => {
+            const user = userEvent.setup();
+            mocks.isEditingMode.set(true);
+            mocks.collections = [groundTruthSource];
+
+            render(SampleDetailsClassificationSegment, { props: defaultProps });
+
+            await user.click(screen.getByRole('button', { name: 'Add classification' }));
+            expect(screen.getByRole('combobox')).toBeInTheDocument();
+
+            await user.click(screen.getByRole('button', { name: 'Remove classification draft' }));
+
+            expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+            expect(mocks.createAnnotation).not.toHaveBeenCalled();
+        });
+
+        it('keeps the draft row when the create fails', async () => {
+            const user = userEvent.setup();
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+            mocks.createAnnotation.mockRejectedValue(new Error('network down'));
+            await openDraftRow(user);
+
+            await user.click(screen.getByRole('option', { name: 'cat' }));
+
+            await waitFor(() => expect(mocks.createAnnotation).toHaveBeenCalled());
+            expect(screen.getByRole('combobox')).toBeInTheDocument();
+        });
+    });
+
+    describe('changing a classification label', () => {
+        const renderEditableRow = () => {
+            mocks.isEditingMode.set(true);
+            mocks.collections = [groundTruthSource];
+            mocks.annotationLabels = [
+                { annotation_label_id: 'label-cat', annotation_label_name: 'cat' },
+                { annotation_label_id: 'label-dog', annotation_label_name: 'dog' }
+            ];
+            const annotations = [
+                createClassification('c1', groundTruthSource.collection_id, 'cat')
+            ];
+
+            render(SampleDetailsClassificationSegment, { props: { ...defaultProps, annotations } });
+        };
+
+        it('shows the current class on the trigger and updates on selection', async () => {
+            const user = userEvent.setup();
+            renderEditableRow();
+
+            expect(screen.getByTestId('select-list-trigger')).toHaveTextContent('cat');
+
+            await user.click(screen.getByTestId('select-list-trigger'));
+            await user.click(screen.getByRole('option', { name: 'dog' }));
+
+            await waitFor(() =>
+                expect(mocks.updateAnnotations).toHaveBeenCalledWith([
+                    {
+                        annotation_id: 'c1',
+                        collection_id: 'collection-1',
+                        label_name: 'dog'
+                    }
+                ])
+            );
+            // The undo entry is pushed before the request, so the old class can be restored.
+            expect(mocks.addReversibleAction).toHaveBeenCalledTimes(1);
+        });
+
+        it('reports an error when the update fails', async () => {
+            const user = userEvent.setup();
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+            mocks.updateAnnotations.mockRejectedValue(new Error('network down'));
+            renderEditableRow();
+
+            await user.click(screen.getByTestId('select-list-trigger'));
+            await user.click(screen.getByRole('option', { name: 'dog' }));
+
+            await waitFor(() => expect(toast.error).toHaveBeenCalled());
+        });
     });
 });


### PR DESCRIPTION
## What has changed and why?

Migrates the last raw `<button>` element in `SampleDetailsClassificationSegment.svelte` (delete-classification icon button and the add-draft-classification button) to the shared `Button` component, for the same consistency reasons as the previous two PRs in this stack. Not async, so no `isPending` wiring here.

## How has it been tested?

- `make static-checks` and the component's unit tests pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated classification controls to use the app’s shared button styling for a more consistent interface.
  * Preserved the existing appearance and visible add action.

* **Bug Fixes**
  * Prevented duplicate delete requests while an annotation removal is in progress.
  * Preserved classification add, delete, and draft-removal behavior, including click handling.
  * Improved handling of failed removal and label-update actions so unsaved information is retained when appropriate.
  * Improved accessibility labeling for the add-classification action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->