### PR TITLE
docs: document supplying your own embeddings

### DIFF
--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -154,9 +154,7 @@ EMBEDDING_DIMENSION = 512
 
 class CustomEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
     def __init__(self) -> None:
-        self._filepath_to_embedding: dict[str, NDArray[np.float32]] = (
-            ...  # Implement the loading logic here.
-        )
+        self._filepath_to_embedding: dict[str, NDArray[np.float32]] = ...  # Implement the loading logic here.
 
     def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate: ...
 

--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -95,8 +95,9 @@ You may want to replace the built-in models — for example to use a domain-spec
 model, or to reuse vectors you already computed in another pipeline.
 
 Both cases use the same mechanism: e.g. for images, implement the `ImageEmbeddingGenerator`
-protocol and register it with `ls.set_default_embedding_model(...)` **before** you create or
-add to a dataset. The only difference is what your implementation of `embed_images` does inside.
+protocol and register it with `ls.set_default_embedding_model(...)` **before** you add to
+a dataset and launch the GUI. The only difference is what your implementation of `embed_images`
+does inside.
 
 | Use-case | What `embed_images` does | Example |
 |---|---|---|
@@ -111,13 +112,13 @@ Implement these protocol methods based on your needs. The
     - `embed_text` to override the text search model.
 - **`ImageEmbeddingGenerator`**:
     - `embed_images` to override the image embedding model.
-    - `embed_image_crops` to override the model for embeding annotations.
+    - `embed_image_crops` to override the model for embedding annotations.
     - `embed_pil_images` to override the model to embed video frames.
 - **`VideoEmbeddingGenerator`**:
-    - `embed_videos`. To override the video embedding model.
+    - `embed_videos` to override the video embedding model.
 
 `ImageEmbeddingGenerator` and `VideoEmbeddingGenerator` both extend the base protocol.
-If you don't need an embedding method raise the `NotImplemented` exception.
+If you don't need an embedding method raise the `NotImplementedError` exception.
 
 Examples below show how an override is done for `ImageEmbeddingGenerator`.
 
@@ -192,6 +193,8 @@ import numpy as np
 import lightly_studio as ls
 from lightly_studio.dataset.embedding_result import EmbeddingResult
 
+EMBEDDING_DIMENSION = 512
+
 
 class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
     def __init__(self):
@@ -213,11 +216,15 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
                 continue
             vectors.append(self._model.encode(image))
             kept_indices.append(index)
-        embeddings = np.stack(vectors).astype(np.float32)
+        embeddings = (
+            np.stack(vectors).astype(np.float32)
+            if vectors
+            else np.empty((0, EMBEDDING_DIMENSION), dtype=np.float32)
+        )
         return EmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
 
 
-ls.set_default_embedding_model(CustomEmbeddingsGenerator())
+ls.set_default_embedding_model(CustomEmbeddingGenerator())
 ```
 
 For the full runnable version, which wraps MobileCLIP and also implements

--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -96,7 +96,7 @@ model, or to reuse vectors you already computed in another pipeline.
 
 Both cases use the same mechanism: e.g. for images, implement the `ImageEmbeddingGenerator`
 protocol and register it with `ls.set_default_embedding_model(...)` **before** you add to
-a dataset and launch the GUI. The only difference is what your implementation of `embed_images`
+a dataset or launch the GUI. The only difference is what your implementation of `embed_images`
 does inside.
 
 | Use-case | What `embed_images` does | Example |

--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -123,11 +123,8 @@ Examples below show how an override is done for `ImageEmbeddingGenerator`.
 
 !!! warning "Some methods also run while the GUI is open"
     LightlyStudio calls your generator at two points: when you add data, and while the
-    GUI is open to answer search queries. `embed_text` runs when a user searches by
-    text, and `embed_images` runs when a user searches by an uploaded image. If a method
-    raises `NotImplementedError`, its search feature is not available in the GUI. A
-    lookup-based `embed_images` has the same effect for a new image: the uploaded file
-    is not in your store, so search by an uploaded image does not work.
+    GUI is open to answer search queries. If a method raises `NotImplementedError`,
+    its search feature is not available in the GUI.
 
 ### Loading precomputed embeddings
 

--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -85,4 +85,148 @@ You can:
 - **Sampling** strategies such as diverse, deduplication, similarity, and
   typicality/outliers. See [Sampling](sampling.md).
 
-<!-- TODO(Michal, 08/2026) ## Using Your Own Embeddings -->
+## Using Your Own Embeddings
+
+!!! example "Beta API"
+    The embeddings API is in beta. Its interface may change in future releases
+    without a deprecation period.
+
+You may want to replace the built-in models — for example to use a domain-specific
+model, or to reuse vectors you already computed in another pipeline.
+
+Both cases use the same mechanism: e.g. for images, implement the `ImageEmbeddingGenerator`
+protocol and register it with `ls.set_default_embedding_model(...)` **before** you create or
+add to a dataset. The only difference is what your implementation of `embed_images` does inside.
+
+| Use-case | What `embed_images` does | Example |
+|---|---|---|
+| Compute embeddings on the fly | Runs your model on the given file paths | [`example_custom_embedding_model.py`](https://github.com/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py) |
+| Load precomputed embeddings | Looks up stored vectors by file path | [`example_load_existing_embeddings.py`](https://github.com/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py) |
+
+Implement these protocol methods based on your needs. The
+[API reference](../api/embeddings.md) gives the full method signatures:
+
+- **`EmbeddingGenerator`** (base):
+    - `get_embedding_model_input` to describe the model to the database.
+    - `embed_text` to override the text search model.
+- **`ImageEmbeddingGenerator`**:
+    - `embed_images` to override the image embedding model.
+    - `embed_image_crops` to override the model for embeding annotations.
+    - `embed_pil_images` to override the model to embed video frames.
+- **`VideoEmbeddingGenerator`**:
+    - `embed_videos`. To override the video embedding model.
+
+`ImageEmbeddingGenerator` and `VideoEmbeddingGenerator` both extend the base protocol.
+If you don't need an embedding method raise the `NotImplemented` exception.
+
+Examples below show how an override is done for `ImageEmbeddingGenerator`.
+
+!!! warning "Some methods also run while the GUI is open"
+    LightlyStudio calls your generator at two points: when you add data, and while the
+    GUI is open to answer search queries. `embed_text` runs when a user searches by
+    text, and `embed_images` runs when a user searches by an uploaded image. If a method
+    raises `NotImplementedError`, its search feature is not available in the GUI. A
+    lookup-based `embed_images` has the same effect for a new image: the uploaded file
+    is not in your store, so search by an uploaded image does not work.
+
+### Loading precomputed embeddings
+
+Use this when you already have vectors — from a previous run, an external pipeline,
+or a research model. Instead of running a model, `embed_images` looks up each file
+path in your store.
+
+`embed_images(filepaths)` returns an `EmbeddingResult(embeddings, kept_indices)`.
+Return a matrix with one row for each file path you have a vector for, and use `kept_indices`
+to list which input positions those rows belong to. This lets you skip any file path
+that has no vector.
+
+```python
+import numpy as np
+
+import lightly_studio as ls
+from lightly_studio.dataset.embedding_result import EmbeddingResult
+
+EMBEDDING_DIMENSION = 512
+
+
+class CustomEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
+    def __init__(self):
+        self._filepath_to_embedding = ...  # Implement the loading logic here.
+
+    def get_embedding_model_input(self, collection_id): ...
+
+    def embed_text(self, text): ...
+
+    def embed_image_crops(self, image_crops, show_progress=True): ...
+
+    def embed_pil_images(self, images, show_progress=True): ...
+
+    def embed_images(self, filepaths, show_progress=True) -> EmbeddingResult:
+        rows, kept_indices = [], []
+        for index, filepath in enumerate(filepaths):
+            embedding = self._filepath_to_embedding.get(filepath)
+            if embedding is None:
+                continue  # No vector for this path, so skip it.
+            rows.append(embedding)
+            kept_indices.append(index)
+        embeddings = (
+            np.stack(rows).astype(np.float32)
+            if rows
+            else np.empty((0, EMBEDDING_DIMENSION), dtype=np.float32)
+        )
+        return EmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
+
+
+ls.set_default_embedding_model(CustomEmbeddingsGenerator())
+```
+
+For the full runnable version, including how to key vectors by the absolute path that
+the backend stores, see
+[`example_load_existing_embeddings.py`](https://github.com/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py).
+
+### Computing embeddings on the fly
+
+Use this when you want a different model than the built-ins. Load your model in
+`__init__` and run it inside `embed_images`.
+
+```python
+import numpy as np
+
+import lightly_studio as ls
+from lightly_studio.dataset.embedding_result import EmbeddingResult
+
+
+class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
+    def __init__(self):
+        ...  # Load your model and preprocessing here.
+
+    def get_embedding_model_input(self, collection_id): ...
+
+    def embed_text(self, text): ...
+
+    def embed_image_crops(self, image_crops, show_progress=True): ...
+
+    def embed_pil_images(self, images, show_progress=True): ...
+
+    def embed_images(self, filepaths, show_progress=True) -> EmbeddingResult:
+        kept_indices, vectors = [], []
+        for index, filepath in enumerate(filepaths):
+            image = self._load(filepath)  # Skip a file you cannot read.
+            if image is None:
+                continue
+            vectors.append(self._model.encode(image))
+            kept_indices.append(index)
+        embeddings = np.stack(vectors).astype(np.float32)
+        return EmbeddingResult(embeddings=embeddings, kept_indices=kept_indices)
+
+
+ls.set_default_embedding_model(CustomEmbeddingsGenerator())
+```
+
+For the full runnable version, which wraps MobileCLIP and also implements
+`embed_text`, `embed_image_crops`, and `embed_pil_images`, see
+[`example_custom_embedding_model.py`](https://github.com/lightly-ai/lightly-studio/blob/main/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py).
+
+!!! note "Text search needs a shared text encoder"
+    For the text search to return meaningful results, your image and text encoder must share the
+    same embedding space.

--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -139,28 +139,42 @@ to list which input positions those rows belong to. This lets you skip any file 
 that has no vector.
 
 ```python
+from uuid import UUID
+
 import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
 
 import lightly_studio as ls
 from lightly_studio.dataset.embedding_result import EmbeddingResult
+from lightly_studio.models.embedding_model import EmbeddingModelCreate
 
 EMBEDDING_DIMENSION = 512
 
 
 class CustomEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
-    def __init__(self):
-        self._filepath_to_embedding = ...  # Implement the loading logic here.
+    def __init__(self) -> None:
+        self._filepath_to_embedding: dict[str, NDArray[np.float32]] = (
+            ...  # Implement the loading logic here.
+        )
 
-    def get_embedding_model_input(self, collection_id): ...
+    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate: ...
 
-    def embed_text(self, text): ...
+    def embed_text(self, text: str) -> list[float]: ...
 
-    def embed_image_crops(self, image_crops, show_progress=True): ...
+    def embed_image_crops(
+        self, image_crops: list[ls.ImageCrop], show_progress: bool = True
+    ) -> EmbeddingResult: ...
 
-    def embed_pil_images(self, images, show_progress=True): ...
+    def embed_pil_images(
+        self, images: list[Image.Image], show_progress: bool = True
+    ) -> NDArray[np.float32]: ...
 
-    def embed_images(self, filepaths, show_progress=True) -> EmbeddingResult:
-        rows, kept_indices = [], []
+    def embed_images(
+        self, filepaths: list[str], show_progress: bool = True
+    ) -> EmbeddingResult:
+        rows: list[NDArray[np.float32]] = []
+        kept_indices: list[int] = []
         for index, filepath in enumerate(filepaths):
             embedding = self._filepath_to_embedding.get(filepath)
             if embedding is None:
@@ -188,28 +202,40 @@ Use this when you want a different model than the built-ins. Load your model in
 `__init__` and run it inside `embed_images`.
 
 ```python
+from uuid import UUID
+
 import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
 
 import lightly_studio as ls
 from lightly_studio.dataset.embedding_result import EmbeddingResult
+from lightly_studio.models.embedding_model import EmbeddingModelCreate
 
 EMBEDDING_DIMENSION = 512
 
 
 class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
-    def __init__(self):
+    def __init__(self) -> None:
         ...  # Load your model and preprocessing here.
 
-    def get_embedding_model_input(self, collection_id): ...
+    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate: ...
 
-    def embed_text(self, text): ...
+    def embed_text(self, text: str) -> list[float]: ...
 
-    def embed_image_crops(self, image_crops, show_progress=True): ...
+    def embed_image_crops(
+        self, image_crops: list[ls.ImageCrop], show_progress: bool = True
+    ) -> EmbeddingResult: ...
 
-    def embed_pil_images(self, images, show_progress=True): ...
+    def embed_pil_images(
+        self, images: list[Image.Image], show_progress: bool = True
+    ) -> NDArray[np.float32]: ...
 
-    def embed_images(self, filepaths, show_progress=True) -> EmbeddingResult:
-        kept_indices, vectors = [], []
+    def embed_images(
+        self, filepaths: list[str], show_progress: bool = True
+    ) -> EmbeddingResult:
+        kept_indices: list[int] = []
+        vectors: list[NDArray[np.float32]] = []
         for index, filepath in enumerate(filepaths):
             image = self._load(filepath)  # Skip a file you cannot read.
             if image is None:


### PR DESCRIPTION
## What has changed and why?

Fills in the stubbed "Using Your Own Embeddings" section of the embeddings docs..

## How has it been tested?

Docs only. Checked the protocol methods, API references, and example links against the code.

Manuallly.
```
cd lightly_studio/docs
make serve
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring custom embedding generators in LightlyStudio.
  * Documented the beta API, registration process, supported methods, and GUI behavior.
  * Included examples for loading precomputed vectors and generating embeddings with custom models.
  * Explained handling missing or unreadable inputs with embedding results and kept indices.
  * Replaced the previous placeholder with complete guidance and working examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->