### PR TITLE
Add keyboard shortcut to focus docs search

### DIFF
--- a/lightly_studio/docs/docs/_static/custom.css
+++ b/lightly_studio/docs/docs/_static/custom.css
@@ -31,7 +31,7 @@
 }
 
 /* Hide hint while search overlay is open */
-.md-search--active .search-shortcut-hint {
+input[data-md-toggle="search"]:checked ~ .md-header .search-shortcut-hint {
     display: none;
 }
 

--- a/lightly_studio/docs/docs/_static/custom.css
+++ b/lightly_studio/docs/docs/_static/custom.css
@@ -1,3 +1,40 @@
+/* Keyboard shortcut hint inside the search input */
+.md-search__form {
+    position: relative;
+}
+
+.search-shortcut-hint {
+    position: absolute;
+    right: 0.6rem;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    pointer-events: none;
+    opacity: 0.55;
+    transition: opacity 0.2s;
+}
+
+.search-shortcut-hint kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.1rem 0.35rem;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 0.25rem;
+    font-family: inherit;
+    font-size: 0.6rem;
+    line-height: 1.4;
+    color: rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.1);
+    box-shadow: none;
+}
+
+/* Hide hint while search overlay is open */
+.md-search--active .search-shortcut-hint {
+    display: none;
+}
+
 /* Card styling with rounded corners */
 .md-typeset .grid.cards > ol > li,
 .md-typeset .grid.cards > ul > li {

--- a/lightly_studio/docs/docs/_static/custom.js
+++ b/lightly_studio/docs/docs/_static/custom.js
@@ -1,0 +1,26 @@
+document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        const searchInput = document.querySelector('.md-search__input');
+        if (searchInput) {
+            searchInput.focus();
+        }
+    }
+});
+
+// Inject a ⌘K / Ctrl+K hint badge into the search form
+function addSearchShortcutHint() {
+    if (document.querySelector('.search-shortcut-hint')) return;
+    const searchForm = document.querySelector('.md-search__form');
+    if (!searchForm) return;
+
+    const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+    const hint = document.createElement('div');
+    hint.className = 'search-shortcut-hint';
+    hint.innerHTML = isMac
+        ? '<kbd>\u2318K</kbd>'
+        : '<kbd>Ctrl+K</kbd>';
+    searchForm.appendChild(hint);
+}
+
+document.addEventListener('DOMContentLoaded', addSearchShortcutHint);

--- a/lightly_studio/docs/docs/_static/custom.js
+++ b/lightly_studio/docs/docs/_static/custom.js
@@ -1,6 +1,11 @@
 document.addEventListener('keydown', function (e) {
-    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+    if ((e.metaKey || e.ctrlKey) && e.code === 'KeyK') {
         e.preventDefault();
+        const searchToggle = document.querySelector('input[data-md-toggle="search"]');
+        if (searchToggle && !searchToggle.checked) {
+            searchToggle.checked = true;
+            searchToggle.dispatchEvent(new Event('change'));
+        }
         const searchInput = document.querySelector('.md-search__input');
         if (searchInput) {
             searchInput.focus();
@@ -8,16 +13,22 @@ document.addEventListener('keydown', function (e) {
     }
 });
 
+function isMacPlatform() {
+    if (navigator.userAgentData) {
+        return navigator.userAgentData.platform === 'macOS';
+    }
+    return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+}
+
 // Inject a ⌘K / Ctrl+K hint badge into the search form
 function addSearchShortcutHint() {
     if (document.querySelector('.search-shortcut-hint')) return;
     const searchForm = document.querySelector('.md-search__form');
     if (!searchForm) return;
 
-    const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
     const hint = document.createElement('div');
     hint.className = 'search-shortcut-hint';
-    hint.innerHTML = isMac
+    hint.innerHTML = isMacPlatform()
         ? '<kbd>\u2318K</kbd>'
         : '<kbd>Ctrl+K</kbd>';
     searchForm.appendChild(hint);

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -101,6 +101,9 @@ validation:
 extra_css:
   - _static/custom.css
 
+extra_javascript:
+  - _static/custom.js
+
 plugins:
   - search
   - mkdocstrings:


### PR DESCRIPTION
## What has changed and why?

Users can now press Command + K (Mac) or Ctrl+K (Windows/Linux) anywhere on the documentation site to instantly jump to the search bar - no need to scroll up and click on it.

A small shortcut badge is also shown inside the search bar itself, so users discover the shortcut naturally without having to look it up.

<img width="628" height="118" alt="Screenshot 2026-08-11 at 07 45 23" src="https://github.com/user-attachments/assets/283579ed-564a-4ec0-a5ef-9e8beb78958f" />

## How has it been tested?

Manual tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ⌘K/Ctrl+K shortcut to quickly focus documentation search.
  * Added a platform-specific keyboard shortcut hint to the search form.
  * Improved shortcut hint styling and visibility while search is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->