### PR TITLE
fast_track: dismiss the bot approval only on a failing run

### DIFF
--- a/fast_track/README.md
+++ b/fast_track/README.md
@@ -15,6 +15,21 @@ invalid, or stale verdict revokes the bot approval. Add the `no-fast-track`
 label to opt out and defer to a human. Locally, `make run-guardrails` judges
 committed changes.
 
+## Trust and approval model
+
+The guardrails CI runs from the current branch while the bot CI runs from main.
+Therefore the bot code is considered trusted; guardrails code less so.
+
+The bot approves the PR if the guardrails pass. However, the main branch protection
+is set up with CODEOWNERS so that for certain paths a Lightly team member approval
+is required. In particular, if the code touches guardrails or CI.
+
+The bot is benevolent in dismissing its past approvals. It does so only when a new bot run
+(after a new push) observes failed guardrails. Therefore there is a window when the PR
+might be approved but the newest potentially failing commit would fail the guardrails.
+This is intentional; it alignes with the current philosophy of not dismissing stale approvals
+to allow a faster development cycle.
+
 ## Local commands
 
 ```bash

--- a/fast_track/README.md
+++ b/fast_track/README.md
@@ -21,13 +21,13 @@ The guardrails CI runs from the current branch while the bot CI runs from main.
 Therefore the bot code is considered trusted; guardrails code less so.
 
 The bot approves the PR if the guardrails pass. However, the main branch protection
-is set up with CODEOWNERS so that for certain paths a Lightly team member approval
-is required. In particular, if the code touches guardrails or CI.
+is set up with CODEOWNERS so that for certain paths a Lightly team member must
+approve, in particular when the code touches the guardrails or CI.
 
-The bot is benevolent in dismissing its past approvals. It does so only when a new bot run
-(after a new push) observes failed guardrails. Therefore there is a window when the PR
-might be approved but the newest potentially failing commit would fail the guardrails.
-This is intentional; it alignes with the current philosophy of not dismissing stale approvals
+The bot is conservative in dismissing its past approvals. It does so only when a new
+bot run (after a new push) does not pass. Therefore there is a window when the PR
+keeps an approval while a newer commit has not been re-judged yet. This is
+intentional; it aligns with the current philosophy of not dismissing stale approvals
 to allow a faster development cycle.
 
 ## Local commands

--- a/fast_track/README.md
+++ b/fast_track/README.md
@@ -24,11 +24,10 @@ The bot approves the PR if the guardrails pass. However, the main branch protect
 is set up with CODEOWNERS so that for certain paths a Lightly team member must
 approve, in particular when the code touches the guardrails or CI.
 
-The bot is conservative in dismissing its past approvals. It does so only when a new
-bot run (after a new push) does not pass. Therefore there is a window when the PR
-keeps an approval while a newer commit has not been re-judged yet. This is
-intentional; it aligns with the current philosophy of not dismissing stale approvals
-to allow a faster development cycle.
+The bot dismisses its past approvals only when a new bot run (after a new push)
+does not pass. Therefore there is a window when the PR keeps an approval while
+a newer commit has not been judged yet. This is intentional; it aligns with the
+current philosophy of not dismissing stale approvals for faster development.
 
 ## Local commands
 

--- a/fast_track/src/bot/review.test.ts
+++ b/fast_track/src/bot/review.test.ts
@@ -60,21 +60,21 @@ describe('approve', () => {
         expect(fake.dismissReview).not.toHaveBeenCalled();
     });
 
-    it('refreshes an approval and dismisses the superseded one', async () => {
+    it('keeps an existing approval on an earlier commit without re-approving or dismissing', async () => {
         const fake = fakeOctokit([{ id: 1, login: BOT_LOGIN, state: 'APPROVED', commitId: 'old' }]);
-        await expect(approve(buildReviewParams(fake.octokit))).resolves.toBe('approved');
-        expect(fake.createReview).toHaveBeenCalledOnce();
-        expect(fake.dismissReview).toHaveBeenCalledWith(expect.objectContaining({ review_id: 1 }));
+        await expect(approve(buildReviewParams(fake.octokit))).resolves.toBe('noop');
+        expect(fake.createReview).not.toHaveBeenCalled();
+        expect(fake.dismissReview).not.toHaveBeenCalled();
     });
 
-    it('keeps only one approval when duplicate approvals exist for the current head', async () => {
+    it('leaves duplicate approvals untouched instead of churning reviews', async () => {
         const fake = fakeOctokit([
             { id: 1, login: BOT_LOGIN, state: 'APPROVED', commitId: HEAD_SHA },
             { id: 2, login: BOT_LOGIN, state: 'APPROVED', commitId: HEAD_SHA }
         ]);
         await expect(approve(buildReviewParams(fake.octokit))).resolves.toBe('noop');
         expect(fake.createReview).not.toHaveBeenCalled();
-        expect(fake.dismissReview).toHaveBeenCalledOnce();
+        expect(fake.dismissReview).not.toHaveBeenCalled();
     });
 });
 

--- a/fast_track/src/bot/review.ts
+++ b/fast_track/src/bot/review.ts
@@ -1,7 +1,6 @@
 import type { Octokit } from '../shared/octokit';
 
 const DISMISS_MESSAGE = 'Fast Track checks no longer pass; dismissing the bot approval.';
-const SUPERSEDED_MESSAGE = 'Superseded by a newer Fast Track approval.';
 
 interface ReviewParams {
     octokit: Octokit;
@@ -15,27 +14,28 @@ interface ApproveParams extends ReviewParams {
     headSha: string;
 }
 
-/** Keep exactly one active bot approval, bound to the validated head. */
+/**
+ * Ensure the bot has an active approval, without churning reviews on a pass.
+ *
+ * A passing run must not dismiss and re-create the approval on every push: that
+ * generates downstream review events for no gain. So an existing bot approval is
+ * left in place, even when it is bound to an earlier commit — the fresh pass
+ * confirms it still holds, and the status comment carries the new head SHA. Only
+ * a failing run dismisses (see `dismissApproval`). An approval is created only
+ * when none exists yet, binding it to the validated head.
+ */
 export async function approve(params: ApproveParams): Promise<'approved' | 'noop'> {
     const reviews = await listBotApprovals(params);
-    const current = reviews.find((review) => review.commit_id === params.headSha);
+    if (reviews.length > 0) return 'noop';
 
-    if (current === undefined) {
-        await params.octokit.rest.pulls.createReview({
-            owner: params.owner,
-            repo: params.repo,
-            pull_number: params.prNumber,
-            commit_id: params.headSha,
-            event: 'APPROVE'
-        });
-    }
-
-    await dismissReviews(
-        params,
-        reviews.filter((review) => review !== current),
-        SUPERSEDED_MESSAGE
-    );
-    return current === undefined ? 'approved' : 'noop';
+    await params.octokit.rest.pulls.createReview({
+        owner: params.owner,
+        repo: params.repo,
+        pull_number: params.prNumber,
+        commit_id: params.headSha,
+        event: 'APPROVE'
+    });
+    return 'approved';
 }
 
 /** Dismiss only the App's active approvals, never a human review. */

--- a/fast_track/src/bot/review.ts
+++ b/fast_track/src/bot/review.ts
@@ -15,14 +15,7 @@ interface ApproveParams extends ReviewParams {
 }
 
 /**
- * Ensure the bot has an active approval, without churning reviews on a pass.
- *
- * A passing run must not dismiss and re-create the approval on every push: that
- * generates downstream review events for no gain. So an existing bot approval is
- * left in place, even when it is bound to an earlier commit — the fresh pass
- * confirms it still holds, and the status comment carries the new head SHA. Only
- * a failing run dismisses (see `dismissApproval`). An approval is created only
- * when none exists yet, binding it to the validated head.
+ * Approve only when no bot approval exists yet.
  */
 export async function approve(params: ApproveParams): Promise<'approved' | 'noop'> {
     const reviews = await listBotApprovals(params);

--- a/fast_track/src/bot/run-bot.test.ts
+++ b/fast_track/src/bot/run-bot.test.ts
@@ -168,6 +168,14 @@ describe('runBot', () => {
         expect(execution.createComment).toHaveBeenCalledOnce();
     });
 
+    it('keeps an existing approval on a current pass without churning reviews', async () => {
+        const execution = run(verdict(), { existingApproval: true });
+        await expect(execution.result).resolves.toEqual({ status: 'approved', prNumber: 7 });
+        expect(execution.createReview).not.toHaveBeenCalled();
+        expect(execution.dismissReview).not.toHaveBeenCalled();
+        expect(execution.createComment).toHaveBeenCalledOnce();
+    });
+
     it('dismisses an existing approval on a failure verdict', async () => {
         const execution = run(verdict({ verdict: 'fail', reason: 'Human review required.' }), {
             existingApproval: true


### PR DESCRIPTION
## What has changed and why?

The Fast Track bot dismissed and re-created its approval on every push, sending review events that triggered downstream automations. It now keeps one approval across passing pushes and dismisses only when a new run fails. The approval stays on the first passing commit, and the status comment tracks the current head SHA.

This relies on branch protection keeping "dismiss stale approvals on push" off, now documented in the `fast_track` README.

## How has it been tested?

`make static-checks` and `make test` in `fast_track` — updated the `approve` unit tests and added end-to-end cases for the no-churn behavior.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Existing bot approvals are now preserved, including approvals from earlier commits.
  - Duplicate approvals on the current commit are left unchanged.
  - Approval actions no longer dismiss or replace existing bot approvals.
  - Passing bot checks continue to post comments without creating additional reviews.

- **Documentation**
  - Added guidance on trust, approval guardrails, required approvals, and bot approval timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->