### PR TITLE
Split the general E2E jobs into three shards

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -206,21 +206,29 @@ jobs:
             success_key: e2e-success-evaluations
             artifact_name: Playwright Report (Evaluations)
             postgres: false
-          - name: General Postgres 1 of 2
+          - name: General Postgres 1 of 3
             index_script: index_general.py
             playwright_project: general
-            shard: "1/2"
+            shard: "1/3"
             success_marker: .e2e-success-general-postgres-1
             success_key: e2e-success-general-postgres-1
             artifact_name: Playwright Report (General Postgres 1)
             postgres: true
-          - name: General Postgres 2 of 2
+          - name: General Postgres 2 of 3
             index_script: index_general.py
             playwright_project: general
-            shard: "2/2"
+            shard: "2/3"
             success_marker: .e2e-success-general-postgres-2
             success_key: e2e-success-general-postgres-2
             artifact_name: Playwright Report (General Postgres 2)
+            postgres: true
+          - name: General Postgres 3 of 3
+            index_script: index_general.py
+            playwright_project: general
+            shard: "3/3"
+            success_marker: .e2e-success-general-postgres-3
+            success_key: e2e-success-general-postgres-3
+            artifact_name: Playwright Report (General Postgres 3)
             postgres: true
           - name: Videos Postgres
             index_script: index_video.py

--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -158,21 +158,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: General 1 of 2
+          - name: General 1 of 3
             index_script: index_general.py
             playwright_project: general
-            shard: "1/2"
+            shard: "1/3"
             success_marker: .e2e-success-general-1
             success_key: e2e-success-general-1
             artifact_name: Playwright Report (General 1)
             postgres: false
-          - name: General 2 of 2
+          - name: General 2 of 3
             index_script: index_general.py
             playwright_project: general
-            shard: "2/2"
+            shard: "2/3"
             success_marker: .e2e-success-general-2
             success_key: e2e-success-general-2
             artifact_name: Playwright Report (General 2)
+            postgres: false
+          - name: General 3 of 3
+            index_script: index_general.py
+            playwright_project: general
+            shard: "3/3"
+            success_marker: .e2e-success-general-3
+            success_key: e2e-success-general-3
+            artifact_name: Playwright Report (General 3)
             postgres: false
           - name: Videos
             index_script: index_video.py
@@ -375,7 +383,7 @@ jobs:
         working-directory: lightly_studio_view
         run: >-
           npx playwright test
-          --reporter=html
+          --reporter=html,list
           --trace=on
           --project=${{ matrix.playwright_project }}
           --shard=${{ matrix.shard }}


### PR DESCRIPTION
## What has changed and why?

The `general` Playwright project has 67 tests and runs with `workers: 1`, so a shard's wall clock is just the sum of its tests. Across two shards the heavier one carried 35, against the step's 6-minute `timeout-minutes` budget. A third shard brings the worst case down to 25.

Both matrix legs get the extra shard, taking four jobs to six: `General 1-3 of 3` and `General Postgres 1-3 of 3`, each with its own success-marker cache key and report artifact.

Also added the `list` reporter alongside `html`. The HTML report is only uploaded on failure, so reading per-test durations means downloading the artifact; `list` streams each test to the job log as it finishes.

## How has it been tested?

`npx playwright test --project=general --shard=N/3 --list` locally: 25 / 20 / 22 tests, against 35 / 32 before. No test code changed, only the workflow matrix.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
