### PR TITLE
fast_track: add the frontend Istanbul coverage report parser

### DIFF
--- a/fast_track/src/guardrails/frontend/coverage.test.ts
+++ b/fast_track/src/guardrails/frontend/coverage.test.ts
@@ -13,7 +13,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { existsSync, readFileSync } from 'node:fs';
-import { fileCoverageRatio, frontendCoverageGuardrail } from './coverage';
+import { fileCoverageRatio, frontendCoverageGuardrail, parseFrontendReport } from './coverage';
 import { FRONTEND_ABS, FRONTEND_PREFIX } from './eslint-runner';
 import type { ChangedFile, GuardrailContext } from '../context/types';
 
@@ -153,6 +153,76 @@ describe('fileCoverageRatio', () => {
             s: {}
         };
         expect(fileCoverageRatio(entry, new Set([1]))).toBe(0);
+    });
+});
+
+describe('parseFrontendReport', () => {
+    it('maps absolute report keys to repo-relative paths', () => {
+        const report = parseFrontendReport(JSON.stringify(FULL_COVERAGE_DATA));
+        expect([...report.keys()]).toEqual([`${FRONTEND_PREFIX}src/lib/foo.ts`]);
+    });
+
+    it('skips entries whose path is outside the frontend prefix', () => {
+        const report = parseFrontendReport(
+            JSON.stringify({
+                '/some/other/repo/src/foo.ts': {
+                    statementMap: {
+                        '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } }
+                    },
+                    s: { '0': 1 }
+                }
+            })
+        );
+        expect(report.size).toBe(0);
+    });
+
+    it('marks a line executable if any statement covers it, covered if any covering statement has hits', () => {
+        const report = parseFrontendReport(
+            JSON.stringify({
+                [`${FRONTEND_ABS}/src/lib/foo.ts`]: {
+                    statementMap: {
+                        '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+                        '1': { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } }
+                    },
+                    s: { '0': 1, '1': 0 }
+                }
+            })
+        );
+        const entry = report.get(`${FRONTEND_PREFIX}src/lib/foo.ts`);
+        expect([...entry!.executable].sort()).toEqual([1, 2]);
+        expect([...entry!.covered].sort()).toEqual([1]);
+    });
+
+    it('spans every line of a multi-line statement', () => {
+        const report = parseFrontendReport(
+            JSON.stringify({
+                [`${FRONTEND_ABS}/src/lib/foo.ts`]: {
+                    statementMap: {
+                        '0': { start: { line: 1, column: 0 }, end: { line: 3, column: 10 } }
+                    },
+                    s: { '0': 2 }
+                }
+            })
+        );
+        const entry = report.get(`${FRONTEND_PREFIX}src/lib/foo.ts`);
+        expect([...entry!.executable].sort()).toEqual([1, 2, 3]);
+        expect([...entry!.covered].sort()).toEqual([1, 2, 3]);
+    });
+
+    it('treats a missing s entry as 0 hits', () => {
+        const report = parseFrontendReport(
+            JSON.stringify({
+                [`${FRONTEND_ABS}/src/lib/foo.ts`]: {
+                    statementMap: {
+                        '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } }
+                    },
+                    s: {}
+                }
+            })
+        );
+        const entry = report.get(`${FRONTEND_PREFIX}src/lib/foo.ts`);
+        expect([...entry!.executable]).toEqual([1]);
+        expect([...entry!.covered]).toEqual([]);
     });
 });
 

--- a/fast_track/src/guardrails/frontend/coverage.test.ts
+++ b/fast_track/src/guardrails/frontend/coverage.test.ts
@@ -162,6 +162,20 @@ describe('parseFrontendReport', () => {
         expect([...report.keys()]).toEqual([`${FRONTEND_PREFIX}src/lib/foo.ts`]);
     });
 
+    it('normalises Windows separators before matching the frontend prefix', () => {
+        const report = parseFrontendReport(
+            JSON.stringify({
+                [`C:\\repo\\${FRONTEND_PREFIX.replace(/\//g, '\\')}src\\lib\\foo.ts`]: {
+                    statementMap: {
+                        '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } }
+                    },
+                    s: { '0': 1 }
+                }
+            })
+        );
+        expect([...report.keys()]).toEqual([`${FRONTEND_PREFIX}src/lib/foo.ts`]);
+    });
+
     it('skips entries whose path is outside the frontend prefix', () => {
         const report = parseFrontendReport(
             JSON.stringify({

--- a/fast_track/src/guardrails/frontend/coverage.ts
+++ b/fast_track/src/guardrails/frontend/coverage.ts
@@ -67,12 +67,7 @@ export function fileCoverageRatio(
     return executable === 0 ? null : covered / executable;
 }
 
-/**
- * Normalises a vitest (Istanbul/v8) coverage report into repo-relative per-line
- * coverage. Each statement is collapsed to the lines it spans: a line is
- * `executable` if any statement covers it, `covered` if any covering statement
- * has a hit count > 0.
- */
+/** Reads a vitest (Istanbul/v8) report into per-line coverage, keyed by repo-relative path. */
 export function parseFrontendReport(raw: string): LineCoverage {
     const data = JSON.parse(raw) as RawCoverage;
     const coverage: LineCoverage = new Map();

--- a/fast_track/src/guardrails/frontend/coverage.ts
+++ b/fast_track/src/guardrails/frontend/coverage.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import type { ChangedFile, Guardrail } from '../context/types';
 import { FRONTEND_ABS, FRONTEND_PREFIX } from './eslint-runner';
 import { createCoverageGuardrail } from '../shared/coverage-base';
+import type { FileLineCoverage, LineCoverage } from '../shared/full-suite-coverage';
 import { runLoggedCommand } from '../shared/utils';
 
 const SRC_PREFIX = FRONTEND_PREFIX + 'src/';
@@ -64,6 +65,37 @@ export function fileCoverageRatio(
         }
     }
     return executable === 0 ? null : covered / executable;
+}
+
+/**
+ * Normalises a vitest (Istanbul/v8) coverage report into repo-relative per-line
+ * coverage. Each statement is collapsed to the lines it spans: a line is
+ * `executable` if any statement covers it, `covered` if any covering statement
+ * has a hit count > 0.
+ */
+export function parseFrontendReport(raw: string): LineCoverage {
+    const data = JSON.parse(raw) as RawCoverage;
+    const coverage: LineCoverage = new Map();
+    for (const [absPath, entry] of Object.entries(data)) {
+        // Istanbul keys are absolute paths; map to the repo-relative suffix.
+        const idx = absPath.indexOf(FRONTEND_PREFIX);
+        if (idx === -1) continue;
+        coverage.set(absPath.slice(idx), toFileLineCoverage(entry));
+    }
+    return coverage;
+}
+
+function toFileLineCoverage(entry: IstanbulFileCoverage): FileLineCoverage {
+    const executable = new Set<number>();
+    const covered = new Set<number>();
+    for (const [idx, loc] of Object.entries(entry.statementMap)) {
+        const hit = (entry.s[idx] ?? 0) > 0;
+        for (let line = loc.start.line; line <= loc.end.line; line++) {
+            executable.add(line);
+            if (hit) covered.add(line);
+        }
+    }
+    return { executable, covered };
 }
 
 export const frontendCoverageGuardrail: Guardrail = createCoverageGuardrail<RawCoverage>({

--- a/fast_track/src/guardrails/frontend/coverage.ts
+++ b/fast_track/src/guardrails/frontend/coverage.ts
@@ -76,8 +76,10 @@ export function fileCoverageRatio(
 export function parseFrontendReport(raw: string): LineCoverage {
     const data = JSON.parse(raw) as RawCoverage;
     const coverage: LineCoverage = new Map();
-    for (const [absPath, entry] of Object.entries(data)) {
-        // Istanbul keys are absolute paths; map to the repo-relative suffix.
+    for (const [rawPath, entry] of Object.entries(data)) {
+        // Istanbul keys are absolute paths; map to the repo-relative suffix,
+        // normalising Windows separators so the slash-based prefix still matches.
+        const absPath = rawPath.replace(/\\/g, '/');
         const idx = absPath.indexOf(FRONTEND_PREFIX);
         if (idx === -1) continue;
         coverage.set(absPath.slice(idx), toFileLineCoverage(entry));


### PR DESCRIPTION
## What has changed and why?

Adds `parseFrontendReport` to read a vitest (Istanbul/v8) coverage report into per-line coverage. First step to move `frontend/coverage` onto the shared full-suite base. Nothing uses it yet.

## How has it been tested?

`make static-checks` and `make test` in `fast_track`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frontend coverage report parsing to produce repository-relative, per-line coverage results.
  * Added support for normalizing file paths, filtering frontend files, mapping multi-line statements, and handling missing hit counts.

* **Tests**
  * Added coverage tests for path normalization, frontend filtering, statement-to-line mapping, multi-line statements, and incomplete coverage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->