### PR TITLE
fast_track: move frontend/coverage onto the full-suite base

### DIFF
--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -130,9 +130,9 @@ jobs:
           npm ci
           npm run prebuild
 
-      # Same arrangement as the backend step above, for frontend/coverage. That guardrail
-      # still runs its own per-file vitest subset until it migrates onto the shared base,
-      # so nothing reads this report yet.
+      # Same arrangement as the backend step above, for frontend/coverage: the guardrail
+      # only reads coverage/coverage-final.json, and a failing suite becomes a fail verdict
+      # rather than killing the job.
       - name: Run frontend tests with coverage
         id: frontend-tests
         if: steps.changes.outputs.frontend_src == 'true'
@@ -154,6 +154,10 @@ jobs:
           # so a skipped step does not read as a failing suite.
           BACKEND_COVERAGE_JSON: ${{ github.workspace }}/lightly_studio/coverage.json
           BACKEND_TESTS_PASSED: ${{ steps.backend-tests.outcome != 'failure' }}
+          # frontend/coverage mirrors the backend vars, reading the report the frontend
+          # test step wrote.
+          FRONTEND_COVERAGE_JSON: ${{ github.workspace }}/lightly_studio_view/coverage/coverage-final.json
+          FRONTEND_TESTS_PASSED: ${{ steps.frontend-tests.outcome != 'failure' }}
         run: npm run guardrails-ci
 
       # JS action, so defaults.run.working-directory doesn't apply — path is repo-root-relative.

--- a/fast_track/src/guardrails/frontend/coverage.test.ts
+++ b/fast_track/src/guardrails/frontend/coverage.test.ts
@@ -1,19 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// Hoist before mocks so the factory can reference it.
-const mockExecFile = vi.hoisted(() => vi.fn());
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('node:fs', () => ({
     existsSync: vi.fn(),
     readFileSync: vi.fn()
 }));
 
-vi.mock('node:child_process', () => ({
-    execFile: mockExecFile
-}));
-
 import { existsSync, readFileSync } from 'node:fs';
-import { fileCoverageRatio, frontendCoverageGuardrail, parseFrontendReport } from './coverage';
+import { filterFrontendFiles, frontendCoverageGuardrail, parseFrontendReport } from './coverage';
 import { FRONTEND_ABS, FRONTEND_PREFIX } from './eslint-runner';
 import type { ChangedFile, GuardrailContext } from '../context/types';
 
@@ -35,130 +28,81 @@ const FRONTEND_FILE: ChangedFile = {
     patch: PATCH
 };
 
-// Coverage data where lines 1–3 of foo.ts are fully covered.
-const FULL_COVERAGE_DATA = {
-    [`${FRONTEND_ABS}/src/lib/foo.ts`]: {
-        statementMap: {
-            '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
-            '1': { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
-            '2': { start: { line: 3, column: 0 }, end: { line: 3, column: 10 } }
-        },
-        s: { '0': 1, '1': 1, '2': 1 }
-    }
-};
-
-// Makes execFile call its callback immediately with success or failure.
-function mockExecFileWith(error: Error | null): void {
-    mockExecFile.mockImplementation((...args: unknown[]) => {
-        (args[args.length - 1] as (err: Error | null, stdout: string, stderr: string) => void)(
-            error,
-            '',
-            ''
-        );
+// One Istanbul entry for foo.ts. Each statement spans a single line; `hits` maps
+// line -> execution count, so { 1: 1, 2: 0 } covers line 1 and misses line 2.
+function fooReport(hits: Record<number, number>): string {
+    const statementMap: Record<string, unknown> = {};
+    const s: Record<string, number> = {};
+    Object.entries(hits).forEach(([line, count], idx) => {
+        const n = Number(line);
+        statementMap[idx] = { start: { line: n, column: 0 }, end: { line: n, column: 10 } };
+        s[idx] = count;
     });
+    return JSON.stringify({ [`${FRONTEND_ABS}/src/lib/foo.ts`]: { statementMap, s } });
 }
 
-// Sets up the two existsSync calls for a full successful run:
-//   1. .test.ts candidate exists (findFrontendTestFile)
-//   2. coverage JSON was produced (runTests)
-function setupSuccessfulRun(coverageData: object = FULL_COVERAGE_DATA): void {
-    mockExistsSync.mockReturnValueOnce(true).mockReturnValueOnce(true);
-    mockExecFileWith(null);
-    mockReadFileSync.mockReturnValue(JSON.stringify(coverageData));
+function setReport(raw: string): void {
+    process.env.FRONTEND_COVERAGE_JSON = '/tmp/lightly_studio_view/coverage/coverage-final.json';
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(raw);
 }
 
 beforeEach(() => {
     vi.resetAllMocks();
 });
 
-describe('fileCoverageRatio', () => {
-    it('returns null when addedLines is empty', () => {
-        const entry = {
-            statementMap: { '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } } },
-            s: { '0': 1 }
-        };
-        expect(fileCoverageRatio(entry, new Set())).toBeNull();
+afterEach(() => {
+    delete process.env.FRONTEND_COVERAGE_JSON;
+    delete process.env.FRONTEND_TESTS_PASSED;
+});
+
+describe('filterFrontendFiles', () => {
+    function file(path: string): ChangedFile {
+        return { path, status: 'modified', additions: 1, deletions: 0 };
+    }
+
+    it('keeps source files under the frontend src prefix', () => {
+        const files = [file(`${FRONTEND_PREFIX}src/lib/foo.ts`)];
+        expect(filterFrontendFiles(files)).toHaveLength(1);
     });
 
-    it('returns null when no added line overlaps any statement', () => {
-        const entry = {
-            statementMap: { '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } } },
-            s: { '0': 1 }
-        };
-        expect(fileCoverageRatio(entry, new Set([5, 6]))).toBeNull();
+    it('excludes files outside the frontend src prefix', () => {
+        const files = [
+            file('lightly_studio/src/lightly_studio/service.py'),
+            file(`${FRONTEND_PREFIX}vite.config.ts`)
+        ];
+        expect(filterFrontendFiles(files)).toHaveLength(0);
     });
 
-    it('returns 1 when all added lines are covered', () => {
-        const entry = {
-            statementMap: {
-                '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
-                '1': { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } }
-            },
-            s: { '0': 1, '1': 3 }
-        };
-        expect(fileCoverageRatio(entry, new Set([1, 2]))).toBe(1);
+    it.each(['foo.test.ts', 'foo.test.js', 'foo.spec.ts', 'foo.spec.js', 'types.d.ts'])(
+        'excludes %s',
+        (name) => {
+            const files = [file(`${FRONTEND_PREFIX}src/lib/${name}`)];
+            expect(filterFrontendFiles(files)).toHaveLength(0);
+        }
+    );
+
+    it('excludes non-source files (.css, .svg)', () => {
+        const files = [
+            file(`${FRONTEND_PREFIX}src/app.css`),
+            file(`${FRONTEND_PREFIX}src/assets/logo.svg`)
+        ];
+        expect(filterFrontendFiles(files)).toHaveLength(0);
     });
 
-    it('returns 0 when all added lines are uncovered', () => {
-        const entry = {
-            statementMap: {
-                '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
-                '1': { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } }
-            },
-            s: { '0': 0, '1': 0 }
-        };
-        expect(fileCoverageRatio(entry, new Set([1, 2]))).toBe(0);
-    });
-
-    it('returns fractional ratio for partial coverage', () => {
-        const entry = {
-            statementMap: {
-                '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
-                '1': { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
-                '2': { start: { line: 3, column: 0 }, end: { line: 3, column: 10 } },
-                '3': { start: { line: 4, column: 0 }, end: { line: 4, column: 10 } }
-            },
-            s: { '0': 1, '1': 1, '2': 0, '3': 0 }
-        };
-        expect(fileCoverageRatio(entry, new Set([1, 2, 3, 4]))).toBe(0.5);
-    });
-
-    it('counts each line of a multi-line statement separately', () => {
-        const entry = {
-            statementMap: {
-                '0': { start: { line: 1, column: 0 }, end: { line: 3, column: 10 } }
-            },
-            s: { '0': 1 }
-        };
-        // Statement spans lines 1–3; all three are in addedLines and all covered.
-        expect(fileCoverageRatio(entry, new Set([1, 2, 3]))).toBe(1);
-    });
-
-    it('only scores lines that appear in addedLines for multi-line statements', () => {
-        const entry = {
-            statementMap: {
-                '0': { start: { line: 1, column: 0 }, end: { line: 3, column: 10 } }
-            },
-            s: { '0': 0 }
-        };
-        // Statement spans lines 1–3 but only line 2 was added; it is not covered.
-        expect(fileCoverageRatio(entry, new Set([2]))).toBe(0);
-    });
-
-    it('treats a missing s entry as 0 hits', () => {
-        const entry = {
-            statementMap: {
-                '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } }
-            },
-            s: {}
-        };
-        expect(fileCoverageRatio(entry, new Set([1]))).toBe(0);
+    it('returns only matching files from a mixed list', () => {
+        const result = filterFrontendFiles([
+            file(`${FRONTEND_PREFIX}src/lib/foo.ts`),
+            file(`${FRONTEND_PREFIX}src/lib/foo.test.ts`),
+            file('lightly_studio/src/lightly_studio/service.py')
+        ]);
+        expect(result.map((f) => f.path)).toEqual([`${FRONTEND_PREFIX}src/lib/foo.ts`]);
     });
 });
 
 describe('parseFrontendReport', () => {
     it('maps absolute report keys to repo-relative paths', () => {
-        const report = parseFrontendReport(JSON.stringify(FULL_COVERAGE_DATA));
+        const report = parseFrontendReport(fooReport({ 1: 1 }));
         expect([...report.keys()]).toEqual([`${FRONTEND_PREFIX}src/lib/foo.ts`]);
     });
 
@@ -191,17 +135,7 @@ describe('parseFrontendReport', () => {
     });
 
     it('marks a line executable if any statement covers it, covered if any covering statement has hits', () => {
-        const report = parseFrontendReport(
-            JSON.stringify({
-                [`${FRONTEND_ABS}/src/lib/foo.ts`]: {
-                    statementMap: {
-                        '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
-                        '1': { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } }
-                    },
-                    s: { '0': 1, '1': 0 }
-                }
-            })
-        );
+        const report = parseFrontendReport(fooReport({ 1: 1, 2: 0 }));
         const entry = report.get(`${FRONTEND_PREFIX}src/lib/foo.ts`);
         expect([...entry!.executable].sort()).toEqual([1, 2]);
         expect([...entry!.covered].sort()).toEqual([1]);
@@ -240,12 +174,12 @@ describe('parseFrontendReport', () => {
     });
 });
 
-describe('frontendCoverageGuardrail – filterFiles', () => {
-    it('passes immediately when only backend files changed', async () => {
+describe('frontendCoverageGuardrail', () => {
+    it('passes immediately when no frontend source file changed', async () => {
         const result = await frontendCoverageGuardrail.run(
             makeCtx([
                 {
-                    path: 'lightly_studio/src/model.py',
+                    path: 'lightly_studio/src/lightly_studio/service.py',
                     status: 'modified',
                     additions: 3,
                     deletions: 0,
@@ -257,180 +191,49 @@ describe('frontendCoverageGuardrail – filterFiles', () => {
         expect(result.summary).toContain('0 file(s) checked');
     });
 
-    it('filters out .test.ts files', async () => {
-        const result = await frontendCoverageGuardrail.run(
-            makeCtx([
-                {
-                    path: `${FRONTEND_PREFIX}src/lib/foo.test.ts`,
-                    status: 'modified',
-                    additions: 3,
-                    deletions: 0,
-                    patch: PATCH
-                }
-            ])
-        );
-        expect(result.status).toBe('pass');
-        expect(result.summary).toContain('0 file(s) checked');
-    });
-
-    it('filters out .spec.ts files', async () => {
-        const result = await frontendCoverageGuardrail.run(
-            makeCtx([
-                {
-                    path: `${FRONTEND_PREFIX}src/lib/foo.spec.ts`,
-                    status: 'modified',
-                    additions: 3,
-                    deletions: 0,
-                    patch: PATCH
-                }
-            ])
-        );
-        expect(result.status).toBe('pass');
-        expect(result.summary).toContain('0 file(s) checked');
-    });
-
-    it('filters out .d.ts files', async () => {
-        const result = await frontendCoverageGuardrail.run(
-            makeCtx([
-                {
-                    path: `${FRONTEND_PREFIX}src/lib/types.d.ts`,
-                    status: 'modified',
-                    additions: 3,
-                    deletions: 0,
-                    patch: PATCH
-                }
-            ])
-        );
-        expect(result.status).toBe('pass');
-        expect(result.summary).toContain('0 file(s) checked');
-    });
-
-    it('filters out non-source files (.css, .svg)', async () => {
-        const nonSourceFiles: ChangedFile[] = [
-            {
-                path: `${FRONTEND_PREFIX}src/app.css`,
-                status: 'modified',
-                additions: 3,
-                deletions: 0,
-                patch: PATCH
-            },
-            {
-                path: `${FRONTEND_PREFIX}src/assets/logo.svg`,
-                status: 'modified',
-                additions: 3,
-                deletions: 0,
-                patch: PATCH
-            }
-        ];
-        const result = await frontendCoverageGuardrail.run(makeCtx(nonSourceFiles));
-        expect(result.status).toBe('pass');
-        expect(result.summary).toContain('0 file(s) checked');
-    });
-
-    it('includes regular .ts files in the frontend src directory', async () => {
-        setupSuccessfulRun();
+    it('skips with an explanatory summary when FRONTEND_COVERAGE_JSON is unset', async () => {
         const result = await frontendCoverageGuardrail.run(makeCtx([FRONTEND_FILE]));
-        expect(result.summary).not.toContain('0 file(s) checked');
+        expect(result.status).toBe('pass');
+        expect(result.summary).toContain('coverage skipped: FRONTEND_COVERAGE_JSON not set');
     });
-});
 
-describe('frontendCoverageGuardrail – findTestFile', () => {
-    it('fails when no test file candidate exists on disk', async () => {
-        mockExistsSync.mockReturnValue(false); // all test file candidates missing
+    it('fails when FRONTEND_TESTS_PASSED is false', async () => {
+        setReport(fooReport({ 1: 1, 2: 1, 3: 1 }));
+        process.env.FRONTEND_TESTS_PASSED = 'false';
         const result = await frontendCoverageGuardrail.run(makeCtx([FRONTEND_FILE]));
         expect(result.status).toBe('fail');
-        expect(result.summary).toContain('no test file found');
-        expect(result.summary).toContain(FRONTEND_FILE.path);
+        expect(result.summary).toContain('test suite failed');
     });
 
-    it('uses the first matching candidate (.test.ts)', async () => {
-        setupSuccessfulRun();
-        await frontendCoverageGuardrail.run(makeCtx([FRONTEND_FILE]));
-        const paths = mockExistsSync.mock.calls.map(([p]) => p as string);
-        expect(paths.some((p) => p.endsWith('foo.test.ts'))).toBe(true);
-    });
-
-    it('skips candidates that do not exist and uses the next match (.spec.ts)', async () => {
-        mockExistsSync
-            .mockReturnValueOnce(false) // foo.test.ts not found
-            .mockReturnValueOnce(false) // foo.test.js not found
-            .mockReturnValueOnce(true) // foo.spec.ts found
-            .mockReturnValueOnce(true); // coverage JSON exists
-        mockExecFileWith(null);
-        mockReadFileSync.mockReturnValue(JSON.stringify(FULL_COVERAGE_DATA));
-
+    it('passes when all added lines are covered', async () => {
+        setReport(fooReport({ 1: 1, 2: 1, 3: 1 }));
         const result = await frontendCoverageGuardrail.run(makeCtx([FRONTEND_FILE]));
-
         expect(result.status).toBe('pass');
-        const paths = mockExistsSync.mock.calls.map(([p]) => p as string);
-        expect(paths.some((p) => p.endsWith('foo.spec.ts'))).toBe(true);
+        expect(result.summary).toContain(`[PASS] ${FRONTEND_FILE.path}`);
     });
-});
 
-describe('frontendCoverageGuardrail – runTests', () => {
-    it('fails when vitest does not produce a coverage file', async () => {
-        mockExistsSync
-            .mockReturnValueOnce(true) // test file candidate exists
-            .mockReturnValueOnce(false); // coverage JSON not produced
-        mockExecFileWith(null);
-
-        const result = await frontendCoverageGuardrail.run(makeCtx([FRONTEND_FILE]));
-
+    it('fails an untested new file instead of auto-passing it', async () => {
+        setReport(fooReport({ 1: 0, 2: 0, 3: 0 }));
+        const result = await frontendCoverageGuardrail.run(
+            makeCtx([{ ...FRONTEND_FILE, status: 'added' }])
+        );
         expect(result.status).toBe('fail');
-        expect(result.summary).toContain('coverage data not found');
+        expect(result.summary).toContain('0.0%');
     });
 
-    it('invokes vitest via npm run test:unit from lightly_studio_view', async () => {
-        setupSuccessfulRun();
-        await frontendCoverageGuardrail.run(makeCtx([FRONTEND_FILE]));
-        const [cmd, args] = mockExecFile.mock.calls[0]! as [string, string[]];
-        expect(cmd).toBe('npm');
-        expect(args).toContain('test:unit');
-    });
-
-    it('still reads coverage when vitest exits non-zero', async () => {
-        mockExistsSync
-            .mockReturnValueOnce(true) // test file candidate exists
-            .mockReturnValueOnce(true); // coverage JSON written despite failure
-        mockExecFileWith(new Error('Tests failed'));
-        mockReadFileSync.mockReturnValue(JSON.stringify(FULL_COVERAGE_DATA));
-
-        const result = await frontendCoverageGuardrail.run(makeCtx([FRONTEND_FILE]));
-
-        expect(result.status).toBe('pass');
-    });
-});
-
-describe('frontendCoverageGuardrail – parseCoverageRatio', () => {
-    it('auto-passes when coverage data contains no entry for the source file', async () => {
-        setupSuccessfulRun({ [`${FRONTEND_ABS}/src/lib/other.ts`]: { statementMap: {}, s: {} } });
-        const result = await frontendCoverageGuardrail.run(makeCtx([FRONTEND_FILE]));
-        expect(result.status).toBe('pass');
-    });
-
-    it('passes when coverage matches via the FRONTEND_PREFIX suffix of the absolute path', async () => {
-        setupSuccessfulRun(FULL_COVERAGE_DATA);
-        const result = await frontendCoverageGuardrail.run(makeCtx([FRONTEND_FILE]));
-        expect(result.status).toBe('pass');
-        expect(result.summary).toContain('[PASS]');
-        expect(result.summary).toContain(FRONTEND_FILE.path);
-    });
-
-    it('fails when added-line coverage is below 80%', async () => {
-        const lowCoverageData = {
-            [`${FRONTEND_ABS}/src/lib/foo.ts`]: {
-                statementMap: {
-                    '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
-                    '1': { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
-                    '2': { start: { line: 3, column: 0 }, end: { line: 3, column: 10 } }
-                },
-                s: { '0': 1, '1': 0, '2': 0 } // 1/3 ≈ 33%
-            }
-        };
-        setupSuccessfulRun(lowCoverageData);
+    it('fails a changed file the report does not mention', async () => {
+        setReport(
+            JSON.stringify({
+                [`${FRONTEND_ABS}/src/lib/other.ts`]: {
+                    statementMap: {
+                        '0': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } }
+                    },
+                    s: { '0': 1 }
+                }
+            })
+        );
         const result = await frontendCoverageGuardrail.run(makeCtx([FRONTEND_FILE]));
         expect(result.status).toBe('fail');
-        expect(result.summary).toContain('[FAIL]');
-        expect(result.summary).toContain(FRONTEND_FILE.path);
+        expect(result.summary).toContain('not found in coverage report');
     });
 });

--- a/fast_track/src/guardrails/frontend/coverage.ts
+++ b/fast_track/src/guardrails/frontend/coverage.ts
@@ -1,18 +1,15 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import type { ChangedFile, Guardrail } from '../context/types';
-import { FRONTEND_ABS, FRONTEND_PREFIX } from './eslint-runner';
-import { createCoverageGuardrail } from '../shared/coverage-base';
-import type { FileLineCoverage, LineCoverage } from '../shared/full-suite-coverage';
-import { runLoggedCommand } from '../shared/utils';
+import {
+    createCoverageGuardrail,
+    type FileLineCoverage,
+    type LineCoverage
+} from '../shared/full-suite-coverage';
+import { FRONTEND_PREFIX } from './eslint-runner';
 
 const SRC_PREFIX = FRONTEND_PREFIX + 'src/';
 
-const NAME = 'frontend/coverage';
 const IGNORE_SUFFIXES = ['.test.ts', '.test.js', '.spec.ts', '.spec.js', '.d.ts'];
 const SOURCE_SUFFIXES = ['.ts', '.js', '.svelte'];
-const MAX_BUFFER = 32 * 1024 * 1024;
-const COVERAGE_JSON = 'coverage/coverage-final.json';
 
 // Istanbul v8 coverage types (as written by @vitest/coverage-v8).
 interface IstanbulLocation {
@@ -30,41 +27,13 @@ interface IstanbulFileCoverage {
 
 type RawCoverage = Record<string, IstanbulFileCoverage>;
 
-// Map a source file (repo-relative) to its test file (relative to FRONTEND_ABS),
-// using the project's *.test.ts / *.spec.ts naming convention.
-function findFrontendTestFile(repoRelative: string): string | undefined {
-    const relToFrontend = repoRelative.slice(FRONTEND_PREFIX.length); // src/lib/foo.ts
-    let withoutExt = relToFrontend.replace(/\.(ts|js|svelte)$/, '');
-    // Strip .svelte suffix from rune module stems (foo.svelte.ts → foo)
-    withoutExt = withoutExt.replace(/\.svelte$/, '');
-    // Strip SvelteKit + prefix from basename (+page → page)
-    withoutExt = withoutExt.replace(/(^|\/)\+/, '$1');
-    const candidates = [
-        `${withoutExt}.test.ts`,
-        `${withoutExt}.test.js`,
-        `${withoutExt}.spec.ts`,
-        `${withoutExt}.spec.js`
-    ];
-    return candidates.find((c) => existsSync(resolve(FRONTEND_ABS, c)));
-}
-
-// Returns coverage ratio (0–1) for added lines only. A statement contributes one
-// count per source line (start.line..end.line) that appears in addedLines.
-// Returns null when no added lines map to executable statements (auto-pass).
-export function fileCoverageRatio(
-    entry: IstanbulFileCoverage,
-    addedLines: Set<number>
-): number | null {
-    let executable = 0;
-    let covered = 0;
-    for (const [idx, loc] of Object.entries(entry.statementMap)) {
-        for (let line = loc.start.line; line <= loc.end.line; line++) {
-            if (!addedLines.has(line)) continue;
-            executable++;
-            if ((entry.s[idx] ?? 0) > 0) covered++;
-        }
-    }
-    return executable === 0 ? null : covered / executable;
+export function filterFrontendFiles(files: ChangedFile[]): ChangedFile[] {
+    return files.filter(
+        (f) =>
+            f.path.startsWith(SRC_PREFIX) &&
+            SOURCE_SUFFIXES.some((s) => f.path.endsWith(s)) &&
+            !IGNORE_SUFFIXES.some((s) => f.path.endsWith(s))
+    );
 }
 
 /** Reads a vitest (Istanbul/v8) report into per-line coverage, keyed by repo-relative path. */
@@ -95,60 +64,10 @@ function toFileLineCoverage(entry: IstanbulFileCoverage): FileLineCoverage {
     return { executable, covered };
 }
 
-export const frontendCoverageGuardrail: Guardrail = createCoverageGuardrail<RawCoverage>({
-    name: NAME,
-
-    filterFiles(files: ChangedFile[]): ChangedFile[] {
-        return files.filter(
-            (f) =>
-                f.path.startsWith(SRC_PREFIX) &&
-                SOURCE_SUFFIXES.some((s) => f.path.endsWith(s)) &&
-                !IGNORE_SUFFIXES.some((s) => f.path.endsWith(s))
-        );
-    },
-
-    findTestFile(sourcePath: string): Promise<string | undefined> {
-        return Promise.resolve(findFrontendTestFile(sourcePath));
-    },
-
-    async runTests(testFiles: string[], sourcePaths: string[]): Promise<RawCoverage | null> {
-        const relSources = sourcePaths.map((p) => p.slice(FRONTEND_PREFIX.length));
-        const coverageIncludes = relSources.map((f) => `--coverage.include=${f}`);
-        try {
-            await runLoggedCommand(
-                NAME,
-                'npm',
-                ['run', 'test:unit', '--', 'run', '--coverage', ...testFiles, ...coverageIncludes],
-                { cwd: FRONTEND_ABS, maxBuffer: MAX_BUFFER }
-            );
-        } catch (err) {
-            // vitest exits non-zero when tests fail; coverage file is still produced.
-            // Re-throw system-level errors (e.g. npm not on PATH, cwd not found):
-            // those have a string code (e.g. 'ENOENT'), whereas non-zero exits have a numeric code.
-            if (typeof (err as NodeJS.ErrnoException).code === 'string') {
-                throw err;
-            }
-        }
-        const coveragePath = resolve(FRONTEND_ABS, COVERAGE_JSON);
-        if (!existsSync(coveragePath)) return null;
-        return JSON.parse(readFileSync(coveragePath, 'utf-8')) as RawCoverage;
-    },
-
-    parseCoverageRatio(
-        data: RawCoverage,
-        sourcePath: string,
-        addedLines: Set<number>
-    ): number | null {
-        // Istanbul keys are absolute paths; resolve the entry by matching the repo-relative suffix.
-        let entry: IstanbulFileCoverage | undefined;
-        for (const [absPath, e] of Object.entries(data)) {
-            const idx = absPath.indexOf(FRONTEND_PREFIX);
-            if (idx !== -1 && absPath.slice(idx) === sourcePath) {
-                entry = e;
-                break;
-            }
-        }
-        if (!entry) return null;
-        return fileCoverageRatio(entry, addedLines);
-    }
+export const frontendCoverageGuardrail: Guardrail = createCoverageGuardrail({
+    name: 'frontend/coverage',
+    coverageJsonEnvVar: 'FRONTEND_COVERAGE_JSON',
+    testsPassedEnvVar: 'FRONTEND_TESTS_PASSED',
+    filterFiles: filterFrontendFiles,
+    parseReport: parseFrontendReport
 });


### PR DESCRIPTION
## What has changed and why?

`frontend/coverage` now reads the full-suite coverage report that CI
already makes. It no longer runs its own tests. Each changed file is
judged on its own added lines.

Stacked on #1913.

## How has it been tested?

`make static-checks` and `make test` in `fast_track`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend coverage validation by consuming generated coverage reports more reliably.
  * Added handling for uncovered newly added frontend files and missing coverage report entries.
  * Updated guardrail behavior to respect configured coverage and test outcomes.

* **Documentation**
  * Clarified that the Fast Track Guardrails workflow uses the generated frontend coverage report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->