### PR TITLE
fast track: harden ci workflows with timeouts and fork guard

### DIFF
--- a/.github/workflows/fast_track_bot.yml
+++ b/.github/workflows/fast_track_bot.yml
@@ -27,6 +27,7 @@ jobs:
     # fresh verdict — reaches the bot, which fails closed and revokes.
     if: github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Mint App Token
         id: app-token
@@ -59,7 +60,6 @@ jobs:
         run: npm ci
 
       - name: Download Verdict
-        id: download
         # Tolerate a missing verdict so the bot still runs and revokes, fail closed.
         continue-on-error: true
         uses: actions/download-artifact@v8

--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -16,14 +16,18 @@ jobs:
     name: Fast Track Guardrails
     # Skip drafts. `edited` fires on any PR edit (title, body, base), so restrict it
     # to base retargets — those change the diff and warrant a re-judge; other edits don't.
+    # Skip fork PRs: they get no secrets, so the toolchain steps would fail with a
+    # confusing red check. The bot already skips forks, so no verdict is expected.
     if: >-
       github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.action != 'edited' || github.event.changes.base != null)
     # Job-level concurrency prevents an unrelated skipped edit from cancelling this job.
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: fast_track
@@ -31,8 +35,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         # Never pushes — keep the git token out of the checkout. The later toolchain steps
-        # expose GCP secrets to PR code (same posture as unit_test.yml); fork PRs get
-        # no secrets, so their toolchain-dependent guardrails error instead of emitting a verdict.
+        # expose GCP secrets to PR code (same posture as unit_test.yml); the job's `if`
+        # restricts it to same-repo PRs, so untrusted fork code never reaches them.
         with:
           persist-credentials: false
 
@@ -162,7 +166,7 @@ jobs:
 
       # JS action, so defaults.run.working-directory doesn't apply — path is repo-root-relative.
       - name: Upload verdict
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fast-track-verdict
           path: fast_track/verdict.json


### PR DESCRIPTION
## What has changed and why?

Small hardening pass on the Fast Track CI workflows:

- Add job `timeout-minutes` (guardrails 15, bot 5) so a hung step can't run for the 6-hour default.
- Skip the guardrails job on fork PRs — they get no secrets and would die at GCP auth with a confusing red check; the bot already skips forks.
- Bump `upload-artifact` to `@v7` to match the rest of the repo.
- Drop the unused `id: download` step id.

## How has it been tested?

Not needed — workflow-only changes; conditions and versions reviewed by inspection.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated approval checks with defined time limits to prevent stalled runs.
  * Updated pull request validation to skip drafts, fork-based requests, and changes without relevant base updates.
* **Chores**
  * Improved handling of missing validation results.
  * Updated artifact handling for greater reliability.
  * Clarified automation comments regarding same-repository secret access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->