### PR TITLE
Tagging by embedding region now correctly limits samples to the selected area

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -26,8 +26,10 @@ from lightly_studio.models.tag import (
     TagTable,
     TagView,
 )
-from lightly_studio.resolvers import tag_resolver
+from lightly_studio.resolvers import embedding_region_resolver, tag_resolver
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.grid_filter import GridFilter
+from lightly_studio.resolvers.image_filter import ImageFilter
 
 tag_router = APIRouter()
 
@@ -234,7 +236,25 @@ def add_samples_to_tag_by_filter(
             detail=f"Tag {tag_id} not found in collection {collection_id}.",
         )
 
-    sample_ids_query = body.filter.build_sample_ids_query(collection_id=collection_id)
+    # Resolve any embedding-plot region selection to concrete sample ids before building
+    # the query (the point-in-polygon test needs the session, which `apply` lacks).
+    grid_filter = body.filter
+    if isinstance(grid_filter, ImageFilter) and grid_filter.sample_filter is not None:
+        if grid_filter.sample_filter.embedding_region is not None:
+            grid_filter.sample_filter.region_sample_ids = (
+                embedding_region_resolver.get_sample_ids_in_region(
+                    session=session,
+                    collection_id=collection_id,
+                    region=grid_filter.sample_filter.embedding_region,
+                )
+            )
+    elif isinstance(grid_filter, AnnotationsFilter) and grid_filter.embedding_region is not None:
+        grid_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
+            session=session,
+            collection_id=collection_id,
+            region=grid_filter.embedding_region,
+        )
+    sample_ids_query = grid_filter.build_sample_ids_query(collection_id=collection_id)
     tag_resolver.add_samples_to_tag_from_query(
         session=session, tag_id=tag_id, sample_ids_query=sample_ids_query
     )

--- a/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/collection_tag.py
@@ -239,15 +239,18 @@ def add_samples_to_tag_by_filter(
     # Resolve any embedding-plot region selection to concrete sample ids before building
     # the query (the point-in-polygon test needs the session, which `apply` lacks).
     grid_filter = body.filter
-    if isinstance(grid_filter, ImageFilter) and grid_filter.sample_filter is not None:
-        if grid_filter.sample_filter.embedding_region is not None:
-            grid_filter.sample_filter.region_sample_ids = (
-                embedding_region_resolver.get_sample_ids_in_region(
-                    session=session,
-                    collection_id=collection_id,
-                    region=grid_filter.sample_filter.embedding_region,
-                )
+    if (
+        isinstance(grid_filter, ImageFilter)
+        and grid_filter.sample_filter is not None
+        and grid_filter.sample_filter.embedding_region is not None
+    ):
+        grid_filter.sample_filter.region_sample_ids = (
+            embedding_region_resolver.get_sample_ids_in_region(
+                session=session,
+                collection_id=collection_id,
+                region=grid_filter.sample_filter.embedding_region,
             )
+        )
     elif isinstance(grid_filter, AnnotationsFilter) and grid_filter.embedding_region is not None:
         grid_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
             session=session,

--- a/lightly_studio/tests/api/routes/api/test_collection_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_tag.py
@@ -220,7 +220,7 @@ def test_add_samples_by_filter__image_filter_with_embedding_region_tags_only_reg
 def test_add_samples_by_filter__annotations_filter_with_embedding_region_tags_only_region_samples(
     db_session: Session, test_client: TestClient
 ) -> None:
-    """Tagging by AnnotationsFilter with an embedding region only tags annotation samples inside the region."""
+    """AnnotationsFilter with embedding region only tags samples inside the region."""
     collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=collection.collection_id)
     label = create_annotation_label(session=db_session, root_collection_id=collection.collection_id)

--- a/lightly_studio/tests/api/routes/api/test_collection_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_tag.py
@@ -12,14 +12,18 @@ from lightly_studio.api.routes.api.status import (
 )
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.sample import SampleTagLinkTable
-from lightly_studio.resolvers import collection_resolver
+from lightly_studio.models.two_dim_embedding import TwoDimEmbeddingTable
+from lightly_studio.resolvers import collection_resolver, sample_embedding_resolver
 from tests.helpers_resolvers import (
     ImageStub,
     create_annotation,
     create_annotation_label,
     create_collection,
+    create_embedding_model,
     create_image,
     create_images,
+    create_sample_embedding,
+    create_samples_with_embeddings,
     create_tag,
 )
 
@@ -139,6 +143,176 @@ def test_add_samples_by_filter__wrong_collection_returns_404(
     )
 
     assert response.status_code == HTTP_STATUS_NOT_FOUND
+
+
+def test_add_samples_by_filter__image_filter_with_embedding_region_tags_only_region_samples(
+    db_session: Session, test_client: TestClient
+) -> None:
+    """Tagging by filter with an embedding region only tags samples inside the region."""
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    tag = create_tag(session=db_session, collection_id=collection_id, kind="sample")
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_dimension=3,
+    )
+    # Two samples inside the square region [0,10]x[0,10], one far outside.
+    images = create_samples_with_embeddings(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        images_and_embeddings=[
+            (ImageStub(path="inside_a.png"), [0.1, 0.2, 0.3]),
+            (ImageStub(path="inside_b.png"), [1.1, 0.2, 0.3]),
+            (ImageStub(path="outside.png"), [2.1, 0.2, 0.3]),
+        ],
+    )
+    inside_a = images[0]
+    inside_b = images[1]
+    outside = images[2]
+    # Seed the 2D embedding cache with known coordinates.
+    cache_key, cached_sample_ids = sample_embedding_resolver.get_hash_by_collection_id(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+    coordinates_by_sample = {
+        inside_a.sample_id: (1.0, 1.0),
+        inside_b.sample_id: (5.0, 5.0),
+        outside.sample_id: (100.0, 100.0),
+    }
+    db_session.add(
+        TwoDimEmbeddingTable(
+            hash=cache_key,
+            x=[coordinates_by_sample[sid][0] for sid in cached_sample_ids],
+            y=[coordinates_by_sample[sid][1] for sid in cached_sample_ids],
+        )
+    )
+    db_session.commit()
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/tags/{tag.tag_id}/add/samples_by_filter",
+        json={
+            "filter": {
+                "filter_type": "image",
+                "sample_filter": {
+                    "embedding_region": {
+                        "polygon": [
+                            {"x": 0.0, "y": 0.0},
+                            {"x": 10.0, "y": 0.0},
+                            {"x": 10.0, "y": 10.0},
+                            {"x": 0.0, "y": 10.0},
+                        ]
+                    }
+                },
+            }
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert _tagged_sample_ids(session=db_session, tag_id=tag.tag_id) == {
+        inside_a.sample_id,
+        inside_b.sample_id,
+    }
+
+
+def test_add_samples_by_filter__annotations_filter_with_embedding_region_tags_only_region_samples(
+    db_session: Session, test_client: TestClient
+) -> None:
+    """Tagging by AnnotationsFilter with an embedding region only tags annotation samples inside the region."""
+    collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    label = create_annotation_label(session=db_session, root_collection_id=collection.collection_id)
+    annotation_collection_id = collection_resolver.get_or_create_child_collection(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    inside_a = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    inside_b = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    outside = create_annotation(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+    )
+    tag = create_tag(session=db_session, collection_id=annotation_collection_id, kind="annotation")
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        embedding_dimension=3,
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=inside_a.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[0.1, 0.2, 0.3],
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=inside_b.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[1.1, 0.2, 0.3],
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=outside.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[2.1, 0.2, 0.3],
+    )
+    # Seed the 2D embedding cache with known coordinates.
+    cache_key, cached_sample_ids = sample_embedding_resolver.get_hash_by_collection_id(
+        session=db_session,
+        collection_id=annotation_collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+    coordinates_by_sample = {
+        inside_a.sample_id: (1.0, 1.0),
+        inside_b.sample_id: (5.0, 5.0),
+        outside.sample_id: (100.0, 100.0),
+    }
+    db_session.add(
+        TwoDimEmbeddingTable(
+            hash=cache_key,
+            x=[coordinates_by_sample[sid][0] for sid in cached_sample_ids],
+            y=[coordinates_by_sample[sid][1] for sid in cached_sample_ids],
+        )
+    )
+    db_session.commit()
+
+    response = test_client.post(
+        f"/api/collections/{annotation_collection_id}/tags/{tag.tag_id}/add/samples_by_filter",
+        json={
+            "filter": {
+                "filter_type": "annotations",
+                "embedding_region": {
+                    "polygon": [
+                        {"x": 0.0, "y": 0.0},
+                        {"x": 10.0, "y": 0.0},
+                        {"x": 10.0, "y": 10.0},
+                        {"x": 0.0, "y": 10.0},
+                    ]
+                },
+            }
+        },
+    )
+
+    assert response.status_code == HTTP_STATUS_CREATED
+    assert _tagged_sample_ids(session=db_session, tag_id=tag.tag_id) == {
+        inside_a.sample_id,
+        inside_b.sample_id,
+    }
 
 
 def _tagged_sample_ids(session: Session, tag_id: UUID) -> set[UUID]:


### PR DESCRIPTION
## What has changed and why?

In the embedding plot, users can draw a polygon to select a region of samples and then tag all samples inside that region. Before this fix, the polygon selection was ignored during the "add samples to tag" step - all samples matched by the other filter conditions were tagged instead of just the ones inside the drawn area.

The root cause: the polygon needed to be translated into a concrete list of sample IDs *before* the database query was built, but that translation step was missing. This fix adds the translation in the right place for both image filters and annotation filters.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection tagging with embedding-region filters.
  * Image and annotation filters now tag only samples whose cached coordinates fall within the selected region.
  * Region-based filtering now works consistently across supported sample filter types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->