### PR TITLE
Extract the keyset seek engine into a shared module

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/adjacents/keyset_seek.py
+++ b/lightly_studio/src/lightly_studio/resolvers/adjacents/keyset_seek.py
@@ -1,0 +1,146 @@
+"""Keyset (seek) engine shared by the adjacency resolvers.
+
+Reads the anchor row's sort-key values once, then jumps straight to its neighbours with
+``LIMIT 1`` queries instead of sorting the whole collection and scanning it with window
+functions. Position and total come from two ``COUNT``s. Callers supply the sort keys and
+the base query, so resolvers for different sample types can share the engine.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Union
+from uuid import UUID
+
+import sqlalchemy
+from sqlalchemy.orm import Mapped
+from sqlalchemy.sql.elements import ColumnElement
+from sqlmodel import Session, select
+from sqlmodel.sql.expression import SelectOfScalar
+
+from lightly_studio.models.adjacents import AdjacentResultView
+
+# A sort key column, either built as an expression or taken from a model with ``col()``.
+SortColumn = Union[ColumnElement[Any], Mapped[Any]]
+
+# A keyset sort key paired with its sort direction (True == ascending).
+SortKey = tuple[SortColumn, bool]
+
+
+def get_adjacent_result(
+    session: Session,
+    sample_id: UUID,
+    base_query: SelectOfScalar[UUID],
+    sort_keys: list[SortKey],
+    anchor: tuple[Any, ...],
+) -> AdjacentResultView:
+    """Assemble the adjacency result from two seeks and two counts.
+
+    Args:
+        session: Database session.
+        sample_id: The anchor sample, already known to be in ``base_query``.
+        base_query: Selects the candidate sample ids, filters applied.
+        sort_keys: The total, deterministic ordering to seek along.
+        anchor: The anchor's sort-key values, positionally aligned with ``sort_keys``.
+
+    Returns:
+        The neighbours plus the anchor's 1-based position and the total.
+    """
+    return AdjacentResultView(
+        previous_sample_id=_seek_neighbor(
+            session=session,
+            base_query=base_query,
+            sort_keys=sort_keys,
+            anchor=anchor,
+            forward=False,
+        ),
+        sample_id=sample_id,
+        next_sample_id=_seek_neighbor(
+            session=session,
+            base_query=base_query,
+            sort_keys=sort_keys,
+            anchor=anchor,
+            forward=True,
+        ),
+        # Position is 1-based: the rows strictly before the anchor, plus the anchor.
+        current_sample_position=_count(
+            session=session,
+            query=base_query.where(
+                _keyset_condition(sort_keys=sort_keys, anchor=anchor, after=False)
+            ),
+        )
+        + 1,
+        total_count=_count(session=session, query=base_query),
+    )
+
+
+def fetch_anchor(session: Session, query: SelectOfScalar[Any]) -> tuple[Any, ...] | None:
+    """Read the anchor's sort-key values, or ``None`` if it is not in the filtered set.
+
+    The returned tuple is aligned positionally with the query's select list and is the
+    reference point every seek and count compares against.
+    """
+    row = session.exec(query).first()
+    if row is None:
+        return None
+    return tuple(row)
+
+
+def _seek_neighbor(
+    session: Session,
+    base_query: SelectOfScalar[UUID],
+    sort_keys: list[SortKey],
+    anchor: tuple[Any, ...],
+    forward: bool,
+) -> UUID | None:
+    """Return the sample_id immediately after (forward) or before the anchor.
+
+    Restricts ``base_query`` to rows on the requested side of the anchor, orders them so
+    the closest neighbour comes first (the sort is reversed when seeking backwards), and
+    takes the first row.
+    """
+    condition = _keyset_condition(sort_keys=sort_keys, anchor=anchor, after=forward)
+    order_columns = [
+        _directional_column(column=column, ascending=ascending, forward=forward)
+        for column, ascending in sort_keys
+    ]
+    query = base_query.where(condition).order_by(*order_columns).limit(1)
+    return session.exec(query).first()
+
+
+def _directional_column(
+    column: SortColumn, *, ascending: bool, forward: bool
+) -> ColumnElement[Any]:
+    """Apply ASC/DESC for the seek direction (reversed when seeking backwards)."""
+    effective_ascending = ascending if forward else not ascending
+    return column.asc() if effective_ascending else column.desc()
+
+
+def _keyset_condition(
+    sort_keys: list[SortKey],
+    anchor: tuple[Any, ...],
+    *,
+    after: bool,
+) -> ColumnElement[bool]:
+    """Build the lexicographic comparison for the rows after (or before) the anchor.
+
+    For keys ``k0, k1, ...`` and anchor values ``v0, v1, ...``::
+
+        k0 > v0 OR (k0 = v0 AND k1 > v1) OR ...
+
+    with ``>`` flipped to ``<`` for descending keys and for ``after=False``. All keys are
+    non-nullable, so NULLs need no handling.
+    """
+    or_terms: list[ColumnElement[bool]] = []
+    for i, (column, ascending) in enumerate(sort_keys):
+        equals_prefix = [sort_keys[j][0] == anchor[j] for j in range(i)]
+        # "After" means greater for an ascending key, smaller for a descending key;
+        # seeking backwards (after=False) flips both.
+        seek_greater = ascending if after else not ascending
+        comparison = (column > anchor[i]) if seek_greater else (column < anchor[i])
+        or_terms.append(sqlalchemy.and_(*equals_prefix, comparison))
+    return sqlalchemy.or_(*or_terms)
+
+
+def _count(session: Session, query: SelectOfScalar[UUID]) -> int:
+    """Count the rows a sample-id query returns."""
+    return session.exec(select(sqlalchemy.func.count()).select_from(query.subquery())).one()

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_adjacent_images/get_adjacent_images_keyset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/get_adjacent_images/get_adjacent_images_keyset.py
@@ -1,14 +1,11 @@
-"""Keyset (seek) implementation of adjacency lookup — the fast path.
+"""Keyset (seek) implementation of image adjacency — the fast path.
 
-Instead of sorting the whole collection and scanning it with window functions, we
-read the anchor sample's sort-key values once and then issue small ``LIMIT 1``
-"seek" queries to jump straight to the neighbours. Position and total are answered
-with two ``COUNT`` queries. None of these touch more than the rows they need, so
-the cost is independent of the collection size.
+The seek engine lives in ``resolvers.adjacents.keyset_seek``; only the sort keys and the
+base query are image-specific.
 
-This only works for sorts that produce a total, deterministic order over
-non-nullable columns; see ``get_adjacent_images._is_keyset_sortable`` for the
-eligibility check and ``get_adjacent_images_window`` for the fallback.
+Needs a total, deterministic order over non-nullable columns; see
+``get_adjacent_images._is_keyset_sortable`` for the eligibility check and
+``get_adjacent_images_window`` for the fallback.
 """
 
 from __future__ import annotations
@@ -16,20 +13,15 @@ from __future__ import annotations
 from typing import Any, cast
 from uuid import UUID
 
-import sqlalchemy
-from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import Session, col, select
-from sqlmodel.sql.expression import SelectOfScalar
 
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
 from lightly_studio.core.dataset_query.order_by import OrderByExpression, OrderByField
 from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample import SampleTable
+from lightly_studio.resolvers.adjacents import keyset_seek
 from lightly_studio.resolvers.image_filter import ImageFilter
-
-# A keyset sort key paired with its sort direction (True == ascending).
-_SortKey = tuple[ColumnElement[Any], bool]
 
 
 def get_adjacent_images_keyset(
@@ -40,15 +32,6 @@ def get_adjacent_images_keyset(
     order_by: list[OrderByExpression] | None,
 ) -> AdjacentResultView | None:
     """Find the previous/next image and the anchor's position via keyset seeks.
-
-    Runs four cheap queries against the (filtered) collection:
-
-    1. Fetch the anchor's sort-key values. Returns ``None`` if the anchor is not
-       part of the filtered collection.
-    2. Seek the first row strictly after the anchor (the next neighbour).
-    3. Seek the first row strictly before the anchor (the previous neighbour).
-    4. Count the total rows and the rows before the anchor to derive the 1-based
-       position.
 
     Args:
         session: Database session.
@@ -62,57 +45,32 @@ def get_adjacent_images_keyset(
     """
     sort_keys = _keyset_sort_keys(order_by)
 
-    anchor = _fetch_anchor_values(
+    anchor = keyset_seek.fetch_anchor(
         session=session,
-        sample_id=sample_id,
-        collection_id=collection_id,
-        filters=filters,
-        sort_keys=sort_keys,
+        query=_keyset_query(
+            columns=[column for column, _ in sort_keys],
+            collection_id=collection_id,
+            filters=filters,
+        ).where(col(ImageTable.sample_id) == sample_id),
     )
     if anchor is None:
         # The sample is not part of the (filtered) collection.
         return None
 
-    base_query = _keyset_sample_id_query(collection_id=collection_id, filters=filters)
-
-    next_sample_id = _seek_neighbor(
+    return keyset_seek.get_adjacent_result(
         session=session,
-        base_query=base_query,
-        sort_keys=sort_keys,
-        anchor=anchor,
-        forward=True,
-    )
-    previous_sample_id = _seek_neighbor(
-        session=session,
-        base_query=base_query,
-        sort_keys=sort_keys,
-        anchor=anchor,
-        forward=False,
-    )
-
-    total_count = session.exec(
-        select(sqlalchemy.func.count()).select_from(base_query.subquery())
-    ).one()
-
-    # Position is 1-based: number of rows strictly before the anchor, plus the anchor.
-    count_before = session.exec(
-        select(sqlalchemy.func.count()).select_from(
-            base_query.where(
-                _keyset_condition(sort_keys=sort_keys, anchor=anchor, after=False)
-            ).subquery()
-        )
-    ).one()
-
-    return AdjacentResultView(
-        previous_sample_id=previous_sample_id,
         sample_id=sample_id,
-        next_sample_id=next_sample_id,
-        current_sample_position=count_before + 1,
-        total_count=total_count,
+        base_query=_keyset_query(
+            columns=[col(ImageTable.sample_id)],
+            collection_id=collection_id,
+            filters=filters,
+        ),
+        sort_keys=sort_keys,
+        anchor=anchor,
     )
 
 
-def _keyset_sort_keys(order_by: list[OrderByExpression] | None) -> list[_SortKey]:
+def _keyset_sort_keys(order_by: list[OrderByExpression] | None) -> list[keyset_seek.SortKey]:
     """Build the ordered, fully deterministic list of keyset sort keys.
 
     Mirrors the window query's ordering: the requested sort columns, then a
@@ -120,31 +78,35 @@ def _keyset_sort_keys(order_by: list[OrderByExpression] | None) -> list[_SortKey
     present, then ``sample_id`` as a unique final tiebreaker so the ordering — and
     therefore prev/next and the position count — is total and stable.
     """
-    keys: list[_SortKey] = []
+    keys: list[keyset_seek.SortKey] = []
     has_file_path = False
     if order_by:
         for expr in order_by:
             field_expr = cast(OrderByField, expr)
-            column = cast(ColumnElement[Any], field_expr.field.get_sqlmodel_field())
-            keys.append((column, expr.ascending))
+            keys.append((field_expr.field.get_sqlmodel_field(), expr.ascending))
             if field_expr.field is ImageSampleField.file_path_abs:
                 has_file_path = True
 
     if not has_file_path:
         primary_ascending = (not order_by) or order_by[0].ascending
-        keys.append((cast(ColumnElement[Any], col(ImageTable.file_path_abs)), primary_ascending))
+        keys.append((col(ImageTable.file_path_abs), primary_ascending))
 
-    keys.append((cast(ColumnElement[Any], col(ImageTable.sample_id)), True))
+    keys.append((col(ImageTable.sample_id), True))
     return keys
 
 
-def _keyset_sample_id_query(
+def _keyset_query(
+    columns: list[keyset_seek.SortColumn],
     collection_id: UUID,
     filters: ImageFilter | None,
-) -> SelectOfScalar[UUID]:
-    """Select image ``sample_id``s in the collection, with filters applied."""
-    query: SelectOfScalar[UUID] = (
-        select(col(ImageTable.sample_id))
+) -> Any:
+    """Select the given columns from the collection's images, with filters applied.
+
+    Type is loosened to Any because the callers select different row shapes: sample ids for
+    the seeks and counts, the sort-key tuple for the anchor.
+    """
+    query = (
+        select(*columns)
         .select_from(ImageTable)
         .join(ImageTable.sample)
         .where(col(SampleTable.collection_id) == collection_id)
@@ -152,91 +114,3 @@ def _keyset_sample_id_query(
     if filters:
         query = filters.apply(query)
     return query
-
-
-def _fetch_anchor_values(
-    session: Session,
-    sample_id: UUID,
-    collection_id: UUID,
-    filters: ImageFilter | None,
-    sort_keys: list[_SortKey],
-) -> tuple[Any, ...] | None:
-    """Return the anchor sample's sort-key values, or ``None`` if it is filtered out.
-
-    The returned tuple is aligned positionally with ``sort_keys`` and is the
-    reference point every seek and count compares against.
-    """
-    query: SelectOfScalar[Any] = (
-        select(*[column for column, _ in sort_keys])
-        .select_from(ImageTable)
-        .join(ImageTable.sample)
-        .where(col(SampleTable.collection_id) == collection_id)
-        .where(col(ImageTable.sample_id) == sample_id)
-    )
-    if filters:
-        query = filters.apply(query)
-
-    row = session.exec(query).first()
-    if row is None:
-        return None
-    return tuple(row)
-
-
-def _seek_neighbor(
-    session: Session,
-    base_query: SelectOfScalar[UUID],
-    sort_keys: list[_SortKey],
-    anchor: tuple[Any, ...],
-    forward: bool,
-) -> UUID | None:
-    """Return the sample_id immediately after (forward) or before the anchor.
-
-    Restricts ``base_query`` to rows on the requested side of the anchor, orders
-    them so the closest neighbour comes first (the sort is reversed when seeking
-    backwards), and takes the first row.
-    """
-    condition = _keyset_condition(sort_keys=sort_keys, anchor=anchor, after=forward)
-    order_columns = [
-        _directional_column(column=column, ascending=ascending, forward=forward)
-        for column, ascending in sort_keys
-    ]
-    query = base_query.where(condition).order_by(*order_columns).limit(1)
-    return session.exec(query).first()
-
-
-def _directional_column(
-    column: ColumnElement[Any], *, ascending: bool, forward: bool
-) -> ColumnElement[Any]:
-    """Apply ASC/DESC for the seek direction (reversed when seeking backwards)."""
-    effective_ascending = ascending if forward else not ascending
-    return column.asc() if effective_ascending else column.desc()
-
-
-def _keyset_condition(
-    sort_keys: list[_SortKey],
-    anchor: tuple[Any, ...],
-    *,
-    after: bool,
-) -> ColumnElement[bool]:
-    """Build the lexicographic keyset comparison for rows after/before the anchor.
-
-    For sort keys ``k0, k1, ...`` with anchor values ``v0, v1, ...`` the rows after
-    the anchor are::
-
-        (k0 AFTER v0)
-        OR (k0 == v0 AND k1 AFTER v1)
-        OR ...
-
-    where ``AFTER`` is ``>`` for an ascending key and ``<`` for a descending key
-    (and flipped for each key when ``after`` is False). All keys are non-nullable,
-    so no NULL handling is required.
-    """
-    or_terms: list[ColumnElement[bool]] = []
-    for i, (column, ascending) in enumerate(sort_keys):
-        equals_prefix = [sort_keys[j][0] == anchor[j] for j in range(i)]
-        # "After" means greater for an ascending key, smaller for a descending key;
-        # seeking backwards (after=False) flips both.
-        seek_greater = ascending if after else not ascending
-        comparison = (column > anchor[i]) if seek_greater else (column < anchor[i])
-        or_terms.append(sqlalchemy.and_(*equals_prefix, comparison))
-    return sqlalchemy.or_(*or_terms)


### PR DESCRIPTION
## What has changed and why?

Second of six in the stack. Pure code movement.

The keyset (seek) machinery lived inside the image adjacency resolver, but nothing about it is
image-specific — a caller only supplies the sort keys and the base query. It moves to
`resolvers/adjacents/keyset_seek.py` so the annotation resolver can use it too.

Three cleanups on the way:

- The image resolver had two query builders that duplicated the collection join and the filters.
  Now one builder, parameterised by the select list.
- The anchor read moves in as `keyset_seek.fetch_anchor`, since both resolvers need it.
- `SortKey`'s column type now matches what `col()` returns, which drops a
  `cast(ColumnElement[Any], ...)` at every call site.

`get_adjacent_result`, `fetch_anchor` and `SortKey` are public; the rest is module-private.

**What to review.** Not everything here is untouched, so the two halves are worth separating:

- *Moved as-is* — the seek, the comparison and the ASC/DESC helper are the same code, only
  re-wrapped to 100 columns and renamed with a leading underscore. `get_adjacent_result` is the same
  four queries that were inline in `get_adjacent_images_keyset`, and `_count` is the count that was
  written out twice.
- *Actually new* — the merged query builder, `fetch_anchor`, the widened `SortKey`, and the
  docstrings. This is where a bug could hide.

## How has it been tested?

`make static-checks` and the full suite (1893 passed), plus the adjacency tests against Postgres.

**The image adjacency tests are untouched and still pass** — that is the argument that this is a
pure move.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved previous and next image navigation across sorted results.
  * Added support for consistent navigation when sorting by multiple fields, including ascending and descending orders.
  * Improved accuracy of each image’s position and total result count.
  * Ensured deterministic navigation when images share the same sort values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->