### PR TITLE
Add composite indexes for annotation adjacency

### DIFF
--- a/lightly_studio/src/lightly_studio/migrations/versions/1786435200_b7c8d9e0f1a2_add_annotation_adjacency_indexes.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1786435200_b7c8d9e0f1a2_add_annotation_adjacency_indexes.py
@@ -1,0 +1,59 @@
+"""add_annotation_adjacency_indexes.
+
+Adds the two composite indexes the keyset (seek) path for annotation prev/next needs:
+
+- ``annotation_base(parent_sample_id, created_at, sample_id)`` — the sort keys that live on
+  the annotation itself, so each parent's annotations can be read already ordered.
+- ``video(file_path_abs, sample_id)`` — the leading sort key for annotations on video
+  frames, mirroring the existing ``image(file_path_abs, sample_id)`` index.
+
+The previous implementation sorted the whole filtered annotation set and read the
+neighbours off it with ``lag``/``lead``/``row_number`` on every prev/next click. Measured
+on PostgreSQL with 4M annotations, that took ~5.9s; the keyset seek these indexes support
+brings the neighbour lookup down to ~1ms.
+
+Note that migrations only run on PostgreSQL. DuckDB builds its schema from the models via
+``create_all``, so new DuckDB databases pick these indexes up automatically but existing
+DuckDB files do not gain them.
+
+Revision ID: b7c8d9e0f1a2
+Revises: e8f9a0b1c2d3
+Create Date: 2026-08-12 14:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c8d9e0f1a2"
+down_revision: Union[str, Sequence[str], None] = "e8f9a0b1c2d3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_index(
+        op.f("ix_annotation_base_parent_sample_id_created_at_sample_id"),
+        "annotation_base",
+        ["parent_sample_id", "created_at", "sample_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_video_file_path_abs_sample_id"),
+        "video",
+        ["file_path_abs", "sample_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_video_file_path_abs_sample_id"), table_name="video")
+    op.drop_index(
+        op.f("ix_annotation_base_parent_sample_id_created_at_sample_id"),
+        table_name="annotation_base",
+    )

--- a/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
+++ b/lightly_studio/src/lightly_studio/models/annotation/annotation_base.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict
 from pydantic import Field as PydanticField
 from sqlalchemy.orm import Mapped
-from sqlmodel import Field, Relationship, SQLModel
+from sqlmodel import Field, Index, Relationship, SQLModel
 
 from lightly_studio.models.annotation.object_detection import (
     ObjectDetectionAnnotationTable,
@@ -50,6 +50,17 @@ class AnnotationBaseTable(SQLModel, table=True):
     """Base class for all annotation models."""
 
     __tablename__ = "annotation_base"
+    # Composite index on the adjacency sort keys that live on the annotation itself. The
+    # keyset seek walks the parent media in path order and looks up each parent's
+    # annotations here, already ordered by the remaining tiebreakers. See LIG-10067.
+    __table_args__ = (
+        Index(
+            "ix_annotation_base_parent_sample_id_created_at_sample_id",
+            "parent_sample_id",
+            "created_at",
+            "sample_id",
+        ),
+    )
 
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), index=True)
 

--- a/lightly_studio/src/lightly_studio/models/video.py
+++ b/lightly_studio/src/lightly_studio/models/video.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict
 from pydantic import Field as PydanticField
 from sqlalchemy.orm import Mapped
-from sqlmodel import Field, Relationship, SQLModel
+from sqlmodel import Field, Index, Relationship, SQLModel
 
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.range import FloatRange, IntRange
@@ -43,6 +43,10 @@ class VideoTable(VideoBase, table=True):
     """This class defines the Video ORM table."""
 
     __tablename__ = "video"
+    # Composite index on the default adjacency sort key (``file_path_abs``) plus the
+    # unique ``sample_id`` tiebreaker, mirroring ``ImageTable``. Lets the keyset seek for
+    # annotations on video frames walk the videos in path order. See LIG-10067.
+    __table_args__ = (Index("ix_video_file_path_abs_sample_id", "file_path_abs", "sample_id"),)
     sample_id: UUID = Field(foreign_key="sample.sample_id", primary_key=True)
     frames: Mapped[list["VideoFrameTable"]] = Relationship(
         sa_relationship_kwargs={"lazy": "select"}, back_populates="video"


### PR DESCRIPTION
## What has changed and why?

First of six in the stack. Adds the two composite indexes that annotation prev/next needs to become a keyset (seek) lookup instead of sorting the whole collection on every click. Split out so the schema change can be reviewed and merged on its own.

- `annotation_base(parent_sample_id, created_at, sample_id)` — the adjacency sort keys that live on the annotation itself, so each parent's annotations can be read already ordered. The table had only single-column indexes.
- `video(file_path_abs, sample_id)` — the leading sort key for annotations on video frames, mirroring the `image` index added for the same reason in #1523.

Both indexes are inert until the resolver change in the follow-up PR. Measured there: the neighbour lookup on PostgreSQL with 4M annotations goes from ~6s to ~3ms.

Note that migrations only run on PostgreSQL. DuckDB builds its schema from the models via `create_all`, so new DuckDB databases pick these up automatically but existing DuckDB files do not gain them.

**What to review.** Two indexes and one migration; no code paths change. The thing to check is that each index's column order matches the sort keys the follow-up seeks on, since a wrong order leaves the index unusable for the seek.

## How has it been tested?

`make static-checks` and the test suite pass (1862 passed). `make migration-check-postgresql` applies the chain to an empty database and reports "No new upgrade operations detected", so the migration matches the models. `downgrade` drops both indexes.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved responsiveness for annotation and video adjacency lookups.
  * Optimized searches involving sample relationships, creation times, and video file paths.
* **Maintenance**
  * Added database migration support to apply and safely revert these performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->