### PR TITLE
Fast Track guardrails housekeeping

### DIFF
--- a/fast_track/src/guardrails/backend/complexity.test.ts
+++ b/fast_track/src/guardrails/backend/complexity.test.ts
@@ -84,7 +84,7 @@ describe('backendComplexityGuardrail', () => {
     });
 
     it('passes for a deleted backend file (does not exist on disk)', async () => {
-        vi.mocked(existsSync).mockReturnValueOnce(false);
+        vi.mocked(existsSync).mockImplementation((p) => !String(p).includes('model.py'));
         const result = await backendComplexityGuardrail.run(makeCtx());
         expect(result.status).toBe('pass');
         expect(result.summary).toContain('deleted');

--- a/fast_track/src/guardrails/ci.ts
+++ b/fast_track/src/guardrails/ci.ts
@@ -12,7 +12,7 @@ import { runGuardrails } from './run-guardrails';
 
 // CI entry: runs the guardrails in a PR workflow. Mirrors the local cli.ts but
 // swaps git for the read-only GitHub API; it only judges, and writes the verdict
-// to a file the bot later consumes (design §2.2). Never holds a write token, never acts.
+// to a file the bot later consumes. Never holds a write token, never acts.
 
 // cwd-relative, so it lands at fast_track/verdict.json (the workflow's upload path).
 const VERDICT_PATH = 'verdict.json';

--- a/fast_track/src/guardrails/cli.ts
+++ b/fast_track/src/guardrails/cli.ts
@@ -5,7 +5,7 @@ import { guardrails, selectGuardrails } from './registry';
 import { runGuardrails } from './run-guardrails';
 
 // Local CLI: judges the branch's committed changes from a plain checkout — no
-// GitHub API. The CI entry that writes the verdict artifact lands in a later PR.
+// GitHub API. The CI entry that writes the verdict artifact lives in ci.ts.
 
 /** Base ref to diff against; overridable so stacked branches can pick their base. */
 const DEFAULT_BASE_REF = 'origin/main';

--- a/fast_track/src/guardrails/context/api-context.test.ts
+++ b/fast_track/src/guardrails/context/api-context.test.ts
@@ -41,6 +41,12 @@ describe('toChangedFile', () => {
             toChangedFile({ filename: 'src/foo.ts', status: 'removed', additions: 0, deletions: 5 })
         ).toEqual({ path: 'src/foo.ts', status: 'deleted', additions: 0, deletions: 5 });
     });
+
+    it("maps an unknown status (e.g. 'changed') to 'modified'", () => {
+        expect(
+            toChangedFile({ filename: 'src/foo.ts', status: 'changed', additions: 1, deletions: 1 })
+        ).toEqual({ path: 'src/foo.ts', status: 'modified', additions: 1, deletions: 1 });
+    });
 });
 
 describe('ApiGuardrailContext', () => {

--- a/fast_track/src/guardrails/context/api-context.ts
+++ b/fast_track/src/guardrails/context/api-context.ts
@@ -70,7 +70,18 @@ export function toChangedFile(file: ListedFile): ChangedFile {
     };
 }
 
-/** GitHub's API uses 'removed' for deleted files; normalise to the shared FileStatus value. */
+/** Maps GitHub's file status (which uses 'removed' for deletions) onto the shared FileStatus value. */
 function toFileStatus(status: string): FileStatus {
-    return status === 'removed' ? 'deleted' : (status as FileStatus);
+    switch (status) {
+        case 'added':
+            return 'added';
+        case 'removed':
+            return 'deleted';
+        case 'renamed':
+            return 'renamed';
+        case 'copied':
+            return 'copied';
+        default:
+            return 'modified';
+    }
 }

--- a/fast_track/src/guardrails/frontend/complexity.test.ts
+++ b/fast_track/src/guardrails/frontend/complexity.test.ts
@@ -2,7 +2,7 @@ import { vi, describe, expect, it } from 'vitest';
 import type { ESLint } from 'eslint';
 import type { ChangedFile, GuardrailContext } from '../context/types';
 import { frontendComplexityGuardrail } from './complexity';
-import { FRONTEND_ABS } from './eslint-runner';
+import { FRONTEND_ABS } from './shared';
 
 vi.mock('node:fs', async (importOriginal) => {
     const actual = await importOriginal<typeof import('node:fs')>();
@@ -50,7 +50,7 @@ describe('frontendComplexityGuardrail', () => {
     });
 
     it('passes when all changed frontend files are deleted', async () => {
-        vi.mocked(existsSync).mockReturnValueOnce(false);
+        vi.mocked(existsSync).mockImplementation((p) => !String(p).includes('deleted'));
         const result = await frontendComplexityGuardrail.run(
             makeCtx([
                 {
@@ -66,7 +66,7 @@ describe('frontendComplexityGuardrail', () => {
     });
 
     it('only lints existing files when some are deleted', async () => {
-        vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(false);
+        vi.mocked(existsSync).mockImplementation((p) => !String(p).includes('deleted'));
         vi.mocked(runEslint).mockResolvedValueOnce([
             { filePath: `${FRONTEND_ABS}/src/foo.ts`, messages: [] }
         ] as unknown as ESLint.LintResult[]);

--- a/fast_track/src/guardrails/frontend/complexity.ts
+++ b/fast_track/src/guardrails/frontend/complexity.ts
@@ -2,7 +2,8 @@ import { existsSync } from 'node:fs';
 import { extname, resolve } from 'node:path';
 import type { ESLint } from 'eslint';
 import type { Guardrail, GuardrailContext, GuardrailOutcome } from '../context/types';
-import { FRONTEND_ABS, FRONTEND_PREFIX, repoRelPath, runEslint } from './eslint-runner';
+import { repoRelPath, runEslint } from './eslint-runner';
+import { FRONTEND_ABS, FRONTEND_PREFIX } from './shared';
 
 const EXTENSIONS = new Set(['.js', '.ts', '.svelte']);
 const ESLINT_CONFIG = 'eslint.complexity.config.js';

--- a/fast_track/src/guardrails/frontend/coverage.test.ts
+++ b/fast_track/src/guardrails/frontend/coverage.test.ts
@@ -7,7 +7,7 @@ vi.mock('node:fs', () => ({
 
 import { existsSync, readFileSync } from 'node:fs';
 import { filterFrontendFiles, frontendCoverageGuardrail, parseFrontendReport } from './coverage';
-import { FRONTEND_ABS, FRONTEND_PREFIX } from './eslint-runner';
+import { FRONTEND_ABS, FRONTEND_PREFIX } from './shared';
 import type { ChangedFile, GuardrailContext } from '../context/types';
 
 const mockExistsSync = vi.mocked(existsSync);

--- a/fast_track/src/guardrails/frontend/coverage.ts
+++ b/fast_track/src/guardrails/frontend/coverage.ts
@@ -4,7 +4,7 @@ import {
     type FileLineCoverage,
     type LineCoverage
 } from '../shared/full-suite-coverage';
-import { FRONTEND_PREFIX } from './eslint-runner';
+import { FRONTEND_PREFIX } from './shared';
 
 const SRC_PREFIX = FRONTEND_PREFIX + 'src/';
 

--- a/fast_track/src/guardrails/frontend/eslint-runner.test.ts
+++ b/fast_track/src/guardrails/frontend/eslint-runner.test.ts
@@ -14,7 +14,8 @@ vi.mock('node:module', async (importOriginal) => {
     };
 });
 
-import { runEslint, repoRelPath, FRONTEND_ABS } from './eslint-runner';
+import { runEslint, repoRelPath } from './eslint-runner';
+import { FRONTEND_ABS } from './shared';
 
 describe('repoRelPath', () => {
     it('converts an absolute path to a repo-relative path', () => {

--- a/fast_track/src/guardrails/frontend/eslint-runner.ts
+++ b/fast_track/src/guardrails/frontend/eslint-runner.ts
@@ -1,14 +1,6 @@
 import { createRequire } from 'node:module';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import type { ESLint } from 'eslint';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-export const FRONTEND_DIR = 'lightly_studio_view';
-// fast_track/src/guardrails/frontend -> fast_track/src/guardrails -> fast_track -> repo root -> lightly_studio_view
-export const FRONTEND_ABS = resolve(__dirname, '../../../..', FRONTEND_DIR);
-export const FRONTEND_PREFIX = FRONTEND_DIR + '/';
+import { FRONTEND_ABS, FRONTEND_DIR } from './shared';
 
 // Converts an absolute ESLint file path to a repo-relative path (e.g. lightly_studio_view/src/foo.ts).
 export function repoRelPath(absPath: string): string {

--- a/fast_track/src/guardrails/frontend/shared.ts
+++ b/fast_track/src/guardrails/frontend/shared.ts
@@ -1,0 +1,9 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const FRONTEND_DIR = 'lightly_studio_view';
+// fast_track/src/guardrails/frontend -> fast_track/src/guardrails -> fast_track -> repo root -> lightly_studio_view
+export const FRONTEND_ABS = resolve(__dirname, '../../../..', FRONTEND_DIR);
+export const FRONTEND_PREFIX = FRONTEND_DIR + '/';

--- a/fast_track/src/guardrails/registry.test.ts
+++ b/fast_track/src/guardrails/registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Guardrail } from './context/types';
-import { selectGuardrails } from './registry';
+import { guardrails, selectGuardrails } from './registry';
 
 const guardrail = (name: string, needsPrContext: boolean): Guardrail => ({
     name,
@@ -39,5 +39,20 @@ describe('selectGuardrails', () => {
         expect(() =>
             selectGuardrails(all, { hasPrContext: false, guardrailNames: ['pr-check'] })
         ).toThrow(/PR context/);
+    });
+});
+
+describe('guardrails registry', () => {
+    it('has unique guardrail names', () => {
+        const names = guardrails.map((g) => g.name);
+        expect(new Set(names).size).toBe(names.length);
+    });
+
+    it('marks at least one guardrail as required', () => {
+        expect(guardrails.some((g) => g.required)).toBe(true);
+    });
+
+    it('gives every guardrail a non-empty name', () => {
+        expect(guardrails.every((g) => g.name.length > 0)).toBe(true);
     });
 });

--- a/fast_track/src/shared/verdict.ts
+++ b/fast_track/src/shared/verdict.ts
@@ -34,7 +34,7 @@ export interface Verdict {
  * The camelCase routing inputs the verdict builders map onto the snake_case wire
  * fields above. Shared by every builder, so it lives here rather than being owned
  * by one builder module. UNTRUSTED: written in PR context, re-derived by the Bot
- * against the trusted commit (design §3).
+ * against the trusted commit.
  */
 export interface VerdictRouting {
     prNumber: number;


### PR DESCRIPTION
## What has changed and why?

Small cleanups to the Fast Track guardrails, no behaviour change for passing PRs:

- Move the shared frontend path constants (`FRONTEND_DIR`, `FRONTEND_ABS`, `FRONTEND_PREFIX`) into their own module so guardrails no longer import them through `eslint-runner`.
- Harden the GitHub file-status mapping to an explicit switch that falls back to `modified` for unknown statuses.
- Strengthen the `existsSync` test mocks to key off the path instead of call order.
- Add registry tests for unique, non-empty names and at least one required guardrail.
- Drop stale design-doc references from comments.

## How has it been tested?

`make static-checks` and `make test` in `fast_track` (199 tests pass).

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved changed-file status handling so unrecognized statuses are treated consistently as modified.
  - Corrected deleted-file detection across backend and frontend validation scenarios.

- **Tests**
  - Expanded coverage for unknown file statuses, deleted files, and guardrail registry consistency.
  - Strengthened validation that configured guardrails have unique, non-empty names and include required checks.

- **Refactor**
  - Centralized frontend path handling for more consistent validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->