### PR TITLE
Render guardrail summary newlines in the status table

### DIFF
--- a/fast_track/src/bot/comment.test.ts
+++ b/fast_track/src/bot/comment.test.ts
@@ -87,8 +87,16 @@ describe('renderComment', () => {
             }),
             headSha: HEAD_SHA
         });
-        expect(body).toContain('| lint\\|check | ❌ | one<br>two\\|three |');
+        expect(body).toContain('| lint&#124;check | ❌ | one<br>two&#124;three |');
         expect(body).toContain('<sub>Reflects `abc1234`.</sub>');
+    });
+
+    it('escapes a backslash before a pipe without splitting the cell', () => {
+        const body = renderComment({
+            verdict: verdict({ guardrails: [{ name: 'g', status: 'fail', summary: 'a\\|b' }] }),
+            headSha: HEAD_SHA
+        });
+        expect(body).toContain('| g | ❌ | a\\&#124;b |');
     });
 
     it('normalizes all line-ending forms to line breaks', () => {

--- a/fast_track/src/bot/comment.test.ts
+++ b/fast_track/src/bot/comment.test.ts
@@ -80,15 +80,33 @@ describe('renderComment', () => {
         );
     });
 
-    it('renders guardrails safely in a Markdown table', () => {
+    it('renders newlines in a summary as line breaks and escapes pipes', () => {
         const body = renderComment({
             verdict: verdict({
                 guardrails: [{ name: 'lint|check', status: 'fail', summary: 'one\ntwo|three' }]
             }),
             headSha: HEAD_SHA
         });
-        expect(body).toContain('| lint\\|check | ❌ | one two\\|three |');
+        expect(body).toContain('| lint\\|check | ❌ | one<br>two\\|three |');
         expect(body).toContain('<sub>Reflects `abc1234`.</sub>');
+    });
+
+    it('normalizes all line-ending forms to line breaks', () => {
+        const body = renderComment({
+            verdict: verdict({ guardrails: [{ name: 'g', status: 'fail', summary: 'a\r\nb\rc' }] }),
+            headSha: HEAD_SHA
+        });
+        expect(body).toContain('| g | ❌ | a<br>b<br>c |');
+    });
+
+    it('HTML-escapes angle brackets so raw linter output stays visible', () => {
+        const body = renderComment({
+            verdict: verdict({
+                guardrails: [{ name: 'g', status: 'fail', summary: '<img src=x>' }]
+            }),
+            headSha: HEAD_SHA
+        });
+        expect(body).toContain('| g | ❌ | &lt;img src=x&gt; |');
     });
 });
 

--- a/fast_track/src/bot/comment.ts
+++ b/fast_track/src/bot/comment.ts
@@ -112,12 +112,16 @@ export async function upsertComment(
  * Format a value for a GFM table cell: render newlines as `<br>`, keep pipes
  * from splitting the cell, and HTML-escape angle brackets so raw linter output
  * (e.g. `<generic>`) shows instead of being dropped by GitHub's sanitizer.
+ *
+ * Pipes become the `&#124;` entity rather than a `\|` backslash escape: a value
+ * such as `\|` would otherwise turn into `\\|`, which GFM reads as an escaped
+ * backslash followed by an active delimiter and the cell splits.
  */
 function formatCell(value: string): string {
     return value
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
-        .replace(/\|/g, '\\|')
+        .replace(/\|/g, '&#124;')
         .replace(/\r\n|\r|\n/g, '<br>');
 }

--- a/fast_track/src/bot/comment.ts
+++ b/fast_track/src/bot/comment.ts
@@ -45,7 +45,7 @@ export function renderComment(params: RenderCommentParams): string {
         for (const guardrail of verdict.guardrails) {
             const icon = guardrail.status === 'pass' ? '✅' : '❌';
             lines.push(
-                `| ${escapeCell(guardrail.name)} | ${icon} | ${escapeCell(guardrail.summary)} |`
+                `| ${formatCell(guardrail.name)} | ${icon} | ${formatCell(guardrail.summary)} |`
             );
         }
     }
@@ -108,6 +108,16 @@ export async function upsertComment(
     return 'updated';
 }
 
-function escapeCell(value: string): string {
-    return value.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+/**
+ * Format a value for a GFM table cell: render newlines as `<br>`, keep pipes
+ * from splitting the cell, and HTML-escape angle brackets so raw linter output
+ * (e.g. `<generic>`) shows instead of being dropped by GitHub's sanitizer.
+ */
+function formatCell(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\|/g, '\\|')
+        .replace(/\r\n|\r|\n/g, '<br>');
 }


### PR DESCRIPTION
## What has changed and why?

Multi-line guardrail summaries were collapsed onto a single line in the Fast Track status comment; table cells now render newlines as `<br>`, escape pipes so cells do not split, and HTML-escape angle brackets so raw output stays visible.

## How has it been tested?

Unit tests cover newline rendering, all line-ending forms, pipe escaping, and angle-bracket escaping. `make static-checks` and `make test` pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment formatting so multiline summaries preserve line breaks.
  * Added consistent handling for different newline formats.
  * Improved escaping of special characters, including angle brackets, ampersands, and table pipe characters, to prevent formatting issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->