### PR TITLE
Add an ordering argument to the annotations-with-payload resolver

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -32,6 +32,9 @@ from lightly_studio.resolvers import (
 from lightly_studio.resolvers.annotation_resolver.get_all import (
     GetAllAnnotationsResult,
 )
+from lightly_studio.resolvers.annotation_resolver.get_all_with_payload import (
+    AnnotationOrdering,
+)
 from lightly_studio.resolvers.annotation_resolver.update_bounding_box import BoundingBoxCoordinates
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
@@ -167,7 +170,7 @@ def read_annotations_with_payload(
             embedding_region=body.embedding_region,
         ),
         collection_id=collection_id,
-        text_embedding=body.text_embedding,
+        ordering=AnnotationOrdering(text_embedding=body.text_embedding),
     )
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/__init__.py
@@ -24,6 +24,7 @@ from lightly_studio.resolvers.annotation_resolver.get_all_by_parent_sample_ids i
     get_all_by_parent_sample_ids,
 )
 from lightly_studio.resolvers.annotation_resolver.get_all_with_payload import (
+    AnnotationOrdering,
     get_all_with_payload,
 )
 from lightly_studio.resolvers.annotation_resolver.get_annotation_crops import (
@@ -59,6 +60,7 @@ from lightly_studio.resolvers.annotation_resolver.update_temporal_span import (
 
 __all__ = [
     "AnnotationCrop",
+    "AnnotationOrdering",
     "build_sample_ids_query",
     "create_many",
     "delete_annotation",

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_with_payload.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_all_with_payload.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
 from sqlalchemy.orm import aliased, joinedload, load_only
+from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import Session, col, func, select
 from sqlmodel.sql.expression import Select
 
 from lightly_studio.api.routes.api.validators import Paginated
+from lightly_studio.core.dataset_query.order_by import OrderByExpression
 from lightly_studio.models.annotation.annotation_base import (
     AnnotationBaseTable,
     AnnotationView,
@@ -36,12 +40,29 @@ from lightly_studio.resolvers.similarity_utils import (
 )
 
 
+@dataclass
+class AnnotationOrdering:
+    """How annotations are ordered before the tiebreaker chain.
+
+    Similarity search dominates: while ``text_embedding`` is set, ``order_by`` is ignored,
+    as in the sample grid where the text query has to be cleared before another sort applies.
+
+    Args:
+        text_embedding: Optional embedding; when given, annotations are ordered by cosine
+            distance of their embedding to it.
+        order_by: Optional order by expression, e.g. an evaluation metric value.
+    """
+
+    text_embedding: list[float] | None = None
+    order_by: OrderByExpression | None = None
+
+
 def get_all_with_payload(
     session: Session,
     collection_id: UUID,
     pagination: Paginated | None = None,
     filters: AnnotationsFilter | None = None,
-    text_embedding: list[float] | None = None,
+    ordering: AnnotationOrdering | None = None,
 ) -> AnnotationWithPayloadAndCountView:
     """Get all annotations with payload from the database.
 
@@ -50,12 +71,12 @@ def get_all_with_payload(
         pagination: Optional pagination parameters
         filters: Optional filters to apply to the query
         collection_id: ID of the collection to get annotations for
-        text_embedding: Optional embedding; when given, annotations are ordered by
-            cosine distance of their embedding to it.
+        ordering: Optional ordering applied before the tiebreaker chain.
 
     Returns:
         List of annotations matching the filters with payload
     """
+    ordering = ordering or AnnotationOrdering()
     parent_collection = collection_resolver.get_parent_collection_id(
         session=session, collection_id=collection_id
     )
@@ -77,8 +98,9 @@ def get_all_with_payload(
         base_query = filters.apply(base_query)
 
     embedding_model_id, distance_expr = get_distance_expression(
-        session=session, collection_id=collection_id, text_embedding=text_embedding
+        session=session, collection_id=collection_id, text_embedding=ordering.text_embedding
     )
+    order_by = ordering.order_by if distance_expr is None else None
     if distance_expr is not None:
         base_query = apply_similarity_join(
             query=base_query,
@@ -86,15 +108,24 @@ def get_all_with_payload(
             embedding_model_id=embedding_model_id,
         )
 
+    # Sort joins stay out of the count query below: they cannot change the count, so joining
+    # there would only run the join a second time per page.
+    rows_query = base_query
+    order_by_keys: list[ColumnElement[Any]] = []
+    if order_by is not None:
+        rows_query = order_by.apply_joins(rows_query)
+        order_by_keys = order_by.to_column_elements()
+
     # Type is loosened to Any because similarity search appends a distance column,
     # changing the row shape from 2-tuple to 3-tuple.
-    annotations_query: Any = base_query.order_by(
+    annotations_query: Any = rows_query.order_by(
+        *order_by_keys,
         *annotation_ordering.build_order_by(
             file_path_abs=annotation_ordering.file_path_abs_expression(sample_type=sample_type),
             created_at=col(AnnotationBaseTable.created_at),
             annotation_sample_id=col(AnnotationBaseTable.sample_id),
             leading_order_key=distance_expr,
-        )
+        ),
     )
     if distance_expr is not None:
         annotations_query = annotations_query.add_columns(distance_expr)
@@ -111,9 +142,24 @@ def get_all_with_payload(
 
     rows = session.exec(annotations_query).all()
 
+    return AnnotationWithPayloadAndCountView(
+        total_count=total_count,
+        next_cursor=next_cursor,
+        annotations=_build_annotation_views(
+            rows=rows, sample_type=sample_type, has_distance=distance_expr is not None
+        ),
+    )
+
+
+def _build_annotation_views(
+    rows: Sequence[Any],
+    sample_type: SampleType,
+    has_distance: bool,
+) -> list[AnnotationWithPayloadView]:
+    """Turn query rows into views, unpacking the distance column when present."""
     annotation_views = []
     for row in rows:
-        if distance_expr is not None:
+        if has_distance:
             annotation, payload, distance = row
             similarity_score = distance_to_similarity(distance)
         else:
@@ -127,12 +173,7 @@ def get_all_with_payload(
                 similarity_score=similarity_score,
             )
         )
-
-    return AnnotationWithPayloadAndCountView(
-        total_count=total_count,
-        next_cursor=next_cursor,
-        annotations=annotation_views,
-    )
+    return annotation_views
 
 
 def _build_base_query(

--- a/lightly_studio/tests/resolvers/annotations/test_get_all_with_payload.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_all_with_payload.py
@@ -263,7 +263,7 @@ def test_get_all_with_payload__orders_by_text_embedding_similarity(
     annotations_page = annotation_resolver.get_all_with_payload(
         session=db_session,
         collection_id=annotation_collection_id,
-        text_embedding=[1.0, 0.0],
+        ordering=annotation_resolver.AnnotationOrdering(text_embedding=[1.0, 0.0]),
     )
 
     assert annotations_page.total_count == 2
@@ -294,7 +294,7 @@ def test_get_all_with_payload__without_embedding_model_has_no_similarity_score(
     annotations_page = annotation_resolver.get_all_with_payload(
         session=db_session,
         collection_id=annotation.sample.collection_id,
-        text_embedding=[1.0, 0.0],
+        ordering=annotation_resolver.AnnotationOrdering(text_embedding=[1.0, 0.0]),
     )
 
     assert annotations_page.annotations[0].similarity_score is None

--- a/lightly_studio/tests/resolvers/annotations/test_get_all_with_payload_metric_sort.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_all_with_payload_metric_sort.py
@@ -1,0 +1,276 @@
+"""Tests for ordering get_all_with_payload by a per-annotation evaluation metric."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlmodel import Session, col
+
+from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluationMetricField
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationSide
+from lightly_studio.resolvers import annotation_resolver, collection_resolver
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_embedding_model,
+    create_image,
+    create_sample_embedding,
+)
+from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
+    FalseNegativeMetricStub,
+    FalsePositiveMetricStub,
+    TruePositiveMetricStub,
+    create_annotation_metrics,
+    create_run,
+)
+
+METRIC_NAME = "iou"
+# Exactly representable as a 32-bit float, so it round-trips through the value column.
+MATCHED_VALUE = 0.75
+
+
+@dataclass
+class _AnnotationEvaluationMetricFixture:
+    """One evaluation run holding every state the ordering has to distinguish."""
+
+    run_id: UUID
+    gt_collection_id: UUID
+    root_collection_id: UUID
+    matched: UUID
+    unmatched: UUID
+    uncovered: UUID
+
+
+def test_get_all_with_payload__orders_by_annotation_evaluation_metric__ascending(
+    db_session: Session,
+) -> None:
+    fixture = _create_annotation_evaluation_metric_fixture(session=db_session)
+
+    annotations_page = annotation_resolver.get_all_with_payload(
+        session=db_session,
+        collection_id=fixture.gt_collection_id,
+        filters=AnnotationsFilter(collection_ids=[fixture.gt_collection_id]),
+        ordering=annotation_resolver.AnnotationOrdering(
+            order_by=OrderByAnnotationEvaluationMetricField(
+                evaluation_run_id=fixture.run_id,
+                metric_name=METRIC_NAME,
+                side=EvaluationAnnotationSide.GROUND_TRUTH,
+                annotation_id_column=col(AnnotationBaseTable.sample_id),
+            )
+        ),
+    )
+
+    # Unmatched orders as 0.0 ahead of the matched value; uncovered orders last. The
+    # count also proves the run's prediction-side annotation was not joined in.
+    assert [a.annotation.sample_id for a in annotations_page.annotations] == [
+        fixture.unmatched,
+        fixture.matched,
+        fixture.uncovered,
+    ]
+    assert annotations_page.total_count == 3
+
+
+def test_get_all_with_payload__orders_by_annotation_evaluation_metric__descending(
+    db_session: Session,
+) -> None:
+    fixture = _create_annotation_evaluation_metric_fixture(session=db_session)
+
+    annotations_page = annotation_resolver.get_all_with_payload(
+        session=db_session,
+        collection_id=fixture.gt_collection_id,
+        filters=AnnotationsFilter(collection_ids=[fixture.gt_collection_id]),
+        ordering=annotation_resolver.AnnotationOrdering(
+            order_by=OrderByAnnotationEvaluationMetricField(
+                evaluation_run_id=fixture.run_id,
+                metric_name=METRIC_NAME,
+                side=EvaluationAnnotationSide.GROUND_TRUTH,
+                annotation_id_column=col(AnnotationBaseTable.sample_id),
+            ).desc()
+        ),
+    )
+
+    # Uncovered stays last in both directions.
+    assert [a.annotation.sample_id for a in annotations_page.annotations] == [
+        fixture.matched,
+        fixture.unmatched,
+        fixture.uncovered,
+    ]
+
+
+def test_get_all_with_payload__text_embedding_takes_precedence_over_order_by(
+    db_session: Session,
+) -> None:
+    fixture = _create_annotation_evaluation_metric_fixture(session=db_session)
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=fixture.gt_collection_id,
+        embedding_dimension=2,
+    )
+    # Similarity orders these differently than the metric does in either direction, so the
+    # expected order only holds if similarity wins.
+    for sample_id, embedding in (
+        (fixture.uncovered, [1.0, 0.0]),
+        (fixture.matched, [0.0, 1.0]),
+        (fixture.unmatched, [-1.0, 0.0]),
+    ):
+        create_sample_embedding(
+            session=db_session,
+            sample_id=sample_id,
+            embedding_model_id=embedding_model.embedding_model_id,
+            embedding=embedding,
+        )
+
+    annotations_page = annotation_resolver.get_all_with_payload(
+        session=db_session,
+        collection_id=fixture.gt_collection_id,
+        filters=AnnotationsFilter(collection_ids=[fixture.gt_collection_id]),
+        ordering=annotation_resolver.AnnotationOrdering(
+            text_embedding=[1.0, 0.0],
+            order_by=OrderByAnnotationEvaluationMetricField(
+                evaluation_run_id=fixture.run_id,
+                metric_name=METRIC_NAME,
+                side=EvaluationAnnotationSide.GROUND_TRUTH,
+                annotation_id_column=col(AnnotationBaseTable.sample_id),
+            ),
+        ),
+    )
+
+    assert [a.annotation.sample_id for a in annotations_page.annotations] == [
+        fixture.uncovered,
+        fixture.matched,
+        fixture.unmatched,
+    ]
+
+
+def test_get_all_with_payload__orders_by_annotation_evaluation_metric__composes_with_label_filter(
+    db_session: Session,
+) -> None:
+    fixture = _create_annotation_evaluation_metric_fixture(session=db_session)
+    other_label = create_annotation_label(
+        session=db_session,
+        root_collection_id=fixture.root_collection_id,
+        label_name="airplane",
+    )
+
+    annotations_page = annotation_resolver.get_all_with_payload(
+        session=db_session,
+        collection_id=fixture.gt_collection_id,
+        filters=AnnotationsFilter(
+            collection_ids=[fixture.gt_collection_id],
+            annotation_label_ids=[other_label.annotation_label_id],
+        ),
+        ordering=annotation_resolver.AnnotationOrdering(
+            order_by=OrderByAnnotationEvaluationMetricField(
+                evaluation_run_id=fixture.run_id,
+                metric_name=METRIC_NAME,
+                side=EvaluationAnnotationSide.GROUND_TRUTH,
+                annotation_id_column=col(AnnotationBaseTable.sample_id),
+            )
+        ),
+    )
+
+    assert annotations_page.total_count == 0
+
+
+def test_get_all_with_payload__orders_by_annotation_evaluation_metric__does_not_multiply_rows(
+    db_session: Session,
+) -> None:
+    root = create_collection(session=db_session)
+    label = create_annotation_label(session=db_session, root_collection_id=root.collection_id)
+    run = create_run(session=db_session, collection_id=root.collection_id)
+    image = create_image(session=db_session, collection_id=root.collection_id)
+    # Two metrics on one annotation: the join must still yield a single grid row.
+    create_annotation_metrics(
+        session=db_session,
+        run_id=run.id,
+        pair_metric_stubs=[
+            TruePositiveMetricStub(
+                sample_id=image.sample_id,
+                metrics={METRIC_NAME: MATCHED_VALUE, "disagreement": 0.25},
+                gt_annotation_label_id=label.annotation_label_id,
+            ),
+        ],
+    )
+
+    annotations_page = annotation_resolver.get_all_with_payload(
+        session=db_session,
+        collection_id=run.gt_annotation_collection_id,
+        filters=AnnotationsFilter(collection_ids=[run.gt_annotation_collection_id]),
+        ordering=annotation_resolver.AnnotationOrdering(
+            order_by=OrderByAnnotationEvaluationMetricField(
+                evaluation_run_id=run.id,
+                metric_name=METRIC_NAME,
+                side=EvaluationAnnotationSide.GROUND_TRUTH,
+                annotation_id_column=col(AnnotationBaseTable.sample_id),
+            )
+        ),
+    )
+
+    assert annotations_page.total_count == 1
+
+
+def _create_annotation_evaluation_metric_fixture(
+    session: Session,
+) -> _AnnotationEvaluationMetricFixture:
+    root = create_collection(session=session)
+    label = create_annotation_label(session=session, root_collection_id=root.collection_id)
+    run = create_run(session=session, collection_id=root.collection_id)
+
+    # Distinct file paths, because the parent file path is the leading tiebreaker.
+    image_matched = create_image(
+        session=session, collection_id=root.collection_id, file_path_abs="/a.png"
+    )
+    image_unmatched = create_image(
+        session=session, collection_id=root.collection_id, file_path_abs="/b.png"
+    )
+    image_uncovered = create_image(
+        session=session, collection_id=root.collection_id, file_path_abs="/c.png"
+    )
+
+    matched_stub, unmatched_stub, _unmatched_pred_stub = create_annotation_metrics(
+        session=session,
+        run_id=run.id,
+        pair_metric_stubs=[
+            TruePositiveMetricStub(
+                sample_id=image_matched.sample_id,
+                metrics={METRIC_NAME: MATCHED_VALUE},
+                gt_annotation_label_id=label.annotation_label_id,
+            ),
+            FalseNegativeMetricStub(
+                sample_id=image_unmatched.sample_id,
+                gt_annotation_label_id=label.annotation_label_id,
+            ),
+            # The matched pairing's other side: must not leak into ground-truth results.
+            FalsePositiveMetricStub(
+                sample_id=image_unmatched.sample_id,
+                pred_annotation_label_id=label.annotation_label_id,
+            ),
+        ],
+    )
+
+    gt_collection = collection_resolver.get_by_id(
+        session=session, collection_id=run.gt_annotation_collection_id
+    )
+    assert gt_collection is not None
+    uncovered = create_annotation(
+        session=session,
+        collection_id=root.collection_id,
+        sample_id=image_uncovered.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name=gt_collection.name,
+    )
+
+    assert matched_stub.gt_annotation_id is not None
+    assert unmatched_stub.gt_annotation_id is not None
+    return _AnnotationEvaluationMetricFixture(
+        run_id=run.id,
+        gt_collection_id=run.gt_annotation_collection_id,
+        root_collection_id=root.collection_id,
+        matched=matched_stub.gt_annotation_id,
+        unmatched=unmatched_stub.gt_annotation_id,
+        uncovered=uncovered.sample_id,
+    )


### PR DESCRIPTION
## What has changed and why?

`get_all_with_payload` to order by an arbitrary order-by expression, so the next part can
wire the endpoint without also reshaping the resolver.

`text_embedding` and the new optional `order_by` move into one `AnnotationOrdering` argument. That
keeps their precedence rule in one place: similarity wins while it is active, as in the sample grid
where the text query has to be cleared before another sort applies. The order-by keys lead the
existing tiebreaker chain.

The sort joins are applied to the rows query only. They cannot change the count, so joining them in
the count query would just run the join a second time per page. The row-to-view loop moves into a
helper to keep the function within the lint limits without ignores.

Returning the ordered value for display is deferred to a follow up. Keeping it out means the
row-unpacking loop, which similarity search also uses, is untouched.

## How has it been tested?

`tests/resolvers/annotations/test_get_all_with_payload_metric_sort.py` — one four-state fixture
holding every state at once: a matched pair with a value, an unmatched annotation whose row has
null metric name and value, an annotation the run never covered with no row at all, and an
annotation on the other side of the run's pairing. It asserts the exact returned sequence ascending
**and** descending and that nulls come last both ways, plus a `total_count` guard proving a run
writing several metrics per annotation does not multiply rows, one test composing the sort with an
annotation class filter, and one proving similarity ordering wins over the metric sort.

`cd lightly_studio && make static-checks && make test`: ruff and mypy clean, 1828 passing.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sorting annotations by evaluation metrics in ascending or descending order.
  * Combined metric-based sorting with text-embedding similarity ordering, while preserving similarity precedence.
  * Improved annotation results across matched, unmatched, and uncovered evaluation data.

* **Bug Fixes**
  * Prevented duplicate annotation results when multiple metrics apply.
  * Excluded prediction-only annotations from annotation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->