### PR TITLE
Fast Track: Remove unused PR-context capability from guardrails

### DIFF
--- a/fast_track/src/guardrails/backend/complexity.test.ts
+++ b/fast_track/src/guardrails/backend/complexity.test.ts
@@ -28,13 +28,12 @@ const backendFile: ChangedFile = {
 };
 
 function makeCtx(files: ChangedFile[] = [backendFile]): GuardrailContext {
-    return { baseRef: 'origin/main', changedFiles: async () => files };
+    return { changedFiles: async () => files };
 }
 
 describe('backendComplexityGuardrail', () => {
-    it('is required and runs locally', () => {
+    it('is required', () => {
         expect(backendComplexityGuardrail.required).toBe(true);
-        expect(backendComplexityGuardrail.needsPrContext).toBe(false);
     });
 
     it('passes immediately when no backend files changed', async () => {

--- a/fast_track/src/guardrails/backend/complexity.ts
+++ b/fast_track/src/guardrails/backend/complexity.ts
@@ -46,7 +46,6 @@ async function runLinter(paths: string[]): Promise<RuffViolation[]> {
 export const backendComplexityGuardrail: Guardrail = {
     name: NAME,
     required: true,
-    needsPrContext: false,
     async run(ctx: GuardrailContext): Promise<GuardrailOutcome> {
         const files = (await ctx.changedFiles()).filter(
             (f) => f.path.startsWith(BACKEND_PREFIX) && f.path.endsWith('.py')

--- a/fast_track/src/guardrails/backend/coverage.test.ts
+++ b/fast_track/src/guardrails/backend/coverage.test.ts
@@ -18,7 +18,7 @@ const mockExistsSync = vi.mocked(existsSync);
 const mockReadFileSync = vi.mocked(readFileSync);
 
 function makeCtx(files: ChangedFile[]): GuardrailContext {
-    return { baseRef: 'origin/main', changedFiles: async () => files };
+    return { changedFiles: async () => files };
 }
 
 function setReport(files: Record<string, CoverageFileData>): void {

--- a/fast_track/src/guardrails/ci.ts
+++ b/fast_track/src/guardrails/ci.ts
@@ -67,8 +67,7 @@ async function main(env: NodeJS.ProcessEnv): Promise<void> {
         baseRef: routing.baseRef
     });
 
-    // hasPrContext: true — unlike the local CLI, pr-only guardrails run here.
-    const selected = selectGuardrails(guardrails, { hasPrContext: true });
+    const selected = selectGuardrails(guardrails, {});
     const run = await runGuardrails(guardrailContext, selected);
     const verdict = buildVerdict(run, routing);
 

--- a/fast_track/src/guardrails/ci.ts
+++ b/fast_track/src/guardrails/ci.ts
@@ -67,7 +67,7 @@ async function main(env: NodeJS.ProcessEnv): Promise<void> {
         baseRef: routing.baseRef
     });
 
-    const selected = selectGuardrails(guardrails, {});
+    const selected = selectGuardrails(guardrails);
     const run = await runGuardrails(guardrailContext, selected);
     const verdict = buildVerdict(run, routing);
 

--- a/fast_track/src/guardrails/cli.ts
+++ b/fast_track/src/guardrails/cli.ts
@@ -10,13 +10,12 @@ import { runGuardrails } from './run-guardrails';
 /** Base ref to diff against; overridable so stacked branches can pick their base. */
 const DEFAULT_BASE_REF = 'origin/main';
 
-/** Print the registry (name, required-ness, availability) and exit. */
+/** Print the registry (name, required-ness) and exit. */
 function listGuardrails(): void {
     console.log('Registered guardrails:');
     for (const g of guardrails) {
         const required = g.required ? 'required' : 'optional';
-        const availability = g.needsPrContext ? 'pr-only' : 'local';
-        console.log(`  ${g.name}  (${required}, ${availability})`);
+        console.log(`  ${g.name}  (${required})`);
     }
 }
 
@@ -41,10 +40,7 @@ async function main(argv: string[], env: NodeJS.ProcessEnv): Promise<number> {
     // Validate the base ref before judging: an empty or unresolvable ref would
     // otherwise diff against nothing and report a vacuous pass (see git-context).
     await context.assertBaseRefResolves();
-    // Local runs have no PR API, so pr-only guardrails are filtered out. An
-    // explicit GUARDRAILS name that needs PR context fails fast (see selectGuardrails).
     const selected = selectGuardrails(guardrails, {
-        hasPrContext: false,
         guardrailNames: selectedNames(env.GUARDRAILS)
     });
 

--- a/fast_track/src/guardrails/context/api-context.ts
+++ b/fast_track/src/guardrails/context/api-context.ts
@@ -28,7 +28,7 @@ export interface ApiGuardrailContextParams {
  */
 export class ApiGuardrailContext implements GuardrailContext {
     readonly baseRef: string;
-    readonly octokit: Octokit;
+    private readonly octokit: Octokit;
     private readonly owner: string;
     private readonly repo: string;
     private readonly prNumber: number;

--- a/fast_track/src/guardrails/context/types.ts
+++ b/fast_track/src/guardrails/context/types.ts
@@ -1,4 +1,3 @@
-import type { Octokit } from '../../shared/octokit';
 import type { GuardrailResult } from '../../shared/verdict';
 
 export type FileStatus = 'added' | 'deleted' | 'modified' | 'renamed' | 'copied';
@@ -14,9 +13,6 @@ export interface ChangedFile {
 
 /** Backed by git locally and the API in CI. */
 export interface GuardrailContext {
-    baseRef: string;
-    /** Present only in CI (`ApiGuardrailContext`); absent locally. */
-    octokit?: Octokit;
     changedFiles(): Promise<ChangedFile[]>;
 }
 
@@ -26,7 +22,5 @@ export type GuardrailOutcome = Omit<GuardrailResult, 'name'>;
 export interface Guardrail {
     name: string;
     required: boolean;
-    /** True if it needs the PR API (CI only); false runs anywhere. */
-    needsPrContext: boolean;
     run(context: GuardrailContext): Promise<GuardrailOutcome>;
 }

--- a/fast_track/src/guardrails/diff-size.test.ts
+++ b/fast_track/src/guardrails/diff-size.test.ts
@@ -3,13 +3,12 @@ import type { ChangedFile, GuardrailContext } from './context/types';
 import { diffSizeGuardrail, isExcluded, MAX_ADDED_LOC } from './diff-size';
 
 function makeCtx(files: ChangedFile[]): GuardrailContext {
-    return { baseRef: 'origin/main', changedFiles: async () => files };
+    return { changedFiles: async () => files };
 }
 
 describe('diffSizeGuardrail', () => {
-    it('is required and runs locally', () => {
+    it('is required', () => {
         expect(diffSizeGuardrail.required).toBe(true);
-        expect(diffSizeGuardrail.needsPrContext).toBe(false);
     });
 
     it('passes when total additions are below the limit', async () => {

--- a/fast_track/src/guardrails/diff-size.ts
+++ b/fast_track/src/guardrails/diff-size.ts
@@ -25,7 +25,6 @@ export function isExcluded(path: string): boolean {
 export const diffSizeGuardrail: Guardrail = {
     name: NAME,
     required: true,
-    needsPrContext: false,
     async run(ctx: GuardrailContext): Promise<GuardrailOutcome> {
         const files = await ctx.changedFiles();
         const totalAdditions = files

--- a/fast_track/src/guardrails/frontend/complexity.test.ts
+++ b/fast_track/src/guardrails/frontend/complexity.test.ts
@@ -25,13 +25,12 @@ const frontendFile = {
 };
 
 function makeCtx(files: ChangedFile[] = [frontendFile]): GuardrailContext {
-    return { baseRef: 'origin/main', changedFiles: async () => files };
+    return { changedFiles: async () => files };
 }
 
 describe('frontendComplexityGuardrail', () => {
-    it('is required and runs locally', () => {
+    it('is required', () => {
         expect(frontendComplexityGuardrail.required).toBe(true);
-        expect(frontendComplexityGuardrail.needsPrContext).toBe(false);
     });
 
     it('passes immediately when no frontend files changed', async () => {

--- a/fast_track/src/guardrails/frontend/complexity.ts
+++ b/fast_track/src/guardrails/frontend/complexity.ts
@@ -11,7 +11,6 @@ const ESLINT_ERROR_SEVERITY = 2;
 export const frontendComplexityGuardrail: Guardrail = {
     name: 'frontend/complexity',
     required: true,
-    needsPrContext: false,
     async run(ctx: GuardrailContext): Promise<GuardrailOutcome> {
         const files = (await ctx.changedFiles()).filter(
             (f) => f.path.startsWith(FRONTEND_PREFIX) && EXTENSIONS.has(extname(f.path))

--- a/fast_track/src/guardrails/frontend/coverage.test.ts
+++ b/fast_track/src/guardrails/frontend/coverage.test.ts
@@ -17,7 +17,7 @@ const mockReadFileSync = vi.mocked(readFileSync);
 const PATCH = '@@ -0,0 +1,3 @@\n+line 1\n+line 2\n+line 3\n';
 
 function makeCtx(files: ChangedFile[]): GuardrailContext {
-    return { baseRef: 'origin/main', changedFiles: async () => files };
+    return { changedFiles: async () => files };
 }
 
 const FRONTEND_FILE: ChangedFile = {

--- a/fast_track/src/guardrails/registry.test.ts
+++ b/fast_track/src/guardrails/registry.test.ts
@@ -3,41 +3,34 @@ import { describe, expect, it } from 'vitest';
 import type { Guardrail } from './context/types';
 import { selectGuardrails } from './registry';
 
-const guardrail = (name: string, needsPrContext: boolean): Guardrail => ({
+const guardrail = (name: string): Guardrail => ({
     name,
     required: true,
-    needsPrContext,
     run: async () => ({ status: 'pass', summary: '' })
 });
 
-const local = guardrail('local-check', false);
-const prOnly = guardrail('pr-check', true);
-const all = [local, prOnly];
+const first = guardrail('first-check');
+const second = guardrail('second-check');
+const all = [first, second];
 
 describe('selectGuardrails', () => {
-    it('drops guardrails needing PR context when it is unavailable', () => {
-        expect(selectGuardrails(all, { hasPrContext: false })).toEqual([local]);
-    });
-
-    it('keeps guardrails needing PR context when it is available', () => {
-        expect(selectGuardrails(all, { hasPrContext: true })).toEqual(all);
+    it('selects all when no names are given', () => {
+        expect(selectGuardrails(all, {})).toEqual(all);
     });
 
     it('restricts to the named subset', () => {
-        expect(selectGuardrails(all, { hasPrContext: true, guardrailNames: ['pr-check'] })).toEqual(
-            [prOnly]
+        expect(selectGuardrails(all, { guardrailNames: ['second-check'] })).toEqual([second]);
+    });
+
+    it('preserves the input order regardless of the requested order', () => {
+        expect(selectGuardrails(all, { guardrailNames: ['second-check', 'first-check'] })).toEqual(
+            all
         );
     });
 
     it('throws on an unknown name rather than passing vacuously', () => {
-        expect(() =>
-            selectGuardrails(all, { hasPrContext: true, guardrailNames: ['typo'] })
-        ).toThrow(/Unknown guardrail/);
-    });
-
-    it('throws when an explicitly named guardrail needs unavailable PR context', () => {
-        expect(() =>
-            selectGuardrails(all, { hasPrContext: false, guardrailNames: ['pr-check'] })
-        ).toThrow(/PR context/);
+        expect(() => selectGuardrails(all, { guardrailNames: ['typo'] })).toThrow(
+            /Unknown guardrail/
+        );
     });
 });

--- a/fast_track/src/guardrails/registry.ts
+++ b/fast_track/src/guardrails/registry.ts
@@ -27,7 +27,7 @@ export interface SelectOptions {
  *
  * The result preserves the input order.
  */
-export function selectGuardrails(all: Guardrail[], options: SelectOptions): Guardrail[] {
+export function selectGuardrails(all: Guardrail[], options: SelectOptions = {}): Guardrail[] {
     let selected = all;
 
     if (options.guardrailNames) {

--- a/fast_track/src/guardrails/registry.ts
+++ b/fast_track/src/guardrails/registry.ts
@@ -15,27 +15,20 @@ export const guardrails: Guardrail[] = [
 ];
 
 export interface SelectOptions {
-    /** False locally, true in CI. */
-    hasPrContext: boolean;
     /** Guardrails to run. Omit to select all; an unknown name throws. */
     guardrailNames?: string[];
 }
 
 /**
- * Choose which guardrails to run from the full set, applying two filters:
+ * Choose which guardrails to run from the full set.
  *
- * 1. If `guardrailNames` is given, keep only those, validating them first — an
- *    unknown name throws, so a typo can't silently select nothing.
- * 2. If the environment has no PR context, drop guardrails that need the API.
- *    A guardrail named explicitly in (1) that needs PR context throws rather
- *    than being silently dropped — an explicit request we can't honour is an
- *    error, whereas an implicit "run everything" quietly skips it.
+ * If `guardrailNames` is given, keep only those, validating them first — an
+ * unknown name throws, so a typo can't silently select nothing.
  *
  * The result preserves the input order.
  */
 export function selectGuardrails(all: Guardrail[], options: SelectOptions): Guardrail[] {
     let selected = all;
-    const hasExplicitGuardrails = options.guardrailNames !== undefined;
 
     if (options.guardrailNames) {
         const known = new Set(all.map((g) => g.name));
@@ -45,18 +38,6 @@ export function selectGuardrails(all: Guardrail[], options: SelectOptions): Guar
         }
         const wanted = new Set(options.guardrailNames);
         selected = selected.filter((g) => wanted.has(g.name));
-    }
-
-    if (!options.hasPrContext) {
-        if (hasExplicitGuardrails) {
-            const unavailable = selected.filter((g) => g.needsPrContext).map((g) => g.name);
-            if (unavailable.length > 0) {
-                throw new Error(
-                    `Unavailable PR context for requested guardrails: ${unavailable.join(', ')}`
-                );
-            }
-        }
-        selected = selected.filter((g) => !g.needsPrContext);
     }
 
     return selected;

--- a/fast_track/src/guardrails/run-guardrails.test.ts
+++ b/fast_track/src/guardrails/run-guardrails.test.ts
@@ -5,7 +5,6 @@ import type { Guardrail, GuardrailContext } from './context/types';
 import { runGuardrails } from './run-guardrails';
 
 const context: GuardrailContext = {
-    baseRef: 'origin/main',
     changedFiles: async () => []
 };
 
@@ -13,7 +12,6 @@ const context: GuardrailContext = {
 const stub = (name: string, status: GuardrailStatus, required = true): Guardrail => ({
     name,
     required,
-    needsPrContext: false,
     run: async () => ({ status, summary: '' })
 });
 
@@ -21,7 +19,6 @@ const stub = (name: string, status: GuardrailStatus, required = true): Guardrail
 const throwing = (name: string, required = true): Guardrail => ({
     name,
     required,
-    needsPrContext: false,
     run: async () => {
         throw new Error('boom');
     }

--- a/fast_track/src/guardrails/shared/full-suite-coverage.test.ts
+++ b/fast_track/src/guardrails/shared/full-suite-coverage.test.ts
@@ -111,7 +111,7 @@ function coverageGuardrail(overrides: Partial<CoverageConfig> = {}): Guardrail {
 }
 
 function runOn(guardrail: Guardrail, ...files: ChangedFile[]): Promise<GuardrailOutcome> {
-    return guardrail.run({ baseRef: 'origin/main', changedFiles: async () => files });
+    return guardrail.run({ changedFiles: async () => files });
 }
 
 function givenTheReportExists(): void {
@@ -144,11 +144,10 @@ beforeEach(() => {
 afterEach(clearEnv);
 
 describe('createCoverageGuardrail', () => {
-    it('is required and runs locally', () => {
+    it('is required', () => {
         const guardrail = coverageGuardrail();
         expect(guardrail.name).toBe('test/coverage');
         expect(guardrail.required).toBe(true);
-        expect(guardrail.needsPrContext).toBe(false);
     });
 
     it('passes without reading the report when no file is in scope', async () => {

--- a/fast_track/src/guardrails/shared/full-suite-coverage.ts
+++ b/fast_track/src/guardrails/shared/full-suite-coverage.ts
@@ -47,7 +47,6 @@ export function createCoverageGuardrail(config: CoverageConfig): Guardrail {
     return {
         name: config.name,
         required: true,
-        needsPrContext: false,
 
         async run(ctx: GuardrailContext): Promise<GuardrailOutcome> {
             const files = await ctx.changedFiles();


### PR DESCRIPTION
## What has changed and why?

Removes the guardrails' unused "PR context" capability. Nothing consumed it:

- every guardrail set `needsPrContext: false`
- no guardrail read `octokit` or `baseRef` off the shared `GuardrailContext`

Deleted:

- the dead shared-interface fields (`octokit`, `baseRef`, `needsPrContext`)
- the `hasPrContext` availability filter and its "Unavailable PR context" error path
- the CLI and CI plumbing that fed it

Unchanged in behavior: guardrail selection is identical locally and in CI. Concrete contexts keep their own internal `baseRef`; `ApiGuardrailContext.octokit` is now private (still used internally).

## How has it been tested?

`make static-checks` and `make test` in `fast_track` (194 tests). Also reviewed by `codex review`, no findings.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified guardrail selection and execution across local and CI environments.
  * Guardrails now consistently use changed-file information without requiring pull request context.
  * The command-line guardrail list now focuses on names and required or optional status.

* **Tests**
  * Updated coverage, complexity, registry, diff-size, and execution tests to reflect the streamlined guardrail behavior.
  * Added validation for default selection, named subsets, ordering, and unknown guardrail names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->