### PR TITLE
(Part 1) Reshape the 2D embedding cache table

### DIFF
--- a/lightly_studio/src/lightly_studio/migrations/versions/1786610418_def3ea185ea7_reshape_two_dim_embeddings.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1786610418_def3ea185ea7_reshape_two_dim_embeddings.py
@@ -1,0 +1,55 @@
+"""reshape-two-dim-embeddings.
+
+Revision ID: def3ea185ea7
+Revises: e8f9a0b1c2d3
+Create Date: 2026-08-13 10:40:18.236504
+
+``two_dim_embeddings`` is a pure cache: every row can be recomputed from
+``sample_embedding``. The table is therefore dropped and recreated rather than altered,
+which keeps the migration simple and avoids backfilling the new NOT NULL columns. The
+projections regenerate on the next request.
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlmodel.sql.sqltypes import AutoString
+
+# revision identifiers, used by Alembic.
+revision: str = "def3ea185ea7"
+down_revision: Union[str, Sequence[str], None] = "e8f9a0b1c2d3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_table("two_dim_embeddings")
+    op.create_table(
+        "two_dim_embeddings",
+        sa.Column("collection_id", sa.Uuid(), nullable=False),
+        sa.Column("embedding_model_id", sa.Uuid(), nullable=False),
+        sa.Column("fingerprint", AutoString(), nullable=False),
+        sa.Column("sample_ids", sa.ARRAY(sa.Uuid()), nullable=True),
+        sa.Column("x", sa.ARRAY(sa.Float()), nullable=True),
+        sa.Column("y", sa.ARRAY(sa.Float()), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["collection_id"], ["collection.collection_id"]),
+        sa.ForeignKeyConstraint(["embedding_model_id"], ["embedding_model.embedding_model_id"]),
+        sa.PrimaryKeyConstraint("collection_id", "embedding_model_id"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("two_dim_embeddings")
+    op.create_table(
+        "two_dim_embeddings",
+        sa.Column("hash", AutoString(), nullable=False),
+        sa.Column("x", sa.ARRAY(sa.Float()), nullable=True),
+        sa.Column("y", sa.ARRAY(sa.Float()), nullable=True),
+        sa.PrimaryKeyConstraint("hash"),
+    )

--- a/lightly_studio/src/lightly_studio/models/two_dim_embedding.py
+++ b/lightly_studio/src/lightly_studio/models/two_dim_embedding.py
@@ -2,15 +2,33 @@
 
 from __future__ import annotations
 
-from sqlalchemy import ARRAY, Float
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import ARRAY, Float, Uuid
 from sqlmodel import Column, Field, SQLModel
 
 
 class TwoDimEmbeddingTable(SQLModel, table=True):
-    """Persisted 2D embedding projection identified by a deterministic hash."""
+    """Cached 2D projection of a collection's embeddings, keyed by collection and model.
+
+    ``sample_ids``, ``x`` and ``y`` are parallel arrays: entry ``i`` of each describes the
+    same point. Storing the sample ids alongside the coordinates is what lets a cache hit
+    answer a request without re-reading ``sample_embedding``.
+
+    ``fingerprint`` identifies the set of samples the projection was computed from. A cache
+    entry is stale as soon as the collection's fingerprint differs from the stored one.
+    """
 
     __tablename__ = "two_dim_embeddings"
 
-    hash: str = Field(primary_key=True)
+    collection_id: UUID = Field(primary_key=True, foreign_key="collection.collection_id")
+    embedding_model_id: UUID = Field(
+        primary_key=True, foreign_key="embedding_model.embedding_model_id"
+    )
+    fingerprint: str
+    # Generic ARRAY (not postgresql.ARRAY) so the column compiles on DuckDB and PostgreSQL.
+    sample_ids: list[UUID] = Field(sa_column=Column(ARRAY(Uuid)))
     x: list[float] = Field(sa_column=Column(ARRAY(Float)))
     y: list[float] = Field(sa_column=Column(ARRAY(Float)))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -41,6 +41,7 @@ from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.models.tag import TagTable
 from lightly_studio.models.temporal_span import TemporalSpanTable
+from lightly_studio.models.two_dim_embedding import TwoDimEmbeddingTable
 from lightly_studio.models.video import VideoFrameTable, VideoTable
 from lightly_studio.resolvers import dataset_resolver
 from lightly_studio.resolvers.dataset_resolver import table_coverage_utils
@@ -109,6 +110,8 @@ def delete_dataset(
     _delete_samples(session=session, dataset_id=dataset_id)
     _delete_annotation_labels(session=session, dataset_id=dataset_id)
     _delete_tags(session=session, dataset_id=dataset_id)
+    # Must precede embedding models (TwoDimEmbeddingTable.embedding_model_id -> embedding_model).
+    _delete_two_dim_embeddings(session=session, dataset_id=dataset_id)
     _delete_embedding_models(session=session, dataset_id=dataset_id)
     _delete_object_tracks(session=session, dataset_id=dataset_id)
     _delete_evaluation_runs(session=session, dataset_id=dataset_id)
@@ -301,6 +304,16 @@ def _delete_tags(session: Session, dataset_id: UUID) -> None:
     session.exec(
         delete(TagTable).where(
             col(TagTable.collection_id).in_(_collection_ids_subquery(dataset_id))
+        ),
+        execution_options=_DELETE_EXECUTION_OPTIONS,
+    )
+
+
+def _delete_two_dim_embeddings(session: Session, dataset_id: UUID) -> None:
+    """Delete cached 2D projections for the dataset's collections."""
+    session.exec(
+        delete(TwoDimEmbeddingTable).where(
+            col(TwoDimEmbeddingTable.collection_id).in_(_collection_ids_subquery(dataset_id))
         ),
         execution_options=_DELETE_EXECUTION_OPTIONS,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -8,13 +8,14 @@ until they are updated to handle the new tables.
 from sqlmodel import SQLModel
 
 # Tables handled by deep_copy and delete_dataset.
-_HANDLED_TABLES_COUNT = 24
+# Note: two_dim_embeddings is deleted by delete_dataset but intentionally not copied by
+# deep_copy - a copied dataset gets fresh collection ids and reprojects on demand.
+_HANDLED_TABLES_COUNT = 25
 
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)
-# - two_dim_embeddings (cached projections, regenerated as needed)
 # - export_job (application-level, no dataset/collection FK)
-_EXCLUDED_TABLES_COUNT = 3
+_EXCLUDED_TABLES_COUNT = 2
 
 _TOTAL_TABLES_COUNT = _HANDLED_TABLES_COUNT + _EXCLUDED_TABLES_COUNT
 

--- a/lightly_studio/src/lightly_studio/resolvers/sample_embedding_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/sample_embedding_resolver.py
@@ -162,15 +162,17 @@ def get_all_by_collection_id(
     ]
 
 
-def get_hash_by_collection_id(
+def get_fingerprint_by_collection_id(
     session: Session,
     collection_id: UUID,
     embedding_model_id: UUID,
-) -> tuple[str, list[UUID]]:
-    """Return a combined hash and ordered sample IDs with embeddings for a collection.
+) -> tuple[int, str]:
+    """Return how many samples have embeddings and a fingerprint identifying that set.
 
-    The cache key is derived from the first dimension of each embedding vector,
-    which is database-agnostic (works with both DuckDB and PostgreSQL).
+    The fingerprint is derived from the first dimension of each embedding vector, in
+    canonical ``sample_id`` order, which is database-agnostic (works with both DuckDB and
+    PostgreSQL). Callers use it to decide whether a cached projection is still valid; it
+    says nothing about the order in which the embeddings are later loaded.
 
     Args:
         session: Database session.
@@ -178,7 +180,7 @@ def get_hash_by_collection_id(
         embedding_model_id: Embedding model identifier.
 
     Returns:
-        Tuple of (combined hash, ordered sample IDs that have stored embeddings).
+        Tuple of (number of samples with stored embeddings, fingerprint).
     """
     first_dim_col = db_vector.vector_element(SampleEmbeddingTable.embedding, 1).label("first_dim")
 
@@ -193,16 +195,11 @@ def get_hash_by_collection_id(
         .order_by(col(SampleEmbeddingTable.sample_id).asc())
     ).all()
 
-    sample_ids: list[UUID] = []
     hasher = hashlib.sha256()
-
     for row in rows:
-        sample_ids.append(row.sample_id)  # type: ignore[attr-defined]
         hasher.update(str(row.first_dim).encode("utf-8"))  # type: ignore[attr-defined]
 
-    if not sample_ids:
-        return "empty", []
-    return hasher.hexdigest(), sample_ids
+    return len(rows), hasher.hexdigest()
 
 
 def get_embedding_count(session: Session, collection_id: UUID, embedding_model_id: UUID) -> int:

--- a/lightly_studio/src/lightly_studio/resolvers/twodim_embedding_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/twodim_embedding_resolver.py
@@ -22,9 +22,10 @@ def get_twodim_embeddings(
 ) -> tuple[NDArray[np.float32], NDArray[np.float32], list[UUID]]:
     """Return cached 2D embeddings together with their sample identifiers.
 
-    Uses a cache to avoid recomputing the 2D embeddings. The cache key combines the sorted
-    sample identifiers with a deterministic 64-bit hash over the stored high-dimensional
-    embeddings.
+    The projection is cached per (collection, embedding model). The cached row stores the
+    sample ids next to the coordinates, so a cache hit never has to re-read
+    ``sample_embedding``. A fingerprint over the collection's embeddings decides whether
+    the cached entry still describes the current set of samples.
 
     Args:
         session: Database session.
@@ -38,54 +39,63 @@ def get_twodim_embeddings(
     if embedding_model is None:
         raise ValueError(f"Embedding model {embedding_model_id} not found.")
 
-    # Check if we have a cached 2D embedding for the given collection and embedding model.
-    cache_key, sample_ids_of_samples_with_embeddings = (
-        sample_embedding_resolver.get_hash_by_collection_id(
-            session=session,
-            collection_id=collection_id,
-            embedding_model_id=embedding_model_id,
-        )
+    sample_count, fingerprint = sample_embedding_resolver.get_fingerprint_by_collection_id(
+        session=session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model_id,
     )
-
-    if not sample_ids_of_samples_with_embeddings:
+    if sample_count == 0:
         empty = np.array([], dtype=np.float32)
         return empty, empty, []
 
-    # If there is a cached entry, return it.
-    cached = session.get(TwoDimEmbeddingTable, cache_key)
-    if cached is not None:
-        x_values = np.array(cached.x, dtype=np.float32)
-        y_values = np.array(cached.y, dtype=np.float32)
-        return x_values, y_values, sample_ids_of_samples_with_embeddings
+    # The length check guards against a corrupted row: the three arrays are written
+    # together and should never diverge, but callers zip the coordinates with the ids, so
+    # a mismatch is treated as a miss rather than propagated.
+    cached = session.get(TwoDimEmbeddingTable, (collection_id, embedding_model_id))
+    if (
+        cached is not None
+        and cached.fingerprint == fingerprint
+        and len(cached.sample_ids) == len(cached.x) == len(cached.y)
+    ):
+        return (
+            np.array(cached.x, dtype=np.float32),
+            np.array(cached.y, dtype=np.float32),
+            list(cached.sample_ids),
+        )
 
-    # No cached entry found - load the high-dimensional embeddings.
-    # The order is defined by sample_ids_of_samples_with_embeddings.
-    sample_embeddings = sample_embedding_resolver.get_by_sample_ids(
+    # Cache miss or stale entry: load the high-dimensional embeddings and reproject.
+    sample_embeddings = sample_embedding_resolver.get_all_by_collection_id(
         session=session,
-        sample_ids=sample_ids_of_samples_with_embeddings,
+        collection_id=collection_id,
         embedding_model_id=embedding_model_id,
     )
-
-    # If there are no embeddings, return empty arrays.
     if not sample_embeddings:
         empty = np.array([], dtype=np.float32)
         return empty, empty, []
 
-    # Compute the 2D embedding from the high-dimensional embeddings.
-    # The order is now defined by sample_embeddings. They are the ordered subset of the
-    # sample_ids_of_samples_with_embeddings that have embeddings.
-    sample_ids_of_samples_with_embeddings = [embedding.sample_id for embedding in sample_embeddings]
+    # The order is the one get_all_by_collection_id produced, not the fingerprint's
+    # canonical sample_id order. Both the coordinates and the stored ids follow it.
+    sample_ids = [embedding.sample_id for embedding in sample_embeddings]
     embedding_values = [embedding.embedding for embedding in sample_embeddings]
     planar_embeddings = _calculate_2d_embeddings(embedding_values)
     embeddings_2d = np.asarray(planar_embeddings, dtype=np.float32)
     x_values, y_values = embeddings_2d[:, 0], embeddings_2d[:, 1]
 
-    # Write the computed 2D embeddings to the cache.
-    cache_entry = TwoDimEmbeddingTable(hash=cache_key, x=list(x_values), y=list(y_values))
-    session.add(cache_entry)
+    # merge() rather than add(): recomputing over an existing key must overwrite the row
+    # in place instead of raising an IntegrityError.
+    session.merge(
+        TwoDimEmbeddingTable(
+            collection_id=collection_id,
+            embedding_model_id=embedding_model_id,
+            fingerprint=fingerprint,
+            sample_ids=sample_ids,
+            x=[float(value) for value in x_values],
+            y=[float(value) for value in y_values],
+        )
+    )
     session.commit()
 
-    return x_values, y_values, sample_ids_of_samples_with_embeddings
+    return x_values, y_values, sample_ids
 
 
 def _calculate_2d_embeddings(

--- a/lightly_studio/tests/resolvers/collection_resolver/test_export.py
+++ b/lightly_studio/tests/resolvers/collection_resolver/test_export.py
@@ -107,7 +107,7 @@ def _setup_embedding_region(
             (ImageStub(path="sample_c.png"), [2.1, 0.2, 0.3]),
         ],
     )
-    cache_key, ordered_sample_ids = sample_embedding_resolver.get_hash_by_collection_id(
+    _, fingerprint = sample_embedding_resolver.get_fingerprint_by_collection_id(
         session=db_session,
         collection_id=collection_id,
         embedding_model_id=embedding_model.embedding_model_id,
@@ -117,9 +117,13 @@ def _setup_embedding_region(
         image_b.sample_id: (5.0, 5.0),
         image_c.sample_id: (100.0, 100.0),
     }
+    ordered_sample_ids = list(coordinates)
     db_session.add(
         TwoDimEmbeddingTable(
-            hash=cache_key,
+            collection_id=collection_id,
+            embedding_model_id=embedding_model.embedding_model_id,
+            fingerprint=fingerprint,
+            sample_ids=ordered_sample_ids,
             x=[coordinates[sid][0] for sid in ordered_sample_ids],
             y=[coordinates[sid][1] for sid in ordered_sample_ids],
         )

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -3,13 +3,14 @@
 import uuid
 
 import pytest
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricCreate
 from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
+from lightly_studio.models.two_dim_embedding import TwoDimEmbeddingTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
     collection_resolver,
@@ -21,6 +22,7 @@ from lightly_studio.resolvers import (
     sample_embedding_resolver,
     sample_resolver,
     tag_resolver,
+    twodim_embedding_resolver,
 )
 from tests.helpers_resolvers import (
     AnnotationDetails,
@@ -183,6 +185,43 @@ def test_delete_dataset__with_embeddings(db_session: Session) -> None:
         embedding_model_id=embedding_model_id,
     )
     assert len(embeddings) == 0
+
+
+def test_delete_dataset__with_two_dim_embeddings(db_session: Session) -> None:
+    """Cached 2D projections are removed; their FKs must not block the delete."""
+    # Arrange
+    dataset = create_collection(session=db_session, collection_name="to_delete")
+    collection_id = dataset.collection_id  # Capture before delete
+    img = create_image(session=db_session, collection_id=collection_id, file_path_abs="/a.png")
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_name="test_model",
+        embedding_dimension=3,
+    )
+    create_sample_embedding(
+        session=db_session,
+        sample_id=img.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[1.0, 2.0, 3.0],
+    )
+    # Populate the cache so a row exists to be deleted.
+    twodim_embedding_resolver.get_twodim_embeddings(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+    assert db_session.exec(select(TwoDimEmbeddingTable)).all() != []
+
+    # Act
+    dataset_resolver.delete_dataset(
+        session=db_session,
+        dataset_id=dataset.dataset_id,
+    )
+
+    # Assert - collection and cached projection deleted
+    assert collection_resolver.get_by_id(session=db_session, collection_id=collection_id) is None
+    assert db_session.exec(select(TwoDimEmbeddingTable)).all() == []
 
 
 def test_delete_dataset__with_tags(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
@@ -1113,14 +1113,18 @@ def _setup_collection_with_2d_coordinates(
     }
     # Seed the cached 2D projection so the region resolver reads deterministic coordinates
     # instead of recomputing them.
-    cache_key, cached_sample_ids = sample_embedding_resolver.get_hash_by_collection_id(
+    _, fingerprint = sample_embedding_resolver.get_fingerprint_by_collection_id(
         session=session,
         collection_id=collection_id,
         embedding_model_id=embedding_model.embedding_model_id,
     )
+    cached_sample_ids = list(coordinates_by_sample)
     session.add(
         TwoDimEmbeddingTable(
-            hash=cache_key,
+            collection_id=collection_id,
+            embedding_model_id=embedding_model.embedding_model_id,
+            fingerprint=fingerprint,
+            sample_ids=cached_sample_ids,
             x=[coordinates_by_sample[sample_id][0] for sample_id in cached_sample_ids],
             y=[coordinates_by_sample[sample_id][1] for sample_id in cached_sample_ids],
         )
@@ -1202,14 +1206,18 @@ def test_get_all_by_collection_id__embedding_region_combined_with_dimension_filt
         images[1].sample_id: (2.0, 2.0),  # inside region, narrow
         images[2].sample_id: (100.0, 100.0),  # outside region, wide
     }
-    cache_key, cached_sample_ids = sample_embedding_resolver.get_hash_by_collection_id(
+    _, fingerprint = sample_embedding_resolver.get_fingerprint_by_collection_id(
         session=db_session,
         collection_id=collection_id,
         embedding_model_id=embedding_model.embedding_model_id,
     )
+    cached_sample_ids = list(coordinates)
     db_session.add(
         TwoDimEmbeddingTable(
-            hash=cache_key,
+            collection_id=collection_id,
+            embedding_model_id=embedding_model.embedding_model_id,
+            fingerprint=fingerprint,
+            sample_ids=cached_sample_ids,
             x=[coordinates[sample_id][0] for sample_id in cached_sample_ids],
             y=[coordinates[sample_id][1] for sample_id in cached_sample_ids],
         )

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_for_export.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_for_export.py
@@ -123,23 +123,25 @@ def test_get_for_export__with_embedding_region_filter(db_session: Session) -> No
     )
 
     # Seed 2D coordinates: inside1 and inside2 within (0,0)-(10,10), outside at (100, 100).
-    cache_key, sample_ids_in_order = sample_embedding_resolver.get_hash_by_collection_id(
+    _, fingerprint = sample_embedding_resolver.get_fingerprint_by_collection_id(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=embedding_model.embedding_model_id,
     )
-    inside1_i = sample_ids_in_order.index(image_inside1.sample_id)
-    inside2_i = sample_ids_in_order.index(image_inside2.sample_id)
-    outside_i = sample_ids_in_order.index(image_outside.sample_id)
-    x = [0.0, 0.0, 0.0]
-    y = [0.0, 0.0, 0.0]
-    x[inside1_i] = 1.0
-    y[inside1_i] = 1.0
-    x[inside2_i] = 5.0
-    y[inside2_i] = 5.0
-    x[outside_i] = 100.0
-    y[outside_i] = 100.0
-    db_session.add(TwoDimEmbeddingTable(hash=cache_key, x=x, y=y))
+    db_session.add(
+        TwoDimEmbeddingTable(
+            collection_id=collection.collection_id,
+            embedding_model_id=embedding_model.embedding_model_id,
+            fingerprint=fingerprint,
+            sample_ids=[
+                image_inside1.sample_id,
+                image_inside2.sample_id,
+                image_outside.sample_id,
+            ],
+            x=[1.0, 5.0, 100.0],
+            y=[1.0, 5.0, 100.0],
+        )
+    )
     db_session.commit()
 
     region = EmbeddingRegion(

--- a/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
@@ -107,14 +107,18 @@ def _seed_2d_coordinates(
 
     Returns the ordered sample ids as ``get_twodim_embeddings`` would return them.
     """
-    cache_key, sample_ids = sample_embedding_resolver.get_hash_by_collection_id(
+    _, fingerprint = sample_embedding_resolver.get_fingerprint_by_collection_id(
         session=session,
         collection_id=collection_id,
         embedding_model_id=embedding_model_id,
     )
+    sample_ids = list(coordinates)
     session.add(
         TwoDimEmbeddingTable(
-            hash=cache_key,
+            collection_id=collection_id,
+            embedding_model_id=embedding_model_id,
+            fingerprint=fingerprint,
+            sample_ids=sample_ids,
             x=[coordinates[sample_id][0] for sample_id in sample_ids],
             y=[coordinates[sample_id][1] for sample_id in sample_ids],
         )

--- a/lightly_studio/tests/resolvers/test_twodim_embedding_resolver.py
+++ b/lightly_studio/tests/resolvers/test_twodim_embedding_resolver.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import numpy as np
 from pytest_mock import MockerFixture
-from sqlmodel import Session
+from sqlmodel import Session, select
 
+from lightly_studio.models.two_dim_embedding import TwoDimEmbeddingTable
 from lightly_studio.resolvers import twodim_embedding_resolver
 from tests import helpers_resolvers
 from tests.helpers_resolvers import (
@@ -207,3 +208,155 @@ def test_get_twodim_embeddings__recomputes_when_samples_change(
     assert x_second.shape == (2,)
     assert y_second.shape == (2,)
     assert len(sample_ids_second) == 2
+
+
+def test_get_twodim_embeddings__identical_embeddings_do_not_share_cache(
+    db_session: Session,
+) -> None:
+    """Two collections with identical embeddings get their own cache row.
+
+    The cache is keyed by (collection, embedding model), so collections whose embeddings
+    hash identically must not read each other's coordinates.
+    """
+    collections = []
+    for name in ("collection_a", "collection_b"):
+        collection = helpers_resolvers.create_collection(session=db_session, collection_name=name)
+        embedding_model = helpers_resolvers.create_embedding_model(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_dimension=3,
+        )
+        helpers_resolvers.create_samples_with_embeddings(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_id=embedding_model.embedding_model_id,
+            # Identical embeddings in both collections.
+            images_and_embeddings=[
+                (ImageStub(path=f"{name}_1.jpg"), [0.1, 0.2, 0.3]),
+                (ImageStub(path=f"{name}_2.jpg"), [0.4, 0.5, 0.6]),
+            ],
+        )
+        collections.append((collection, embedding_model))
+
+    results = [
+        twodim_embedding_resolver.get_twodim_embeddings(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_id=embedding_model.embedding_model_id,
+        )
+        for collection, embedding_model in collections
+    ]
+
+    # Each collection got its own row, holding its own sample ids.
+    cached_rows = db_session.exec(select(TwoDimEmbeddingTable)).all()
+    assert len(cached_rows) == 2
+    assert {row.collection_id for row in cached_rows} == {
+        collection.collection_id for collection, _ in collections
+    }
+    sample_ids_a, sample_ids_b = results[0][2], results[1][2]
+    assert set(sample_ids_a).isdisjoint(sample_ids_b)
+
+
+def test_get_twodim_embeddings__recompute_overwrites_existing_row(
+    db_session: Session,
+) -> None:
+    """Recomputing over an existing key updates the row instead of raising."""
+    collection = helpers_resolvers.create_collection(
+        session=db_session, collection_name="overwrite_collection"
+    )
+    embedding_model = helpers_resolvers.create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_dimension=3,
+    )
+    first_sample = helpers_resolvers.create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/overwrite_0.jpg",
+    )
+    helpers_resolvers.create_sample_embedding(
+        session=db_session,
+        sample_id=first_sample.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[0.1, 0.1, 0.1],
+    )
+    twodim_embedding_resolver.get_twodim_embeddings(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+    fingerprint_before = db_session.exec(select(TwoDimEmbeddingTable)).one().fingerprint
+
+    # Change the sample set so the next call recomputes over the same key.
+    second_sample = helpers_resolvers.create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/overwrite_1.jpg",
+    )
+    helpers_resolvers.create_sample_embedding(
+        session=db_session,
+        sample_id=second_sample.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[0.2, 0.2, 0.2],
+    )
+    twodim_embedding_resolver.get_twodim_embeddings(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+
+    cached_rows = db_session.exec(select(TwoDimEmbeddingTable)).all()
+    assert len(cached_rows) == 1
+    assert cached_rows[0].fingerprint != fingerprint_before
+    assert len(cached_rows[0].sample_ids) == 2
+
+
+def test_get_twodim_embeddings__cached_row_with_mismatched_lengths_recomputes(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    """A cached row whose arrays disagree in length is recomputed instead of returned.
+
+    Callers zip the coordinates with the sample ids, so returning a row where the two
+    differ in length would fail downstream rather than here.
+    """
+    collection = helpers_resolvers.create_collection(
+        session=db_session, collection_name="mismatch_collection"
+    )
+    embedding_model = helpers_resolvers.create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_dimension=3,
+    )
+    helpers_resolvers.create_samples_with_embeddings(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        images_and_embeddings=[
+            (ImageStub(path="mismatch_1.jpg"), [0.1, 0.2, 0.3]),
+            (ImageStub(path="mismatch_2.jpg"), [0.4, 0.5, 0.6]),
+        ],
+    )
+    _, _, sample_ids = twodim_embedding_resolver.get_twodim_embeddings(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+
+    # Corrupt the cached row: drop one coordinate pair but keep both sample ids.
+    cached = db_session.exec(select(TwoDimEmbeddingTable)).one()
+    cached.x = cached.x[:1]
+    cached.y = cached.y[:1]
+    db_session.add(cached)
+    db_session.commit()
+
+    calculate_spy = mocker.spy(twodim_embedding_resolver, "_calculate_2d_embeddings")
+    x_values, y_values, sample_ids_after = twodim_embedding_resolver.get_twodim_embeddings(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+    )
+
+    calculate_spy.assert_called_once()
+    assert len(x_values) == len(y_values) == len(sample_ids_after) == 2
+    assert sorted(sample_ids_after, key=str) == sorted(sample_ids, key=str)


### PR DESCRIPTION
## What has changed and why?

The `two_dim_embeddings` table stores the 2D projection of a collection's embeddings so we don't recompute it on every request.

The old version used a hash of the high-dimensional embeddings as its key. To look up a row, we first had to read every embedding in the collection to build that key. So even when the cache had the answer, we still paid for the slow read.

Now the key is `(collection_id, embedding_model_id)`. We already have both when the request comes in, so a cache hit is fast.

Two new columns support this:

- `sample_ids`: an array alongside `x` and `y`. Item `i` in all three arrays describes the same point. We need the ids to know which sample each point belongs to. Before, they came from the same slow read that built the key.
- `fingerprint`: records which samples the projection was built from. With the old key, a changed embedding produced a different key, so a stale row could never be found. The new key stays the same, so we check the fingerprint instead. If it doesn't match, we treat it as a miss and recompute.

### About the migration

The migration drops the table and creates it again instead of altering it. Two reasons: the table is only a cache, so every row can be rebuilt from `sample_embedding`; and the new `NOT NULL` columns can't be filled in from an old hash-keyed row. After the upgrade, the first request per collection is a cache miss.


## How has it been tested?

`make static-checks` and `make test` in `lightly_studio`.

Added tests in `test_twodim_embedding_resolver.py` for cache hits, stale fingerprints, and recomputing over a row that already exists. `test_delete_dataset.py` covers the new deletion order.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
