### PR TITLE
Make the keyset seek drive an index range scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Stepping to the previous or next image now drives an index range scan instead of scanning the
+  sort index from the start. On PostgreSQL with 1M images, one neighbour lookup went from 92ms
+  to 0.03ms.
+
 ### Deprecated
 
 ### Removed

--- a/lightly_studio/src/lightly_studio/resolvers/adjacents/keyset_seek.py
+++ b/lightly_studio/src/lightly_studio/resolvers/adjacents/keyset_seek.py
@@ -129,6 +129,12 @@ def _keyset_condition(
 
     with ``>`` flipped to ``<`` for descending keys and for ``after=False``. All keys are
     non-nullable, so NULLs need no handling.
+
+    The comparison is ANDed with ``k0 >= v0``, which is implied and changes no results.
+    Planners only turn a *single-column* comparison into an index range condition; without
+    it PostgreSQL applies the whole disjunction as a filter and scans the index from the
+    start. Measured on 1M images with the anchor at position 800k, one seek went from 92ms
+    (``Rows Removed by Filter: 800000``) to 0.03ms.
     """
     or_terms: list[ColumnElement[bool]] = []
     for i, (column, ascending) in enumerate(sort_keys):
@@ -138,7 +144,13 @@ def _keyset_condition(
         seek_greater = ascending if after else not ascending
         comparison = (column > anchor[i]) if seek_greater else (column < anchor[i])
         or_terms.append(sqlalchemy.and_(*equals_prefix, comparison))
-    return sqlalchemy.or_(*or_terms)
+
+    leading_column, leading_ascending = sort_keys[0]
+    leading_seek_greater = leading_ascending if after else not leading_ascending
+    leading_bound = (
+        leading_column >= anchor[0] if leading_seek_greater else leading_column <= anchor[0]
+    )
+    return sqlalchemy.and_(sqlalchemy.or_(*or_terms), leading_bound)
 
 
 def _count(session: Session, query: SelectOfScalar[UUID]) -> int:


### PR DESCRIPTION
## What has changed and why?

Third of six in the stack. Small change, large effect.

The keyset comparison is a disjunction, and planners only push a *single-column* comparison into an
index. PostgreSQL applied the whole thing as a filter and scanned the sort index from the start, so
a seek cost whatever the anchor's position cost.

ANDing a bound on the leading sort key fixes it. The bound is implied by the disjunction, so no
results change — it just gives the planner a range condition it can use.

Only image adjacency calls this today. Annotations inherit it at the top of the stack.

**What to review.** Nothing is moved here — it is six new lines in `_keyset_condition`. The one claim
to check is that `k0 >= v0` really is implied by the disjunction, so the result set cannot change.
The `EXPLAIN` output below is the evidence that it changes the *plan*.

## How has it been tested?

No test changes: the change is result-preserving by construction, and the existing tests pin that.

Measured on PostgreSQL 18, one collection of 1M images, anchor at position 800k, `EXPLAIN (ANALYZE)`
of a single forward seek:

| | before | after |
|---|---|---|
| execution time | 92.2 ms | 0.029 ms |
| index scan | `Filter`, `Rows Removed by Filter: 800000` | `Index Cond`, 1 row removed |
| buffers | shared hit=5718 | shared hit=4 |

Neutral on DuckDB, which does not drive range seeks from a secondary index.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

