### PR TITLE
Speed up annotation prev/next with a keyset seek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python SDK: `ImageDataset.add_images_from_path` now accepts `tag_depth > 1` to tag images by several leading directory levels (previously only `tag_depth=1` was supported).
 
 - Stepping to the previous or next annotation in the annotation details view no longer sorts the
-  whole collection on every click. On PostgreSQL with 4M annotations a click went from 6.3s to
-  1.3s; the neighbour lookup itself went from ~6s to 3ms, and the remaining 1.2s is the exact
-  position and total counts.
+  whole collection on every click, for annotations on images and on video frames. On PostgreSQL
+  with 4M annotations a click went from 6.3s to 1.3s; the neighbour lookup itself went from ~6s
+  to 3ms, and the remaining 1.2s is the exact position and total counts.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to 0.03ms.
 - Python SDK: `ImageDataset.add_images_from_path` now accepts `tag_depth > 1` to tag images by several leading directory levels (previously only `tag_depth=1` was supported).
 
+- Stepping to the previous or next annotation in the annotation details view no longer sorts the
+  whole collection on every click. On PostgreSQL with 4M annotations a click went from 6.3s to
+  1.3s; the neighbour lookup itself went from ~6s to 3ms, and the remaining 1.2s is the exact
+  position and total counts.
+
 ### Deprecated
 
 ### Removed

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations.py
@@ -8,10 +8,19 @@ from sqlmodel import Session
 
 from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluationMetricField
 from lightly_studio.models.adjacents import AdjacentResultView
+from lightly_studio.models.collection import SampleType
+from lightly_studio.resolvers import collection_resolver
+from lightly_studio.resolvers.annotation_resolver.get_adjacent_annotations_keyset import (
+    get_adjacent_annotations_keyset,
+)
 from lightly_studio.resolvers.annotation_resolver.get_adjacent_annotations_window import (
     get_adjacent_annotations_window,
 )
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+
+# Parent sample types whose file path is a plain column on a single table, so the keyset
+# seek can drive an index range scan over it.
+_KEYSET_PARENT_SAMPLE_TYPES = (SampleType.IMAGE, SampleType.VIDEO_FRAME)
 
 
 def get_adjacent_annotations(
@@ -21,6 +30,10 @@ def get_adjacent_annotations(
     order_by: OrderByAnnotationEvaluationMetricField | None = None,
 ) -> AdjacentResultView | None:
     """Get the adjacent annotations for a given annotation ID.
+
+    Uses a keyset (seek) lookup when the annotations' parent kind is known, so prev/next
+    and the position/total counts avoid sorting and windowing the whole collection.
+    Everything else falls back to the window-function implementation.
 
     Args:
         session: Database session.
@@ -37,9 +50,41 @@ def get_adjacent_annotations(
     if not filters.collection_ids:
         raise ValueError("Collection IDs must be provided in filters.")
 
+    parent_sample_type = _keyset_parent_sample_type(session=session, filters=filters)
+    if parent_sample_type is not None:
+        return get_adjacent_annotations_keyset(
+            session=session,
+            sample_id=sample_id,
+            filters=filters,
+            parent_sample_type=parent_sample_type,
+        )
+
     return get_adjacent_annotations_window(
         session=session,
         sample_id=sample_id,
         filters=filters,
         order_by=order_by,
     )
+
+
+def _keyset_parent_sample_type(
+    session: Session,
+    filters: AnnotationsFilter,
+) -> SampleType | None:
+    """Return the parent sample type the keyset path can serve, or ``None``.
+
+    The keyset path joins exactly one parent table, so it needs a single annotation
+    collection with a supported parent kind. Spanning several collections could mix parent
+    kinds, so those requests keep the window implementation.
+    """
+    if filters.collection_ids is None or len(filters.collection_ids) != 1:
+        return None
+
+    parent_collection = collection_resolver.get_parent_collection_id(
+        session=session, collection_id=filters.collection_ids[0]
+    )
+    if parent_collection is None:
+        return None
+    if parent_collection.sample_type not in _KEYSET_PARENT_SAMPLE_TYPES:
+        return None
+    return parent_collection.sample_type

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations.py
@@ -10,10 +10,8 @@ from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluati
 from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import collection_resolver
-from lightly_studio.resolvers.annotation_resolver.get_adjacent_annotations_keyset import (
+from lightly_studio.resolvers.annotation_resolver import (
     get_adjacent_annotations_keyset,
-)
-from lightly_studio.resolvers.annotation_resolver.get_adjacent_annotations_window import (
     get_adjacent_annotations_window,
 )
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
@@ -52,14 +50,14 @@ def get_adjacent_annotations(
 
     parent_sample_type = _keyset_parent_sample_type(session=session, filters=filters)
     if parent_sample_type is not None:
-        return get_adjacent_annotations_keyset(
+        return get_adjacent_annotations_keyset.get_adjacent_annotations_keyset(
             session=session,
             sample_id=sample_id,
             filters=filters,
             parent_sample_type=parent_sample_type,
         )
 
-    return get_adjacent_annotations_window(
+    return get_adjacent_annotations_window.get_adjacent_annotations_window(
         session=session,
         sample_id=sample_id,
         filters=filters,

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations.py
@@ -29,9 +29,9 @@ def get_adjacent_annotations(
 ) -> AdjacentResultView | None:
     """Get the adjacent annotations for a given annotation ID.
 
-    Uses a keyset (seek) lookup when the annotations' parent kind is known, so prev/next
-    and the position/total counts avoid sorting and windowing the whole collection.
-    Everything else falls back to the window-function implementation.
+    Uses a keyset (seek) lookup when the annotations' parent kind is known and the default
+    ordering applies, so prev/next and the position/total counts avoid sorting and windowing
+    the whole collection. Everything else falls back to the window-function implementation.
 
     Args:
         session: Database session.
@@ -48,7 +48,9 @@ def get_adjacent_annotations(
     if not filters.collection_ids:
         raise ValueError("Collection IDs must be provided in filters.")
 
-    parent_sample_type = _keyset_parent_sample_type(session=session, filters=filters)
+    parent_sample_type = _keyset_parent_sample_type(
+        session=session, filters=filters, order_by=order_by
+    )
     if parent_sample_type is not None:
         return get_adjacent_annotations_keyset.get_adjacent_annotations_keyset(
             session=session,
@@ -68,13 +70,18 @@ def get_adjacent_annotations(
 def _keyset_parent_sample_type(
     session: Session,
     filters: AnnotationsFilter,
+    order_by: OrderByAnnotationEvaluationMetricField | None,
 ) -> SampleType | None:
     """Return the parent sample type the keyset path can serve, or ``None``.
 
-    The keyset path joins exactly one parent table, so it needs a single annotation
-    collection with a supported parent kind. Spanning several collections could mix parent
-    kinds, so those requests keep the window implementation.
+    The keyset path seeks on the parent's file path, so it can only serve the default
+    ordering — a custom leading sort key stays on the window path. It also joins exactly one
+    parent table, so it needs a single annotation collection with a supported parent kind.
+    Spanning several collections could mix parent kinds, so those requests keep the window
+    implementation too.
     """
+    if order_by is not None:
+        return None
     if filters.collection_ids is None or len(filters.collection_ids) != 1:
         return None
 

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations_keyset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations_keyset.py
@@ -1,0 +1,109 @@
+"""Keyset (seek) implementation of annotation adjacency — the fast path.
+
+An annotation sorts by its parent media's ``file_path_abs``. The window path reaches that
+through a ``coalesce`` over two outer-joined tables, which no index can drive an ordered
+scan over. Every annotation in a collection shares one parent kind, so resolving that kind
+up front lets us inner-join a single parent table and seek on a plain indexed column.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+
+from lightly_studio.models.adjacents import AdjacentResultView
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.image import ImageTable
+from lightly_studio.models.video import VideoFrameTable, VideoTable
+from lightly_studio.resolvers.adjacents import keyset_seek
+from lightly_studio.resolvers.annotations import annotation_ordering
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+
+
+def get_adjacent_annotations_keyset(
+    session: Session,
+    sample_id: UUID,
+    filters: AnnotationsFilter,
+    parent_sample_type: SampleType,
+) -> AdjacentResultView | None:
+    """Find the previous/next annotation and the anchor's position via keyset seeks.
+
+    Args:
+        session: Database session.
+        sample_id: The anchor annotation whose neighbours we want.
+        filters: Annotation filters constraining the set; must scope the collection.
+        parent_sample_type: Sample type of the annotations' parent samples.
+
+    Returns:
+        The adjacency result, or ``None`` if the anchor is not in the filtered set.
+    """
+    sort_keys = annotation_ordering.build_sort_keys(
+        file_path_abs=annotation_ordering.file_path_abs_expression(sample_type=parent_sample_type),
+        created_at=col(AnnotationBaseTable.created_at),
+        annotation_sample_id=col(AnnotationBaseTable.sample_id),
+    )
+
+    anchor = keyset_seek.fetch_anchor(
+        session=session,
+        query=_filtered_query(
+            columns=[column for column, _ in sort_keys],
+            filters=filters,
+            parent_sample_type=parent_sample_type,
+        ).where(col(AnnotationBaseTable.sample_id) == sample_id),
+    )
+    if anchor is None:
+        # The annotation is not part of the filtered set.
+        return None
+
+    return keyset_seek.get_adjacent_result(
+        session=session,
+        sample_id=sample_id,
+        base_query=_filtered_query(
+            columns=[col(AnnotationBaseTable.sample_id)],
+            filters=filters,
+            parent_sample_type=parent_sample_type,
+        ),
+        sort_keys=sort_keys,
+        anchor=anchor,
+    )
+
+
+def _filtered_query(
+    columns: list[keyset_seek.SortColumn],
+    filters: AnnotationsFilter,
+    parent_sample_type: SampleType,
+) -> Any:
+    """Select the given columns from the filtered annotations, joined to their parents.
+
+    Type is loosened to Any because the callers select different row shapes: sample ids for
+    the seeks and counts, the sort-key tuple for the anchor.
+    """
+    query = select(*columns).select_from(AnnotationBaseTable)
+    return filters.apply(_join_parent_media(query=query, parent_sample_type=parent_sample_type))
+
+
+def _join_parent_media(query: Any, parent_sample_type: SampleType) -> Any:
+    """Inner-join the one parent table the annotations' sort key lives on.
+
+    Raises:
+        NotImplementedError: If the sample type has no parent file path.
+    """
+    if parent_sample_type == SampleType.IMAGE:
+        return query.join(
+            ImageTable,
+            col(ImageTable.sample_id) == col(AnnotationBaseTable.parent_sample_id),
+        )
+
+    if parent_sample_type == SampleType.VIDEO_FRAME:
+        return query.join(
+            VideoFrameTable,
+            col(VideoFrameTable.sample_id) == col(AnnotationBaseTable.parent_sample_id),
+        ).join(
+            VideoTable,
+            col(VideoTable.sample_id) == col(VideoFrameTable.parent_sample_id),
+        )
+
+    raise NotImplementedError(f"Unsupported parent sample type: {parent_sample_type}")

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations_keyset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations_keyset.py
@@ -8,6 +8,7 @@ up front lets us inner-join a single parent table and seek on a plain indexed co
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 from uuid import UUID
 
@@ -72,7 +73,7 @@ def get_adjacent_annotations_keyset(
 
 
 def _filtered_query(
-    columns: list[keyset_seek.SortColumn],
+    columns: Sequence[keyset_seek.SortColumn],
     filters: AnnotationsFilter,
     parent_sample_type: SampleType,
 ) -> Any:

--- a/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
@@ -1,5 +1,7 @@
+import importlib
 from collections.abc import Sequence
 from datetime import datetime, timezone
+from typing import Any, NoReturn
 from unittest import mock
 from uuid import UUID
 
@@ -21,6 +23,17 @@ from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
     create_run,
 )
 from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
+
+# The resolver package re-exports the entry point under its module's own name, shadowing
+# it, so the module has to be looked up by import path to patch what it dispatches to.
+_dispatch_module = importlib.import_module(
+    "lightly_studio.resolvers.annotation_resolver.get_adjacent_annotations"
+)
+
+
+def _fail_if_called(**kwargs: Any) -> NoReturn:  # noqa: ARG001
+    """Stand-in for the adjacency path a test expects the dispatch not to take."""
+    raise AssertionError("Unexpected adjacency implementation was used.")
 
 
 def test_get_adjacent_annotations__orders_by_path(db_session: Session) -> None:
@@ -504,6 +517,180 @@ def test_get_adjacent_annotations__orders_annotations_sharing_a_parent_image(
     _assert_matches_expected_order(
         session=db_session, filters=filters, expected_order=expected_order
     )
+
+
+@pytest.mark.parametrize(
+    ("annotation_collection_names", "path_not_taken"),
+    [
+        # One collection has a known parent kind, so it can seek. Several could mix parent
+        # kinds, so the keyset path bows out.
+        (["annotations"], "get_adjacent_annotations_window"),
+        (["annotations_a", "annotations_b"], "get_adjacent_annotations_keyset"),
+    ],
+    ids=["one_collection_seeks", "several_collections_fall_back"],
+)
+def test_get_adjacent_annotations__dispatches_on_collection_count(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    annotation_collection_names: list[str],
+    path_not_taken: str,
+) -> None:
+    collection = helpers_resolvers.create_collection(
+        session=db_session, sample_type=SampleType.IMAGE
+    )
+    label = helpers_resolvers.create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+    image = helpers_resolvers.create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/images/a.png",
+    )
+    annotations = [
+        helpers_resolvers.create_annotation(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_id=image.sample_id,
+            annotation_label_id=label.annotation_label_id,
+            annotation_collection_name=name,
+        )
+        for name in annotation_collection_names
+    ]
+
+    monkeypatch.setattr(_dispatch_module, path_not_taken, _fail_if_called)
+
+    result = annotation_resolver.get_adjacent_annotations(
+        session=db_session,
+        sample_id=annotations[0].sample_id,
+        filters=AnnotationsFilter(
+            collection_ids=[annotation.sample.collection_id for annotation in annotations]
+        ),
+    )
+
+    assert result is not None
+    assert result.total_count == len(annotations)
+
+
+def test_get_adjacent_annotations__falls_back_for_video_level_annotations(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Annotations on a video rather than on one of its frames. The keyset path cannot serve
+    # them — it joins one parent table and there is no join from an annotation to its video
+    # — so the dispatch has to bow out, which is what the monkeypatch below asserts.
+    #
+    # The window query it falls back to reaches VideoTable only through VideoFrameTable, so
+    # these annotations get no path to sort by at all: their leading key is the coalesce's
+    # empty-string default. Only the created-at and sample-id tiebreakers order them, which
+    # is why this asserts a total order rather than an order by video path.
+    collection = helpers_resolvers.create_collection(
+        session=db_session, sample_type=SampleType.VIDEO
+    )
+    label = helpers_resolvers.create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="label",
+    )
+
+    videos = [
+        create_video_with_frames(
+            session=db_session,
+            collection_id=collection.collection_id,
+            video=VideoStub(path=path, duration_s=0.2, fps=10.0),
+        )
+        for path in ("/videos/c.mp4", "/videos/a.mp4", "/videos/b.mp4")
+    ]
+
+    annotations = helpers_resolvers.create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        annotations=[
+            helpers_resolvers.AnnotationDetails(
+                sample_id=video.video_sample_id,
+                annotation_label_id=label.annotation_label_id,
+            )
+            for video in videos
+        ],
+    )
+    filters = AnnotationsFilter(collection_ids=[annotations[0].sample.collection_id])
+
+    monkeypatch.setattr(_dispatch_module, "get_adjacent_annotations_keyset", _fail_if_called)
+
+    results = {}
+    for annotation in annotations:
+        result = annotation_resolver.get_adjacent_annotations(
+            session=db_session, sample_id=annotation.sample_id, filters=filters
+        )
+        assert result is not None
+        results[annotation.sample_id] = result
+
+    by_position = {result.current_sample_position: key for key, result in results.items()}
+    assert sorted(by_position) == [1, 2, 3]
+    for position, sample_id in by_position.items():
+        result = results[sample_id]
+        assert result.total_count == len(annotations)
+        assert result.previous_sample_id == by_position.get(position - 1)
+        assert result.next_sample_id == by_position.get(position + 1)
+
+
+def test_get_adjacent_annotations__returns_none_when_anchor_filtered_out_of_keyset_path(
+    db_session: Session,
+) -> None:
+    # The keyset counterpart of __returns_none_when_sample_not_in_filter, which reaches the
+    # same result through the window path: here the collection is scoped so the seek runs,
+    # and the anchor's own label is what the filter excludes.
+    collection = helpers_resolvers.create_collection(
+        session=db_session, sample_type=SampleType.IMAGE
+    )
+    dog_label = helpers_resolvers.create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="dog",
+    )
+    cat_label = helpers_resolvers.create_annotation_label(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        label_name="cat",
+    )
+
+    image_a = helpers_resolvers.create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/images/a.png",
+    )
+    image_b = helpers_resolvers.create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/images/b.png",
+    )
+
+    annotation_dog, annotation_cat = helpers_resolvers.create_annotations(
+        session=db_session,
+        collection_id=collection.collection_id,
+        annotations=[
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=dog_label.annotation_label_id,
+            ),
+            helpers_resolvers.AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=cat_label.annotation_label_id,
+            ),
+        ],
+    )
+
+    result = annotation_resolver.get_adjacent_annotations(
+        session=db_session,
+        sample_id=annotation_cat.sample_id,
+        filters=AnnotationsFilter(
+            collection_ids=[annotation_dog.sample.collection_id],
+            annotation_label_ids=[dog_label.annotation_label_id],
+        ),
+    )
+
+    assert result is None
 
 
 def _create_annotations_with_pinned_created_at(

--- a/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
@@ -763,6 +763,7 @@ def _assert_matches_expected_order(
 
 def test_get_adjacent_annotations__sort_by_annotation_evaluation_metric(
     db_session: Session,
+    mocker: MockerFixture,
 ) -> None:
     # Unmatched (0.0) < matched (0.75); uncovered (NULL) sorts last
     root = helpers_resolvers.create_collection(session=db_session)
@@ -819,6 +820,9 @@ def test_get_adjacent_annotations__sort_by_annotation_evaluation_metric(
         annotation_id_column=col(AnnotationBaseTable.sample_id),
     )
     filters = AnnotationsFilter(collection_ids=[run.gt_annotation_collection_id])
+
+    # The keyset path seeks on the parent's file path, so it cannot order by a metric.
+    _fail_if_used(mocker=mocker, path=_KEYSET_PATH)
 
     # Query from the middle: matched is position 2 (unmatched=0.0, matched=0.75, uncovered=NULL)
     result = annotation_resolver.get_adjacent_annotations(

--- a/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
@@ -583,8 +583,9 @@ def test_get_adjacent_annotations__falls_back_for_video_level_annotations(
     #
     # The window query it falls back to reaches VideoTable only through VideoFrameTable, so
     # these annotations get no path to sort by at all: their leading key is the coalesce's
-    # empty-string default. Only the created-at and sample-id tiebreakers order them, which
-    # is why this asserts a total order rather than an order by video path.
+    # empty-string default. Only the created-at and sample-id tiebreakers order them, which is
+    # why two of them are pinned to the same created_at below and this asserts a total order
+    # rather than an order by video path.
     collection = helpers_resolvers.create_collection(
         session=db_session, sample_type=SampleType.VIDEO
     )
@@ -603,8 +604,9 @@ def test_get_adjacent_annotations__falls_back_for_video_level_annotations(
         for path in ("/videos/c.mp4", "/videos/a.mp4", "/videos/b.mp4")
     ]
 
-    annotations = helpers_resolvers.create_annotations(
+    annotations = _create_annotations_with_pinned_created_at(
         session=db_session,
+        monkeypatch=monkeypatch,
         collection_id=collection.collection_id,
         annotations=[
             helpers_resolvers.AnnotationDetails(
@@ -614,25 +616,16 @@ def test_get_adjacent_annotations__falls_back_for_video_level_annotations(
             for video in videos
         ],
     )
+    expected_order = sorted(
+        annotations, key=lambda annotation: (annotation.created_at, annotation.sample_id)
+    )
     filters = AnnotationsFilter(collection_ids=[annotations[0].sample.collection_id])
 
     monkeypatch.setattr(_dispatch_module, "get_adjacent_annotations_keyset", _fail_if_called)
 
-    results = {}
-    for annotation in annotations:
-        result = annotation_resolver.get_adjacent_annotations(
-            session=db_session, sample_id=annotation.sample_id, filters=filters
-        )
-        assert result is not None
-        results[annotation.sample_id] = result
-
-    by_position = {result.current_sample_position: key for key, result in results.items()}
-    assert sorted(by_position) == [1, 2, 3]
-    for position, sample_id in by_position.items():
-        result = results[sample_id]
-        assert result.total_count == len(annotations)
-        assert result.previous_sample_id == by_position.get(position - 1)
-        assert result.next_sample_id == by_position.get(position + 1)
+    _assert_matches_expected_order(
+        session=db_session, filters=filters, expected_order=expected_order
+    )
 
 
 def test_get_adjacent_annotations__returns_none_when_anchor_filtered_out_of_keyset_path(

--- a/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
@@ -1,11 +1,10 @@
-import importlib
 from collections.abc import Sequence
 from datetime import datetime, timezone
-from typing import Any, NoReturn
-from unittest import mock
+from types import ModuleType
 from uuid import UUID
 
 import pytest
+from pytest_mock import MockerFixture
 from sqlmodel import Session, col
 
 from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluationMetricField
@@ -14,6 +13,10 @@ from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationSide
 from lightly_studio.resolvers import annotation_resolver, collection_resolver, tag_resolver
+from lightly_studio.resolvers.annotation_resolver import (
+    get_adjacent_annotations_keyset,
+    get_adjacent_annotations_window,
+)
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from tests import helpers_resolvers
 from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
@@ -24,16 +27,10 @@ from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
 )
 from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
 
-# The resolver package re-exports the entry point under its module's own name, shadowing
-# it, so the module has to be looked up by import path to patch what it dispatches to.
-_dispatch_module = importlib.import_module(
-    "lightly_studio.resolvers.annotation_resolver.get_adjacent_annotations"
-)
-
-
-def _fail_if_called(**kwargs: Any) -> NoReturn:  # noqa: ARG001
-    """Stand-in for the adjacency path a test expects the dispatch not to take."""
-    raise AssertionError("Unexpected adjacency implementation was used.")
+# The two adjacency implementations the entry point dispatches to, as the (module, function)
+# pairs `_fail_if_used` patches.
+_KEYSET_PATH = (get_adjacent_annotations_keyset, "get_adjacent_annotations_keyset")
+_WINDOW_PATH = (get_adjacent_annotations_window, "get_adjacent_annotations_window")
 
 
 def test_get_adjacent_annotations__orders_by_path(db_session: Session) -> None:
@@ -425,9 +422,9 @@ def test_get_adjacent_annotations__returns_none_when_sample_not_in_filter(
 
 def test_get_adjacent_annotations__orders_video_frame_annotations_by_video_path(
     db_session: Session,
-    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
 ) -> None:
-    monkeypatch.setattr(_dispatch_module, "get_adjacent_annotations_window", _fail_if_called)
+    _fail_if_used(mocker=mocker, path=_WINDOW_PATH)
 
     collection = helpers_resolvers.create_collection(
         session=db_session, sample_type=SampleType.VIDEO
@@ -482,7 +479,7 @@ def test_get_adjacent_annotations__orders_video_frame_annotations_by_video_path(
 
 def test_get_adjacent_annotations__orders_annotations_sharing_a_parent_image(
     db_session: Session,
-    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
 ) -> None:
     # Annotations on the same image share the leading sort key, so the order is only total if
     # the created-at and sample-id tiebreakers are applied. Two of them are pinned to the same
@@ -502,7 +499,7 @@ def test_get_adjacent_annotations__orders_annotations_sharing_a_parent_image(
     )
     annotations = _create_annotations_with_pinned_created_at(
         session=db_session,
-        monkeypatch=monkeypatch,
+        mocker=mocker,
         collection_id=collection.collection_id,
         annotations=[
             helpers_resolvers.AnnotationDetails(
@@ -527,16 +524,16 @@ def test_get_adjacent_annotations__orders_annotations_sharing_a_parent_image(
     [
         # One collection has a known parent kind, so it can seek. Several could mix parent
         # kinds, so the keyset path bows out.
-        (["annotations"], "get_adjacent_annotations_window"),
-        (["annotations_a", "annotations_b"], "get_adjacent_annotations_keyset"),
+        (["annotations"], _WINDOW_PATH),
+        (["annotations_a", "annotations_b"], _KEYSET_PATH),
     ],
     ids=["one_collection_seeks", "several_collections_fall_back"],
 )
 def test_get_adjacent_annotations__dispatches_on_collection_count(
     db_session: Session,
-    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
     annotation_collection_names: list[str],
-    path_not_taken: str,
+    path_not_taken: tuple[ModuleType, str],
 ) -> None:
     collection = helpers_resolvers.create_collection(
         session=db_session, sample_type=SampleType.IMAGE
@@ -562,7 +559,7 @@ def test_get_adjacent_annotations__dispatches_on_collection_count(
         for name in annotation_collection_names
     ]
 
-    monkeypatch.setattr(_dispatch_module, path_not_taken, _fail_if_called)
+    _fail_if_used(mocker=mocker, path=path_not_taken)
 
     result = annotation_resolver.get_adjacent_annotations(
         session=db_session,
@@ -578,17 +575,13 @@ def test_get_adjacent_annotations__dispatches_on_collection_count(
 
 def test_get_adjacent_annotations__falls_back_for_video_level_annotations(
     db_session: Session,
-    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
 ) -> None:
-    # Annotations on a video rather than on one of its frames. The keyset path cannot serve
-    # them — it joins one parent table and there is no join from an annotation to its video
-    # — so the dispatch has to bow out, which is what the monkeypatch below asserts.
-    #
+    # Annotations on a video rather than on one of its frames, which the keyset path cannot
+    # serve: it joins one parent table and there is no join from an annotation to its video.
     # The window query it falls back to reaches VideoTable only through VideoFrameTable, so
-    # these annotations get no path to sort by at all: their leading key is the coalesce's
-    # empty-string default. Only the created-at and sample-id tiebreakers order them, which is
-    # why two of them are pinned to the same created_at below and this asserts a total order
-    # rather than an order by video path.
+    # these annotations have no path to sort by — only the created-at and sample-id
+    # tiebreakers order them, which is why created_at is pinned below.
     collection = helpers_resolvers.create_collection(
         session=db_session, sample_type=SampleType.VIDEO
     )
@@ -609,7 +602,7 @@ def test_get_adjacent_annotations__falls_back_for_video_level_annotations(
 
     annotations = _create_annotations_with_pinned_created_at(
         session=db_session,
-        monkeypatch=monkeypatch,
+        mocker=mocker,
         collection_id=collection.collection_id,
         annotations=[
             helpers_resolvers.AnnotationDetails(
@@ -624,7 +617,7 @@ def test_get_adjacent_annotations__falls_back_for_video_level_annotations(
     )
     filters = AnnotationsFilter(collection_ids=[annotations[0].sample.collection_id])
 
-    monkeypatch.setattr(_dispatch_module, "get_adjacent_annotations_keyset", _fail_if_called)
+    _fail_if_used(mocker=mocker, path=_KEYSET_PATH)
 
     _assert_matches_expected_order(
         session=db_session, filters=filters, expected_order=expected_order
@@ -691,7 +684,7 @@ def test_get_adjacent_annotations__returns_none_when_anchor_filtered_out_of_keys
 
 def _create_annotations_with_pinned_created_at(
     session: Session,
-    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
     collection_id: UUID,
     annotations: list[helpers_resolvers.AnnotationDetails],
 ) -> list[AnnotationBaseTable]:
@@ -706,7 +699,7 @@ def _create_annotations_with_pinned_created_at(
 
     Args:
         session: Database session.
-        monkeypatch: Fixture used to pin the annotation module's clock.
+        mocker: Fixture used to pin the annotation module's clock.
         collection_id: ID of the collection.
         annotations: Exactly 3 annotation details to create.
 
@@ -717,10 +710,25 @@ def _create_annotations_with_pinned_created_at(
     tied_created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
     later_created_at = datetime(2024, 1, 2, tzinfo=timezone.utc)
     times = iter([tied_created_at, tied_created_at, later_created_at])
-    monkeypatch.setattr(annotation_base_module, "datetime", mock.Mock(now=lambda _tz: next(times)))
+    mocker.patch.object(
+        annotation_base_module, "datetime", mocker.Mock(now=lambda _tz: next(times))
+    )
 
     return helpers_resolvers.create_annotations(
         session=session, collection_id=collection_id, annotations=annotations
+    )
+
+
+def _fail_if_used(mocker: MockerFixture, path: tuple[ModuleType, str]) -> None:
+    """Make the adjacency implementation at `path` fail if the dispatch calls it.
+
+    Args:
+        mocker: Fixture used to patch the implementation.
+        path: The `(module, function name)` pair the dispatch must not call.
+    """
+    module, function_name = path
+    mocker.patch.object(
+        module, function_name, side_effect=AssertionError("Unexpected adjacency implementation.")
     )
 
 

--- a/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
@@ -425,7 +425,10 @@ def test_get_adjacent_annotations__returns_none_when_sample_not_in_filter(
 
 def test_get_adjacent_annotations__orders_video_frame_annotations_by_video_path(
     db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(_dispatch_module, "get_adjacent_annotations_window", _fail_if_called)
+
     collection = helpers_resolvers.create_collection(
         session=db_session, sample_type=SampleType.VIDEO
     )


### PR DESCRIPTION
## What has changed and why?

Last of six in the stack — the optimization itself.

Stepping to the previous or next annotation sorted the whole filtered set on every click and read
the neighbours off it with `lag`/`lead`/`row_number`. At 4M annotations that took 6.3s. This
replaces that with a keyset seek on an indexed column; the module docstring of
`get_adjacent_annotations_keyset.py` explains why the old ordering could not use an index.

The window path stays as the fallback for filters spanning several annotation collections (which
could mix parent kinds) and for video-level annotations, whose parent is the video rather than a
frame — tests assert the dispatch bows out for both.

**What to review.** All new logic, nothing moved. `_keyset_parent_sample_type` must not claim a
parent kind for a set that could mix kinds, and the sort keys have to match the grid's ordering
exactly — the two ordering tests added in #1942 are unchanged by this PR and still pass, which is
the evidence that the seek reproduces the window query's order.

## How has it been tested?

`make static-checks`, the resolver, service and route tests (843 passed) and the resolver and
service tests against Postgres (612 passed). New here: the dispatch (one collection vs several),
the video-level fallback above, and `None` for an anchor the filter excludes on the keyset path.

Measured on PostgreSQL 18, 1M images with 4 annotations each, anchor at position 1,999,997, median
of 5 calls. Neighbours, position and total are identical before and after.

| | before | after |
|---|---|---|
| whole call | 6297 ms | 1323 ms |

Position and total are still exact `COUNT(*)`s and are 1190 ms of that remainder; making them
opt-out is the follow-up. Neutral on DuckDB, which does not drive range seeks from a secondary
index — the win is on PostgreSQL.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


Suggested reviewer: @ikondrat, who reviewed #1942 in this stack. Alternative: @horatiualmasan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster previous and next annotation navigation in the annotation details view.
  * Reduced sorting work and improved lookup performance for supported image and video-frame annotations, especially in large collections.
  * PostgreSQL benchmarks improved navigation from 6.3 seconds to 1.3 seconds for collections with 4 million annotations.

* **Bug Fixes**
  * Improved handling when the current annotation is excluded by active filters.
  * Preserved reliable navigation for video-level annotations and other unsupported cases.
  * Maintained correct ordering when sorting by annotation evaluation metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

