### PR TITLE
Exclude story and test-setup files from frontend coverage checks

### DIFF
--- a/fast_track/src/guardrails/frontend/coverage.test.ts
+++ b/fast_track/src/guardrails/frontend/coverage.test.ts
@@ -81,7 +81,11 @@ describe('filterFrontendFiles', () => {
         'foo.spec.ts',
         'foo.spec.js',
         'foo.spec.svelte',
-        'types.d.ts'
+        'types.d.ts',
+        'Alert.stories.svelte',
+        'Button.stories.ts',
+        'ClassSetConfigDialog.stories.js',
+        'setupTests.ts'
     ])('excludes %s', (name) => {
         const files = [file(`${FRONTEND_PREFIX}src/lib/${name}`)];
         expect(filterFrontendFiles(files)).toHaveLength(0);

--- a/fast_track/src/guardrails/frontend/coverage.ts
+++ b/fast_track/src/guardrails/frontend/coverage.ts
@@ -15,7 +15,11 @@ const IGNORE_SUFFIXES = [
     '.spec.ts',
     '.spec.js',
     '.spec.svelte',
-    '.d.ts'
+    '.d.ts',
+    '.stories.svelte',
+    '.stories.ts',
+    '.stories.js',
+    'setupTests.ts'
 ];
 const SOURCE_SUFFIXES = ['.ts', '.js', '.svelte'];
 


### PR DESCRIPTION
## What has changed and why?

This PR adds Storybook files (`.stories.svelte`, `.stories.ts`, `.stories.js`) and the test setup file (`setupTests.ts`) to the ignore list so they are no longer counted.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Frontend coverage checks now correctly exclude TypeScript declaration files, story files, and test setup files.
  * Coverage results more accurately reflect application source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->