### PR TITLE
State the annotation tiebreaker chain once

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/annotations/annotation_ordering.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotations/annotation_ordering.py
@@ -42,11 +42,41 @@ def build_order_by(
         Order by clauses: the leading order key if given, then ascending file path,
         creation time and annotation sample ID.
     """
+    sort_keys = build_sort_keys(
+        file_path_abs=file_path_abs,
+        created_at=created_at,
+        annotation_sample_id=annotation_sample_id,
+    )
     return [
         *([leading_order_key] if leading_order_key is not None else []),
-        file_path_abs.asc(),
-        created_at.asc(),
-        annotation_sample_id.asc(),
+        *(column.asc() if ascending else column.desc() for column, ascending in sort_keys),
+    ]
+
+
+def build_sort_keys(
+    file_path_abs: OrderExpression,
+    created_at: OrderExpression,
+    annotation_sample_id: OrderExpression,
+) -> list[tuple[OrderExpression, bool]]:
+    """Build the tiebreaker chain as (column, ascending) pairs.
+
+    This is the source of truth `build_order_by` derives its clauses from. Callers that
+    need the columns themselves — a keyset seek compares against them rather than sorting
+    by them — use this directly.
+
+    Args:
+        file_path_abs: Expression for the parent sample's absolute file path.
+        created_at: Expression for the annotation's creation time.
+        annotation_sample_id: Expression for the annotation's sample ID.
+
+    Returns:
+        The parent file path, the creation time and the annotation sample ID, all
+        ascending. The sample ID makes the ordering total.
+    """
+    return [
+        (file_path_abs, True),
+        (created_at, True),
+        (annotation_sample_id, True),
     ]
 
 


### PR DESCRIPTION
## What has changed and why?

Fifth of six in the stack. No behaviour change.

Every query that orders annotations has to use the same tiebreaker chain, or the grid and the detail
view's next/prev navigation drift apart. `build_order_by` spelled that chain out as order-by clauses,
which is all its four callers need.

A keyset seek needs the same chain as *columns*, because it compares against them instead of sorting
by them. Rather than have the seek restate the chain and let the two copies diverge,
`build_sort_keys` now returns the `(column, ascending)` pairs and `build_order_by` derives its
clauses from them. The seek that consumes the pairs is the last PR in the stack.

**What to review.** Whether `build_order_by` still produces the same clauses. Its four callers —
`get_all.py`, `get_all_by_parent_sample_ids.py`, `get_all_with_payload.py` and
`get_adjacent_annotations_window.py` — are untouched, and this is the only file in the stack whose
blast radius reaches the grid rather than just adjacency, which is why it is on its own.

## How has it been tested?

`make static-checks` and `pytest tests/resolvers` (547 passed). No test changes: the four callers keep
their existing tests, and a change in the emitted ordering would fail them.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation ordering consistency by applying stable tiebreakers with the correct ascending or descending direction.
  * Preserved the existing behavior for optional leading sort criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->