### PR TITLE
Add a lightweight video frame info lookup by sample ID.

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/__init__.py
@@ -13,6 +13,10 @@ from lightly_studio.resolvers.video_frame_resolver.get_all_by_video_ids import (
 from lightly_studio.resolvers.video_frame_resolver.get_by_id import (
     get_by_id,
 )
+from lightly_studio.resolvers.video_frame_resolver.get_frame_infos_by_ids import (
+    VideoFrameInfoRow,
+    get_frame_infos_by_ids,
+)
 from lightly_studio.resolvers.video_frame_resolver.get_sample_ids import (
     build_sample_ids_query,
     get_sample_ids,
@@ -29,12 +33,14 @@ from lightly_studio.resolvers.video_frame_resolver.video_frame_adjacent_filter i
 
 __all__ = [
     "VideoFrameAdjacentFilter",
+    "VideoFrameInfoRow",
     "build_sample_ids_query",
     "create_many",
     "get_adjacent_video_frames",
     "get_all_by_collection_id",
     "get_all_by_video_ids",
     "get_by_id",
+    "get_frame_infos_by_ids",
     "get_sample_ids",
     "get_table_fields_bounds",
     "get_video_frames_count_annotation_views",

--- a/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/get_frame_infos_by_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/get_frame_infos_by_ids.py
@@ -8,17 +8,12 @@ from uuid import UUID
 
 from sqlmodel import Session, col, select
 
-from lightly_studio.database import db_array
 from lightly_studio.models.video import VideoFrameTable
+from lightly_studio.utils import batching
 
 
 class VideoFrameInfoRow(NamedTuple):
-    """A frame's sample ID paired with its position in the parent video.
-
-    Lightweight read result for ``get_frame_infos_by_ids``: only the three columns
-    below are loaded, never a full ``VideoFrameTable`` object. Callers that walk
-    every frame of a collection would otherwise hydrate one mapped entity per frame.
-    """
+    """A frame's sample ID paired with its position in the parent video."""
 
     sample_id: UUID
     parent_sample_id: UUID
@@ -41,22 +36,24 @@ def get_frame_infos_by_ids(
     Returns:
         Frame info rows, in the same order as ``sample_ids``.
     """
-    if not sample_ids:
-        return []
-
-    statement = select(
-        VideoFrameTable.sample_id,
-        VideoFrameTable.parent_sample_id,
-        VideoFrameTable.frame_number,
-    ).where(db_array.in_array(column=col(VideoFrameTable.sample_id), values=sample_ids))
-    row_by_sample_id = {
-        sample_id: VideoFrameInfoRow(
-            sample_id=sample_id,
-            parent_sample_id=parent_sample_id,
-            frame_number=frame_number,
+    row_by_sample_id: dict[UUID, VideoFrameInfoRow] = {}
+    # Batch the ids to stay under PostgreSQL's 65,535 bind-parameter limit.
+    for batch in batching.batched(items=sample_ids):
+        statement = select(
+            VideoFrameTable.sample_id,
+            VideoFrameTable.parent_sample_id,
+            VideoFrameTable.frame_number,
+        ).where(col(VideoFrameTable.sample_id).in_(batch))
+        row_by_sample_id.update(
+            {
+                sample_id: VideoFrameInfoRow(
+                    sample_id=sample_id,
+                    parent_sample_id=parent_sample_id,
+                    frame_number=frame_number,
+                )
+                for sample_id, parent_sample_id, frame_number in session.exec(statement).all()
+            }
         )
-        for sample_id, parent_sample_id, frame_number in session.exec(statement).all()
-    }
     return [
         row_by_sample_id[sample_id] for sample_id in sample_ids if sample_id in row_by_sample_id
     ]

--- a/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/get_frame_infos_by_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_frame_resolver/get_frame_infos_by_ids.py
@@ -1,0 +1,62 @@
+"""Retrieve lightweight video frame info rows by sample ID."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import NamedTuple
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+
+from lightly_studio.database import db_array
+from lightly_studio.models.video import VideoFrameTable
+
+
+class VideoFrameInfoRow(NamedTuple):
+    """A frame's sample ID paired with its position in the parent video.
+
+    Lightweight read result for ``get_frame_infos_by_ids``: only the three columns
+    below are loaded, never a full ``VideoFrameTable`` object. Callers that walk
+    every frame of a collection would otherwise hydrate one mapped entity per frame.
+    """
+
+    sample_id: UUID
+    parent_sample_id: UUID
+    frame_number: int
+
+
+def get_frame_infos_by_ids(
+    session: Session,
+    sample_ids: Sequence[UUID],
+) -> list[VideoFrameInfoRow]:
+    """Retrieve sample ID, parent video and frame number for the given sample IDs.
+
+    Output order matches the input order. Sample IDs with no matching frame
+    are omitted.
+
+    Args:
+        session: The database session.
+        sample_ids: Frame sample IDs to load.
+
+    Returns:
+        Frame info rows, in the same order as ``sample_ids``.
+    """
+    if not sample_ids:
+        return []
+
+    statement = select(
+        VideoFrameTable.sample_id,
+        VideoFrameTable.parent_sample_id,
+        VideoFrameTable.frame_number,
+    ).where(db_array.in_array(column=col(VideoFrameTable.sample_id), values=sample_ids))
+    row_by_sample_id = {
+        sample_id: VideoFrameInfoRow(
+            sample_id=sample_id,
+            parent_sample_id=parent_sample_id,
+            frame_number=frame_number,
+        )
+        for sample_id, parent_sample_id, frame_number in session.exec(statement).all()
+    }
+    return [
+        row_by_sample_id[sample_id] for sample_id in sample_ids if sample_id in row_by_sample_id
+    ]

--- a/lightly_studio/tests/resolvers/video/video_frame_resolver/test_get_frame_infos_by_ids.py
+++ b/lightly_studio/tests/resolvers/video/video_frame_resolver/test_get_frame_infos_by_ids.py
@@ -1,0 +1,82 @@
+from uuid import uuid4
+
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.resolvers import video_frame_resolver
+from tests.helpers_resolvers import create_collection
+from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
+
+
+def test_get_frame_infos_by_ids__preserves_input_sample_id_order(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video_a = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/data/a.mp4", duration_s=2.0, fps=1.0),
+    )
+    video_b = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/data/b.mp4", duration_s=2.0, fps=1.0),
+    )
+    # Reverse of insertion order so SQL IN cannot accidentally match.
+    input_sample_ids = list(video_b.frame_sample_ids) + list(video_a.frame_sample_ids)
+
+    frames = video_frame_resolver.get_frame_infos_by_ids(
+        session=db_session, sample_ids=input_sample_ids
+    )
+
+    assert [frame.sample_id for frame in frames] == input_sample_ids
+
+
+def test_get_frame_infos_by_ids__returns_parent_and_frame_number(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/data/a.mp4", duration_s=3.0, fps=1.0),
+    )
+
+    frames = video_frame_resolver.get_frame_infos_by_ids(
+        session=db_session, sample_ids=video.frame_sample_ids
+    )
+
+    assert [frame.frame_number for frame in frames] == [0, 1, 2]
+    assert {frame.parent_sample_id for frame in frames} == {video.video_sample_id}
+
+
+def test_get_frame_infos_by_ids__omits_missing_ids(db_session: Session) -> None:
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/data/a.mp4", duration_s=2.0, fps=1.0),
+    )
+
+    frames = video_frame_resolver.get_frame_infos_by_ids(
+        session=db_session,
+        sample_ids=[uuid4(), video.frame_sample_ids[0], uuid4()],
+    )
+
+    assert [frame.sample_id for frame in frames] == [video.frame_sample_ids[0]]
+
+
+def test_get_frame_infos_by_ids__empty(db_session: Session) -> None:
+    assert video_frame_resolver.get_frame_infos_by_ids(session=db_session, sample_ids=[]) == []
+
+
+def test_get_frame_infos_by_ids__exceeds_postgres_param_limit(db_session: Session) -> None:
+    """Only PostgreSQL has the 65,535 bind cap; on DuckDB this checks the plain IN path."""
+    collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
+    video = create_video_with_frames(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video=VideoStub(path="/data/a.mp4", duration_s=1.0, fps=1.0),
+    )
+    sample_ids = [uuid4() for _ in range(70_000)]
+    sample_ids.append(video.frame_sample_ids[0])
+
+    frames = video_frame_resolver.get_frame_infos_by_ids(session=db_session, sample_ids=sample_ids)
+
+    assert [frame.sample_id for frame in frames] == [video.frame_sample_ids[0]]

--- a/lightly_studio/tests/resolvers/video/video_frame_resolver/test_get_frame_infos_by_ids.py
+++ b/lightly_studio/tests/resolvers/video/video_frame_resolver/test_get_frame_infos_by_ids.py
@@ -4,6 +4,7 @@ from sqlmodel import Session
 
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import video_frame_resolver
+from lightly_studio.utils import batching
 from tests.helpers_resolvers import create_collection
 from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
 
@@ -66,15 +67,16 @@ def test_get_frame_infos_by_ids__empty(db_session: Session) -> None:
     assert video_frame_resolver.get_frame_infos_by_ids(session=db_session, sample_ids=[]) == []
 
 
-def test_get_frame_infos_by_ids__exceeds_postgres_param_limit(db_session: Session) -> None:
-    """Only PostgreSQL has the 65,535 bind cap; on DuckDB this checks the plain IN path."""
+def test_get_frame_infos_by_ids__spans_multiple_batches(db_session: Session) -> None:
+    """More ids than one batch holds, so the results must be merged across batches."""
     collection = create_collection(session=db_session, sample_type=SampleType.VIDEO)
     video = create_video_with_frames(
         session=db_session,
         collection_id=collection.collection_id,
         video=VideoStub(path="/data/a.mp4", duration_s=1.0, fps=1.0),
     )
-    sample_ids = [uuid4() for _ in range(70_000)]
+    # The only matching id goes last, so it lands in a batch after the first one.
+    sample_ids = [uuid4() for _ in range(batching.DEFAULT_BATCH_SIZE)]
     sample_ids.append(video.frame_sample_ids[0])
 
     frames = video_frame_resolver.get_frame_infos_by_ids(session=db_session, sample_ids=sample_ids)


### PR DESCRIPTION
## What has changed and why?

- Add `get_frame_infos_by_ids` to load only `sample_id`, `parent_sample_id`, and `frame_number` without hydrating full `VideoFrameTable` rows.
- Will be used in the next prs when creating the sequences of frames. 

## How has it been tested?

New tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving video frame details by sample ID, including parent video and frame number.
  * Results preserve the requested order and exclude unavailable sample IDs.
  * Supports empty requests and large inputs processed across multiple batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->