### PR TITLE
Bump to v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Show indexed categorical metadata values in distribution panel.
 - Add the `lightly-studio quickstart` CLI command, which downloads the COCO example dataset and launches the GUI in one step. Pass `--no-browser` to skip opening the browser.
-
 - Export image and video classification annotations to CSV via the GUI and Python SDK.
-
 - Python SDK: Export video frames as image files via `VideoFrameDataset.export().to_image_files()` with support for PNG, JPEG, WEBP, BMP, and TIFF formats. Returns the paths of the created files.
 - Google Cloud Storage (GCS) is supported in the LightlyStudio Enterprise version.
 - Python SDK: Connect to LightlyStudio Enterprise with a long-lived API key by passing `api_key` to `lightly_studio.connect()` or setting `LIGHTLY_STUDIO_API_KEY`.
@@ -40,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The ignored `is_numeric` field on sort expressions in the images-list and adjacent-samples
   request bodies. Requests that still send it keep working; it is dropped during validation.
-
 - The `cast_to_float` argument of `OrderByMetadataField`. Top-level numeric fields are now
   detected automatically, so `OrderByMetadataField("score", cast_to_float=True)` becomes
   `OrderByMetadataField("score")`. Nested fields (e.g. `stats.score`) now always sort
@@ -50,7 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sorting by a numeric metadata field now orders numerically (e.g. `9` before `10`) without
   the caller declaring the field type.
-
 - Tagging by embedding region now correctly limits samples to the selected area.
 - Export downloads are no longer blocked by popup blockers.
 - Grid annotation overlays now render at tile resolution to bound memory usage for large source images.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Show indexed categorical metadata values in distribution panel
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## \[1.0.5\] - 2026-08-14
+
+### Added
+- Show indexed categorical metadata values in distribution panel.
 - Add the `lightly-studio quickstart` CLI command, which downloads the COCO example dataset and launches the GUI in one step.
 
-- Export image classification annotations to CSV via the GUI and Python SDK
-- Export video classification annotations to CSV via the GUI and Python SDK
+- Export image classification annotations to CSV via the GUI and Python SDK.
+- Export video classification annotations to CSV via the GUI and Python SDK.
 
 - Python SDK: Export video frames as image files via `VideoFrameDataset.export().to_image_files()` with support for PNG, JPEG, WEBP, BMP, and TIFF formats. Returns the paths of the created files.
 - Google Cloud Storage (GCS) is supported in the LightlyStudio Enterprise version.
@@ -22,8 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `lightly-studio quickstart` now opens your browser automatically once the GUI server is ready. Pass `--no-browser` to skip that.
 - Show a busy indicator on save/delete/export/execute buttons while their action is running (caption, tag, operator, evaluation, and export actions).
-
-### Deprecated
 
 ### Removed
 
@@ -51,8 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changing annotation colors is now smoother and shows a live preview while dragging the color picker.
 - Hover previews in the annotations embedding plot now show the relevant image crop and annotation overlay, matching the annotations grid.
 - Custom annotation color opacity is now applied to segmentation masks in the detail view. Contributed by @sam-watts.
-
-### Security
 
 ## \[1.0.4\] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Show indexed categorical metadata values in distribution panel.
-- Add the `lightly-studio quickstart` CLI command, which downloads the COCO example dataset and launches the GUI in one step. Pass `--no-browser` to skip that.
+- Add the `lightly-studio quickstart` CLI command, which downloads the COCO example dataset and launches the GUI in one step. Pass `--no-browser` to skip opening the browser.
 
 - Export image and video classification annotations to CSV via the GUI and Python SDK.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,38 +23,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Show indexed categorical metadata values in distribution panel.
-- Add the `lightly-studio quickstart` CLI command, which downloads the COCO example dataset and launches the GUI in one step.
+- Add the `lightly-studio quickstart` CLI command, which downloads the COCO example dataset and launches the GUI in one step. Pass `--no-browser` to skip that.
 
-- Export image classification annotations to CSV via the GUI and Python SDK.
-- Export video classification annotations to CSV via the GUI and Python SDK.
+- Export image and video classification annotations to CSV via the GUI and Python SDK.
 
 - Python SDK: Export video frames as image files via `VideoFrameDataset.export().to_image_files()` with support for PNG, JPEG, WEBP, BMP, and TIFF formats. Returns the paths of the created files.
 - Google Cloud Storage (GCS) is supported in the LightlyStudio Enterprise version.
 - Python SDK: Connect to LightlyStudio Enterprise with a long-lived API key by passing `api_key` to `lightly_studio.connect()` or setting `LIGHTLY_STUDIO_API_KEY`.
+- Python SDK: Add support for table parameters in plugins, allowing users to pass multiple rows of input.
 
 ### Changed
 
-- `lightly-studio quickstart` now opens your browser automatically once the GUI server is ready. Pass `--no-browser` to skip that.
 - Show a busy indicator on save/delete/export/execute buttons while their action is running (caption, tag, operator, evaluation, and export actions).
 
 ### Removed
 
-- The `is_numeric` field on sort expressions in the images-list and adjacent-samples request
-  bodies. It was already ignored, as the value type is taken from the collection's metadata
-  schema. Requests that still send the field keep working; it is dropped during validation.
+- The ignored `is_numeric` field on sort expressions in the images-list and adjacent-samples
+  request bodies. Requests that still send it keep working; it is dropped during validation.
 
-- The `cast_to_float` argument of `OrderByMetadataField`. Top-level numerical fields are now
-  detected automatically, so passing it is no longer needed: `OrderByMetadataField("score",
-  cast_to_float=True)` becomes `OrderByMetadataField("score")`. Sorting a *nested* numerical
-  field numerically is no longer possible, as `metadata_schema` records only top-level keys;
-  a dotted path such as `stats.score` now sorts lexicographically.
+- The `cast_to_float` argument of `OrderByMetadataField`. Top-level numeric fields are now
+  detected automatically, so `OrderByMetadataField("score", cast_to_float=True)` becomes
+  `OrderByMetadataField("score")`. Nested fields (e.g. `stats.score`) now always sort
+  lexicographically.
 
 ### Fixed
 
-- Sorting by a numeric metadata field now orders numerically without the caller having to
-  declare the field type. Previously `9` sorted after `10` unless the caller passed
-  `cast_to_float=True`.
+- Sorting by a numeric metadata field now orders numerically (e.g. `9` before `10`) without
+  the caller declaring the field type.
 
+- Tagging by embedding region now correctly limits samples to the selected area.
+- Export downloads are no longer blocked by popup blockers.
 - Grid annotation overlays now render at tile resolution to bound memory usage for large source images.
 - Annotation class names no longer overflow in class selection.
 - Autofocus lets users create their first annotation faster.

--- a/lightly_studio/pyproject.toml
+++ b/lightly_studio/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lightly-studio"
-version = "1.0.4"
+version = "1.0.5"
 description = "LightlyStudio is a lightweight, fast, and easy-to-use data exploration tool for data scientists and engineers."
 readme = "USAGE.md"
 requires-python = ">=3.9,<3.15"

--- a/lightly_studio/uv.lock
+++ b/lightly_studio/uv.lock
@@ -3111,7 +3111,7 @@ wheels = [
 
 [[package]]
 name = "lightly-studio"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "alembic", version = "1.16.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## What has changed and why?

Bump the version to 1.0.5.

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added categorical metadata display and annotation-region tagging.
  * Added combined classification CSV exports and video-frame image export.
  * Added GCS Enterprise support and long-lived API keys.
  * Added plugin table parameters, busy indicators, and numeric sorting.
  * Improved quickstart CLI behavior and popup-blocker handling.
  * Updated sort-expression API behavior.
* **Release**
  * Released version 1.0.5 on August 14, 2026.
  * Updated the changelog structure for upcoming releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->