### PR TITLE
Rename json_extract_string to json_extract_key_as_text

### DIFF
--- a/lightly_studio/src/lightly_studio/database/db_json.py
+++ b/lightly_studio/src/lightly_studio/database/db_json.py
@@ -70,20 +70,26 @@ class json_extract(GenericFunction[Any]):  # noqa: N801
         super().__init__(column)
 
 
-class json_extract_string(GenericFunction[str]):  # noqa: N801
-    """Extract a top-level JSON scalar as plain text.
+class json_extract_key_as_text(GenericFunction[str]):  # noqa: N801
+    """Read one top-level JSON key as plain text.
 
-    The key is bound rather than interpolated into SQL. It is treated literally,
-    so dots and quotes in metadata keys do not become path syntax.
+    The key is bound rather than interpolated into SQL. It is taken literally, so unlike
+    :class:`json_extract` a dot in it stays part of the key rather than stepping into a
+    nested object, and a quote cannot become path syntax.
     """
 
     inherit_cache = False
     type = Text()
 
-    def __init__(self, column: Any, field: str) -> None:
-        """Initialize with a JSON column and top-level field name."""
-        field_parameter = sqlalchemy.literal(field, type_=_JsonTopLevelKeyType())
-        super().__init__(column, field_parameter)
+    def __init__(self, column: Any, key: str) -> None:
+        """Initialize with a JSON column and the top-level key to read.
+
+        Args:
+            column: The JSON column expression.
+            key: The top-level key to read, dots and all.
+        """
+        key_parameter = sqlalchemy.literal(key, type_=_JsonKeyType())
+        super().__init__(column, key_parameter)
 
 
 @compiles(json_extract)
@@ -122,9 +128,9 @@ def _compile_json_extract_postgresql(
     )
 
 
-@compiles(json_extract_string)
-def _compile_json_extract_string_unsupported(
-    element: json_extract_string, compiler: SQLCompiler, **kw: Any
+@compiles(json_extract_key_as_text)
+def _compile_json_extract_key_as_text_unsupported(
+    element: json_extract_key_as_text, compiler: SQLCompiler, **kw: Any
 ) -> str:
     """Raise for unsupported dialects."""
     raise NotImplementedError(
@@ -133,26 +139,26 @@ def _compile_json_extract_string_unsupported(
     )
 
 
-@compiles(json_extract_string, "duckdb")
-def _compile_json_extract_string_duckdb(
-    element: json_extract_string, compiler: SQLCompiler, **kw: Any
+@compiles(json_extract_key_as_text, "duckdb")
+def _compile_json_extract_key_as_text_duckdb(
+    element: json_extract_key_as_text, compiler: SQLCompiler, **kw: Any
 ) -> str:
     """Extract a JSON scalar as plain text on DuckDB."""
-    column, field = element.clauses
-    return f"json_extract_string({compiler.process(column, **kw)}, {compiler.process(field, **kw)})"
+    column, key = element.clauses
+    return f"json_extract_string({compiler.process(column, **kw)}, {compiler.process(key, **kw)})"
 
 
-@compiles(json_extract_string, "postgresql")
-def _compile_json_extract_string_postgresql(
-    element: json_extract_string, compiler: SQLCompiler, **kw: Any
+@compiles(json_extract_key_as_text, "postgresql")
+def _compile_json_extract_key_as_text_postgresql(
+    element: json_extract_key_as_text, compiler: SQLCompiler, **kw: Any
 ) -> str:
     """Extract a JSON scalar as plain text on PostgreSQL."""
-    column, field = element.clauses
-    return f"{compiler.process(column, **kw)}->>{compiler.process(field, **kw)}"
+    column, key = element.clauses
+    return f"{compiler.process(column, **kw)}->>{compiler.process(key, **kw)}"
 
 
-class _JsonTopLevelKeyType(TypeDecorator[str]):
-    """Bind a literal top-level JSON key for each supported database."""
+class _JsonKeyType(TypeDecorator[str]):
+    """Bind one literal object key for each supported database."""
 
     impl = Text
     cache_ok = True

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
@@ -171,8 +171,8 @@ def _build_in_condition(
     metadata_model: type[M], metadata_filter: MetadataFilter
 ) -> ColumnElement[bool]:
     """Build an OR predicate for a validated categorical ``in`` filter."""
-    extract_expr = db_json.json_extract_string(
-        column=metadata_model.data, field=metadata_filter.key
+    extract_expr = db_json.json_extract_key_as_text(
+        column=metadata_model.data, key=metadata_filter.key
     )
     values = [
         str(value).lower() if isinstance(value, bool) else value

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
@@ -74,7 +74,7 @@ def _get_field_value_counts(
     metadata_type: str,
     filters: ImageFilter | None,
 ) -> MetadataValueCountsView:
-    value_expr = db_json.json_extract_string(column=SampleMetadataTable.data, field=metadata_key)
+    value_expr = db_json.json_extract_key_as_text(column=SampleMetadataTable.data, key=metadata_key)
     rows = _get_top_value_counts(
         session=session,
         collection_id=collection_id,

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_values_for_key.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_values_for_key.py
@@ -32,11 +32,11 @@ def get_metadata_values_for_key(
             - The schema type for `key`, or `None` if the key is not present in
               the collection schema.
     """
-    schema_type_expr = db_json.json_extract_string(
+    schema_type_expr = db_json.json_extract_key_as_text(
         column=SampleMetadataTable.metadata_schema,
-        field=key,
+        key=key,
     )
-    value_expr = db_json.json_extract_string(column=SampleMetadataTable.data, field=key)
+    value_expr = db_json.json_extract_key_as_text(column=SampleMetadataTable.data, key=key)
 
     rows = session.exec(
         select(SampleMetadataTable.sample_id, value_expr, schema_type_expr)

--- a/lightly_studio/tests/database/test_db_json.py
+++ b/lightly_studio/tests/database/test_db_json.py
@@ -118,49 +118,49 @@ def test_json_extract__sqlite_raises() -> None:
         expr.compile(dialect=sqlite.dialect())
 
 
-def test_json_extract_string__duckdb() -> None:
-    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field="location")
+def test_json_extract_key_as_text__duckdb() -> None:
+    expr = db_json.json_extract_key_as_text(column=sqlalchemy.column("data"), key="location")
     result = expr.compile(dialect=Dialect())
     assert str(result) == "json_extract_string(data, %(param_1)s)"
     assert result.params == {"param_1": "location"}
 
 
-def test_json_extract_string__postgresql() -> None:
-    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field="location")
+def test_json_extract_key_as_text__postgresql() -> None:
+    expr = db_json.json_extract_key_as_text(column=sqlalchemy.column("data"), key="location")
     result = expr.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
     assert str(result) == "data->>%(param_1)s"
     assert result.params == {"param_1": "location"}
 
 
-@pytest.mark.parametrize("field", ["site.name", "owner's site"])
-def test_json_extract_string__special_key_is_bound(field: str) -> None:
-    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field=field)
+@pytest.mark.parametrize("key", ["site.name", "owner's site"])
+def test_json_extract_key_as_text__special_key_is_bound(key: str) -> None:
+    expr = db_json.json_extract_key_as_text(column=sqlalchemy.column("data"), key=key)
     duckdb_result = expr.compile(dialect=Dialect())
     postgres_result = expr.compile(
         dialect=postgresql.dialect()  # type: ignore[no-untyped-call]
     )
 
     assert str(duckdb_result) == "json_extract_string(data, %(param_1)s)"
-    assert duckdb_result.params == {"param_1": field}
+    assert duckdb_result.params == {"param_1": key}
     assert str(postgres_result) == "data->>%(param_1)s"
-    assert postgres_result.params == {"param_1": field}
+    assert postgres_result.params == {"param_1": key}
 
 
 @pytest.mark.parametrize(
-    ("field", "expected"),
+    ("key", "expected"),
     [
         ("site.name", "/site.name"),
         ("owner's site", "/owner's site"),
         ("path/to~site", "/path~1to~0site"),
     ],
 )
-def test_json_top_level_key_type__duckdb_path(field: str, expected: str) -> None:
-    type_ = db_json._JsonTopLevelKeyType()
-    assert type_.process_bind_param(value=field, dialect=Dialect()) == expected
+def test_json_key_type__duckdb_path(key: str, expected: str) -> None:
+    type_ = db_json._JsonKeyType()
+    assert type_.process_bind_param(value=key, dialect=Dialect()) == expected
 
 
-def test_json_extract_string__sqlite_raises() -> None:
-    expr = db_json.json_extract_string(column=sqlalchemy.column("data"), field="location")
+def test_json_extract_key_as_text__sqlite_raises() -> None:
+    expr = db_json.json_extract_key_as_text(column=sqlalchemy.column("data"), key="location")
     with pytest.raises(NotImplementedError, match="Unsupported dialect: sqlite"):
         expr.compile(dialect=sqlite.dialect())
 


### PR DESCRIPTION
Split out of #1905. Bottom of the stack — merge this one first.

## What has changed and why?

`json_extract_string` sat next to `json_extract` and said nothing about which one takes a path and which one takes a literal key. Both return text, so the distinction was invisible at the call site, and the next commit adds more of these functions.

Rename the argument to `key` for the same reason, rename `_JsonTopLevelKeyType` to `_JsonKeyType` since it binds any object key rather than only a top-level one, and say in the module docstring what separates a field from a key.

No behaviour change.

## How has it been tested?

`make static-checks` and `make test`, plus the metadata suites under `--postgres`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved JSON metadata extraction to clearly support literal keys, including keys with special characters.
  - Updated metadata filtering and value retrieval to use refined key-based extraction behavior.
  - Renamed the public extraction interface to clarify that it retrieves values by literal key.

- **Bug Fixes**
  - Improved consistency when extracting metadata across supported database systems.

- **Tests**
  - Expanded coverage for special keys, database-specific behavior, JSON paths, and unsupported SQLite operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->