### PR TITLE
Fix: use SQLAlchemy JSON indexing instead of hand-built SQL

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
@@ -188,7 +188,7 @@ class OrderByMetadataField(OrderByExpression):
         )
 
     def _sort_key_expressions(self) -> list[ColumnElement[Any]]:
-        """Return the numerical key, NULL for non-numerical fields, then the raw value."""
+        """Return the numerical key, NULL for non-numerical fields, then the text value."""
         return [self._order_value_expression(), self._extracted_value()]
 
     def to_column_elements(self) -> list[ColumnElement[Any]]:
@@ -198,16 +198,19 @@ class OrderByMetadataField(OrderByExpression):
     def _is_numerical_field(self) -> ColumnElement[bool]:
         """Return whether ``metadata_schema`` records this field as a number.
 
-        Uses the same path syntax as the value, so the two cannot disagree.
+        ``metadata_schema`` maps a key to the name of its type, so this reads a type name
+        rather than a value. Uses the same path syntax as the value so the two cannot
+        disagree.
         """
-        return db_json.json_extract(
+        schema_type_name = db_json.json_extract_as_text(
             column=self._metadata_alias.metadata_schema,
             field=self.field_name,
-        ).in_([db_json.json_literal(type_name) for type_name in NUMERIC_TYPE_NAMES])
+        )
+        return schema_type_name.in_(NUMERIC_TYPE_NAMES)
 
     def _extracted_value(self) -> ColumnElement[Any]:
-        """Return the raw JSON value of the field."""
-        return db_json.json_extract(column=self._metadata_alias.data, field=self.field_name)
+        """Return the field's value as text, which is what ``ORDER BY`` can sort."""
+        return db_json.json_extract_as_text(column=self._metadata_alias.data, field=self.field_name)
 
     def apply_joins(self, query: SelectT) -> SelectT:
         """Left-outer-join aliased ``SampleMetadataTable`` on ``sample_id``."""

--- a/lightly_studio/src/lightly_studio/database/db_array.py
+++ b/lightly_studio/src/lightly_studio/database/db_array.py
@@ -31,7 +31,7 @@ class in_array(ColumnElement[bool]):  # noqa: N801
      expanding IN clause, which DuckDB handles efficiently.
     """
 
-    # Holds a raw Python list, which is not safely cache-keyable (like db_json.json_extract).
+    # Holds a raw Python list, which is not safely cache-keyable.
     inherit_cache = False
     type = Boolean()
 

--- a/lightly_studio/src/lightly_studio/database/db_json.py
+++ b/lightly_studio/src/lightly_studio/database/db_json.py
@@ -1,231 +1,171 @@
 """Dialect-aware JSON extraction functions.
 
-Provides ``json_extract`` and ``json_literal`` that compile to the correct SQL
-syntax for DuckDB and PostgreSQL.
+Thin wrappers over SQLAlchemy's JSON indexing, which compiles to the right operator
+chain for DuckDB and PostgreSQL and binds every key as a parameter.
+
+Every function reads the value as text or as a float, never as raw ``json``: neither
+database compares ``json`` against a plain value, PostgreSQL can neither order nor cast
+it, and only the text form turns a stored JSON ``null`` into SQL NULL, which is what a
+presence test needs.
 """
 
 from __future__ import annotations
 
-import json
-from typing import Any
+import functools
+import operator
+import re
+from typing import Any, cast
 
 import sqlalchemy
-from sqlalchemy import Text
+from sqlalchemy import ColumnElement, Text
 from sqlalchemy.engine.interfaces import Dialect
-from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.sql.compiler import SQLCompiler
-from sqlalchemy.sql.elements import BindParameter
-from sqlalchemy.sql.functions import GenericFunction
 from sqlalchemy.types import TypeDecorator
 
+_DUCKDB_DIALECT = "duckdb"
 
-def json_literal(value: Any) -> BindParameter[Any]:
-    """Create a dialect-aware literal for JSON comparisons.
+_ARRAY_INDEX_PATTERN = re.compile(r"^\[(-?[0-9]+)\]$")
 
-    For string values the returned bind parameter uses ``_JsonStringType``
-    which JSON-encodes the value on DuckDB (matching ``json_extract`` output)
-    while passing it through unchanged on PostgreSQL (where ``->>`` already
-    returns plain text).
+# PostgreSQL's "->" subscript takes a 32-bit integer; a wider one raises rather than
+# missing. Out-of-range indices address nothing anyway.
+_INT32_MIN = -(2**31)
+_INT32_MAX = 2**31 - 1
 
-    For non-string values a regular ``literal()`` is returned.
+
+def json_extract_as_text(column: Any, field: str) -> ColumnElement[str]:
+    """Index into a JSON column by field path and read the value as text.
+
+    Text is what comparisons and ``ORDER BY`` need, and it is undecorated on both
+    databases.
+
+    Args:
+        column: The JSON column expression.
+        field: Dot-separated path into the JSON object, as in :func:`_json_extract`.
+
+    Returns:
+        The extracted value as text.
     """
-    if isinstance(value, str):
-        return sqlalchemy.literal(value, type_=_JsonStringType())
-    return sqlalchemy.literal(value)
+    return cast(ColumnElement[str], _json_extract(column=column, field=field).as_string())
 
 
-class json_extract(GenericFunction[Any]):  # noqa: N801
-    """Extract a value from a JSON column by field path.
+def json_extract_as_float(column: Any, field: str) -> ColumnElement[float]:
+    """Index into a JSON column by field path and read the value as a float.
 
-    Compiles to dialect-specific SQL:
-    - DuckDB:      ``json_extract(col, '$.field')``
-    - PostgreSQL:  ``col->>'field'``
+    Casting a non-numeric value fails on PostgreSQL, so guard the call when the
+    field's type is not known.
 
-    When *cast_to_float* is ``True``:
-    - DuckDB:      ``CAST(json_extract(col, '$.field') AS FLOAT)``
-    - PostgreSQL:  ``(col->>'field')::float``
+    Args:
+        column: The JSON column expression.
+        field: Dot-separated path into the JSON object, as in :func:`_json_extract`.
 
-    ``field`` supports dot-separated paths (``a.b.c``) and array indices (``a.list[0]``).
+    Returns:
+        The extracted value as a float.
     """
-
-    # Field path and cast flag vary per instance, so caching is unsafe.
-    inherit_cache = False
-
-    def __init__(
-        self,
-        column: Any,
-        field: str,
-        *,
-        cast_to_float: bool = False,
-    ) -> None:
-        """Initialize with a column, field path, and optional float cast.
-
-        Args:
-            column: The JSON column expression (e.g. ``SampleMetadataTable.data``).
-            field: Dot-separated path into the JSON object.
-            cast_to_float: If True, cast the extracted value to float.
-        """
-        self.field = field
-        self.cast_to_float = cast_to_float
-        super().__init__(column)
+    return cast(ColumnElement[float], _json_extract(column=column, field=field).as_float())
 
 
-class json_extract_key_as_text(GenericFunction[str]):  # noqa: N801
-    """Read one top-level JSON key as plain text.
+def json_extract_key_as_text(column: Any, key: str) -> ColumnElement[str]:
+    """Read one top-level JSON key as text.
 
-    The key is bound rather than interpolated into SQL. It is taken literally, so unlike
-    :class:`json_extract` a dot in it stays part of the key rather than stepping into a
-    nested object, and a quote cannot become path syntax.
+    The key is taken literally, so unlike :func:`json_extract_as_text` a dot in it
+    stays part of the key rather than stepping into a nested object.
+
+    Args:
+        column: The JSON column expression.
+        key: The top-level key to read, dots and all.
+
+    Returns:
+        The extracted value as text.
     """
-
-    inherit_cache = False
-    type = Text()
-
-    def __init__(self, column: Any, key: str) -> None:
-        """Initialize with a JSON column and the top-level key to read.
-
-        Args:
-            column: The JSON column expression.
-            key: The top-level key to read, dots and all.
-        """
-        key_parameter = sqlalchemy.literal(key, type_=_JsonKeyType())
-        super().__init__(column, key_parameter)
-
-
-@compiles(json_extract)
-def _compile_json_extract_unsupported(
-    element: json_extract, compiler: SQLCompiler, **kw: Any
-) -> str:
-    """Raise for unsupported dialects."""
-    raise NotImplementedError(
-        f"Unsupported dialect: {compiler.dialect.name}."
-        " Only 'postgresql' and 'duckdb' are supported."
-    )
-
-
-@compiles(json_extract, "duckdb")
-def _compile_json_extract_duckdb(element: json_extract, compiler: SQLCompiler, **kw: Any) -> str:
-    """DuckDB compilation: ``json_extract(col, '$.field')``."""
-    # element.clauses contains a single item: the column passed to __init__.
-    col = next(iter(element.clauses))
-    json_path = "$." + element.field
-    expr = f"json_extract({compiler.process(col, **kw)}, '{json_path}')"
-    if element.cast_to_float:
-        expr = f"CAST({expr} AS FLOAT)"
-    return expr
-
-
-@compiles(json_extract, "postgresql")
-def _compile_json_extract_postgresql(
-    element: json_extract, compiler: SQLCompiler, **kw: Any
-) -> str:
-    """PostgreSQL compilation: ``col->>'field'`` with optional ``::float`` cast."""
-    # element.clauses contains a single item: the column passed to __init__.
-    col = next(iter(element.clauses))
-    col_sql = compiler.process(col, **kw)
-    return _build_pg_json_accessor(
-        column=col_sql, field=element.field, cast_to_float=element.cast_to_float
-    )
-
-
-@compiles(json_extract_key_as_text)
-def _compile_json_extract_key_as_text_unsupported(
-    element: json_extract_key_as_text, compiler: SQLCompiler, **kw: Any
-) -> str:
-    """Raise for unsupported dialects."""
-    raise NotImplementedError(
-        f"Unsupported dialect: {compiler.dialect.name}."
-        " Only 'postgresql' and 'duckdb' are supported."
-    )
-
-
-@compiles(json_extract_key_as_text, "duckdb")
-def _compile_json_extract_key_as_text_duckdb(
-    element: json_extract_key_as_text, compiler: SQLCompiler, **kw: Any
-) -> str:
-    """Extract a JSON scalar as plain text on DuckDB."""
-    column, key = element.clauses
-    return f"json_extract_string({compiler.process(column, **kw)}, {compiler.process(key, **kw)})"
-
-
-@compiles(json_extract_key_as_text, "postgresql")
-def _compile_json_extract_key_as_text_postgresql(
-    element: json_extract_key_as_text, compiler: SQLCompiler, **kw: Any
-) -> str:
-    """Extract a JSON scalar as plain text on PostgreSQL."""
-    column, key = element.clauses
-    return f"{compiler.process(column, **kw)}->>{compiler.process(key, **kw)}"
+    return cast(ColumnElement[str], column[_bind_key(key)].as_string())
 
 
 class _JsonKeyType(TypeDecorator[str]):
-    """Bind one literal object key for each supported database."""
+    """Bind one object key so that each database reads it as a key and nothing else.
+
+    DuckDB's ``->`` is ``json_extract``, which reads a leading ``$`` as JSONPath and a
+    leading ``/`` as a JSON Pointer. A key such as ``$.temp`` would therefore address
+    another part of the document, and ``$x`` would raise. Sending a one-segment JSON
+    Pointer removes the ambiguity, because a pointer states where each segment ends.
+
+    PostgreSQL's ``->`` takes a key and nothing else, so the key passes through.
+    """
 
     impl = Text
     cache_ok = True
 
     def process_bind_param(self, value: str | None, dialect: Dialect) -> str | None:
-        """Convert DuckDB keys to JSON Pointer and leave PostgreSQL keys raw."""
-        if value is None or dialect.name != "duckdb":
+        """Convert a DuckDB key to a JSON Pointer and leave a PostgreSQL key raw.
+
+        Args:
+            value: The key to bind, or None.
+            dialect: The dialect the statement compiles for.
+
+        Returns:
+            The value to send to the database.
+        """
+        if value is None or dialect.name != _DUCKDB_DIALECT:
             return value
         escaped = value.replace("~", "~0").replace("/", "~1")
         return f"/{escaped}"
 
 
-class _JsonStringType(TypeDecorator[str]):
-    r"""Bind-parameter type that JSON-encodes strings on DuckDB only.
+def _json_extract(column: Any, field: str) -> ColumnElement[Any]:
+    """Index into a JSON column by field path.
 
-    DuckDB's ``json_extract`` returns JSON-encoded values, so comparison
-    values must also be JSON-encoded to match.  PostgreSQL's ``->>``
-    returns plain text, so strings pass through unchanged.
+    Compiles to a ``col -> :key`` chain, so keys are bound rather than interpolated
+    into SQL and quotes or dots in them cannot alter the statement.
 
-    Example for ``{"key": "value"}``:
-
-    - DuckDB:      ``json_extract(data, '$.key')`` returns ``'"value"'``
-                    -> bind param must be ``'"value"'`` (via ``json.dumps``)
-    - PostgreSQL:  ``data->>'key'`` returns ``'value'``
-                    -> bind param must be ``'value'`` (raw string)
-    """
-
-    impl = Text
-    cache_ok = True
-
-    def process_bind_param(self, value: str | None, dialect: Dialect) -> str | None:
-        """Encode string values as JSON for DuckDB, pass through for PostgreSQL."""
-        if value is None:
-            return None
-        if dialect.name == "duckdb":
-            return json.dumps(value)
-        return value
-
-
-def _build_pg_json_accessor(column: str, field: str, *, cast_to_float: bool = False) -> str:
-    """Build a PostgreSQL JSON accessor expression from a dot-separated field path.
-
-    Converts paths like ``dict.key`` into ``col->'dict'->>'key'`` operator chains.
+    ``field`` supports dot-separated paths (``a.b.c``) and array indices
+    (``a.list[0]``), including negative indices counting from the end
+    (``a.list[-1]``), which both databases apply natively.
 
     Args:
-        column: Already-compiled column SQL string.
+        column: The JSON column expression (e.g. ``SampleMetadataTable.data``).
         field: Dot-separated path into the JSON object.
-        cast_to_float: If True, wrap the expression in ``(...)::float``.
 
     Returns:
-        A raw SQL expression string.
+        The indexed JSON expression.
     """
+    segments = [
+        segment if isinstance(segment, int) else _bind_key(segment)
+        for segment in _parse_field_path(field)
+    ]
+    return cast(ColumnElement[Any], functools.reduce(operator.getitem, segments, column))
+
+
+def _bind_key(key: str) -> ColumnElement[str]:
+    """Return the key as a bound parameter that each database reads literally.
+
+    Args:
+        key: One object key, taken literally.
+
+    Returns:
+        The bound key.
+    """
+    return sqlalchemy.literal(key, type_=_JsonKeyType())
+
+
+def _parse_field_path(field: str) -> list[str | int]:
+    """Split a field path into key and array-index segments.
+
+    ``"a.list[0]"`` becomes ``["a", "list", 0]``. A bracket group that does not hold an
+    index becomes a literal key segment of its own: ``"weird[key]"`` becomes
+    ``["weird", "[key]"]``, so it cannot reach SQL as an index. Indices outside the
+    32-bit range PostgreSQL subscripts accept are literal keys for the same reason.
+
+    Args:
+        field: Dot-separated path into a JSON object.
+
+    Returns:
+        The segments, in path order, with array indices as integers.
+    """
+    segments: list[str | int] = []
     # Split on '.' but keep bracket notation (e.g. "nested_list[0]" -> "nested_list", "[0]")
-    parts = field.replace("[", ".[").split(".")
-
-    accessors: list[str] = []
-    for i, part in enumerate(parts):
-        is_last = i == len(parts) - 1
-        op = "->>" if is_last else "->"
-        if part.startswith("[") and part.endswith("]"):
-            # Array index access: ->>0 or ->0 (unquoted integer)
-            index = part[1:-1]
-            accessors.append(f"{op}{index}")
-        else:
-            accessors.append(f"{op}'{part}'")
-
-    expr = column + "".join(accessors)
-    if cast_to_float:
-        expr = f"({expr})::float"
-    return expr
+    for part in field.replace("[", ".[").split("."):
+        index_match = _ARRAY_INDEX_PATTERN.match(part)
+        if index_match is None:
+            segments.append(part)
+            continue
+        index = int(index_match.group(1))
+        segments.append(index if _INT32_MIN <= index <= _INT32_MAX else part)
+    return segments

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
@@ -155,13 +155,15 @@ def apply_metadata_filters(
                 _build_in_condition(metadata_model=metadata_model, metadata_filter=meta_filter)
             )
             continue
-        extract_expr = db_json.json_extract(
-            column=metadata_model.data,
-            field=meta_filter.key,
-            cast_to_float=isinstance(meta_filter.value, (int, float)),
+        # Numbers compare as floats, everything else as text.
+        extract = (
+            db_json.json_extract_as_float
+            if isinstance(meta_filter.value, (int, float))
+            else db_json.json_extract_as_text
         )
+        extract_expr = extract(column=metadata_model.data, field=meta_filter.key)
         compare_op = _OP_MAP[meta_filter.op]
-        condition = compare_op(extract_expr, db_json.json_literal(meta_filter.value))
+        condition = compare_op(extract_expr, meta_filter.value)
         query = query.where(condition)
 
     return query

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
@@ -127,10 +127,8 @@ def _get_metadata_min_max_count(
     Returns:
         A ``(min, max, count)`` tuple, or ``None`` if the key has no values.
     """
-    value_expr = db_json.json_extract(
-        column=SampleMetadataTable.data, field=metadata_key, cast_to_float=True
-    )
-    json_not_null_expr = db_json.json_extract(
+    value_expr = db_json.json_extract_as_float(column=SampleMetadataTable.data, field=metadata_key)
+    json_not_null_expr = db_json.json_extract_as_text(
         column=SampleMetadataTable.data, field=metadata_key
     ).isnot(None)
 
@@ -205,10 +203,8 @@ def _compute_histogram(  # noqa: PLR0913
 
     width = (max_value - min_value) / bin_count
 
-    value_expr = db_json.json_extract(
-        column=SampleMetadataTable.data, field=metadata_key, cast_to_float=True
-    )
-    json_not_null_expr = db_json.json_extract(
+    value_expr = db_json.json_extract_as_float(column=SampleMetadataTable.data, field=metadata_key)
+    json_not_null_expr = db_json.json_extract_as_text(
         column=SampleMetadataTable.data, field=metadata_key
     ).isnot(None)
 
@@ -250,7 +246,7 @@ def _count_metadata_values(
     filters: ImageFilter | None,
 ) -> int:
     """Count non-null values for a metadata key under the given filters."""
-    json_not_null_expr = db_json.json_extract(
+    json_not_null_expr = db_json.json_extract_as_text(
         column=SampleMetadataTable.data, field=metadata_key
     ).isnot(None)
     query = (

--- a/lightly_studio/tests/core/dataset_query/test_dataset_query__order_by.py
+++ b/lightly_studio/tests/core/dataset_query/test_dataset_query__order_by.py
@@ -262,6 +262,38 @@ class TestDatasetQueryOrderBy:
             image_a.sample_id,
         ]
 
+    def test_order_by__metadata_key_with_quote(self, db_session: Session) -> None:
+        """Test that a quote in the key is bound, not compiled into the statement."""
+        dataset = create_collection(session=db_session)
+        image_a = create_image(
+            session=db_session,
+            collection_id=dataset.collection_id,
+            file_path_abs="/path/to/a.jpg",
+        )
+        image_b = create_image(
+            session=db_session,
+            collection_id=dataset.collection_id,
+            file_path_abs="/path/to/b.jpg",
+        )
+        metadata_resolver.bulk_update_metadata(
+            db_session,
+            [
+                (image_a.sample_id, {"sco're": 2}),
+                (image_b.sample_id, {"sco're": 1}),
+            ],
+        )
+
+        result_samples = (
+            DatasetQuery(dataset=dataset, session=db_session)
+            .order_by(OrderByMetadataField("sco're"))
+            .to_list()
+        )
+
+        assert [sample.sample_id for sample in result_samples] == [
+            image_b.sample_id,
+            image_a.sample_id,
+        ]
+
     def test_order_by__string_metadata_field(self, db_session: Session) -> None:
         """Test that string metadata keeps lexicographic ordering."""
         dataset = create_collection(session=db_session)

--- a/lightly_studio/tests/core/dataset_query/test_order_by.py
+++ b/lightly_studio/tests/core/dataset_query/test_order_by.py
@@ -75,12 +75,14 @@ class TestOrderByField:
 class TestOrderByMetadataField:
     dialect = DuckDBDialect()
 
+    # The key is bound, so it only appears as a literal under literal_binds. DuckDB reads
+    # it as a one-segment JSON Pointer, hence the leading slash.
     _NUMERIC_KEY = (
-        "cast(case when (json_extract(metadata_1.metadata_schema, '$.brightness')"
-        " in ('\"integer\"', '\"float\"')) then json_extract(metadata_1.data, '$.brightness') end"
+        "cast(case when (cast((metadata_1.metadata_schema ->> '/brightness') as varchar)"
+        " in ('integer', 'float')) then cast(metadata_1.data ->> '/brightness' as varchar) end"
         " as double precision)"
     )
-    _RAW_KEY = "json_extract(metadata_1.data, '$.brightness')"
+    _RAW_KEY = "cast(metadata_1.data ->> '/brightness' as varchar)"
 
     def _compile(self, query: object) -> str:
         return str(

--- a/lightly_studio/tests/database/test_db_json.py
+++ b/lightly_studio/tests/database/test_db_json.py
@@ -2,196 +2,227 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 import sqlalchemy
 from duckdb_engine import Dialect
-from sqlalchemy.dialects import postgresql, sqlite
+from sqlalchemy.dialects import postgresql
 
 from lightly_studio.database import db_json
 
+# Both databases speak the same JSON operators, so every expression below has to
+# compile identically for each of them.
+_DIALECTS = [Dialect(), postgresql.dialect()]  # type: ignore[no-untyped-call]
 
-def test_build_pg_json_accessor__simple_key() -> None:
-    result = db_json._build_pg_json_accessor(column="metadata.data", field="temperature")
-    assert result == "metadata.data->>'temperature'"
+_COLUMN = sqlalchemy.column("data", sqlalchemy.JSON)
+
+# A key that closes the string literal and appends SQL, if it were interpolated.
+_INJECTION_KEY = "x') AS FLOAT), (SELECT 1 FROM secrets"
+_SPECIAL_KEYS = [
+    _INJECTION_KEY,
+    "owner's key",
+    'say "hi"',
+    "back\\slash",
+    "path/to~key",
+    # Closes the string literal and starts a new statement.
+    "x'); DROP TABLE victim; --",
+    # Concatenates a subquery into the value.
+    "'||(SELECT count(*) FROM victim)||'",
+]
+
+# Keys that DuckDB reads as JSONPath or as a JSON Pointer unless they are bound as
+# pointers: "$" addresses the whole document, "$.temp" addresses another key, "$x"
+# raises, and a leading "/" starts a pointer. PostgreSQL reads all of them as keys.
+_PATH_SYNTAX_KEYS = ["$", "$.temp", "$x", "$[0]", "/a", "/", "~1"]
 
 
-def test_build_pg_json_accessor__nested_key() -> None:
-    result = db_json._build_pg_json_accessor(column="metadata.data", field="test_dict.int_key")
-    assert result == "metadata.data->'test_dict'->>'int_key'"
+def _compile(expression: Any, dialect: Any) -> Any:
+    return expression.compile(dialect=dialect)
 
 
-def test_build_pg_json_accessor__deeply_nested_key() -> None:
-    result = db_json._build_pg_json_accessor(column="metadata.data", field="a.b.c")
-    assert result == "metadata.data->'a'->'b'->>'c'"
+def _every_entry_point(field: str) -> list[Any]:
+    """Return one expression per entry point, all reading the same field."""
+    return [
+        db_json._json_extract(column=_COLUMN, field=field),
+        db_json.json_extract_as_text(column=_COLUMN, field=field),
+        db_json.json_extract_as_float(column=_COLUMN, field=field),
+        db_json.json_extract_key_as_text(column=_COLUMN, key=field),
+    ]
 
 
-def test_build_pg_json_accessor__array_index() -> None:
-    result = db_json._build_pg_json_accessor(
-        column="metadata.data", field="test_dict.nested_list[0]"
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    [
+        ("temperature", ["temperature"]),
+        ("test_dict.int_key", ["test_dict", "int_key"]),
+        ("a.b.c", ["a", "b", "c"]),
+        ("test_dict.nested_list[0]", ["test_dict", "nested_list", 0]),
+        ("nested_list[10][2]", ["nested_list", 10, 2]),
+        ("nested_list[-1]", ["nested_list", -1]),
+        # Only integer brackets are indices; anything else becomes a key of its own.
+        ("weird[key]", ["weird", "[key]"]),
+        ("weird[0x1]", ["weird", "[0x1]"]),
+        # The largest indices PostgreSQL subscripts accept.
+        ("nested_list[2147483647]", ["nested_list", 2147483647]),
+        ("nested_list[-2147483648]", ["nested_list", -2147483648]),
+    ],
+)
+def test_parse_field_path(field: str, expected: list[str | int]) -> None:
+    assert db_json._parse_field_path(field) == expected
+
+
+@pytest.mark.parametrize("index", ["2147483648", "-2147483649", "99999999999999999999"])
+def test_parse_field_path__out_of_range_index_stays_a_key(index: str) -> None:
+    """An index PostgreSQL cannot subscript with addresses nothing, so it stays a key."""
+    assert db_json._parse_field_path(f"nested_list[{index}]") == ["nested_list", f"[{index}]"]
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+def test_json_extract__simple_key(dialect: Any) -> None:
+    result = _compile(db_json._json_extract(column=_COLUMN, field="temperature"), dialect)
+    assert str(result) == "data -> %(param_1)s"
+    assert result.params == {"param_1": "temperature"}
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+def test_json_extract__nested_key(dialect: Any) -> None:
+    """Each segment is its own bound step, so no key can be read as path syntax."""
+    result = _compile(db_json._json_extract(column=_COLUMN, field="test_dict.int_key"), dialect)
+    assert str(result) == "(data -> %(param_1)s) -> %(param_2)s"
+    assert result.params == {"param_1": "test_dict", "param_2": "int_key"}
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+def test_json_extract__array_index(dialect: Any) -> None:
+    result = _compile(db_json._json_extract(column=_COLUMN, field="nested_list[0]"), dialect)
+    assert str(result) == "(data -> %(param_1)s) -> %(param_2)s"
+    assert result.params == {"param_1": "nested_list", "param_2": 0}
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+@pytest.mark.parametrize("index", [-1, -3])
+def test_json_extract__negative_index(dialect: Any, index: int) -> None:
+    """Both databases subscript from the end natively, so the index passes straight through."""
+    result = _compile(db_json._json_extract(column=_COLUMN, field=f"nested_list[{index}]"), dialect)
+    assert result.params == {"param_1": "nested_list", "param_2": index}
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+def test_json_extract__out_of_range_index_is_a_bound_key(dialect: Any) -> None:
+    """An index wider than int32 raises when subscripted, so it is bound as a key instead."""
+    result = _compile(
+        db_json._json_extract(column=_COLUMN, field="nested_list[2147483648]"), dialect
     )
-    assert result == "metadata.data->'test_dict'->'nested_list'->>0"
+    assert result.params == {"param_1": "nested_list", "param_2": "[2147483648]"}
 
 
-def test_build_pg_json_accessor__cast_to_float() -> None:
-    result = db_json._build_pg_json_accessor(
-        column="metadata.data", field="temperature", cast_to_float=True
-    )
-    assert result == "(metadata.data->>'temperature')::float"
+@pytest.mark.parametrize("dialect", _DIALECTS)
+@pytest.mark.parametrize("field", _SPECIAL_KEYS)
+def test_json_extract__special_key_is_bound(dialect: Any, field: str) -> None:
+    """Special characters stay inside the parameter and never reach the statement."""
+    result = _compile(db_json._json_extract(column=_COLUMN, field=field), dialect)
+    assert str(result) == "data -> %(param_1)s"
+    assert result.params == {"param_1": field}
 
 
-def test_build_pg_json_accessor__nested_cast_to_float() -> None:
-    result = db_json._build_pg_json_accessor(
-        column="metadata.data", field="test_dict.int_key", cast_to_float=True
-    )
-    assert result == "(metadata.data->'test_dict'->>'int_key')::float"
+@pytest.mark.parametrize("dialect", _DIALECTS)
+@pytest.mark.parametrize("field", [f"weird[{_INJECTION_KEY}]", "weird[0; DROP TABLE t]"])
+def test_json_extract__non_integer_index_is_bound(dialect: Any, field: str) -> None:
+    """Brackets holding anything but an integer are bound as keys, so they smuggle nothing."""
+    result = _compile(db_json._json_extract(column=_COLUMN, field=field), dialect)
+    assert str(result) == "(data -> %(param_1)s) -> %(param_2)s"
 
 
-def test_build_pg_json_accessor__custom_column() -> None:
-    result = db_json._build_pg_json_accessor(column="my_table.json_col", field="key")
-    assert result == "my_table.json_col->>'key'"
+@pytest.mark.parametrize("dialect", _DIALECTS)
+def test_json_extract_as_float(dialect: Any) -> None:
+    result = _compile(db_json.json_extract_as_float(column=_COLUMN, field="temperature"), dialect)
+    assert str(result) == "CAST(data ->> %(param_1)s AS FLOAT)"
+    assert result.params == {"param_1": "temperature"}
 
 
-def test_json_extract__duckdb_simple_key() -> None:
-    expr = db_json.json_extract(column=sqlalchemy.column("data"), field="temperature")
-    result = expr.compile(dialect=Dialect())
-    assert str(result) == "json_extract(data, '$.temperature')"
+@pytest.mark.parametrize("dialect", _DIALECTS)
+def test_json_extract_as_text(dialect: Any) -> None:
+    result = _compile(db_json.json_extract_as_text(column=_COLUMN, field="temperature"), dialect)
+    assert str(result) == "CAST(data ->> %(param_1)s AS VARCHAR)"
+    assert result.params == {"param_1": "temperature"}
 
 
-def test_json_extract__duckdb_nested_key() -> None:
-    expr = db_json.json_extract(column=sqlalchemy.column("data"), field="test_dict.int_key")
-    result = expr.compile(dialect=Dialect())
-    assert str(result) == "json_extract(data, '$.test_dict.int_key')"
+@pytest.mark.parametrize("dialect", _DIALECTS)
+def test_json_extract_as_text__presence_test_uses_the_text_operator(dialect: Any) -> None:
+    """``->>`` is SQL NULL for a stored JSON null, while ``->`` yields the JSON null.
+
+    So a presence test has to read the value as text; the raw index would count a row
+    whose key is present but null.
+    """
+    expression = db_json.json_extract_as_text(column=_COLUMN, field="temperature").isnot(None)
+
+    result = _compile(expression, dialect)
+
+    assert str(result) == "CAST((data ->> %(param_1)s) AS VARCHAR) IS NOT NULL"
 
 
-def test_json_extract__duckdb_cast_to_float() -> None:
-    expr = db_json.json_extract(
-        column=sqlalchemy.column("data"), field="temperature", cast_to_float=True
-    )
-    result = expr.compile(dialect=Dialect())
-    assert str(result) == "CAST(json_extract(data, '$.temperature') AS FLOAT)"
-
-
-def test_json_extract__duckdb_array_index() -> None:
-    expr = db_json.json_extract(column=sqlalchemy.column("data"), field="test_dict.nested_list[0]")
-    result = expr.compile(dialect=Dialect())
-    assert str(result) == "json_extract(data, '$.test_dict.nested_list[0]')"
-
-
-def test_json_extract__pg_simple_key() -> None:
-    expr = db_json.json_extract(column=sqlalchemy.column("data"), field="temperature")
-    # SQLAlchemy dialect factory functions lack type stubs.
-    result = expr.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
-    assert str(result) == "data->>'temperature'"
-
-
-def test_json_extract__pg_nested_key() -> None:
-    expr = db_json.json_extract(column=sqlalchemy.column("data"), field="test_dict.int_key")
-    result = expr.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
-    assert str(result) == "data->'test_dict'->>'int_key'"
-
-
-def test_json_extract__pg_cast_to_float() -> None:
-    expr = db_json.json_extract(
-        column=sqlalchemy.column("data"), field="temperature", cast_to_float=True
-    )
-    result = expr.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
-    assert str(result) == "(data->>'temperature')::float"
-
-
-def test_json_extract__pg_nested_cast_to_float() -> None:
-    expr = db_json.json_extract(
-        column=sqlalchemy.column("data"), field="test_dict.int_key", cast_to_float=True
-    )
-    result = expr.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
-    assert str(result) == "(data->'test_dict'->>'int_key')::float"
-
-
-def test_json_extract__pg_array_index() -> None:
-    expr = db_json.json_extract(column=sqlalchemy.column("data"), field="test_dict.nested_list[0]")
-    result = expr.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
-    assert str(result) == "data->'test_dict'->'nested_list'->>0"
-
-
-def test_json_extract__sqlite_raises() -> None:
-    expr = db_json.json_extract(column=sqlalchemy.column("data"), field="key")
-    with pytest.raises(NotImplementedError, match="Unsupported dialect: sqlite"):
-        expr.compile(dialect=sqlite.dialect())
-
-
-def test_json_extract_key_as_text__duckdb() -> None:
-    expr = db_json.json_extract_key_as_text(column=sqlalchemy.column("data"), key="location")
-    result = expr.compile(dialect=Dialect())
-    assert str(result) == "json_extract_string(data, %(param_1)s)"
-    assert result.params == {"param_1": "location"}
-
-
-def test_json_extract_key_as_text__postgresql() -> None:
-    expr = db_json.json_extract_key_as_text(column=sqlalchemy.column("data"), key="location")
-    result = expr.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
-    assert str(result) == "data->>%(param_1)s"
-    assert result.params == {"param_1": "location"}
-
-
-@pytest.mark.parametrize("key", ["site.name", "owner's site"])
-def test_json_extract_key_as_text__special_key_is_bound(key: str) -> None:
-    expr = db_json.json_extract_key_as_text(column=sqlalchemy.column("data"), key=key)
-    duckdb_result = expr.compile(dialect=Dialect())
-    postgres_result = expr.compile(
-        dialect=postgresql.dialect()  # type: ignore[no-untyped-call]
-    )
-
-    assert str(duckdb_result) == "json_extract_string(data, %(param_1)s)"
-    assert duckdb_result.params == {"param_1": key}
-    assert str(postgres_result) == "data->>%(param_1)s"
-    assert postgres_result.params == {"param_1": key}
+@pytest.mark.parametrize("dialect", _DIALECTS)
+@pytest.mark.parametrize("key", ["site.name", *_SPECIAL_KEYS])
+def test_json_extract_key_as_text__key_is_literal_and_bound(dialect: Any, key: str) -> None:
+    """The whole argument is one key, so a dot in it does not step into a nested object."""
+    result = _compile(db_json.json_extract_key_as_text(column=_COLUMN, key=key), dialect)
+    assert str(result) == "CAST(data ->> %(param_1)s AS VARCHAR)"
+    assert result.params == {"param_1": key}
 
 
 @pytest.mark.parametrize(
     ("key", "expected"),
     [
-        ("site.name", "/site.name"),
-        ("owner's site", "/owner's site"),
-        ("path/to~site", "/path~1to~0site"),
+        ("$", "/$"),
+        ("$.temp", "/$.temp"),
+        ("$x", "/$x"),
+        ("/a", "/~1a"),
+        ("/", "/~1"),
+        ("~1", "/~01"),
+        ("path/to~key", "/path~1to~0key"),
+        ("temp", "/temp"),
     ],
 )
-def test_json_key_type__duckdb_path(key: str, expected: str) -> None:
-    type_ = db_json._JsonKeyType()
-    assert type_.process_bind_param(value=key, dialect=Dialect()) == expected
+def test_json_key_type__duckdb_gets_a_pointer(key: str, expected: str) -> None:
+    """DuckDB reads a leading "$" as JSONPath and a leading "/" as a pointer.
+
+    Binding every key as a one-segment pointer removes the ambiguity.
+    """
+    key_type = db_json._JsonKeyType()
+    assert key_type.process_bind_param(value=key, dialect=Dialect()) == expected
 
 
-def test_json_extract_key_as_text__sqlite_raises() -> None:
-    expr = db_json.json_extract_key_as_text(column=sqlalchemy.column("data"), key="location")
-    with pytest.raises(NotImplementedError, match="Unsupported dialect: sqlite"):
-        expr.compile(dialect=sqlite.dialect())
+@pytest.mark.parametrize("key", _PATH_SYNTAX_KEYS)
+def test_json_key_type__postgres_gets_the_raw_key(key: str) -> None:
+    """PostgreSQL reads a key and nothing else, so it needs no pointer."""
+    key_type = db_json._JsonKeyType()
+    postgres = postgresql.dialect()  # type: ignore[no-untyped-call]
+    assert key_type.process_bind_param(value=key, dialect=postgres) == key
 
 
-def test_json_literal__duckdb_string_value() -> None:
-    """String values are JSON-encoded for DuckDB."""
-    lit = db_json.json_literal("hello")
-    type_ = lit.type
-    assert isinstance(type_, db_json._JsonStringType)
-    assert type_.process_bind_param(value="hello", dialect=Dialect()) == '"hello"'
+@pytest.mark.parametrize("dialect", _DIALECTS)
+@pytest.mark.parametrize("field", _SPECIAL_KEYS)
+def test_json_extract__special_key_never_reaches_the_statement(dialect: Any, field: str) -> None:
+    """Every entry point binds the key, so no payload becomes part of the SQL text."""
+    for expression in _every_entry_point(field):
+        sql = str(_compile(expression, dialect))
+
+        assert field not in sql
+        # Nothing the payloads carry survives into the statement.
+        assert ";" not in sql
+        assert "drop" not in sql.lower()
+        assert "select" not in sql.lower()
 
 
-def test_json_literal__pg_string_value() -> None:
-    """String values pass through unchanged for PostgreSQL."""
-    lit = db_json.json_literal("hello")
-    type_ = lit.type
-    assert isinstance(type_, db_json._JsonStringType)
-    # SQLAlchemy dialect factory functions lack type stubs.
-    assert type_.process_bind_param(value="hello", dialect=postgresql.dialect()) == "hello"  # type: ignore[no-untyped-call]
+@pytest.mark.parametrize("dialect", _DIALECTS)
+def test_json_extract__repeated_renders_share_one_parameter(dialect: Any) -> None:
+    """One parameter per key, so GROUP BY renders the same expression as SELECT."""
+    expr = db_json._json_extract(column=_COLUMN, field="score")
+    query = sqlalchemy.select(expr).group_by(expr)
 
+    result = _compile(query, dialect)
 
-def test_json_literal__none() -> None:
-    type_ = db_json._JsonStringType()
-    assert type_.process_bind_param(value=None, dialect=Dialect()) is None
-
-
-def test_json_literal__numeric_value() -> None:
-    lit = db_json.json_literal(10)
-    assert not isinstance(lit.type, db_json._JsonStringType)
-
-
-def test_json_literal__float_value() -> None:
-    lit = db_json.json_literal(1.23)
-    assert not isinstance(lit.type, db_json._JsonStringType)
+    assert len(result.params) == 1
+    select_sql, group_by_sql = str(result).split(" GROUP BY ")
+    assert group_by_sql.strip() in select_sql

--- a/lightly_studio/tests/metadata/test_get_metadata_histograms.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_histograms.py
@@ -130,6 +130,27 @@ def test_get_metadata_histograms__custom_bin_count(db_session: Session) -> None:
     assert sum(score.counts) == 10
 
 
+def test_get_metadata_histograms__key_with_quote(db_session: Session) -> None:
+    """A quote in the key is bound, not compiled into the statement."""
+    collection = create_collection(session=db_session)
+    for i in range(4):
+        sample = create_image(
+            session=db_session,
+            collection_id=collection.collection_id,
+            file_path_abs=f"/path/to/sample{i}.png",
+        ).sample
+        sample["sco're"] = float(i)
+
+    histograms = get_metadata_info.get_metadata_histograms(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    score = histograms["sco're"]
+    assert score.bin_edges[0] == pytest.approx(0.0)
+    assert score.bin_edges[-1] == pytest.approx(3.0)
+    assert sum(score.counts) == 4
+
+
 def test_get_metadata_histograms__skips_non_numeric_keys(db_session: Session) -> None:
     """String and boolean keys produce no histogram."""
     collection = create_collection(session=db_session)

--- a/lightly_studio/tests/resolvers/metadata_resolvers/sample/test_sample_metadata_filtering.py
+++ b/lightly_studio/tests/resolvers/metadata_resolvers/sample/test_sample_metadata_filtering.py
@@ -1,5 +1,6 @@
 """Test metadata resolver."""
 
+import pytest
 from sqlmodel import Session
 
 from lightly_studio.resolvers import sample_resolver
@@ -175,6 +176,125 @@ def test_metadata_in_filter__missing(db_session: Session) -> None:
         other_metadata.sample_id,
         no_metadata.sample_id,
     }
+
+
+@pytest.mark.parametrize(("index", "expected_value"), [(-1, 3), (-3, 1)])
+def test_metadata_filter__negative_index(
+    db_session: Session, index: int, expected_value: int
+) -> None:
+    """A negative index counts from the end of the array."""
+    collection = create_collection(session=db_session)
+    matching = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/matching.png",
+    ).sample
+    excluded = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/excluded.png",
+    ).sample
+    matching["test_dict"] = {"nested_list": [1, 2, 3]}
+    excluded["test_dict"] = {"nested_list": [9, 9, 9]}
+
+    filters = SampleFilter(
+        metadata_filters=[Metadata(f"test_dict.nested_list[{index}]") == expected_value]
+    )
+    samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    assert [sample.sample_id for sample in samples] == [matching.sample_id]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # Closes the string literal and starts a new statement.
+        "x'); DROP TABLE victim; --",
+        # Closes the DuckDB json_extract call and appends a subquery.
+        "x') AS FLOAT), (SELECT 1 FROM victim) --",
+        # Turns the comparison into a tautology.
+        "temp' OR '1'='1",
+        # Rides in through the array-index brackets, which once rendered unquoted.
+        "a[0; DROP TABLE victim]",
+        # Reads as JSONPath rather than as a key name.
+        "$.temp",
+        # Concatenates a subquery into the value.
+        "'||(SELECT count(*) FROM victim)||'",
+    ],
+)
+def test_metadata_filter__injection_payload_is_inert(db_session: Session, payload: str) -> None:
+    """A payload key runs as a lookup that finds nothing and leaves the data alone."""
+    collection = create_collection(session=db_session)
+    sample = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/sample.png",
+    ).sample
+    sample["temp"] = 25
+
+    payload_filter = SampleFilter(metadata_filters=[Metadata(payload) == 25])
+    matched = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=payload_filter
+    ).samples
+
+    assert matched == []
+
+    # The sample and its metadata survived, so nothing the payload carried ran.
+    intact_filter = SampleFilter(metadata_filters=[Metadata("temp") == 25])
+    still_there = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=intact_filter
+    ).samples
+
+    assert [found.sample_id for found in still_there] == [sample.sample_id]
+
+
+@pytest.mark.parametrize("key", ["$", "$.temp", "$x", "/temp", "/"])
+def test_metadata_filter__path_syntax_key_is_a_key(db_session: Session, key: str) -> None:
+    """DuckDB reads these as paths unless they are bound as pointers.
+
+    Without that, `$.temp` reads the `temp` field of the same document and matches,
+    and `$x` raises. Neither database has a `key` field here, so nothing matches.
+    """
+    collection = create_collection(session=db_session)
+    sample = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/sample.png",
+    ).sample
+    sample["temp"] = 25
+
+    filters = SampleFilter(metadata_filters=[Metadata(key) == 25])
+    matched = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    assert matched == []
+
+
+def test_metadata_filter__key_with_quote(db_session: Session) -> None:
+    """A quote in the key is bound, not compiled into the statement."""
+    collection = create_collection(session=db_session)
+    matching = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/matching.png",
+    ).sample
+    excluded = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/excluded.png",
+    ).sample
+    matching["temp're"] = 25
+    excluded["temp're"] = 15
+
+    filters = SampleFilter(metadata_filters=[Metadata("temp're") > 20])
+    samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    assert [sample.sample_id for sample in samples] == [matching.sample_id]
 
 
 def test_metadata_in_filter__concrete_and_missing_special_key(db_session: Session) -> None:


### PR DESCRIPTION
Split out of #1905, second in the stack. This is the security fix.

## What has changed and why?

`json_extract` built the JSON path as a string and pasted it into the SQL statement. A metadata key with a quote closed the string literal, and the database ran the rest of the key as SQL. Keys arrive from filter and sort fields in request bodies.

SQLAlchemy already does this safely. `col['a']['b']` compiles to the right operator chain for DuckDB and PostgreSQL, and it binds every key. So this deletes the hand-built SQL: the compiler hooks, the PostgreSQL accessor builder and both bind types are gone. The tuple form `col[('a', 'b')]` compiles to the `#>` operator, which DuckDB cannot parse; chained indexing avoids it, and that is most likely the reason for the hand-built SQL in the first place.

One thing SQLAlchemy does not solve. DuckDB's `->` is `json_extract`, which reads a leading `$` as JSONPath and a leading `/` as a JSON Pointer. The key `$.temp` read another field of the same document, and the key `$x` raised. So every key now binds through `_JsonKeyType`, which sends a one-segment JSON Pointer to DuckDB and the raw key to PostgreSQL. A pointer states where each segment ends, so no key becomes path syntax.

Two consequences worth calling out for review:

- Comparisons use `as_text` and `as_float`, because the raw JSON expression compares against no plain value, and PostgreSQL can neither order nor cast it. The metadata sort key is therefore text.
- The presence guards in `get_metadata_info` now read text, which turns a stored JSON null into SQL NULL. Such rows drop out of the histograms and counts instead of inflating the first bin. Stack 4/5 pins that with tests.

Array indices outside the 32-bit range stay keys, because PostgreSQL raises for a wider subscript, which would surface as a 500 response.

### Why this one is larger than 200 lines

Deleting `json_extract` and `json_literal` removes the only raw-JSON extractor, so every caller has to move in the same commit. Of the diff, ~170 lines are deletions and ~130 are docstrings. The executable code in `db_json.py` drops from 110 lines to 45, and half the remaining diff is the `test_db_json.py` rewrite.

## How has it been tested?

Injection payloads run at two levels. The compiled SQL must never contain a payload, and a filter that uses a payload as its key must match nothing and leave the data alone. The end-to-end level runs on DuckDB and on PostgreSQL, because it uses the `db_session` fixture.

Keys that look like path syntax have tests too. A filter on `$.temp` must not read the `temp` field. That test is what found the DuckDB behaviour above.

`make static-checks` and `make test` pass, and the metadata suites also pass under `--postgres`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metadata filtering, sorting, counts, and histograms for numeric and text values.
  - Fixed handling of metadata keys containing quotes, special characters, nested paths, and array indexes.
  - Prevented malformed or injection-like metadata keys from causing query errors or unintended behavior.
  - Improved compatibility across supported database systems when extracting metadata values.

- **Tests**
  - Added coverage for numeric ordering, histogram generation, special-character keys, nested paths, and negative array indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->