### PR TITLE
Fix: support boolean metadata filters

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/metadata_filter.py
@@ -155,15 +155,18 @@ def apply_metadata_filters(
                 _build_in_condition(metadata_model=metadata_model, metadata_filter=meta_filter)
             )
             continue
-        # Numbers compare as floats, everything else as text.
+        # Numbers compare as floats, everything else as text. A bool is an int in
+        # Python, but both databases read it back as "true" or "false", so it is text.
+        is_boolean = isinstance(meta_filter.value, bool)
         extract = (
             db_json.json_extract_as_float
-            if isinstance(meta_filter.value, (int, float))
+            if isinstance(meta_filter.value, (int, float)) and not is_boolean
             else db_json.json_extract_as_text
         )
+        value = str(meta_filter.value).lower() if is_boolean else meta_filter.value
         extract_expr = extract(column=metadata_model.data, field=meta_filter.key)
         compare_op = _OP_MAP[meta_filter.op]
-        condition = compare_op(extract_expr, meta_filter.value)
+        condition = compare_op(extract_expr, value)
         query = query.where(condition)
 
     return query

--- a/lightly_studio/tests/resolvers/metadata_resolvers/sample/test_sample_metadata_filtering.py
+++ b/lightly_studio/tests/resolvers/metadata_resolvers/sample/test_sample_metadata_filtering.py
@@ -147,6 +147,62 @@ def test_metadata_in_filter__concrete_values_and_other_keys(db_session: Session)
     assert [sample.sample_id for sample in samples] == [first.sample_id]
 
 
+@pytest.mark.parametrize("wanted", [True, False])
+def test_metadata_filter__boolean_equality(db_session: Session, wanted: bool) -> None:
+    """A boolean compares as text, because both databases read it back as text.
+
+    Python calls a bool an int, so the numeric branch would cast "true" to a float
+    and the database would raise.
+    """
+    collection = create_collection(session=db_session)
+    reviewed = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/reviewed.png",
+    ).sample
+    pending = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/pending.png",
+    ).sample
+    reviewed["reviewed"] = True
+    pending["reviewed"] = False
+
+    filters = SampleFilter(metadata_filters=[Metadata("reviewed") == wanted])
+    samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    expected = reviewed if wanted else pending
+    assert [sample.sample_id for sample in samples] == [expected.sample_id]
+
+
+@pytest.mark.parametrize("unwanted", [True, False])
+def test_metadata_filter__boolean_inequality(db_session: Session, unwanted: bool) -> None:
+    """``!=`` on a boolean compares as text too."""
+    collection = create_collection(session=db_session)
+    reviewed = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/reviewed.png",
+    ).sample
+    pending = create_image(
+        session=db_session,
+        collection_id=collection.collection_id,
+        file_path_abs="/path/to/pending.png",
+    ).sample
+    reviewed["reviewed"] = True
+    pending["reviewed"] = False
+
+    filters = SampleFilter(metadata_filters=[Metadata("reviewed") != unwanted])
+    samples = sample_resolver.get_filtered_samples(
+        session=db_session, collection_id=collection.collection_id, filters=filters
+    ).samples
+
+    expected = pending if unwanted else reviewed
+    assert [sample.sample_id for sample in samples] == [expected.sample_id]
+
+
 def test_metadata_in_filter__missing(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     concrete = create_image(


### PR DESCRIPTION
Split out of #1905, third in the stack.

## What has changed and why?

Python calls a bool an int, so a boolean filter took the numeric branch and the database was asked to cast `"true"` to a float. On PostgreSQL that raised, so boolean filters never worked there.

Both databases read a boolean back as the text `"true"` or `"false"`, so compare it as text and lowercase the Python value to match. The categorical `in` filter already did exactly this.

## How has it been tested?

Equality and inequality tests, each parametrized over `True` and `False`. They use the `db_session` fixture, so they run on DuckDB and on PostgreSQL. Verified under `--postgres`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata filtering for boolean values by comparing them consistently as text.
  * Boolean equality and inequality filters now return the correct matching samples.
* **Tests**
  * Added coverage for filtering both `True` and `False` metadata values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->