### PR TITLE
Pin that metadata histograms skip explicit JSON nulls

### DIFF
--- a/lightly_studio/tests/metadata/test_get_metadata_histograms.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_histograms.py
@@ -1,10 +1,12 @@
 """Test the filtered metadata histograms resolver."""
 
+from typing import Any
 from uuid import UUID
 
 import pytest
 from sqlmodel import Session
 
+from lightly_studio.models.metadata import SampleMetadataTable
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.metadata_resolver.metadata_filter import MetadataFilter
 from lightly_studio.resolvers.metadata_resolver.sample import get_metadata_info
@@ -23,6 +25,32 @@ def _create_samples_with_scores(db_session: Session, collection_id: UUID) -> Non
         sample["score"] = float(i)
         sample["even_score"] = i % 2
         sample["constant"] = 5.0
+
+
+def _create_sample_with_raw_metadata(
+    db_session: Session,
+    collection_id: UUID,
+    data: dict[str, Any],
+    metadata_schema: dict[str, str],
+) -> None:
+    """Insert a metadata row directly, without the per-row type check in ``set_value``.
+
+    A collection can hold a JSON null under a numeric key, because ``metadata_schema`` is
+    per sample and the merged collection schema takes the type from the last row.
+    """
+    image = create_image(
+        session=db_session,
+        collection_id=collection_id,
+        file_path_abs="/path/to/explicit-null.png",
+    )
+    db_session.add(
+        SampleMetadataTable(
+            sample_id=image.sample_id,
+            data=data,
+            metadata_schema=metadata_schema,
+        )
+    )
+    db_session.commit()
 
 
 def test_get_metadata_histograms__unfiltered_matches_totals(db_session: Session) -> None:
@@ -168,3 +196,55 @@ def test_get_metadata_histograms__skips_non_numeric_keys(db_session: Session) ->
 
     assert "location" not in histograms
     assert "score" in histograms
+
+
+def test_get_metadata_histograms__skips_explicit_json_null(db_session: Session) -> None:
+    """A stored JSON null is not a value, so it must not be counted."""
+    collection = create_collection(session=db_session)
+    _create_samples_with_scores(db_session, collection.collection_id)
+    _create_sample_with_raw_metadata(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        data={"score": None},
+        metadata_schema={"score": "float"},
+    )
+
+    histograms = get_metadata_info.get_metadata_histograms(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    score = histograms["score"]
+    assert sum(score.counts) == 10
+    # A null value has no bucket, and the clamping to [0, bin_count - 1] turns it into the
+    # first one, so a counted null row would show up here next to score 0.
+    assert score.counts[0] == 1
+
+
+def test_get_metadata_histograms__degenerate_bin_skips_explicit_json_null(
+    db_session: Session,
+) -> None:
+    """The single-bin count comes from its own query, which also has to skip JSON nulls."""
+    collection = create_collection(session=db_session)
+    _create_samples_with_scores(db_session, collection.collection_id)
+    # The score passes the filter below, so only the null constant keeps the row out.
+    _create_sample_with_raw_metadata(
+        db_session=db_session,
+        collection_id=collection.collection_id,
+        data={"score": 1.0, "constant": None},
+        metadata_schema={"score": "float", "constant": "float"},
+    )
+
+    histograms = get_metadata_info.get_metadata_histograms(
+        session=db_session,
+        collection_id=collection.collection_id,
+        filters=ImageFilter(
+            sample_filter=SampleFilter(
+                metadata_filters=[MetadataFilter(key="score", op="<=", value=3)]
+            )
+        ),
+    )
+
+    constant = histograms["constant"]
+    assert constant.bin_edges == pytest.approx([5.0, 5.0])
+    # score <= 3 keeps 4 samples carrying the constant, plus the null row on top.
+    assert constant.counts == [4]


### PR DESCRIPTION
Split out of #1905, fourth in the stack. Tests only.

## What has changed and why?

No source change. Reading the presence guard as text, which #1953 did because there is no raw-JSON variant left, is what fixes this. These tests lock the behaviour in and record the failure mode, so it does not silently come back.

The guard used to test the raw JSON index, which is not SQL NULL for a stored JSON null on either database. Such a row passed the guard, and since `GREATEST` and `LEAST` clamp its NULL bucket to 0, it inflated the first histogram bin and the degenerate-range count.

A collection reaches that state through the public API: `metadata_schema` is per sample, so one sample can hold a float under a key while another holds `None`, and the merged collection schema reports the key as numeric. The helper inserts the row directly, because `set_value` type-checks per row.

## How has it been tested?

Both tests fail if the guard goes back to `db_json._json_extract(...).isnot(None)`, and nothing else fails, so they pin this behaviour and not something incidental. They run on DuckDB and on PostgreSQL via the `db_session` fixture.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected metadata histogram behavior so explicit `null` values are excluded from histogram results.
  * Applied the fix to both standard histograms and single-bin (degenerate) histograms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->