### PR TITLE
Fix: read metadata statistics keys literally

### DIFF
--- a/lightly_studio/src/lightly_studio/database/db_json.py
+++ b/lightly_studio/src/lightly_studio/database/db_json.py
@@ -79,6 +79,25 @@ def json_extract_key_as_text(column: Any, key: str) -> ColumnElement[str]:
     return cast(ColumnElement[str], column[_bind_key(key)].as_string())
 
 
+def json_extract_key_as_float(column: Any, key: str) -> ColumnElement[float]:
+    """Read one top-level JSON key as a float.
+
+    The key is taken literally, so unlike :func:`json_extract_as_float` a dot in it
+    stays part of the key rather than stepping into a nested object.
+
+    Casting a non-numeric value fails on PostgreSQL, so guard the call when the key's
+    type is not known.
+
+    Args:
+        column: The JSON column expression.
+        key: The top-level key to read, dots and all.
+
+    Returns:
+        The extracted value as a float.
+    """
+    return cast(ColumnElement[float], column[_bind_key(key)].as_float())
+
+
 class _JsonKeyType(TypeDecorator[str]):
     """Bind one object key so that each database reads it as a key and nothing else.
 

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/get_metadata_info.py
@@ -127,9 +127,11 @@ def _get_metadata_min_max_count(
     Returns:
         A ``(min, max, count)`` tuple, or ``None`` if the key has no values.
     """
-    value_expr = db_json.json_extract_as_float(column=SampleMetadataTable.data, field=metadata_key)
-    json_not_null_expr = db_json.json_extract_as_text(
-        column=SampleMetadataTable.data, field=metadata_key
+    value_expr = db_json.json_extract_key_as_float(
+        column=SampleMetadataTable.data, key=metadata_key
+    )
+    json_not_null_expr = db_json.json_extract_key_as_text(
+        column=SampleMetadataTable.data, key=metadata_key
     ).isnot(None)
 
     query = (
@@ -203,9 +205,11 @@ def _compute_histogram(  # noqa: PLR0913
 
     width = (max_value - min_value) / bin_count
 
-    value_expr = db_json.json_extract_as_float(column=SampleMetadataTable.data, field=metadata_key)
-    json_not_null_expr = db_json.json_extract_as_text(
-        column=SampleMetadataTable.data, field=metadata_key
+    value_expr = db_json.json_extract_key_as_float(
+        column=SampleMetadataTable.data, key=metadata_key
+    )
+    json_not_null_expr = db_json.json_extract_key_as_text(
+        column=SampleMetadataTable.data, key=metadata_key
     ).isnot(None)
 
     # Bucket index in [0, bin_count - 1]; values equal to max map to the last bin.
@@ -246,8 +250,8 @@ def _count_metadata_values(
     filters: ImageFilter | None,
 ) -> int:
     """Count non-null values for a metadata key under the given filters."""
-    json_not_null_expr = db_json.json_extract_as_text(
-        column=SampleMetadataTable.data, field=metadata_key
+    json_not_null_expr = db_json.json_extract_key_as_text(
+        column=SampleMetadataTable.data, key=metadata_key
     ).isnot(None)
     query = (
         select(func.count())

--- a/lightly_studio/tests/database/test_db_json.py
+++ b/lightly_studio/tests/database/test_db_json.py
@@ -48,6 +48,7 @@ def _every_entry_point(field: str) -> list[Any]:
         db_json.json_extract_as_text(column=_COLUMN, field=field),
         db_json.json_extract_as_float(column=_COLUMN, field=field),
         db_json.json_extract_key_as_text(column=_COLUMN, key=field),
+        db_json.json_extract_key_as_float(column=_COLUMN, key=field),
     ]
 
 
@@ -168,6 +169,15 @@ def test_json_extract_key_as_text__key_is_literal_and_bound(dialect: Any, key: s
     """The whole argument is one key, so a dot in it does not step into a nested object."""
     result = _compile(db_json.json_extract_key_as_text(column=_COLUMN, key=key), dialect)
     assert str(result) == "CAST(data ->> %(param_1)s AS VARCHAR)"
+    assert result.params == {"param_1": key}
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+@pytest.mark.parametrize("key", ["site.name", *_SPECIAL_KEYS])
+def test_json_extract_key_as_float__key_is_literal_and_bound(dialect: Any, key: str) -> None:
+    """The whole argument is one key, so a dot in it does not step into a nested object."""
+    result = _compile(db_json.json_extract_key_as_float(column=_COLUMN, key=key), dialect)
+    assert str(result) == "CAST(data ->> %(param_1)s AS FLOAT)"
     assert result.params == {"param_1": key}
 
 

--- a/lightly_studio/tests/metadata/test_get_metadata_histograms.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_histograms.py
@@ -179,6 +179,27 @@ def test_get_metadata_histograms__key_with_quote(db_session: Session) -> None:
     assert sum(score.counts) == 4
 
 
+def test_get_metadata_histograms__key_with_dot(db_session: Session) -> None:
+    """A dot in the key is part of the key, not a step into a nested object."""
+    collection = create_collection(session=db_session)
+    for i in range(4):
+        sample = create_image(
+            session=db_session,
+            collection_id=collection.collection_id,
+            file_path_abs=f"/path/to/sample{i}.png",
+        ).sample
+        sample["sensor.temp"] = float(i)
+
+    histograms = get_metadata_info.get_metadata_histograms(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    temp = histograms["sensor.temp"]
+    assert temp.bin_edges[0] == pytest.approx(0.0)
+    assert temp.bin_edges[-1] == pytest.approx(3.0)
+    assert sum(temp.counts) == 4
+
+
 def test_get_metadata_histograms__skips_non_numeric_keys(db_session: Session) -> None:
     """String and boolean keys produce no histogram."""
     collection = create_collection(session=db_session)

--- a/lightly_studio/tests/metadata/test_get_metadata_info.py
+++ b/lightly_studio/tests/metadata/test_get_metadata_info.py
@@ -192,3 +192,28 @@ def test_get_all_metadata_keys_and_schema__histogram_constant_values(
     assert score_info.max == pytest.approx(7.0)
     assert score_info.histogram is not None
     assert sum(score_info.histogram.counts) == 3
+
+
+def test_get_all_metadata_keys_and_schema__key_with_dot(
+    db_session: Session,
+) -> None:
+    """A dot in the key is part of the key, so the stats read the value it holds."""
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    for i in range(3):
+        sample = create_image(
+            session=db_session,
+            collection_id=collection_id,
+            file_path_abs=f"/path/to/sample{i}.png",
+        ).sample
+        sample["sensor.temp"] = float(i)
+
+    result = get_all_metadata_keys_and_schema(session=db_session, collection_id=collection_id)
+    temp_info = next(item for item in result if item.name == "sensor.temp")
+
+    assert temp_info.type == "float"
+    assert temp_info.min == pytest.approx(0.0)
+    assert temp_info.max == pytest.approx(2.0)
+    assert temp_info.histogram is not None
+    assert sum(temp_info.histogram.counts) == 3


### PR DESCRIPTION
Split out of #1905, top of the stack.

## What has changed and why?

The min/max and histogram resolvers enumerate top-level keys from the merged schema, but passed them as field paths, so a key like `sensor.temp` was read as `data["sensor"]["temp"]`. Such a key silently got no min, no max and no histogram. Their categorical siblings already read keys literally.

Adds the missing `json_extract_key_as_float`, since only the text variant had a literal-key form, which is what pushed the numeric path onto field paths.

Filters and `ORDER BY` keep field paths: `Metadata("a.list[0]")` is a documented part of the query API.

## How has it been tested?

A key with a dot now gets a histogram and shows up in the collection schema. Both tests use the `db_session` fixture, so they run on DuckDB and on PostgreSQL. The compiled-SQL tests cover the new `json_extract_key_as_float` alongside the existing entry points.

The full backend suite passes at this tip: 1997 passed, 32 skipped.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata fields with dots or other special characters are now treated as literal keys.
  * Numeric metadata values now produce accurate type information, minimum and maximum values, histograms, and filtered counts.
  * Improved compatibility when extracting numeric values across supported database dialects.

* **Tests**
  * Added coverage for special-character metadata keys and numeric extraction.
  * Added regression tests validating histogram ranges, counts, and metadata summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->