### PR TITLE
Add a "Start for free" CTA to the landing and enterprise pages

### DIFF
--- a/lightly_studio/docs/docs/enterprise/index.md
+++ b/lightly_studio/docs/docs/enterprise/index.md
@@ -10,6 +10,8 @@ We offer it in two deployment variants:
 
 Contact [sales@lightly.ai](mailto:sales@lightly.ai) to find the right option for your team.
 
+Not registered yet? [Start for free](https://www.lightly.ai/studio-signup) to get access.
+
 ## A Look Inside
 
 === "Single Sign-On"

--- a/lightly_studio/docs/docs/index.md
+++ b/lightly_studio/docs/docs/index.md
@@ -5,6 +5,10 @@ your data workflows from curation, annotation and management. Built with Rust fo
 efficiency, it lets you work seamlessly with datasets like COCO and ImageNet, even on a MacBook Pro
 with an M1 chip and 16 GB of memory.
 
+Working in a team and looking for collaboration features, role-based access permissions, and
+centrally managed cloud credentials? Check out [LightlyStudio Enterprise](enterprise/index.md)
+and [start for free with your team](https://www.lightly.ai/studio-signup).
+
 <p align="center">
   <video src="_static/hero_showcase.mp4" width="100%" autoplay loop muted playsinline></video>
 </p>


### PR DESCRIPTION
## What has changed and why?

The LightlyStudio documentation had no clear way to sign up. This pull request adds a call to action on two pages. It closes LIG-10275.

Changes:

- Landing page (index.md): one sentence above the hero video. It teases LightlyStudio Enterprise and links to the signup page.
- Enterprise page (enterprise/index.md): one line that sends unregistered readers to the signup page.
- Both pages link to [the signup page](https://www.lightly.ai/studio-signup).

The text is a plain link, not a button. A filled button was too loud at the top of the page.

Documentation only. No product code changes and no dependencies.

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added links to Enterprise documentation on the Welcome page.
  * Added free team signup links for visitors.
  * Added a free LightlyStudio trial invitation for unregistered users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->