### PR TITLE
Add preselected tag to sampling API

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from typing import Annotated, Union
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+from sqlmodel import Session
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.collection import CollectionTable, SampleType
-from lightly_studio.resolvers import image_resolver, video_resolver
+from lightly_studio.resolvers import image_resolver, tag_resolver, video_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
 from lightly_studio.sampling.sampling_config import (
@@ -49,6 +51,13 @@ class SamplingRequest(BaseModel):
     sampling_result_tag_name: str = Field(min_length=1, description="Name for the result tag")
     strategies: list[Strategy]
     filter: CollectionFilter | None = None
+    preselected_tag_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Sample tag whose samples should be considered already selected and included in the "
+            "result tag"
+        ),
+    )
 
 
 @sampling_router.post(
@@ -117,11 +126,25 @@ def create_sampling(
             filters=video_filter,
         )
     input_sample_ids = list(all_samples_result)
-    # Validate we have enough samples to select from.
-    if len(input_sample_ids) < request.n_samples_to_select:
+    preselected_sample_ids = _get_preselected_sample_ids(
+        session=session,
+        collection_id=collection.collection_id,
+        preselected_tag_id=request.preselected_tag_id,
+    )
+    if not set(preselected_sample_ids).issubset(input_sample_ids):
         raise HTTPException(
             status_code=400,
-            detail=f"collection has only {len(input_sample_ids)} samples, "
+            detail="All samples in the preselected tag must match the current filters.",
+        )
+    # Validate we have enough samples to select from.
+    n_candidates = len(input_sample_ids) - len(preselected_sample_ids)
+    if n_candidates < request.n_samples_to_select:
+        candidates_description = (
+            "samples not in the preselected set" if preselected_sample_ids else "samples"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=f"collection has only {n_candidates} {candidates_description}, "
             f"cannot select {request.n_samples_to_select}",
         )
     # Create SamplingConfig with diversity strategy.
@@ -132,4 +155,23 @@ def create_sampling(
         strategies=request.strategies,
     )
     # Perform sampling via database.
-    sampling_via_database(session=session, config=config, input_sample_ids=input_sample_ids)
+    sampling_via_database(
+        session=session,
+        config=config,
+        input_sample_ids=input_sample_ids,
+        preselected_sample_ids=preselected_sample_ids,
+    )
+
+
+def _get_preselected_sample_ids(
+    session: Session,
+    collection_id: UUID,
+    preselected_tag_id: UUID | None,
+) -> list[UUID]:
+    """Resolve and validate the optional preselected sample tag."""
+    if preselected_tag_id is None:
+        return []
+    tag = tag_resolver.get_by_id(session=session, tag_id=preselected_tag_id)
+    if tag is None or tag.collection_id != collection_id or tag.kind != "sample":
+        raise HTTPException(status_code=400, detail="Invalid preselected sample tag.")
+    return tag_resolver.get_sample_ids_by_tag_id(session=session, tag_id=preselected_tag_id)

--- a/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
@@ -132,7 +132,8 @@ def create_sampling(
         collection_id=collection.collection_id,
         preselected_tag_id=request.preselected_tag_id,
     )
-    _validate_preselection(
+    input_sample_ids.extend(set(preselected_sample_ids) - set(input_sample_ids))
+    _validate_sample_count(
         input_sample_ids=input_sample_ids,
         preselected_sample_ids=preselected_sample_ids,
         n_samples_to_select=request.n_samples_to_select,
@@ -167,16 +168,12 @@ def _get_preselected_sample_ids(
     return tag_resolver.get_sample_ids_by_tag_id(session=session, tag_id=preselected_tag_id)
 
 
-def _validate_preselection(
+def _validate_sample_count(
     input_sample_ids: list[UUID],
     preselected_sample_ids: list[UUID],
     n_samples_to_select: int,
 ) -> None:
-    """Validate the preselection against the sampling input and requested sample count."""
-    if not set(preselected_sample_ids).issubset(input_sample_ids):
-        raise InvalidSamplingRequestError(
-            "All samples in the preselected tag must match the current filters."
-        )
+    """Validate the requested sample count against the available candidates."""
     n_candidates = len(input_sample_ids) - len(preselected_sample_ids)
     if n_candidates < n_samples_to_select:
         candidates_description = (

--- a/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/sampling.py
@@ -11,6 +11,7 @@ from sqlmodel import Session
 
 from lightly_studio.api.routes.api.collection import get_and_validate_collection_id
 from lightly_studio.database.db_manager import SessionDep
+from lightly_studio.errors import InvalidSamplingRequestError, InvalidTagError
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.resolvers import image_resolver, tag_resolver, video_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
@@ -131,22 +132,11 @@ def create_sampling(
         collection_id=collection.collection_id,
         preselected_tag_id=request.preselected_tag_id,
     )
-    if not set(preselected_sample_ids).issubset(input_sample_ids):
-        raise HTTPException(
-            status_code=400,
-            detail="All samples in the preselected tag must match the current filters.",
-        )
-    # Validate we have enough samples to select from.
-    n_candidates = len(input_sample_ids) - len(preselected_sample_ids)
-    if n_candidates < request.n_samples_to_select:
-        candidates_description = (
-            "samples not in the preselected set" if preselected_sample_ids else "samples"
-        )
-        raise HTTPException(
-            status_code=400,
-            detail=f"collection has only {n_candidates} {candidates_description}, "
-            f"cannot select {request.n_samples_to_select}",
-        )
+    _validate_preselection(
+        input_sample_ids=input_sample_ids,
+        preselected_sample_ids=preselected_sample_ids,
+        n_samples_to_select=request.n_samples_to_select,
+    )
     # Create SamplingConfig with diversity strategy.
     config = SamplingConfig(
         collection_id=collection.collection_id,
@@ -173,5 +163,26 @@ def _get_preselected_sample_ids(
         return []
     tag = tag_resolver.get_by_id(session=session, tag_id=preselected_tag_id)
     if tag is None or tag.collection_id != collection_id or tag.kind != "sample":
-        raise HTTPException(status_code=400, detail="Invalid preselected sample tag.")
+        raise InvalidTagError("Invalid preselected sample tag.")
     return tag_resolver.get_sample_ids_by_tag_id(session=session, tag_id=preselected_tag_id)
+
+
+def _validate_preselection(
+    input_sample_ids: list[UUID],
+    preselected_sample_ids: list[UUID],
+    n_samples_to_select: int,
+) -> None:
+    """Validate the preselection against the sampling input and requested sample count."""
+    if not set(preselected_sample_ids).issubset(input_sample_ids):
+        raise InvalidSamplingRequestError(
+            "All samples in the preselected tag must match the current filters."
+        )
+    n_candidates = len(input_sample_ids) - len(preselected_sample_ids)
+    if n_candidates < n_samples_to_select:
+        candidates_description = (
+            "samples not in the preselected set" if preselected_sample_ids else "samples"
+        )
+        raise InvalidSamplingRequestError(
+            f"collection has only {n_candidates} {candidates_description}, "
+            f"cannot select {n_samples_to_select}",
+        )

--- a/lightly_studio/src/lightly_studio/errors.py
+++ b/lightly_studio/src/lightly_studio/errors.py
@@ -9,5 +9,13 @@ class TagNotFoundError(Exception):
     """Exception signaling that a tag has not been found."""
 
 
+class InvalidTagError(ValueError):
+    """Exception signaling that a tag is invalid for the requested operation."""
+
+
+class InvalidSamplingRequestError(ValueError):
+    """Exception signaling that sampling request parameters are inconsistent."""
+
+
 class QueryExprError(Exception):
     """Exception raised when a query expression cannot be translated."""

--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -275,6 +275,12 @@ def get_tags_by_sample(
     return result
 
 
+def get_sample_ids_by_tag_id(session: Session, tag_id: UUID) -> list[UUID]:
+    """Return all sample IDs assigned to a tag."""
+    statement = select(SampleTagLinkTable.sample_id).where(col(SampleTagLinkTable.tag_id) == tag_id)
+    return [sample_id for sample_id in session.exec(statement).all() if sample_id is not None]
+
+
 def get_or_create_sample_tag_by_name(
     session: Session,
     collection_id: UUID,

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -234,7 +234,7 @@ def sampling_via_database(
         config: Sampling configuration.
         input_sample_ids: Candidate sample IDs.
         preselected_sample_ids: Sample IDs that should inform the sampling as
-            already selected. They are excluded from the result tag.
+            already selected. They are included in the result tag.
 
     Raises:
         ValueError: If the preselected sample IDs contain duplicates or are not
@@ -260,6 +260,13 @@ def sampling_via_database(
     )
     if n_samples_to_select == 0:
         logger.warning("No samples available for sampling.")
+        if preselected_indices:
+            sampling_helpers.create_result_tag(
+                session=session,
+                collection_id=config.collection_id,
+                tag_name=config.sampling_result_tag_name,
+                selected_sample_ids=[input_sample_ids[index] for index in preselected_indices],
+            )
         return
 
     # Get root dataset id for balancing strategies
@@ -286,9 +293,7 @@ def sampling_via_database(
         n_samples=len(preselected_indices) + n_samples_to_select,
         preselected_indices=preselected_indices,
     )
-    selected_sample_ids = [
-        input_sample_ids[index] for index in selected_indices[len(preselected_indices) :]
-    ]
+    selected_sample_ids = [input_sample_ids[index] for index in selected_indices]
     sampling_helpers.create_result_tag(
         session=session,
         collection_id=config.collection_id,

--- a/lightly_studio/tests/api/routes/api/test_sampling.py
+++ b/lightly_studio/tests/api/routes/api/test_sampling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from uuid import UUID
 
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
@@ -67,9 +68,7 @@ def test_create_combination_sampling__diversity_success(
     assert len(result.samples) == 3
 
 
-def test_create_combination_sampling__preselected_tag(
-    test_client: TestClient, db_session: Session
-) -> None:
+def test_create_sampling__preselected_tag(test_client: TestClient, db_session: Session) -> None:
     collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
         session=db_session, n_samples=10, embedding_model_names=["test_embedding_model"]
     )
@@ -77,33 +76,17 @@ def test_create_combination_sampling__preselected_tag(
         image_resolver.get_sample_ids(session=db_session, collection_id=collection_id)
     )
     preselected_sample_ids = sample_ids[:2]
-    preselected_tag = tag_resolver.create(
+    preselected_tag_id = _create_sample_tag(
         session=db_session,
-        tag=TagCreate(collection_id=collection_id, name="preselected", kind="sample"),
-    )
-    tag_resolver.add_sample_ids_to_tag_id(
-        session=db_session,
-        tag_id=preselected_tag.tag_id,
+        collection_id=collection_id,
         sample_ids=preselected_sample_ids,
     )
 
     response = test_client.post(
         f"/api/collections/{collection_id}/sampling",
-        json={
-            "n_samples_to_select": 3,
-            "sampling_result_tag_name": "new_batch",
-            "preselected_tag_id": str(preselected_tag.tag_id),
-            "strategies": [
-                {
-                    "strategy_name": "diversity",
-                    "embedding_model_name": "test_embedding_model",
-                }
-            ],
-            "filter": {
-                "filter_type": "image",
-                "sample_filter": {"sample_ids": [str(sample_id) for sample_id in sample_ids]},
-            },
-        },
+        json=_preselection_sampling_request(
+            preselected_tag_id=preselected_tag_id, n_samples_to_select=3
+        ),
     )
 
     assert response.status_code == 204
@@ -116,7 +99,7 @@ def test_create_combination_sampling__preselected_tag(
     assert set(preselected_sample_ids).issubset(result_ids)
 
 
-def test_create_combination_sampling__preselected_samples_outside_input(
+def test_create_sampling__preselected_samples_outside_input(
     test_client: TestClient, db_session: Session
 ) -> None:
     collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
@@ -125,43 +108,28 @@ def test_create_combination_sampling__preselected_samples_outside_input(
     sample_ids = list(
         image_resolver.get_sample_ids(session=db_session, collection_id=collection_id)
     )
-    preselected_tag = tag_resolver.create(
+    preselected_tag_id = _create_sample_tag(
         session=db_session,
-        tag=TagCreate(collection_id=collection_id, name="preselected", kind="sample"),
-    )
-    tag_resolver.add_sample_ids_to_tag_id(
-        session=db_session,
-        tag_id=preselected_tag.tag_id,
+        collection_id=collection_id,
         sample_ids=sample_ids[:2],
     )
 
     response = test_client.post(
         f"/api/collections/{collection_id}/sampling",
-        json={
-            "n_samples_to_select": 1,
-            "sampling_result_tag_name": "new_batch",
-            "preselected_tag_id": str(preselected_tag.tag_id),
-            "strategies": [
-                {
-                    "strategy_name": "diversity",
-                    "embedding_model_name": "test_embedding_model",
-                }
-            ],
-            "filter": {
-                "filter_type": "image",
-                "sample_filter": {"sample_ids": [str(sample_id) for sample_id in sample_ids[2:]]},
-            },
-        },
+        json=_preselection_sampling_request(
+            preselected_tag_id=preselected_tag_id,
+            filter_sample_ids=sample_ids[2:],
+        ),
     )
 
     assert response.status_code == 400
     assert (
-        response.json()["detail"]
+        response.json()["error"]
         == "All samples in the preselected tag must match the current filters."
     )
 
 
-def test_create_combination_sampling__preselected_tag_from_another_collection(
+def test_create_sampling__preselected_tag_from_another_collection(
     test_client: TestClient, db_session: Session
 ) -> None:
     collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
@@ -170,32 +138,18 @@ def test_create_combination_sampling__preselected_tag_from_another_collection(
     other_collection = helpers_resolvers.create_collection(
         session=db_session, collection_name="other"
     )
-    preselected_tag = tag_resolver.create(
+    preselected_tag_id = _create_sample_tag(
         session=db_session,
-        tag=TagCreate(
-            collection_id=other_collection.collection_id,
-            name="preselected",
-            kind="sample",
-        ),
+        collection_id=other_collection.collection_id,
     )
 
     response = test_client.post(
         f"/api/collections/{collection_id}/sampling",
-        json={
-            "n_samples_to_select": 1,
-            "sampling_result_tag_name": "new_batch",
-            "preselected_tag_id": str(preselected_tag.tag_id),
-            "strategies": [
-                {
-                    "strategy_name": "diversity",
-                    "embedding_model_name": "test_embedding_model",
-                }
-            ],
-        },
+        json=_preselection_sampling_request(preselected_tag_id=preselected_tag_id),
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "Invalid preselected sample tag."
+    assert response.json()["error"] == "Invalid preselected sample tag."
 
 
 def test_create_sampling__passes_request_to_sampling(
@@ -324,8 +278,8 @@ def test_create_combination_sampling__insufficient_samples(
     response = test_client.post(f"/api/collections/{collection_id}/sampling", json=request_data)
 
     assert response.status_code == 400
-    assert "cannot select 5" in response.json()["detail"]
-    assert "has only 2 samples" in response.json()["detail"]
+    assert "cannot select 5" in response.json()["error"]
+    assert "has only 2 samples" in response.json()["error"]
 
 
 def test_create_combination_sampling__duplicate_tag_name(
@@ -875,3 +829,40 @@ def test_create_combination_sampling__video_collection_rejects_image_filter(
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Invalid filter type for video collection."
+
+
+def _create_sample_tag(
+    session: Session,
+    collection_id: UUID,
+    sample_ids: list[UUID] | None = None,
+) -> UUID:
+    tag = tag_resolver.create(
+        session=session,
+        tag=TagCreate(collection_id=collection_id, name="preselected", kind="sample"),
+    )
+    if sample_ids:
+        tag_resolver.add_sample_ids_to_tag_id(
+            session=session, tag_id=tag.tag_id, sample_ids=sample_ids
+        )
+    return tag.tag_id
+
+
+def _preselection_sampling_request(
+    preselected_tag_id: UUID,
+    n_samples_to_select: int = 1,
+    filter_sample_ids: list[UUID] | None = None,
+) -> dict[str, object]:
+    request: dict[str, object] = {
+        "n_samples_to_select": n_samples_to_select,
+        "sampling_result_tag_name": "new_batch",
+        "preselected_tag_id": str(preselected_tag_id),
+        "strategies": [
+            {"strategy_name": "diversity", "embedding_model_name": "test_embedding_model"}
+        ],
+    }
+    if filter_sample_ids is not None:
+        request["filter"] = {
+            "filter_type": "image",
+            "sample_filter": {"sample_ids": [str(sample_id) for sample_id in filter_sample_ids]},
+        }
+    return request

--- a/lightly_studio/tests/api/routes/api/test_sampling.py
+++ b/lightly_studio/tests/api/routes/api/test_sampling.py
@@ -85,7 +85,9 @@ def test_create_sampling__preselected_tag(test_client: TestClient, db_session: S
     response = test_client.post(
         f"/api/collections/{collection_id}/sampling",
         json=_preselection_sampling_request(
-            preselected_tag_id=preselected_tag_id, n_samples_to_select=3
+            preselected_tag_id=preselected_tag_id,
+            result_tag_name="new_batch",
+            n_samples_to_select=3,
         ),
     )
 
@@ -99,7 +101,7 @@ def test_create_sampling__preselected_tag(test_client: TestClient, db_session: S
     assert set(preselected_sample_ids).issubset(result_ids)
 
 
-def test_create_sampling__preselected_samples_outside_input(
+def test_create_sampling__preselected_samples_outside_filter(
     test_client: TestClient, db_session: Session
 ) -> None:
     collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
@@ -118,15 +120,19 @@ def test_create_sampling__preselected_samples_outside_input(
         f"/api/collections/{collection_id}/sampling",
         json=_preselection_sampling_request(
             preselected_tag_id=preselected_tag_id,
+            result_tag_name="new_batch",
             filter_sample_ids=sample_ids[2:],
         ),
     )
 
-    assert response.status_code == 400
-    assert (
-        response.json()["error"]
-        == "All samples in the preselected tag must match the current filters."
+    assert response.status_code == 204
+    result_tag = tag_resolver.get_by_name(
+        session=db_session, tag_name="new_batch", collection_id=collection_id
     )
+    assert result_tag is not None
+    result_ids = tag_resolver.get_sample_ids_by_tag_id(session=db_session, tag_id=result_tag.tag_id)
+    assert len(result_ids) == 3
+    assert set(sample_ids[:2]).issubset(result_ids)
 
 
 def test_create_sampling__preselected_tag_from_another_collection(
@@ -145,7 +151,9 @@ def test_create_sampling__preselected_tag_from_another_collection(
 
     response = test_client.post(
         f"/api/collections/{collection_id}/sampling",
-        json=_preselection_sampling_request(preselected_tag_id=preselected_tag_id),
+        json=_preselection_sampling_request(
+            preselected_tag_id=preselected_tag_id, result_tag_name="new_batch"
+        ),
     )
 
     assert response.status_code == 400
@@ -849,12 +857,13 @@ def _create_sample_tag(
 
 def _preselection_sampling_request(
     preselected_tag_id: UUID,
+    result_tag_name: str,
     n_samples_to_select: int = 1,
     filter_sample_ids: list[UUID] | None = None,
 ) -> dict[str, object]:
     request: dict[str, object] = {
         "n_samples_to_select": n_samples_to_select,
-        "sampling_result_tag_name": "new_batch",
+        "sampling_result_tag_name": result_tag_name,
         "preselected_tag_id": str(preselected_tag_id),
         "strategies": [
             {"strategy_name": "diversity", "embedding_model_name": "test_embedding_model"}

--- a/lightly_studio/tests/api/routes/api/test_sampling.py
+++ b/lightly_studio/tests/api/routes/api/test_sampling.py
@@ -11,6 +11,7 @@ from sqlmodel import Session
 from lightly_studio.api.routes.api import sampling as sampling_api
 from lightly_studio.metadata import compute_typicality
 from lightly_studio.models.collection import SampleType
+from lightly_studio.models.tag import TagCreate
 from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
@@ -64,6 +65,137 @@ def test_create_combination_sampling__diversity_success(
         session=db_session, collection_id=collection_id, filters=tag_filter
     )
     assert len(result.samples) == 3
+
+
+def test_create_combination_sampling__preselected_tag(
+    test_client: TestClient, db_session: Session
+) -> None:
+    collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
+        session=db_session, n_samples=10, embedding_model_names=["test_embedding_model"]
+    )
+    sample_ids = list(
+        image_resolver.get_sample_ids(session=db_session, collection_id=collection_id)
+    )
+    preselected_sample_ids = sample_ids[:2]
+    preselected_tag = tag_resolver.create(
+        session=db_session,
+        tag=TagCreate(collection_id=collection_id, name="preselected", kind="sample"),
+    )
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=preselected_tag.tag_id,
+        sample_ids=preselected_sample_ids,
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/sampling",
+        json={
+            "n_samples_to_select": 3,
+            "sampling_result_tag_name": "new_batch",
+            "preselected_tag_id": str(preselected_tag.tag_id),
+            "strategies": [
+                {
+                    "strategy_name": "diversity",
+                    "embedding_model_name": "test_embedding_model",
+                }
+            ],
+            "filter": {
+                "filter_type": "image",
+                "sample_filter": {"sample_ids": [str(sample_id) for sample_id in sample_ids]},
+            },
+        },
+    )
+
+    assert response.status_code == 204
+    result_tag = tag_resolver.get_by_name(
+        session=db_session, tag_name="new_batch", collection_id=collection_id
+    )
+    assert result_tag is not None
+    result_ids = tag_resolver.get_sample_ids_by_tag_id(session=db_session, tag_id=result_tag.tag_id)
+    assert len(result_ids) == 5
+    assert set(preselected_sample_ids).issubset(result_ids)
+
+
+def test_create_combination_sampling__preselected_samples_outside_input(
+    test_client: TestClient, db_session: Session
+) -> None:
+    collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
+        session=db_session, n_samples=5, embedding_model_names=["test_embedding_model"]
+    )
+    sample_ids = list(
+        image_resolver.get_sample_ids(session=db_session, collection_id=collection_id)
+    )
+    preselected_tag = tag_resolver.create(
+        session=db_session,
+        tag=TagCreate(collection_id=collection_id, name="preselected", kind="sample"),
+    )
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=preselected_tag.tag_id,
+        sample_ids=sample_ids[:2],
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/sampling",
+        json={
+            "n_samples_to_select": 1,
+            "sampling_result_tag_name": "new_batch",
+            "preselected_tag_id": str(preselected_tag.tag_id),
+            "strategies": [
+                {
+                    "strategy_name": "diversity",
+                    "embedding_model_name": "test_embedding_model",
+                }
+            ],
+            "filter": {
+                "filter_type": "image",
+                "sample_filter": {"sample_ids": [str(sample_id) for sample_id in sample_ids[2:]]},
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "All samples in the preselected tag must match the current filters."
+    )
+
+
+def test_create_combination_sampling__preselected_tag_from_another_collection(
+    test_client: TestClient, db_session: Session
+) -> None:
+    collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
+        session=db_session, n_samples=3, embedding_model_names=["test_embedding_model"]
+    )
+    other_collection = helpers_resolvers.create_collection(
+        session=db_session, collection_name="other"
+    )
+    preselected_tag = tag_resolver.create(
+        session=db_session,
+        tag=TagCreate(
+            collection_id=other_collection.collection_id,
+            name="preselected",
+            kind="sample",
+        ),
+    )
+
+    response = test_client.post(
+        f"/api/collections/{collection_id}/sampling",
+        json={
+            "n_samples_to_select": 1,
+            "sampling_result_tag_name": "new_batch",
+            "preselected_tag_id": str(preselected_tag.tag_id),
+            "strategies": [
+                {
+                    "strategy_name": "diversity",
+                    "embedding_model_name": "test_embedding_model",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid preselected sample tag."
 
 
 def test_create_sampling__passes_request_to_sampling(

--- a/lightly_studio/tests/sampling/test_sampling_via_db.py
+++ b/lightly_studio/tests/sampling/test_sampling_via_db.py
@@ -528,7 +528,7 @@ def test_sampling_via_database__preselection_matches_single_sampling(
         session=db_session, tag_name="second_batch", collection_id=collection_id
     )
     assert second_tag is not None
-    second_batch = _sample_ids_by_tag(
+    continued_selection = _sample_ids_by_tag(
         session=db_session, collection_id=collection_id, tag_id=second_tag.tag_id
     )
 
@@ -550,8 +550,40 @@ def test_sampling_via_database__preselection_matches_single_sampling(
         session=db_session, collection_id=collection_id, tag_id=single_tag.tag_id
     )
 
-    assert set(first_batch).isdisjoint(second_batch)
-    assert set(first_batch + second_batch) == set(single_batch)
+    assert set(first_batch).issubset(continued_selection)
+    assert set(continued_selection) == set(single_batch)
+
+
+def test_sampling_via_database__only_preselected_samples_available(
+    db_session: Session,
+) -> None:
+    collection_id = fill_db_with_samples_and_embeddings(
+        db_session, n_samples=2, embedding_model_names=["embedding_model_1"]
+    )
+    sample_ids = _all_sample_ids(db_session, collection_id)
+
+    sampling_via_database(
+        session=db_session,
+        config=SamplingConfig(
+            collection_id=collection_id,
+            n_samples_to_select=1,
+            sampling_result_tag_name="result",
+            strategies=[EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1")],
+        ),
+        input_sample_ids=sample_ids,
+        preselected_sample_ids=sample_ids,
+    )
+
+    result_tag = tag_resolver.get_by_name(
+        session=db_session, tag_name="result", collection_id=collection_id
+    )
+    assert result_tag is not None
+    result_sample_ids = _sample_ids_by_tag(
+        session=db_session,
+        collection_id=collection_id,
+        tag_id=result_tag.tag_id,
+    )
+    assert set(result_sample_ids) == set(sample_ids)
 
 
 def test_sampling_via_database__preselected_sample_id_not_in_input(


### PR DESCRIPTION
## What has changed and why?
This will allow us to add preselection to Sampling UI.

## How has it been tested?
Added tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sampling requests can include samples preselected through a sample tag.
  - Preselected samples remain included in the resulting selection, including when no additional samples are available.
  - Preselected samples can be included even when they fall outside the active filter.

- **Bug Fixes**
  - Invalid tags, tags from another collection, and insufficient remaining candidates are rejected with clear errors.

- **Tests**
  - Added coverage for successful preselection, validation failures, and fully preselected sample sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->