### PR TITLE
Require preselected tag ID

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/tag_resolver.py
@@ -275,6 +275,12 @@ def get_tags_by_sample(
     return result
 
 
+def get_sample_ids_by_tag_id(session: Session, tag_id: UUID) -> list[UUID]:
+    """Return all sample IDs assigned to a tag."""
+    statement = select(SampleTagLinkTable.sample_id).where(col(SampleTagLinkTable.tag_id) == tag_id)
+    return [sample_id for sample_id in session.exec(statement).all() if sample_id is not None]
+
+
 def get_or_create_sample_tag_by_name(
     session: Session,
     collection_id: UUID,

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -221,7 +221,7 @@ def sampling_via_database(
     session: Session,
     config: SamplingConfig,
     input_sample_ids: list[UUID],
-    preselected_sample_ids: Iterable[UUID] | None = None,
+    preselected_tag_id: UUID | None = None,
 ) -> None:
     """Run sampling using the provided candidate sample ids.
 
@@ -233,13 +233,24 @@ def sampling_via_database(
         session: Database session used to resolve and store sampling data.
         config: Sampling configuration.
         input_sample_ids: Candidate sample IDs.
-        preselected_sample_ids: Sample IDs that should inform the sampling as
+        preselected_tag_id: Tag whose sample IDs should inform the sampling as
             already selected. They are excluded from the result tag.
 
     Raises:
         ValueError: If the preselected sample IDs contain duplicates or are not
             a subset of the input sample IDs.
     """
+    preselected_sample_ids = (
+        list(
+            tag_resolver.get_tags_by_sample(
+                session=session,
+                tag_ids=[preselected_tag_id],
+            )
+        )
+        if preselected_tag_id is not None
+        else []
+    )
+
     # Check if the tag name is already used
     existing_tag = tag_resolver.get_by_name(
         session=session,

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -237,19 +237,18 @@ def sampling_via_database(
             already selected. They are excluded from the result tag.
 
     Raises:
-        ValueError: If the preselected sample IDs contain duplicates or are not
-            a subset of the input sample IDs.
+        ValueError: If the preselected tag does not exist or its sample IDs are
+            not a subset of the input sample IDs.
     """
-    preselected_sample_ids = (
-        list(
-            tag_resolver.get_tags_by_sample(
-                session=session,
-                tag_ids=[preselected_tag_id],
-            )
+    if preselected_tag_id is not None:
+        preselected_tag = tag_resolver.get_by_id(session=session, tag_id=preselected_tag_id)
+        if preselected_tag is None:
+            raise ValueError(f"Preselected tag with ID {preselected_tag_id} not found.")
+        preselected_sample_ids = list(
+            tag_resolver.get_tags_by_sample(session=session, tag_ids=[preselected_tag_id]).keys()
         )
-        if preselected_tag_id is not None
-        else []
-    )
+    else:
+        preselected_sample_ids = []
 
     # Check if the tag name is already used
     existing_tag = tag_resolver.get_by_name(

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -244,8 +244,8 @@ def sampling_via_database(
         preselected_tag = tag_resolver.get_by_id(session=session, tag_id=preselected_tag_id)
         if preselected_tag is None:
             raise ValueError(f"Preselected tag with ID {preselected_tag_id} not found.")
-        preselected_sample_ids = list(
-            tag_resolver.get_tags_by_sample(session=session, tag_ids=[preselected_tag_id]).keys()
+        preselected_sample_ids = tag_resolver.get_sample_ids_by_tag_id(
+            session=session, tag_id=preselected_tag_id
         )
     else:
         preselected_sample_ids = []

--- a/lightly_studio/tests/sampling/test_sampling_via_db.py
+++ b/lightly_studio/tests/sampling/test_sampling_via_db.py
@@ -522,7 +522,7 @@ def test_sampling_via_database__preselection_matches_single_sampling(
             strategies=[strategy],
         ),
         input_sample_ids=sample_ids,
-        preselected_sample_ids=first_batch,
+        preselected_tag_id=first_tag.tag_id,
     )
     second_tag = tag_resolver.get_by_name(
         session=db_session, tag_name="second_batch", collection_id=collection_id
@@ -557,7 +557,19 @@ def test_sampling_via_database__preselection_matches_single_sampling(
 def test_sampling_via_database__preselected_sample_id_not_in_input(
     db_session: Session,
 ) -> None:
-    sample_id = uuid4()
+    collection_id = fill_db_with_samples_and_embeddings(
+        db_session, n_samples=1, embedding_model_names=[]
+    )
+    sample_id = _all_sample_ids(db_session, collection_id)[0]
+    preselected_tag = tag_resolver.create(
+        session=db_session,
+        tag=TagCreate(collection_id=collection_id, name="preselected", kind="sample"),
+    )
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=preselected_tag.tag_id,
+        sample_ids=[sample_id],
+    )
 
     with pytest.raises(
         ValueError, match="Preselected sample IDs must be a subset of input sample IDs"
@@ -565,32 +577,13 @@ def test_sampling_via_database__preselected_sample_id_not_in_input(
         sampling_via_database(
             session=db_session,
             config=SamplingConfig(
-                collection_id=uuid4(),
+                collection_id=collection_id,
                 n_samples_to_select=1,
                 sampling_result_tag_name="result",
                 strategies=[],
             ),
             input_sample_ids=[],
-            preselected_sample_ids=[sample_id],
-        )
-
-
-def test_sampling_via_database__duplicate_preselected_sample_id(
-    db_session: Session,
-) -> None:
-    sample_id = uuid4()
-
-    with pytest.raises(ValueError, match="Preselected sample IDs must be unique"):
-        sampling_via_database(
-            session=db_session,
-            config=SamplingConfig(
-                collection_id=uuid4(),
-                n_samples_to_select=1,
-                sampling_result_tag_name="result",
-                strategies=[],
-            ),
-            input_sample_ids=[sample_id],
-            preselected_sample_ids=[sample_id, sample_id],
+            preselected_tag_id=preselected_tag.tag_id,
         )
 
 

--- a/lightly_studio/tests/sampling/test_sampling_via_db.py
+++ b/lightly_studio/tests/sampling/test_sampling_via_db.py
@@ -554,6 +554,25 @@ def test_sampling_via_database__preselection_matches_single_sampling(
     assert set(first_batch + second_batch) == set(single_batch)
 
 
+def test_sampling_via_database__preselected_tag_not_found(
+    db_session: Session,
+) -> None:
+    preselected_tag_id = uuid4()
+
+    with pytest.raises(ValueError, match=f"Preselected tag with ID {preselected_tag_id} not found"):
+        sampling_via_database(
+            session=db_session,
+            config=SamplingConfig(
+                collection_id=uuid4(),
+                n_samples_to_select=1,
+                sampling_result_tag_name="result",
+                strategies=[],
+            ),
+            input_sample_ids=[],
+            preselected_tag_id=preselected_tag_id,
+        )
+
+
 def test_sampling_via_database__preselected_sample_id_not_in_input(
     db_session: Session,
 ) -> None:


### PR DESCRIPTION
## What has changed and why?
`sampling_via_database()` took a list of preselected samples IDs, but we require the preselected samples to be tagged, so the API could have been used in a wrong way - by provided samples from different tags, are samples without any tag.

This is both safer and easier for the caller.

## How has it been tested?
Existing tests 

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Database-backed sampling can now use an existing tag to identify preselected samples.
  - Preselected samples remain excluded from newly created result tags.
  - Sampling defaults to no preselected samples when no tag is provided.

- **Bug Fixes**
  - Improved validation for preselected samples, including invalid subsets.
  - Sampling now reports an error when the specified preselection tag cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->