### PR TITLE
Serialize access to the shared persistent database session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix requests failing intermittently while the GUI is under load, caused by concurrent access to a shared database session.
+
 ### Security
 
 ## \[1.0.5\] - 2026-08-14

--- a/lightly_studio/src/lightly_studio/database/db_manager.py
+++ b/lightly_studio/src/lightly_studio/database/db_manager.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import atexit
 import logging
+import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 from enum import Enum
@@ -46,6 +47,7 @@ class DatabaseEngine:
     _engine_url: str
     _engine: Engine
     _persistent_session: Session | None = None
+    _persistent_session_lock: threading.RLock
     _backend: DatabaseBackend
 
     def __init__(
@@ -68,6 +70,14 @@ class DatabaseEngine:
             FileNotFoundError: If must_exist is True and the database does not exist.
             RuntimeError: If the DuckDB file is already open in another process.
         """
+        # Guards every access to the persistent session. A SQLAlchemy Session is not
+        # thread-safe, and the session below is reached from many threads at once: FastAPI
+        # runs the sync session dependency on Starlette's threadpool, the async media
+        # routes open sessions on the event loop thread, and the Python API uses the
+        # persistent session on the caller's own thread. Re-entrant because
+        # _commit_persistent_session calls get_persistent_session.
+        self._persistent_session_lock = threading.RLock()
+
         if engine_url is not None:
             self._engine_url = engine_url
         elif LIGHTLY_STUDIO_DATABASE_URL is not None:
@@ -133,9 +143,7 @@ class DatabaseEngine:
         # in the persistent session.
         # TODO(Mihnea, 02/2026): Consider making this DuckDB specific,
         #  as this won't be a problem in Postgres.
-        if self.get_persistent_session().in_transaction():
-            logging.debug("The persistent session is in transaction, committing changes.")
-            self.get_persistent_session().commit()
+        self._commit_persistent_session()
 
         session = Session(self._engine, close_resets_only=False)
         try:
@@ -146,9 +154,7 @@ class DatabaseEngine:
 
             # Commit the persistent session if it has an active transaction.
             # This ensures the session sees the latest data changes made by short-lived sessions.
-            persistent_session = self.get_persistent_session()
-            if persistent_session.in_transaction():
-                persistent_session.commit()
+            self._commit_persistent_session()
         except Exception:
             session.rollback()
             raise
@@ -162,26 +168,50 @@ class DatabaseEngine:
 
     def get_persistent_session(self) -> Session:
         """Get the persistent database session."""
-        if self._persistent_session is None:
-            self._persistent_session = Session(
-                self._engine, close_resets_only=False, expire_on_commit=True
-            )
-        return self._persistent_session
+        with self._persistent_session_lock:
+            if self._persistent_session is None:
+                self._persistent_session = Session(
+                    self._engine, close_resets_only=False, expire_on_commit=True
+                )
+            return self._persistent_session
 
     def close(self) -> None:
         """Close the persistent session and dispose the engine."""
-        if self._persistent_session is not None:
-            try:
-                if self._persistent_session.in_transaction():
-                    logging.debug(
-                        "The persistent session is in transaction, committing before close."
-                    )
-                    self._persistent_session.commit()
-            finally:
-                self._persistent_session.close()
-                self._persistent_session = None
+        with self._persistent_session_lock:
+            if self._persistent_session is not None:
+                try:
+                    if self._persistent_session.in_transaction():
+                        logging.debug(
+                            "The persistent session is in transaction, committing before close."
+                        )
+                        self._persistent_session.commit()
+                finally:
+                    self._persistent_session.close()
+                    self._persistent_session = None
 
         self._engine.dispose()
+
+    def _commit_persistent_session(self) -> None:
+        """Commit the persistent session if it has an active transaction.
+
+        The persistent session is shared between the Python API and every thread that opens
+        a short-lived session, and a SQLAlchemy Session is not thread-safe. Without the
+        lock, two threads entering `session` at the same time both call `commit()` on the
+        same session and SQLAlchemy raises IllegalStateChangeError. The lock is
+        deliberately not held across the `yield` in `session`, so requests still run
+        concurrently.
+
+        The lock does not cover Python API code that uses the persistent session directly,
+        so a Python API call made while `start_gui_background` serves requests can still
+        race.
+        TODO(Iunir, 08/2026): Stop sharing one session between the Python API and the
+         threads serving requests, so that no locking is needed here.
+        """
+        with self._persistent_session_lock:
+            persistent_session = self.get_persistent_session()
+            if persistent_session.in_transaction():
+                logging.debug("The persistent session is in transaction, committing changes.")
+                persistent_session.commit()
 
 
 # Global database engine instance instantiated lazily.

--- a/lightly_studio/tests/database/test_db_manager.py
+++ b/lightly_studio/tests/database/test_db_manager.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import duckdb
@@ -12,6 +15,7 @@ import pytest
 import sqlmodel
 from pytest_mock import MockerFixture
 from sqlalchemy.exc import OperationalError
+from sqlmodel import Session
 
 from lightly_studio import ImageDataset
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
@@ -191,6 +195,91 @@ def test_session_data_consistency(mocker: MockerFixture, tmp_path: Path) -> None
     assert len(samples) == 2
     assert samples[0].file_path_abs == "image.png"
     assert samples[1].file_path_abs == "image2.png"
+
+
+def test_session__persistent_session_commits_are_serialized(
+    tmp_path: Path,
+    postgres_url: str | None,
+    mocker: MockerFixture,
+) -> None:
+    """Test that concurrent session() callers never commit the persistent session at once.
+
+    A SQLAlchemy Session is not thread-safe. FastAPI runs the sync session dependency on
+    Starlette's threadpool and three async media routes call session() on the event loop
+    thread, so many threads enter session() concurrently and each commits the one shared
+    persistent session. Unserialized, that raises IllegalStateChangeError.
+    """
+    db_url = postgres_url or f"duckdb:///{tmp_path / 'concurrency.db'}"
+    # A pooled engine, not single_threaded: StaticPool hands the same connection to every
+    # session, so it cannot reproduce concurrent access.
+    engine = DatabaseEngine(engine_url=db_url)
+    persistent_session = engine.get_persistent_session()
+    original_commit = persistent_session.commit
+
+    counter_lock = threading.Lock()
+    commits_in_flight = 0
+    max_commits_in_flight = 0
+
+    def tracked_commit() -> None:
+        nonlocal commits_in_flight, max_commits_in_flight
+        with counter_lock:
+            commits_in_flight += 1
+            max_commits_in_flight = max(max_commits_in_flight, commits_in_flight)
+        # Widen the window so an unserialized commit is guaranteed to overlap.
+        time.sleep(0.01)
+        try:
+            original_commit()
+        finally:
+            with counter_lock:
+                commits_in_flight -= 1
+
+    # Force the commit branch. Otherwise the first caller ends the transaction and every
+    # later caller skips the commit, closing the window under test.
+    mocker.patch.object(persistent_session, "in_transaction", return_value=True)
+    mocker.patch.object(persistent_session, "commit", tracked_commit)
+
+    def read_in_session() -> None:
+        with engine.session() as session:
+            session.exec(sqlmodel.select(CollectionTable)).all()
+
+    try:
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(read_in_session) for _ in range(24)]
+            for future in futures:
+                future.result()
+    finally:
+        engine.close()
+
+    assert max_commits_in_flight == 1
+
+
+def test_get_persistent_session__concurrent_threads_share_one_session(
+    tmp_path: Path,
+    postgres_url: str | None,
+) -> None:
+    """Test that concurrent first-time callers all receive the same persistent session.
+
+    The lazy initialization is a check-then-set: unserialized, two threads can each build
+    a Session and one is silently dropped while it still holds a pool connection.
+    """
+    db_url = postgres_url or f"duckdb:///{tmp_path / 'lazy_init.db'}"
+    engine = DatabaseEngine(engine_url=db_url)
+    thread_count = 8
+    all_threads_ready = threading.Barrier(parties=thread_count)
+
+    def get_persistent_session() -> Session:
+        # Line the threads up so they race the lazy initialization.
+        all_threads_ready.wait()
+        return engine.get_persistent_session()
+
+    try:
+        with ThreadPoolExecutor(max_workers=thread_count) as pool:
+            futures = [pool.submit(get_persistent_session) for _ in range(thread_count)]
+            sessions = [future.result() for future in futures]
+    finally:
+        engine.close()
+
+    assert all(session is sessions[0] for session in sessions)
 
 
 def test_close__removes_wal_and_allows_reconnect(


### PR DESCRIPTION
## What has changed and why?

`DatabaseEngine` keeps one persistent session and commits it on both entry and exit of `session()`, but a SQLAlchemy `Session` is not thread-safe and `session()` runs concurrently on Starlette's threadpool, on the event loop thread via the async media routes, and on the Python API's own thread. Two overlapping commits raise `IllegalStateChangeError` and the request 500s. This guards every access to that session with a per-engine `RLock`, which also closes the unguarded lazy init that could build two sessions and leak one along with its pool connection. The lock is never held across the `yield`, so requests still run concurrently. Fixes #1964.

The pre-commit stays put: besides the foreign key workaround it documents, it is what lets the `StaticPool` test engines share one connection between the persistent and short-lived sessions, so dropping it breaks a lot of the suite. Python API code still commits that session without the lock, which remains racy under `start_gui_background()` — narrower than what this fixes, and noted as a TODO on the new helper.

## How has it been tested?

The new regression test fails before this change and passes after, on both DuckDB and Postgres, and `test_session_data_consistency` still pins the cross-session visibility contract. `make static-checks` and the full suite pass, except `test_server.py::test__get_available_port__preferred_port_in_use`, which also fails on a clean `main` locally and looks environmental. I also drove `TestClient` against a pooled engine with no `dependency_overrides`, so requests went through the real session dependency: that reproduced the reported traceback in roughly 1 of 60 concurrent requests before the change, and all 60 succeeded after.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database session handling to prevent intermittent GUI request failures during concurrent activity.
  * Serialized shared session commits while allowing requests to continue executing concurrently.
  * Ensured simultaneous initial requests consistently use the same persistent session.

* **Documentation**
  * Added an unreleased changelog entry describing the concurrency-related fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->