### PR TITLE
Check out the exact PR commit in fast track guardrails

### DIFF
--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -39,6 +39,7 @@ jobs:
         # restricts it to same-repo PRs, so untrusted fork code never reaches them.
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Detect which areas changed, so we install only the toolchains their guardrails need.
       - name: Detect changed areas


### PR DESCRIPTION
## What has changed and why?

Pin the checkout step to the PR's head commit SHA so the workflow runs against exactly what the author pushed, not a synthetic merge commit that GitHub creates internally.

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow checkouts to use the pull request’s specific commit, improving validation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->