### PR TITLE
LIG-10232 Add distribution percentage mode

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
+++ b/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
@@ -4,7 +4,11 @@
     import { BarChart as EchartsBarChart } from 'echarts/charts';
     import { GridComponent, LegendComponent, TooltipComponent } from 'echarts/components';
     import { CanvasRenderer } from 'echarts/renderers';
-    import { buildEchartsOption, type BarChartOrientation } from './buildEchartsOption';
+    import {
+        buildEchartsOption,
+        type BarChartOrientation,
+        type BarChartValueMode
+    } from './buildEchartsOption';
     import type { CategoryCount, CategoryCountSeries } from './types';
 
     echarts.use([
@@ -22,6 +26,8 @@
         series?: CategoryCountSeries[];
         /** Bar orientation (default 'vertical'). */
         orientation?: BarChartOrientation;
+        /** Whether bars show raw counts or percentages (default 'number'). */
+        valueMode?: BarChartValueMode;
         /**
          * Caps the chart width in px. Vertical bars scroll horizontally once they
          * exceed it; horizontal bars fill it. Defaults to the parent width.
@@ -50,6 +56,7 @@
         data,
         series = [],
         orientation = 'vertical',
+        valueMode = 'number',
         maxWidthPx,
         maxHeightPx,
         totalCount,
@@ -116,7 +123,13 @@
     $effect(() => {
         if (!chart) return;
         chart.setOption(
-            buildEchartsOption(data, { totalCount, orientation, series, gridTopPx }),
+            buildEchartsOption(data, {
+                totalCount,
+                orientation,
+                series,
+                valueMode,
+                gridTopPx
+            }),
             true
         );
     });

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -173,6 +173,25 @@ describe('buildEchartsOption', () => {
         expect(option.series.map((series) => series.data)).toEqual([[3], [1]]);
     });
 
+    it('shows each grouped series as its own percentage distribution', () => {
+        const option = buildEchartsOption(
+            [
+                { label: 'car', count: 4 },
+                { label: 'dog', count: 0 }
+            ],
+            { series: groupedSeries, valueMode: 'percentage' }
+        ) as {
+            yAxis: { max: number };
+            series: { data: number[] }[];
+        };
+
+        expect(option.yAxis.max).toBe(100);
+        expect(option.series.map((series) => series.data)).toEqual([
+            [100, 0],
+            [100, 0]
+        ]);
+    });
+
     it('uses stable colours and identifies every series in grouped tooltips', () => {
         expect(colorForSeries('tag-a')).toBe(colorForSeries('tag-a'));
         expect(colorForSeries('tag-a')).not.toBe(colorForSeries('tag-b'));

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -32,6 +32,7 @@ export function colorForSeries(id: string): string {
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
 export type BarChartOrientation = 'vertical' | 'horizontal';
+export type BarChartValueMode = 'number' | 'percentage';
 
 interface BuildEchartsOptionOptions {
     /**
@@ -46,6 +47,8 @@ interface BuildEchartsOptionOptions {
     gridTopPx?: number;
     /** Named grouped-bar series rendered instead of the single `data` series. */
     series?: CategoryCountSeries[];
+    /** Whether bars show raw counts or each series' percentage distribution. */
+    valueMode?: BarChartValueMode;
 }
 
 /** Builds the ECharts option for a category-count bar chart (pass to `setOption`). */
@@ -59,6 +62,7 @@ export function buildEchartsOption(
     const isHorizontal = orientation === 'horizontal';
     const groupedSeries = options.series ?? [];
     const isGrouped = groupedSeries.length > 0;
+    const valueMode = options.valueMode ?? 'number';
 
     const labels = data.map((item) => item.label);
     // When any category is actively selected, dim the rest — mirrors the range
@@ -96,25 +100,31 @@ export function buildEchartsOption(
         // Counts are whole numbers, so keep ticks on integer boundaries. Without
         // this, a max count of 1 makes ECharts split [0,1] into 0.2 steps and
         // render fractional labels (0, 0.2, 0.4 …).
-        minInterval: 1,
-        axisLabel: CHART_AXIS_LABEL,
+        minInterval: valueMode === 'number' ? 1 : undefined,
+        max: valueMode === 'percentage' ? 100 : undefined,
+        axisLabel:
+            valueMode === 'percentage'
+                ? { ...CHART_AXIS_LABEL, formatter: (value: number) => `${value}%` }
+                : CHART_AXIS_LABEL,
         splitLine: { lineStyle: { color: CHART_LINE_COLOR } }
     };
 
     const formatter = buildTooltipFormatter(totalCount);
+    const toChartValue = (count: number, denominator: number): number =>
+        valueMode === 'percentage' && denominator > 0 ? (count / denominator) * 100 : count;
 
     // Foreground bar: coloured at the filtered count (or full count when no filter).
     const foregroundData = data.map((item) => {
         // Simple items with no selection/filter state can be returned as raw numbers,
         // which ECharts renders without per-item itemStyle overhead.
         if (item.selected == null && item.selectable == null && item.filteredCount == null) {
-            return item.count;
+            return toChartValue(item.count, totalCount);
         }
         const foregroundCount =
             hasActiveFilter && item.filteredCount !== undefined ? item.filteredCount : item.count;
         const isDimmed = hasAnySelected && !item.selected;
         return {
-            value: foregroundCount,
+            value: toChartValue(foregroundCount, totalCount),
             itemStyle: {
                 color: isDimmed ? BAR_COLOR_DIMMED : BAR_COLOR,
                 opacity: item.selectable === false ? 0.45 : 1
@@ -139,7 +149,7 @@ export function buildEchartsOption(
         ? {
               type: 'bar',
               data: data.map((item) => ({
-                  value: item.count,
+                  value: toChartValue(item.count, totalCount),
                   itemStyle: {
                       color: BAR_COLOR_BACKGROUND,
                       opacity: item.selectable === false ? 0.45 : 1
@@ -160,11 +170,15 @@ export function buildEchartsOption(
               const countsByLabel = new Map(
                   item.data.map((count) => [count.label, count.count])
               );
+              const seriesTotal =
+                  item.totalCount ?? item.data.reduce((sum, count) => sum + count.count, 0);
               return {
                   id: item.id,
                   name: item.label,
                   type: 'bar',
-                  data: labels.map((label) => countsByLabel.get(label) ?? 0),
+                  data: labels.map((label) =>
+                      toChartValue(countsByLabel.get(label) ?? 0, seriesTotal)
+                  ),
                   itemStyle: { color: colorForSeries(item.id) },
                   barCategoryGap: '25%',
                   emphasis: CHART_EMPHASIS

--- a/lightly_studio_view/src/lib/components/BarChart/index.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/index.ts
@@ -1,3 +1,3 @@
 export { default as BarChart } from './BarChart.svelte';
 export type { CategoryCount, CategoryCountSeries } from './types';
-export type { BarChartOrientation } from './buildEchartsOption';
+export type { BarChartOrientation, BarChartValueMode } from './buildEchartsOption';

--- a/lightly_studio_view/src/lib/components/BarChart/types.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/types.ts
@@ -25,4 +25,6 @@ export interface CategoryCountSeries {
     id: string;
     label: string;
     data: CategoryCount[];
+    /** Full-series total, used when the visible data is a top-N subset. */
+    totalCount?: number;
 }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.svelte
@@ -142,7 +142,8 @@
         activeComparisonData.map((tag) => ({
             id: tag.sample_tag_id,
             label: tag.sample_tag_name,
-            data: tag.counts.map((item) => ({ label: item.label_name, count: item.count }))
+            data: tag.counts.map((item) => ({ label: item.label_name, count: item.count })),
+            totalCount: tag.counts.reduce((sum, item) => sum + item.count, 0)
         }))
     );
     // Rank the shared axis by the aggregate across tags; individual series stay independent.
@@ -209,7 +210,8 @@
         sortBy: 'count',
         manualClasses: [],
         orientation: 'horizontal',
-        countMode: untrack(() => initialCountMode)
+        countMode: untrack(() => initialCountMode),
+        valueMode: 'number'
     });
     const defaultCategoricalConfig: DistributionConfig = {
         mode: 'topN',
@@ -217,7 +219,8 @@
         sortBy: 'count',
         manualClasses: [],
         orientation: 'horizontal',
-        countMode: AnnotationCountMode.SAMPLES
+        countMode: AnnotationCountMode.SAMPLES,
+        valueMode: 'number'
     };
     let categoricalConfigs = $state<Record<string, DistributionConfig>>({});
     const categoricalConfig = $derived<DistributionConfig>(
@@ -228,6 +231,7 @@
               })
             : defaultCategoricalConfig
     );
+    let wasComparingTags = $state(false);
     let configDialogOpen = $state(false);
     let expandOpen = $state(false);
     let histogramExpandOpen = $state(false);
@@ -242,6 +246,14 @@
     let clientWidth = $state(0);
 
     const activeCountMode = $derived(config.countMode ?? AnnotationCountMode.OBJECTS);
+    const isComparingTags = $derived(
+        activeSource.id === 'classes' && selectedComparisonTagIds.length > 0
+    );
+    $effect(() => {
+        if (isComparingTags === wasComparingTags) return;
+        wasComparingTags = isComparingTags;
+        config = { ...config, valueMode: isComparingTags ? 'percentage' : 'number' };
+    });
     const showTotalCount = $derived(activeCountMode !== AnnotationCountMode.SAMPLES);
 
     const sourceItems = $derived<SelectItem[]>(
@@ -474,6 +486,7 @@
                 seriesCount={activeSeries.length || undefined}
                 {valueNoun}
                 onConfigure={() => (configDialogOpen = true)}
+                onValueModeChange={(valueMode) => (config = { ...config, valueMode })}
                 onShowAll={() => (config = { ...config, mode: 'topN', n: activeData.length })}
                 onToggleOrientation={() =>
                     (config = {
@@ -539,6 +552,7 @@
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
                 series={activeCategorical ? [] : visibleSeries}
+                valueMode={activeCategorical ? 'number' : config.valueMode}
                 onBarClick={activeCategorical ? handleCategoricalBarClick : onBarClick}
                 emptyState={activeCategorical ? categoricalEmptyState : undefined}
                 gridTopPx={4}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -253,6 +253,29 @@ describe('DatasetDistributionPanel', () => {
         await waitFor(() => expect(screen.getAllByText(/2 sample tags/)).toHaveLength(2));
     });
 
+    it('defaults tag comparisons to percentage and allows switching to numbers', async () => {
+        const user = userEvent.setup();
+        render(DatasetDistributionPanel, {
+            props: {
+                sources: [
+                    {
+                        id: 'classes',
+                        label: 'Annotation classes',
+                        comparisonData
+                    }
+                ],
+                selectedComparisonTagIds: ['tag-a', 'tag-b']
+            }
+        });
+
+        const valueMode = screen.getByTestId('dataset-distribution-value-mode');
+        await waitFor(() => expect(valueMode).toHaveTextContent('Percentage'));
+
+        await user.click(valueMode);
+        await user.click(screen.getByRole('option', { name: 'Number' }));
+        await waitFor(() => expect(valueMode).toHaveTextContent('Number'));
+    });
+
     it('renders comparison data from the selected annotation-type group', async () => {
         const user = userEvent.setup();
         render(DatasetDistributionPanel, {

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
@@ -84,6 +84,7 @@
             {categoryNounPlural}
             {sortLabels}
             onConfigure={() => (configDialogOpen = true)}
+            onValueModeChange={(valueMode) => onConfigChange({ ...config, valueMode })}
             onShowAll={() => onConfigChange({ ...config, mode: 'topN', n: data.length })}
             onToggleOrientation={() =>
                 onConfigChange({
@@ -103,6 +104,7 @@
                 maxWidthPx={clientWidth || undefined}
                 {totalCount}
                 series={visibleSeries}
+                valueMode={config.valueMode}
                 {onBarClick}
                 gridTopPx={4}
             />

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/PanelHeader/PanelHeader.svelte
@@ -6,6 +6,8 @@
         BarChartHorizontal as BarChartHorizontalIcon
     } from '@lucide/svelte';
     import { Button } from '$lib/components';
+    import { Select, type SelectItem } from '$lib/components/Select';
+    import type { BarChartValueMode } from '$lib/components/BarChart';
     import { DISTRIBUTION_SORT_LABELS, type DistributionConfig } from '../types';
 
     interface Props {
@@ -28,6 +30,8 @@
         sortLabels?: Record<keyof typeof DISTRIBUTION_SORT_LABELS, string>;
         /** Opens the view-config dialog (top-N and sort order). */
         onConfigure: () => void;
+        /** Switches the chart between raw counts and percentage distributions. */
+        onValueModeChange?: (mode: BarChartValueMode) => void;
         /** Quick action showing all classes; rendered only while a subset is visible. */
         onShowAll?: () => void;
         /** Toggles between vertical and horizontal bar layouts. */
@@ -49,11 +53,17 @@
         categoryNounPlural = 'classes',
         sortLabels = DISTRIBUTION_SORT_LABELS,
         onConfigure,
+        onValueModeChange,
         onShowAll,
         onToggleOrientation,
         onExpand,
         testIdPrefix = 'dataset-distribution'
     }: Props = $props();
+
+    const valueModeItems: SelectItem[] = [
+        { value: 'number', label: 'Number' },
+        { value: 'percentage', label: 'Percentage' }
+    ];
 </script>
 
 <div class="flex flex-row items-center gap-2">
@@ -99,6 +109,17 @@
                 onclick: onToggleOrientation,
                 'data-testid': `${testIdPrefix}-toggle-orientation`
             }}
+        />
+    {/if}
+    {#if onValueModeChange}
+        <Select
+            items={valueModeItems}
+            value={config.valueMode ?? 'number'}
+            size="xs"
+            class="w-28"
+            testId={`${testIdPrefix}-value-mode`}
+            selectProps={{ 'aria-label': 'Distribution value mode' }}
+            onValueChange={(value) => onValueModeChange(value as BarChartValueMode)}
         />
     {/if}
     <Button

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/types.ts
@@ -1,4 +1,4 @@
-import type { CategoryCount } from '$lib/components/BarChart';
+import type { BarChartValueMode, CategoryCount } from '$lib/components/BarChart';
 import type { ClassSetSelection } from '$lib/components/ClassSetConfig';
 import type {
     AnnotationCountMode,
@@ -119,4 +119,6 @@ export interface DistributionConfig extends ClassSetSelection<DistributionSortOp
     orientation: DistributionOrientation;
     /** Whether to count annotation objects or distinct annotated samples (default OBJECTS). */
     countMode?: AnnotationCountMode;
+    /** Whether categorical distributions show counts or percentages. */
+    valueMode?: BarChartValueMode;
 }


### PR DESCRIPTION
## What changed

- add a Number/Percentage selector to categorical distribution charts
- normalize each compared tag against its own total
- default tag comparisons to Percentage and ordinary distributions to Number
- keep the selected mode synchronized with the expanded chart

## Why

Comparing differently sized tag subsets by raw counts can obscure differences in their class distributions. Percentage mode makes those shapes directly comparable while preserving access to raw numbers.

## Impact

Users can switch the distribution chart between raw values and percentages. Selecting tags starts in Percentage mode by default.

## Validation

- frontend static checks
- 55 focused BarChart and DatasetDistributionPanel tests

## Stack

Base: #1703 (`kondrat-lig-10241-coverage-sample-tag-class-distribution-comparison`)

Linear: [LIG-10232](https://linear.app/lightly/issue/LIG-10232/compare-class-distributions-across-selected-tags)