### PR TITLE
LIG-10232 Show number and percentage in distribution tooltips

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -68,6 +68,7 @@ describe('buildEchartsOption', () => {
                             value: number;
                             seriesName?: string;
                             marker?: string;
+                            seriesIndex?: number;
                         }[]
                     ) => string;
                 };
@@ -204,6 +205,19 @@ describe('buildEchartsOption', () => {
                 { name: 'car', value: 3, seriesName: 'Reviewed', marker: '● ' },
                 { name: 'car', value: 1, seriesName: 'Priority', marker: '■ ' }
             ])
-        ).toBe('<b>car</b><br/>● Reviewed: <b>3</b><br/>■ Priority: <b>1</b>');
+        ).toBe('<b>car</b><br/>● Reviewed: <b>3</b> (100.0%)<br/>■ Priority: <b>1</b> (100.0%)');
+    });
+
+    it('keeps raw counts and percentages in percentage-mode tooltips', () => {
+        const formatter = getFormatter(
+            buildEchartsOption([{ label: 'car', count: 20 }], {
+                totalCount: 80,
+                valueMode: 'percentage'
+            })
+        );
+
+        expect(formatter([{ name: 'car', value: 25 }])).toBe(
+            '<b>car</b><br/>Count: <b>20</b> (25.0%)'
+        );
     });
 });

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -1,9 +1,14 @@
 import type { EChartsCoreOption } from 'echarts/core';
 import escape from 'lodash-es/escape';
 import { truncate } from 'lodash-es';
-import { CHART_AXIS_LABEL, CHART_EMPHASIS, CHART_LINE_COLOR, CHART_TEXT_COLOR } from '$lib/utils';
+import {
+    CHART_AXIS_LABEL,
+    CHART_EMPHASIS,
+    CHART_LINE_COLOR,
+    CHART_TEXT_COLOR,
+    formatPercent
+} from '$lib/utils';
 import type { CategoryCount, CategoryCountSeries } from './';
-import { buildTooltipFormatter } from './buildTooltipFormatter';
 
 // Same accent as Histogram (the Lightly primary green, --color-lightly-primary #3bd99f).
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
@@ -50,6 +55,19 @@ interface BuildEchartsOptionOptions {
     /** Whether bars show raw counts or each series' percentage distribution. */
     valueMode?: BarChartValueMode;
 }
+
+interface TooltipParam {
+    name: string;
+    value: number;
+    seriesName?: string;
+    seriesIndex?: number;
+    marker?: string;
+}
+
+const formatTooltipValue = (count: number, total: number): string => {
+    const percent = total > 0 ? ` (${formatPercent(count / total)})` : '';
+    return `<b>${count}</b>${percent}`;
+};
 
 /** Builds the ECharts option for a category-count bar chart (pass to `setOption`). */
 export function buildEchartsOption(
@@ -109,7 +127,6 @@ export function buildEchartsOption(
         splitLine: { lineStyle: { color: CHART_LINE_COLOR } }
     };
 
-    const formatter = buildTooltipFormatter(totalCount);
     const toChartValue = (count: number, denominator: number): number =>
         valueMode === 'percentage' && denominator > 0 ? (count / denominator) * 100 : count;
 
@@ -192,25 +209,27 @@ export function buildEchartsOption(
             trigger: 'axis',
             axisPointer: { type: 'shadow' },
             appendTo: 'body',
-            formatter: isGrouped
-                ? (
-                      params: {
-                          name: string;
-                          value: number;
-                          seriesName?: string;
-                          marker?: string;
-                      }[]
-                  ) => {
-                      if (params.length === 0) return '';
-                      const values = params
-                          .map(
-                              (item) =>
-                                  `${item.marker ?? ''}${escape(item.seriesName ?? '')}: <b>${item.value}</b>`
-                          )
-                          .join('<br/>');
-                      return `<b>${escape(params[0].name)}</b><br/>${values}`;
-                  }
-                : formatter
+            formatter: (params: TooltipParam[]) => {
+                if (params.length === 0) return '';
+                const [{ name }] = params;
+                if (isGrouped) {
+                    const values = params
+                        .map((item, index) => {
+                            const series = groupedSeries[item.seriesIndex ?? index];
+                            const count =
+                                series?.data.find((entry) => entry.label === name)?.count ?? 0;
+                            const seriesTotal =
+                                series?.totalCount ??
+                                series?.data.reduce((sum, entry) => sum + entry.count, 0) ??
+                                0;
+                            return `${item.marker ?? ''}${escape(item.seriesName ?? '')}: ${formatTooltipValue(count, seriesTotal)}`;
+                        })
+                        .join('<br/>');
+                    return `<b>${escape(name)}</b><br/>${values}`;
+                }
+                const count = data.find((entry) => entry.label === name)?.count ?? 0;
+                return `<b>${escape(name)}</b><br/>Count: ${formatTooltipValue(count, totalCount)}`;
+            }
         },
         legend: isGrouped
             ? { type: 'scroll', top: 0, textStyle: { color: CHART_TEXT_COLOR } }

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/ExpandDialog/ExpandDialog.svelte
@@ -70,7 +70,7 @@
         <Dialog.Header>
             <Dialog.Title>Distribution</Dialog.Title>
             <Dialog.Description>
-                Hover a bar for the full {categoryNoun} name and count
+                Hover a bar for the full {categoryNoun} name, number, and percentage
             </Dialog.Description>
         </Dialog.Header>
         <PanelHeader


### PR DESCRIPTION
## What changed

- show both the raw number and percentage for every hovered bar
- calculate grouped-series percentages independently per tag
- keep tooltip values based on raw data when bar heights are percentages
- update expanded-chart guidance

## Why

The chart display mode should not hide the complementary value. Users need both the absolute size and relative share when inspecting a class.

## Impact

Hovering any distribution bar shows its number and percentage in both Number and Percentage modes.

## Validation

- frontend static checks
- 16 focused BarChart and expanded-dialog tests

## Stack

Depends on #1967.

Linear: [LIG-10232](https://linear.app/lightly/issue/LIG-10232/compare-class-distributions-across-selected-tags)