### PR TITLE
LIG-10232 Make distribution series colors distinct

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -208,6 +208,21 @@ describe('buildEchartsOption', () => {
         ).toBe('<b>car</b><br/>● Reviewed: <b>3</b> (100.0%)<br/>■ Priority: <b>1</b> (100.0%)');
     });
 
+    it('resolves palette collisions between visible series', () => {
+        const collidingSeries = [
+            { id: 'a', label: 'First', data: [{ label: 'car', count: 1 }] },
+            { id: 'k', label: 'Second', data: [{ label: 'car', count: 1 }] }
+        ];
+        expect(colorForSeries('a')).toBe(colorForSeries('k'));
+
+        const option = buildEchartsOption([{ label: 'car', count: 2 }], {
+            series: collidingSeries
+        }) as { series: { itemStyle: { color: string; borderWidth: number } }[] };
+
+        expect(option.series[0].itemStyle.color).not.toBe(option.series[1].itemStyle.color);
+        expect(option.series.every((series) => series.itemStyle.borderWidth === 1)).toBe(true);
+    });
+
     it('keeps raw counts and percentages in percentage-mode tooltips', () => {
         const formatter = getFormatter(
             buildEchartsOption([{ label: 'car', count: 20 }], {

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -26,13 +26,33 @@ const SERIES_COLORS = [
     '#76B7B2',
     '#EDC948',
     '#FF9DA7',
-    '#9C755F'
+    '#9C755F',
+    '#BAB0AC'
 ];
 
 /** Maps a stable series ID to the same accessible chart colour across renders. */
 export function colorForSeries(id: string): string {
-    const hash = [...id].reduce((value, character) => value * 31 + character.charCodeAt(0), 0);
-    return SERIES_COLORS[Math.abs(hash) % SERIES_COLORS.length];
+    const index = [...id].reduce(
+        (value, character) => (value * 31 + character.charCodeAt(0)) % SERIES_COLORS.length,
+        0
+    );
+    return SERIES_COLORS[index];
+}
+
+/** Resolves hash collisions so simultaneously visible series always differ. */
+function assignSeriesColors(seriesIds: string[]): Map<string, string> {
+    const colors = new Map<string, string>();
+    const usedColors = new Set<string>();
+    for (const id of seriesIds) {
+        let index = SERIES_COLORS.indexOf(colorForSeries(id));
+        while (usedColors.has(SERIES_COLORS[index]) && usedColors.size < SERIES_COLORS.length) {
+            index = (index + 1) % SERIES_COLORS.length;
+        }
+        const color = SERIES_COLORS[index];
+        colors.set(id, color);
+        usedColors.add(color);
+    }
+    return colors;
 }
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
@@ -80,6 +100,7 @@ export function buildEchartsOption(
     const isHorizontal = orientation === 'horizontal';
     const groupedSeries = options.series ?? [];
     const isGrouped = groupedSeries.length > 0;
+    const groupedColors = assignSeriesColors(groupedSeries.map((series) => series.id));
     const valueMode = options.valueMode ?? 'number';
 
     const labels = data.map((item) => item.label);
@@ -196,7 +217,11 @@ export function buildEchartsOption(
                   data: labels.map((label) =>
                       toChartValue(countsByLabel.get(label) ?? 0, seriesTotal)
                   ),
-                  itemStyle: { color: colorForSeries(item.id) },
+                  itemStyle: {
+                      color: groupedColors.get(item.id),
+                      borderColor: 'rgba(255,255,255,0.75)',
+                      borderWidth: 1
+                  },
                   barCategoryGap: '25%',
                   emphasis: CHART_EMPHASIS
               };


### PR DESCRIPTION
## What changed

- detect color-hash collisions among visible tag series
- assign the next unused qualitative palette color when a collision occurs
- add a subtle contrasting border between adjacent grouped bars
- cover colliding tag IDs with a regression test

## Why

Stable color hashing could map multiple selected tags to the same color, making their series difficult or impossible to distinguish.

## Impact

Visible tag series now receive distinct colors until the qualitative palette is exhausted, while colors remain deterministic when no collision exists.

## Validation

- frontend static checks
- 12 focused BarChart option tests

## Stack

Depends on #1968 (and #1967).

Linear: [LIG-10232](https://linear.app/lightly/issue/LIG-10232/compare-class-distributions-across-selected-tags)