### PR TITLE
LIG-10232 Align distribution select styles

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -205,9 +205,7 @@ export function buildEchartsOption(
         : [foregroundSeries];
     const chartSeries = isGrouped
         ? groupedSeries.map((item) => {
-              const countsByLabel = new Map(
-                  item.data.map((count) => [count.label, count.count])
-              );
+              const countsByLabel = new Map(item.data.map((count) => [count.label, count.count]));
               const seriesTotal =
                   item.totalCount ?? item.data.reduce((sum, count) => sum + count.count, 0);
               return {

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/TagComparisonSelect.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/TagComparisonSelect.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Check, ChevronsUpDown } from '@lucide/svelte';
+    import { Check, ChevronDown } from '@lucide/svelte';
     import { Button } from '$lib/components/ui/button';
     import * as Command from '$lib/components/ui/command';
     import * as Popover from '$lib/components/ui/popover';
@@ -33,13 +33,13 @@
         <Button
             variant="outline"
             size="sm"
-            class="h-8 min-w-0 flex-1 justify-between"
+            class="m-0 h-8 min-w-0 flex-1 justify-start gap-2 rounded-md px-3 text-xs font-normal"
             role="combobox"
             aria-expanded={open}
             data-testid="dataset-distribution-tag-select"
         >
             <span class="truncate">{label}</span>
-            <ChevronsUpDown class="ml-2 shrink-0 opacity-50" />
+            <ChevronDown class="ml-auto size-4 shrink-0 opacity-50" />
         </Button>
     </Popover.Trigger>
     <Popover.Content class="w-[260px] p-0">


### PR DESCRIPTION
## What changed

- align the sample-tag multi-select with the standard distribution selects
- use the same compact text size, normal weight, height, padding, and left alignment
- replace the bidirectional chevrons with the standard down-chevron treatment

## Why

The custom comparison selector looked visually heavier than the source, annotation-type, and value-mode selects beside it.

## Impact

Distribution controls now use a consistent select-box appearance while preserving searchable multi-selection behavior.

## Validation

- frontend static checks
- focused `TagComparisonSelect` component tests: 2 passed

## Stack

Depends on #1969 and is intended as the new top layer of native stack #1970.

Linear: [LIG-10232](https://linear.app/lightly/issue/LIG-10232/compare-class-distributions-across-selected-tags)