### PR TITLE
Scope export jobs to their collection and enforce it in export_download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Scope export downloads to the collection they were prepared for, so an export key from one collection can no longer be used to download an export prepared for a different collection.
+
 ## \[1.0.5\] - 2026-08-14
 
 ### Added

--- a/lightly_studio/src/lightly_studio/api/routes/api/export.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/export.py
@@ -110,7 +110,9 @@ def export_collection_prepare(
     output_path = temp_dir / filename
     try:
         output_path.write_text("\n".join(exported))
-        export = export_job_resolver.create(session=session, export_path=str(output_path))
+        export = export_job_resolver.create(
+            session=session, collection_id=collection.collection_id, export_path=str(output_path)
+        )
     except Exception:
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise
@@ -145,7 +147,9 @@ def export_collection_youtube_vis_prepare(
             samples=dataset_query,
             output_json=output_path,
         )
-        export = export_job_resolver.create(session=session, export_path=str(output_path))
+        export = export_job_resolver.create(
+            session=session, collection_id=collection.collection_id, export_path=str(output_path)
+        )
     except Exception:
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise
@@ -187,7 +191,9 @@ def export_collection_annotations_prepare(
             annotation_collection_id=body.annotation_collection_id,
             temp_dir=temp_dir,
         )
-        export = export_job_resolver.create(session=session, export_path=str(export_path))
+        export = export_job_resolver.create(
+            session=session, collection_id=collection.collection_id, export_path=str(export_path)
+        )
     except Exception:
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise
@@ -220,7 +226,9 @@ def export_collection_captions_prepare(
             dataset_id=collection.dataset_id,
             samples=dataset_query,
         ).to_coco_captions(output_json=output_path)
-        export = export_job_resolver.create(session=session, export_path=str(output_path))
+        export = export_job_resolver.create(
+            session=session, collection_id=collection.collection_id, export_path=str(output_path)
+        )
     except Exception:
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise
@@ -230,7 +238,7 @@ def export_collection_captions_prepare(
 
 @export_router.get("/export/download/{export_key}")
 def export_download(
-    _collection: Annotated[
+    collection: Annotated[
         CollectionTable,
         Path(title="collection Id"),
         Depends(collection_api.get_and_validate_collection_id),
@@ -240,7 +248,7 @@ def export_download(
 ) -> StreamingResponse:
     """Stream the export identified by *export_key*."""
     job = export_job_resolver.get(session=session, export_key=export_key)
-    if job is None:
+    if job is None or job.collection_id != collection.collection_id:
         raise NotFoundError("Export key not found.")
 
     export_path = PathlibPath(job.export_path)

--- a/lightly_studio/src/lightly_studio/migrations/versions/1786917600_a3b4c5d6e7f8_scope_export_job_to_collection.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1786917600_a3b4c5d6e7f8_scope_export_job_to_collection.py
@@ -43,8 +43,11 @@ def _remove_existing_export_artifacts() -> None:
     for export_path in export_paths:
         resolved_path = Path(export_path).resolve()
         try:
-            resolved_path.relative_to(temp_dir)
+            relative_path = resolved_path.relative_to(temp_dir)
         except ValueError:
+            continue
+        if relative_path == Path():
+            # Equality is not raised by `relative_to`; reject the temp directory root itself.
             continue
         if resolved_path.is_dir():
             shutil.rmtree(resolved_path, ignore_errors=True)

--- a/lightly_studio/src/lightly_studio/migrations/versions/1786917600_a3b4c5d6e7f8_scope_export_job_to_collection.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1786917600_a3b4c5d6e7f8_scope_export_job_to_collection.py
@@ -5,7 +5,8 @@ Adds ``export_job.collection_id`` so a download request can be rejected when the
 prepared for. Existing rows are dropped first: an export job outlives only the
 single prepare/download round trip, its ``export_path`` points at a temp
 directory, and rows left over from before this migration cannot be attributed
-to a collection.
+to a collection. Their on-disk artifacts are removed before the rows are
+dropped, since deleting the row is the only reference to where they live.
 
 Revision ID: a3b4c5d6e7f8
 Revises: b7c8d9e0f1a2
@@ -13,7 +14,10 @@ Create Date: 2026-08-17 00:00:00.000000
 
 """
 
+import shutil
+import tempfile
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Union
 
 import sqlalchemy as sa
@@ -26,8 +30,31 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _remove_existing_export_artifacts() -> None:
+    """Remove the on-disk artifact of every existing export job.
+
+    Every ``export_path`` is generated under the system temp directory (see
+    ``lightly_studio.api.routes.api.export``); paths outside of it are left untouched rather
+    than removed, since they cannot be confirmed to be export-owned.
+    """
+    connection = op.get_bind()
+    export_paths = connection.execute(sa.text("SELECT export_path FROM export_job")).scalars()
+    temp_dir = Path(tempfile.gettempdir()).resolve()
+    for export_path in export_paths:
+        resolved_path = Path(export_path).resolve()
+        try:
+            resolved_path.relative_to(temp_dir)
+        except ValueError:
+            continue
+        if resolved_path.is_dir():
+            shutil.rmtree(resolved_path, ignore_errors=True)
+        else:
+            resolved_path.unlink(missing_ok=True)
+
+
 def upgrade() -> None:
     """Upgrade schema."""
+    _remove_existing_export_artifacts()
     op.execute(sa.text("DELETE FROM export_job"))
     op.add_column("export_job", sa.Column("collection_id", sa.Uuid(), nullable=False))
     op.create_index(

--- a/lightly_studio/src/lightly_studio/migrations/versions/1786917600_a3b4c5d6e7f8_scope_export_job_to_collection.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1786917600_a3b4c5d6e7f8_scope_export_job_to_collection.py
@@ -1,0 +1,49 @@
+"""scope_export_job_to_collection.
+
+Adds ``export_job.collection_id`` so a download request can be rejected when the
+``collection_id`` in the path does not match the collection the export was
+prepared for. Existing rows are dropped first: an export job outlives only the
+single prepare/download round trip, its ``export_path`` points at a temp
+directory, and rows left over from before this migration cannot be attributed
+to a collection.
+
+Revision ID: a3b4c5d6e7f8
+Revises: b7c8d9e0f1a2
+Create Date: 2026-08-17 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a3b4c5d6e7f8"
+down_revision: Union[str, Sequence[str], None] = "b7c8d9e0f1a2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute(sa.text("DELETE FROM export_job"))
+    op.add_column("export_job", sa.Column("collection_id", sa.Uuid(), nullable=False))
+    op.create_index(
+        op.f("ix_export_job_collection_id"), "export_job", ["collection_id"], unique=False
+    )
+    op.create_foreign_key(
+        "fk_export_job_collection_id",
+        "export_job",
+        "collection",
+        ["collection_id"],
+        ["collection_id"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("fk_export_job_collection_id", "export_job", type_="foreignkey")
+    op.drop_index(op.f("ix_export_job_collection_id"), table_name="export_job")
+    op.drop_column("export_job", "collection_id")

--- a/lightly_studio/src/lightly_studio/models/export_job.py
+++ b/lightly_studio/src/lightly_studio/models/export_job.py
@@ -13,6 +13,8 @@ class ExportJobTable(SQLModel, table=True):
 
     Attributes:
         export_key: Unique identifier for the export job (primary key).
+        collection_id: Collection the export was prepared for; downloads are
+            rejected unless the requested collection matches.
         export_path: Absolute path to the pre-generated export file or directory.
         created_at: Timestamp when the export job was created.
     """
@@ -20,5 +22,6 @@ class ExportJobTable(SQLModel, table=True):
     __tablename__ = "export_job"
 
     export_key: UUID = Field(default_factory=uuid4, primary_key=True)
+    collection_id: UUID = Field(foreign_key="collection.collection_id", index=True)
     export_path: str
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -4,6 +4,9 @@ This is an enterprise-only / PostgreSQL-only operation. It deletes everything be
 dataset with server-side, set-based ``DELETE``s scoped by subquery, so no rows cross the Python
 boundary. All deletes run in a single transaction with one final commit.
 
+The one exception is ``export_job``: its row is the only reference to where its on-disk artifact
+lives, so the affected paths are selected into Python and removed before the rows are deleted.
+
 The per-table scoping below is the source of truth for what gets deleted. If a new table with a
 dataset/sample/collection FK is added, add a delete here; ``verify_table_coverage()`` fails fast
 until you do.
@@ -11,6 +14,10 @@ until you do.
 
 from __future__ import annotations
 
+import logging
+import shutil
+import tempfile
+from pathlib import Path
 from uuid import UUID
 
 from sqlmodel import Session, col, delete, select
@@ -52,6 +59,8 @@ from lightly_studio.resolvers.dataset_resolver import table_coverage_utils
 # of deleted rows. Nothing is loaded in this session, so we disable synchronization and the delete
 # runs entirely server-side with bounded memory regardless of dataset size.
 _DELETE_EXECUTION_OPTIONS = {"synchronize_session": False}
+
+logger = logging.getLogger(__name__)
 
 
 def delete_dataset(
@@ -369,13 +378,43 @@ def _delete_evaluation_runs(session: Session, dataset_id: UUID) -> None:
 
 
 def _delete_export_jobs(session: Session, dataset_id: UUID) -> None:
-    """Delete export jobs for the dataset's collections."""
+    """Remove export artifacts, then delete export jobs for the dataset's collections."""
+    export_paths = session.exec(
+        select(ExportJobTable.export_path).where(
+            col(ExportJobTable.collection_id).in_(_collection_ids_subquery(dataset_id))
+        )
+    ).all()
+    for export_path in export_paths:
+        _remove_export_artifact(export_path)
     session.exec(
         delete(ExportJobTable).where(
             col(ExportJobTable.collection_id).in_(_collection_ids_subquery(dataset_id))
         ),
         execution_options=_DELETE_EXECUTION_OPTIONS,
     )
+
+
+def _remove_export_artifact(export_path: str) -> None:
+    """Best-effort removal of an export job's on-disk artifact.
+
+    Every ``export_path`` is generated under the system temp directory (see
+    ``lightly_studio.api.routes.api.export``); paths outside of it are left untouched rather than
+    removed, since they cannot be confirmed to be export-owned.
+
+    Args:
+        export_path: Absolute path to the export job's file or directory.
+    """
+    resolved_path = Path(export_path).resolve()
+    temp_dir = Path(tempfile.gettempdir()).resolve()
+    try:
+        resolved_path.relative_to(temp_dir)
+    except ValueError:
+        logger.warning("Skipping export artifact outside the temp directory: %s", export_path)
+        return
+    if resolved_path.is_dir():
+        shutil.rmtree(resolved_path, ignore_errors=True)
+    else:
+        resolved_path.unlink(missing_ok=True)
 
 
 def _delete_collections(session: Session, dataset_id: UUID) -> None:

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -34,6 +34,7 @@ from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricTable
+from lightly_studio.models.export_job import ExportJobTable
 from lightly_studio.models.group import GroupTable, SampleGroupLinkTable
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.metadata import SampleMetadataTable
@@ -112,6 +113,7 @@ def delete_dataset(
     _delete_embedding_models(session=session, dataset_id=dataset_id)
     _delete_object_tracks(session=session, dataset_id=dataset_id)
     _delete_evaluation_runs(session=session, dataset_id=dataset_id)
+    _delete_export_jobs(session=session, dataset_id=dataset_id)
 
     # 6. Collections (single statement; self-FK satisfied at statement end).
     _delete_collections(session=session, dataset_id=dataset_id)
@@ -361,6 +363,16 @@ def _delete_evaluation_runs(session: Session, dataset_id: UUID) -> None:
             col(EvaluationRunTable.gt_annotation_collection_id).in_(
                 _collection_ids_subquery(dataset_id)
             )
+        ),
+        execution_options=_DELETE_EXECUTION_OPTIONS,
+    )
+
+
+def _delete_export_jobs(session: Session, dataset_id: UUID) -> None:
+    """Delete export jobs for the dataset's collections."""
+    session.exec(
+        delete(ExportJobTable).where(
+            col(ExportJobTable.collection_id).in_(_collection_ids_subquery(dataset_id))
         ),
         execution_options=_DELETE_EXECUTION_OPTIONS,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -407,9 +407,15 @@ def _remove_export_artifact(export_path: str) -> None:
     resolved_path = Path(export_path).resolve()
     temp_dir = Path(tempfile.gettempdir()).resolve()
     try:
-        resolved_path.relative_to(temp_dir)
+        relative_path = resolved_path.relative_to(temp_dir)
     except ValueError:
         logger.warning("Skipping export artifact outside the temp directory: %s", export_path)
+        return
+    if relative_path == Path():
+        # Equality is not raised by `relative_to`; reject the temp directory root itself.
+        logger.warning(
+            "Skipping export artifact that is the temp directory itself: %s", export_path
+        )
         return
     if resolved_path.is_dir():
         shutil.rmtree(resolved_path, ignore_errors=True)

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -8,13 +8,15 @@ until they are updated to handle the new tables.
 from sqlmodel import SQLModel
 
 # Tables handled by deep_copy and delete_dataset.
-_HANDLED_TABLES_COUNT = 24
+# - export_job is handled by delete_dataset only (its collection_id FK must be cleared
+#   before the collection is deleted); deep_copy intentionally leaves it alone since a job
+#   is a transient download token, not data worth duplicating.
+_HANDLED_TABLES_COUNT = 25
 
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)
 # - two_dim_embeddings (cached projections, regenerated as needed)
-# - export_job (application-level, no dataset/collection FK)
-_EXCLUDED_TABLES_COUNT = 3
+_EXCLUDED_TABLES_COUNT = 2
 
 _TOTAL_TABLES_COUNT = _HANDLED_TABLES_COUNT + _EXCLUDED_TABLES_COUNT
 

--- a/lightly_studio/src/lightly_studio/resolvers/export_job_resolver/create.py
+++ b/lightly_studio/src/lightly_studio/resolvers/export_job_resolver/create.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from sqlmodel import Session
 
 from lightly_studio.models.export_job import ExportJobTable
@@ -9,18 +11,20 @@ from lightly_studio.models.export_job import ExportJobTable
 
 def create(
     session: Session,
+    collection_id: UUID,
     export_path: str,
 ) -> ExportJobTable:
     """Persist a new export job and return it.
 
     Args:
         session: Database session.
+        collection_id: Collection the export was prepared for.
         export_path: Absolute path to the pre-generated export file or directory.
 
     Returns:
         The created ExportJobTable row.
     """
-    job = ExportJobTable(export_path=export_path)
+    job = ExportJobTable(collection_id=collection_id, export_path=export_path)
     session.add(job)
     session.commit()
     session.refresh(job)

--- a/lightly_studio/tests/api/routes/api/test_export.py
+++ b/lightly_studio/tests/api/routes/api/test_export.py
@@ -123,6 +123,31 @@ def test_export_download__not_found_returns_404(
     assert response.status_code == HTTP_STATUS_NOT_FOUND
 
 
+def test_export_download__wrong_collection_returns_404(
+    tmp_path: Path,
+    db_session: Session,
+    test_client: TestClient,
+) -> None:
+    owning_collection = create_collection(session=db_session)
+    other_collection = create_collection(session=db_session)
+
+    export_path = tmp_path / "export.json"
+    export_path.write_text('{"items": [1, 2, 3]}')
+    job = export_job_resolver.create(
+        session=db_session,
+        collection_id=owning_collection.collection_id,
+        export_path=str(export_path),
+    )
+
+    response = test_client.get(
+        f"/api/collections/{other_collection.collection_id}/export/download/{job.export_key}"
+    )
+
+    assert response.status_code == HTTP_STATUS_NOT_FOUND
+    assert export_job_resolver.get(session=db_session, export_key=job.export_key) is not None
+    assert export_path.exists()
+
+
 def test_export_download__json_file_streams_content_and_deletes_job(
     tmp_path: Path,
     db_session: Session,
@@ -135,7 +160,9 @@ def test_export_download__json_file_streams_content_and_deletes_job(
     export_path = export_dir / "export.json"
     export_path.write_text('{"items": [1, 2, 3]}')
 
-    job = export_job_resolver.create(session=db_session, export_path=str(export_path))
+    job = export_job_resolver.create(
+        session=db_session, collection_id=collection.collection_id, export_path=str(export_path)
+    )
 
     response = test_client.get(
         f"/api/collections/{collection.collection_id}/export/download/{job.export_key}"
@@ -162,7 +189,9 @@ def test_export_download__txt_file_streams_content_and_deletes_job(
     export_path = export_dir / "export.txt"
     export_path.write_text("path/a.jpg\npath/b.jpg\n")
 
-    job = export_job_resolver.create(session=db_session, export_path=str(export_path))
+    job = export_job_resolver.create(
+        session=db_session, collection_id=collection.collection_id, export_path=str(export_path)
+    )
 
     response = test_client.get(
         f"/api/collections/{collection.collection_id}/export/download/{job.export_key}"
@@ -187,7 +216,9 @@ def test_export_download__csv_file_streams_content_and_deletes_job(
     export_dir.mkdir()
     export_path = export_dir / "classification_export.csv"
     export_path.write_text("file_path_abs,class_name\n/data/img1.jpg,cat\n")
-    job = export_job_resolver.create(session=db_session, export_path=str(export_path))
+    job = export_job_resolver.create(
+        session=db_session, collection_id=collection.collection_id, export_path=str(export_path)
+    )
 
     response = test_client.get(
         f"/api/collections/{collection.collection_id}/export/download/{job.export_key}"
@@ -217,7 +248,9 @@ def test_export_download__directory_streams_as_zip_and_deletes_job(
     export_dir.mkdir()
     (export_dir / "labels.txt").write_text("cat\ndog\n")
 
-    job = export_job_resolver.create(session=db_session, export_path=str(export_dir))
+    job = export_job_resolver.create(
+        session=db_session, collection_id=collection.collection_id, export_path=str(export_dir)
+    )
 
     response = test_client.get(
         f"/api/collections/{collection.collection_id}/export/download/{job.export_key}"

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -17,6 +17,7 @@ from lightly_studio.resolvers import (
     evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
     evaluation_sample_metric_resolver,
+    export_job_resolver,
     metadata_resolver,
     sample_embedding_resolver,
     sample_resolver,
@@ -203,6 +204,28 @@ def test_delete_dataset__with_tags(db_session: Session) -> None:
     # Assert - collection and tags deleted
     assert collection_resolver.get_by_id(session=db_session, collection_id=collection_id) is None
     assert tag_resolver.get_by_id(session=db_session, tag_id=tag_id) is None
+
+
+def test_delete_dataset__with_export_job(db_session: Session) -> None:
+    # Arrange
+    dataset = create_collection(session=db_session, collection_name="to_delete")
+    collection_id = dataset.collection_id  # Capture before delete
+    job = export_job_resolver.create(
+        session=db_session,
+        collection_id=collection_id,
+        export_path="/exports/coco.json",
+    )
+    export_key = job.export_key  # Capture before delete
+
+    # Act
+    dataset_resolver.delete_dataset(
+        session=db_session,
+        dataset_id=dataset.dataset_id,
+    )
+
+    # Assert - collection and its export job deleted
+    assert collection_resolver.get_by_id(session=db_session, collection_id=collection_id) is None
+    assert export_job_resolver.get(session=db_session, export_key=export_key) is None
 
 
 def test_delete_dataset__does_not_affect_other_datasets(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -1,8 +1,10 @@
 """Tests for delete_dataset resolver."""
 
 import uuid
+from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.models.annotation.annotation_base import AnnotationType
@@ -206,14 +208,16 @@ def test_delete_dataset__with_tags(db_session: Session) -> None:
     assert tag_resolver.get_by_id(session=db_session, tag_id=tag_id) is None
 
 
-def test_delete_dataset__with_export_job(db_session: Session) -> None:
+def test_delete_dataset__with_export_job(db_session: Session, tmp_path: Path) -> None:
     # Arrange
     dataset = create_collection(session=db_session, collection_name="to_delete")
     collection_id = dataset.collection_id  # Capture before delete
+    export_path = tmp_path / "coco.json"
+    export_path.write_text("{}")
     job = export_job_resolver.create(
         session=db_session,
         collection_id=collection_id,
-        export_path="/exports/coco.json",
+        export_path=str(export_path),
     )
     export_key = job.export_key  # Capture before delete
 
@@ -223,9 +227,68 @@ def test_delete_dataset__with_export_job(db_session: Session) -> None:
         dataset_id=dataset.dataset_id,
     )
 
-    # Assert - collection and its export job deleted
+    # Assert - collection, export job, and its on-disk artifact are all gone
     assert collection_resolver.get_by_id(session=db_session, collection_id=collection_id) is None
     assert export_job_resolver.get(session=db_session, export_key=export_key) is None
+    assert not export_path.exists()
+
+
+def test_delete_dataset__with_export_job__removes_directory_artifact(
+    db_session: Session, tmp_path: Path
+) -> None:
+    # Arrange
+    dataset = create_collection(session=db_session, collection_name="to_delete")
+    collection_id = dataset.collection_id  # Capture before delete
+    export_dir = tmp_path / "yolo"
+    export_dir.mkdir()
+    (export_dir / "labels.txt").write_text("cat")
+    job = export_job_resolver.create(
+        session=db_session,
+        collection_id=collection_id,
+        export_path=str(export_dir),
+    )
+    export_key = job.export_key  # Capture before delete
+
+    # Act
+    dataset_resolver.delete_dataset(
+        session=db_session,
+        dataset_id=dataset.dataset_id,
+    )
+
+    # Assert - export job and its directory artifact are both gone
+    assert export_job_resolver.get(session=db_session, export_key=export_key) is None
+    assert not export_dir.exists()
+
+
+def test_delete_dataset__with_export_job__leaves_artifact_outside_temp_dir(
+    db_session: Session, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    # Arrange - the fake temp directory does not contain the export artifact below
+    mocker.patch(
+        "lightly_studio.resolvers.dataset_resolver.delete_dataset.tempfile.gettempdir",
+        return_value=str(tmp_path / "temp"),
+    )
+    dataset = create_collection(session=db_session, collection_name="to_delete")
+    collection_id = dataset.collection_id  # Capture before delete
+    export_path = tmp_path / "outside" / "coco.json"
+    export_path.parent.mkdir()
+    export_path.write_text("{}")
+    job = export_job_resolver.create(
+        session=db_session,
+        collection_id=collection_id,
+        export_path=str(export_path),
+    )
+    export_key = job.export_key  # Capture before delete
+
+    # Act
+    dataset_resolver.delete_dataset(
+        session=db_session,
+        dataset_id=dataset.dataset_id,
+    )
+
+    # Assert - the DB row is gone but the untrusted artifact path is left untouched
+    assert export_job_resolver.get(session=db_session, export_key=export_key) is None
+    assert export_path.exists()
 
 
 def test_delete_dataset__does_not_affect_other_datasets(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/export_job_resolver/test_create.py
+++ b/lightly_studio/tests/resolvers/export_job_resolver/test_create.py
@@ -5,13 +5,18 @@ from uuid import UUID
 from sqlmodel import Session
 
 from lightly_studio.resolvers import export_job_resolver
+from tests.helpers_resolvers import create_collection
 
 
 def test_create(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+
     job = export_job_resolver.create(
         session=db_session,
+        collection_id=collection.collection_id,
         export_path="/exports/coco.json",
     )
 
     assert isinstance(job.export_key, UUID)
+    assert job.collection_id == collection.collection_id
     assert job.export_path == "/exports/coco.json"

--- a/lightly_studio/tests/resolvers/export_job_resolver/test_delete.py
+++ b/lightly_studio/tests/resolvers/export_job_resolver/test_delete.py
@@ -5,11 +5,14 @@ from uuid import uuid4
 from sqlmodel import Session
 
 from lightly_studio.resolvers import export_job_resolver
+from tests.helpers_resolvers import create_collection
 
 
 def test_delete(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
     job = export_job_resolver.create(
         session=db_session,
+        collection_id=collection.collection_id,
         export_path="/exports/coco.json",
     )
 

--- a/lightly_studio/tests/resolvers/export_job_resolver/test_get.py
+++ b/lightly_studio/tests/resolvers/export_job_resolver/test_get.py
@@ -5,11 +5,14 @@ from uuid import uuid4
 from sqlmodel import Session
 
 from lightly_studio.resolvers import export_job_resolver
+from tests.helpers_resolvers import create_collection
 
 
 def test_get(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
     job = export_job_resolver.create(
         session=db_session,
+        collection_id=collection.collection_id,
         export_path="/exports/coco_captions.json",
     )
 


### PR DESCRIPTION
## What has changed and why?

`export_download` declared the `collection_id` path dependency but never used it (`_collection`), and `export_job` had no collection/dataset FK at all — just `export_key` plus an absolute `export_path`. So any valid `export_key` could stream any export file, regardless of the `collection_id` in the path.

Fixes LIG-10432 by:
- Adding `collection_id` to `export_job`, set at creation by all four prepare endpoints.
- Rejecting `export_download` when the path's `collection_id` doesn't match the job's (404, same as an unknown key).
- Scoping `delete_dataset` to also delete `export_job` rows for the dataset's collections, since the new FK would otherwise block deleting a collection with a pending export job.
- An Alembic migration adding the column/FK/index (existing rows are dropped first — they cannot be attributed to a collection and are just leftover, mid-flight download tokens).

## How has it been tested?

```
cd lightly_studio
make static-checks
make test
```

Both pass. Added a regression test asserting a download request with a mismatched `collection_id` returns 404 and leaves the job/file untouched, plus a `delete_dataset` test covering the new FK-driven cleanup.

`make test-postgres` and `make migration-check-postgresql` were not run (no Docker/Postgres available in this environment) — worth a run in CI before merge.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Export downloads are restricted to the collection that requested the export.
  * Attempts to access an export from another collection return a not-found response.

* **Data Management**
  * Export jobs and their temporary files are automatically removed when the associated dataset is deleted.
  * Files outside the temporary export location are preserved.

* **Documentation**
  * Added an unreleased changelog entry documenting the export access restriction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->