### PR TITLE
docs: add PR description & reviewer guidance to pull-requests skill

### DIFF
--- a/.agents/skills/pull-requests/SKILL.md
+++ b/.agents/skills/pull-requests/SKILL.md
@@ -47,7 +47,7 @@ review together.
 
 - Follow `.github/pull_request_template.md`. Keep the description short and human readable.
 - Assign the reviewer most likely to help, based on `git blame`/`git log` history of the touched
-  files or lines, and recommend a second one at the end of the description.
+  files or lines, and recommend an alternative one at the end of the description.
 - For a stack of PRs, prefer the same reviewer(s) for each item in the stack, unless the items
   can be reviewed independently.
 

--- a/.agents/skills/pull-requests/SKILL.md
+++ b/.agents/skills/pull-requests/SKILL.md
@@ -46,9 +46,9 @@ review together.
 ### 4. Description & Suggested Reviewers
 
 - Follow `.github/pull_request_template.md`. Keep the description short and human readable.
-- At the end of the description, suggest 2 reviewers likely to help, based on `git blame`/`git
-  log` history of the touched files or lines.
-- For a stack of PRs, suggest the same reviewer(s) for each item in the stack, unless the items
+- Assign the reviewer most likely to help, based on `git blame`/`git log` history of the touched
+  files or lines, and recommend a second one at the end of the description.
+- For a stack of PRs, prefer the same reviewer(s) for each item in the stack, unless the items
   can be reviewed independently.
 
 ## Exceptions

--- a/.agents/skills/pull-requests/SKILL.md
+++ b/.agents/skills/pull-requests/SKILL.md
@@ -43,6 +43,14 @@ means:
 In some cases, the tests or a docs change may be in a separate PR if it would be too large to
 review together.
 
+### 4. Description & Suggested Reviewers
+
+- Follow `.github/pull_request_template.md`. Keep the description short and human readable.
+- At the end of the description, suggest 2 reviewers likely to help, based on `git blame`/`git
+  log` history of the touched files or lines.
+- For a stack of PRs, suggest the same reviewer(s) for each item in the stack, unless the items
+  can be reviewed independently.
+
 ## Exceptions
 
 Some PRs will not fit the normal shape. Examples:


### PR DESCRIPTION
## What has changed and why?

Adds a short "Description & Suggested Reviewers" subsection to the `pull-requests` skill: point PR descriptions at `.github/pull_request_template.md` but keep them short and human readable, assign the top reviewer from git blame history, and recommend an alternative one at the end of the description. For stacked PRs, prefer the same reviewer across the stack unless items can be reviewed independently.

## How has it been tested?

Docs-only change; read through the updated `SKILL.md` to confirm formatting matches the rest of the file.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)

---

Assigned @ikondrat (top contributor via `git blame` on `.agents/skills/pull-requests/SKILL.md`). Alternative reviewer: @michal-lightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for writing concise pull request descriptions.
  * Documented reviewer assignment practices, including history-based selection and consistency across stacked pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->