### PR TITLE
Move the annotation source visibility rules into one hook

### DIFF
--- a/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
@@ -20,8 +20,12 @@
         (annotationCollectionsQuery.data ?? []).map((c) => ({ id: c.collection_id, name: c.name }))
     );
 
-    const { setSelectedCollectionIds, selectedCollectionIds, seedSelectionIfNeeded } =
-        useAnnotationCollectionsFilter();
+    const {
+        setSelectedCollectionIds,
+        selectedCollectionIds,
+        multipleSourcesVisible,
+        seedSelectionIfNeeded
+    } = useAnnotationCollectionsFilter();
     const { enforceColoringByClassStore } = useSettings();
     const { trackEvent } = usePostHog();
 
@@ -51,7 +55,7 @@
     <Segment title="Annotation Sources">
         <SideMenu
             showColorMarker={resolveEffectiveColorBySource({
-                multipleSourcesVisible: $selectedCollectionIds.length > 1,
+                multipleSourcesVisible: $multipleSourcesVisible,
                 enforceColoringByClass: $enforceColoringByClassStore
             })}
             enableColorPicker

--- a/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.test.ts
@@ -25,15 +25,17 @@ vi.mock('$lib/hooks/useAnnotationCollections/useAnnotationCollections', () => ({
 }));
 
 vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter', async () => {
-    const { writable } = await import('svelte/store');
+    const { derived, writable } = await import('svelte/store');
     // A real writable backs the store so the controlled checkboxes reflect intermediate
     // state across consecutive toggles.
     mocks.selectedCollectionIds = writable<string[]>([]);
     mocks.setSelectedCollectionIds = vi.fn((ids: string[]) => mocks.selectedCollectionIds.set(ids));
+    const multipleSourcesVisible = derived(mocks.selectedCollectionIds, ($ids) => $ids.length > 1);
     return {
         useAnnotationCollectionsFilter: vi.fn(() => ({
             selectedCollectionIds: mocks.selectedCollectionIds,
             setSelectedCollectionIds: mocks.setSelectedCollectionIds,
+            multipleSourcesVisible,
             seedSelectionIfNeeded: mocks.seedSelectionIfNeeded
         }))
     };

--- a/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationsGrid/AnnotationClassificationGridItem/AnnotationClassificationGridItem.svelte
@@ -71,8 +71,5 @@
     aria-selected={selected}
     style="width: {containerWidth}px; height: {containerHeight}px; background-image: url('{thumbnailUrl}'); background-size: cover; background-position: center;"
 >
-    <SampleClassificationPills
-        sample={{ annotations: [annotation.annotation] }}
-        selectedCollectionIds={[]}
-    />
+    <SampleClassificationPills sample={{ annotations: [annotation.annotation] }} showAllSources />
 </div>

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
@@ -26,13 +26,13 @@
         showVisibilityToggle = false
     }: Props = $props();
 
-    const { selectedCollectionIds } = useAnnotationCollectionsFilter();
+    const { multipleSourcesVisible } = useAnnotationCollectionsFilter();
     const { enforceColoringByClassStore } = useSettings();
     const { hiddenClassNamesStore, toggleClassVisibility } = useAnnotationClassVisibility();
 
     const showClassColorLegend = $derived(
         !resolveEffectiveColorBySource({
-            multipleSourcesVisible: $selectedCollectionIds.length > 1,
+            multipleSourcesVisible: $multipleSourcesVisible,
             enforceColoringByClass: $enforceColoringByClassStore
         })
     );

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.test.ts
@@ -13,11 +13,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter', async () => {
-    const { writable } = await import('svelte/store');
+    const { derived, writable } = await import('svelte/store');
     mocks.selectedCollectionIds = writable<string[]>([]);
+    const multipleSourcesVisible = derived(mocks.selectedCollectionIds, ($ids) => $ids.length > 1);
     return {
         useAnnotationCollectionsFilter: () => ({
-            selectedCollectionIds: mocks.selectedCollectionIds
+            selectedCollectionIds: mocks.selectedCollectionIds,
+            multipleSourcesVisible
         })
     };
 });

--- a/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotation/SampleAnnotation.svelte
@@ -45,12 +45,12 @@
     } = $props();
 
     const { customLabelColorsStore } = useCustomLabelColors();
-    const { selectedCollectionIds, collectionIdToName } = useAnnotationCollectionsFilter();
+    const { multipleSourcesVisible, collectionIdToName } = useAnnotationCollectionsFilter();
 
     const label = $derived(annotation.annotation_label.annotation_label_name);
 
     const colorLabel = $derived.by(() => {
-        const bySource = colorBySource ?? $selectedCollectionIds.length >= 2;
+        const bySource = colorBySource ?? $multipleSourcesVisible;
         if (!bySource) return label;
         return $collectionIdToName[annotation.annotation_collection_id] ?? label;
     });

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.svelte
@@ -35,7 +35,8 @@
     const { isHidden } = useHideAnnotations();
     const { hiddenClassNamesStore } = useAnnotationClassVisibility();
     const { showBoundingBoxesForSegmentationStore, enforceColoringByClassStore } = useSettings();
-    const { selectedCollectionIds, collectionIdToName } = useAnnotationCollectionsFilter();
+    const { isSourceVisible, multipleSourcesVisible, collectionIdToName } =
+        useAnnotationCollectionsFilter();
 
     // Normalize backend annotation variants into the smaller canvas render contract.
     const mapToCanvasAnnotation = (
@@ -72,20 +73,16 @@
 
     const annotationsWithVisuals: AnnotationCanvasAnnotation[] = $derived.by(() => {
         const showInstanceSegmentationBoundingBoxes = $showBoundingBoxesForSegmentationStore;
-        const selectedIds = $selectedCollectionIds;
+        const sourceIsVisible = $isSourceVisible;
         const idToName = $collectionIdToName;
         const hiddenClasses = $hiddenClassNamesStore;
         const colorBySource = resolveEffectiveColorBySource({
-            multipleSourcesVisible: selectedIds.length > 1,
+            multipleSourcesVisible: $multipleSourcesVisible,
             enforceColoringByClass: $enforceColoringByClassStore
         });
 
         return sample.annotations
-            .filter(
-                (annotation) =>
-                    selectedIds.length === 0 ||
-                    selectedIds.includes(annotation.annotation_collection_id)
-            )
+            .filter((annotation) => sourceIsVisible(annotation.annotation_collection_id))
             .filter((annotation) => annotation.annotation_type !== 'classification')
             .filter(
                 (annotation) =>

--- a/lightly_studio_view/src/lib/components/SampleClassificationPills/SampleClassificationPills.svelte
+++ b/lightly_studio_view/src/lib/components/SampleClassificationPills/SampleClassificationPills.svelte
@@ -15,31 +15,33 @@
         hasBottomOverlay?: boolean;
         hasRightOverlay?: boolean;
         /**
-         * When provided, overrides the collection filter from `useAnnotationCollectionsFilter`.
-         * Pass `[]` to show all annotations regardless of the active source filter (e.g. in the
-         * annotations grid, where the tile already represents a single annotation).
+         * Shows every annotation regardless of the active source filter, and colors pills by
+         * class. Used where the tile already represents a single annotation or a video, so the
+         * grid's source filter does not apply.
          */
-        selectedCollectionIds?: string[];
+        showAllSources?: boolean;
     }
 
     let {
         sample,
         hasBottomOverlay = false,
         hasRightOverlay = false,
-        selectedCollectionIds: selectedCollectionIdsOverride = undefined
+        showAllSources = false
     }: Props = $props();
 
     let containerWidth = $state(0);
     let pillsWidth = $state(0);
 
-    const { selectedCollectionIds, collectionIdToName } = useAnnotationCollectionsFilter();
+    const { isSourceVisible, multipleSourcesVisible, collectionIdToName } =
+        useAnnotationCollectionsFilter();
     const { customLabelColorsStore } = useCustomLabelColors();
     const { enforceColoringByClassStore } = useSettings();
 
     const pills = $derived(
         getSampleClassificationPills({
             annotations: sample.annotations,
-            selectedCollectionIds: selectedCollectionIdsOverride ?? $selectedCollectionIds,
+            isSourceVisible: showAllSources ? () => true : $isSourceVisible,
+            multipleSourcesVisible: showAllSources ? false : $multipleSourcesVisible,
             collectionIdToName: $collectionIdToName,
             enforceColoringByClass: $enforceColoringByClassStore
         })

--- a/lightly_studio_view/src/lib/components/SampleClassificationPills/getSampleClassificationPills.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleClassificationPills/getSampleClassificationPills.test.ts
@@ -37,6 +37,19 @@ function createAnnotation({
     };
 }
 
+/**
+ * Builds the source-visibility params from a selection, mirroring what
+ * `useAnnotationCollectionsFilter` derives. Keeps these tests about pills rather than about
+ * the selection rule, which `useAnnotationCollectionsFilter.test.ts` covers.
+ */
+function sourceFilter(selectedCollectionIds: string[]) {
+    return {
+        isSourceVisible: (sourceId: string) =>
+            selectedCollectionIds.length === 0 || selectedCollectionIds.includes(sourceId),
+        multipleSourcesVisible: selectedCollectionIds.length > 1
+    };
+}
+
 describe('getSampleClassificationPills', () => {
     it('returns only visible classification annotations', () => {
         const pills = getSampleClassificationPills({
@@ -55,7 +68,7 @@ describe('getSampleClassificationPills', () => {
                     annotationType: AnnotationType.OBJECT_DETECTION
                 })
             ],
-            selectedCollectionIds: ['collection-1'],
+            ...sourceFilter(['collection-1']),
             collectionIdToName: {
                 'collection-1': 'Animals',
                 'collection-2': 'Vehicles'
@@ -86,7 +99,7 @@ describe('getSampleClassificationPills', () => {
                     annotationLabelName: 'car'
                 })
             ],
-            selectedCollectionIds: [],
+            ...sourceFilter([]),
             collectionIdToName: {
                 'collection-1': 'Source A',
                 'collection-2': 'Source B'
@@ -117,7 +130,7 @@ describe('getSampleClassificationPills', () => {
                     annotationLabelName: 'car'
                 })
             ],
-            selectedCollectionIds: ['collection-1', 'collection-2'],
+            ...sourceFilter(['collection-1', 'collection-2']),
             collectionIdToName: {
                 'collection-1': 'Source A',
                 'collection-2': 'Source B'
@@ -159,7 +172,7 @@ describe('getSampleClassificationPills', () => {
                     annotationLabelName: 'apple'
                 })
             ],
-            selectedCollectionIds: ['collection-b', 'collection-a'],
+            ...sourceFilter(['collection-b', 'collection-a']),
             collectionIdToName: {
                 'collection-a': 'Collection A',
                 'collection-b': 'Collection B'
@@ -182,7 +195,7 @@ describe('getSampleClassificationPills', () => {
                     annotationLabelName: 'person'
                 })
             ],
-            selectedCollectionIds: ['missing-collection', 'collection-2'],
+            ...sourceFilter(['missing-collection', 'collection-2']),
             collectionIdToName: {
                 'collection-2': 'Known Source'
             },
@@ -216,7 +229,7 @@ describe('getSampleClassificationPills', () => {
                     annotationLabelName: 'truck'
                 })
             ],
-            selectedCollectionIds: ['collection-1', 'collection-2'],
+            ...sourceFilter(['collection-1', 'collection-2']),
             collectionIdToName: {
                 'collection-1': 'Ground Truth',
                 'collection-2': 'Predictions'
@@ -246,7 +259,7 @@ describe('getSampleClassificationPills', () => {
                     annotationLabelName: 'hippopotamus'
                 })
             ],
-            selectedCollectionIds: [],
+            ...sourceFilter([]),
             collectionIdToName: {},
             enforceColoringByClass: false
         });

--- a/lightly_studio_view/src/lib/components/SampleClassificationPills/getSampleClassificationPills.ts
+++ b/lightly_studio_view/src/lib/components/SampleClassificationPills/getSampleClassificationPills.ts
@@ -3,7 +3,10 @@ import { resolveEffectiveColorBySource } from '$lib/utils';
 
 interface GetSampleClassificationPillsParams {
     annotations: AnnotationView[];
-    selectedCollectionIds: string[];
+    /** Whether annotations from a given source should be shown. */
+    isSourceVisible: (sourceId: string) => boolean;
+    /** Whether more than one source is visible, which switches pill colors to per-source. */
+    multipleSourcesVisible: boolean;
     collectionIdToName: Record<string, string>;
     enforceColoringByClass: boolean;
 }
@@ -30,13 +33,6 @@ export interface SampleClassificationPill {
     displayLabel: string;
     colorKey: string;
     title: string;
-}
-
-function isVisibleAnnotation(annotation: AnnotationView, selectedCollectionIds: string[]): boolean {
-    return (
-        selectedCollectionIds.length === 0 ||
-        selectedCollectionIds.includes(annotation.annotation_collection_id)
-    );
 }
 
 function isClassificationAnnotation(annotation: AnnotationView): boolean {
@@ -77,18 +73,19 @@ function dedupeAndSortPills(pills: SampleClassificationPill[]): SampleClassifica
 
 export function getSampleClassificationPills({
     annotations,
-    selectedCollectionIds,
+    isSourceVisible,
+    multipleSourcesVisible,
     collectionIdToName,
     enforceColoringByClass
 }: GetSampleClassificationPillsParams): SampleClassificationPill[] {
     const showSourceColors = resolveEffectiveColorBySource({
-        multipleSourcesVisible: selectedCollectionIds.length > 1,
+        multipleSourcesVisible,
         enforceColoringByClass
     });
 
     return dedupeAndSortPills(
         annotations
-            .filter((annotation) => isVisibleAnnotation(annotation, selectedCollectionIds))
+            .filter((annotation) => isSourceVisible(annotation.annotation_collection_id))
             .filter(isClassificationAnnotation)
             .map((annotation) =>
                 createSampleClassificationPill({

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -72,7 +72,7 @@
     });
 
     const annotationCollectionsQuery = useAnnotationCollections(() => ({ collectionId }));
-    const { selectedCollectionIds } = useAnnotationCollectionsFilter();
+    const { selectedCollectionIds, multipleSourcesVisible } = useAnnotationCollectionsFilter();
     const annotationSources = $derived(annotationCollectionsQuery.data ?? []);
     const isGrouped = $derived(annotationSources.length > 1);
     const sourceGroups = $derived(
@@ -89,7 +89,7 @@
     // coloring is not enforced, mirroring the annotation segment and canvas behavior.
     const colorBySource = $derived(
         resolveEffectiveColorBySource({
-            multipleSourcesVisible: $selectedCollectionIds.length > 1,
+            multipleSourcesVisible: $multipleSourcesVisible,
             enforceColoringByClass: $enforceColoringByClassStore
         })
     );

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -35,7 +35,8 @@ vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilte
     const { readable } = await import('svelte/store');
     return {
         useAnnotationCollectionsFilter: vi.fn(() => ({
-            selectedCollectionIds: readable(mocks.selectedCollectionIds)
+            selectedCollectionIds: readable(mocks.selectedCollectionIds),
+            multipleSourcesVisible: readable(mocks.selectedCollectionIds.length > 1)
         }))
     };
 });

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsSidePanel/SampleDetailsSidePanelAnnotation/SampleDetailsSidePanelAnnotation.svelte
@@ -80,8 +80,8 @@
     // Label colors only match the boxes on the image while they are not colored by
     // source. The colorBySource prop drives this on the details page; the global
     // selection rule is the fallback, mirroring the behavior of LabelsMenu.
-    const { selectedCollectionIds } = useAnnotationCollectionsFilter();
-    const showLabelColorLegend = $derived(!(colorBySource ?? $selectedCollectionIds.length >= 2));
+    const { multipleSourcesVisible } = useAnnotationCollectionsFilter();
+    const showLabelColorLegend = $derived(!(colorBySource ?? $multipleSourcesVisible));
 
     const annotationId = $derived(annotationProp.sample_id);
 

--- a/lightly_studio_view/src/lib/components/VideoItem/VideoItem.svelte
+++ b/lightly_studio_view/src/lib/components/VideoItem/VideoItem.svelte
@@ -183,7 +183,7 @@
         sample={{ annotations: videoClassificationAnnotations }}
         hasBottomOverlay={Boolean(caption)}
         hasRightOverlay={video.similarity_score !== undefined && video.similarity_score !== null}
-        selectedCollectionIds={[]}
+        showAllSources
     />
     {#if video.similarity_score !== undefined && video.similarity_score !== null}
         <div

--- a/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.test.ts
@@ -52,4 +52,39 @@ describe('useAnnotationCollectionsFilter', () => {
 
         expect(get(selectedCollectionIds)).toEqual(['a', 'b']);
     });
+
+    describe('isSourceVisible', () => {
+        it('shows only the selected sources', async () => {
+            const { isSourceVisible, setSelectedCollectionIds, seedSelectionIfNeeded } =
+                await importHook();
+
+            seedSelectionIfNeeded('collection-1', sources);
+            setSelectedCollectionIds(['gt']);
+
+            expect(get(isSourceVisible)('gt')).toBe(true);
+            expect(get(isSourceVisible)('pred')).toBe(false);
+        });
+
+        it('shows every source while the selection is empty', async () => {
+            const { isSourceVisible } = await importHook();
+
+            expect(get(isSourceVisible)('gt')).toBe(true);
+            expect(get(isSourceVisible)('pred')).toBe(true);
+        });
+    });
+
+    describe('multipleSourcesVisible', () => {
+        it('is true only while more than one source is selected', async () => {
+            const { multipleSourcesVisible, setSelectedCollectionIds, seedSelectionIfNeeded } =
+                await importHook();
+
+            expect(get(multipleSourcesVisible)).toBe(false);
+
+            seedSelectionIfNeeded('collection-1', sources);
+            expect(get(multipleSourcesVisible)).toBe(true);
+
+            setSelectedCollectionIds(['gt']);
+            expect(get(multipleSourcesVisible)).toBe(false);
+        });
+    });
 });

--- a/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.ts
@@ -1,7 +1,21 @@
-import { writable } from 'svelte/store';
+import { derived, writable, type Readable } from 'svelte/store';
 
 const selectedCollectionIds = writable<string[]>([]);
 const collectionIdToName = writable<Record<string, string>>({});
+
+// Whether annotations from a given source should be drawn. An empty selection means the filter
+// has not been seeded for this collection yet, so nothing is filtered out.
+const isSourceVisible: Readable<(sourceId: string) => boolean> = derived(
+    selectedCollectionIds,
+    ($ids) => (sourceId: string) => $ids.length === 0 || $ids.includes(sourceId)
+);
+
+// Annotations are colored per source instead of per class while more than one source is
+// visible. Pass this to resolveEffectiveColorBySource rather than reading the selection length.
+const multipleSourcesVisible: Readable<boolean> = derived(
+    selectedCollectionIds,
+    ($ids) => $ids.length > 1
+);
 
 // Remembers which annotation collection the grid filter was last seeded for.
 // Module-level so it survives component remounts (e.g. grid <-> image details), which lets
@@ -13,6 +27,8 @@ export const useAnnotationCollectionsFilter = () => {
     return {
         selectedCollectionIds,
         setSelectedCollectionIds: (ids: string[]) => selectedCollectionIds.set(ids),
+        isSourceVisible,
+        multipleSourcesVisible,
         collectionIdToName,
         setCollectionIdToName: (map: Record<string, string>) => collectionIdToName.set(map),
         /**


### PR DESCRIPTION
## What has changed and why?

This is the first of two PRs. The second one fixes a reported bug: in the annotation grid, unchecking every annotation source made every box reappear instead of hiding them all. That fix has to change both of the rules that decide how boxes are drawn, and those rules were copy-pasted across the view. Moving them into one place first keeps the fix small enough to read.

So the rules move first. Whether a box from a given source is drawn (duplicated in 3 files) and whether boxes are colored per source instead of per class (7 files) now live in `useAnnotationCollectionsFilter`, as `isSourceVisible` and `multipleSourcesVisible`. `SampleClassificationPills` picks up the same treatment, swapping its empty-selection override for an explicit `showAllSources` prop.

Nothing changes for the user.

## How has it been tested?

`make static-checks` in `lightly_studio_view` is clean, and `npx vitest run` passes 2593 unit tests. No new behavior to test, so the existing suite is the check.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved annotation source filtering across grids, details, labels, and classification views.
  * Empty source selections now display annotations from all available sources.
  * Added consistent source-based coloring and legend behavior when multiple sources are visible.
  * Classification pills can now explicitly display all annotation sources.

* **Bug Fixes**
  * Corrected source visibility and color handling when selections change.

* **Tests**
  * Added coverage for source visibility, multiple-source states, and classification filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->