### PR TITLE
Scope the annotation source filter to the current collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix requests failing intermittently while the GUI is under load, caused by concurrent access to a shared database session.
+- Hide every bounding box when all annotation sources are unchecked, instead of showing them all.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix requests failing intermittently while the GUI is under load, caused by concurrent access to a shared database session.
-- Hide every bounding box when all annotation sources are unchecked, instead of showing them all.
+- Hide every bounding box and its annotation counts when all annotation sources are unchecked, instead of showing them all.
 
 ### Security
 

--- a/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.svelte
@@ -20,24 +20,15 @@
         (annotationCollectionsQuery.data ?? []).map((c) => ({ id: c.collection_id, name: c.name }))
     );
 
-    const {
-        setSelectedCollectionIds,
-        selectedCollectionIds,
-        multipleSourcesVisible,
-        seedSelectionIfNeeded
-    } = useAnnotationCollectionsFilter();
+    const { setSelectedCollectionIds, selectedCollectionIds, multipleSourcesVisible } =
+        useAnnotationCollectionsFilter();
     const { enforceColoringByClassStore } = useSettings();
     const { trackEvent } = usePostHog();
 
+    // Checkboxes are only worth showing when there is a choice to make. The selection itself is
+    // filled by useSeedAnnotationSourceFilter in the collection layout, which runs for every
+    // collection including those with a single source.
     const isEnabled = $derived(items.length > 1);
-
-    // Seed all sources the first time this collection is shown; remounts (e.g. returning
-    // from image details) keep the user's existing selection. See seedSelectionIfNeeded.
-    $effect(() => {
-        if (isEnabled) {
-            seedSelectionIfNeeded(collectionId, items);
-        }
-    });
 
     const handleChangeSelectedItems = (newIds: string[]) => {
         handleAnnotationSourceFilterChange({

--- a/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/AnnotationCollectionsMenu/AnnotationCollectionsMenu.test.ts
@@ -16,7 +16,6 @@ const mocks = vi.hoisted(() => ({
     collections: [] as { collection_id: string; name: string }[],
     selectedCollectionIds: null as unknown as Writable<string[]>,
     setSelectedCollectionIds: vi.fn(),
-    seedSelectionIfNeeded: vi.fn(),
     enforceColoringByClassStore: null as unknown as Writable<boolean>
 }));
 
@@ -35,8 +34,7 @@ vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilte
         useAnnotationCollectionsFilter: vi.fn(() => ({
             selectedCollectionIds: mocks.selectedCollectionIds,
             setSelectedCollectionIds: mocks.setSelectedCollectionIds,
-            multipleSourcesVisible,
-            seedSelectionIfNeeded: mocks.seedSelectionIfNeeded
+            multipleSourcesVisible
         }))
     };
 });
@@ -74,25 +72,6 @@ describe('AnnotationCollectionsMenu', () => {
         render(AnnotationCollectionsMenu, defaultProps);
         expect(screen.queryByText('Annotation Sources')).not.toBeInTheDocument();
         expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
-    });
-
-    it('does not seed the annotation source filter when there is only one collection', () => {
-        mocks.collections = [{ collection_id: 'c1', name: 'Ground Truth' }];
-        render(AnnotationCollectionsMenu, defaultProps);
-        expect(mocks.seedSelectionIfNeeded).not.toHaveBeenCalled();
-    });
-
-    it('seeds the annotation source filter with all collections when there are two or more', () => {
-        mocks.collections = [
-            { collection_id: 'c1', name: 'Dogs' },
-            { collection_id: 'c2', name: 'Cats' }
-        ];
-        render(AnnotationCollectionsMenu, defaultProps);
-
-        expect(mocks.seedSelectionIfNeeded).toHaveBeenCalledWith('col-1', [
-            { id: 'c1', name: 'Dogs' },
-            { id: 'c2', name: 'Cats' }
-        ]);
     });
 
     it('renders a menu item for each collection when there are two or more', () => {

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.svelte
@@ -26,7 +26,7 @@
         showVisibilityToggle = false
     }: Props = $props();
 
-    const { multipleSourcesVisible } = useAnnotationCollectionsFilter();
+    const { multipleSourcesVisible, allSourcesHidden } = useAnnotationCollectionsFilter();
     const { enforceColoringByClassStore } = useSettings();
     const { hiddenClassNamesStore, toggleClassVisibility } = useAnnotationClassVisibility();
 
@@ -40,7 +40,14 @@
 
 <Segment title="Annotation Classes">
     <div class="width-full space-y-2 overflow-hidden">
-        {#if $annotationFilterRows.length === 0}
+        {#if $allSourcesHidden}
+            <!-- The rows are empty here because every source is unchecked, not because the
+                 dataset has no annotations. Say so, otherwise the message below sends the user
+                 off to import annotations they already have. -->
+            <p class="text-sm text-diffuse-foreground" data-testid="labels-menu-no-sources">
+                No annotation sources selected. Select one to see its annotation classes.
+            </p>
+        {:else if $annotationFilterRows.length === 0}
             <p class="text-sm text-diffuse-foreground">
                 No annotations yet.
                 <a

--- a/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.test.ts
+++ b/lightly_studio_view/src/lib/components/LabelsMenu/LabelsMenu.test.ts
@@ -7,6 +7,7 @@ import type { Annotation } from '$lib/types';
 
 const mocks = vi.hoisted(() => ({
     selectedCollectionIds: null as unknown as Writable<string[]>,
+    allSourcesHidden: null as unknown as Writable<boolean>,
     enforceColoringByClassStore: null as unknown as Writable<boolean>,
     hiddenClassNamesStore: null as unknown as Writable<string[]>,
     toggleClassVisibility: vi.fn()
@@ -15,10 +16,12 @@ const mocks = vi.hoisted(() => ({
 vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter', async () => {
     const { derived, writable } = await import('svelte/store');
     mocks.selectedCollectionIds = writable<string[]>([]);
+    mocks.allSourcesHidden = writable<boolean>(false);
     const multipleSourcesVisible = derived(mocks.selectedCollectionIds, ($ids) => $ids.length > 1);
     return {
         useAnnotationCollectionsFilter: () => ({
             selectedCollectionIds: mocks.selectedCollectionIds,
+            allSourcesHidden: mocks.allSourcesHidden,
             multipleSourcesVisible
         })
     };
@@ -82,6 +85,7 @@ describe('LabelsMenu', () => {
 
     beforeEach(() => {
         mocks.selectedCollectionIds.set([]);
+        mocks.allSourcesHidden.set(false);
         mocks.enforceColoringByClassStore.set(false);
         mocks.hiddenClassNamesStore.set([]);
         mocks.toggleClassVisibility.mockReset();
@@ -112,6 +116,21 @@ describe('LabelsMenu', () => {
         expect(screen.getAllByTestId('labels-menu-item')).toHaveLength(2);
         expect(screen.getByText('car')).toBeInTheDocument();
         expect(screen.getByText('person')).toBeInTheDocument();
+    });
+
+    it('explains the empty list when every annotation source is unchecked', () => {
+        mocks.allSourcesHidden.set(true);
+        render(LabelsMenu, { ...defaultProps, annotationFilterRows: writable<Annotation[]>([]) });
+
+        expect(screen.getByTestId('labels-menu-no-sources')).toBeInTheDocument();
+        expect(screen.queryByText(/No annotations yet/)).not.toBeInTheDocument();
+    });
+
+    it('points at labeling when the collection genuinely has no annotations', () => {
+        render(LabelsMenu, { ...defaultProps, annotationFilterRows: writable<Annotation[]>([]) });
+
+        expect(screen.getByText(/No annotations yet/)).toBeInTheDocument();
+        expect(screen.queryByTestId('labels-menu-no-sources')).not.toBeInTheDocument();
     });
 
     it('shows visibility toggle buttons when showVisibilityToggle is true', () => {

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.test.ts
@@ -91,6 +91,8 @@ type Mock2dContext = {
     strokeRect: ReturnType<typeof vi.fn>;
 };
 
+const SAMPLE_SOURCE_ID = 'col-default';
+
 const createSample = (): ComponentProps<typeof SampleAnnotations>['sample'] =>
     ({
         width: 100,
@@ -98,6 +100,7 @@ const createSample = (): ComponentProps<typeof SampleAnnotations>['sample'] =>
         annotations: [
             {
                 sample_id: 'object-detection-1',
+                annotation_collection_id: SAMPLE_SOURCE_ID,
                 annotation_type: 'object_detection',
                 annotation_label: { annotation_label_name: 'car' },
                 object_detection_details: {
@@ -109,6 +112,7 @@ const createSample = (): ComponentProps<typeof SampleAnnotations>['sample'] =>
             },
             {
                 sample_id: 'instance-segmentation-1',
+                annotation_collection_id: SAMPLE_SOURCE_ID,
                 annotation_type: 'segmentation_mask',
                 annotation_label: { annotation_label_name: 'person' },
                 segmentation_details: {
@@ -171,6 +175,10 @@ describe('SampleAnnotations', () => {
         );
 
         useAnnotationClassVisibility().hiddenClassNamesStore.set([]);
+        const { setSelectedCollectionIds, setCollectionIdToName } =
+            useAnnotationCollectionsFilter();
+        setCollectionIdToName({ [SAMPLE_SOURCE_ID]: 'Ground truth' });
+        setSelectedCollectionIds([SAMPLE_SOURCE_ID]);
     });
 
     afterEach(() => {
@@ -206,6 +214,42 @@ describe('SampleAnnotations', () => {
         await waitFor(() => {
             expect(hasStrokeRectCall(mockContext, 10, 21, 30, 41)).toBe(true);
             expect(hasStrokeRectCall(mockContext, 2, 3, 4, 5)).toBe(true);
+        });
+    });
+
+    it('draws nothing once the user unchecks every annotation source', async () => {
+        setShowBoundingBoxesForSegmentation(true);
+        useAnnotationCollectionsFilter().setSelectedCollectionIds([]);
+
+        render(SampleAnnotations, {
+            props: {
+                sample: createSample()
+            }
+        });
+
+        // Give the idle-callback canvas mount a chance to run before asserting nothing drew.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(mockContext.strokeRect).not.toHaveBeenCalled();
+    });
+
+    // On the videos grid the frame annotations come from the frames collection, which is not
+    // among the videos collection's own sources, so the filter must leave them alone.
+    it('keeps drawing annotations from a source the filter does not know about', async () => {
+        setShowBoundingBoxesForSegmentation(true);
+        const { setSelectedCollectionIds, setCollectionIdToName } =
+            useAnnotationCollectionsFilter();
+        setCollectionIdToName({});
+        setSelectedCollectionIds([]);
+
+        render(SampleAnnotations, {
+            props: {
+                sample: createSample()
+            }
+        });
+
+        await waitFor(() => {
+            expect(hasStrokeRectCall(mockContext, 10, 21, 30, 41)).toBe(true);
         });
     });
 

--- a/lightly_studio_view/src/lib/components/SampleAnnotations/index.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleAnnotations/index.test.ts
@@ -183,6 +183,7 @@ describe('SampleAnnotations', () => {
 
     afterEach(() => {
         vi.restoreAllMocks();
+        vi.useRealTimers();
     });
 
     it('keeps object-detection boxes visible when showBoundingBoxesForSegmentation is disabled', async () => {
@@ -218,6 +219,7 @@ describe('SampleAnnotations', () => {
     });
 
     it('draws nothing once the user unchecks every annotation source', async () => {
+        vi.useFakeTimers();
         setShowBoundingBoxesForSegmentation(true);
         useAnnotationCollectionsFilter().setSelectedCollectionIds([]);
 
@@ -227,8 +229,8 @@ describe('SampleAnnotations', () => {
             }
         });
 
-        // Give the idle-callback canvas mount a chance to run before asserting nothing drew.
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        // The canvas mounts from an idle callback; drain it before asserting nothing drew.
+        await vi.runAllTimersAsync();
 
         expect(mockContext.strokeRect).not.toHaveBeenCalled();
     });

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.helpers.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.helpers.test.ts
@@ -155,42 +155,34 @@ describe('toggleSourceVisibility', () => {
 });
 
 describe('computeSeededHiddenIds', () => {
-    const sources = [groundTruthSource, predictionsSource];
     const annotations = [
         createAnnotation('gt-1', groundTruthSource.collection_id, 'cat'),
         createAnnotation('pred-1', predictionsSource.collection_id, 'cat'),
         createAnnotation('pred-2', predictionsSource.collection_id, 'dog')
     ];
 
+    const visibleSources = (selectedIds: string[]) => (sourceId: string) =>
+        selectedIds.includes(sourceId);
+
     it('hides annotations whose source is not selected', () => {
         const hiddenIds = computeSeededHiddenIds(
             annotations,
-            [groundTruthSource.collection_id],
-            sources
+            visibleSources([groundTruthSource.collection_id])
         );
 
         expect(hiddenIds).toEqual(new Set(['pred-1', 'pred-2']));
     });
 
-    it('hides nothing when the selection is empty', () => {
-        expect(computeSeededHiddenIds(annotations, [], sources)).toEqual(new Set());
+    it('hides everything when no source is selected', () => {
+        expect(computeSeededHiddenIds(annotations, visibleSources([]))).toEqual(
+            new Set(['gt-1', 'pred-1', 'pred-2'])
+        );
     });
 
     it('hides nothing when all sources are selected', () => {
         const hiddenIds = computeSeededHiddenIds(
             annotations,
-            [groundTruthSource.collection_id, predictionsSource.collection_id],
-            sources
-        );
-
-        expect(hiddenIds).toEqual(new Set());
-    });
-
-    it('hides nothing when the selection does not apply to this dataset', () => {
-        const hiddenIds = computeSeededHiddenIds(
-            annotations,
-            ['source-from-another-dataset'],
-            sources
+            visibleSources([groundTruthSource.collection_id, predictionsSource.collection_id])
         );
 
         expect(hiddenIds).toEqual(new Set());
@@ -203,8 +195,7 @@ describe('computeSeededHiddenIds', () => {
 
         const hiddenIds = computeSeededHiddenIds(
             predictionsOnly,
-            [groundTruthSource.collection_id],
-            sources
+            visibleSources([groundTruthSource.collection_id])
         );
 
         expect(hiddenIds).toEqual(new Set(['pred-1']));

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.helpers.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.helpers.ts
@@ -103,23 +103,16 @@ export const toggleSourceVisibility = (
  * Computes the initially hidden annotations when entering the details page:
  * annotations whose source is not selected in the grid's source filter start hidden.
  *
- * The selection is first intersected with this dataset's sources so that a stale
- * selection from another dataset never hides anything.
- * When that intersection is empty (no filter, or a filter that does not apply here),
- * nothing is hidden.
+ * The selection always describes the collection on screen, because
+ * useSeedAnnotationSourceFilter fills it for every collection route, so no intersection with
+ * this dataset's sources is needed here.
  */
 export const computeSeededHiddenIds = (
     annotations: AnnotationView[],
-    selectedCollectionIds: string[],
-    sources: AnnotationCollectionView[]
-): Set<string> => {
-    const sourceIds = new Set(sources.map((source) => source.collection_id));
-    const applicableSelectedIds = new Set(selectedCollectionIds.filter((id) => sourceIds.has(id)));
-    if (applicableSelectedIds.size === 0) return new Set();
-
-    return new Set(
+    isSourceVisible: (sourceId: string) => boolean
+): Set<string> =>
+    new Set(
         annotations
-            .filter((annotation) => !applicableSelectedIds.has(annotation.annotation_collection_id))
+            .filter((annotation) => !isSourceVisible(annotation.annotation_collection_id))
             .map((annotation) => annotation.sample_id)
     );
-};

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.svelte
@@ -58,7 +58,7 @@
     const { selectAnnotation } = useAnnotationSelection();
 
     const annotationCollectionsQuery = useAnnotationCollections(() => ({ collectionId }));
-    const { selectedCollectionIds, seedSelectionIfNeeded } = useAnnotationCollectionsFilter();
+    const { isSourceVisible } = useAnnotationCollectionsFilter();
     const { enforceColoringByClassStore } = useSettings();
 
     const annotationsSort = $derived.by(() => {
@@ -83,9 +83,7 @@
 
     // Hidden set implied by the grid filter, as a derived so it's readable at mount (unlike
     // the effect-written `annotationsIdsToHide`); drives the seed and the initial collapse.
-    const seededHiddenIds = $derived(
-        computeSeededHiddenIds(annotationsSort, $selectedCollectionIds, annotationSources)
-    );
+    const seededHiddenIds = $derived(computeSeededHiddenIds(annotationsSort, $isSourceVisible));
 
     // Annotations are colored by source only while multiple sources are visible and class
     // coloring is not enforced, matching the details canvas. Swatches are shown only when
@@ -97,18 +95,6 @@
             enforceColoringByClass: $enforceColoringByClassStore
         })
     );
-
-    // Seed the global annotation source stores the first time this collection is shown
-    // (e.g. landing directly on the details page via deep link), so annotations are colored
-    // by source. seedSelectionIfNeeded keeps an existing selection from the grid filter.
-    $effect(() => {
-        if (annotationSources.length > 1) {
-            seedSelectionIfNeeded(
-                collectionId,
-                annotationSources.map((source) => ({ id: source.collection_id, name: source.name }))
-            );
-        }
-    });
 
     // Tracks which sample the hidden set was seeded for. Intentionally not reactive:
     // it must not re-trigger the seeding effect.

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsAnnotationSegment/SampleDetailsAnnotationSegment.test.ts
@@ -8,7 +8,6 @@ const mocks = vi.hoisted(() => ({
     collections: [] as { collection_id: string; name: string }[],
     selectedCollectionIds: [] as string[],
     lastCreatedAnnotationId: null as string | null,
-    seedSelectionIfNeeded: vi.fn(),
     enforceColoringByClassStore: undefined as unknown as { set: (value: boolean) => void }
 }));
 
@@ -31,7 +30,9 @@ vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilte
     return {
         useAnnotationCollectionsFilter: vi.fn(() => ({
             selectedCollectionIds: readable(mocks.selectedCollectionIds),
-            seedSelectionIfNeeded: mocks.seedSelectionIfNeeded
+            isSourceVisible: readable((sourceId: string) =>
+                mocks.selectedCollectionIds.includes(sourceId)
+            )
         }))
     };
 });
@@ -164,6 +165,10 @@ describe('SampleDetailsAnnotationSegment', () => {
 
     it('excludes classification annotations from the source groups', () => {
         mocks.collections = [groundTruthSource, predictionsSource];
+        mocks.selectedCollectionIds = [
+            groundTruthSource.collection_id,
+            predictionsSource.collection_id
+        ];
         const annotations = [
             createAnnotation('a1', groundTruthSource.collection_id, 'cat'),
             {
@@ -179,28 +184,6 @@ describe('SampleDetailsAnnotationSegment', () => {
         expect(headers).toHaveLength(1);
         expect(headers[0]).toHaveTextContent(groundTruthSource.name);
         expect(screen.getAllByTestId('mock-annotation-row')).toHaveLength(1);
-    });
-
-    it('seeds the annotation source filter with all sources', () => {
-        mocks.collections = [groundTruthSource, predictionsSource];
-        mocks.selectedCollectionIds = [];
-
-        render(SampleDetailsAnnotationSegment, { props: defaultProps });
-
-        // The keyed no-op guarantee (keeping an existing selection) lives in the hook's
-        // own unit test; here we only assert the segment delegates with the full source list.
-        expect(mocks.seedSelectionIfNeeded).toHaveBeenCalledWith('collection-1', [
-            { id: groundTruthSource.collection_id, name: groundTruthSource.name },
-            { id: predictionsSource.collection_id, name: predictionsSource.name }
-        ]);
-    });
-
-    it('does not seed the annotation source filter for a single source', () => {
-        mocks.collections = [groundTruthSource];
-
-        render(SampleDetailsAnnotationSegment, { props: defaultProps });
-
-        expect(mocks.seedSelectionIfNeeded).not.toHaveBeenCalled();
     });
 
     describe('source visibility toggle', () => {
@@ -338,15 +321,18 @@ describe('SampleDetailsAnnotationSegment', () => {
             expect(screen.queryByTestId('source-group-eye-off')).not.toBeInTheDocument();
         });
 
-        it('ignores a selection that belongs to another dataset', () => {
-            mocks.selectedCollectionIds = ['source-from-another-dataset'];
+        it('hides every annotation when the grid has no source selected', async () => {
+            const user = userEvent.setup();
+            mocks.selectedCollectionIds = [];
 
             render(SampleDetailsAnnotationSegment, { props: { ...defaultProps, annotations } });
 
-            expect(getRow('gt-1')).not.toHaveAttribute('data-hidden', 'true');
-            expect(getRow('pred-1')).not.toHaveAttribute('data-hidden', 'true');
-            expect(getRow('pred-2')).not.toHaveAttribute('data-hidden', 'true');
-            expect(screen.queryByTestId('source-group-eye-off')).not.toBeInTheDocument();
+            // Both groups seed fully hidden, so both start collapsed with a closed eye.
+            expect(screen.queryAllByTestId('mock-annotation-row')).toHaveLength(0);
+            expect(screen.getAllByTestId('source-group-eye-off')).toHaveLength(2);
+
+            await user.click(screen.getByText(groundTruthSource.name));
+            expect(getRow('gt-1')).toHaveAttribute('data-hidden', 'true');
         });
 
         it('seeds once the annotations become available', async () => {

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.svelte
@@ -72,7 +72,7 @@
     });
 
     const annotationCollectionsQuery = useAnnotationCollections(() => ({ collectionId }));
-    const { selectedCollectionIds, multipleSourcesVisible } = useAnnotationCollectionsFilter();
+    const { isSourceVisible, multipleSourcesVisible } = useAnnotationCollectionsFilter();
     const annotationSources = $derived(annotationCollectionsQuery.data ?? []);
     const isGrouped = $derived(annotationSources.length > 1);
     const sourceGroups = $derived(
@@ -82,7 +82,7 @@
     // Hidden set implied by the grid filter, as a derived so it's readable at mount (unlike
     // the effect-written `annotationsIdsToHide`); drives the seed and the initial collapse.
     const seededHiddenIds = $derived(
-        computeSeededHiddenIds(classificationAnnotations, $selectedCollectionIds, annotationSources)
+        computeSeededHiddenIds(classificationAnnotations, $isSourceVisible)
     );
 
     // Color source group headers by source only when multiple sources are visible and class

--- a/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
+++ b/lightly_studio_view/src/lib/components/SampleDetails/SampleDetailsClassificationSegment/SampleDetailsClassificationSegment.test.ts
@@ -35,7 +35,9 @@ vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilte
     const { readable } = await import('svelte/store');
     return {
         useAnnotationCollectionsFilter: vi.fn(() => ({
-            selectedCollectionIds: readable(mocks.selectedCollectionIds),
+            isSourceVisible: readable((sourceId: string) =>
+                mocks.selectedCollectionIds.includes(sourceId)
+            ),
             multipleSourcesVisible: readable(mocks.selectedCollectionIds.length > 1)
         }))
     };
@@ -214,6 +216,10 @@ describe('SampleDetailsClassificationSegment', () => {
 
     it('groups classifications under one header per source for multiple sources', () => {
         mocks.collections = [groundTruthSource, predictionsSource];
+        mocks.selectedCollectionIds = [
+            groundTruthSource.collection_id,
+            predictionsSource.collection_id
+        ];
         const annotations = [
             createClassification('c1', groundTruthSource.collection_id, 'cat'),
             createClassification('c2', predictionsSource.collection_id, 'zebra'),
@@ -364,6 +370,10 @@ describe('SampleDetailsClassificationSegment', () => {
         const user = userEvent.setup();
         mocks.isEditingMode.set(true);
         mocks.collections = [groundTruthSource, predictionsSource];
+        mocks.selectedCollectionIds = [
+            groundTruthSource.collection_id,
+            predictionsSource.collection_id
+        ];
         const annotations = [
             createClassification('c1', groundTruthSource.collection_id, 'cat'),
             createClassification('c2', predictionsSource.collection_id, 'zebra'),

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -26,6 +26,7 @@ export { useTextEmbedding } from '$lib/hooks/useTextEmbedding/useTextEmbedding';
 export { useSearchEmbedding } from '$lib/hooks/useSearchEmbedding/useSearchEmbedding';
 export { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
 export { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
+export { useSeedAnnotationSourceFilter } from '$lib/hooks/useSeedAnnotationSourceFilter/useSeedAnnotationSourceFilter.svelte';
 export { useEvaluationSampleMetricsInfo } from '$lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo';
 export { useEvaluationRuns } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
 export { useEvaluationConfusionMatrix } from '$lib/hooks/useEvaluationConfusionMatrix/useEvaluationConfusionMatrix.svelte';

--- a/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.test.ts
@@ -65,11 +65,34 @@ describe('useAnnotationCollectionsFilter', () => {
             expect(get(isSourceVisible)('pred')).toBe(false);
         });
 
-        it('shows every source while the selection is empty', async () => {
+        it('hides every source once the user unchecks them all', async () => {
+            const { isSourceVisible, setSelectedCollectionIds, seedSelectionIfNeeded } =
+                await importHook();
+
+            seedSelectionIfNeeded('collection-1', sources);
+            setSelectedCollectionIds([]);
+
+            expect(get(isSourceVisible)('gt')).toBe(false);
+            expect(get(isSourceVisible)('pred')).toBe(false);
+        });
+
+        // The videos grid draws frame annotations whose sources hang off the frames
+        // collection, so they are absent from the videos collection's own source list.
+        // The filter has no say over them and must not hide them.
+        it('shows a source it does not know about', async () => {
+            const { isSourceVisible, setSelectedCollectionIds, seedSelectionIfNeeded } =
+                await importHook();
+
+            seedSelectionIfNeeded('collection-1', sources);
+            setSelectedCollectionIds([]);
+
+            expect(get(isSourceVisible)('source-from-the-frames-collection')).toBe(true);
+        });
+
+        it('shows everything before any collection has been seeded', async () => {
             const { isSourceVisible } = await importHook();
 
             expect(get(isSourceVisible)('gt')).toBe(true);
-            expect(get(isSourceVisible)('pred')).toBe(true);
         });
     });
 

--- a/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.test.ts
@@ -145,6 +145,44 @@ describe('useAnnotationCollectionsFilter', () => {
         });
     });
 
+    describe('allSourcesHidden', () => {
+        it('is false before any collection has been seeded', async () => {
+            const { allSourcesHidden } = await importHook();
+
+            expect(get(allSourcesHidden)).toBe(false);
+        });
+
+        it('is false while a source is still selected', async () => {
+            const { allSourcesHidden, setSelectedCollectionIds, seedSelectionIfNeeded } =
+                await importHook();
+
+            seedSelectionIfNeeded('collection-1', sources);
+            setSelectedCollectionIds(['gt']);
+
+            expect(get(allSourcesHidden)).toBe(false);
+        });
+
+        it('is true once the user unchecks every source', async () => {
+            const { allSourcesHidden, setSelectedCollectionIds, seedSelectionIfNeeded } =
+                await importHook();
+
+            seedSelectionIfNeeded('collection-1', sources);
+            setSelectedCollectionIds([]);
+
+            expect(get(allSourcesHidden)).toBe(true);
+        });
+
+        // A collection without annotation sources has an empty selection too, but the user
+        // never hid anything, so the counts must stay as they are.
+        it('is false for a collection that has no sources', async () => {
+            const { allSourcesHidden, seedSelectionIfNeeded } = await importHook();
+
+            seedSelectionIfNeeded('collection-1', []);
+
+            expect(get(allSourcesHidden)).toBe(false);
+        });
+    });
+
     describe('multipleSourcesVisible', () => {
         it('is true only while more than one source is selected', async () => {
             const { multipleSourcesVisible, setSelectedCollectionIds, seedSelectionIfNeeded } =

--- a/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.test.ts
@@ -39,6 +39,55 @@ describe('useAnnotationCollectionsFilter', () => {
         expect(get(selectedCollectionIds)).toEqual(['gt']);
     });
 
+    it('learns a source that appears after the first seed', async () => {
+        const { isSourceVisible, setSelectedCollectionIds, seedSelectionIfNeeded } =
+            await importHook();
+
+        seedSelectionIfNeeded('collection-1', sources);
+        // an annotation was written to a brand-new source, so the list refetches longer
+        seedSelectionIfNeeded('collection-1', [...sources, { id: 'new', name: 'Manual' }]);
+        setSelectedCollectionIds(['gt', 'pred']);
+
+        expect(get(isSourceVisible)('new')).toBe(false);
+    });
+
+    it('keeps the selection and checks the source that appeared', async () => {
+        const { selectedCollectionIds, setSelectedCollectionIds, seedSelectionIfNeeded } =
+            await importHook();
+
+        seedSelectionIfNeeded('collection-1', sources);
+        setSelectedCollectionIds(['gt']);
+        seedSelectionIfNeeded('collection-1', [...sources, { id: 'new', name: 'Manual' }]);
+
+        expect(get(selectedCollectionIds)).toEqual(['gt', 'new']);
+    });
+
+    it('drops a source that is gone from the list', async () => {
+        const { selectedCollectionIds, collectionIdToName, seedSelectionIfNeeded } =
+            await importHook();
+
+        seedSelectionIfNeeded('collection-1', sources);
+        seedSelectionIfNeeded('collection-1', [{ id: 'gt', name: 'Ground truth' }]);
+
+        expect(get(selectedCollectionIds)).toEqual(['gt']);
+        expect(get(collectionIdToName)).toEqual({ gt: 'Ground truth' });
+    });
+
+    it('does not notify subscribers when the source list is unchanged', async () => {
+        const { isSourceVisible, seedSelectionIfNeeded } = await importHook();
+
+        seedSelectionIfNeeded('collection-1', sources);
+
+        let emissions = 0;
+        const unsubscribe = isSourceVisible.subscribe(() => {
+            emissions += 1;
+        });
+        seedSelectionIfNeeded('collection-1', sources); // e.g. a window-focus refetch
+        unsubscribe();
+
+        expect(emissions).toBe(1); // the subscribe call itself
+    });
+
     it('re-seeds all sources when the collection changes', async () => {
         const { selectedCollectionIds, setSelectedCollectionIds, seedSelectionIfNeeded } =
             await importHook();

--- a/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.ts
@@ -1,10 +1,11 @@
-import { derived, writable, type Readable } from 'svelte/store';
+import { derived, get, writable, type Readable } from 'svelte/store';
 
 const selectedCollectionIds = writable<string[]>([]);
 const collectionIdToName = writable<Record<string, string>>({});
 
 // The sources the filter knows about, which are the annotation sources of the collection the
-// user is looking at. Seeded together with the selection, so its keys are always in step.
+// user is looking at. Follows the source list rather than the selection, so a source created
+// while the collection is open can still be hidden.
 const knownSourceIds: Readable<Set<string>> = derived(
     collectionIdToName,
     ($idToName) => new Set(Object.keys($idToName))
@@ -48,19 +49,43 @@ export const useAnnotationCollectionsFilter = () => {
         collectionIdToName,
         setCollectionIdToName: (map: Record<string, string>) => collectionIdToName.set(map),
         /**
-         * Seeds the filter with every source selected the first time a collection is shown.
-         * No-op on later calls for the same collection, so a user's manual selection is
-         * preserved across navigation; re-seeds when the collection changes so a stale
-         * selection never leaks across datasets.
+         * Points the filter at a collection's annotation sources.
+         *
+         * The first call for a collection selects every source. Later calls for the same
+         * collection keep the user's selection and fold in sources that appeared since, because
+         * an annotation can be written to a brand-new source and the filter can only hide what
+         * it knows about. Switching collection selects everything again, so a stale selection
+         * never leaks across datasets.
          */
         seedSelectionIfNeeded: (
             collectionId: string,
             collections: { id: string; name: string }[]
         ) => {
-            if (seededCollectionId === collectionId) return;
-            seededCollectionId = collectionId;
-            selectedCollectionIds.set(collections.map((c) => c.id));
-            collectionIdToName.set(Object.fromEntries(collections.map((c) => [c.id, c.name])));
+            const nextIdToName = Object.fromEntries(collections.map((c) => [c.id, c.name]));
+
+            if (seededCollectionId !== collectionId) {
+                seededCollectionId = collectionId;
+                collectionIdToName.set(nextIdToName);
+                selectedCollectionIds.set(collections.map((c) => c.id));
+                return;
+            }
+
+            // Same collection, but the source list can still grow: an annotation may be written
+            // to a brand-new source, and the filter can only hide sources it knows about.
+            const previousIdToName = get(collectionIdToName);
+            const unchanged =
+                Object.keys(previousIdToName).length === collections.length &&
+                collections.every((c) => previousIdToName[c.id] === c.name);
+            if (unchanged) return;
+
+            const addedIds = collections.map((c) => c.id).filter((id) => !(id in previousIdToName));
+
+            collectionIdToName.set(nextIdToName);
+            // A new source starts checked, so an annotation just drawn into one stays on screen.
+            selectedCollectionIds.update(($ids) => [
+                ...$ids.filter((id) => id in nextIdToName),
+                ...addedIds
+            ]);
         }
     };
 };

--- a/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.ts
@@ -3,11 +3,25 @@ import { derived, writable, type Readable } from 'svelte/store';
 const selectedCollectionIds = writable<string[]>([]);
 const collectionIdToName = writable<Record<string, string>>({});
 
-// Whether annotations from a given source should be drawn. An empty selection means the filter
-// has not been seeded for this collection yet, so nothing is filtered out.
+// The sources the filter knows about, which are the annotation sources of the collection the
+// user is looking at. Seeded together with the selection, so its keys are always in step.
+const knownSourceIds: Readable<Set<string>> = derived(
+    collectionIdToName,
+    ($idToName) => new Set(Object.keys($idToName))
+);
+
+// Whether annotations from a given source should be drawn.
+//
+// An unknown source is drawn. Not every collection owns the sources of the annotations shown
+// on it: video frame annotations hang off the frames collection while the user is on the
+// videos tab, so this filter has nothing to say about them. Only sources it knows about, and
+// which the user has therefore had a chance to uncheck, can be hidden. That is what makes
+// unchecking the last source hide the last source rather than switching the filter off.
 const isSourceVisible: Readable<(sourceId: string) => boolean> = derived(
-    selectedCollectionIds,
-    ($ids) => (sourceId: string) => $ids.length === 0 || $ids.includes(sourceId)
+    [selectedCollectionIds, knownSourceIds],
+    ([$ids, $known]) =>
+        (sourceId: string) =>
+            !$known.has(sourceId) || $ids.includes(sourceId)
 );
 
 // Annotations are colored per source instead of per class while more than one source is
@@ -21,6 +35,8 @@ const multipleSourcesVisible: Readable<boolean> = derived(
 // Module-level so it survives component remounts (e.g. grid <-> image details), which lets
 // the user's source selection persist within a dataset while still resetting to
 // "all selected" when switching to a different collection/dataset.
+// useSeedAnnotationSourceFilter calls the seeder for every collection the user opens, so the
+// selection always describes the collection on screen and never leaks across tabs.
 let seededCollectionId: string | undefined;
 
 export const useAnnotationCollectionsFilter = () => {

--- a/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter.ts
@@ -25,6 +25,13 @@ const isSourceVisible: Readable<(sourceId: string) => boolean> = derived(
             !$known.has(sourceId) || $ids.includes(sourceId)
 );
 
+// True while the filter knows about sources and the user has unchecked all of them. Nothing is
+// drawn in that state, so nothing counted per source should survive either.
+const allSourcesHidden: Readable<boolean> = derived(
+    [selectedCollectionIds, knownSourceIds],
+    ([$ids, $known]) => $known.size > 0 && $ids.length === 0
+);
+
 // Annotations are colored per source instead of per class while more than one source is
 // visible. Pass this to resolveEffectiveColorBySource rather than reading the selection length.
 const multipleSourcesVisible: Readable<boolean> = derived(
@@ -45,6 +52,7 @@ export const useAnnotationCollectionsFilter = () => {
         selectedCollectionIds,
         setSelectedCollectionIds: (ids: string[]) => selectedCollectionIds.set(ids),
         isSourceVisible,
+        allSourcesHidden,
         multipleSourcesVisible,
         collectionIdToName,
         setCollectionIdToName: (map: Record<string, string>) => collectionIdToName.set(map),

--- a/lightly_studio_view/src/lib/hooks/useSeedAnnotationSourceFilter/UseSeedAnnotationSourceFilter.harness.svelte
+++ b/lightly_studio_view/src/lib/hooks/useSeedAnnotationSourceFilter/UseSeedAnnotationSourceFilter.harness.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    import { useSeedAnnotationSourceFilter } from './useSeedAnnotationSourceFilter.svelte';
+
+    // The hook runs a $effect, which needs a component instance to attach to.
+    interface Props {
+        collectionId: string;
+    }
+
+    let { collectionId }: Props = $props();
+
+    useSeedAnnotationSourceFilter(() => collectionId);
+</script>

--- a/lightly_studio_view/src/lib/hooks/useSeedAnnotationSourceFilter/useSeedAnnotationSourceFilter.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useSeedAnnotationSourceFilter/useSeedAnnotationSourceFilter.svelte.ts
@@ -1,0 +1,27 @@
+import { useAnnotationCollections } from '$lib/hooks/useAnnotationCollections/useAnnotationCollections';
+import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
+
+/**
+ * Fills the annotation source filter with the sources of the collection on screen.
+ *
+ * Call this once per collection route. The Annotation Sources menu only renders on the images
+ * grid, so seeding from the menu left the selection describing another tab's sources (or, for
+ * a single-source collection, never filled at all). Every grid draws its boxes against this
+ * one selection, so it has to be filled everywhere the boxes are drawn.
+ */
+export function useSeedAnnotationSourceFilter(getCollectionId: () => string): void {
+    const annotationCollectionsQuery = useAnnotationCollections(() => ({
+        collectionId: getCollectionId()
+    }));
+    const { seedSelectionIfNeeded } = useAnnotationCollectionsFilter();
+
+    $effect(() => {
+        const sources = annotationCollectionsQuery.data;
+        if (!sources) return;
+
+        seedSelectionIfNeeded(
+            getCollectionId(),
+            sources.map((source) => ({ id: source.collection_id, name: source.name }))
+        );
+    });
+}

--- a/lightly_studio_view/src/lib/hooks/useSeedAnnotationSourceFilter/useSeedAnnotationSourceFilter.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useSeedAnnotationSourceFilter/useSeedAnnotationSourceFilter.test.ts
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import UseSeedAnnotationSourceFilterHarness from './UseSeedAnnotationSourceFilter.harness.svelte';
+
+const mocks = vi.hoisted(() => ({
+    collections: undefined as { collection_id: string; name: string }[] | undefined,
+    seedSelectionIfNeeded: vi.fn()
+}));
+
+vi.mock('$lib/hooks/useAnnotationCollections/useAnnotationCollections', () => ({
+    useAnnotationCollections: vi.fn(() => ({ data: mocks.collections }))
+}));
+
+vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter', () => ({
+    useAnnotationCollectionsFilter: vi.fn(() => ({
+        seedSelectionIfNeeded: mocks.seedSelectionIfNeeded
+    }))
+}));
+
+describe('useSeedAnnotationSourceFilter', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.collections = undefined;
+    });
+
+    it('waits for the sources query before seeding', () => {
+        render(UseSeedAnnotationSourceFilterHarness, { collectionId: 'images-1' });
+
+        expect(mocks.seedSelectionIfNeeded).not.toHaveBeenCalled();
+    });
+
+    it('seeds with every source of the collection on screen', () => {
+        mocks.collections = [
+            { collection_id: 'gt', name: 'Ground truth' },
+            { collection_id: 'pred', name: 'Predictions' }
+        ];
+
+        render(UseSeedAnnotationSourceFilterHarness, { collectionId: 'images-1' });
+
+        expect(mocks.seedSelectionIfNeeded).toHaveBeenCalledWith('images-1', [
+            { id: 'gt', name: 'Ground truth' },
+            { id: 'pred', name: 'Predictions' }
+        ]);
+    });
+
+    // The Annotation Sources menu hides itself for a single source. Seeding still has to run,
+    // otherwise the selection stays unloaded and no boxes are drawn.
+    it('seeds a collection that has a single source', () => {
+        mocks.collections = [{ collection_id: 'gt', name: 'Ground truth' }];
+
+        render(UseSeedAnnotationSourceFilterHarness, { collectionId: 'images-1' });
+
+        expect(mocks.seedSelectionIfNeeded).toHaveBeenCalledWith('images-1', [
+            { id: 'gt', name: 'Ground truth' }
+        ]);
+    });
+
+    // Every grid draws boxes against one shared selection, so a tab without the menu still
+    // has to replace it. seedSelectionIfNeeded keys on the collection id and does the swap.
+    it('seeds a collection that has no sources at all', () => {
+        mocks.collections = [];
+
+        render(UseSeedAnnotationSourceFilterHarness, { collectionId: 'videos-1' });
+
+        expect(mocks.seedSelectionIfNeeded).toHaveBeenCalledWith('videos-1', []);
+    });
+});

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -62,7 +62,6 @@
     } from '$lib/api/lightly_studio_local/types.gen';
     import type { AnnotationsFilter } from '$lib/api/lightly_studio_local/types.gen';
     import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
-    import { useSeedAnnotationSourceFilter } from '$lib/hooks/useSeedAnnotationSourceFilter/useSeedAnnotationSourceFilter.svelte';
     import type { DistributionSource } from '$lib/components/DatasetDistributionPanel';
     import { buildImageFilter } from '$lib/utils/buildImageFilter';
     import {
@@ -77,7 +76,8 @@
         useImageAnnotationCountsQueryKey,
         useNumericMetadataDistribution,
         usePostHog,
-        useCategoricalMetadataDistribution
+        useCategoricalMetadataDistribution,
+        useSeedAnnotationSourceFilter
     } from '$lib/hooks';
     import { useSelectAll } from '$lib/hooks/useSelectAll/useSelectAll';
     import { isInputElement } from '$lib/utils';

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -62,6 +62,7 @@
     } from '$lib/api/lightly_studio_local/types.gen';
     import type { AnnotationsFilter } from '$lib/api/lightly_studio_local/types.gen';
     import { useAnnotationCollectionsFilter } from '$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter';
+    import { useSeedAnnotationSourceFilter } from '$lib/hooks/useSeedAnnotationSourceFilter/useSeedAnnotationSourceFilter.svelte';
     import type { DistributionSource } from '$lib/components/DatasetDistributionPanel';
     import { buildImageFilter } from '$lib/utils/buildImageFilter';
     import {
@@ -358,6 +359,11 @@
         $imageFilterFromHook?.sample_filter?.confusion_cell ?? null
     );
     const plotFilterQueryExpr = $derived($imageFilterFromHook?.sample_filter?.query_expr ?? null);
+
+    // Fill the annotation source filter for whatever collection is on screen. Every grid draws
+    // its boxes against this one selection, so seeding only from the images-grid menu left the
+    // other tabs filtering against another tab's sources.
+    useSeedAnnotationSourceFilter(() => collectionId);
 
     // Selected annotation sources (annotation collections). When a subset is
     // selected the distribution counts only annotations from those sources; the

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -368,11 +368,15 @@
     // Selected annotation sources (annotation collections). When a subset is
     // selected the distribution counts only annotations from those sources; the
     // backend restricts the counted annotations by their own collection id.
-    const { selectedCollectionIds: selectedAnnotationSourceIds } = useAnnotationCollectionsFilter();
+    const { selectedCollectionIds: selectedAnnotationSourceIds, allSourcesHidden } =
+        useAnnotationCollectionsFilter();
     const annotationFilterForCounts = $derived.by<AnnotationsFilter | undefined>(() => {
         const base = $annotationFilterStore;
         const sourceIds =
             isAnnotations || isAnnotationDetails ? [collectionId] : $selectedAnnotationSourceIds;
+        // An empty list cannot be sent: the backend skips collection_ids when it is falsy, so
+        // it would read as "every source". The unchecked-everything case is handled on the
+        // results instead, via allSourcesHidden below.
         if (sourceIds.length === 0) return base;
         return {
             ...(base ?? { filter_type: 'annotations' }),
@@ -450,10 +454,14 @@
         return imageAnnotationCountsQuery;
     });
 
+    // With every known source unchecked nothing is drawn, so nothing is counted either.
+    // The request itself cannot say that, so the empty result is produced here.
+    const annotationCountsData = $derived($allSourcesHidden ? [] : annotationCounts.data);
+
     // Feed annotation counts back into the hook for UI-ready filter rows.
     // Only update when data is present to avoid flicker during query refetch.
     $effect(() => {
-        const countsData = annotationCounts.data;
+        const countsData = annotationCountsData;
         if (countsData) {
             setAnnotationCounts(
                 countsData as { label_name: string; total_count: number; current_count?: number }[]
@@ -466,7 +474,7 @@
     });
 
     const totalAnnotations = $derived.by(() => {
-        const countsData = annotationCounts.data;
+        const countsData = annotationCountsData;
         if (!countsData) return 0;
         return countsData.reduce(
             (sum: number, item: { [key: string]: string | number }) =>
@@ -486,8 +494,10 @@
     // sources fetch classification / detection / segmentation counts on demand
     // while the panel is open. We map `current_count` so the plot tracks the
     // active filters, dropping labels with no matches in the current view.
+    // Same rule as annotationCountsData: with every source hidden the class distribution has
+    // nothing to show, whichever count query it came from.
     const toCategoryCounts = (countsData: unknown[] | undefined) =>
-        (countsData ?? [])
+        ($allSourcesHidden ? [] : (countsData ?? []))
             .map((item) => {
                 const row = item as { [key: string]: unknown };
                 return { label: String(row['label_name']), count: Number(row['current_count']) };

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -756,9 +756,9 @@
         <div class="flex min-h-0 flex-1 gap-4 px-4" data-testid="workspace-body">
             {#if isCollectionGrid}
                 <!--
-                    Keep the panel mounted while collapsed (only visually hidden). Children such as
-                    AnnotationCollectionsMenu run mount-time $effects (e.g. seeding the annotation
-                    source selection) that must still fire after a reload with the panel collapsed.
+                    Keep the panel mounted while collapsed (only visually hidden). Its children
+                    run mount-time $effects that must still fire after a reload with the panel
+                    collapsed.
                 -->
                 <div
                     class="h-full min-h-0 w-80 flex-col {$filterPanelCollapsed ? 'hidden' : 'flex'}"

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -131,7 +131,10 @@ vi.mock('$lib/hooks/useVideoFilters/useVideoFilters', () => ({
     useVideoFilters: vi.fn(() => ({ videoFilter: writable(null) }))
 }));
 vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter', () => ({
-    useAnnotationCollectionsFilter: vi.fn(() => ({ selectedCollectionIds: writable([]) }))
+    useAnnotationCollectionsFilter: vi.fn(() => ({
+        selectedCollectionIds: writable([]),
+        allSourcesHidden: writable(false)
+    }))
 }));
 vi.mock('$lib/hooks/useSeedAnnotationSourceFilter/useSeedAnnotationSourceFilter.svelte', () => ({
     useSeedAnnotationSourceFilter: vi.fn()

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -136,9 +136,6 @@ vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilte
         allSourcesHidden: writable(false)
     }))
 }));
-vi.mock('$lib/hooks/useSeedAnnotationSourceFilter/useSeedAnnotationSourceFilter.svelte', () => ({
-    useSeedAnnotationSourceFilter: vi.fn()
-}));
 vi.mock('$lib/hooks', () => ({
     useSelectionSummary: vi.fn(() => ({
         selectedCount: writable(0),
@@ -154,7 +151,8 @@ vi.mock('$lib/hooks', () => ({
         refetch: vi.fn()
     })),
     usePostHog: vi.fn(() => ({ trackEvent: vi.fn() })),
-    useTrackSampleInspected: vi.fn()
+    useTrackSampleInspected: vi.fn(),
+    useSeedAnnotationSourceFilter: vi.fn()
 }));
 vi.mock('$lib/hooks/useSelectAll/useSelectAll', () => ({
     useSelectAll: vi.fn(() => ({ handleSelectAll: vi.fn() }))

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -133,6 +133,9 @@ vi.mock('$lib/hooks/useVideoFilters/useVideoFilters', () => ({
 vi.mock('$lib/hooks/useAnnotationCollectionsFilter/useAnnotationCollectionsFilter', () => ({
     useAnnotationCollectionsFilter: vi.fn(() => ({ selectedCollectionIds: writable([]) }))
 }));
+vi.mock('$lib/hooks/useSeedAnnotationSourceFilter/useSeedAnnotationSourceFilter.svelte', () => ({
+    useSeedAnnotationSourceFilter: vi.fn()
+}));
 vi.mock('$lib/hooks', () => ({
     useSelectionSummary: vi.fn(() => ({
         selectedCount: writable(0),


### PR DESCRIPTION
## What has changed and why?

A dataset had three annotation sources, and unchecking them one by one hid their annotations in turn. Unchecking the last made all three reappear. An empty selection meant "draw everything".

That selection is shared by every grid, and only the images grid fills it, so reversing the rule would hide annotations elsewhere. The store behind `useAnnotationCollectionsFilter` now tracks the current collection's annotation sources and draws each only while checked. Untracked sources still draw, so video frame annotations stay on the videos grid. The new `useSeedAnnotationSourceFilter` hook fills the selection on every collection route.

Unchecking a source also clears annotation class filters. That predates this change; the selection scopes the annotation counts query, which prunes unlisted classes.

## How has it been tested?

New unit tests: unchecking every source draws nothing, an untracked source still draws, and seeding covers single- and empty-source collections. `make static-checks` and `npx vitest run` pass in lightly_studio_view (2596 tests).

Not checked manually against a running app. To reproduce, run the object-detection evaluation example, a COCO dataset with two annotation sources, then uncheck both on the images grid.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Annotation and category counts are now hidden when all annotation sources are unchecked.
  * Annotations correctly disappear when their sources are hidden, while annotations from unknown sources remain visible.
  * Empty-state messaging now distinguishes hidden sources from collections with no annotations.
  * Source selections stay synchronized as annotation sources are added or removed.

* **Tests**
  * Expanded coverage for source visibility, selection updates, hidden annotations, and count behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->