### PR TITLE
Skip GCP auth in End2End Test when the build/success cache already hits

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -30,13 +30,6 @@ jobs:
         with:
           submodules: recursive
 
-      # Authenticate to download dev versions of lightly-mundig.
-      - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v3'
-        with:
-          project_id: boris-250909
-          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
-
       - name: Compute cache key file hash
         id: file-hash
         run: >-
@@ -62,6 +55,15 @@ jobs:
             lightly_studio_view/build
             lightly_studio/src/lightly_studio/dist_lightly_studio_view_app
           key: python-build-${{ steps.file-hash.outputs.hash }}
+
+      # Authenticate to download dev versions of lightly-mundig. Only needed
+      # when the build cache misses, same as the steps that consume it below.
+      - name: Authenticate with GCP
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        uses: 'google-github-actions/auth@v3'
+        with:
+          project_id: boris-250909
+          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
 
       - name: Cache Playwright browsers
         id: cache-playwright-browsers
@@ -267,13 +269,6 @@ jobs:
         with:
           submodules: recursive
 
-      # Authenticate to download dev versions of lightly-mundig.
-      - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v3'
-        with:
-          project_id: boris-250909
-          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
-
       - name: Check e2e success cache
         id: cache-success
         uses: actions/cache@v5
@@ -281,6 +276,15 @@ jobs:
           lookup-only: true
           path: ${{ matrix.success_marker }}
           key: ${{ matrix.success_key }}-${{ needs.prepare-caches.outputs.file-hash }}
+
+      # Authenticate to download dev versions of lightly-mundig. Only needed
+      # when the e2e success cache misses, same as the steps that consume it below.
+      - name: Authenticate with GCP
+        if: steps.cache-success.outputs.cache-hit != 'true'
+        uses: 'google-github-actions/auth@v3'
+        with:
+          project_id: boris-250909
+          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
 
       ### Restore caches ###
 


### PR DESCRIPTION
## What has changed and why?

`Authenticate with GCP` ran unconditionally in both `prepare-caches` and `end-to-end`, before
either job even checked its own cache. Every step that actually needs those credentials was
already skipped on a cache hit, so this just moves auth after the cache lookup and gates it the
same way. On a cache hit (e.g. a docs-only PR like #1762), auth is skipped entirely — which also
means it no longer fails for fork PRs that don't have repo secrets.

## How has it been tested?

Checked the Makefile: only the keyring install, schema export, and optional-deps install steps
actually use the GCP credentials, and all three were already gated behind the same cache-hit
check auth is now gated on. `success-check` is untouched.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)