### PR TITLE
test: skip long-running test_export__lightly_format

### DIFF
--- a/lightly_studio/tests/few_shot_classifier/test_random_forest_classifier.py
+++ b/lightly_studio/tests/few_shot_classifier/test_random_forest_classifier.py
@@ -329,6 +329,7 @@ class TestRandomForestClassifier:
         )
         assert np.allclose(predictions, predictions_exported_model, atol=1e-8)
 
+    @pytest.mark.skip(reason="Skipped a long running test, lightly format should be removed.")
     def test_export__lightly_format(self, tmp_path: Path) -> None:
         """Test the export raw functionality."""
         n_samples = 1000


### PR DESCRIPTION
## What has changed and why?

Skip `test_export__lightly_format` — it is slow (trains a 1000-sample / 100-class random forest) and the `lightly` export format it covers is slated for removal.

## How has it been tested?

`pytest` collection confirms the test is skipped; the rest of the suite is unaffected.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Skipped the long-running Lightly-format export test to streamline the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->