### PR TITLE
[LIG-10238] Add grouped class-count resolver by sample tags

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/__init__.py
@@ -2,6 +2,7 @@
 
 from lightly_studio.resolvers.image_resolver.count_image_annotations_by_collection import (
     count_image_annotations_by_collection,
+    count_image_annotations_by_sample_tags,
 )
 from lightly_studio.resolvers.image_resolver.create_many import create_many
 from lightly_studio.resolvers.image_resolver.delete import delete
@@ -29,6 +30,7 @@ __all__ = [
     "ImageExportPreload",
     "build_sample_ids_query",
     "count_image_annotations_by_collection",
+    "count_image_annotations_by_sample_tags",
     "create_many",
     "delete",
     "get_adjacent_images",

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/count_image_annotations_by_collection.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, TypeVar
 from uuid import UUID
 
 from sqlalchemy import ColumnElement
@@ -18,7 +19,8 @@ from lightly_studio.models.annotation.annotation_base import (
 )
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.image import ImageTable
-from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample import SampleTable, SampleTagLinkTable
+from lightly_studio.models.tag import TagTable
 from lightly_studio.resolvers import embedding_region_resolver
 from lightly_studio.resolvers.image_filter import ImageFilter
 
@@ -28,6 +30,101 @@ class AnnotationCountMode(str, Enum):
 
     OBJECTS = "objects"
     SAMPLES = "samples"
+
+
+@dataclass(frozen=True)
+class AnnotationClassCount:
+    """Annotation count for one class.
+
+    Attributes:
+        label_name: Annotation class name on the shared class axis.
+        count: Number of matching annotation objects or distinct annotated samples.
+    """
+
+    label_name: str
+    count: int
+
+
+@dataclass(frozen=True)
+class SampleTagAnnotationCounts:
+    """Annotation class counts for one sample tag.
+
+    Attributes:
+        sample_tag_id: ID of the selected sample tag.
+        sample_tag_name: Name of the selected sample tag.
+        counts: Zero-filled counts on the shared class axis.
+    """
+
+    sample_tag_id: UUID
+    sample_tag_name: str
+    counts: list[AnnotationClassCount]
+
+
+def count_image_annotations_by_sample_tags(  # noqa: PLR0913
+    session: Session,
+    collection_id: UUID,
+    sample_tag_ids: list[UUID],
+    image_filter: ImageFilter | None = None,
+    annotation_type: AnnotationType | None = None,
+    count_mode: AnnotationCountMode = AnnotationCountMode.OBJECTS,
+) -> list[SampleTagAnnotationCounts]:
+    """Count image annotations independently for each requested sample tag.
+
+    The active image filter is intersected with each sample tag. Annotation source
+    restrictions inside the filter also scope the shared class axis.
+
+    Args:
+        session: Database session used to validate tags and execute count queries.
+        collection_id: ID of the image collection whose annotations are counted.
+        sample_tag_ids: Ordered sample tag IDs. Empty input returns no series.
+        image_filter: Active image filter applied in addition to each sample tag.
+        annotation_type: Optional annotation type restriction.
+        count_mode: Whether to count annotation objects or distinct parent samples.
+
+    Returns:
+        One zero-filled class-count series per requested tag, preserving request order.
+
+    Raises:
+        ValueError: If a requested ID is not a sample tag in the target collection.
+    """
+    if not sample_tag_ids:
+        return []
+
+    sample_tags = _get_and_validate_sample_tags(
+        session=session,
+        collection_id=collection_id,
+        sample_tag_ids=sample_tag_ids,
+    )
+    _resolve_embedding_region(
+        session=session,
+        collection_id=collection_id,
+        image_filter=image_filter,
+    )
+    annotation_collection_ids = _get_annotation_collection_ids(image_filter=image_filter)
+    class_names = list(
+        _get_total_counts(
+            session=session,
+            collection_id=collection_id,
+            annotation_type=annotation_type,
+            count_mode=count_mode,
+            annotation_collection_ids=annotation_collection_ids,
+        )
+    )
+    grouped_counts = _get_counts_grouped_by_sample_tag(
+        session=session,
+        collection_id=collection_id,
+        sample_tag_ids=sample_tag_ids,
+        image_filter=image_filter,
+        annotation_type=annotation_type,
+        annotation_collection_ids=annotation_collection_ids,
+        count_mode=count_mode,
+    )
+    return _build_sample_tag_counts(
+        sample_tag_ids=sample_tag_ids,
+        sample_tags=sample_tags,
+        class_names=class_names,
+        grouped_counts=grouped_counts,
+    )
 
 
 def count_image_annotations_by_collection(
@@ -58,20 +155,12 @@ def count_image_annotations_by_collection(
     from the total as well, so the total never counts labels the current view does
     not care about (e.g. viewing a single source shows "2 of 2", not "2 of 4").
     """
-    # Resolve any embedding-plot region selection to concrete sample ids on the filter before the
-    # query is built (the point-in-polygon test needs the session, which `apply` lacks).
-    sample_filter = image_filter.sample_filter if image_filter is not None else None
-    if sample_filter is not None and sample_filter.embedding_region is not None:
-        sample_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
-            session=session,
-            collection_id=collection_id,
-            region=sample_filter.embedding_region,
-        )
-    annotation_collection_ids = (
-        sample_filter.annotations_filter.collection_ids
-        if sample_filter is not None and sample_filter.annotations_filter is not None
-        else None
+    _resolve_embedding_region(
+        session=session,
+        collection_id=collection_id,
+        image_filter=image_filter,
     )
+    annotation_collection_ids = _get_annotation_collection_ids(image_filter=image_filter)
     total_counts = _get_total_counts(
         session=session,
         collection_id=collection_id,
@@ -94,16 +183,62 @@ def count_image_annotations_by_collection(
     ]
 
 
+def _get_and_validate_sample_tags(
+    session: Session,
+    collection_id: UUID,
+    sample_tag_ids: list[UUID],
+) -> dict[UUID, str]:
+    query = select(TagTable.tag_id, TagTable.name).where(
+        col(TagTable.collection_id) == collection_id,
+        col(TagTable.kind) == "sample",
+        db_array.in_array(column=col(TagTable.tag_id), values=sample_tag_ids),
+    )
+    sample_tags = dict(session.exec(query).all())
+    invalid_ids = set(sample_tag_ids) - sample_tags.keys()
+    if invalid_ids:
+        ids = ", ".join(sorted(str(tag_id) for tag_id in invalid_ids))
+        raise ValueError(
+            f"Tags must be sample tags belonging to collection {collection_id}: {ids}."
+        )
+    return sample_tags
+
+
+def _resolve_embedding_region(
+    session: Session,
+    collection_id: UUID,
+    image_filter: ImageFilter | None,
+) -> None:
+    """Resolve an embedding region to sample IDs before applying the image filter."""
+    sample_filter = image_filter.sample_filter if image_filter is not None else None
+    if sample_filter is None or sample_filter.embedding_region is None:
+        return
+    sample_filter.region_sample_ids = embedding_region_resolver.get_sample_ids_in_region(
+        session=session,
+        collection_id=collection_id,
+        region=sample_filter.embedding_region,
+    )
+
+
+def _get_annotation_collection_ids(image_filter: ImageFilter | None) -> list[UUID] | None:
+    sample_filter = image_filter.sample_filter if image_filter is not None else None
+    if sample_filter is None or sample_filter.annotations_filter is None:
+        return None
+    return sample_filter.annotations_filter.collection_ids
+
+
 def _build_count_expression(count_mode: AnnotationCountMode) -> ColumnElement[int]:
     if count_mode == AnnotationCountMode.SAMPLES:
         return func.count(func.distinct(col(AnnotationBaseTable.parent_sample_id)))
     return func.count(col(AnnotationBaseTable.sample_id))
 
 
+_SelectRow = TypeVar("_SelectRow")
+
+
 def _restrict_to_annotation_sources(
-    query: Select[tuple[Any, int]],
+    query: Select[_SelectRow],
     annotation_collection_ids: list[UUID],
-) -> Select[tuple[Any, int]]:
+) -> Select[_SelectRow]:
     """Restrict the counted annotations to the given source collections.
 
     The annotation's own sample (aliased to avoid clashing with the image sample
@@ -119,6 +254,79 @@ def _restrict_to_annotation_sources(
             values=annotation_collection_ids,
         )
     )
+
+
+def _get_counts_grouped_by_sample_tag(  # noqa: PLR0913
+    session: Session,
+    collection_id: UUID,
+    sample_tag_ids: list[UUID],
+    image_filter: ImageFilter | None,
+    annotation_type: AnnotationType | None,
+    annotation_collection_ids: list[UUID] | None,
+    count_mode: AnnotationCountMode,
+) -> dict[tuple[UUID, str], int]:
+    query: Any = (
+        select(
+            SampleTagLinkTable.tag_id,
+            AnnotationLabelTable.annotation_label_name,
+            _build_count_expression(count_mode).label("count"),
+        )
+        .join(
+            AnnotationBaseTable,
+            col(AnnotationBaseTable.annotation_label_id)
+            == col(AnnotationLabelTable.annotation_label_id),
+        )
+        .join(
+            ImageTable,
+            col(ImageTable.sample_id) == col(AnnotationBaseTable.parent_sample_id),
+        )
+        .join(SampleTable, col(SampleTable.sample_id) == col(ImageTable.sample_id))
+        .join(
+            SampleTagLinkTable,
+            col(SampleTagLinkTable.sample_id) == col(SampleTable.sample_id),
+        )
+        .where(
+            col(SampleTable.collection_id) == collection_id,
+            db_array.in_array(column=col(SampleTagLinkTable.tag_id), values=sample_tag_ids),
+        )
+    )
+    if annotation_type is not None:
+        query = query.where(col(AnnotationBaseTable.annotation_type) == annotation_type)
+    if annotation_collection_ids:
+        query = _restrict_to_annotation_sources(query, annotation_collection_ids)
+    if image_filter is not None:
+        query = image_filter.apply(query)
+    query = query.group_by(
+        col(SampleTagLinkTable.tag_id),
+        AnnotationLabelTable.annotation_label_name,
+    )
+    result: dict[tuple[UUID, str], int] = {}
+    for tag_id, label_name, count in session.exec(query).all():
+        assert tag_id is not None
+        result[(tag_id, label_name)] = count
+    return result
+
+
+def _build_sample_tag_counts(
+    sample_tag_ids: list[UUID],
+    sample_tags: dict[UUID, str],
+    class_names: list[str],
+    grouped_counts: dict[tuple[UUID, str], int],
+) -> list[SampleTagAnnotationCounts]:
+    return [
+        SampleTagAnnotationCounts(
+            sample_tag_id=tag_id,
+            sample_tag_name=sample_tags[tag_id],
+            counts=[
+                AnnotationClassCount(
+                    label_name=class_name,
+                    count=grouped_counts.get((tag_id, class_name), 0),
+                )
+                for class_name in class_names
+            ],
+        )
+        for tag_id in sample_tag_ids
+    ]
 
 
 def _get_total_counts(

--- a/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_sample_tags.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_count_image_annotations_by_sample_tags.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel import Session
+
+from lightly_studio.models.annotation.annotation_base import AnnotationType
+from lightly_studio.resolvers import image_resolver, tag_resolver
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.resolvers.image_resolver.count_image_annotations_by_collection import (
+    AnnotationCountMode,
+)
+from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
+from tests.helpers_resolvers import (
+    AnnotationDetails,
+    create_annotation_label,
+    create_annotations,
+    create_collection,
+    create_image,
+    create_tag,
+)
+
+
+def test_count_image_annotations_by_sample_tags__overlap_order_and_zero_fill(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    image_a = create_image(session=db_session, collection_id=collection_id, file_path_abs="a.png")
+    image_b = create_image(session=db_session, collection_id=collection_id, file_path_abs="b.png")
+    image_c = create_image(session=db_session, collection_id=collection_id, file_path_abs="c.png")
+    cat = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="cat"
+    )
+    dog = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="dog"
+    )
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=dog.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=dog.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=cat.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_c.sample_id,
+                annotation_label_id=dog.annotation_label_id,
+            ),
+        ],
+    )
+    tag_ab = create_tag(session=db_session, collection_id=collection_id, tag_name="a-and-b")
+    tag_bc = create_tag(session=db_session, collection_id=collection_id, tag_name="b-and-c")
+    empty_tag = create_tag(session=db_session, collection_id=collection_id, tag_name="empty")
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=tag_ab.tag_id,
+        sample_ids=[image_a.sample_id, image_b.sample_id],
+    )
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=tag_bc.tag_id,
+        sample_ids=[image_b.sample_id, image_c.sample_id],
+    )
+
+    result = image_resolver.count_image_annotations_by_sample_tags(
+        session=db_session,
+        collection_id=collection_id,
+        sample_tag_ids=[tag_bc.tag_id, empty_tag.tag_id, tag_ab.tag_id],
+    )
+
+    assert [series.sample_tag_id for series in result] == [
+        tag_bc.tag_id,
+        empty_tag.tag_id,
+        tag_ab.tag_id,
+    ]
+    assert [[(row.label_name, row.count) for row in series.counts] for series in result] == [
+        [("cat", 1), ("dog", 1)],
+        [("cat", 0), ("dog", 0)],
+        [("cat", 1), ("dog", 2)],
+    ]
+
+
+def test_count_image_annotations_by_sample_tags__samples_mode_and_active_tag_filter(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    image_a = create_image(session=db_session, collection_id=collection_id, file_path_abs="a.png")
+    image_b = create_image(session=db_session, collection_id=collection_id, file_path_abs="b.png")
+    dog = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="dog"
+    )
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=dog.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_a.sample_id,
+                annotation_label_id=dog.annotation_label_id,
+            ),
+            AnnotationDetails(
+                sample_id=image_b.sample_id,
+                annotation_label_id=dog.annotation_label_id,
+            ),
+        ],
+    )
+    comparison_tag = create_tag(
+        session=db_session, collection_id=collection_id, tag_name="comparison"
+    )
+    active_tag = create_tag(session=db_session, collection_id=collection_id, tag_name="active")
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=comparison_tag.tag_id,
+        sample_ids=[image_a.sample_id, image_b.sample_id],
+    )
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=active_tag.tag_id,
+        sample_ids=[image_a.sample_id],
+    )
+
+    result = image_resolver.count_image_annotations_by_sample_tags(
+        session=db_session,
+        collection_id=collection_id,
+        sample_tag_ids=[comparison_tag.tag_id],
+        image_filter=ImageFilter(sample_filter=SampleFilter(tag_ids=[active_tag.tag_id])),
+        count_mode=AnnotationCountMode.SAMPLES,
+    )
+
+    assert [(row.label_name, row.count) for row in result[0].counts] == [("dog", 1)]
+
+
+def test_count_image_annotations_by_sample_tags__annotation_source_and_type_scope(
+    db_session: Session,
+) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+    image = create_image(session=db_session, collection_id=collection_id)
+    scene = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="scene"
+    )
+    dog = create_annotation_label(
+        session=db_session, root_collection_id=collection_id, label_name="dog"
+    )
+    source_a = create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=scene.annotation_label_id,
+                annotation_type=AnnotationType.CLASSIFICATION,
+            )
+        ],
+        collection_name="source-a",
+    )
+    create_annotations(
+        session=db_session,
+        collection_id=collection_id,
+        annotations=[
+            AnnotationDetails(
+                sample_id=image.sample_id,
+                annotation_label_id=dog.annotation_label_id,
+                annotation_type=AnnotationType.OBJECT_DETECTION,
+            )
+        ],
+        collection_name="source-b",
+    )
+    tag = create_tag(session=db_session, collection_id=collection_id)
+    tag_resolver.add_sample_ids_to_tag_id(
+        session=db_session,
+        tag_id=tag.tag_id,
+        sample_ids=[image.sample_id],
+    )
+
+    result = image_resolver.count_image_annotations_by_sample_tags(
+        session=db_session,
+        collection_id=collection_id,
+        sample_tag_ids=[tag.tag_id],
+        image_filter=ImageFilter(
+            sample_filter=SampleFilter(
+                annotations_filter=AnnotationsFilter(
+                    collection_ids=[source_a[0].annotation_collection_id]
+                )
+            )
+        ),
+        annotation_type=AnnotationType.CLASSIFICATION,
+    )
+
+    assert [(row.label_name, row.count) for row in result[0].counts] == [("scene", 1)]
+
+
+@pytest.mark.parametrize("invalid_tag_kind", ["missing", "foreign", "annotation"])
+def test_count_image_annotations_by_sample_tags__rejects_invalid_tags(
+    db_session: Session,
+    invalid_tag_kind: str,
+) -> None:
+    collection = create_collection(session=db_session)
+    invalid_tag_id = _create_invalid_tag_id(
+        session=db_session,
+        collection_id=collection.collection_id,
+        invalid_tag_kind=invalid_tag_kind,
+    )
+
+    with pytest.raises(ValueError, match="must be sample tags belonging to collection"):
+        image_resolver.count_image_annotations_by_sample_tags(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_tag_ids=[invalid_tag_id],
+        )
+
+
+def test_count_image_annotations_by_sample_tags__empty_selection(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+
+    result = image_resolver.count_image_annotations_by_sample_tags(
+        session=db_session,
+        collection_id=collection.collection_id,
+        sample_tag_ids=[],
+    )
+
+    assert result == []
+
+
+def _create_invalid_tag_id(
+    session: Session,
+    collection_id: UUID,
+    invalid_tag_kind: str,
+) -> UUID:
+    if invalid_tag_kind == "missing":
+        return uuid4()
+    if invalid_tag_kind == "annotation":
+        return create_tag(
+            session=session,
+            collection_id=collection_id,
+            kind="annotation",
+        ).tag_id
+    foreign_collection = create_collection(session=session)
+    return create_tag(session=session, collection_id=foreign_collection.collection_id).tag_id


### PR DESCRIPTION
## Summary

- add resolver support for counting image annotations independently by an ordered list of sample tags
- validate that every requested tag is a sample tag owned by the target collection
- intersect each comparison tag with the active image filter and annotation source/type scope
- preserve requested tag order and zero-fill missing classes on a shared class axis
- support both annotation-object and distinct-sample count modes
- add focused resolver coverage for overlap, ordering, filters, modes, invalid tags, and empty selections

## Why

Class-distribution comparison needs independent counts for overlapping sample tags. Keeping the resolver logic and its acceptance matrix separate makes the data-query behavior reviewable without the API transport layer.

## Stack

- This PR: resolver changes and resolver tests
- Next: API route, request/response models, and API tests in #1692

## Testing

From `lightly_studio/`:

```bash
make static-checks
uv run pytest -q tests/resolvers/image_resolver/test_count_image_annotations_by_sample_tags.py
```

Validated locally:

- Ruff, mypy, and formatting checks pass
- focused resolver suite: 7 passed

## Linear

[LIG-10238](https://linear.app/lightly/issue/LIG-10238/backend-batch-class-counts-by-selected-sample-tags)