### PR TITLE
Make collection_id required in collection_resolver.get_root_collection

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/collection_resolver/get_collection.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_resolver/get_collection.py
@@ -4,58 +4,44 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from sqlmodel import Session, col, select
+from sqlmodel import Session
 
 from lightly_studio.models.collection import CollectionTable
 
 
-# TODO (Mihnea, 12/2025): Update the collection_id to be required.
-#  The collection_id is currently optional for backwards compatibility.
-def get_root_collection(session: Session, collection_id: UUID | None = None) -> CollectionTable:
-    """Retrieve the root collection for a given collection or the first root collection.
+def get_root_collection(session: Session, collection_id: UUID) -> CollectionTable:
+    """Retrieve the root collection for a given collection.
 
-    If collection_id is provided, traverses up the hierarchy to find the root ancestor.
-    If collection_id is None, returns the first root collection (backwards compatibility).
+    Traverses up the hierarchy to find the root ancestor.
 
     A root collection (dataset) is defined as a collection where parent_collection_id is None.
     The root collection may or may not have children.
 
     Args:
         session: The database session.
-        collection_id: Optional ID of a collection to find the root for.
+        collection_id: ID of a collection to find the root for.
 
     Returns:
         The root collection.
 
     Raises:
-        ValueError: If no root collection is found or collection_id doesn't exist.
+        ValueError: If collection_id doesn't exist.
     """
-    if collection_id is not None:
-        # Find the collection.
-        collection = session.get(CollectionTable, collection_id)
-        if collection is None:
-            raise ValueError(f"Collection with ID {collection_id} not found.")
+    # Find the collection.
+    collection = session.get(CollectionTable, collection_id)
+    if collection is None:
+        raise ValueError(f"Collection with ID {collection_id} not found.")
 
-        # Traverse up the hierarchy until we find the root.
-        # TODO (Mihnea, 12/2025): Consider replacing the loop with a recursive CTE,
-        #  if this becomes a bottleneck.
-        while collection.parent_collection_id is not None:
-            parent = session.get(CollectionTable, collection.parent_collection_id)
-            if parent is None:
-                raise ValueError(
-                    f"Parent collection {collection.parent_collection_id} not found "
-                    f"for collection {collection.collection_id}."
-                )
-            collection = parent
+    # Traverse up the hierarchy until we find the root.
+    # TODO (Mihnea, 12/2025): Consider replacing the loop with a recursive CTE,
+    #  if this becomes a bottleneck.
+    while collection.parent_collection_id is not None:
+        parent = session.get(CollectionTable, collection.parent_collection_id)
+        if parent is None:
+            raise ValueError(
+                f"Parent collection {collection.parent_collection_id} not found "
+                f"for collection {collection.collection_id}."
+            )
+        collection = parent
 
-        return collection
-
-    # Backwards compatibility: return first root collection
-    root_collections = session.exec(
-        select(CollectionTable).where(col(CollectionTable.parent_collection_id).is_(None))
-    ).all()
-
-    if len(root_collections) == 0:
-        raise ValueError("No root collection found. A root collection must exist.")
-
-    return root_collections[0]
+    return collection

--- a/lightly_studio/tests/resolvers/collection_resolver/test_get_root_dataset.py
+++ b/lightly_studio/tests/resolvers/collection_resolver/test_get_root_dataset.py
@@ -73,11 +73,3 @@ def test_get_root_collection__non_existent_collection(
         collection_resolver.get_root_collection(
             session=db_session, collection_id=not_found_collection_id
         )
-
-
-def test_get_root_collection__collection_id_required(
-    db_session: Session,
-) -> None:
-    """`collection_id` must be required; `None` is no longer a valid value."""
-    with pytest.raises(ValueError, match=r"Collection with ID None not found."):
-        collection_resolver.get_root_collection(session=db_session, collection_id=None)  # type: ignore[arg-type]

--- a/lightly_studio/tests/resolvers/collection_resolver/test_get_root_dataset.py
+++ b/lightly_studio/tests/resolvers/collection_resolver/test_get_root_dataset.py
@@ -29,9 +29,6 @@ def test_get_root_collection(
         ),
     )
 
-    root_collection = collection_resolver.get_root_collection(session=db_session)
-    assert root_collection.collection_id == ds_a.collection_id
-
     root_collection = collection_resolver.get_root_collection(
         session=db_session, collection_id=ds_a.collection_id
     )
@@ -55,9 +52,6 @@ def test_get_root_collection__multiple_root_collections(
         session=db_session, collection=CollectionCreate(name="ds_b", sample_type=SampleType.IMAGE)
     )
 
-    root_collection = collection_resolver.get_root_collection(session=db_session)
-    assert root_collection.collection_id == first_root_collection.collection_id
-
     root_collection = collection_resolver.get_root_collection(
         session=db_session, collection_id=first_root_collection.collection_id
     )
@@ -69,14 +63,9 @@ def test_get_root_collection__multiple_root_collections(
     assert root_collection.collection_id == second_root_collection.collection_id
 
 
-def test_get_root_collection__no_collection(
+def test_get_root_collection__non_existent_collection(
     db_session: Session,
 ) -> None:
-    with pytest.raises(
-        ValueError, match=r"No root collection found. A root collection must exist."
-    ):
-        collection_resolver.get_root_collection(session=db_session)
-
     not_found_collection_id = uuid.uuid4()
     with pytest.raises(
         ValueError, match=f"Collection with ID {not_found_collection_id} not found."
@@ -84,3 +73,11 @@ def test_get_root_collection__no_collection(
         collection_resolver.get_root_collection(
             session=db_session, collection_id=not_found_collection_id
         )
+
+
+def test_get_root_collection__collection_id_required(
+    db_session: Session,
+) -> None:
+    """`collection_id` must be required; `None` is no longer a valid value."""
+    with pytest.raises(ValueError, match=r"Collection with ID None not found."):
+        collection_resolver.get_root_collection(session=db_session, collection_id=None)  # type: ignore[arg-type]


### PR DESCRIPTION
## What has changed and why?

Completes the TODO in `get_root_collection` by making `collection_id` required and removing the backwards-compatibility fallback that returned an arbitrary root collection when it was omitted.

In a shared database, "return whichever root collection sorts first" could return another tenant's dataset.

- Removed the `collection_id: UUID | None = None` fallback branch in `resolvers/collection_resolver/get_collection.py`; `collection_id` is now required.
- All three production call sites (`sampling_via_db.py`, `run_evaluation.py`, `api/routes/api/collection.py`) already passed `collection_id` explicitly, so no caller changes were needed.
- Updated tests to drop coverage of the removed fallback and added a regression test asserting `collection_id=None` is rejected.

Closes [LIG-10433](https://linear.app/lightly/issue/LIG-10433/make-collection-id-required-in-collection-resolverget-root-collection).

## How has it been tested?

```
cd lightly_studio
make static-checks
make test
```

All tests pass (pre-existing failures for `tests/test_enterprise.py` etc. due to missing optional `gcsfs`/`s3fs` deps are unrelated to this change and present on `main` too).

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Root collection retrieval now consistently resolves the root ancestor for a specified collection.
  * Collection identification is required, eliminating ambiguous fallback behavior when no collection is specified.
  * Requests for nonexistent collections are handled consistently.

* **Tests**
  * Expanded coverage for root and child collection resolution.
  * Added checks for separate collection trees and nonexistent collection IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->