### PR TITLE
feat: introduce posibility to render series of bars for BarChart for buildChartOptions

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.test.ts
@@ -45,14 +45,12 @@ describe('buildChartTooltipFormatter — standard (non-grouped)', () => {
 
     it('shows label, count, and percentage', () => {
         const result = fmt([param('car', 6)]);
-        expect(result).toContain('<b>car</b>');
-        expect(result).toContain('<b>6</b>');
-        expect(result).toContain('60.0%');
+        expect(result).toBe('<b>car</b><br/>Count: <b>6</b> (60.0%)');
     });
 
     it('shows 0 count when the category is not found in data', () => {
         const result = fmt([param('unknown', 0)]);
-        expect(result).toContain('<b>0</b>');
+        expect(result).toBe('<b>unknown</b><br/>Count: <b>0</b> (0.0%)');
     });
 
     it('omits percentage when totalCount is 0', () => {
@@ -64,7 +62,7 @@ describe('buildChartTooltipFormatter — standard (non-grouped)', () => {
             hasActiveFilter: false
         });
         const result = fmt0([param('car', 6)]);
-        expect(result).not.toContain('%');
+        expect(result).toBe('<b>car</b><br/>Count: <b>6</b>');
     });
 
     it('escapes HTML in the category label', () => {
@@ -77,7 +75,9 @@ describe('buildChartTooltipFormatter — standard (non-grouped)', () => {
             hasActiveFilter: false
         });
         const result = fmtXss([param('<script>alert(1)</script>', 1)]);
-        expect(result).not.toContain('<script>');
+        expect(result).toBe(
+            '<b>&lt;script&gt;alert(1)&lt;/script&gt;</b><br/>Count: <b>1</b> (100.0%)'
+        );
     });
 
     it('looks up categories by id while displaying their label', () => {
@@ -90,8 +90,7 @@ describe('buildChartTooltipFormatter — standard (non-grouped)', () => {
             hasActiveFilter: false
         });
 
-        expect(fmtById([param('category-1', 6)])).toContain('<b>car</b>');
-        expect(fmtById([param('category-1', 6)])).toContain('<b>6</b>');
+        expect(fmtById([param('category-1', 6)])).toBe('<b>car</b><br/>Count: <b>6</b> (60.0%)');
     });
 });
 
@@ -106,9 +105,7 @@ describe('buildChartTooltipFormatter — standard with active filter', () => {
             hasActiveFilter: true
         });
         const result = fmt([param('car', 2)]);
-        expect(result).toContain('of');
-        expect(result).toContain('<b>2</b>');
-        expect(result).toContain('<b>6</b>');
+        expect(result).toBe('<b>car</b><br/>Count: <b>2</b> (20.0%) of <b>6</b> (60.0%) total');
     });
 
     it('does not show "of total" when filteredCount equals count', () => {
@@ -121,7 +118,7 @@ describe('buildChartTooltipFormatter — standard with active filter', () => {
             hasActiveFilter: true
         });
         const result = fmt([param('car', 6)]);
-        expect(result).not.toContain('of');
+        expect(result).toBe('<b>car</b><br/>Count: <b>6</b> (60.0%)');
     });
 
     it('does not show "of total" when filteredCount is absent', () => {
@@ -133,7 +130,7 @@ describe('buildChartTooltipFormatter — standard with active filter', () => {
             hasActiveFilter: true
         });
         const result = fmt([param('car', 6)]);
-        expect(result).not.toContain('of');
+        expect(result).toBe('<b>car</b><br/>Count: <b>6</b> (60.0%)');
     });
 });
 
@@ -152,7 +149,7 @@ describe('buildChartTooltipFormatter — grouped', () => {
 
     it('uses the category name as a bold header', () => {
         const result = fmt([param('car', 3, { seriesIndex: 0, seriesName: 'Reviewed' })]);
-        expect(result.startsWith('<b>car</b>')).toBe(true);
+        expect(result).toBe('<b>car</b><br/>Reviewed: <b>3</b> (60.0%)');
     });
 
     it('shows each series name and its count', () => {
@@ -160,28 +157,27 @@ describe('buildChartTooltipFormatter — grouped', () => {
             param('car', 3, { seriesIndex: 0, seriesName: 'Reviewed' }),
             param('car', 1, { seriesIndex: 1, seriesName: 'Priority' })
         ]);
-        expect(result).toContain('Reviewed');
-        expect(result).toContain('Priority');
-        expect(result).toContain('<b>3</b>');
-        expect(result).toContain('<b>1</b>');
+        expect(result).toBe(
+            '<b>car</b><br/>Reviewed: <b>3</b> (60.0%)<br/>Priority: <b>1</b> (10.0%)'
+        );
     });
 
     it('uses totalCount as denominator when provided on the series', () => {
         // tag-b has totalCount: 10
         const result = fmt([param('car', 1, { seriesIndex: 1, seriesName: 'Priority' })]);
-        expect(result).toContain('10.0%'); // 1/10
+        expect(result).toBe('<b>car</b><br/>Priority: <b>1</b> (10.0%)');
     });
 
     it('sums series data as denominator when totalCount is absent', () => {
         // tag-a: 3 + 2 = 5 total; car count = 3 → 60%
         const result = fmt([param('car', 3, { seriesIndex: 0, seriesName: 'Reviewed' })]);
-        expect(result).toContain('60.0%');
+        expect(result).toBe('<b>car</b><br/>Reviewed: <b>3</b> (60.0%)');
     });
 
     it('shows 0 count for a series missing the hovered category', () => {
         // tag-b has no 'dog' entry
         const result = fmt([param('dog', 0, { seriesIndex: 1, seriesName: 'Priority' })]);
-        expect(result).toContain('<b>0</b>');
+        expect(result).toBe('<b>dog</b><br/>Priority: <b>0</b> (0.0%)');
     });
 
     it('escapes HTML in the series name', () => {
@@ -198,7 +194,7 @@ describe('buildChartTooltipFormatter — grouped', () => {
         const result = fmtXss([
             param('car', 1, { seriesIndex: 0, seriesName: '<img src=x onerror=alert(1)>' })
         ]);
-        expect(result).not.toContain('<img');
+        expect(result).toBe('<b>car</b><br/>&lt;img src=x onerror=alert(1)&gt;: <b>1</b> (100.0%)');
     });
 
     it('keeps duplicate labels distinct by category id', () => {
@@ -224,7 +220,11 @@ describe('buildChartTooltipFormatter — grouped', () => {
             hasActiveFilter: false
         });
 
-        expect(fmtById([param('first', 3, { seriesIndex: 0 })])).toContain('<b>3</b>');
-        expect(fmtById([param('second', 1, { seriesIndex: 0 })])).toContain('<b>1</b>');
+        expect(fmtById([param('first', 3, { seriesIndex: 0 })])).toBe(
+            '<b>Missing</b><br/>: <b>3</b> (75.0%)'
+        );
+        expect(fmtById([param('second', 1, { seriesIndex: 0 })])).toBe(
+            '<b>Missing</b><br/>: <b>1</b> (25.0%)'
+        );
     });
 });

--- a/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { buildChartTooltipFormatter } from './buildChartTooltipFormatter';
+import type { CategoryCount, CategoryCountSeries } from '../types';
+
+const data: CategoryCount[] = [
+    { label: 'car', count: 6 },
+    { label: 'dog', count: 4 }
+];
+
+const groupedSeries: CategoryCountSeries[] = [
+    {
+        id: 'tag-a',
+        label: 'Reviewed',
+        data: [
+            { label: 'car', count: 3 },
+            { label: 'dog', count: 2 }
+        ]
+    },
+    {
+        id: 'tag-b',
+        label: 'Priority',
+        data: [{ label: 'car', count: 1 }],
+        totalCount: 10
+    }
+];
+
+const param = (name: string, value: number, overrides: object = {}) => ({
+    name,
+    value,
+    ...overrides
+});
+
+describe('buildChartTooltipFormatter — standard (non-grouped)', () => {
+    const fmt = buildChartTooltipFormatter(false, data, [], 10, false);
+
+    it('returns empty string for empty params', () => {
+        expect(fmt([])).toBe('');
+    });
+
+    it('shows label, count, and percentage', () => {
+        const result = fmt([param('car', 6)]);
+        expect(result).toContain('<b>car</b>');
+        expect(result).toContain('<b>6</b>');
+        expect(result).toContain('60.0%');
+    });
+
+    it('shows 0 count when the category is not found in data', () => {
+        const result = fmt([param('unknown', 0)]);
+        expect(result).toContain('<b>0</b>');
+    });
+
+    it('omits percentage when totalCount is 0', () => {
+        const fmt0 = buildChartTooltipFormatter(false, data, [], 0, false);
+        const result = fmt0([param('car', 6)]);
+        expect(result).not.toContain('%');
+    });
+
+    it('escapes HTML in the category label', () => {
+        const xssData: CategoryCount[] = [{ label: '<script>alert(1)</script>', count: 1 }];
+        const fmtXss = buildChartTooltipFormatter(false, xssData, [], 1, false);
+        const result = fmtXss([param('<script>alert(1)</script>', 1)]);
+        expect(result).not.toContain('<script>');
+    });
+});
+
+describe('buildChartTooltipFormatter — standard with active filter', () => {
+    it('shows filtered and total counts when filteredCount differs from count', () => {
+        const filtered: CategoryCount[] = [{ label: 'car', count: 6, filteredCount: 2 }];
+        const fmt = buildChartTooltipFormatter(false, filtered, [], 10, true);
+        const result = fmt([param('car', 2)]);
+        expect(result).toContain('of');
+        expect(result).toContain('<b>2</b>');
+        expect(result).toContain('<b>6</b>');
+    });
+
+    it('does not show "of total" when filteredCount equals count', () => {
+        const filtered: CategoryCount[] = [{ label: 'car', count: 6, filteredCount: 6 }];
+        const fmt = buildChartTooltipFormatter(false, filtered, [], 10, true);
+        const result = fmt([param('car', 6)]);
+        expect(result).not.toContain('of');
+    });
+
+    it('does not show "of total" when filteredCount is absent', () => {
+        const fmt = buildChartTooltipFormatter(false, data, [], 10, true);
+        const result = fmt([param('car', 6)]);
+        expect(result).not.toContain('of');
+    });
+});
+
+describe('buildChartTooltipFormatter — grouped', () => {
+    const fmt = buildChartTooltipFormatter(true, [], groupedSeries, 0, false);
+
+    it('returns empty string for empty params', () => {
+        expect(fmt([])).toBe('');
+    });
+
+    it('uses the category name as a bold header', () => {
+        const result = fmt([param('car', 3, { seriesIndex: 0, seriesName: 'Reviewed' })]);
+        expect(result.startsWith('<b>car</b>')).toBe(true);
+    });
+
+    it('shows each series name and its count', () => {
+        const result = fmt([
+            param('car', 3, { seriesIndex: 0, seriesName: 'Reviewed' }),
+            param('car', 1, { seriesIndex: 1, seriesName: 'Priority' })
+        ]);
+        expect(result).toContain('Reviewed');
+        expect(result).toContain('Priority');
+        expect(result).toContain('<b>3</b>');
+        expect(result).toContain('<b>1</b>');
+    });
+
+    it('uses totalCount as denominator when provided on the series', () => {
+        // tag-b has totalCount: 10
+        const result = fmt([param('car', 1, { seriesIndex: 1, seriesName: 'Priority' })]);
+        expect(result).toContain('10.0%'); // 1/10
+    });
+
+    it('sums series data as denominator when totalCount is absent', () => {
+        // tag-a: 3 + 2 = 5 total; car count = 3 → 60%
+        const result = fmt([param('car', 3, { seriesIndex: 0, seriesName: 'Reviewed' })]);
+        expect(result).toContain('60.0%');
+    });
+
+    it('shows 0 count for a series missing the hovered category', () => {
+        // tag-b has no 'dog' entry
+        const result = fmt([param('dog', 0, { seriesIndex: 1, seriesName: 'Priority' })]);
+        expect(result).toContain('<b>0</b>');
+    });
+
+    it('escapes HTML in the series name', () => {
+        const xssSeries: CategoryCountSeries[] = [
+            { id: 'x', label: '<img src=x onerror=alert(1)>', data: [{ label: 'car', count: 1 }] }
+        ];
+        const fmtXss = buildChartTooltipFormatter(true, [], xssSeries, 0, false);
+        const result = fmtXss([
+            param('car', 1, { seriesIndex: 0, seriesName: '<img src=x onerror=alert(1)>' })
+        ]);
+        expect(result).not.toContain('<img');
+    });
+});

--- a/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.test.ts
@@ -31,7 +31,13 @@ const param = (name: string, value: number, overrides: object = {}) => ({
 });
 
 describe('buildChartTooltipFormatter — standard (non-grouped)', () => {
-    const fmt = buildChartTooltipFormatter(false, data, [], 10, false);
+    const fmt = buildChartTooltipFormatter({
+        isGrouped: false,
+        data,
+        groupedSeries: [],
+        totalCount: 10,
+        hasActiveFilter: false
+    });
 
     it('returns empty string for empty params', () => {
         expect(fmt([])).toBe('');
@@ -50,21 +56,39 @@ describe('buildChartTooltipFormatter — standard (non-grouped)', () => {
     });
 
     it('omits percentage when totalCount is 0', () => {
-        const fmt0 = buildChartTooltipFormatter(false, data, [], 0, false);
+        const fmt0 = buildChartTooltipFormatter({
+            isGrouped: false,
+            data,
+            groupedSeries: [],
+            totalCount: 0,
+            hasActiveFilter: false
+        });
         const result = fmt0([param('car', 6)]);
         expect(result).not.toContain('%');
     });
 
     it('escapes HTML in the category label', () => {
         const xssData: CategoryCount[] = [{ label: '<script>alert(1)</script>', count: 1 }];
-        const fmtXss = buildChartTooltipFormatter(false, xssData, [], 1, false);
+        const fmtXss = buildChartTooltipFormatter({
+            isGrouped: false,
+            data: xssData,
+            groupedSeries: [],
+            totalCount: 1,
+            hasActiveFilter: false
+        });
         const result = fmtXss([param('<script>alert(1)</script>', 1)]);
         expect(result).not.toContain('<script>');
     });
 
     it('looks up categories by id while displaying their label', () => {
         const categories: CategoryCount[] = [{ id: 'category-1', label: 'car', count: 6 }];
-        const fmtById = buildChartTooltipFormatter(false, categories, [], 10, false);
+        const fmtById = buildChartTooltipFormatter({
+            isGrouped: false,
+            data: categories,
+            groupedSeries: [],
+            totalCount: 10,
+            hasActiveFilter: false
+        });
 
         expect(fmtById([param('category-1', 6)])).toContain('<b>car</b>');
         expect(fmtById([param('category-1', 6)])).toContain('<b>6</b>');
@@ -74,7 +98,13 @@ describe('buildChartTooltipFormatter — standard (non-grouped)', () => {
 describe('buildChartTooltipFormatter — standard with active filter', () => {
     it('shows filtered and total counts when filteredCount differs from count', () => {
         const filtered: CategoryCount[] = [{ label: 'car', count: 6, filteredCount: 2 }];
-        const fmt = buildChartTooltipFormatter(false, filtered, [], 10, true);
+        const fmt = buildChartTooltipFormatter({
+            isGrouped: false,
+            data: filtered,
+            groupedSeries: [],
+            totalCount: 10,
+            hasActiveFilter: true
+        });
         const result = fmt([param('car', 2)]);
         expect(result).toContain('of');
         expect(result).toContain('<b>2</b>');
@@ -83,20 +113,38 @@ describe('buildChartTooltipFormatter — standard with active filter', () => {
 
     it('does not show "of total" when filteredCount equals count', () => {
         const filtered: CategoryCount[] = [{ label: 'car', count: 6, filteredCount: 6 }];
-        const fmt = buildChartTooltipFormatter(false, filtered, [], 10, true);
+        const fmt = buildChartTooltipFormatter({
+            isGrouped: false,
+            data: filtered,
+            groupedSeries: [],
+            totalCount: 10,
+            hasActiveFilter: true
+        });
         const result = fmt([param('car', 6)]);
         expect(result).not.toContain('of');
     });
 
     it('does not show "of total" when filteredCount is absent', () => {
-        const fmt = buildChartTooltipFormatter(false, data, [], 10, true);
+        const fmt = buildChartTooltipFormatter({
+            isGrouped: false,
+            data,
+            groupedSeries: [],
+            totalCount: 10,
+            hasActiveFilter: true
+        });
         const result = fmt([param('car', 6)]);
         expect(result).not.toContain('of');
     });
 });
 
 describe('buildChartTooltipFormatter — grouped', () => {
-    const fmt = buildChartTooltipFormatter(true, [], groupedSeries, 0, false);
+    const fmt = buildChartTooltipFormatter({
+        isGrouped: true,
+        data: [],
+        groupedSeries,
+        totalCount: 0,
+        hasActiveFilter: false
+    });
 
     it('returns empty string for empty params', () => {
         expect(fmt([])).toBe('');
@@ -140,7 +188,13 @@ describe('buildChartTooltipFormatter — grouped', () => {
         const xssSeries: CategoryCountSeries[] = [
             { id: 'x', label: '<img src=x onerror=alert(1)>', data: [{ label: 'car', count: 1 }] }
         ];
-        const fmtXss = buildChartTooltipFormatter(true, [], xssSeries, 0, false);
+        const fmtXss = buildChartTooltipFormatter({
+            isGrouped: true,
+            data: [],
+            groupedSeries: xssSeries,
+            totalCount: 0,
+            hasActiveFilter: false
+        });
         const result = fmtXss([
             param('car', 1, { seriesIndex: 0, seriesName: '<img src=x onerror=alert(1)>' })
         ]);
@@ -162,13 +216,13 @@ describe('buildChartTooltipFormatter — grouped', () => {
                 ]
             }
         ];
-        const fmtById = buildChartTooltipFormatter(
-            true,
-            categories,
-            duplicateLabelSeries,
-            0,
-            false
-        );
+        const fmtById = buildChartTooltipFormatter({
+            isGrouped: true,
+            data: categories,
+            groupedSeries: duplicateLabelSeries,
+            totalCount: 0,
+            hasActiveFilter: false
+        });
 
         expect(fmtById([param('first', 3, { seriesIndex: 0 })])).toContain('<b>3</b>');
         expect(fmtById([param('second', 1, { seriesIndex: 0 })])).toContain('<b>1</b>');

--- a/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.test.ts
@@ -61,6 +61,14 @@ describe('buildChartTooltipFormatter — standard (non-grouped)', () => {
         const result = fmtXss([param('<script>alert(1)</script>', 1)]);
         expect(result).not.toContain('<script>');
     });
+
+    it('looks up categories by id while displaying their label', () => {
+        const categories: CategoryCount[] = [{ id: 'category-1', label: 'car', count: 6 }];
+        const fmtById = buildChartTooltipFormatter(false, categories, [], 10, false);
+
+        expect(fmtById([param('category-1', 6)])).toContain('<b>car</b>');
+        expect(fmtById([param('category-1', 6)])).toContain('<b>6</b>');
+    });
 });
 
 describe('buildChartTooltipFormatter — standard with active filter', () => {
@@ -137,5 +145,32 @@ describe('buildChartTooltipFormatter — grouped', () => {
             param('car', 1, { seriesIndex: 0, seriesName: '<img src=x onerror=alert(1)>' })
         ]);
         expect(result).not.toContain('<img');
+    });
+
+    it('keeps duplicate labels distinct by category id', () => {
+        const categories: CategoryCount[] = [
+            { id: 'first', label: 'Missing', count: 4 },
+            { id: 'second', label: 'Missing', count: 2 }
+        ];
+        const duplicateLabelSeries: CategoryCountSeries[] = [
+            {
+                id: 'tag-a',
+                label: 'Reviewed',
+                data: [
+                    { id: 'first', label: 'Missing', count: 3 },
+                    { id: 'second', label: 'Missing', count: 1 }
+                ]
+            }
+        ];
+        const fmtById = buildChartTooltipFormatter(
+            true,
+            categories,
+            duplicateLabelSeries,
+            0,
+            false
+        );
+
+        expect(fmtById([param('first', 3, { seriesIndex: 0 })])).toContain('<b>3</b>');
+        expect(fmtById([param('second', 1, { seriesIndex: 0 })])).toContain('<b>1</b>');
     });
 });

--- a/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.ts
@@ -27,6 +27,8 @@ export function buildChartTooltipFormatter(
     return (params: TooltipParam[]) => {
         if (params.length === 0) return '';
         const [{ name }] = params;
+        const category = data.find((entry) => categoryKey(entry) === name);
+        const header = `<b>${escape(category?.label ?? name)}</b>`;
 
         if (isGrouped) {
             const values = params
@@ -41,13 +43,11 @@ export function buildChartTooltipFormatter(
                     return `${item.marker ?? ''}${escape(item.seriesName ?? '')}: ${formatTooltipValue(count, seriesTotal)}`;
                 })
                 .join('<br/>');
-            return `<b>${escape(name)}</b><br/>${values}`;
+            return `${header}<br/>${values}`;
         }
 
-        const entry = data.find((e) => categoryKey(e) === name);
-        const count = entry?.count ?? 0;
-        const filteredCount = entry?.filteredCount;
-        const header = `<b>${escape(entry?.label ?? name)}</b>`;
+        const count = category?.count ?? 0;
+        const filteredCount = category?.filteredCount;
         if (hasActiveFilter && filteredCount !== undefined && filteredCount !== count) {
             return `${header}<br/>Count: ${formatTooltipValue(filteredCount, totalCount)} of ${formatTooltipValue(count, totalCount)} total`;
         }

--- a/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.ts
@@ -16,14 +16,27 @@ const formatTooltipValue = (count: number, total: number): string => {
     return `<b>${count}</b>${percent}`;
 };
 
+interface ChartTooltipFormatterOptions {
+    /** Whether the chart displays grouped (multi-series) bars. */
+    isGrouped: boolean;
+    /** Flat category counts used for standard (non-grouped) tooltips. */
+    data: CategoryCount[];
+    /** Per-series category counts used for grouped tooltips. */
+    groupedSeries: CategoryCountSeries[];
+    /** Total sample count used as the percentage denominator. */
+    totalCount: number;
+    /** Whether a dataset filter is currently active, enabling filtered vs. total display. */
+    hasActiveFilter: boolean;
+}
+
 /** Builds the ECharts tooltip formatter for grouped or standard bar charts. */
-export function buildChartTooltipFormatter(
-    isGrouped: boolean,
-    data: CategoryCount[],
-    groupedSeries: CategoryCountSeries[],
-    totalCount: number,
-    hasActiveFilter: boolean
-): (params: TooltipParam[]) => string {
+export function buildChartTooltipFormatter({
+    isGrouped,
+    data,
+    groupedSeries,
+    totalCount,
+    hasActiveFilter
+}: ChartTooltipFormatterOptions): (params: TooltipParam[]) => string {
     return (params: TooltipParam[]) => {
         if (params.length === 0) return '';
         const [{ name }] = params;

--- a/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/buildChartTooltipFormatter.ts
@@ -1,0 +1,56 @@
+import escape from 'lodash-es/escape';
+import { formatPercent } from '$lib/utils';
+import type { CategoryCount, CategoryCountSeries } from '../types';
+import { categoryKey } from '../buildGroupedSeries';
+
+interface TooltipParam {
+    name: string;
+    value: number;
+    seriesName?: string;
+    seriesIndex?: number;
+    marker?: string;
+}
+
+const formatTooltipValue = (count: number, total: number): string => {
+    const percent = total > 0 ? ` (${formatPercent(count / total)})` : '';
+    return `<b>${count}</b>${percent}`;
+};
+
+/** Builds the ECharts tooltip formatter for grouped or standard bar charts. */
+export function buildChartTooltipFormatter(
+    isGrouped: boolean,
+    data: CategoryCount[],
+    groupedSeries: CategoryCountSeries[],
+    totalCount: number,
+    hasActiveFilter: boolean
+): (params: TooltipParam[]) => string {
+    return (params: TooltipParam[]) => {
+        if (params.length === 0) return '';
+        const [{ name }] = params;
+
+        if (isGrouped) {
+            const values = params
+                .map((item, index) => {
+                    const series = groupedSeries[item.seriesIndex ?? index];
+                    const entry = series?.data.find((e) => categoryKey(e) === name);
+                    const count = entry?.count ?? 0;
+                    const seriesTotal =
+                        series?.totalCount ??
+                        series?.data.reduce((sum, e) => sum + e.count, 0) ??
+                        0;
+                    return `${item.marker ?? ''}${escape(item.seriesName ?? '')}: ${formatTooltipValue(count, seriesTotal)}`;
+                })
+                .join('<br/>');
+            return `<b>${escape(name)}</b><br/>${values}`;
+        }
+
+        const entry = data.find((e) => categoryKey(e) === name);
+        const count = entry?.count ?? 0;
+        const filteredCount = entry?.filteredCount;
+        const header = `<b>${escape(entry?.label ?? name)}</b>`;
+        if (hasActiveFilter && filteredCount !== undefined && filteredCount !== count) {
+            return `${header}<br/>Count: ${formatTooltipValue(filteredCount, totalCount)} of ${formatTooltipValue(count, totalCount)} total`;
+        }
+        return `${header}<br/>Count: ${formatTooltipValue(count, totalCount)}`;
+    };
+}

--- a/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/index.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildChartTooltipFormatter/index.ts
@@ -1,0 +1,1 @@
+export { buildChartTooltipFormatter } from './buildChartTooltipFormatter';

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -235,4 +235,17 @@ describe('buildEchartsOption', () => {
             '<b>car</b><br/>Count: <b>20</b> (25.0%)'
         );
     });
+
+    it('uses category ids on the axis and formats them as labels', () => {
+        const option = buildEchartsOption([
+            { id: 'first', label: 'Missing', count: 4 },
+            { id: 'second', label: 'Missing', count: 2 }
+        ]) as {
+            xAxis: { data: string[]; axisLabel: { formatter: (key: string) => string } };
+        };
+
+        expect(option.xAxis.data).toEqual(['first', 'second']);
+        expect(option.xAxis.axisLabel.formatter('first')).toBe('Missing');
+        expect(option.xAxis.axisLabel.formatter('second')).toBe('Missing');
+    });
 });

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from 'vitest';
-import { buildEchartsOption } from './buildEchartsOption';
+import { buildEchartsOption, colorForSeries } from './buildEchartsOption';
+import type { CategoryCountSeries } from './types';
 import { balanced } from './fixtures';
+
+const groupedSeries: CategoryCountSeries[] = [
+    {
+        id: 'tag-a',
+        label: 'Reviewed',
+        data: [
+            { label: 'car', count: 3 },
+            { label: 'dog', count: 0 }
+        ]
+    },
+    {
+        id: 'tag-b',
+        label: 'Priority',
+        data: [{ label: 'car', count: 1 }]
+    }
+];
 
 describe('buildEchartsOption', () => {
     it('maps labels to the category axis and counts to the bar series', () => {
@@ -40,6 +57,23 @@ describe('buildEchartsOption', () => {
         expect(vertical.yAxis.minInterval).toBe(1);
         expect(horizontal.xAxis.minInterval).toBe(1);
     });
+
+    const getFormatter = (option: unknown) =>
+        (
+            option as {
+                tooltip: {
+                    formatter: (
+                        params: {
+                            name: string;
+                            value: number;
+                            seriesName?: string;
+                            marker?: string;
+                            seriesIndex?: number;
+                        }[]
+                    ) => string;
+                };
+            }
+        ).tooltip.formatter;
 
     it('unselected bars are dimmed while the selected bar remains green', () => {
         const option = buildEchartsOption([
@@ -100,5 +134,105 @@ describe('buildEchartsOption', () => {
 
         expect(standard.grid.top).toBe(16);
         expect(compact.grid.top).toBe(4);
+    });
+
+    it('renders named grouped series on a shared axis and zero-fills missing values', () => {
+        const option = buildEchartsOption(
+            [
+                { label: 'car', count: 4 },
+                { label: 'dog', count: 0 }
+            ],
+            { series: groupedSeries }
+        ) as {
+            xAxis: { data: string[] };
+            legend: { type: string };
+            series: { name: string; data: number[]; itemStyle: { color: string } }[];
+        };
+
+        expect(option.xAxis.data).toEqual(['car', 'dog']);
+        expect(option.legend.type).toBe('scroll');
+        expect(option.series.map((series) => series.name)).toEqual(['Reviewed', 'Priority']);
+        expect(option.series.map((series) => series.data)).toEqual([
+            [3, 0],
+            [1, 0]
+        ]);
+        expect(option.series[0].itemStyle.color).not.toBe(option.series[1].itemStyle.color);
+    });
+
+    it('supports grouped series with a horizontal category axis', () => {
+        const option = buildEchartsOption([{ label: 'car', count: 4 }], {
+            orientation: 'horizontal',
+            series: groupedSeries
+        }) as {
+            xAxis: { type: string };
+            yAxis: { type: string; data: string[] };
+            series: { data: number[] }[];
+        };
+
+        expect(option.xAxis.type).toBe('value');
+        expect(option.yAxis).toMatchObject({ type: 'category', data: ['car'] });
+        expect(option.series.map((series) => series.data)).toEqual([[3], [1]]);
+    });
+
+    it('shows each grouped series as its own percentage distribution', () => {
+        const option = buildEchartsOption(
+            [
+                { label: 'car', count: 4 },
+                { label: 'dog', count: 0 }
+            ],
+            { series: groupedSeries, valueMode: 'percentage' }
+        ) as {
+            yAxis: { max: number };
+            series: { data: number[] }[];
+        };
+
+        expect(option.yAxis.max).toBe(100);
+        expect(option.series.map((series) => series.data)).toEqual([
+            [100, 0],
+            [100, 0]
+        ]);
+    });
+
+    it('uses stable colours and identifies every series in grouped tooltips', () => {
+        expect(colorForSeries('tag-a')).toBe(colorForSeries('tag-a'));
+        expect(colorForSeries('tag-a')).not.toBe(colorForSeries('tag-b'));
+
+        const formatter = getFormatter(
+            buildEchartsOption([{ label: 'car', count: 4 }], { series: groupedSeries })
+        );
+        expect(
+            formatter([
+                { name: 'car', value: 3, seriesName: 'Reviewed', marker: '● ' },
+                { name: 'car', value: 1, seriesName: 'Priority', marker: '■ ' }
+            ])
+        ).toBe('<b>car</b><br/>● Reviewed: <b>3</b> (100.0%)<br/>■ Priority: <b>1</b> (100.0%)');
+    });
+
+    it('resolves palette collisions between visible series', () => {
+        const collidingSeries = [
+            { id: 'a', label: 'First', data: [{ label: 'car', count: 1 }] },
+            { id: 'k', label: 'Second', data: [{ label: 'car', count: 1 }] }
+        ];
+        expect(colorForSeries('a')).toBe(colorForSeries('k'));
+
+        const option = buildEchartsOption([{ label: 'car', count: 2 }], {
+            series: collidingSeries
+        }) as { series: { itemStyle: { color: string; borderWidth: number } }[] };
+
+        expect(option.series[0].itemStyle.color).not.toBe(option.series[1].itemStyle.color);
+        expect(option.series.every((series) => series.itemStyle.borderWidth === 1)).toBe(true);
+    });
+
+    it('keeps raw counts and percentages in percentage-mode tooltips', () => {
+        const formatter = getFormatter(
+            buildEchartsOption([{ label: 'car', count: 20 }], {
+                totalCount: 80,
+                valueMode: 'percentage'
+            })
+        );
+
+        expect(formatter([{ name: 'car', value: 25 }])).toBe(
+            '<b>car</b><br/>Count: <b>20</b> (25.0%)'
+        );
     });
 });

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -1,8 +1,12 @@
 import type { EChartsCoreOption } from 'echarts/core';
 import { truncate } from 'lodash-es';
 import { CHART_AXIS_LABEL, CHART_EMPHASIS, CHART_LINE_COLOR, CHART_TEXT_COLOR } from '$lib/utils';
-import type { CategoryCount } from './';
-import { buildTooltipFormatter } from './buildTooltipFormatter';
+import type { CategoryCount, CategoryCountSeries } from './types';
+import { assignSeriesColors } from './seriesColors';
+import { buildGroupedSeries } from './buildGroupedSeries';
+import { buildChartTooltipFormatter } from './buildChartTooltipFormatter';
+
+export { colorForSeries } from './seriesColors';
 
 // Same accent as Histogram (the Lightly primary green, --color-lightly-primary #3bd99f).
 const BAR_COLOR = 'rgba(59,217,159,0.85)';
@@ -14,6 +18,7 @@ const BAR_COLOR_BACKGROUND = '#374151';
 
 /** Bar layout: 'vertical' bars grow upward, 'horizontal' bars grow rightward. */
 export type BarChartOrientation = 'vertical' | 'horizontal';
+export type BarChartValueMode = 'number' | 'percentage';
 
 interface BuildEchartsOptionOptions {
     /**
@@ -26,6 +31,10 @@ interface BuildEchartsOptionOptions {
     orientation?: BarChartOrientation;
     /** Top chart-grid padding in px (default 16). */
     gridTopPx?: number;
+    /** Named grouped-bar series rendered instead of the single `data` series. */
+    series?: CategoryCountSeries[];
+    /** Whether bars show raw counts or each series' percentage distribution. */
+    valueMode?: BarChartValueMode;
 }
 
 /** Builds the ECharts option for a category-count bar chart (pass to `setOption`). */
@@ -37,6 +46,10 @@ export function buildEchartsOption(
     const orientation = options.orientation ?? 'vertical';
     const gridTopPx = options.gridTopPx ?? 16;
     const isHorizontal = orientation === 'horizontal';
+    const groupedSeries = options.series ?? [];
+    const isGrouped = groupedSeries.length > 0;
+    const groupedColors = assignSeriesColors(groupedSeries.map((series) => series.id));
+    const valueMode = options.valueMode ?? 'number';
 
     const labels = data.map((item) => item.label);
     // When any category is actively selected, dim the rest — mirrors the range
@@ -74,25 +87,30 @@ export function buildEchartsOption(
         // Counts are whole numbers, so keep ticks on integer boundaries. Without
         // this, a max count of 1 makes ECharts split [0,1] into 0.2 steps and
         // render fractional labels (0, 0.2, 0.4 …).
-        minInterval: 1,
-        axisLabel: CHART_AXIS_LABEL,
+        minInterval: valueMode === 'number' ? 1 : undefined,
+        max: valueMode === 'percentage' ? 100 : undefined,
+        axisLabel:
+            valueMode === 'percentage'
+                ? { ...CHART_AXIS_LABEL, formatter: (value: number) => `${value}%` }
+                : CHART_AXIS_LABEL,
         splitLine: { lineStyle: { color: CHART_LINE_COLOR } }
     };
 
-    const formatter = buildTooltipFormatter(totalCount);
+    const toChartValue = (count: number, denominator: number): number =>
+        valueMode === 'percentage' && denominator > 0 ? (count / denominator) * 100 : count;
 
     // Foreground bar: coloured at the filtered count (or full count when no filter).
     const foregroundData = data.map((item) => {
         // Simple items with no selection/filter state can be returned as raw numbers,
         // which ECharts renders without per-item itemStyle overhead.
         if (item.selected == null && item.selectable == null && item.filteredCount == null) {
-            return item.count;
+            return toChartValue(item.count, totalCount);
         }
         const foregroundCount =
             hasActiveFilter && item.filteredCount !== undefined ? item.filteredCount : item.count;
         const isDimmed = hasAnySelected && !item.selected;
         return {
-            value: foregroundCount,
+            value: toChartValue(foregroundCount, totalCount),
             itemStyle: {
                 color: isDimmed ? BAR_COLOR_DIMMED : BAR_COLOR,
                 opacity: item.selectable === false ? 0.45 : 1
@@ -117,7 +135,7 @@ export function buildEchartsOption(
         ? {
               type: 'bar',
               data: data.map((item) => ({
-                  value: item.count,
+                  value: toChartValue(item.count, totalCount),
                   itemStyle: {
                       color: BAR_COLOR_BACKGROUND,
                       opacity: item.selectable === false ? 0.45 : 1
@@ -130,7 +148,13 @@ export function buildEchartsOption(
           }
         : null;
 
-    const series = hasActiveFilter ? [backgroundSeries, foregroundSeries] : [foregroundSeries];
+    const standardSeries = hasActiveFilter
+        ? [backgroundSeries, foregroundSeries]
+        : [foregroundSeries];
+
+    const chartSeries = isGrouped
+        ? buildGroupedSeries(data, groupedSeries, groupedColors, toChartValue)
+        : standardSeries;
 
     return {
         backgroundColor: 'transparent',
@@ -138,12 +162,21 @@ export function buildEchartsOption(
             trigger: 'axis',
             axisPointer: { type: 'shadow' },
             appendTo: 'body',
-            formatter
+            formatter: buildChartTooltipFormatter(
+                isGrouped,
+                data,
+                groupedSeries,
+                totalCount,
+                hasActiveFilter
+            )
         },
-        grid: { left: 8, right: 8, top: gridTopPx, bottom: 8, containLabel: true },
+        legend: isGrouped
+            ? { type: 'scroll', top: 0, textStyle: { color: CHART_TEXT_COLOR } }
+            : undefined,
+        grid: { left: 8, right: 8, top: isGrouped ? 48 : gridTopPx, bottom: 8, containLabel: true },
         // Swap which axis holds the categories so bars grow rightward when horizontal.
         xAxis: isHorizontal ? valueAxis : categoryAxis,
         yAxis: isHorizontal ? categoryAxis : valueAxis,
-        series
+        series: chartSeries
     };
 }

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -3,7 +3,7 @@ import { truncate } from 'lodash-es';
 import { CHART_AXIS_LABEL, CHART_EMPHASIS, CHART_LINE_COLOR, CHART_TEXT_COLOR } from '$lib/utils';
 import type { CategoryCount, CategoryCountSeries } from './types';
 import { assignSeriesColors } from './seriesColors';
-import { buildGroupedSeries } from './buildGroupedSeries';
+import { buildGroupedSeries, categoryKey } from './buildGroupedSeries';
 import { buildChartTooltipFormatter } from './buildChartTooltipFormatter';
 
 export { colorForSeries } from './seriesColors';
@@ -51,7 +51,8 @@ export function buildEchartsOption(
     const groupedColors = assignSeriesColors(groupedSeries.map((series) => series.id));
     const valueMode = options.valueMode ?? 'number';
 
-    const labels = data.map((item) => item.label);
+    const categoryLabels = new Map(data.map((item) => [categoryKey(item), item.label]));
+    const categoryKeys = data.map(categoryKey);
     // When any category is actively selected, dim the rest — mirrors the range
     // highlighting in the numeric Histogram where out-of-range bins go grey.
     const hasAnySelected = data.some((item) => item.selected === true);
@@ -64,7 +65,7 @@ export function buildEchartsOption(
 
     const categoryAxis = {
         type: 'category' as const,
-        data: labels,
+        data: categoryKeys,
         axisLabel: {
             // Vertical layout rotates long labels so they don't overflow the
             // canvas edge (echarts containLabel ignores rotation); horizontal
@@ -74,7 +75,8 @@ export function buildEchartsOption(
             color: CHART_TEXT_COLOR,
             fontSize: 12,
             // Cap long labels on the axis; the tooltip still shows the full name.
-            formatter: (label: string) => truncate(label, { length: 24, omission: '…' })
+            formatter: (key: string) =>
+                truncate(categoryLabels.get(key) ?? key, { length: 24, omission: '…' })
         },
         axisLine: { lineStyle: { color: CHART_LINE_COLOR } },
         axisTick: { alignWithLabel: true },

--- a/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildEchartsOption.ts
@@ -164,13 +164,13 @@ export function buildEchartsOption(
             trigger: 'axis',
             axisPointer: { type: 'shadow' },
             appendTo: 'body',
-            formatter: buildChartTooltipFormatter(
+            formatter: buildChartTooltipFormatter({
                 isGrouped,
                 data,
                 groupedSeries,
                 totalCount,
                 hasActiveFilter
-            )
+            })
         },
         legend: isGrouped
             ? { type: 'scroll', top: 0, textStyle: { color: CHART_TEXT_COLOR } }

--- a/lightly_studio_view/src/lib/components/BarChart/buildGroupedSeries/buildGroupedSeries.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildGroupedSeries/buildGroupedSeries.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import { buildGroupedSeries, categoryKey } from './buildGroupedSeries';
+import type { CategoryCount, CategoryCountSeries } from '../types';
+
+const identity = (count: number) => count;
+const asPercent = (count: number, denominator: number) => count / denominator;
+
+const categories: CategoryCount[] = [
+    { label: 'car', count: 10 },
+    { label: 'dog', count: 5 },
+    { label: 'cat', count: 3 }
+];
+
+const series: CategoryCountSeries[] = [
+    {
+        id: 'tag-a',
+        label: 'Reviewed',
+        data: [
+            { label: 'car', count: 6 },
+            { label: 'dog', count: 2 }
+        ]
+    },
+    {
+        id: 'tag-b',
+        label: 'Priority',
+        data: [
+            { label: 'car', count: 4 },
+            { label: 'cat', count: 3 }
+        ]
+    }
+];
+
+const colors = new Map([
+    ['tag-a', '#ff0000'],
+    ['tag-b', '#0000ff']
+]);
+
+describe('categoryKey', () => {
+    it('returns id when present', () => {
+        expect(categoryKey({ id: 'my-id', label: 'My Label', count: 1 })).toBe('my-id');
+    });
+
+    it('falls back to label when id is absent', () => {
+        expect(categoryKey({ label: 'My Label', count: 1 })).toBe('My Label');
+    });
+});
+
+describe('buildGroupedSeries', () => {
+    it('produces one ECharts series per input series', () => {
+        const result = buildGroupedSeries(categories, series, colors, identity);
+        expect(result).toHaveLength(2);
+    });
+
+    it('sets id and name from the input series', () => {
+        const [a, b] = buildGroupedSeries(categories, series, colors, identity);
+        expect(a.id).toBe('tag-a');
+        expect(a.name).toBe('Reviewed');
+        expect(b.id).toBe('tag-b');
+        expect(b.name).toBe('Priority');
+    });
+
+    it('aligns data to the category order from the data array', () => {
+        const [a, b] = buildGroupedSeries(categories, series, colors, identity);
+        // categories: car=0, dog=1, cat=2
+        expect(a.data).toEqual([6, 2, 0]); // cat missing → 0
+        expect(b.data).toEqual([4, 0, 3]); // dog missing → 0
+    });
+
+    it('applies toChartValue to each count', () => {
+        const seriesWithTotal: CategoryCountSeries[] = [
+            { id: 'tag-a', label: 'Reviewed', data: [{ label: 'car', count: 5 }], totalCount: 10 }
+        ];
+        const [a] = buildGroupedSeries(
+            [{ label: 'car', count: 10 }],
+            seriesWithTotal,
+            colors,
+            asPercent
+        );
+        expect(a.data).toEqual([0.5]);
+    });
+
+    it('uses totalCount as denominator when provided', () => {
+        const denominators: number[] = [];
+        const captureDenominator = (count: number, denominator: number) => {
+            denominators.push(denominator);
+            return count;
+        };
+        const seriesWithTotal: CategoryCountSeries[] = [
+            {
+                id: 'tag-a',
+                label: 'Reviewed',
+                data: [{ label: 'car', count: 3 }],
+                totalCount: 99
+            }
+        ];
+        buildGroupedSeries(
+            [{ label: 'car', count: 10 }],
+            seriesWithTotal,
+            colors,
+            captureDenominator
+        );
+        expect(denominators[0]).toBe(99);
+    });
+
+    it('sums data counts as denominator when totalCount is absent', () => {
+        const denominators: number[] = [];
+        const captureDenominator = (count: number, denominator: number) => {
+            denominators.push(denominator);
+            return count;
+        };
+        const seriesNoTotal: CategoryCountSeries[] = [
+            {
+                id: 'tag-a',
+                label: 'Reviewed',
+                data: [
+                    { label: 'car', count: 4 },
+                    { label: 'dog', count: 6 }
+                ]
+            }
+        ];
+        buildGroupedSeries(
+            [
+                { label: 'car', count: 10 },
+                { label: 'dog', count: 5 }
+            ],
+            seriesNoTotal,
+            colors,
+            captureDenominator
+        );
+        expect(denominators[0]).toBe(10); // 4 + 6
+    });
+
+    it('assigns the correct color from groupedColors', () => {
+        const [a, b] = buildGroupedSeries(categories, series, colors, identity);
+        expect(a.itemStyle.color).toBe('#ff0000');
+        expect(b.itemStyle.color).toBe('#0000ff');
+    });
+
+    it('uses id-based key over label when id is present', () => {
+        const categoriesWithId: CategoryCount[] = [{ id: 'c-1', label: 'car', count: 10 }];
+        const seriesWithId: CategoryCountSeries[] = [
+            {
+                id: 'tag-a',
+                label: 'Reviewed',
+                data: [{ id: 'c-1', label: 'car', count: 7 }]
+            }
+        ];
+        const [a] = buildGroupedSeries(categoriesWithId, seriesWithId, colors, identity);
+        expect(a.data).toEqual([7]);
+    });
+
+    it('returns an empty array when groupedSeries is empty', () => {
+        expect(buildGroupedSeries(categories, [], colors, identity)).toEqual([]);
+    });
+});

--- a/lightly_studio_view/src/lib/components/BarChart/buildGroupedSeries/buildGroupedSeries.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildGroupedSeries/buildGroupedSeries.ts
@@ -1,0 +1,33 @@
+import { CHART_EMPHASIS } from '$lib/utils';
+import type { CategoryCount, CategoryCountSeries } from '../types';
+
+export const categoryKey = (item: CategoryCount) => item.id ?? item.label;
+
+/** Builds the ECharts series array for a grouped (multi-series) bar chart. */
+export function buildGroupedSeries(
+    data: CategoryCount[],
+    groupedSeries: CategoryCountSeries[],
+    groupedColors: Map<string, string>,
+    toChartValue: (count: number, denominator: number) => number
+) {
+    const categoryKeys = data.map(categoryKey);
+
+    return groupedSeries.map((series) => {
+        const countsByKey = new Map(series.data.map((entry) => [categoryKey(entry), entry.count]));
+        const seriesTotal =
+            series.totalCount ?? series.data.reduce((sum, entry) => sum + entry.count, 0);
+        return {
+            id: series.id,
+            name: series.label,
+            type: 'bar',
+            data: categoryKeys.map((key) => toChartValue(countsByKey.get(key) ?? 0, seriesTotal)),
+            itemStyle: {
+                color: groupedColors.get(series.id),
+                borderColor: 'rgba(255,255,255,0.75)',
+                borderWidth: 1
+            },
+            barCategoryGap: '25%',
+            emphasis: CHART_EMPHASIS
+        };
+    });
+}

--- a/lightly_studio_view/src/lib/components/BarChart/buildGroupedSeries/index.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/buildGroupedSeries/index.ts
@@ -1,0 +1,1 @@
+export { buildGroupedSeries, categoryKey } from './buildGroupedSeries';

--- a/lightly_studio_view/src/lib/components/BarChart/index.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/index.ts
@@ -1,3 +1,3 @@
 export { default as BarChart } from './BarChart.svelte';
-export type { CategoryCount } from './types';
+export type { CategoryCount, CategoryCountSeries } from './types';
 export type { BarChartOrientation } from './buildEchartsOption';

--- a/lightly_studio_view/src/lib/components/BarChart/seriesColors/index.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/seriesColors/index.ts
@@ -1,0 +1,6 @@
+export {
+    colorForSeries,
+    assignSeriesColors,
+    extendedSeriesColor,
+    SERIES_COLORS
+} from './seriesColors';

--- a/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+    assignSeriesColors,
+    colorForSeries,
+    extendedSeriesColor,
+    SERIES_COLORS
+} from './seriesColors';
+
+describe('extendedSeriesColor', () => {
+    it('returns the palette color for indices within the first cycle', () => {
+        for (let i = 0; i < SERIES_COLORS.length; i++) {
+            expect(extendedSeriesColor(i)).toBe(SERIES_COLORS[i]);
+        }
+    });
+
+    it('appends an opacity suffix in the second cycle', () => {
+        const color = extendedSeriesColor(SERIES_COLORS.length);
+        expect(color).toMatch(/^#[0-9A-Fa-f]{6}[0-9A-Fa-f]{2}$/);
+        expect(color.startsWith(SERIES_COLORS[0])).toBe(true);
+    });
+
+    it('produces a darker opacity in the third cycle than the second', () => {
+        const second = extendedSeriesColor(SERIES_COLORS.length);
+        const third = extendedSeriesColor(SERIES_COLORS.length * 2);
+        const secondOpacity = parseInt(second.slice(7), 16);
+        const thirdOpacity = parseInt(third.slice(7), 16);
+        expect(thirdOpacity).toBeLessThan(secondOpacity);
+    });
+});
+
+describe('colorForSeries', () => {
+    it('always returns a color from the palette', () => {
+        for (const id of ['a', 'tag-1', 'abc', 'hello-world', '']) {
+            expect(SERIES_COLORS).toContain(colorForSeries(id));
+        }
+    });
+
+    it('returns the same color for the same id', () => {
+        expect(colorForSeries('stable-id')).toBe(colorForSeries('stable-id'));
+    });
+
+    it('returns different colors for different ids (best-effort)', () => {
+        const colors = ['id-one', 'id-two', 'id-three'].map(colorForSeries);
+        const unique = new Set(colors);
+        expect(unique.size).toBeGreaterThan(1);
+    });
+});
+
+describe('assignSeriesColors', () => {
+    it('returns an empty map for an empty list', () => {
+        expect(assignSeriesColors([])).toEqual(new Map());
+    });
+
+    it('assigns a color to every series id', () => {
+        const ids = ['a', 'b', 'c'];
+        const result = assignSeriesColors(ids);
+        for (const id of ids) {
+            expect(result.has(id)).toBe(true);
+        }
+    });
+
+    it('assigns unique colors to all series', () => {
+        const ids = Array.from({ length: SERIES_COLORS.length }, (_, i) => `series-${i}`);
+        const result = assignSeriesColors(ids);
+        const assigned = [...result.values()];
+        expect(new Set(assigned).size).toBe(ids.length);
+    });
+
+    it('resolves collisions when two ids hash to the same color', () => {
+        // Force a collision by finding two ids that share the same colorForSeries result.
+        const groups = new Map<string, string[]>();
+        for (let i = 0; i < 100; i++) {
+            const id = `id-${i}`;
+            const color = colorForSeries(id);
+            const list = groups.get(color) ?? [];
+            list.push(id);
+            groups.set(color, list);
+        }
+        const colliding = [...groups.values()].find((list) => list.length >= 2);
+        if (!colliding) return; // no collision found in range — skip
+
+        const result = assignSeriesColors(colliding.slice(0, 2));
+        const [c1, c2] = [...result.values()];
+        expect(c1).not.toBe(c2);
+    });
+
+    it('produces the same assignment regardless of prior renders', () => {
+        const ids = ['x', 'y', 'z'];
+        expect(assignSeriesColors(ids)).toEqual(assignSeriesColors(ids));
+    });
+});

--- a/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.test.ts
@@ -88,4 +88,10 @@ describe('assignSeriesColors', () => {
         const ids = ['x', 'y', 'z'];
         expect(assignSeriesColors(ids)).toEqual(assignSeriesColors(ids));
     });
+
+    it('assigns colliding ids consistently regardless of input order', () => {
+        expect(colorForSeries('a')).toBe(colorForSeries('k'));
+
+        expect(assignSeriesColors(['a', 'k'])).toEqual(assignSeriesColors(['k', 'a']));
+    });
 });

--- a/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.test.ts
@@ -13,18 +13,18 @@ describe('extendedSeriesColor', () => {
         }
     });
 
-    it('appends an opacity suffix in the second cycle', () => {
+    it('generates an opaque color after the base palette', () => {
         const color = extendedSeriesColor(SERIES_COLORS.length);
-        expect(color).toMatch(/^#[0-9A-Fa-f]{6}[0-9A-Fa-f]{2}$/);
-        expect(color.startsWith(SERIES_COLORS[0])).toBe(true);
+        expect(color).toMatch(/^hsl\([\d.]+ 60% 55%\)$/);
     });
 
-    it('produces a darker opacity in the third cycle than the second', () => {
-        const second = extendedSeriesColor(SERIES_COLORS.length);
-        const third = extendedSeriesColor(SERIES_COLORS.length * 2);
-        const secondOpacity = parseInt(second.slice(7), 16);
-        const thirdOpacity = parseInt(third.slice(7), 16);
-        expect(thirdOpacity).toBeLessThan(secondOpacity);
+    it('keeps later-cycle colors valid, opaque, and distinct', () => {
+        const colors = [extendedSeriesColor(40), extendedSeriesColor(50)];
+        expect(colors).toEqual([
+            expect.stringMatching(/^hsl\([\d.]+ 60% 55%\)$/),
+            expect.stringMatching(/^hsl\([\d.]+ 60% 55%\)$/)
+        ]);
+        expect(new Set(colors).size).toBe(2);
     });
 });
 

--- a/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.ts
@@ -12,15 +12,12 @@ export const SERIES_COLORS = [
     '#BAB0AC'
 ];
 
-/** Generates additional colors beyond the palette by cycling with reduced opacity. */
+/** Generates additional opaque colors beyond the base palette. */
 export function extendedSeriesColor(index: number): string {
-    const base = SERIES_COLORS[index % SERIES_COLORS.length];
-    const cycle = Math.floor(index / SERIES_COLORS.length);
-    return cycle === 0
-        ? base
-        : `${base}${Math.round((1 - cycle * 0.25) * 255)
-              .toString(16)
-              .padStart(2, '0')}`;
+    if (index < SERIES_COLORS.length) return SERIES_COLORS[index];
+
+    const hue = (index * 137.508) % 360;
+    return `hsl(${hue} 60% 55%)`;
 }
 
 /** Maps a stable series ID to the same accessible chart colour across renders. */

--- a/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.ts
@@ -33,7 +33,7 @@ export function colorForSeries(id: string): string {
 export function assignSeriesColors(seriesIds: string[]): Map<string, string> {
     const colors = new Map<string, string>();
     const usedColors = new Set<string>();
-    for (const id of seriesIds) {
+    for (const id of [...new Set(seriesIds)].sort()) {
         let index = SERIES_COLORS.indexOf(colorForSeries(id));
         let cycle = 0;
         while (usedColors.has(extendedSeriesColor(index + cycle * SERIES_COLORS.length))) {

--- a/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/seriesColors/seriesColors.ts
@@ -1,0 +1,55 @@
+// Same Tableau 10 palette used by the Histogram component.
+export const SERIES_COLORS = [
+    '#4E79A7',
+    '#F28E2B',
+    '#59A14F',
+    '#E15759',
+    '#B07AA1',
+    '#76B7B2',
+    '#EDC948',
+    '#FF9DA7',
+    '#9C755F',
+    '#BAB0AC'
+];
+
+/** Generates additional colors beyond the palette by cycling with reduced opacity. */
+export function extendedSeriesColor(index: number): string {
+    const base = SERIES_COLORS[index % SERIES_COLORS.length];
+    const cycle = Math.floor(index / SERIES_COLORS.length);
+    return cycle === 0
+        ? base
+        : `${base}${Math.round((1 - cycle * 0.25) * 255)
+              .toString(16)
+              .padStart(2, '0')}`;
+}
+
+/** Maps a stable series ID to the same accessible chart colour across renders. */
+export function colorForSeries(id: string): string {
+    const index = [...id].reduce(
+        (value, character) => (value * 31 + character.charCodeAt(0)) % SERIES_COLORS.length,
+        0
+    );
+    return SERIES_COLORS[index];
+}
+
+/** Resolves hash collisions so simultaneously visible series always differ. */
+export function assignSeriesColors(seriesIds: string[]): Map<string, string> {
+    const colors = new Map<string, string>();
+    const usedColors = new Set<string>();
+    for (const id of seriesIds) {
+        let index = SERIES_COLORS.indexOf(colorForSeries(id));
+        let cycle = 0;
+        while (usedColors.has(extendedSeriesColor(index + cycle * SERIES_COLORS.length))) {
+            if (index + 1 < SERIES_COLORS.length) {
+                index++;
+            } else {
+                index = 0;
+                cycle++;
+            }
+        }
+        const color = extendedSeriesColor(index + cycle * SERIES_COLORS.length);
+        colors.set(id, color);
+        usedColors.add(color);
+    }
+    return colors;
+}

--- a/lightly_studio_view/src/lib/components/BarChart/types.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/types.ts
@@ -18,3 +18,15 @@ export interface CategoryCount {
     /** Keeps semantic buckets visible when a top-N view is applied. */
     pinned?: boolean;
 }
+
+/** A named series of category counts for grouped bar charts. */
+export interface CategoryCountSeries {
+    /** Stable series identity used for color assignment. */
+    id: string;
+    /** Display name shown in the legend and tooltip. */
+    label: string;
+    /** Per-category counts for this series. */
+    data: CategoryCount[];
+    /** Denominator for tooltip percentages; defaults to the sum of `data`. */
+    totalCount?: number;
+}

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/DatasetDistributionPanel.test.ts
@@ -266,11 +266,16 @@ describe('DatasetDistributionPanel', () => {
         render(DatasetDistributionPanel, { props: { sources, onCategoricalValueToggle } });
 
         const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
-            yAxis: { data: string[] };
+            yAxis: { data: string[]; axisLabel: { formatter: (key: string) => string } };
             series: [{ data: { itemStyle: { color: string } }[] }];
             grid: { top: number };
         };
-        expect(option.yAxis.data).toEqual(['Missing', 'Missing', 'Other']);
+        expect(option.yAxis.data).toEqual(['literal', 'missing', 'other']);
+        expect(option.yAxis.data.map(option.yAxis.axisLabel.formatter)).toEqual([
+            'Missing',
+            'Missing',
+            'Other'
+        ]);
         expect(option.grid.top).toBe(4);
         // 'Missing' (value) is selected → accent green; the others are dimmed grey.
         expect(option.series[0].data[0].itemStyle.color).toBe('rgba(59,217,159,0.85)');
@@ -423,10 +428,11 @@ describe('DatasetDistributionPanel', () => {
         await fireEvent.click(screen.getByTestId('distribution-config-apply'));
 
         const option = echartsMock.instance.setOption.mock.lastCall?.[0] as {
-            yAxis: { data: string[] };
+            yAxis: { data: string[]; axisLabel: { formatter: (key: string) => string } };
             series: [{ data: { value: number }[] }];
         };
-        expect(option.yAxis.data).toEqual(['Missing']);
+        expect(option.yAxis.data).toEqual(['semantic-missing']);
+        expect(option.yAxis.axisLabel.formatter('semantic-missing')).toBe('Missing');
         expect(option.series[0].data[0].value).toBe(3);
     });
 

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/TagComparisonSelect/TagComparisonSelect.stories.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/TagComparisonSelect/TagComparisonSelect.stories.svelte
@@ -1,6 +1,8 @@
 <script module>
     import { defineMeta } from '@storybook/addon-svelte-csf';
     import TagComparisonSelect from './TagComparisonSelect.svelte';
+    import { MultiSelectList } from '$lib/components/MultiSelectList';
+    import type { ComponentProps } from 'svelte';
 
     const { Story } = defineMeta({
         title: 'Components/DatasetDistributionPanel/TagComparisonSelect',
@@ -20,7 +22,7 @@
 </script>
 
 <script lang="ts">
-    import type { MultiSelectItem } from '$lib/components/MultiSelectList';
+    type MultiSelectItem = ComponentProps<typeof MultiSelectList>['items'];
 
     const MANY_ITEMS: MultiSelectItem[] = Array.from({ length: 20 }, (_, i) => ({
         value: `tag-${i + 1}`,

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/TagComparisonSelect/TagComparisonSelect.stories.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/TagComparisonSelect/TagComparisonSelect.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
     import { defineMeta } from '@storybook/addon-svelte-csf';
     import TagComparisonSelect from './TagComparisonSelect.svelte';
     import { MultiSelectList } from '$lib/components/MultiSelectList';

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/TagComparisonSelect/TagComparisonSelect.stories.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/TagComparisonSelect/TagComparisonSelect.stories.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <script lang="ts">
-    type MultiSelectItem = ComponentProps<typeof MultiSelectList>['items'];
+    type MultiSelectItem = ComponentProps<typeof MultiSelectList>['items'][number];
 
     const MANY_ITEMS: MultiSelectItem[] = Array.from({ length: 20 }, (_, i) => ({
         value: `tag-${i + 1}`,

--- a/lightly_studio_view/src/lib/components/DatasetDistributionPanel/TagComparisonSelect/TagComparisonSelect.stories.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetDistributionPanel/TagComparisonSelect/TagComparisonSelect.stories.svelte
@@ -1,8 +1,6 @@
-<script module lang="ts">
+<script module>
     import { defineMeta } from '@storybook/addon-svelte-csf';
     import TagComparisonSelect from './TagComparisonSelect.svelte';
-    import { MultiSelectList } from '$lib/components/MultiSelectList';
-    import type { ComponentProps } from 'svelte';
 
     const { Story } = defineMeta({
         title: 'Components/DatasetDistributionPanel/TagComparisonSelect',
@@ -22,6 +20,8 @@
 </script>
 
 <script lang="ts">
+    import type { ComponentProps } from 'svelte';
+    import { MultiSelectList } from '$lib/components/MultiSelectList';
     type MultiSelectItem = ComponentProps<typeof MultiSelectList>['items'][number];
 
     const MANY_ITEMS: MultiSelectItem[] = Array.from({ length: 20 }, (_, i) => ({


### PR DESCRIPTION
## What has changed and why?

This PR introduces options to render series of bars for function creation options for BarChart

It is organised as stacked diff commits, as solid requirement for BarChart 

It is better to review changes commit by commit
Starting from https://github.com/lightly-ai/lightly-studio/pull/1992/changes/b92ff99ca7f46b421a6df3c4a933d02d4d568761

## How has it been tested?

It should be enough to pass ci checks

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added grouped bar charts with aligned categories, distinct series colors, and optional scrollable legends.
- Added number and percentage display modes, including filtered-versus-total counts.
- Improved tooltips with grouped labels, percentages, counts, and escaped content.
- Added stable category handling for duplicate or missing labels.
- Added deterministic colors that avoid collisions between series.

## Tests
- Expanded coverage for charts, tooltips, filtering, colors, and edge cases.

## Documentation
- Updated component stories to use current multi-select definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->