### PR TITLE
simple e2e test to check what you can select tasks and information is updated

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -197,6 +197,14 @@ jobs:
             success_key: e2e-success-evaluations
             artifact_name: Playwright Report (Evaluations)
             postgres: false
+          - name: Distribution
+            index_script: index_distribution.py
+            playwright_project: distribution
+            shard: "1/1"
+            success_marker: .e2e-success-distribution
+            success_key: e2e-success-distribution
+            artifact_name: Playwright Report (Distribution)
+            postgres: false
           - name: General Postgres 1 of 3
             index_script: index_general.py
             playwright_project: general

--- a/lightly_studio_view/e2e/distribution/distribution-comparison.e2e-test.ts
+++ b/lightly_studio_view/e2e/distribution/distribution-comparison.e2e-test.ts
@@ -1,3 +1,4 @@
+import type { Request } from '@playwright/test';
 import { expect, test } from '../utils';
 import { distributionComparison } from './fixtures';
 
@@ -18,7 +19,7 @@ test('compares overlapping and empty sample tags without reloading or filtering 
     let navigationCount = 0;
     let imageListRequestCount = 0;
     const recordNavigation = () => navigationCount++;
-    const recordImageListRequest = (request: { url: () => string }) => {
+    const recordImageListRequest = (request: Request) => {
         if (request.url().includes('/images/list')) imageListRequestCount++;
     };
     page.on('framenavigated', recordNavigation);

--- a/lightly_studio_view/e2e/distribution/distribution-comparison.e2e-test.ts
+++ b/lightly_studio_view/e2e/distribution/distribution-comparison.e2e-test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '../utils';
+import { distributionComparison } from './fixtures';
+
+test('compares overlapping and empty sample tags without reloading or filtering the grid', async ({
+    page,
+    samplesPage
+}) => {
+    const firstId = await samplesPage.getTagIdByName(distributionComparison.firstTag);
+    const secondId = await samplesPage.getTagIdByName(distributionComparison.secondTag);
+    const emptyId = await samplesPage.getTagIdByName(distributionComparison.emptyTag);
+    expect(firstId).toBeTruthy();
+    expect(secondId).toBeTruthy();
+    expect(emptyId).toBeTruthy();
+
+    await page.getByTestId('side-panel-tabs-distribution').click();
+    await expect(page.getByTestId('dataset-distribution-panel')).toBeVisible();
+    const urlBeforeComparison = page.url();
+    let navigationCount = 0;
+    let imageListRequestCount = 0;
+    const recordNavigation = () => navigationCount++;
+    const recordImageListRequest = (request: { url: () => string }) => {
+        if (request.url().includes('/images/list')) imageListRequestCount++;
+    };
+    page.on('framenavigated', recordNavigation);
+    page.on('request', recordImageListRequest);
+
+    const waitForGroupedCounts = (tagCount: number) =>
+        page.waitForResponse((response) => {
+            if (!response.url().includes('/annotations/count-by-sample-tags')) return false;
+            const body = response.request().postDataJSON() as { sample_tag_ids?: string[] };
+            return response.status() === 200 && body.sample_tag_ids?.length === tagCount;
+        });
+    const selectTag = async (tagId: string, expectedCount: number) => {
+        const option = page.getByTestId(`dataset-distribution-tag-option-${tagId}`);
+        if (!(await option.isVisible())) {
+            await page.getByTestId('dataset-distribution-tag-select').click();
+        }
+        const responsePromise = waitForGroupedCounts(expectedCount);
+        await option.click();
+        return responsePromise;
+    };
+
+    await selectTag(firstId!, 1);
+    await selectTag(secondId!, 2);
+    const response = await selectTag(emptyId!, 3);
+    const requestBody = response.request().postDataJSON() as { sample_tag_ids: string[] };
+    expect(requestBody.sample_tag_ids).toEqual([firstId, secondId, emptyId]);
+    const groupedCounts = (await response.json()) as {
+        sample_tag_id: string;
+        counts: { count: number }[];
+    }[];
+    const emptyCounts = groupedCounts.find((item) => item.sample_tag_id === emptyId)?.counts;
+    expect(emptyCounts?.length).toBeGreaterThan(0);
+    expect(emptyCounts?.every((item) => item.count === 0)).toBe(true);
+
+    await expect(page.getByText(/3 sample tags/)).toBeVisible();
+    expect(page.url()).toBe(urlBeforeComparison);
+    expect(navigationCount).toBe(0);
+    expect(imageListRequestCount).toBe(0);
+    page.off('framenavigated', recordNavigation);
+    page.off('request', recordImageListRequest);
+});

--- a/lightly_studio_view/e2e/distribution/distribution-comparison.e2e-test.ts
+++ b/lightly_studio_view/e2e/distribution/distribution-comparison.e2e-test.ts
@@ -1,4 +1,4 @@
-import type { Request } from '@playwright/test';
+import type { Request, Response } from '@playwright/test';
 import { expect, test } from '../utils';
 import { distributionComparison } from './fixtures';
 
@@ -15,6 +15,7 @@ test('compares overlapping and empty sample tags without reloading or filtering 
 
     await page.getByTestId('side-panel-tabs-distribution').click();
     await expect(page.getByTestId('dataset-distribution-panel')).toBeVisible();
+
     const urlBeforeComparison = page.url();
     let navigationCount = 0;
     let imageListRequestCount = 0;
@@ -25,18 +26,22 @@ test('compares overlapping and empty sample tags without reloading or filtering 
     page.on('framenavigated', recordNavigation);
     page.on('request', recordImageListRequest);
 
-    const waitForGroupedCounts = (tagCount: number) =>
+    // Waits for the grouped-counts response that carries exactly `tagCount` tag IDs.
+    const waitForGroupedCounts = (tagCount: number): Promise<Response> =>
         page.waitForResponse((response) => {
             if (!response.url().includes('/annotations/count-by-sample-tags')) return false;
             const body = response.request().postDataJSON() as { sample_tag_ids?: string[] };
             return response.status() === 200 && body.sample_tag_ids?.length === tagCount;
         });
-    const selectTag = async (tagId: string, expectedCount: number) => {
+
+    // Opens the tag selector if needed, clicks the tag option, and waits for
+    // the API response carrying the updated selection.
+    const selectTag = async (tagId: string, expectedTagCount: number): Promise<Response> => {
         const option = page.getByTestId(`dataset-distribution-tag-option-${tagId}`);
         if (!(await option.isVisible())) {
             await page.getByTestId('dataset-distribution-tag-select').click();
         }
-        const responsePromise = waitForGroupedCounts(expectedCount);
+        const responsePromise = waitForGroupedCounts(expectedTagCount);
         await option.click();
         return responsePromise;
     };
@@ -44,20 +49,26 @@ test('compares overlapping and empty sample tags without reloading or filtering 
     await selectTag(firstId!, 1);
     await selectTag(secondId!, 2);
     const response = await selectTag(emptyId!, 3);
+
+    // Verify the final request carries all three tag IDs in selection order.
     const requestBody = response.request().postDataJSON() as { sample_tag_ids: string[] };
     expect(requestBody.sample_tag_ids).toEqual([firstId, secondId, emptyId]);
+
+    // The empty tag must appear in the response with every class at count 0.
     const groupedCounts = (await response.json()) as {
         sample_tag_id: string;
         counts: { count: number }[];
     }[];
-    const emptyCounts = groupedCounts.find((item) => item.sample_tag_id === emptyId)?.counts;
+    const emptyCounts = groupedCounts.find((g) => g.sample_tag_id === emptyId)?.counts;
     expect(emptyCounts?.length).toBeGreaterThan(0);
-    expect(emptyCounts?.every((item) => item.count === 0)).toBe(true);
+    expect(emptyCounts?.every((c) => c.count === 0)).toBe(true);
 
+    // Selecting comparison tags must not navigate or re-fetch the image grid.
     await expect(page.getByText(/3 sample tags/)).toBeVisible();
     expect(page.url()).toBe(urlBeforeComparison);
     expect(navigationCount).toBe(0);
     expect(imageListRequestCount).toBe(0);
+
     page.off('framenavigated', recordNavigation);
     page.off('request', recordImageListRequest);
 });

--- a/lightly_studio_view/e2e/distribution/fixtures.ts
+++ b/lightly_studio_view/e2e/distribution/fixtures.ts
@@ -1,0 +1,5 @@
+export const distributionComparison = {
+    firstTag: 'distribution_reviewed',
+    secondTag: 'distribution_priority',
+    emptyTag: 'distribution_empty'
+} as const;

--- a/lightly_studio_view/playwright.config.ts
+++ b/lightly_studio_view/playwright.config.ts
@@ -50,6 +50,10 @@ export default defineConfig({
         {
             name: 'evaluations',
             testDir: './e2e/evaluations'
+        },
+        {
+            name: 'distribution',
+            testDir: './e2e/distribution'
         }
     ],
 

--- a/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.svelte
+++ b/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.svelte
@@ -9,6 +9,8 @@
         value: string;
         /** Display text shown in the list. */
         label: string;
+        /** Optional `data-testid` for the list item element. */
+        testId?: string;
     }
 
     interface Props {
@@ -86,6 +88,7 @@
                     value={item.value}
                     keywords={[item.label]}
                     onSelect={() => toggleItem(item.value)}
+                    data-testid={item.testId}
                 >
                     <CheckIcon
                         class={cn(!selectedIds.includes(item.value) && 'text-transparent')}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -517,7 +517,11 @@
         useTags({ collection_id: datasetId, kind: ['sample'] })
     );
     const distributionSampleTagItems = $derived(
-        $distributionSampleTags.map((tag) => ({ value: tag.tag_id, label: tag.name }))
+        $distributionSampleTags.map((tag) => ({
+            value: tag.tag_id,
+            label: tag.name,
+            testId: `dataset-distribution-tag-option-${tag.tag_id}`
+        }))
     );
     $effect(() => {
         const validIds = new Set($distributionSampleTags.map((tag) => tag.tag_id));


### PR DESCRIPTION
## What has changed and why?

simple e2e test to check what you can select tasks and information is updated

It is very simple e2e test checking:
- we call endpoint by tags selections
- we have changes information about selected tags

## How has it been tested?

By e2e test ci pass

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distribution tag comparison so multiple selections retain cumulative counts, including empty tags showing zero results.
  * Selecting distribution tags no longer unexpectedly navigates away from or reloads the image grid.

* **Tests**
  * Added end-to-end coverage for distribution comparisons and non-Postgres distribution workflows.
  * Added reliable identifiers for distribution tag controls to support automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->