### PR TITLE
[external] feat: support tag_depth > 1 in add_images_from_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stepping to the previous or next image now drives an index range scan instead of scanning the
   sort index from the start. On PostgreSQL with 1M images, one neighbour lookup went from 92ms
   to 0.03ms.
+- Python SDK: `ImageDataset.add_images_from_path` now accepts `tag_depth > 1` to tag images by several leading directory levels (previously only `tag_depth=1` was supported).
 
 ### Deprecated
 
@@ -86,7 +87,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Python SDK: `ImageDataset.add_images_from_path` now accepts `tag_depth > 1` to tag images by several leading directory levels (previously only `tag_depth=1` was supported).
 - The left filter panel can now be collapsed entirely to reclaim space for the grid; a "Filters" button in the grid header restores it.
 - Image and video opening paths (indexing and embedding) now handle errors consistently: broken files are tolerated and skipped instead of breaking the whole operation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Python SDK: `ImageDataset.add_images_from_path` now accepts `tag_depth > 1` to tag images by several leading directory levels (previously only `tag_depth=1` was supported).
 - The left filter panel can now be collapsed entirely to reclaim space for the grid; a "Filters" button in the grid header restores it.
 - Image and video opening paths (indexing and embedding) now handle errors consistently: broken files are tolerated and skipped instead of breaking the whole operation.
 

--- a/lightly_studio/docs/docs/concepts_and_tools/tags.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/tags.md
@@ -63,7 +63,7 @@ tag samples during loading.
 #### By folder structure
 
 When loading images from a folder, pass `tag_depth=1` to automatically create a tag for each image
-based on its parent directory's name.
+based on its top-level folder below the loaded path.
 
 ```python
 import lightly_studio as ls
@@ -85,6 +85,11 @@ Given this layout, each sample receives a tag matching its folder:
 ```
 
 The default is `tag_depth=0`, which skips automatic tagging.
+
+To tag by more than one directory level, pass a larger `tag_depth`. With `tag_depth=N` each image is
+tagged with the names of the first `N` folders below the loaded path (or fewer if it is nested less
+deeply), so an image can receive several tags. For example, with `tag_depth=2` an image at
+`/data/images/dogs/husky/dog1.jpg` is tagged both `dogs` and `husky`.
 
 #### By dataset split
 

--- a/lightly_studio/docs/docs/dataset_setup/image_dataset.md
+++ b/lightly_studio/docs/docs/dataset_setup/image_dataset.md
@@ -34,8 +34,9 @@ supported, see [Using Cloud Storage](cloud_storage.md) for more details.
 Added images are automatically embedded so that embedding plot and image search are enabled.
 To skip embedding, pass `embed=False` to the method.
 
-The method supports additional arguments, e.g. you can pass `tag_depth=1` to add the image parent
-folder name as a tag to each sample. See the [API reference](../api/dataset.md#lightly_studio.ImageDataset.add_images_from_path) for full details.
+The method supports additional arguments, e.g. you can pass `tag_depth=1` to tag each image with its
+top-level folder name, or a larger `tag_depth` to tag by several nested folder levels. See the
+[API reference](../api/dataset.md#lightly_studio.ImageDataset.add_images_from_path) for full details.
 
 ### From an Annotation Format
 

--- a/lightly_studio/src/lightly_studio/core/image/add_images.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_images.py
@@ -423,6 +423,7 @@ def tag_samples_by_directory(
     Raises:
         ValueError: If tag_depth is negative.
     """
+    # TODO (Mihnea, 08/2026): Consider refactoring this, as it is getting quite big.
     if tag_depth < 0:
         raise ValueError(f"tag_depth must be non-negative, got {tag_depth}.")
     if tag_depth == 0:

--- a/lightly_studio/src/lightly_studio/core/image/add_images.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_images.py
@@ -405,11 +405,28 @@ def tag_samples_by_directory(
     sample_ids: list[UUID],
     tag_depth: int,
 ) -> None:
-    """Tags samples based on their first-level subdirectory relative to input_path."""
+    """Tags samples by the leading directory levels of their path below input_path.
+
+    For ``tag_depth=N`` each sample is tagged with the names of the first ``N``
+    directory levels below ``input_path``, or fewer if the sample is nested less
+    deeply, so a sample may receive several tags. Samples that lie directly in
+    ``input_path`` are not tagged.
+
+    Args:
+        session: The database session.
+        collection_id: The collection the samples belong to.
+        input_path: The root path the samples were loaded from.
+        sample_ids: The ids of the samples to tag.
+        tag_depth: The number of leading directory levels to tag by. ``tag_depth=0``
+            skips tagging.
+
+    Raises:
+        ValueError: If tag_depth is negative.
+    """
+    if tag_depth < 0:
+        raise ValueError(f"tag_depth must be non-negative, got {tag_depth}.")
     if tag_depth == 0:
         return
-    if tag_depth > 1:
-        raise NotImplementedError("tag_depth > 1 is not yet implemented for add_images_from_path.")
 
     input_path_abs = add_annotations.normalize_images_root(input_path)
 
@@ -420,17 +437,19 @@ def tag_samples_by_directory(
     newly_created_samples = [ImageSample(inner=image) for image in newly_created_images]
 
     logger.info(f"Adding directory tags to {len(sample_ids)} new samples.")
-    parent_dir_to_sample_ids: defaultdict[str, list[UUID]] = defaultdict(list)
+    tag_name_to_sample_ids: defaultdict[str, list[UUID]] = defaultdict(list)
     for sample in newly_created_samples:
         sample_path_abs = Path(sample.file_path_abs)
         relative_path = sample_path_abs.relative_to(input_path_abs)
 
-        if len(relative_path.parts) > 1:
-            tag_name = relative_path.parts[0]
+        # relative_path.parts holds the directory levels followed by the file name,
+        # so the number of directory levels is one less than the number of parts.
+        num_directory_levels = len(relative_path.parts) - 1
+        for tag_name in relative_path.parts[: min(tag_depth, num_directory_levels)]:
             if tag_name:
-                parent_dir_to_sample_ids[tag_name].append(sample.sample_id)
+                tag_name_to_sample_ids[tag_name].append(sample.sample_id)
 
-    for tag_name, s_ids in parent_dir_to_sample_ids.items():
+    for tag_name, s_ids in tag_name_to_sample_ids.items():
         tag = tag_resolver.get_or_create_sample_tag_by_name(
             session=session,
             collection_id=collection_id,
@@ -441,7 +460,7 @@ def tag_samples_by_directory(
             tag_id=tag.tag_id,
             sample_ids=s_ids,
         )
-    logger.info(f"Created {len(parent_dir_to_sample_ids)} tags from directories.")
+    logger.info(f"Created {len(tag_name_to_sample_ids)} tags from directories.")
 
 
 def _group_captions_by_image_id(

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -144,13 +144,15 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             embed: If True, generate embeddings for the newly added images.
             tag_depth: Defines the tagging behavior based on directory depth.
                 - `tag_depth=0` (default): No automatic tagging is performed.
-                - `tag_depth=1`: Automatically creates a tag for each
-                  image based on its parent directory's name.
+                - `tag_depth=N` (N >= 1): Creates a tag for each of the first `N`
+                  directory levels below `path`, or fewer if an image is nested
+                  less deeply, so an image may receive several tags. Images
+                  directly under `path` are not tagged.
             limit: Maximum number of samples to load. By default, all samples are loaded.
 
         Raises:
-            NotImplementedError: If tag_depth > 1.
-            ValueError: If limit is not None and not greater than 0.
+            ValueError: If tag_depth is negative, or if limit is not None and not
+                greater than 0.
             AllInputFilesFailedError: If every image in the path is missing or broken.
         """
         fsspec_lister.validate_limit(limit)

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -156,6 +156,8 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
             AllInputFilesFailedError: If every image in the path is missing or broken.
         """
         fsspec_lister.validate_limit(limit)
+        if tag_depth < 0:
+            raise ValueError(f"tag_depth must be non-negative, got {tag_depth}.")
         # Collect image file paths.
         if allowed_extensions:
             allowed_extensions_set = {ext.lower() for ext in allowed_extensions}

--- a/lightly_studio/tests/core/image/test_add_images.py
+++ b/lightly_studio/tests/core/image/test_add_images.py
@@ -664,7 +664,7 @@ def test_create_label_map(db_session: Session) -> None:
     assert label_map_2[2] not in label_map_1.values()  # bird is new
 
 
-def test_tag_samples_by_directory_tag_depth_negative(
+def test_tag_samples_by_directory__tag_depth_negative(
     db_session: Session,
 ) -> None:
     """Tests that a negative tag_depth raises an error."""
@@ -679,7 +679,7 @@ def test_tag_samples_by_directory_tag_depth_negative(
         )
 
 
-def test_tag_samples_by_directory_tag_depth_0(
+def test_tag_samples_by_directory__tag_depth_0(
     db_session: Session,
 ) -> None:
     """Tests the default behavior (tag_depth=0) adds samples but no tags."""
@@ -713,7 +713,7 @@ def test_tag_samples_by_directory_tag_depth_0(
         assert len(sample.sample.tags) == 0
 
 
-def test_tag_samples_by_directory_tag_depth_1(
+def test_tag_samples_by_directory__tag_depth_1(
     db_session: Session,
 ) -> None:
     """Tests that tag_depth=1 correctly tags samples based on directory structure."""
@@ -751,7 +751,7 @@ def test_tag_samples_by_directory_tag_depth_1(
     assert sample_filename_to_tags["root_img.png"] == set()
 
 
-def test_tag_samples_by_directory_tag_depth_2(
+def test_tag_samples_by_directory__tag_depth_2(
     db_session: Session,
 ) -> None:
     """Tests that tag_depth=2 tags samples by their first two directory levels."""

--- a/lightly_studio/tests/core/image/test_add_images.py
+++ b/lightly_studio/tests/core/image/test_add_images.py
@@ -664,21 +664,18 @@ def test_create_label_map(db_session: Session) -> None:
     assert label_map_2[2] not in label_map_1.values()  # bird is new
 
 
-def test_tag_samples_by_directory_tag_depth_invalid(
+def test_tag_samples_by_directory_tag_depth_negative(
     db_session: Session,
 ) -> None:
-    """Tests that tag_depth > 1 raises an error."""
-    # We don't need a full collection, just the function call
-    with pytest.raises(
-        NotImplementedError,
-        match="tag_depth > 1 is not yet implemented for add_images_from_path",
-    ):
+    """Tests that a negative tag_depth raises an error."""
+    # We don't need a full collection, just the function call.
+    with pytest.raises(ValueError, match="tag_depth must be non-negative"):
         add_images.tag_samples_by_directory(
             session=db_session,
             collection_id=UUID(int=0),
             input_path=".",
             sample_ids=[],
-            tag_depth=2,
+            tag_depth=-1,
         )
 
 
@@ -752,6 +749,43 @@ def test_tag_samples_by_directory_tag_depth_1(
     assert sample_filename_to_tags["img2.png"] == {"site_1"}
     assert sample_filename_to_tags["img3.png"] == {" site_2 "}
     assert sample_filename_to_tags["root_img.png"] == set()
+
+
+def test_tag_samples_by_directory_tag_depth_2(
+    db_session: Session,
+) -> None:
+    """Tests that tag_depth=2 tags samples by their first two directory levels."""
+    mock_root_path = "/mock/path"
+    collection_table = helpers_resolvers.create_collection(db_session, "test_collection")
+    created_images = helpers_resolvers.create_images(
+        db_session=db_session,
+        collection_id=collection_table.collection_id,
+        images=[
+            ImageStub(path=f"{mock_root_path}/root_img.png"),
+            ImageStub(path=f"{mock_root_path}/dogs/img1.png"),
+            ImageStub(path=f"{mock_root_path}/dogs/husky/img2.png"),
+            ImageStub(path=f"{mock_root_path}/dogs/husky/puppy/img3.png"),
+        ],
+    )
+    # Run with tag_depth=2
+    add_images.tag_samples_by_directory(
+        session=db_session,
+        collection_id=collection_table.collection_id,
+        input_path=mock_root_path,
+        sample_ids=[img.sample_id for img in created_images],
+        tag_depth=2,
+    )
+
+    samples = image_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection_table.collection_id
+    ).samples
+    assert len(samples) == 4
+
+    sample_filename_to_tags = {s.file_name: {t.name for t in s.sample.tags} for s in samples}
+    assert sample_filename_to_tags["root_img.png"] == set()
+    assert sample_filename_to_tags["img1.png"] == {"dogs"}
+    assert sample_filename_to_tags["img2.png"] == {"dogs", "husky"}
+    assert sample_filename_to_tags["img3.png"] == {"dogs", "husky"}
 
 
 def test_tag_samples_by_directory__file_url_normalization(

--- a/lightly_studio/tests/core/image/test_image_dataset__path.py
+++ b/lightly_studio/tests/core/image/test_image_dataset__path.py
@@ -251,6 +251,17 @@ class TestDataset:
         with pytest.raises(ValueError, match=r"limit must be greater than 0"):
             dataset.add_images_from_path(path=tmp_path, limit=limit)
 
+    @pytest.mark.parametrize("tag_depth", [-1, -5])
+    def test_dataset_add_images_from_path__invalid_tag_depth(
+        self,
+        patch_collection: None,  # noqa: ARG002
+        tmp_path: Path,
+        tag_depth: int,
+    ) -> None:
+        dataset = ImageDataset.create(name="test_dataset")
+        with pytest.raises(ValueError, match="tag_depth must be non-negative"):
+            dataset.add_images_from_path(path=tmp_path, tag_depth=tag_depth)
+
     def test_add_images_from_path_calls_tag_samples_by_directory(
         self,
         patch_collection: None,  # noqa: ARG002


### PR DESCRIPTION
## What has changed and why?

Recreates #1775 by @lorinczszabolcs so the CI passes 

## How has it been tested?
N/A


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image imports now support tagging by multiple leading folder levels using `tag_depth`.
  - Images can receive multiple tags based on their nested directory structure.
  - Root-level images remain untagged when no directory-based tag applies.

- **Bug Fixes**
  - Invalid negative `tag_depth` values now raise a clear validation error.

- **Documentation**
  - Updated tagging and image dataset guidance to explain multi-level folder tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->