### PR TITLE
introduce build_count_expression

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/__init__.py
@@ -1,0 +1,5 @@
+from .build_count_expression import build_count_expression
+
+__all__ = [
+    "build_count_expression",
+]

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/build_count_expression.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/build_count_expression.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import sqlmodel
 from sqlalchemy import ColumnElement
-from sqlmodel import col, func
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.resolvers.image_resolver.annotation_count_types import AnnotationCountMode
@@ -12,5 +12,6 @@ from lightly_studio.resolvers.image_resolver.annotation_count_types import Annot
 def build_count_expression(count_mode: AnnotationCountMode) -> ColumnElement[int]:
     """Return a SQL count expression for the given count mode."""
     if count_mode == AnnotationCountMode.SAMPLES:
-        return func.count(func.distinct(col(AnnotationBaseTable.parent_sample_id)))
-    return func.count(col(AnnotationBaseTable.sample_id))
+        distinct = sqlmodel.func.distinct(sqlmodel.col(AnnotationBaseTable.parent_sample_id))
+        return sqlmodel.func.count(distinct)
+    return sqlmodel.func.count(sqlmodel.col(AnnotationBaseTable.sample_id))

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/build_count_expression.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/build_count_expression.py
@@ -1,0 +1,16 @@
+"""Build a SQL count expression for annotation count mode."""
+
+from __future__ import annotations
+
+from sqlalchemy import ColumnElement
+from sqlmodel import col, func
+
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.resolvers.image_resolver.annotation_count_types import AnnotationCountMode
+
+
+def build_count_expression(count_mode: AnnotationCountMode) -> ColumnElement[int]:
+    """Return a SQL count expression for the given count mode."""
+    if count_mode == AnnotationCountMode.SAMPLES:
+        return func.count(func.distinct(col(AnnotationBaseTable.parent_sample_id)))
+    return func.count(col(AnnotationBaseTable.sample_id))

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_types.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_types.py
@@ -1,0 +1,42 @@
+"""Types for image annotation count resolvers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from uuid import UUID
+
+
+class AnnotationCountMode(str, Enum):
+    """Controls what the annotation count represents."""
+
+    OBJECTS = "objects"
+    SAMPLES = "samples"
+
+
+@dataclass(frozen=True)
+class AnnotationClassCount:
+    """Annotation count for one class.
+
+    Attributes:
+        label_name: Annotation class name on the shared class axis.
+        count: Number of matching annotation objects or distinct annotated samples.
+    """
+
+    label_name: str
+    count: int
+
+
+@dataclass(frozen=True)
+class SampleTagAnnotationCounts:
+    """Annotation class counts for one sample tag.
+
+    Attributes:
+        sample_tag_id: ID of the selected sample tag.
+        sample_tag_name: Name of the selected sample tag.
+        counts: Zero-filled counts on the shared class axis.
+    """
+
+    sample_tag_id: UUID
+    sample_tag_name: str
+    counts: list[AnnotationClassCount]

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_types.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_types.py
@@ -39,4 +39,4 @@ class SampleTagAnnotationCounts:
 
     sample_tag_id: UUID
     sample_tag_name: str
-    counts: list[AnnotationClassCount]
+    counts: tuple[AnnotationClassCount, ...]

--- a/lightly_studio/tests/resolvers/image_resolver/annotation_count_helpers/test_build_count_expression.py
+++ b/lightly_studio/tests/resolvers/image_resolver/annotation_count_helpers/test_build_count_expression.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from lightly_studio.resolvers.image_resolver import annotation_count_helpers
+from lightly_studio.resolvers.image_resolver.annotation_count_types import AnnotationCountMode
+
+
+def test_build_count_expression__objects_mode() -> None:
+    expr = annotation_count_helpers.build_count_expression(AnnotationCountMode.OBJECTS)
+
+    assert "distinct" not in str(expr).lower()
+    assert "sample_id" in str(expr)
+
+
+def test_build_count_expression__samples_mode() -> None:
+    expr = annotation_count_helpers.build_count_expression(AnnotationCountMode.SAMPLES)
+
+    assert "distinct" in str(expr).lower()
+    assert "parent_sample_id" in str(expr)

--- a/lightly_studio/tests/resolvers/image_resolver/annotation_count_helpers/test_build_count_expression.py
+++ b/lightly_studio/tests/resolvers/image_resolver/annotation_count_helpers/test_build_count_expression.py
@@ -9,6 +9,7 @@ def test_build_count_expression__objects_mode() -> None:
 
     assert "distinct" not in str(expr).lower()
     assert "sample_id" in str(expr)
+    assert "parent_sample_id" not in str(expr)
 
 
 def test_build_count_expression__samples_mode() -> None:


### PR DESCRIPTION
Introduce build_count_expression
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for counting image annotations by individual objects or distinct samples.
  * Added structured annotation count results, including per-class counts and sample-tag summaries.
  * Count results now provide consistent, immutable collections for reliable handling.

* **Tests**
  * Added coverage verifying both counting modes and their identifier handling.
  * Confirmed object counts avoid duplicate-sample deduplication, while sample counts correctly count distinct samples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->