### PR TITLE
add get_annotation_collection_ids

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/__init__.py
@@ -9,5 +9,5 @@ __all__ = [
     "build_grouped_count_query",
     "build_sample_tag_counts",
     "get_and_validate_sample_tags",
-    "get_annotation_collection_ids"
+    "get_annotation_collection_ids",
 ]

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/__init__.py
@@ -2,10 +2,12 @@ from .build_count_expression import build_count_expression
 from .build_grouped_count_query import build_grouped_count_query
 from .build_sample_tag_counts import build_sample_tag_counts
 from .get_and_validate_sample_tags import get_and_validate_sample_tags
+from .get_annotation_collection_ids import get_annotation_collection_ids
 
 __all__ = [
     "build_count_expression",
     "build_grouped_count_query",
     "build_sample_tag_counts",
     "get_and_validate_sample_tags",
+    "get_annotation_collection_ids"
 ]

--- a/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/get_annotation_collection_ids.py
+++ b/lightly_studio/src/lightly_studio/resolvers/image_resolver/annotation_count_helpers/get_annotation_collection_ids.py
@@ -1,0 +1,15 @@
+"""Extract annotation source collection IDs from an image filter."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from lightly_studio.resolvers.image_filter import ImageFilter
+
+
+def get_annotation_collection_ids(image_filter: ImageFilter | None) -> list[UUID] | None:
+    """Return the annotation source collection IDs from the filter, or None if unrestricted."""
+    sample_filter = image_filter.sample_filter if image_filter is not None else None
+    if sample_filter is None or sample_filter.annotations_filter is None:
+        return None
+    return sample_filter.annotations_filter.collection_ids

--- a/lightly_studio/tests/resolvers/image_resolver/annotation_count_helpers/test_get_annotation_collection_ids.py
+++ b/lightly_studio/tests/resolvers/image_resolver/annotation_count_helpers/test_get_annotation_collection_ids.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
+from lightly_studio.resolvers.image_filter import ImageFilter
+from lightly_studio.resolvers.image_resolver import annotation_count_helpers
+from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
+
+
+def test_get_annotation_collection_ids__no_filter() -> None:
+    result = annotation_count_helpers.get_annotation_collection_ids(image_filter=None)
+
+    assert result is None
+
+
+def test_get_annotation_collection_ids__filter_without_annotations_filter() -> None:
+    image_filter = ImageFilter(sample_filter=SampleFilter())
+
+    result = annotation_count_helpers.get_annotation_collection_ids(image_filter=image_filter)
+
+    assert result is None
+
+
+def test_get_annotation_collection_ids__returns_collection_ids() -> None:
+    collection_id = uuid4()
+    image_filter = ImageFilter(
+        sample_filter=SampleFilter(
+            annotations_filter=AnnotationsFilter(collection_ids=[collection_id])
+        )
+    )
+
+    result = annotation_count_helpers.get_annotation_collection_ids(image_filter=image_filter)
+
+    assert result == [collection_id]


### PR DESCRIPTION
## What has changed and why?

(Delete this: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving annotation collection IDs from image filters.
  * Handles missing filters or filters without annotations by returning no collection IDs.

* **Tests**
  * Added coverage for missing filters, filters without annotations, and filters containing annotation collection IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->