### PR TITLE
Drop the orphaned Playwright install-deps step from End2End Test

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -22,6 +22,8 @@ jobs:
   prepare-caches:
     name: Build Cache
     runs-on: ubuntu-latest
+    # Recent runs: 3.5min median, 10min worst.
+    timeout-minutes: 15
     outputs:
       file-hash: ${{ steps.file-hash.outputs.hash }}
     steps:
@@ -122,12 +124,6 @@ jobs:
 
       ### Build caches ###
 
-      # Always ensure system packages for browsers are present on Ubuntu
-      - name: Install Playwright system dependencies
-        if: steps.cache-build.outputs.cache-hit != 'true'
-        working-directory: lightly_studio_view
-        run: npx playwright install-deps chromium
-
       # Only download browser binaries when cache misses; otherwise reuse cache
       - name: Install Playwright browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
@@ -162,6 +158,8 @@ jobs:
   end-to-end:
     name: End2End Test (${{ matrix.name }})
     runs-on: ubuntu-latest
+    # Recent runs: 5.7min median, 9.2min worst.
+    timeout-minutes: 20
     needs: prepare-caches
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What has changed and why?

Removes the `Install Playwright system dependencies` step from `Build Cache`, and adds
job-level `timeout-minutes` to `Build Cache` and `End2End Test`.

**The step never affected the tests it was meant to enable.** `install-deps` ran in
`prepare-caches`; `playwright test` runs in `end-to-end`. Separate jobs, separate VMs,
and apt state does not travel between them — only the `actions/cache` entries do. It
installed system libraries on a machine that never launches a browser. A leftover from
#218, which split the original job in two and moved `playwright test` out without
moving `install-deps` with it.

Safe to drop because the e2e jobs already run without it: the step was gated on a
cache miss, so every cache-hit run skipped it and e2e passed anyway. `ubuntu-latest`
ships Chromium's libraries already, and the only packages the step added were 21 MB of
fonts and `xvfb` that nothing here uses (headless, no visual assertions). If a runner
image ever does drop a library, Playwright's launch-time check fails with the exact
missing `.so`.

**Timeouts:** the workflow only had step-level ones, so `Build Cache` inherited the
360-minute default and sat in apt retries for 30-45 minutes this week when the runner
image's preferred mirror went unreachable. Values sized off 25 recent runs, ~2x the worst observed (`Build Cache`
3.5min median / 10min worst, shards 5.7min median / 9.2min worst).

Also removes ~3 minutes from every cache-missing run.

## How has it been tested?

`install-deps` appears nowhere else in the repo, no step in `end-to-end` installs
system dependencies, and those jobs pass today — that is the proof the packages are
unnecessary. `unit_test.yml` runs vitest, not Playwright. This PR's own End2End run
exercises the cache-miss path with the step gone, since the workflow file is part of
the cache key.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @michal-lightly (top author here, authored #218). Alternative:
@fruet, who reshaped these jobs in #1912.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added time limits to cache preparation and end-to-end test jobs.
  * Removed an unnecessary system-dependency installation step from cache preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->