### PR TITLE
Drop the private lightly-pypi index, GCP auth, and keyring

### DIFF
--- a/.github/workflows/end2end_test.yml
+++ b/.github/workflows/end2end_test.yml
@@ -58,15 +58,6 @@ jobs:
             lightly_studio/src/lightly_studio/dist_lightly_studio_view_app
           key: python-build-${{ steps.file-hash.outputs.hash }}
 
-      # Authenticate to download dev versions of lightly-mundig. Only needed
-      # when the build cache misses, same as the steps that consume it below.
-      - name: Authenticate with GCP
-        if: steps.cache-build.outputs.cache-hit != 'true'
-        uses: 'google-github-actions/auth@v3'
-        with:
-          project_id: boris-250909
-          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
-
       - name: Cache Playwright browsers
         id: cache-playwright-browsers
         uses: actions/cache@v5
@@ -102,13 +93,6 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
-
-      - name: Install Google Artifact Registry keyring
-        if: steps.cache-build.outputs.cache-hit != 'true'
-        working-directory: lightly_studio
-        # `make export-schema` below invokes `uv run` before the end-to-end job
-        # installs optional dependencies, so registry authentication is needed here.
-        run: make install-google-artifact-registry-keyring
 
       - name: Set Up Node.js
         uses: actions/setup-node@v6
@@ -274,15 +258,6 @@ jobs:
           lookup-only: true
           path: ${{ matrix.success_marker }}
           key: ${{ matrix.success_key }}-${{ needs.prepare-caches.outputs.file-hash }}
-
-      # Authenticate to download dev versions of lightly-mundig. Only needed
-      # when the e2e success cache misses, same as the steps that consume it below.
-      - name: Authenticate with GCP
-        if: steps.cache-success.outputs.cache-hit != 'true'
-        uses: 'google-github-actions/auth@v3'
-        with:
-          project_id: boris-250909
-          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
 
       ### Restore caches ###
 

--- a/.github/workflows/fast_track_guardrails.yml
+++ b/.github/workflows/fast_track_guardrails.yml
@@ -34,9 +34,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
-        # Never pushes — keep the git token out of the checkout. The later toolchain steps
-        # expose GCP secrets to PR code (same posture as unit_test.yml); the job's `if`
-        # restricts it to same-repo PRs, so untrusted fork code never reaches them.
+        # Never pushes — keep the git token out of the checkout. This job runs PR code
+        # (builds and tests) with the workflow token, and the job's `if` restricts it to
+        # same-repo PRs, so untrusted fork code never runs in that context.
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
@@ -62,13 +62,6 @@ jobs:
       # --- Backend toolchain -------------------------------------------------
       # Full backend venv for backend guardrails (e.g. backend/complexity, backend/coverage);
       # frontend PRs need it too, to export the schema for their generated API client.
-      - name: Authenticate with GCP
-        if: steps.changes.outputs.backend == 'true' || steps.changes.outputs.frontend == 'true'
-        uses: 'google-github-actions/auth@v3'
-        with:
-          project_id: boris-250909
-          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
-
       - name: Set Up Python
         if: steps.changes.outputs.backend == 'true' || steps.changes.outputs.frontend == 'true'
         uses: actions/setup-python@v6

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -73,13 +73,6 @@ jobs:
         with:
           submodules: recursive
 
-      # Authenticate to download dev versions of lightly-mundig.
-      - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v3'
-        with:
-          project_id: boris-250909
-          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
-
       - name: Set Up uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
@@ -110,12 +103,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-
-      - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v3'
-        with:
-          project_id: boris-250909
-          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
 
       - name: Set Up Python
         uses: actions/setup-python@v6
@@ -174,13 +161,6 @@ jobs:
         with:
           submodules: recursive
 
-      # Authenticate to download dev versions of lightly-mundig.
-      - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v3'
-        with:
-          project_id: boris-250909
-          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
-
       - name: Set Up uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
@@ -224,13 +204,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-
-      # Authenticate to download dev versions of lightly-mundig.
-      - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v3'
-        with:
-          project_id: boris-250909
-          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
 
       - name: Set Up Python
         uses: actions/setup-python@v6
@@ -277,13 +250,6 @@ jobs:
         with:
           submodules: recursive
 
-      # Authenticate to download dev versions of lightly-mundig.
-      - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v3'
-        with:
-          project_id: boris-250909
-          credentials_json: ${{ secrets.GCP_LIGHTLY_STUDIO_CI_READONLY }}
-
       - name: Set Up uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
@@ -295,7 +261,6 @@ jobs:
         with:
           python-version: "3.9"
 
-      # Installs keyring to download dev versions of lightly-mundig.
       - name: Install LightlyStudio dependencies
         working-directory: lightly_studio
         run: make install-optional-deps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,6 @@ After you have your changes ready, and you create a new pull request, a maintain
 - Python **3.9–3.14** (3.9 recommended)
 - Uv version **0.8.17+**
 - Node.js **24+** (exact version pinned in `lightly_studio_view/.nvmrc`)
-- Access to **Google Cloud Platform** (request permissions from @IgorSusmelj)
 
 ## Development Quickstart
 

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -21,17 +21,8 @@ endif
 
 # Note: Install target with default dependencies is not necessary as uv will
 # install the default dependencies automatically on e.g. `uv run` etc.
-.PHONY: install-google-artifact-registry-keyring
-install-google-artifact-registry-keyring:
-	@echo "Installing keyring provider for Google Artifact Registry..."
-# Install keyring in the global python environment. It is not possible to install it
-# in the uv environment because uv needs it already during `uv sync`. Note that
-# we cannot use `uv tool` because it does not support tool installations for more
-# than one python version at the same time.
-	pip install keyrings.google-artifactregistry-auth
-
 .PHONY: install-optional-deps
-install-optional-deps: install-google-artifact-registry-keyring
+install-optional-deps:
 	@echo "Installing with optional dependencies..."
 	uv sync --all-groups --all-extras
 

--- a/lightly_studio/pyproject.toml
+++ b/lightly_studio/pyproject.toml
@@ -45,15 +45,8 @@ dependencies = [
     "open-clip-torch>=2.20.0",
     "torch>=2.6.0",
     "torchvision>=0.20.0",
-    # Public Mundig versions are found at https://pypi.org/project/lightly-mundig/
-    # Internal Mundig versions are found at
-    # https://console.cloud.google.com/artifacts/python/boris-250909/europe-west3/lightly-pypi/lightly-mundig
-    #
-    # To update to an internal version, first install the new version
-    # uv pip install --upgrade --keyring-provider subprocess --extra-index-url \
-    #   https://oauth2accesstoken@europe-west3-python.pkg.dev/boris-250909/lightly-pypi/simple/ \
-    #   lightly-mundig==$version
-    # Then lock the version. The uv.lock file is updated accordingly.
+    # Mundig releases are published to PyPI: https://pypi.org/project/lightly-mundig/
+    # To update, bump the pin below and relock:
     # uv lock --upgrade-package lightly-mundig==$version
     "lightly-mundig==0.1.14",
     "pyarrow>=17.0.0",
@@ -165,18 +158,12 @@ packages = ["src/lightly_studio"]
 allow-direct-references = true
 
 [tool.uv]
-keyring-provider = "subprocess"
 required-version = ">=0.8.17"
 # moto[server] pulls in antlr4-python3-runtime unconstrained (latest 4.13.x), but it
 # only loads it lazily for StepFunctions mocking, which we never use (moto is only
 # used for S3 mocking in tests). The lightly_train plugin's omegaconf/hydra require
 # antlr 4.9.* and crash on import with 4.13.x, so we pin it back to 4.9.3.
 constraint-dependencies = ["antlr4-python3-runtime==4.9.3"]
-
-[[tool.uv.index]]
-name = "lightly-pypi"
-url = "https://oauth2accesstoken@europe-west3-python.pkg.dev/boris-250909/lightly-pypi/simple/"
-explicit = true
 
 [tool.hatch.build]
 artifacts = [


### PR DESCRIPTION
## What has changed and why?

`lightly-mundig` is now published to public PyPI, so the private Google Artifact Registry index and everything that authenticated to it are dead weight.

Removed:
- `[[tool.uv.index]]` (lightly-pypi) and `keyring-provider` from `pyproject.toml`
- The keyring install Makefile target and its prereq on `install-optional-deps`
- All GCP auth steps across the CI workflows, plus the e2e keyring install step
- The GCP access requirement for contributors in `CONTRIBUTING.md`

Follow-up (outside this PR): the now-unused `GCP_LIGHTLY_STUDIO_CI_READONLY` Actions secret can be deleted, and its service-account key revoked.

## How has it been tested?

- `uv lock --check` passes — resolution unchanged (`lightly-mundig` already locked from public PyPI)
- All workflow YAML validated
- `make install-optional-deps` runs `uv sync` with no auth

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified automated testing and validation workflows by removing unnecessary cloud authentication steps.
  * Removed the requirement for contributors to access Google Cloud Platform.
  * Streamlined optional dependency installation and removed private package registry setup.
  * Updated dependency documentation to reference the public PyPI release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->