### PR TITLE
Annotations sort: add adjancent ordering support endpoint

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from sqlmodel import Session
 
+from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluationMetricField
 from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.resolvers.annotation_resolver.get_adjacent_annotations_window import (
     get_adjacent_annotations_window,
@@ -17,6 +18,7 @@ def get_adjacent_annotations(
     session: Session,
     sample_id: UUID,
     filters: AnnotationsFilter,
+    order_by: OrderByAnnotationEvaluationMetricField | None = None,
 ) -> AdjacentResultView | None:
     """Get the adjacent annotations for a given annotation ID.
 
@@ -24,6 +26,7 @@ def get_adjacent_annotations(
         session: Database session.
         sample_id: The anchor annotation whose neighbours we want.
         filters: Annotation filters constraining the set; must scope the collection.
+        order_by: Optional leading sort key applied before the tiebreaker chain.
 
     Returns:
         The adjacency result, or ``None`` if the anchor is not in the filtered set.
@@ -38,4 +41,5 @@ def get_adjacent_annotations(
         session=session,
         sample_id=sample_id,
         filters=filters,
+        order_by=order_by,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations_window.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations_window.py
@@ -30,7 +30,14 @@ def get_adjacent_annotations_window(
     filters: AnnotationsFilter,
     order_by: OrderByAnnotationEvaluationMetricField | None = None,
 ) -> AdjacentResultView | None:
-    """Get the adjacent annotations by sorting and windowing the whole filtered set."""
+    """Get the adjacent annotations by sorting and windowing the whole filtered set.
+
+    Args:
+        session: Database session.
+        sample_id: The anchor annotation whose neighbours we want.
+        filters: Annotation filters constraining the set; must scope the collection.
+        order_by: Optional leading sort key applied before the tiebreaker chain.
+    """
     return adjacents.get_sample_adjacent_info(
         session=session,
         sample_id=sample_id,

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations_window.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations_window.py
@@ -10,10 +10,11 @@ from typing import Any
 from uuid import UUID
 
 import sqlmodel
-from sqlalchemy import func
+from sqlalchemy import ColumnElement, func
 from sqlmodel import Session, col, select
 from sqlmodel.sql.expression import Select, SelectOfScalar
 
+from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluationMetricField
 from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.image import ImageTable
@@ -27,30 +28,41 @@ def get_adjacent_annotations_window(
     session: Session,
     sample_id: UUID,
     filters: AnnotationsFilter,
+    order_by: OrderByAnnotationEvaluationMetricField | None = None,
 ) -> AdjacentResultView | None:
     """Get the adjacent annotations by sorting and windowing the whole filtered set."""
     return adjacents.get_sample_adjacent_info(
         session=session,
         sample_id=sample_id,
-        samples_query=_build_window_query(filters),
+        samples_query=_build_window_query(filters, order_by=order_by),
     )
 
 
-def _build_window_query(filters: AnnotationsFilter) -> Select[Any]:
+def _build_window_query(
+    filters: AnnotationsFilter,
+    order_by: OrderByAnnotationEvaluationMetricField | None = None,
+) -> Select[Any]:
     # Start from raw annotation rows so tag filters can join/distinct before windowing.
     base_rows: SelectOfScalar[AnnotationBaseTable] = select(AnnotationBaseTable)
     filtered_rows = filters.apply(base_rows).subquery()
 
-    # TODO(Jonas, 07/2026): No leading order key here, so next/prev drifts from the grid
-    # whenever the grid sorts by similarity. A leading key added there must be added here.
+    # The metric join must match against filtered_rows.c.sample_id, not the ORM table column,
+    # because AnnotationBaseTable is not directly in the FROM — only the subquery is.
+    if order_by is not None:
+        order_by.annotation_id_column = filtered_rows.c.sample_id
+        leading_order_key: ColumnElement[Any] | None = order_by.to_column_elements()[0]
+    else:
+        leading_order_key = None
+
     ordering_expression = annotation_ordering.build_order_by(
         file_path_abs=annotation_ordering.coalesced_file_path_abs_expression(),
         created_at=filtered_rows.c.created_at,
         annotation_sample_id=filtered_rows.c.sample_id,
+        leading_order_key=leading_order_key,
     )
 
     # Compute lag/lead/row_number on the already filtered set to avoid tag duplicates.
-    return (
+    query: Select[Any] = (
         select(
             filtered_rows.c.sample_id.label("sample_id"),
             func.lag(filtered_rows.c.sample_id)
@@ -72,3 +84,8 @@ def _build_window_query(filters: AnnotationsFilter) -> Select[Any]:
             col(VideoTable.sample_id) == sqlmodel.col(VideoFrameTable.parent_sample_id),
         )
     )
+
+    if order_by is not None:
+        query = order_by.apply_joins(query)
+
+    return query

--- a/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations_window.py
+++ b/lightly_studio/src/lightly_studio/resolvers/annotation_resolver/get_adjacent_annotations_window.py
@@ -57,7 +57,9 @@ def _build_window_query(
     # because AnnotationBaseTable is not directly in the FROM — only the subquery is.
     if order_by is not None:
         order_by.annotation_id_column = filtered_rows.c.sample_id
-        leading_order_key: ColumnElement[Any] | None = order_by.to_column_elements()[0]
+        leading_order_key: ColumnElement[Any] | None = order_by.to_column_elements()[
+            0
+        ]  # Safe only while order_by yields a single sort key.
     else:
         leading_order_key = None
 

--- a/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
+++ b/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
@@ -68,6 +68,10 @@ def _build_annotation_order_by(
     collection_ids = filters.collection_ids or []
     if not (annotation_sort_by and collection_ids):
         return None
+    if len(collection_ids) > 1:
+        raise ValueError(
+            "annotation_sort_by is not supported when multiple collection_ids are provided"
+        )
     return annotation_metric_sort.sort_expr_to_order_by(
         session=session,
         annotation_collection_id=collection_ids[0],

--- a/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
+++ b/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 from sqlmodel import Session, col
 
+from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluationMetricField
 from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
@@ -43,6 +44,36 @@ class AdjacentRequest(BaseModel):
     text_embedding: list[float] | None = None
     sort_by: list[SortExpr] | None = None
     annotation_sort_by: AnnotationEvaluationMetricSortExpr | None = None
+
+
+def _build_annotation_order_by(
+    session: Session,
+    filters: AnnotationsFilter,
+    annotation_sort_by: AnnotationEvaluationMetricSortExpr | None,
+) -> OrderByAnnotationEvaluationMetricField | None:
+    """Resolve the order-by clause for an annotation adjacent query.
+
+    Normalises the collection ID list from the filter and, when a sort
+    expression is present, translates it into a database-backed order-by
+    expression tied to the first collection.
+
+    Args:
+        session: Database session used to look up the evaluation run.
+        filters: The annotation filters carrying the collection IDs.
+        annotation_sort_by: Optional sort expression from the request.
+
+    Returns:
+        An order-by expression, or None when no sort should be applied.
+    """
+    collection_ids = filters.collection_ids or []
+    if not (annotation_sort_by and collection_ids):
+        return None
+    return annotation_metric_sort.sort_expr_to_order_by(
+        session=session,
+        annotation_collection_id=collection_ids[0],
+        sort_expr=annotation_sort_by,
+        annotation_id_column=col(AnnotationBaseTable.sample_id),
+    )
 
 
 def get_adjacent_samples(
@@ -105,22 +136,15 @@ def get_adjacent_samples(
                 "Invalid filter provided. Expected AnnotationsFilter"
                 f" for sample type '{request.sample_type.value}'."
             )
-        collection_ids = request.filters.collection_ids or []
-        annotation_order_by = (
-            annotation_metric_sort.sort_expr_to_order_by(
-                session=session,
-                annotation_collection_id=collection_ids[0],
-                sort_expr=request.annotation_sort_by,
-                annotation_id_column=col(AnnotationBaseTable.sample_id),
-            )
-            if request.annotation_sort_by and collection_ids
-            else None
-        )
         return annotation_resolver.get_adjacent_annotations(
             session=session,
             filters=request.filters,
             sample_id=sample_id,
-            order_by=annotation_order_by,
+            order_by=_build_annotation_order_by(
+                session=session,
+                filters=request.filters,
+                annotation_sort_by=request.annotation_sort_by,
+            ),
         )
     raise NotImplementedError(
         f"Adjacent samples retrieval is not implemented for sample type: {request.sample_type}"

--- a/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
+++ b/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
@@ -6,9 +6,11 @@ from typing import Annotated
 from uuid import UUID
 
 from pydantic import BaseModel, Field
-from sqlmodel import Session
+from sqlmodel import Session, col
 
 from lightly_studio.models.adjacents import AdjacentResultView
+from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
 from lightly_studio.models.collection import SampleType
 from lightly_studio.models.sort import SortExpr, sort_expr_to_order_by
 from lightly_studio.resolvers import (
@@ -17,6 +19,7 @@ from lightly_studio.resolvers import (
     video_frame_resolver,
     video_resolver,
 )
+from lightly_studio.resolvers.annotations import annotation_metric_sort
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
 )
@@ -39,6 +42,7 @@ class AdjacentRequest(BaseModel):
     ) = None
     text_embedding: list[float] | None = None
     sort_by: list[SortExpr] | None = None
+    annotation_sort_by: AnnotationEvaluationMetricSortExpr | None = None
 
 
 def get_adjacent_samples(
@@ -101,10 +105,22 @@ def get_adjacent_samples(
                 "Invalid filter provided. Expected AnnotationsFilter"
                 f" for sample type '{request.sample_type.value}'."
             )
+        collection_ids = request.filters.collection_ids or []
+        annotation_order_by = (
+            annotation_metric_sort.sort_expr_to_order_by(
+                session=session,
+                annotation_collection_id=collection_ids[0],
+                sort_expr=request.annotation_sort_by,
+                annotation_id_column=col(AnnotationBaseTable.sample_id),
+            )
+            if request.annotation_sort_by and collection_ids
+            else None
+        )
         return annotation_resolver.get_adjacent_annotations(
             session=session,
             filters=request.filters,
             sample_id=sample_id,
+            order_by=annotation_order_by,
         )
     raise NotImplementedError(
         f"Adjacent samples retrieval is not implemented for sample type: {request.sample_type}"

--- a/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
@@ -4,14 +4,22 @@ from unittest import mock
 from uuid import UUID
 
 import pytest
-from sqlmodel import Session
+from sqlmodel import Session, col
 
+from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluationMetricField
 from lightly_studio.models.annotation import annotation_base as annotation_base_module
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.collection import SampleType
-from lightly_studio.resolvers import annotation_resolver, tag_resolver
+from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationSide
+from lightly_studio.resolvers import annotation_resolver, collection_resolver, tag_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from tests import helpers_resolvers
+from tests.resolvers.evaluation_sample_metric_resolver.helpers import (
+    FalseNegativeMetricStub,
+    TruePositiveMetricStub,
+    create_annotation_metrics,
+    create_run,
+)
 from tests.resolvers.video.helpers import VideoStub, create_video_with_frames
 
 
@@ -560,3 +568,78 @@ def _assert_matches_expected_order(
             previous_annotation.sample_id if previous_annotation else None
         )
         assert result.next_sample_id == (next_annotation.sample_id if next_annotation else None)
+
+
+def test_get_adjacent_annotations__sort_by_annotation_evaluation_metric(
+    db_session: Session,
+) -> None:
+    # unmatched (0.0) < matched (0.75); uncovered (NULL) sorts last
+    root = helpers_resolvers.create_collection(session=db_session)
+    label = helpers_resolvers.create_annotation_label(
+        session=db_session, root_collection_id=root.collection_id
+    )
+    run = create_run(session=db_session, collection_id=root.collection_id)
+
+    image_matched = helpers_resolvers.create_image(
+        session=db_session, collection_id=root.collection_id, file_path_abs="/a.png"
+    )
+    image_unmatched = helpers_resolvers.create_image(
+        session=db_session, collection_id=root.collection_id, file_path_abs="/b.png"
+    )
+    image_uncovered = helpers_resolvers.create_image(
+        session=db_session, collection_id=root.collection_id, file_path_abs="/c.png"
+    )
+
+    matched_stub, unmatched_stub = create_annotation_metrics(
+        session=db_session,
+        run_id=run.id,
+        pair_metric_stubs=[
+            TruePositiveMetricStub(
+                sample_id=image_matched.sample_id,
+                metrics={"iou": 0.75},
+                gt_annotation_label_id=label.annotation_label_id,
+            ),
+            FalseNegativeMetricStub(
+                sample_id=image_unmatched.sample_id,
+                gt_annotation_label_id=label.annotation_label_id,
+            ),
+        ],
+    )
+
+    gt_collection = collection_resolver.get_by_id(
+        session=db_session, collection_id=run.gt_annotation_collection_id
+    )
+    assert gt_collection is not None
+    uncovered = helpers_resolvers.create_annotation(
+        session=db_session,
+        collection_id=root.collection_id,
+        sample_id=image_uncovered.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name=gt_collection.name,
+    )
+
+    assert matched_stub.gt_annotation_id is not None
+    assert unmatched_stub.gt_annotation_id is not None
+
+    order_by = OrderByAnnotationEvaluationMetricField(
+        evaluation_run_id=run.id,
+        metric_name="iou",
+        side=EvaluationAnnotationSide.GROUND_TRUTH,
+        annotation_id_column=col(AnnotationBaseTable.sample_id),
+    )
+    filters = AnnotationsFilter(collection_ids=[run.gt_annotation_collection_id])
+
+    # Query from the middle: matched is position 2 (unmatched=0.0, matched=0.75, uncovered=NULL)
+    result = annotation_resolver.get_adjacent_annotations(
+        session=db_session,
+        sample_id=matched_stub.gt_annotation_id,
+        filters=filters,
+        order_by=order_by,
+    )
+
+    assert result is not None
+    assert result.previous_sample_id == unmatched_stub.gt_annotation_id
+    assert result.sample_id == matched_stub.gt_annotation_id
+    assert result.next_sample_id == uncovered.sample_id
+    assert result.current_sample_position == 2
+    assert result.total_count == 3

--- a/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_adjacent_annotations.py
@@ -573,7 +573,7 @@ def _assert_matches_expected_order(
 def test_get_adjacent_annotations__sort_by_annotation_evaluation_metric(
     db_session: Session,
 ) -> None:
-    # unmatched (0.0) < matched (0.75); uncovered (NULL) sorts last
+    # Unmatched (0.0) < matched (0.75); uncovered (NULL) sorts last
     root = helpers_resolvers.create_collection(session=db_session)
     label = helpers_resolvers.create_annotation_label(
         session=db_session, root_collection_id=root.collection_id

--- a/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
+++ b/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
@@ -236,6 +236,35 @@ def test_get_adjacent_samples__translates_annotation_sort_by_before_delegating(
     )
 
 
+def test_get_adjacent_samples__raises_when_annotation_sort_by_with_multiple_collection_ids(
+    db_session: Session,
+) -> None:
+    collection_id_a = uuid4()
+    collection_id_b = uuid4()
+    filters = AnnotationsFilter(collection_ids=[collection_id_a, collection_id_b])
+    annotation_sort_by = AnnotationEvaluationMetricSortExpr(
+        evaluation_run_id=uuid4(),
+        metric_name="iou",
+        direction=SortDirection.desc,
+    )
+    request = AdjacentRequest(
+        sample_type=SampleType.ANNOTATION,
+        collection_id=uuid4(),
+        filters=filters,
+        annotation_sort_by=annotation_sort_by,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="annotation_sort_by is not supported when multiple collection_ids are provided",
+    ):
+        get_adjacent_samples(
+            session=db_session,
+            sample_id=uuid4(),
+            request=request,
+        )
+
+
 def test_get_adjacent_samples__raises_for_image_with_wrong_filter_type(
     db_session: Session,
 ) -> None:

--- a/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
+++ b/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -9,7 +10,9 @@ from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from lightly_studio.models.adjacents import AdjacentResultView
+from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
 from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sort_direction import SortDirection
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
 )
@@ -178,6 +181,58 @@ def test_get_adjacent_samples__delegates_to_annotation_resolver(
         filters=filters,
         sample_id=sample_id,
         order_by=None,
+    )
+
+
+def test_get_adjacent_samples__translates_annotation_sort_by_before_delegating(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    expected = _make_adjacent_result()
+    mock_get_adjacent_annotations = mocker.patch(
+        "lightly_studio.resolvers.annotation_resolver.get_adjacent_annotations",
+        return_value=expected,
+    )
+    fake_order_by = mocker.MagicMock()
+    mock_sort_expr_to_order_by = mocker.patch(
+        "lightly_studio.resolvers.annotations.annotation_metric_sort.sort_expr_to_order_by",
+        return_value=fake_order_by,
+    )
+
+    sample_id = uuid4()
+    collection_id = uuid4()
+    evaluation_run_id = uuid4()
+    filters = AnnotationsFilter(collection_ids=[collection_id])
+    annotation_sort_by = AnnotationEvaluationMetricSortExpr(
+        evaluation_run_id=evaluation_run_id,
+        metric_name="iou",
+        direction=SortDirection.desc,
+    )
+    request = AdjacentRequest(
+        sample_type=SampleType.ANNOTATION,
+        collection_id=uuid4(),
+        filters=filters,
+        annotation_sort_by=annotation_sort_by,
+    )
+
+    result = get_adjacent_samples(
+        session=db_session,
+        sample_id=sample_id,
+        request=request,
+    )
+
+    assert result == expected
+    mock_sort_expr_to_order_by.assert_called_once_with(
+        session=db_session,
+        annotation_collection_id=collection_id,
+        sort_expr=annotation_sort_by,
+        annotation_id_column=mock.ANY,
+    )
+    mock_get_adjacent_annotations.assert_called_once_with(
+        session=db_session,
+        filters=filters,
+        sample_id=sample_id,
+        order_by=fake_order_by,
     )
 
 

--- a/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
+++ b/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
@@ -177,6 +177,7 @@ def test_get_adjacent_samples__delegates_to_annotation_resolver(
         session=db_session,
         filters=filters,
         sample_id=sample_id,
+        order_by=None,
     )
 
 

--- a/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
+++ b/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -226,7 +225,7 @@ def test_get_adjacent_samples__translates_annotation_sort_by_before_delegating(
         session=db_session,
         annotation_collection_id=collection_id,
         sort_expr=annotation_sort_by,
-        annotation_id_column=mock.ANY,
+        annotation_id_column=mocker.ANY,
     )
     mock_get_adjacent_annotations.assert_called_once_with(
         session=db_session,


### PR DESCRIPTION
## What has changed and why?

Introduces the `order_by` field to the annotation adjacent endpoint to respect the ordering from the annotations grid view while navigating between the previous and next annotation sample.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sorting adjacent annotation samples by evaluation metrics.
  * Added an optional annotation sorting option to adjacent-sample requests.
  * Annotations without metric coverage are placed last when sorting by evaluation metric.

* **Bug Fixes**
  * Improved ordering behavior so unmatched annotations appear before matched annotations when applicable.
  * Added validation for annotation sorting requests involving multiple collections.

* **Tests**
  * Added coverage for evaluation-metric ordering and annotation sorting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->