### PR TITLE
Annotations sort: use the adjacent ordering on the GUI

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { writable } from 'svelte/store';
 import { SampleType } from '$lib/api/lightly_studio_local';
+import type { AnnotationEvaluationMetricSortExpr } from '$lib/api/lightly_studio_local/types.gen';
 
 const useAdjacentSamplesMock = vi.fn();
 const selectedAnnotationFilterIds = writable<Set<string>>(new Set());
 const tagsSelected = writable<Set<string>>(new Set());
+const getSortByMock = vi.fn<(collectionId: string) => AnnotationEvaluationMetricSortExpr | null>();
 
 vi.mock('../useAdjacentSamples/useAdjacentSamples', () => ({
     useAdjacentSamples: (...args: unknown[]) => useAdjacentSamplesMock(...args)
@@ -22,6 +24,10 @@ vi.mock('../useTags/useTags', () => ({
     })
 }));
 
+vi.mock('$lib/hooks', () => ({
+    useAnnotationSortBy: () => ({ getSortBy: getSortByMock })
+}));
+
 import { useAdjacentAnnotations } from './useAdjacentAnnotations';
 
 describe('useAdjacentAnnotations', () => {
@@ -30,6 +36,7 @@ describe('useAdjacentAnnotations', () => {
         useAdjacentSamplesMock.mockReset();
         selectedAnnotationFilterIds.set(new Set());
         tagsSelected.set(new Set());
+        getSortByMock.mockReturnValue(null);
         useAdjacentSamplesMock.mockReturnValue({ query: 'query-result', refetch: vi.fn() });
     });
 
@@ -50,7 +57,8 @@ describe('useAdjacentAnnotations', () => {
                         collection_ids: ['col-9'],
                         annotation_label_ids: ['label-1', 'label-2'],
                         tag_ids: ['tag-1']
-                    }
+                    },
+                    annotation_sort_by: undefined
                 }
             }
         });
@@ -71,9 +79,43 @@ describe('useAdjacentAnnotations', () => {
                         collection_ids: ['col-3'],
                         annotation_label_ids: undefined,
                         tag_ids: undefined
-                    }
+                    },
+                    annotation_sort_by: undefined
                 }
             }
         });
+    });
+
+    it('passes annotation_sort_by to useAdjacentSamples when a sort is active', () => {
+        const sort: AnnotationEvaluationMetricSortExpr = {
+            evaluation_run_id: 'run-1',
+            metric_name: 'iou',
+            direction: 'desc'
+        };
+        getSortByMock.mockReturnValue(sort);
+
+        useAdjacentAnnotations({ sampleId: 'ann-123', collectionId: 'col-9' });
+
+        expect(useAdjacentSamplesMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    body: expect.objectContaining({ annotation_sort_by: sort })
+                })
+            })
+        );
+    });
+
+    it('passes annotation_sort_by as undefined when no sort is active', () => {
+        getSortByMock.mockReturnValue(null);
+
+        useAdjacentAnnotations({ sampleId: 'ann-123', collectionId: 'col-9' });
+
+        expect(useAdjacentSamplesMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    body: expect.objectContaining({ annotation_sort_by: undefined })
+                })
+            })
+        );
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.test.ts
@@ -8,7 +8,6 @@ const selectedAnnotationFilterIds = writable<Set<string>>(new Set());
 const tagsSelected = writable<Set<string>>(new Set());
 const textEmbedding = writable<TextEmbedding | undefined>(undefined);
 const getSortByMock = vi.fn<(collectionId: string) => AnnotationEvaluationMetricSortExpr | null>();
-const hasEmbeddingsQueryStore = writable<{ data: boolean | undefined }>({ data: undefined });
 
 vi.mock('../useAdjacentSamples/useAdjacentSamples', () => ({
     useAdjacentSamples: (...args: unknown[]) => useAdjacentSamplesMock(...args)
@@ -31,10 +30,6 @@ vi.mock('$lib/hooks', () => ({
     useAnnotationSortBy: () => ({ getSortBy: getSortByMock })
 }));
 
-vi.mock('../useHasEmbeddings/useHasEmbeddings', () => ({
-    useHasEmbeddings: () => hasEmbeddingsQueryStore
-}));
-
 import { useAdjacentAnnotations } from './useAdjacentAnnotations';
 
 describe('useAdjacentAnnotations', () => {
@@ -44,7 +39,6 @@ describe('useAdjacentAnnotations', () => {
         selectedAnnotationFilterIds.set(new Set());
         tagsSelected.set(new Set());
         textEmbedding.set(undefined);
-        hasEmbeddingsQueryStore.set({ data: undefined });
         getSortByMock.mockReturnValue(null);
         useAdjacentSamplesMock.mockReturnValue({ query: 'query-result', refetch: vi.fn() });
     });
@@ -114,14 +108,13 @@ describe('useAdjacentAnnotations', () => {
         );
     });
 
-    it('suppresses annotation_sort_by when a similarity search is active on a collection with embeddings', () => {
+    it('suppresses annotation_sort_by when a similarity search is active', () => {
         const sort: AnnotationEvaluationMetricSortExpr = {
             evaluation_run_id: 'run-1',
             metric_name: 'iou',
             direction: 'desc'
         };
         getSortByMock.mockReturnValue(sort);
-        hasEmbeddingsQueryStore.set({ data: true });
         textEmbedding.set({ queryText: 'a dog', embedding: [0.1, 0.2] });
 
         useAdjacentAnnotations({ sampleId: 'ann-123', collectionId: 'col-9' });
@@ -130,27 +123,6 @@ describe('useAdjacentAnnotations', () => {
             expect.objectContaining({
                 params: expect.objectContaining({
                     body: expect.objectContaining({ annotation_sort_by: undefined })
-                })
-            })
-        );
-    });
-
-    it('keeps annotation_sort_by when a search embedding is set but the collection has no embeddings', () => {
-        const sort: AnnotationEvaluationMetricSortExpr = {
-            evaluation_run_id: 'run-1',
-            metric_name: 'iou',
-            direction: 'desc'
-        };
-        getSortByMock.mockReturnValue(sort);
-        hasEmbeddingsQueryStore.set({ data: false });
-        textEmbedding.set({ queryText: 'a dog', embedding: [0.1, 0.2] });
-
-        useAdjacentAnnotations({ sampleId: 'ann-123', collectionId: 'col-9' });
-
-        expect(useAdjacentSamplesMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                params: expect.objectContaining({
-                    body: expect.objectContaining({ annotation_sort_by: sort })
                 })
             })
         );

--- a/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { writable } from 'svelte/store';
 import { SampleType, type AnnotationEvaluationMetricSortExpr } from '$lib/api/lightly_studio_local';
+import type { TextEmbedding } from '$lib/hooks/useGlobalStorage';
 
 const useAdjacentSamplesMock = vi.fn();
 const selectedAnnotationFilterIds = writable<Set<string>>(new Set());
 const tagsSelected = writable<Set<string>>(new Set());
+const textEmbedding = writable<TextEmbedding | undefined>(undefined);
 const getSortByMock = vi.fn<(collectionId: string) => AnnotationEvaluationMetricSortExpr | null>();
+const hasEmbeddingsQueryStore = writable<{ data: boolean | undefined }>({ data: undefined });
 
 vi.mock('../useAdjacentSamples/useAdjacentSamples', () => ({
     useAdjacentSamples: (...args: unknown[]) => useAdjacentSamplesMock(...args)
@@ -13,7 +16,8 @@ vi.mock('../useAdjacentSamples/useAdjacentSamples', () => ({
 
 vi.mock('../useGlobalStorage', () => ({
     useGlobalStorage: () => ({
-        selectedAnnotationFilterIds
+        selectedAnnotationFilterIds,
+        textEmbedding
     })
 }));
 
@@ -27,6 +31,10 @@ vi.mock('$lib/hooks', () => ({
     useAnnotationSortBy: () => ({ getSortBy: getSortByMock })
 }));
 
+vi.mock('../useHasEmbeddings/useHasEmbeddings', () => ({
+    useHasEmbeddings: () => hasEmbeddingsQueryStore
+}));
+
 import { useAdjacentAnnotations } from './useAdjacentAnnotations';
 
 describe('useAdjacentAnnotations', () => {
@@ -35,6 +43,8 @@ describe('useAdjacentAnnotations', () => {
         useAdjacentSamplesMock.mockReset();
         selectedAnnotationFilterIds.set(new Set());
         tagsSelected.set(new Set());
+        textEmbedding.set(undefined);
+        hasEmbeddingsQueryStore.set({ data: undefined });
         getSortByMock.mockReturnValue(null);
         useAdjacentSamplesMock.mockReturnValue({ query: 'query-result', refetch: vi.fn() });
     });
@@ -92,6 +102,48 @@ describe('useAdjacentAnnotations', () => {
             direction: 'desc'
         };
         getSortByMock.mockReturnValue(sort);
+
+        useAdjacentAnnotations({ sampleId: 'ann-123', collectionId: 'col-9' });
+
+        expect(useAdjacentSamplesMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    body: expect.objectContaining({ annotation_sort_by: sort })
+                })
+            })
+        );
+    });
+
+    it('suppresses annotation_sort_by when a similarity search is active on a collection with embeddings', () => {
+        const sort: AnnotationEvaluationMetricSortExpr = {
+            evaluation_run_id: 'run-1',
+            metric_name: 'iou',
+            direction: 'desc'
+        };
+        getSortByMock.mockReturnValue(sort);
+        hasEmbeddingsQueryStore.set({ data: true });
+        textEmbedding.set({ queryText: 'a dog', embedding: [0.1, 0.2] });
+
+        useAdjacentAnnotations({ sampleId: 'ann-123', collectionId: 'col-9' });
+
+        expect(useAdjacentSamplesMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    body: expect.objectContaining({ annotation_sort_by: undefined })
+                })
+            })
+        );
+    });
+
+    it('keeps annotation_sort_by when a search embedding is set but the collection has no embeddings', () => {
+        const sort: AnnotationEvaluationMetricSortExpr = {
+            evaluation_run_id: 'run-1',
+            metric_name: 'iou',
+            direction: 'desc'
+        };
+        getSortByMock.mockReturnValue(sort);
+        hasEmbeddingsQueryStore.set({ data: false });
+        textEmbedding.set({ queryText: 'a dog', embedding: [0.1, 0.2] });
 
         useAdjacentAnnotations({ sampleId: 'ann-123', collectionId: 'col-9' });
 

--- a/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.test.ts
@@ -103,18 +103,4 @@ describe('useAdjacentAnnotations', () => {
             })
         );
     });
-
-    it('passes annotation_sort_by as undefined when no sort is active', () => {
-        getSortByMock.mockReturnValue(null);
-
-        useAdjacentAnnotations({ sampleId: 'ann-123', collectionId: 'col-9' });
-
-        expect(useAdjacentSamplesMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                params: expect.objectContaining({
-                    body: expect.objectContaining({ annotation_sort_by: undefined })
-                })
-            })
-        );
-    });
 });

--- a/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { writable } from 'svelte/store';
-import { SampleType } from '$lib/api/lightly_studio_local';
-import type { AnnotationEvaluationMetricSortExpr } from '$lib/api/lightly_studio_local/types.gen';
+import { SampleType, type AnnotationEvaluationMetricSortExpr } from '$lib/api/lightly_studio_local';
 
 const useAdjacentSamplesMock = vi.fn();
 const selectedAnnotationFilterIds = writable<Set<string>>(new Set());

--- a/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.ts
@@ -22,7 +22,7 @@ export const useAdjacentAnnotations = ({
     // Similarity search takes precedence over metric sort: when a search is active on a
     // collection with embeddings, suppress the metric sort so next/prev follows the same
     // similarity ordering shown in the grid.
-    const searchEmbedding = get(hasEmbeddingsQuery).data ? get(textEmbedding) : undefined;
+    const searchEmbedding = hasEmbeddingsQuery.data ? get(textEmbedding) : undefined;
 
     return useAdjacentSamples({
         params: {

--- a/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.ts
@@ -1,6 +1,7 @@
 import { SampleType } from '$lib/api/lightly_studio_local';
 import { get } from 'svelte/store';
 import { useAdjacentSamples } from '../useAdjacentSamples/useAdjacentSamples';
+import { useAnnotationSortBy } from '$lib/hooks';
 import { useGlobalStorage } from '../useGlobalStorage';
 import { useTags } from '../useTags/useTags';
 
@@ -13,6 +14,8 @@ export const useAdjacentAnnotations = ({
 }) => {
     const { selectedAnnotationFilterIds } = useGlobalStorage();
     const { tagsSelected } = useTags({ collection_id: collectionId });
+    const { getSortBy } = useAnnotationSortBy();
+    const sortBy = getSortBy(collectionId);
 
     return useAdjacentSamples({
         params: {
@@ -28,7 +31,8 @@ export const useAdjacentAnnotations = ({
                             ? Array.from(get(selectedAnnotationFilterIds))
                             : undefined,
                     tag_ids: get(tagsSelected).size > 0 ? Array.from(get(tagsSelected)) : undefined
-                }
+                },
+                annotation_sort_by: sortBy ?? undefined
             }
         }
     });

--- a/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.ts
@@ -3,7 +3,6 @@ import { get } from 'svelte/store';
 import { useAdjacentSamples } from '../useAdjacentSamples/useAdjacentSamples';
 import { useAnnotationSortBy } from '$lib/hooks';
 import { useGlobalStorage } from '../useGlobalStorage';
-import { useHasEmbeddings } from '../useHasEmbeddings/useHasEmbeddings';
 import { useTags } from '../useTags/useTags';
 
 export const useAdjacentAnnotations = ({
@@ -16,13 +15,8 @@ export const useAdjacentAnnotations = ({
     const { selectedAnnotationFilterIds, textEmbedding } = useGlobalStorage();
     const { tagsSelected } = useTags({ collection_id: collectionId });
     const { getSortBy } = useAnnotationSortBy();
-    const sortBy = getSortBy(collectionId);
-    const hasEmbeddingsQuery = useHasEmbeddings(() => ({ collectionId }));
-
-    // Similarity search takes precedence over metric sort: when a search is active on a
-    // collection with embeddings, suppress the metric sort so next/prev follows the same
-    // similarity ordering shown in the grid.
-    const searchEmbedding = hasEmbeddingsQuery.data ? get(textEmbedding) : undefined;
+    const embedding = get(textEmbedding);
+    const sortBy = embedding ? undefined : (getSortBy(collectionId) ?? undefined);
 
     return useAdjacentSamples({
         params: {
@@ -39,7 +33,7 @@ export const useAdjacentAnnotations = ({
                             : undefined,
                     tag_ids: get(tagsSelected).size > 0 ? Array.from(get(tagsSelected)) : undefined
                 },
-                annotation_sort_by: searchEmbedding ? undefined : (sortBy ?? undefined)
+                annotation_sort_by: sortBy
             }
         }
     });

--- a/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentAnnotations/useAdjacentAnnotations.ts
@@ -3,6 +3,7 @@ import { get } from 'svelte/store';
 import { useAdjacentSamples } from '../useAdjacentSamples/useAdjacentSamples';
 import { useAnnotationSortBy } from '$lib/hooks';
 import { useGlobalStorage } from '../useGlobalStorage';
+import { useHasEmbeddings } from '../useHasEmbeddings/useHasEmbeddings';
 import { useTags } from '../useTags/useTags';
 
 export const useAdjacentAnnotations = ({
@@ -12,10 +13,16 @@ export const useAdjacentAnnotations = ({
     sampleId: string;
     collectionId: string;
 }) => {
-    const { selectedAnnotationFilterIds } = useGlobalStorage();
+    const { selectedAnnotationFilterIds, textEmbedding } = useGlobalStorage();
     const { tagsSelected } = useTags({ collection_id: collectionId });
     const { getSortBy } = useAnnotationSortBy();
     const sortBy = getSortBy(collectionId);
+    const hasEmbeddingsQuery = useHasEmbeddings(() => ({ collectionId }));
+
+    // Similarity search takes precedence over metric sort: when a search is active on a
+    // collection with embeddings, suppress the metric sort so next/prev follows the same
+    // similarity ordering shown in the grid.
+    const searchEmbedding = get(hasEmbeddingsQuery).data ? get(textEmbedding) : undefined;
 
     return useAdjacentSamples({
         params: {
@@ -32,7 +39,7 @@ export const useAdjacentAnnotations = ({
                             : undefined,
                     tag_ids: get(tagsSelected).size > 0 ? Array.from(get(tagsSelected)) : undefined
                 },
-                annotation_sort_by: sortBy ?? undefined
+                annotation_sort_by: searchEmbedding ? undefined : (sortBy ?? undefined)
             }
         }
     });

--- a/lightly_studio_view/src/lib/hooks/useAdjacentSamples/useAdjacentSamples.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentSamples/useAdjacentSamples.ts
@@ -2,6 +2,7 @@ import { getAdjacentSamplesOptions } from '$lib/api/lightly_studio_local/@tansta
 import { createQuery, useQueryClient, type QueryClient } from '@tanstack/svelte-query';
 
 import type {
+    AnnotationEvaluationMetricSortExpr,
     AnnotationsFilter,
     ImageFilter,
     SampleType,
@@ -33,6 +34,7 @@ export type AdjacentSamplesRequestBody =
           sample_type: Extract<SampleType, 'annotation'>;
           collection_id: string;
           filters?: ({ filter_type: 'annotations' } & AnnotationsFilter) | null;
+          annotation_sort_by?: AnnotationEvaluationMetricSortExpr | null;
       };
 
 type AdjacentSamplesParams = {

--- a/lightly_studio_view/src/lib/hooks/useAdjacentSamples/useAdjacentSamples.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentSamples/useAdjacentSamples.ts
@@ -34,7 +34,7 @@ export type AdjacentSamplesRequestBody =
           sample_type: Extract<SampleType, 'annotation'>;
           collection_id: string;
           filters?: ({ filter_type: 'annotations' } & AnnotationsFilter) | null;
-          annotation_sort_by?: AnnotationEvaluationMetricSortExpr | null;
+          annotation_sort_by?: AnnotationEvaluationMetricSortExpr;
       };
 
 type AdjacentSamplesParams = {


### PR DESCRIPTION
## What has changed and why?

Uses the annotation adjacent ordering field to respect the annotation grid while navigating between the previous and next annotation sample

## How has it been tested?

Unit tests + manual tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Adjacent samples now follow the configured annotation sorting preference.
  * Annotation sorting is automatically disabled during similarity searches to preserve relevant results.

* **Bug Fixes**
  * Improved consistency between annotation sorting settings and adjacent-sample results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->