### PR TITLE
Fix: Update distribution panel empty state text

### DIFF
--- a/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
+++ b/lightly_studio_view/src/lib/components/BarChart/BarChart.svelte
@@ -116,8 +116,9 @@
         {#if emptyState}
             {@render emptyState()}
         {:else}
-            No data to display.
-            <br />Check the
+            No distribution data to display.
+            <br />Add annotations or metadata to see their distribution.
+            <br />Learn more in the
             <a
                 href="https://docs.lightly.ai/studio/"
                 target="_blank"
@@ -125,8 +126,7 @@
                 class="text-primary underline-offset-4 hover:underline"
             >
                 documentation
-            </a>
-            to learn how to add data.
+            </a>.
         {/if}
     </div>
 {:else}

--- a/lightly_studio_view/src/lib/components/BarChart/BarChart.test.ts
+++ b/lightly_studio_view/src/lib/components/BarChart/BarChart.test.ts
@@ -48,7 +48,16 @@ describe('BarChart', () => {
 
     it('renders the default empty message when no emptyState snippet is provided', () => {
         render(BarChart, { props: { data: empty } });
-        expect(screen.getByTestId('bar-chart-empty')).toHaveTextContent('No data to display.');
+        const emptyState = screen.getByTestId('bar-chart-empty');
+
+        expect(emptyState).toHaveTextContent('No distribution data to display.');
+        expect(emptyState).toHaveTextContent(
+            'Add annotations or metadata to see their distribution.'
+        );
+        expect(screen.getByRole('link', { name: 'documentation' })).toHaveAttribute(
+            'href',
+            'https://docs.lightly.ai/studio/'
+        );
     });
 
     it('renders a custom emptyState snippet instead of the default message', () => {
@@ -57,7 +66,7 @@ describe('BarChart', () => {
         }));
         render(BarChart, { props: { data: empty, emptyState } });
         expect(screen.getByTestId('custom-empty')).toBeInTheDocument();
-        expect(screen.queryByText('No data to display.')).not.toBeInTheDocument();
+        expect(screen.queryByText('No distribution data to display.')).not.toBeInTheDocument();
     });
 
     it('renders the chart container for non-empty data', () => {


### PR DESCRIPTION
## What has changed and why?

- Minor change in the GUI. Replaced text to be more clear what data is required for the distribution plot.

Before
<img width="393" height="314" alt="image" src="https://github.com/user-attachments/assets/cdcee895-5b6a-49f6-858b-aa0cdb4ded4c" />

After (with this PR):
<img width="423" height="327" alt="image" src="https://github.com/user-attachments/assets/b4937769-cccd-4420-9fdd-2644db3a0847" />


## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the distribution chart’s empty state with clearer guidance about required annotations or metadata.
  * Added a link to relevant documentation for additional help.

* **Tests**
  * Updated coverage to verify the revised default and custom empty-state messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->