### PR TITLE
feat: introduce shared component MultiSelectList to render selectable lists

### DIFF
--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { MultiSelectList } from '$lib/components/MultiSelectList';
-    import type { MultiSelectItem } from '$lib/components/MultiSelectList';
 
     interface Props {
         /** Currently selected class labels. Bindable — mutated on toggle / Select all / Clear. */
@@ -8,7 +7,7 @@
         /** Full list of class labels to choose from, in the order they should be displayed. */
         allClasses?: string[];
         /** Optional stable values and display labels; labels need not be unique. */
-        items?: MultiSelectItem[];
+        items?: { value: string; label: string }[];
         itemNoun?: string;
         itemNounPlural?: string;
         /** test-id for the search input; lets each host keep its own id scheme. */

--- a/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
+++ b/lightly_studio_view/src/lib/components/ClassSetConfig/ManualClassSelector.svelte
@@ -1,13 +1,6 @@
 <script lang="ts">
-    import { Check as CheckIcon } from '@lucide/svelte';
-    import { Button } from '$lib/components';
-    import * as Command from '$lib/components/ui/command';
-    import { cn } from '$lib/utils';
-
-    interface ManualSelectionItem {
-        value: string;
-        label: string;
-    }
+    import { MultiSelectList } from '$lib/components/MultiSelectList';
+    import type { MultiSelectItem } from '$lib/components/MultiSelectList';
 
     interface Props {
         /** Currently selected class labels. Bindable — mutated on toggle / Select all / Clear. */
@@ -15,7 +8,7 @@
         /** Full list of class labels to choose from, in the order they should be displayed. */
         allClasses?: string[];
         /** Optional stable values and display labels; labels need not be unique. */
-        items?: ManualSelectionItem[];
+        items?: MultiSelectItem[];
         itemNoun?: string;
         itemNounPlural?: string;
         /** test-id for the search input; lets each host keep its own id scheme. */
@@ -34,58 +27,16 @@
     const resolvedItems = $derived(
         items ?? (allClasses ?? []).map((className) => ({ value: className, label: className }))
     );
-
-    const isSelected = (value: string) => selected.includes(value);
-
-    const toggle = (value: string) => {
-        selected = selected.includes(value)
-            ? selected.filter((selectedValue) => selectedValue !== value)
-            : [...selected, value];
-    };
 </script>
 
 <div class="pt-2">
-    <div class="mb-1 flex items-center justify-between">
-        <span class="text-xs text-muted-foreground">
-            {selected.length} of {resolvedItems.length} selected
-        </span>
-        <div class="flex gap-1">
-            <Button
-                variant="ghost"
-                buttonProps={{
-                    size: 'sm',
-                    class: 'h-6 px-2 text-xs',
-                    onclick: () => (selected = resolvedItems.map((item) => item.value))
-                }}
-            >
-                Select all
-            </Button>
-            <Button
-                variant="ghost"
-                buttonProps={{
-                    size: 'sm',
-                    class: 'h-6 px-2 text-xs',
-                    onclick: () => (selected = [])
-                }}
-            >
-                Clear
-            </Button>
-        </div>
-    </div>
-    <Command.Root class="rounded-md border">
-        <Command.Input placeholder="Search {itemNounPlural}..." data-testid={searchTestId} />
-        <Command.List class="max-h-[220px] dark:[color-scheme:dark]">
-            <Command.Empty>No {itemNoun} found.</Command.Empty>
-            {#each resolvedItems as item (item.value)}
-                <Command.Item
-                    value={item.value}
-                    keywords={[item.label]}
-                    onSelect={() => toggle(item.value)}
-                >
-                    <CheckIcon class={cn(!isSelected(item.value) && 'text-transparent')} />
-                    <span class="min-w-0 flex-1 truncate">{item.label}</span>
-                </Command.Item>
-            {/each}
-        </Command.List>
-    </Command.Root>
+    <MultiSelectList
+        items={resolvedItems}
+        selectedIds={selected}
+        onChange={(ids) => (selected = ids)}
+        showSelectAll
+        {itemNoun}
+        {itemNounPlural}
+        {searchTestId}
+    />
 </div>

--- a/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.stories.svelte
+++ b/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.stories.svelte
@@ -21,27 +21,101 @@
 </script>
 
 <script lang="ts">
-    import type { MultiSelectItem } from './MultiSelectList.svelte';
-
-    const MANY_ITEMS: MultiSelectItem[] = Array.from({ length: 30 }, (_, i) => ({
+    const manyItems = Array.from({ length: 30 }, (_, i) => ({
         value: `item-${i + 1}`,
         label: `Item ${i + 1}`
     }));
+
+    let selectedIds = $state<string[]>([]);
+    let selectedIdsWithCat = $state<string[]>(['cat', 'bird']);
+    let selectedIdsWithSelectAll = $state<string[]>(['cat']);
+    let allSelected = $state<string[]>(['cat', 'dog', 'bird', 'horse', 'fish']);
+    let customNounSelected = $state<string[]>([]);
+    let manySelected = $state<string[]>([]);
 </script>
 
-<Story name="Empty (no selection)" />
+<Story name="Empty (no selection)">
+    <MultiSelectList
+        items={[
+            { value: 'cat', label: 'Cat' },
+            { value: 'dog', label: 'Dog' },
+            { value: 'bird', label: 'Bird' },
+            { value: 'horse', label: 'Horse' },
+            { value: 'fish', label: 'Fish' }
+        ]}
+        {selectedIds}
+        onChange={(ids) => (selectedIds = ids)}
+    />
+</Story>
 
-<Story name="With selection" args={{ selectedIds: ['cat', 'bird'] }} />
+<Story name="With selection">
+    <MultiSelectList
+        items={[
+            { value: 'cat', label: 'Cat' },
+            { value: 'dog', label: 'Dog' },
+            { value: 'bird', label: 'Bird' },
+            { value: 'horse', label: 'Horse' },
+            { value: 'fish', label: 'Fish' }
+        ]}
+        selectedIds={selectedIdsWithCat}
+        onChange={(ids) => (selectedIdsWithCat = ids)}
+    />
+</Story>
 
-<Story name="With select all / clear" args={{ selectedIds: ['cat'], showSelectAll: true }} />
+<Story name="With select all / clear">
+    <MultiSelectList
+        items={[
+            { value: 'cat', label: 'Cat' },
+            { value: 'dog', label: 'Dog' },
+            { value: 'bird', label: 'Bird' },
+            { value: 'horse', label: 'Horse' },
+            { value: 'fish', label: 'Fish' }
+        ]}
+        selectedIds={selectedIdsWithSelectAll}
+        onChange={(ids) => (selectedIdsWithSelectAll = ids)}
+        showSelectAll
+    />
+</Story>
 
-<Story
-    name="All selected"
-    args={{ selectedIds: ['cat', 'dog', 'bird', 'horse', 'fish'], showSelectAll: true }}
-/>
+<Story name="All selected">
+    <MultiSelectList
+        items={[
+            { value: 'cat', label: 'Cat' },
+            { value: 'dog', label: 'Dog' },
+            { value: 'bird', label: 'Bird' },
+            { value: 'horse', label: 'Horse' },
+            { value: 'fish', label: 'Fish' }
+        ]}
+        selectedIds={allSelected}
+        onChange={(ids) => (allSelected = ids)}
+        showSelectAll
+    />
+</Story>
 
-<Story name="Custom noun" args={{ itemNoun: 'tag', itemNounPlural: 'tags', showSelectAll: true }} />
+<Story name="Custom noun">
+    <MultiSelectList
+        items={[
+            { value: 'cat', label: 'Cat' },
+            { value: 'dog', label: 'Dog' },
+            { value: 'bird', label: 'Bird' },
+            { value: 'horse', label: 'Horse' },
+            { value: 'fish', label: 'Fish' }
+        ]}
+        selectedIds={customNounSelected}
+        onChange={(ids) => (customNounSelected = ids)}
+        itemNoun="tag"
+        itemNounPlural="tags"
+        showSelectAll
+    />
+</Story>
 
-<Story name="Many items (scroll)" args={{ items: MANY_ITEMS, showSelectAll: true }} />
+<Story name="Many items (scroll)">
+    <MultiSelectList
+        items={manyItems}
+        selectedIds={manySelected}
+        onChange={(ids) => (manySelected = ids)}
+        showSelectAll
+    />
+</Story>
 
 <Story name="No items" args={{ items: [] }} />

--- a/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.stories.svelte
+++ b/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.stories.svelte
@@ -1,0 +1,47 @@
+<script module>
+    import { defineMeta } from '@storybook/addon-svelte-csf';
+    import MultiSelectList from './MultiSelectList.svelte';
+
+    const { Story } = defineMeta({
+        title: 'Components/MultiSelectList',
+        component: MultiSelectList,
+        tags: ['autodocs'],
+        args: {
+            items: [
+                { value: 'cat', label: 'Cat' },
+                { value: 'dog', label: 'Dog' },
+                { value: 'bird', label: 'Bird' },
+                { value: 'horse', label: 'Horse' },
+                { value: 'fish', label: 'Fish' }
+            ],
+            selectedIds: [],
+            onChange: () => {}
+        }
+    });
+</script>
+
+<script lang="ts">
+    import type { MultiSelectItem } from './MultiSelectList.svelte';
+
+    const MANY_ITEMS: MultiSelectItem[] = Array.from({ length: 30 }, (_, i) => ({
+        value: `item-${i + 1}`,
+        label: `Item ${i + 1}`
+    }));
+</script>
+
+<Story name="Empty (no selection)" />
+
+<Story name="With selection" args={{ selectedIds: ['cat', 'bird'] }} />
+
+<Story name="With select all / clear" args={{ selectedIds: ['cat'], showSelectAll: true }} />
+
+<Story
+    name="All selected"
+    args={{ selectedIds: ['cat', 'dog', 'bird', 'horse', 'fish'], showSelectAll: true }}
+/>
+
+<Story name="Custom noun" args={{ itemNoun: 'tag', itemNounPlural: 'tags', showSelectAll: true }} />
+
+<Story name="Many items (scroll)" args={{ items: MANY_ITEMS, showSelectAll: true }} />
+
+<Story name="No items" args={{ items: [] }} />

--- a/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.svelte
+++ b/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.svelte
@@ -5,18 +5,26 @@
     import { cn } from '$lib/utils';
 
     export interface MultiSelectItem {
+        /** Unique identifier used as the selection key. */
         value: string;
+        /** Display text shown in the list. */
         label: string;
     }
 
     interface Props {
+        /** List of available options. */
         items: MultiSelectItem[];
+        /** Values of currently selected items. */
         selectedIds: string[];
+        /** Called with the new selection whenever an item is toggled, all selected, or cleared. */
         onChange: (ids: string[]) => void;
         /** Show "X of Y selected" counter and Select all / Clear buttons. */
         showSelectAll?: boolean;
+        /** Singular noun used in the empty state and search placeholder (e.g. "tag"). */
         itemNoun?: string;
+        /** Plural noun used in the empty state and search placeholder (e.g. "tags"). */
         itemNounPlural?: string;
+        /** `data-testid` applied to the search input. */
         searchTestId?: string;
     }
 

--- a/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.svelte
+++ b/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+    import { Check as CheckIcon } from '@lucide/svelte';
+    import { Button } from '$lib/components';
+    import * as Command from '$lib/components/ui/command';
+    import { cn } from '$lib/utils';
+
+    export interface MultiSelectItem {
+        value: string;
+        label: string;
+    }
+
+    interface Props {
+        items: MultiSelectItem[];
+        selectedIds: string[];
+        onChange: (ids: string[]) => void;
+        /** Show "X of Y selected" counter and Select all / Clear buttons. */
+        showSelectAll?: boolean;
+        itemNoun?: string;
+        itemNounPlural?: string;
+        searchTestId?: string;
+    }
+
+    const {
+        items,
+        selectedIds,
+        onChange,
+        showSelectAll = false,
+        itemNoun = 'item',
+        itemNounPlural = 'items',
+        searchTestId
+    }: Props = $props();
+</script>
+
+<div>
+    {#if showSelectAll}
+        <div class="mb-1 flex items-center justify-between">
+            <span class="text-xs text-muted-foreground">
+                {selectedIds.length} of {items.length} selected
+            </span>
+            <div class="flex gap-1">
+                <Button
+                    variant="ghost"
+                    buttonProps={{
+                        size: 'sm',
+                        class: 'h-6 px-2 text-xs',
+                        onclick: () => onChange(items.map((item) => item.value))
+                    }}
+                >
+                    Select all
+                </Button>
+                <Button
+                    variant="ghost"
+                    buttonProps={{
+                        size: 'sm',
+                        class: 'h-6 px-2 text-xs',
+                        onclick: () => onChange([])
+                    }}
+                >
+                    Clear
+                </Button>
+            </div>
+        </div>
+    {/if}
+    <Command.Root class="rounded-md border">
+        <Command.Input placeholder="Search {itemNounPlural}..." data-testid={searchTestId} />
+        <Command.List class="max-h-[220px] dark:[color-scheme:dark]">
+            <Command.Empty>No {itemNoun} found.</Command.Empty>
+            {#each items as item (item.value)}
+                <Command.Item
+                    value={item.value}
+                    keywords={[item.label]}
+                    onSelect={() =>
+                        onChange(
+                            selectedIds.includes(item.value)
+                                ? selectedIds.filter((id) => id !== item.value)
+                                : [...selectedIds, item.value]
+                        )}
+                >
+                    <CheckIcon
+                        class={cn(!selectedIds.includes(item.value) && 'text-transparent')}
+                    />
+                    <span class="min-w-0 flex-1 truncate">{item.label}</span>
+                </Command.Item>
+            {/each}
+        </Command.List>
+    </Command.Root>
+</div>

--- a/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.svelte
+++ b/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.svelte
@@ -4,7 +4,7 @@
     import * as Command from '$lib/components/ui/command';
     import { cn } from '$lib/utils';
 
-    export interface MultiSelectItem {
+    interface MultiSelectItem {
         /** Unique identifier used as the selection key. */
         value: string;
         /** Display text shown in the list. */
@@ -37,6 +37,14 @@
         itemNounPlural = 'items',
         searchTestId
     }: Props = $props();
+
+    function toggleItem(value: string) {
+        onChange(
+            selectedIds.includes(value)
+                ? selectedIds.filter((id) => id !== value)
+                : [...selectedIds, value]
+        );
+    }
 </script>
 
 <div>
@@ -77,12 +85,7 @@
                 <Command.Item
                     value={item.value}
                     keywords={[item.label]}
-                    onSelect={() =>
-                        onChange(
-                            selectedIds.includes(item.value)
-                                ? selectedIds.filter((id) => id !== item.value)
-                                : [...selectedIds, item.value]
-                        )}
+                    onSelect={() => toggleItem(item.value)}
                 >
                     <CheckIcon
                         class={cn(!selectedIds.includes(item.value) && 'text-transparent')}

--- a/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.test.ts
+++ b/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.test.ts
@@ -53,13 +53,6 @@ describe('MultiSelectList', () => {
         expect(screen.getByText('Clear')).toBeInTheDocument();
     });
 
-    it('does not show the counter or Select all / Clear by default', () => {
-        render(MultiSelectList, { props: defaultProps });
-
-        expect(screen.queryByText('Select all')).not.toBeInTheDocument();
-        expect(screen.queryByText('Clear')).not.toBeInTheDocument();
-    });
-
     it('calls onChange with all ids when Select all is clicked', async () => {
         const onChange = vi.fn();
         render(MultiSelectList, {

--- a/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.test.ts
+++ b/lightly_studio_view/src/lib/components/MultiSelectList/MultiSelectList.test.ts
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import MultiSelectList from './MultiSelectList.svelte';
+
+const items = [
+    { value: 'cat', label: 'Cat' },
+    { value: 'dog', label: 'Dog' },
+    { value: 'bird', label: 'Bird' }
+];
+
+const defaultProps = {
+    items,
+    selectedIds: [] as string[],
+    onChange: vi.fn()
+};
+
+describe('MultiSelectList', () => {
+    it('renders all items', () => {
+        render(MultiSelectList, { props: defaultProps });
+
+        for (const item of items) {
+            expect(screen.getByText(item.label)).toBeInTheDocument();
+        }
+    });
+
+    it('calls onChange with added id when an unselected item is clicked', async () => {
+        const onChange = vi.fn();
+        render(MultiSelectList, { props: { ...defaultProps, onChange } });
+
+        await fireEvent.click(screen.getByText('Cat'));
+
+        expect(onChange).toHaveBeenCalledWith(['cat']);
+    });
+
+    it('calls onChange with removed id when a selected item is clicked', async () => {
+        const onChange = vi.fn();
+        render(MultiSelectList, {
+            props: { ...defaultProps, selectedIds: ['cat', 'dog'], onChange }
+        });
+
+        await fireEvent.click(screen.getByText('Cat'));
+
+        expect(onChange).toHaveBeenCalledWith(['dog']);
+    });
+
+    it('shows the selected count and Select all / Clear when showSelectAll is true', () => {
+        render(MultiSelectList, {
+            props: { ...defaultProps, selectedIds: ['cat'], showSelectAll: true }
+        });
+
+        expect(screen.getByText('1 of 3 selected')).toBeInTheDocument();
+        expect(screen.getByText('Select all')).toBeInTheDocument();
+        expect(screen.getByText('Clear')).toBeInTheDocument();
+    });
+
+    it('does not show the counter or Select all / Clear by default', () => {
+        render(MultiSelectList, { props: defaultProps });
+
+        expect(screen.queryByText('Select all')).not.toBeInTheDocument();
+        expect(screen.queryByText('Clear')).not.toBeInTheDocument();
+    });
+
+    it('calls onChange with all ids when Select all is clicked', async () => {
+        const onChange = vi.fn();
+        render(MultiSelectList, {
+            props: { ...defaultProps, showSelectAll: true, onChange }
+        });
+
+        await fireEvent.click(screen.getByText('Select all'));
+
+        expect(onChange).toHaveBeenCalledWith(['cat', 'dog', 'bird']);
+    });
+
+    it('calls onChange with empty array when Clear is clicked', async () => {
+        const onChange = vi.fn();
+        render(MultiSelectList, {
+            props: { ...defaultProps, selectedIds: ['cat', 'dog'], showSelectAll: true, onChange }
+        });
+
+        await fireEvent.click(screen.getByText('Clear'));
+
+        expect(onChange).toHaveBeenCalledWith([]);
+    });
+
+    it('uses itemNounPlural in the search placeholder', () => {
+        render(MultiSelectList, {
+            props: { ...defaultProps, itemNounPlural: 'animals' }
+        });
+
+        expect(screen.getByPlaceholderText('Search animals...')).toBeInTheDocument();
+    });
+
+    it('applies searchTestId to the search input', () => {
+        render(MultiSelectList, {
+            props: { ...defaultProps, searchTestId: 'my-search' }
+        });
+
+        expect(screen.getByTestId('my-search')).toBeInTheDocument();
+    });
+
+    it('shows the empty message when no items are provided', () => {
+        render(MultiSelectList, { props: { ...defaultProps, items: [], itemNoun: 'animal' } });
+
+        expect(screen.getByText('No animal found.')).toBeInTheDocument();
+    });
+});

--- a/lightly_studio_view/src/lib/components/MultiSelectList/index.ts
+++ b/lightly_studio_view/src/lib/components/MultiSelectList/index.ts
@@ -1,0 +1,2 @@
+export { default as MultiSelectList } from './MultiSelectList.svelte';
+export type { MultiSelectItem } from './MultiSelectList.svelte';

--- a/lightly_studio_view/src/lib/components/MultiSelectList/index.ts
+++ b/lightly_studio_view/src/lib/components/MultiSelectList/index.ts
@@ -1,2 +1,1 @@
 export { default as MultiSelectList } from './MultiSelectList.svelte';
-export type { MultiSelectItem } from './MultiSelectList.svelte';

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -72,3 +72,5 @@ export { default as SamplingCombinationDialog } from '$lib/components/Sampling/S
 export { default as MetadataFilterChips } from '$lib/components/MetadataFilterChips/MetadataFilterChips.svelte';
 export { default as FormField } from '$lib/components/FormField/FormField.svelte';
 export { default as AnnotationSourceSelect } from '$lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte';
+export { MultiSelectList } from '$lib/components/MultiSelectList';
+export type { MultiSelectItem } from '$lib/components/MultiSelectList';

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -73,4 +73,3 @@ export { default as MetadataFilterChips } from '$lib/components/MetadataFilterCh
 export { default as FormField } from '$lib/components/FormField/FormField.svelte';
 export { default as AnnotationSourceSelect } from '$lib/components/AnnotationSourceSelect/AnnotationSourceSelect.svelte';
 export { MultiSelectList } from '$lib/components/MultiSelectList';
-export type { MultiSelectItem } from '$lib/components/MultiSelectList';


### PR DESCRIPTION
## What has changed and why?

Introduce component to render selectable lists. We have already similar component to use and reuse component by [ManualClassSelector.svelte‎](https://github.com/lightly-ai/lightly-studio/pull/2021/changes#diff-caeadf18468ac9ae23401c82d491c7278612d16c344e3deea65d92ec745aba03)

It is also be reused to render list of selectable tasks for distribution tags comparison

## How has it been tested?

By unit tests and storybook story
<img width="1165" height="1101" alt="Screenshot 2026-08-20 at 15 23 19" src="https://github.com/user-attachments/assets/7c014021-ea83-46e6-89ed-e65b7a2a1354" />

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable multi-select list with search, selection counts, Select all, Clear, and empty-state support.
  * Added configurable labels, test identifiers, and scrolling for large item lists.
  * Updated manual class selection to use the shared multi-select experience.

* **Tests**
  * Added comprehensive coverage for selection, search, bulk actions, optional controls, and empty states.

* **Documentation**
  * Added interactive examples covering common multi-select scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->