### PR TITLE
Prefix the image-only sort symbols with Image

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/image/routes.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/image/routes.py
@@ -15,10 +15,11 @@ from lightly_studio.api.routes.api.image.count_by_sample_tags import (
 from lightly_studio.api.routes.api.status import HTTP_STATUS_NOT_FOUND
 from lightly_studio.api.routes.api.validators import Paginated
 from lightly_studio.database.db_manager import SessionDep
+from lightly_studio.models import sort
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.image import ImageView, ImageViewsWithCount
-from lightly_studio.models.sort import ImageSortExpr, image_sort_expr_to_order_by
+from lightly_studio.models.sort import ImageSortExpr
 from lightly_studio.resolvers import (
     image_resolver,
 )
@@ -65,7 +66,7 @@ def read_images(
         A list of filtered samples.
     """
     order_by = (
-        [image_sort_expr_to_order_by(expr) for expr in body.sort_by] if body.sort_by else None
+        [sort.image_sort_expr_to_order_by(expr) for expr in body.sort_by] if body.sort_by else None
     )
     result = image_resolver.get_all_by_collection_id(
         session=session,

--- a/lightly_studio/src/lightly_studio/api/routes/api/image/routes.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/image/routes.py
@@ -18,7 +18,7 @@ from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.image import ImageView, ImageViewsWithCount
-from lightly_studio.models.sort import SortExpr, sort_expr_to_order_by
+from lightly_studio.models.sort import ImageSortExpr, image_sort_expr_to_order_by
 from lightly_studio.resolvers import (
     image_resolver,
 )
@@ -45,7 +45,7 @@ class ReadImagesRequest(BaseModel):
     pagination: Paginated | None = Field(
         None, description="Pagination parameters for offset and limit"
     )
-    sort_by: list[SortExpr] | None = Field(None, description="Sort expressions for ordering")
+    sort_by: list[ImageSortExpr] | None = Field(None, description="Sort expressions for ordering")
 
 
 @image_router.post("/collections/{collection_id}/images/list")
@@ -64,7 +64,9 @@ def read_images(
     Returns:
         A list of filtered samples.
     """
-    order_by = [sort_expr_to_order_by(expr) for expr in body.sort_by] if body.sort_by else None
+    order_by = (
+        [image_sort_expr_to_order_by(expr) for expr in body.sort_by] if body.sort_by else None
+    )
     result = image_resolver.get_all_by_collection_id(
         session=session,
         collection_id=collection_id,

--- a/lightly_studio/src/lightly_studio/models/sort.py
+++ b/lightly_studio/src/lightly_studio/models/sort.py
@@ -42,7 +42,7 @@ class SortFieldExprBase(BaseModel):
     direction: SortDirection
 
 
-class SortFieldExpr(SortFieldExprBase):
+class ImageSortFieldExpr(SortFieldExprBase):
     """A sorting expression for a single field of an image."""
 
     source: Literal[SortFieldSource.image, SortFieldSource.metadata]
@@ -73,8 +73,8 @@ class EvaluationMetricSortExpr(BaseModel):
     direction: SortDirection
 
 
-SortExpr = Annotated[
-    Union[SortFieldExpr, EvaluationMetricSortExpr],
+ImageSortExpr = Annotated[
+    Union[ImageSortFieldExpr, EvaluationMetricSortExpr],
     Field(discriminator="source"),
 ]
 
@@ -94,8 +94,8 @@ def sort_field_expr_to_order_by(expr: SortFieldExprBase) -> OrderByExpression:
     )
 
 
-def sort_expr_to_order_by(expr: SortExpr) -> OrderByExpression:
-    """Translate a SortExpr (image, metadata, or evaluation metric) to an OrderByExpression.
+def image_sort_expr_to_order_by(expr: ImageSortExpr) -> OrderByExpression:
+    """Translate an ImageSortExpr (image, metadata, or evaluation metric) to an OrderByExpression.
 
     Args:
         expr: The sort expression from the API request.

--- a/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
+++ b/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
@@ -13,7 +13,7 @@ from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
 from lightly_studio.models.collection import SampleType
-from lightly_studio.models.sort import SortExpr, sort_expr_to_order_by
+from lightly_studio.models.sort import ImageSortExpr, image_sort_expr_to_order_by
 from lightly_studio.resolvers import (
     annotation_resolver,
     image_resolver,
@@ -42,7 +42,7 @@ class AdjacentRequest(BaseModel):
         | None
     ) = None
     text_embedding: list[float] | None = None
-    sort_by: list[SortExpr] | None = None
+    sort_by: list[ImageSortExpr] | None = None
     annotation_sort_by: AnnotationEvaluationMetricSortExpr | None = None
 
 
@@ -100,7 +100,9 @@ def get_adjacent_samples(
                 f" for sample type '{request.sample_type.value}'."
             )
         order_by = (
-            [sort_expr_to_order_by(expr) for expr in request.sort_by] if request.sort_by else None
+            [image_sort_expr_to_order_by(expr) for expr in request.sort_by]
+            if request.sort_by
+            else None
         )
         return image_resolver.get_adjacent_images(
             session=session,

--- a/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
+++ b/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
@@ -9,11 +9,12 @@ from pydantic import BaseModel, Field
 from sqlmodel import Session, col
 
 from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluationMetricField
+from lightly_studio.models import sort
 from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
 from lightly_studio.models.collection import SampleType
-from lightly_studio.models.sort import ImageSortExpr, image_sort_expr_to_order_by
+from lightly_studio.models.sort import ImageSortExpr
 from lightly_studio.resolvers import (
     annotation_resolver,
     image_resolver,
@@ -100,7 +101,7 @@ def get_adjacent_samples(
                 f" for sample type '{request.sample_type.value}'."
             )
         order_by = (
-            [image_sort_expr_to_order_by(expr) for expr in request.sort_by]
+            [sort.image_sort_expr_to_order_by(expr) for expr in request.sort_by]
             if request.sort_by
             else None
         )

--- a/lightly_studio/tests/models/test_sort.py
+++ b/lightly_studio/tests/models/test_sort.py
@@ -15,11 +15,11 @@ from lightly_studio.core.dataset_query.video_sample_field import VideoSampleFiel
 from lightly_studio.errors import QueryExprError
 from lightly_studio.models.sort import (
     EvaluationMetricSortExpr,
-    SortExpr,
-    SortFieldExpr,
+    ImageSortExpr,
+    ImageSortFieldExpr,
     SortFieldSource,
     VideoSortFieldExpr,
-    sort_expr_to_order_by,
+    image_sort_expr_to_order_by,
     sort_field_expr_to_order_by,
 )
 from lightly_studio.models.sort_direction import SortDirection
@@ -43,12 +43,12 @@ _VIDEO_SORT_FIELD_TO_COLUMN = {
 
 
 def test_sort_field_expr__valid_directions() -> None:
-    expr_asc = SortFieldExpr(
+    expr_asc = ImageSortFieldExpr(
         source=SortFieldSource.image,
         field_name="file_name",
         direction=SortDirection.asc,
     )
-    expr_desc = SortFieldExpr(
+    expr_desc = ImageSortFieldExpr(
         source=SortFieldSource.image,
         field_name="file_name",
         direction=SortDirection.desc,
@@ -60,7 +60,7 @@ def test_sort_field_expr__valid_directions() -> None:
 
 def test_sort_field_expr__rejects_invalid_direction() -> None:
     with pytest.raises(ValidationError):
-        SortFieldExpr.model_validate(
+        ImageSortFieldExpr.model_validate(
             {
                 "source": "image",
                 "field_name": "file_name",
@@ -70,7 +70,7 @@ def test_sort_field_expr__rejects_invalid_direction() -> None:
 
 
 def test_sort_field_expr_to_order_by__rejects_unknown_field() -> None:
-    expr = SortFieldExpr(
+    expr = ImageSortFieldExpr(
         source=SortFieldSource.image,
         field_name="invalid_field",
         direction=SortDirection.asc,
@@ -80,7 +80,7 @@ def test_sort_field_expr_to_order_by__rejects_unknown_field() -> None:
 
 
 def test_sort_field_expr_to_order_by__ascending() -> None:
-    expr = SortFieldExpr(
+    expr = ImageSortFieldExpr(
         source=SortFieldSource.image,
         field_name="file_name",
         direction=SortDirection.asc,
@@ -90,7 +90,7 @@ def test_sort_field_expr_to_order_by__ascending() -> None:
 
 
 def test_sort_field_expr_to_order_by__descending() -> None:
-    expr = SortFieldExpr(
+    expr = ImageSortFieldExpr(
         source=SortFieldSource.image,
         field_name="width",
         direction=SortDirection.desc,
@@ -101,7 +101,7 @@ def test_sort_field_expr_to_order_by__descending() -> None:
 
 def test_sort_field_expr_to_order_by__all_fields_map() -> None:
     for field_name, expected_field in _IMAGE_SORT_FIELD_TO_COLUMN.items():
-        expr = SortFieldExpr(
+        expr = ImageSortFieldExpr(
             source=SortFieldSource.image,
             field_name=field_name,
             direction=SortDirection.asc,
@@ -113,7 +113,7 @@ def test_sort_field_expr_to_order_by__all_fields_map() -> None:
 
 def test_sort_field_expr_to_order_by__image_field_name_not_shared_with_video() -> None:
     # `duration_s` exists on videos only; the source must select the right registry.
-    expr = SortFieldExpr(
+    expr = ImageSortFieldExpr(
         source=SortFieldSource.image,
         field_name="duration_s",
         direction=SortDirection.asc,
@@ -126,7 +126,9 @@ def test_sort_field_expr__rejects_video_source() -> None:
     # Image queries do not have `VideoTable` in the FROM clause, so a video field
     # would be cross-joined rather than sorted by.
     with pytest.raises(ValidationError):
-        SortFieldExpr.model_validate({"source": "video", "field_name": "fps", "direction": "asc"})
+        ImageSortFieldExpr.model_validate(
+            {"source": "video", "field_name": "fps", "direction": "asc"}
+        )
 
 
 def test_sort_field_expr_to_order_by__video_all_fields_map() -> None:
@@ -176,7 +178,7 @@ def test_video_sort_field_expr__rejects_evaluation_metric_source() -> None:
 
 
 def test_sort_field_expr_to_order_by__metadata_ascending() -> None:
-    expr = SortFieldExpr(
+    expr = ImageSortFieldExpr(
         source=SortFieldSource.metadata,
         field_name="brightness",
         direction=SortDirection.asc,
@@ -188,7 +190,7 @@ def test_sort_field_expr_to_order_by__metadata_ascending() -> None:
 
 
 def test_sort_field_expr_to_order_by__metadata_descending() -> None:
-    expr = SortFieldExpr(
+    expr = ImageSortFieldExpr(
         source=SortFieldSource.metadata,
         field_name="score",
         direction=SortDirection.desc,
@@ -200,7 +202,7 @@ def test_sort_field_expr_to_order_by__metadata_descending() -> None:
 
 
 def test_sort_field_expr_to_order_by__metadata_arbitrary_field() -> None:
-    expr = SortFieldExpr(
+    expr = ImageSortFieldExpr(
         source=SortFieldSource.metadata,
         field_name="custom_metric",
         direction=SortDirection.asc,
@@ -216,7 +218,7 @@ def test_sort_expr_to_order_by__evaluation_metric_ascending() -> None:
         metric_name="score",
         direction=SortDirection.asc,
     )
-    order_by = sort_expr_to_order_by(expr=expr)
+    order_by = image_sort_expr_to_order_by(expr=expr)
     assert isinstance(order_by, OrderByEvaluationMetricField)
     assert order_by.evaluation_run_name == "run1"
     assert order_by.metric_name == "score"
@@ -229,7 +231,7 @@ def test_sort_expr_to_order_by__evaluation_metric_descending() -> None:
         metric_name="precision",
         direction=SortDirection.desc,
     )
-    order_by = sort_expr_to_order_by(expr=expr)
+    order_by = image_sort_expr_to_order_by(expr=expr)
     assert isinstance(order_by, OrderByEvaluationMetricField)
     assert order_by.evaluation_run_name == "run1"
     assert order_by.metric_name == "precision"
@@ -237,7 +239,7 @@ def test_sort_expr_to_order_by__evaluation_metric_descending() -> None:
 
 
 def test_sort_expr_discriminated_union__routes_to_evaluation_metric() -> None:
-    adapter: TypeAdapter[SortExpr] = TypeAdapter(SortExpr)
+    adapter: TypeAdapter[ImageSortExpr] = TypeAdapter(ImageSortExpr)
     expr = adapter.validate_python(
         {
             "source": "evaluation_metric",
@@ -252,7 +254,7 @@ def test_sort_expr_discriminated_union__routes_to_evaluation_metric() -> None:
 
 
 def test_sort_expr_discriminated_union__routes_to_sort_field_expr() -> None:
-    adapter: TypeAdapter[SortExpr] = TypeAdapter(SortExpr)
+    adapter: TypeAdapter[ImageSortExpr] = TypeAdapter(ImageSortExpr)
     expr = adapter.validate_python(
         {
             "source": "image",
@@ -260,5 +262,5 @@ def test_sort_expr_discriminated_union__routes_to_sort_field_expr() -> None:
             "direction": "asc",
         }
     )
-    assert isinstance(expr, SortFieldExpr)
+    assert isinstance(expr, ImageSortFieldExpr)
     assert expr.field_name == "file_name"

--- a/lightly_studio/tests/models/test_sort.py
+++ b/lightly_studio/tests/models/test_sort.py
@@ -42,7 +42,7 @@ _VIDEO_SORT_FIELD_TO_COLUMN = {
 }
 
 
-def test_sort_field_expr__valid_directions() -> None:
+def test_image_sort_field_expr__valid_directions() -> None:
     expr_asc = ImageSortFieldExpr(
         source=SortFieldSource.image,
         field_name="file_name",
@@ -58,7 +58,7 @@ def test_sort_field_expr__valid_directions() -> None:
     assert expr_desc.direction == SortDirection.desc
 
 
-def test_sort_field_expr__rejects_invalid_direction() -> None:
+def test_image_sort_field_expr__rejects_invalid_direction() -> None:
     with pytest.raises(ValidationError):
         ImageSortFieldExpr.model_validate(
             {
@@ -69,7 +69,7 @@ def test_sort_field_expr__rejects_invalid_direction() -> None:
         )
 
 
-def test_sort_field_expr_to_order_by__rejects_unknown_field() -> None:
+def test_sort_field_expr_to_order_by__image_rejects_unknown_field() -> None:
     expr = ImageSortFieldExpr(
         source=SortFieldSource.image,
         field_name="invalid_field",
@@ -79,7 +79,7 @@ def test_sort_field_expr_to_order_by__rejects_unknown_field() -> None:
         sort_field_expr_to_order_by(expr=expr)
 
 
-def test_sort_field_expr_to_order_by__ascending() -> None:
+def test_sort_field_expr_to_order_by__image_ascending() -> None:
     expr = ImageSortFieldExpr(
         source=SortFieldSource.image,
         field_name="file_name",
@@ -89,7 +89,7 @@ def test_sort_field_expr_to_order_by__ascending() -> None:
     assert order_by.ascending is True
 
 
-def test_sort_field_expr_to_order_by__descending() -> None:
+def test_sort_field_expr_to_order_by__image_descending() -> None:
     expr = ImageSortFieldExpr(
         source=SortFieldSource.image,
         field_name="width",
@@ -99,7 +99,7 @@ def test_sort_field_expr_to_order_by__descending() -> None:
     assert order_by.ascending is False
 
 
-def test_sort_field_expr_to_order_by__all_fields_map() -> None:
+def test_sort_field_expr_to_order_by__image_all_fields_map() -> None:
     for field_name, expected_field in _IMAGE_SORT_FIELD_TO_COLUMN.items():
         expr = ImageSortFieldExpr(
             source=SortFieldSource.image,
@@ -122,7 +122,7 @@ def test_sort_field_expr_to_order_by__image_field_name_not_shared_with_video() -
         sort_field_expr_to_order_by(expr=expr)
 
 
-def test_sort_field_expr__rejects_video_source() -> None:
+def test_image_sort_field_expr__rejects_video_source() -> None:
     # Image queries do not have `VideoTable` in the FROM clause, so a video field
     # would be cross-joined rather than sorted by.
     with pytest.raises(ValidationError):
@@ -177,7 +177,7 @@ def test_video_sort_field_expr__rejects_evaluation_metric_source() -> None:
         )
 
 
-def test_sort_field_expr_to_order_by__metadata_ascending() -> None:
+def test_sort_field_expr_to_order_by__image_metadata_ascending() -> None:
     expr = ImageSortFieldExpr(
         source=SortFieldSource.metadata,
         field_name="brightness",
@@ -189,7 +189,7 @@ def test_sort_field_expr_to_order_by__metadata_ascending() -> None:
     assert order_by.ascending is True
 
 
-def test_sort_field_expr_to_order_by__metadata_descending() -> None:
+def test_sort_field_expr_to_order_by__image_metadata_descending() -> None:
     expr = ImageSortFieldExpr(
         source=SortFieldSource.metadata,
         field_name="score",
@@ -201,7 +201,7 @@ def test_sort_field_expr_to_order_by__metadata_descending() -> None:
     assert order_by.ascending is False
 
 
-def test_sort_field_expr_to_order_by__metadata_arbitrary_field() -> None:
+def test_sort_field_expr_to_order_by__image_metadata_arbitrary_field() -> None:
     expr = ImageSortFieldExpr(
         source=SortFieldSource.metadata,
         field_name="custom_metric",
@@ -212,7 +212,7 @@ def test_sort_field_expr_to_order_by__metadata_arbitrary_field() -> None:
     assert order_by.field_name == "custom_metric"
 
 
-def test_sort_expr_to_order_by__evaluation_metric_ascending() -> None:
+def test_image_sort_expr_to_order_by__evaluation_metric_ascending() -> None:
     expr = EvaluationMetricSortExpr(
         evaluation_run_name="run1",
         metric_name="score",
@@ -225,7 +225,7 @@ def test_sort_expr_to_order_by__evaluation_metric_ascending() -> None:
     assert order_by.ascending is True
 
 
-def test_sort_expr_to_order_by__evaluation_metric_descending() -> None:
+def test_image_sort_expr_to_order_by__evaluation_metric_descending() -> None:
     expr = EvaluationMetricSortExpr(
         evaluation_run_name="run1",
         metric_name="precision",
@@ -238,7 +238,7 @@ def test_sort_expr_to_order_by__evaluation_metric_descending() -> None:
     assert order_by.ascending is False
 
 
-def test_sort_expr_discriminated_union__routes_to_evaluation_metric() -> None:
+def test_image_sort_expr_discriminated_union__routes_to_evaluation_metric() -> None:
     adapter: TypeAdapter[ImageSortExpr] = TypeAdapter(ImageSortExpr)
     expr = adapter.validate_python(
         {
@@ -253,7 +253,7 @@ def test_sort_expr_discriminated_union__routes_to_evaluation_metric() -> None:
     assert expr.metric_name == "score"
 
 
-def test_sort_expr_discriminated_union__routes_to_sort_field_expr() -> None:
+def test_image_sort_expr_discriminated_union__routes_to_sort_field_expr() -> None:
     adapter: TypeAdapter[ImageSortExpr] = TypeAdapter(ImageSortExpr)
     expr = adapter.validate_python(
         {

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { AnnotationOrderBy, CollectionSearch, GridHeader, OrderBy } from '$lib/components';
+    import { AnnotationOrderBy, CollectionSearch, GridHeader, ImageOrderBy } from '$lib/components';
     import GridHeaderSelectAllButton from '$lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte';
 
     type SearchImage = { name: string; previewUrl: string };
@@ -58,7 +58,7 @@
     {/snippet}
     {#snippet auxControls()}
         {#if isImages}
-            <OrderBy {collectionId} datasetId={collectionDatasetId} />
+            <ImageOrderBy {collectionId} datasetId={collectionDatasetId} />
         {:else if isAnnotations}
             <AnnotationOrderBy {collectionId} />
         {/if}

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -13,8 +13,8 @@ vi.mock('$lib/hooks/useGlobalStorage', () => {
     };
 });
 
-vi.mock('$lib/hooks/useOrderBy/useOrderBy', () => ({
-    useOrderBy: () => ({
+vi.mock('$lib/hooks/useImageOrderBy/useImageOrderBy', () => ({
+    useImageOrderBy: () => ({
         allSortFields: readable([]),
         selectedDirection: readable('asc'),
         selectedLabel: readable(null),
@@ -92,7 +92,7 @@ describe('DatasetGridHeader', () => {
         expect(defaultProps.onSelectAll).not.toHaveBeenCalled();
     });
 
-    it('renders the OrderBy control only for image collections', () => {
+    it('renders the ImageOrderBy control only for image collections', () => {
         const { unmount } = render(DatasetGridHeader, {
             props: { ...defaultProps, isImages: true }
         });

--- a/lightly_studio_view/src/lib/components/OrderBy/ImageOrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/ImageOrderBy.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { useOrderBy } from '$lib/hooks/useOrderBy/useOrderBy';
+    import { useImageOrderBy } from '$lib/hooks/useImageOrderBy/useImageOrderBy';
     import { useGlobalStorage, usePostHog } from '$lib/hooks';
     import { type SelectItem } from '$lib/components/Select';
     import OrderByControl from './OrderByControl.svelte';
@@ -23,7 +23,7 @@
         handleFieldClick,
         toggleDirection,
         dispose
-    } = useOrderBy({ collectionId: () => collectionId, datasetId: () => datasetId });
+    } = useImageOrderBy({ collectionId: () => collectionId, datasetId: () => datasetId });
 
     $effect(() => {
         return () => dispose();

--- a/lightly_studio_view/src/lib/components/OrderBy/ImageOrderBy.test.ts
+++ b/lightly_studio_view/src/lib/components/OrderBy/ImageOrderBy.test.ts
@@ -6,11 +6,11 @@ import { SortDirection } from '$lib/api/lightly_studio_local';
 import type { MetadataInfoView } from '$lib/api/lightly_studio_local';
 import type { EvaluationRunMetricsInfoView } from '$lib/api/lightly_studio_local/types.gen';
 import type { TextEmbedding } from '$lib/hooks/useGlobalStorage';
-import OrderBy from './OrderBy.svelte';
-import type { SortExpr } from '$lib/hooks/useImagesInfinite/types';
+import ImageOrderBy from './ImageOrderBy.svelte';
+import type { ImageSortExpr } from '$lib/hooks/useImagesInfinite/types';
 
 const mocks = vi.hoisted(() => ({
-    imageSortByValue: null as SortExpr[] | null,
+    imageSortByValue: null as ImageSortExpr[] | null,
     updateSortBy: vi.fn(),
     metadataInfoValue: [] as MetadataInfoView[],
     metricsProxy: { data: null as EvaluationRunMetricsInfoView[] | null, dataUpdatedAt: 0 },
@@ -44,7 +44,7 @@ vi.mock('$lib/hooks/useGlobalStorage', () => ({
     })
 }));
 
-describe('OrderBy', () => {
+describe('ImageOrderBy', () => {
     beforeAll(() => {
         Element.prototype.hasPointerCapture = vi.fn(() => false);
         Element.prototype.setPointerCapture = vi.fn();
@@ -63,13 +63,13 @@ describe('OrderBy', () => {
     });
 
     it('shows placeholder text when no field is selected', () => {
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).toHaveTextContent('Sort by');
     });
 
     it('shows a tooltip on hover over the sort trigger', async () => {
         const user = userEvent.setup();
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.hover(screen.getByTestId('sort-by-trigger'));
 
@@ -84,12 +84,12 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).toHaveTextContent('file name');
     });
 
     it('direction button is disabled when no field is selected', () => {
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-direction-button')).toBeDisabled();
     });
 
@@ -101,7 +101,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-direction-button')).not.toBeDisabled();
     });
 
@@ -114,7 +114,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.hover(screen.getByTestId('sort-direction-button'));
 
@@ -130,7 +130,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.DESC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.hover(screen.getByTestId('sort-direction-button'));
 
@@ -139,7 +139,7 @@ describe('OrderBy', () => {
 
     it('selects a field and calls updateSortBy with asc direction by default', async () => {
         const user = userEvent.setup();
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-file_name'));
@@ -162,7 +162,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-file_name'));
@@ -179,7 +179,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.DESC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-width'));
@@ -201,7 +201,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await fireEvent.click(screen.getByTestId('sort-direction-button'));
 
@@ -222,7 +222,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.DESC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await fireEvent.click(screen.getByTestId('sort-direction-button'));
 
@@ -236,7 +236,7 @@ describe('OrderBy', () => {
     });
 
     it('does not call updateSortBy when direction button is clicked with no field selected', async () => {
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await fireEvent.click(screen.getByTestId('sort-direction-button'));
 
@@ -245,7 +245,7 @@ describe('OrderBy', () => {
 
     it('lists all sort fields in the dropdown', async () => {
         const user = userEvent.setup();
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
 
@@ -264,7 +264,7 @@ describe('OrderBy', () => {
             { name: 'label', type: 'string' },
             { name: 'active', type: 'boolean' }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
 
@@ -283,7 +283,7 @@ describe('OrderBy', () => {
             { name: 'nested', type: 'dict' },
             { name: 'score', type: 'float' }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
 
@@ -295,7 +295,7 @@ describe('OrderBy', () => {
     it('selects a metadata field', async () => {
         const user = userEvent.setup();
         mocks.metadataInfoValue = [{ name: 'score', type: 'float' }];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-score'));
@@ -318,7 +318,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).toHaveTextContent('metadata.brightness');
     });
 
@@ -331,7 +331,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await fireEvent.click(screen.getByTestId('sort-direction-button'));
 
@@ -355,7 +355,7 @@ describe('OrderBy', () => {
                 ]
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
 
@@ -371,7 +371,7 @@ describe('OrderBy', () => {
                 metrics: [{ metric_name: 'precision', min_value: 0, max_value: 1 }]
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-run1-precision'));
@@ -402,7 +402,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await user.click(screen.getByTestId('sort-by-trigger'));
         await user.click(screen.getByTestId('sort-field-run1-precision'));
@@ -419,13 +419,13 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).toHaveTextContent('run1.precision');
     });
 
     it('disables the sort select when text embedding is active', () => {
         mocks.textEmbeddingValue = { embedding: [0.1, 0.2], queryText: 'dogs' };
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).toBeDisabled();
     });
 
@@ -438,13 +438,13 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-direction-button')).toBeDisabled();
     });
 
     it('enables the sort select when text embedding is inactive', () => {
         mocks.textEmbeddingValue = undefined;
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
         expect(screen.getByTestId('sort-by-trigger')).not.toBeDisabled();
     });
 
@@ -457,7 +457,7 @@ describe('OrderBy', () => {
                 direction: SortDirection.ASC
             }
         ];
-        render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        render(ImageOrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
 
         await fireEvent.click(screen.getByTestId('sort-direction-button'));
 
@@ -472,7 +472,9 @@ describe('OrderBy', () => {
     });
 
     it('passes a reactive datasetId getter that tracks the current prop after navigation', async () => {
-        const { rerender } = render(OrderBy, { props: { collectionId: 'col1', datasetId: 'ds1' } });
+        const { rerender } = render(ImageOrderBy, {
+            props: { collectionId: 'col1', datasetId: 'ds1' }
+        });
 
         expect(mocks.capturedDatasetIdGetter!()).toBe('ds1');
 

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -66,7 +66,7 @@ export { default as Separator } from '$lib/components/ui/separator/separator.sve
 export { default as CollectionSearch } from '$lib/components/CollectionSearch/CollectionSearch.svelte';
 export { default as CollectionSearchImage } from '$lib/components/CollectionSearch/CollectionSearchImage/CollectionSearchImage.svelte';
 export { default as CollectionSearchInput } from '$lib/components/CollectionSearch/SearchInput/CollectionSearchInput.svelte';
-export { default as OrderBy } from '$lib/components/OrderBy/OrderBy.svelte';
+export { default as ImageOrderBy } from '$lib/components/OrderBy/ImageOrderBy.svelte';
 export { default as AnnotationOrderBy } from '$lib/components/OrderBy/AnnotationOrderBy.svelte';
 export { default as SamplingCombinationDialog } from '$lib/components/Sampling/SamplingCombinationDialog.svelte';
 export { default as MetadataFilterChips } from '$lib/components/MetadataFilterChips/MetadataFilterChips.svelte';

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -30,11 +30,11 @@ export { useSeedAnnotationSourceFilter } from '$lib/hooks/useSeedAnnotationSourc
 export { useEvaluationSampleMetricsInfo } from '$lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo';
 export { useEvaluationRuns } from '$lib/hooks/useEvaluationRuns/useEvaluationRuns';
 export { useEvaluationConfusionMatrix } from '$lib/hooks/useEvaluationConfusionMatrix/useEvaluationConfusionMatrix.svelte';
-export { useOrderBy } from '$lib/hooks/useOrderBy/useOrderBy';
+export { useImageOrderBy } from '$lib/hooks/useImageOrderBy/useImageOrderBy';
 export {
-    useSortFields,
+    useImageSortFields,
     formatEvaluationMetricLabel
-} from '$lib/hooks/useSortFields/useSortFields.svelte';
+} from '$lib/hooks/useImageSortFields/useImageSortFields.svelte';
 export { useSelectClassDialog } from '$lib/hooks/useSelectClassDialog/useSelectClassDialog';
 export { usePendingOperations } from '$lib/hooks/usePendingOperations/usePendingOperations';
 export { useSegmentationMaskBrush } from '$lib/hooks/useSegmentationMaskBrush';

--- a/lightly_studio_view/src/lib/hooks/useAdjacentImages/useAdjacentImages.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentImages/useAdjacentImages.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { writable } from 'svelte/store';
 import { SampleType } from '$lib/api/lightly_studio_local';
-import type { ImageFilter, SortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
+import type { ImageFilter, ImageSortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
 import type { TextEmbedding } from '../useGlobalStorage';
 
 const useAdjacentSamplesMock = vi.fn();
 const imageFilterStore = writable<ImageFilter | null>(null);
-const imageSortByStore = writable<SortFieldExpr[] | null>(null);
+const imageSortByStore = writable<ImageSortFieldExpr[] | null>(null);
 const textEmbeddingStore = writable<TextEmbedding | undefined>(undefined);
 
 vi.mock('../useAdjacentSamples/useAdjacentSamples', () => ({
@@ -108,7 +108,9 @@ describe('useAdjacentImages', () => {
 
     it('passes sort_by to useAdjacentSamples when imageSortBy is set and text embedding is inactive', () => {
         textEmbeddingStore.set(undefined);
-        const sort: SortFieldExpr[] = [{ source: 'image', field_name: 'score', direction: 'desc' }];
+        const sort: ImageSortFieldExpr[] = [
+            { source: 'image', field_name: 'score', direction: 'desc' }
+        ];
         imageSortByStore.set(sort);
 
         useAdjacentImages({ sampleId: 'sample-123', collectionId: 'collection-1' });
@@ -139,7 +141,9 @@ describe('useAdjacentImages', () => {
 
     it('passes sort_by as undefined when text embedding is active, even if imageSortBy is set', () => {
         textEmbeddingStore.set({ embedding: [0.12, 0.34], queryText: 'cats' });
-        const sort: SortFieldExpr[] = [{ source: 'image', field_name: 'score', direction: 'desc' }];
+        const sort: ImageSortFieldExpr[] = [
+            { source: 'image', field_name: 'score', direction: 'desc' }
+        ];
         imageSortByStore.set(sort);
 
         useAdjacentImages({ sampleId: 'sample-123', collectionId: 'collection-1' });

--- a/lightly_studio_view/src/lib/hooks/useAdjacentSamples/useAdjacentSamples.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentSamples/useAdjacentSamples.ts
@@ -9,7 +9,7 @@ import type {
     VideoFilter,
     VideoFrameAdjacentFilter
 } from '$lib/api/lightly_studio_local/types.gen';
-import type { SortExpr } from '../useImagesInfinite/types';
+import type { ImageSortExpr } from '../useImagesInfinite/types';
 
 export type AdjacentSamplesRequestBody =
     | {
@@ -17,7 +17,7 @@ export type AdjacentSamplesRequestBody =
           collection_id: string;
           filters?: ({ filter_type: 'image' } & ImageFilter) | null;
           text_embedding?: number[];
-          sort_by?: SortExpr[] | null;
+          sort_by?: ImageSortExpr[] | null;
       }
     | {
           sample_type: Extract<SampleType, 'video'>;

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 import { useImageFilters } from './useImageFilters';
-import type { QueryExpr, SortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
+import type { QueryExpr, ImageSortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
 import { SortDirection } from '$lib/api/lightly_studio_local/types.gen';
 
 const queryExpr = {
@@ -33,7 +33,7 @@ describe('useImageFilters', () => {
     describe('updateSortBy', () => {
         it('sets imageSortBy to the provided sort fields', () => {
             const { imageSortBy, updateSortBy } = useImageFilters();
-            const sort: SortFieldExpr[] = [
+            const sort: ImageSortFieldExpr[] = [
                 {
                     source: 'image',
                     field_name: 'score',

--- a/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageFilters/useImageFilters.ts
@@ -11,7 +11,7 @@ import type {
     QueryExpr,
     SampleFilter
 } from '$lib/api/lightly_studio_local';
-import type { SortExpr } from '../useImagesInfinite/types';
+import type { ImageSortExpr } from '../useImagesInfinite/types';
 
 const filterParams = writable<ImagesInfiniteParams>({} as ImagesInfiniteParams);
 
@@ -125,7 +125,7 @@ const imageFilter = derived(
     }
 );
 
-const imageSortBy = writable<SortExpr[] | null>([
+const imageSortBy = writable<ImageSortExpr[] | null>([
     {
         source: 'image',
         field_name: 'file_path_abs',
@@ -205,7 +205,7 @@ export const useImageFilters = () => {
         filterParams.set(newParams);
     };
 
-    const updateSortBy = (sort: SortExpr[] | null) => {
+    const updateSortBy = (sort: ImageSortExpr[] | null) => {
         imageSortBy.set(sort);
     };
 

--- a/lightly_studio_view/src/lib/hooks/useImageOrderBy/useImageOrderBy.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageOrderBy/useImageOrderBy.test.ts
@@ -1,12 +1,12 @@
 import { get, writable } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SortDirection } from '$lib/api/lightly_studio_local';
-import type { SortField } from '$lib/hooks/useSortFields/useSortFields.svelte';
-import { IMAGE_SORT_FIELDS } from '$lib/hooks/useSortFields/useSortFields.svelte';
-import { useOrderBy } from './useOrderBy';
-import type { SortExpr } from '../useImagesInfinite/types';
+import type { SortField } from '$lib/hooks/useImageSortFields/useImageSortFields.svelte';
+import { IMAGE_SORT_FIELDS } from '$lib/hooks/useImageSortFields/useImageSortFields.svelte';
+import { useImageOrderBy } from './useImageOrderBy';
+import type { ImageSortExpr } from '../useImagesInfinite/types';
 
-const imageSortBy = writable<SortExpr[] | null>(null);
+const imageSortBy = writable<ImageSortExpr[] | null>(null);
 const allSortFields = writable<SortField[]>([...IMAGE_SORT_FIELDS]);
 const updateSortBy = vi.fn();
 
@@ -14,16 +14,18 @@ vi.mock('$lib/hooks/useImageFilters/useImageFilters', () => ({
     useImageFilters: () => ({ imageSortBy, updateSortBy })
 }));
 
-vi.mock('$lib/hooks/useSortFields/useSortFields.svelte', async (importOriginal) => {
+vi.mock('$lib/hooks/useImageSortFields/useImageSortFields.svelte', async (importOriginal) => {
     const original =
-        await importOriginal<typeof import('$lib/hooks/useSortFields/useSortFields.svelte')>();
+        await importOriginal<
+            typeof import('$lib/hooks/useImageSortFields/useImageSortFields.svelte')
+        >();
     return {
         ...original,
-        useSortFields: () => ({ allSortFields })
+        useImageSortFields: () => ({ allSortFields })
     };
 });
 
-describe('useOrderBy', () => {
+describe('useImageOrderBy', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         imageSortBy.set(null);
@@ -32,7 +34,7 @@ describe('useOrderBy', () => {
 
     describe('selectedDirection', () => {
         it('returns ASC when no sort is active', () => {
-            const { selectedDirection } = useOrderBy({
+            const { selectedDirection } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -47,7 +49,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.DESC
                 }
             ]);
-            const { selectedDirection } = useOrderBy({
+            const { selectedDirection } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -57,7 +59,7 @@ describe('useOrderBy', () => {
 
     describe('selectedLabel', () => {
         it('returns null when no sort is active', () => {
-            const { selectedLabel } = useOrderBy({
+            const { selectedLabel } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -72,7 +74,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { selectedLabel } = useOrderBy({
+            const { selectedLabel } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -95,7 +97,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { selectedLabel } = useOrderBy({
+            const { selectedLabel } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -120,7 +122,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { selectedLabel } = useOrderBy({
+            const { selectedLabel } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -130,7 +132,7 @@ describe('useOrderBy', () => {
 
     describe('isFieldSelected', () => {
         it('returns false for any field when no sort is active', () => {
-            const { isFieldSelected } = useOrderBy({
+            const { isFieldSelected } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -147,7 +149,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { isFieldSelected } = useOrderBy({
+            const { isFieldSelected } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -166,7 +168,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { isFieldSelected } = useOrderBy({
+            const { isFieldSelected } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -191,7 +193,7 @@ describe('useOrderBy', () => {
         });
 
         it('updates reactively when imageSortBy changes', () => {
-            const { isFieldSelected } = useOrderBy({
+            const { isFieldSelected } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -213,7 +215,7 @@ describe('useOrderBy', () => {
 
     describe('handleFieldClick', () => {
         it('selects an image field with ASC direction by default', () => {
-            const { handleFieldClick } = useOrderBy({
+            const { handleFieldClick } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -237,7 +239,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { handleFieldClick } = useOrderBy({
+            const { handleFieldClick } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -255,7 +257,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.DESC
                 }
             ]);
-            const { handleFieldClick } = useOrderBy({
+            const { handleFieldClick } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -272,7 +274,7 @@ describe('useOrderBy', () => {
         });
 
         it('selects a metadata field', () => {
-            const { handleFieldClick } = useOrderBy({
+            const { handleFieldClick } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -293,7 +295,7 @@ describe('useOrderBy', () => {
         });
 
         it('selects an evaluation metric field', () => {
-            const { handleFieldClick } = useOrderBy({
+            const { handleFieldClick } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -318,7 +320,7 @@ describe('useOrderBy', () => {
 
     describe('toggleDirection', () => {
         it('does nothing when no sort is active', () => {
-            const { toggleDirection } = useOrderBy({
+            const { toggleDirection } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -336,7 +338,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { toggleDirection } = useOrderBy({
+            const { toggleDirection } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -375,7 +377,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { toggleDirection } = useOrderBy({
+            const { toggleDirection } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });
@@ -400,7 +402,7 @@ describe('useOrderBy', () => {
                     direction: SortDirection.ASC
                 }
             ]);
-            const { toggleDirection } = useOrderBy({
+            const { toggleDirection } = useImageOrderBy({
                 collectionId: () => 'col1',
                 datasetId: () => 'ds1'
             });

--- a/lightly_studio_view/src/lib/hooks/useImageOrderBy/useImageOrderBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageOrderBy/useImageOrderBy.ts
@@ -4,11 +4,11 @@ import { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
 import { usePostHog } from '$lib/hooks';
 import {
     formatEvaluationMetricLabel,
-    useSortFields,
-    type ImageSortField,
+    useImageSortFields,
+    type ColumnSortField,
     type SortField
-} from '$lib/hooks/useSortFields/useSortFields.svelte';
-import type { SortExpr } from '$lib/hooks/useImagesInfinite/types';
+} from '$lib/hooks/useImageSortFields/useImageSortFields.svelte';
+import type { ImageSortExpr } from '$lib/hooks/useImagesInfinite/types';
 
 interface UseOrderByParams {
     collectionId: () => string;
@@ -26,7 +26,7 @@ interface UseOrderByReturn {
     dispose: () => void;
 }
 
-function checkIsFieldSelected(field: SortField, current: SortExpr | undefined): boolean {
+function checkIsFieldSelected(field: SortField, current: ImageSortExpr | undefined): boolean {
     if (!current) return false;
     if (field.source === 'evaluation_metric') {
         return (
@@ -42,7 +42,7 @@ function checkIsFieldSelected(field: SortField, current: SortExpr | undefined): 
     );
 }
 
-function sortExprAnalytics(expr: SortExpr): { sort_source: string; field_name: string } {
+function sortExprAnalytics(expr: ImageSortExpr): { sort_source: string; field_name: string } {
     if (expr.source === 'evaluation_metric') {
         return {
             sort_source: 'evaluation_metric',
@@ -55,9 +55,9 @@ function sortExprAnalytics(expr: SortExpr): { sort_source: string; field_name: s
     };
 }
 
-export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOrderByReturn {
+export function useImageOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOrderByReturn {
     const { imageSortBy, updateSortBy } = useImageFilters();
-    const { allSortFields, dispose } = useSortFields({ datasetId });
+    const { allSortFields, dispose } = useImageSortFields({ datasetId });
     const { trackEvent } = usePostHog();
 
     const selectedDirection = derived(
@@ -83,7 +83,7 @@ export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOr
             }
             return (
                 $allSortFields
-                    .filter((f): f is ImageSortField => f.source !== 'evaluation_metric')
+                    .filter((f): f is ColumnSortField => f.source !== 'evaluation_metric')
                     .find((f) => f.source === current.source && f.value === current.field_name)
                     ?.label ?? null
             );
@@ -106,7 +106,7 @@ export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOr
             return;
         }
         const direction = get(selectedDirection);
-        const next: SortExpr =
+        const next: ImageSortExpr =
             field.source === 'evaluation_metric'
                 ? {
                       source: 'evaluation_metric',
@@ -134,7 +134,7 @@ export function useOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOr
         if (!current) return;
         const direction =
             get(selectedDirection) === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC;
-        const next: SortExpr = { ...current, direction };
+        const next: ImageSortExpr = { ...current, direction };
         updateSortBy([next]);
         const { sort_source, field_name } = sortExprAnalytics(next);
         trackEvent('grid_sorted', {

--- a/lightly_studio_view/src/lib/hooks/useImageOrderBy/useImageOrderBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageOrderBy/useImageOrderBy.ts
@@ -10,12 +10,12 @@ import {
 } from '$lib/hooks/useImageSortFields/useImageSortFields.svelte';
 import type { ImageSortExpr } from '$lib/hooks/useImagesInfinite/types';
 
-interface UseOrderByParams {
+interface UseImageOrderByParams {
     collectionId: () => string;
     datasetId: () => string;
 }
 
-interface UseOrderByReturn {
+interface UseImageOrderByReturn {
     allSortFields: Readable<SortField[]>;
     selectedDirection: Readable<SortDirection>;
     selectedLabel: Readable<string | null>;
@@ -55,7 +55,10 @@ function sortExprAnalytics(expr: ImageSortExpr): { sort_source: string; field_na
     };
 }
 
-export function useImageOrderBy({ collectionId, datasetId }: UseOrderByParams): UseOrderByReturn {
+export function useImageOrderBy({
+    collectionId,
+    datasetId
+}: UseImageOrderByParams): UseImageOrderByReturn {
     const { imageSortBy, updateSortBy } = useImageFilters();
     const { allSortFields, dispose } = useImageSortFields({ datasetId });
     const { trackEvent } = usePostHog();

--- a/lightly_studio_view/src/lib/hooks/useImageSortFields/useImageSortFields.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageSortFields/useImageSortFields.svelte.ts
@@ -21,11 +21,11 @@ export interface EvalSortField {
 
 export type SortField = ColumnSortField | EvalSortField;
 
-interface UseSortFieldsParams {
+interface UseImageSortFieldsParams {
     datasetId: () => string;
 }
 
-interface UseSortFieldsReturn {
+interface UseImageSortFieldsReturn {
     allSortFields: Readable<SortField[]>;
     /** Dispose the detached $effect.root. Call on cleanup to prevent leaks. */
     dispose: () => void;
@@ -56,7 +56,9 @@ function mapRunsToEvalFields(runs: EvaluationRunMetricsInfoView[]): EvalSortFiel
     );
 }
 
-export function useImageSortFields({ datasetId }: UseSortFieldsParams): UseSortFieldsReturn {
+export function useImageSortFields({
+    datasetId
+}: UseImageSortFieldsParams): UseImageSortFieldsReturn {
     const { metadataInfo } = useMetadataFilters();
     const metricsInfo = useEvaluationSampleMetricsInfo({ datasetId });
 

--- a/lightly_studio_view/src/lib/hooks/useImageSortFields/useImageSortFields.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageSortFields/useImageSortFields.svelte.ts
@@ -1,10 +1,13 @@
 import { derived, writable, type Readable } from 'svelte/store';
-import type { SortFieldExpr, EvaluationRunMetricsInfoView } from '$lib/api/lightly_studio_local';
+import type {
+    ImageSortFieldExpr,
+    EvaluationRunMetricsInfoView
+} from '$lib/api/lightly_studio_local';
 import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
 import { useEvaluationSampleMetricsInfo } from '$lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInfo';
 
-export interface ImageSortField {
-    source: SortFieldExpr['source'];
+export interface ColumnSortField {
+    source: ImageSortFieldExpr['source'];
     value: string;
     label: string;
 }
@@ -16,7 +19,7 @@ export interface EvalSortField {
     label: string;
 }
 
-export type SortField = ImageSortField | EvalSortField;
+export type SortField = ColumnSortField | EvalSortField;
 
 interface UseSortFieldsParams {
     datasetId: () => string;
@@ -28,7 +31,7 @@ interface UseSortFieldsReturn {
     dispose: () => void;
 }
 
-export const IMAGE_SORT_FIELDS: ImageSortField[] = [
+export const IMAGE_SORT_FIELDS: ColumnSortField[] = [
     { source: 'image', value: 'file_name', label: 'file name' },
     { source: 'image', value: 'file_path_abs', label: 'file path' },
     { source: 'image', value: 'created_at', label: 'created at' },
@@ -53,7 +56,7 @@ function mapRunsToEvalFields(runs: EvaluationRunMetricsInfoView[]): EvalSortFiel
     );
 }
 
-export function useSortFields({ datasetId }: UseSortFieldsParams): UseSortFieldsReturn {
+export function useImageSortFields({ datasetId }: UseSortFieldsParams): UseSortFieldsReturn {
     const { metadataInfo } = useMetadataFilters();
     const metricsInfo = useEvaluationSampleMetricsInfo({ datasetId });
 
@@ -61,8 +64,8 @@ export function useSortFields({ datasetId }: UseSortFieldsParams): UseSortFields
         ($metadataInfo ?? [])
             .filter((info) => ['integer', 'float', 'string', 'boolean'].includes(info.type))
             .map(
-                (info): ImageSortField => ({
-                    source: 'metadata' as SortFieldExpr['source'],
+                (info): ColumnSortField => ({
+                    source: 'metadata' as ImageSortFieldExpr['source'],
                     value: info.name,
                     label: `metadata.${info.name}`
                 })

--- a/lightly_studio_view/src/lib/hooks/useImageSortFields/useImageSortFields.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImageSortFields/useImageSortFields.test.ts
@@ -3,7 +3,7 @@ import { flushSync } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MetadataInfoView } from '$lib/api/lightly_studio_local';
 import type { EvaluationRunMetricsInfoView } from '$lib/api/lightly_studio_local/types.gen';
-import { useSortFields } from './useSortFields.svelte';
+import { useImageSortFields } from './useImageSortFields.svelte';
 
 const metadataInfo = writable<MetadataInfoView[]>([]);
 
@@ -22,7 +22,7 @@ vi.mock('$lib/hooks/useEvaluationSampleMetricsInfo/useEvaluationSampleMetricsInf
     useEvaluationSampleMetricsInfo: () => metricsInfoMock
 }));
 
-describe('useSortFields', () => {
+describe('useImageSortFields', () => {
     beforeEach(() => {
         metadataInfo.set([]);
         metricsInfoMock.data = null;
@@ -31,7 +31,7 @@ describe('useSortFields', () => {
 
     describe('allSortFields', () => {
         it('contains the five base image sort fields', () => {
-            const { allSortFields } = useSortFields({ datasetId: () => 'ds1' });
+            const { allSortFields } = useImageSortFields({ datasetId: () => 'ds1' });
             flushSync();
             const fields = get(allSortFields);
 
@@ -53,7 +53,7 @@ describe('useSortFields', () => {
                 { name: 'label', type: 'string' },
                 { name: 'active', type: 'boolean' }
             ]);
-            const { allSortFields } = useSortFields({ datasetId: () => 'ds1' });
+            const { allSortFields } = useImageSortFields({ datasetId: () => 'ds1' });
             flushSync();
             const fields = get(allSortFields);
 
@@ -89,7 +89,7 @@ describe('useSortFields', () => {
                 { name: 'nested', type: 'dict' },
                 { name: 'score', type: 'float' }
             ]);
-            const { allSortFields } = useSortFields({ datasetId: () => 'ds1' });
+            const { allSortFields } = useImageSortFields({ datasetId: () => 'ds1' });
             flushSync();
             const fields = get(allSortFields);
 
@@ -107,7 +107,7 @@ describe('useSortFields', () => {
                     ]
                 }
             ];
-            const { allSortFields } = useSortFields({ datasetId: () => 'ds1' });
+            const { allSortFields } = useImageSortFields({ datasetId: () => 'ds1' });
             flushSync();
             const fields = get(allSortFields);
 
@@ -130,7 +130,7 @@ describe('useSortFields', () => {
         });
 
         it('updates reactively when metadataInfo changes', () => {
-            const { allSortFields } = useSortFields({ datasetId: () => 'ds1' });
+            const { allSortFields } = useImageSortFields({ datasetId: () => 'ds1' });
             flushSync();
 
             expect(

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/createImagesInfiniteOptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createImagesInfiniteOptions } from './createImagesInfiniteOptions';
-import type { SortFieldExpr } from '$lib/api/lightly_studio_local';
+import type { ImageSortFieldExpr } from '$lib/api/lightly_studio_local';
 
 type Options = ReturnType<typeof createImagesInfiniteOptions>;
 type QueryFnContext = { pageParam: number; signal: AbortSignal };
@@ -54,7 +54,7 @@ describe('createImagesInfiniteOptions', () => {
         });
 
         it('includes sort_by in query key', () => {
-            const sort: SortFieldExpr[] = [
+            const sort: ImageSortFieldExpr[] = [
                 { source: 'image', field_name: 'score', direction: 'desc' }
             ];
             const options = createImagesInfiniteOptions({
@@ -75,10 +75,10 @@ describe('createImagesInfiniteOptions', () => {
         });
 
         it('produces different keys for different sort_by values', () => {
-            const sort1: SortFieldExpr[] = [
+            const sort1: ImageSortFieldExpr[] = [
                 { source: 'image', field_name: 'score', direction: 'desc' }
             ];
-            const sort2: SortFieldExpr[] = [
+            const sort2: ImageSortFieldExpr[] = [
                 { source: 'image', field_name: 'filename', direction: 'asc' }
             ];
             const options1 = createImagesInfiniteOptions({
@@ -121,7 +121,7 @@ describe('createImagesInfiniteOptions', () => {
 
     describe('queryFn', () => {
         it('passes sort_by to readImages', async () => {
-            const sort: SortFieldExpr[] = [
+            const sort: ImageSortFieldExpr[] = [
                 { source: 'image', field_name: 'score', direction: 'desc' }
             ];
             const options = createImagesInfiniteOptions({

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/types.ts
@@ -4,7 +4,7 @@ import type {
     QueryExpr,
     ReadImagesRequest,
     SampleFilter,
-    SortFieldExpr
+    ImageSortFieldExpr
 } from '$lib/api/lightly_studio_local';
 import type { DimensionBounds } from '$lib/services/loadDimensionBounds';
 import type { CategoricalMetadataValues, MetadataValues } from '$lib/services/types';
@@ -45,4 +45,6 @@ export type SamplesQueryKey = readonly [
     ReadImagesRequest['sort_by']
 ];
 
-export type SortExpr = SortFieldExpr | ({ source: 'evaluation_metric' } & EvaluationMetricSortExpr);
+export type ImageSortExpr =
+    | ImageSortFieldExpr
+    | ({ source: 'evaluation_metric' } & EvaluationMetricSortExpr);

--- a/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useImagesInfinite/useImagesInfinite.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { buildRequestBody, type ImagesInfiniteParams } from './useImagesInfinite';
-import type { SortFieldExpr } from '$lib/api/lightly_studio_local';
+import type { ImageSortFieldExpr } from '$lib/api/lightly_studio_local';
 import type { QueryClient, CreateInfiniteQueryResult } from '@tanstack/svelte-query';
 import * as tanstackQuery from '@tanstack/svelte-query';
 import { useImagesInfinite } from './useImagesInfinite';
@@ -39,7 +39,7 @@ describe('useImagesInfinite', () => {
 
     describe('sort_by in query key', () => {
         it('includes sort_by in the query key when provided', () => {
-            const sort: SortFieldExpr[] = [
+            const sort: ImageSortFieldExpr[] = [
                 { source: 'image', field_name: 'score', direction: 'desc' }
             ];
 
@@ -55,10 +55,10 @@ describe('useImagesInfinite', () => {
         });
 
         it('produces different query keys for different sort_by values', () => {
-            const sort1: SortFieldExpr[] = [
+            const sort1: ImageSortFieldExpr[] = [
                 { source: 'image', field_name: 'score', direction: 'desc' }
             ];
-            const sort2: SortFieldExpr[] = [
+            const sort2: ImageSortFieldExpr[] = [
                 { source: 'image', field_name: 'filename', direction: 'asc' }
             ];
 
@@ -74,7 +74,7 @@ describe('useImagesInfinite', () => {
 
     describe('sort_by in request body', () => {
         it('passes sort_by to readImages when provided', async () => {
-            const sort: SortFieldExpr[] = [
+            const sort: ImageSortFieldExpr[] = [
                 { source: 'image', field_name: 'score', direction: 'desc' }
             ];
 


### PR DESCRIPTION
## What has changed and why?

Pure rename, no behavior change. Groundwork before adding sorting to the Videos grid.

#2022 added `VideoSortFieldExpr` next to the image sort types in `models/sort.py`, and those image types have no `Image` prefix, so they read as shared when they are image-only. This prefixes them so the split is explicit before a later PR adds the video sort control as a sibling.

Backend: `SortFieldExpr` to `ImageSortFieldExpr`, `SortExpr` to `ImageSortExpr`, `sort_expr_to_order_by` to `image_sort_expr_to_order_by`.

Frontend: the image-only `OrderBy` / `useOrderBy` / `useSortFields` become `Image`-prefixed siblings; `ImageSortField` becomes `ColumnSortField`. The generated `types.gen.ts` is regenerated from the renamed schema.

`EvaluationMetricSortExpr` stays unprefixed since evaluations are image-only. The genuinely shared `SortFieldSource`, `SortFieldExprBase`, and `sort_field_expr_to_order_by` are untouched.

Stacked on #2022 (base of this PR).

## How has it been tested?

Backend `ruff`, `mypy`, `pytest`; frontend `make static-checks` and vitest. The rename is behavior-preserving, so the existing suites are the check.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image sorting now uses dedicated image-specific controls and handling across the dataset grid, filtering, and adjacent-sample views.
  * Sorting continues to support image fields, metadata, evaluation metrics, and text embeddings.

* **Bug Fixes**
  * Improved separation of image sorting behavior to ensure sorting requests and controls use the correct image-specific options.

* **Tests**
  * Updated coverage for image sorting, filtering, ordering, and adjacent-sample scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->