### PR TITLE
Label usage events with the cohort of the installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,15 @@ Now edit the `.env` file:
 * Optionally change the `EXAMPLES_*` paths to point to data on your machine. You can leave the
 defaults to use the cloned dataset examples data.
 
+### Mark Your Machine as Internal
+
+Lightly staff should mark their machine once, so that internal usage is filtered out of the
+product metrics. `LIGHTLY_STUDIO_INTERNAL=1`, in `.env` or the environment, does the same per run:
+
+```shell
+mkdir -p ~/.cache/lightly-studio && touch ~/.cache/lightly-studio/internal
+```
+
 ### Run Examples
 
 Choose a script in `lightly_studio/src/lightly_studio/examples` directory and run it like this:

--- a/lightly_studio/src/lightly_studio/analytics/cohort.py
+++ b/lightly_studio/src/lightly_studio/analytics/cohort.py
@@ -1,0 +1,93 @@
+"""Cohort a running installation belongs to.
+
+Internal usage has to be separable from real users, otherwise a handful of devs and CI runs
+dominate the product signal while the user base is small.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from enum import Enum
+from importlib import metadata
+from pathlib import Path
+
+from lightly_studio.dataset.env import (
+    LIGHTLY_STUDIO_INTERNAL,
+    LIGHTLY_STUDIO_MODEL_CACHE_DIR,
+)
+
+# Shares the directory with the installation ID, so marking a machine survives recreating the
+# virtualenv. LIGHTLY_STUDIO_INTERNAL alone is forgotten when it matters most, on a fresh
+# container or a new laptop.
+INTERNAL_MARKER_PATH: Path = LIGHTLY_STUDIO_MODEL_CACHE_DIR / "internal"
+
+# Set by every CI provider we run on, GitHub Actions included. A build matrix otherwise looks like
+# one very active user.
+_CI_ENV_VAR = "CI"
+
+
+class UserCohort(str, Enum):
+    """Who is behind the events of one installation.
+
+    Attributes:
+        STAFF: A Lightly dev or staff member, opted in explicitly.
+        CI: An automated build, not a person.
+        SOURCE_BUILD: Installed from a checkout, so staff who did not opt in, or a contributor.
+        USER: Everyone else, a released package on someone else's machine.
+    """
+
+    STAFF = "staff"
+    CI = "ci"
+    SOURCE_BUILD = "source_build"
+    USER = "user"
+
+
+def get_cohort(marker_path: Path = INTERNAL_MARKER_PATH) -> UserCohort:
+    """Get the cohort of this installation.
+
+    Args:
+        marker_path: File whose presence marks the machine as internal.
+
+    Returns:
+        The cohort. `USER` whenever nothing indicates otherwise, so a misdetection loses internal
+        traffic from the internal metrics rather than polluting the product metrics.
+    """
+    # The deliberate signal wins: a marked machine stays internal even when a tool exports CI in
+    # the shell.
+    if LIGHTLY_STUDIO_INTERNAL or marker_path.exists():
+        return UserCohort.STAFF
+    if os.environ.get(_CI_ENV_VAR):
+        return UserCohort.CI
+    if _is_source_build():
+        return UserCohort.SOURCE_BUILD
+    return UserCohort.USER
+
+
+def is_test_run() -> bool:
+    """Whether the current process runs the test suite, whose events are dropped entirely."""
+    return "PYTEST_CURRENT_TEST" in os.environ or "pytest" in sys.modules
+
+
+def _is_source_build() -> bool:
+    """Whether the installed package was built from a local checkout rather than a release.
+
+    A `dir_info` entry in the PEP 610 `direct_url.json` record means the install came from a
+    directory on disk, covering both `pip install -e .` and a plain install from a checkout.
+    """
+    try:
+        direct_url = metadata.distribution("lightly-studio").read_text("direct_url.json")
+    except metadata.PackageNotFoundError:
+        # Running straight from a checkout, without the package installed at all.
+        return True
+
+    if direct_url is None:
+        return False
+    try:
+        record = json.loads(direct_url)
+    except json.JSONDecodeError:
+        return False
+    # A record that is not an object is malformed. `in` would raise on null or a number, and match
+    # the wrong thing on a string or an array.
+    return isinstance(record, dict) and "dir_info" in record

--- a/lightly_studio/src/lightly_studio/analytics/posthog_tracker.py
+++ b/lightly_studio/src/lightly_studio/analytics/posthog_tracker.py
@@ -9,7 +9,7 @@ from importlib import metadata
 
 from posthog import Posthog
 
-from lightly_studio.analytics import install_id
+from lightly_studio.analytics import cohort, install_id
 from lightly_studio.analytics.tracker import Tracker
 
 # One retry rather than the default three. Delivery happens on a background thread, but the flush
@@ -80,10 +80,15 @@ def _silence_delivery_logging() -> None:
         logger.propagate = False
 
 
-def _common_properties() -> dict[str, str]:
+def _common_properties() -> dict[str, object]:
     """Build the properties attached to every event."""
+    user_cohort = cohort.get_cohort().value
     return {
         "lightly_studio_version": metadata.version("lightly-studio"),
         "python_version": platform.python_version(),
         "os": platform.system(),
+        "user_cohort": user_cohort,
+        # Also stored on the person, so a PostHog cohort and the project-wide internal user filter
+        # can select on it without reading event properties.
+        "$set": {"user_cohort": user_cohort},
     }

--- a/lightly_studio/src/lightly_studio/analytics/tracking.py
+++ b/lightly_studio/src/lightly_studio/analytics/tracking.py
@@ -12,6 +12,7 @@ import threading
 from collections.abc import Mapping
 from enum import Enum
 
+from lightly_studio.analytics import cohort
 from lightly_studio.analytics.posthog_tracker import PostHogTracker
 from lightly_studio.analytics.tracker import Tracker
 from lightly_studio.dataset.env import (
@@ -93,6 +94,11 @@ def _get_tracker() -> Tracker:
 def _create_tracker() -> Tracker:
     """Build the tracker matching the current configuration."""
     if not LIGHTLY_STUDIO_ANALYTICS_ENABLED or not LIGHTLY_STUDIO_POSTHOG_KEY:
+        return NoOpTracker()
+
+    # Tracking is on by default, so without this the test suite reports events of its own. They
+    # say nothing about how the app is used, and no cohort would keep them out of the metrics.
+    if cohort.is_test_run():
         return NoOpTracker()
 
     tracker = PostHogTracker(

--- a/lightly_studio/src/lightly_studio/dataset/env.py
+++ b/lightly_studio/src/lightly_studio/dataset/env.py
@@ -39,6 +39,10 @@ LIGHTLY_STUDIO_POSTHOG_KEY: str = env.str(
 LIGHTLY_STUDIO_POSTHOG_HOST: str = env.str(
     "LIGHTLY_STUDIO_POSTHOG_HOST", "https://eu.i.posthog.com"
 )
+# Marks this machine as a Lightly dev or staff machine, so internal usage can be filtered out of
+# the product metrics. See lightly_studio/analytics/cohort.py for the alternative marker file,
+# which survives recreating the virtualenv.
+LIGHTLY_STUDIO_INTERNAL: bool = env.bool("LIGHTLY_STUDIO_INTERNAL", False)
 
 LIGHTLY_STUDIO_REQUEST_TIMING_ENABLED: bool = env.bool(
     "LIGHTLY_STUDIO_REQUEST_TIMING_ENABLED", False

--- a/lightly_studio/tests/analytics/test_cohort.py
+++ b/lightly_studio/tests/analytics/test_cohort.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from lightly_studio.analytics import cohort
+from lightly_studio.analytics.cohort import UserCohort
+
+
+# Signals are (marker file present, LIGHTLY_STUDIO_INTERNAL, CI variable, installed from source).
+@pytest.mark.parametrize(
+    ("signals", "expected"),
+    [
+        # Either deliberate signal marks the machine, and both win over a CI variable.
+        ((True, False, "true", False), UserCohort.STAFF),
+        ((False, True, "true", False), UserCohort.STAFF),
+        ((False, False, "true", False), UserCohort.CI),
+        # An emptied variable is how CI providers unset it.
+        ((False, False, "", True), UserCohort.SOURCE_BUILD),
+        ((False, False, "", False), UserCohort.USER),
+    ],
+)
+def test_get_cohort(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+    signals: tuple[bool, bool, str, bool],
+    expected: UserCohort,
+) -> None:
+    marked, internal_env, ci, is_source_build = signals
+    marker_path = tmp_path / "internal"
+    if marked:
+        marker_path.touch()
+    monkeypatch.setenv(cohort._CI_ENV_VAR, ci)
+    mocker.patch.object(cohort, "LIGHTLY_STUDIO_INTERNAL", internal_env)
+    mocker.patch.object(cohort, "_is_source_build", return_value=is_source_build)
+
+    assert cohort.get_cohort(marker_path=marker_path) == expected
+
+
+def test_is_test_run() -> None:
+    assert cohort.is_test_run()
+
+
+@pytest.mark.parametrize(
+    ("direct_url", "expected"),
+    [
+        (json.dumps({"url": "file:///repo", "dir_info": {"editable": True}}), True),
+        # A wheel from PyPI records no direct URL at all.
+        (None, False),
+        (json.dumps({"url": "https://example.com/pkg.whl"}), False),
+        # Malformed records must not raise, nor match the wrong thing.
+        ("null", False),
+        ('"dir_info"', False),
+        ("not json", False),
+    ],
+)
+def test_is_source_build(mocker: MockerFixture, direct_url: str | None, expected: bool) -> None:
+    distribution = mocker.MagicMock()
+    distribution.read_text.return_value = direct_url
+    mocker.patch.object(metadata, "distribution", return_value=distribution)
+
+    assert cohort._is_source_build() == expected
+
+
+def test_is_source_build__without_the_package_installed(mocker: MockerFixture) -> None:
+    mocker.patch.object(metadata, "distribution", side_effect=metadata.PackageNotFoundError)
+
+    assert cohort._is_source_build()

--- a/lightly_studio/tests/analytics/test_posthog_tracker.py
+++ b/lightly_studio/tests/analytics/test_posthog_tracker.py
@@ -5,11 +5,13 @@ from uuid import UUID
 import pytest
 from pytest_mock import MockerFixture
 
-from lightly_studio.analytics import install_id, posthog_tracker
+from lightly_studio.analytics import cohort, install_id, posthog_tracker
+from lightly_studio.analytics.cohort import UserCohort
 from lightly_studio.analytics.posthog_tracker import PostHogTracker
 
 INSTALL_ID = UUID("0199f1a2-b775-76b8-9b09-c2fd260c67c1")
 POSTHOG_HOST = "https://eu.i.posthog.com"
+_BASE_PROPERTIES = ("lightly_studio_version", "python_version", "os")
 
 
 class RecordingHandler(logging.Handler):
@@ -104,8 +106,13 @@ def test_shutdown(mocker: MockerFixture) -> None:
     client.shutdown.assert_called_once_with()
 
 
-def test_common_properties() -> None:
+def test_common_properties(mocker: MockerFixture) -> None:
+    """The cohort goes on the person too, which is what the internal user filter selects on."""
+    mocker.patch.object(cohort, "get_cohort", return_value=UserCohort.CI)
+
     properties = posthog_tracker._common_properties()
 
-    assert set(properties) == {"lightly_studio_version", "python_version", "os"}
+    assert set(properties) == {*_BASE_PROPERTIES, "user_cohort", "$set"}
     assert all(properties.values())
+    assert properties["user_cohort"] == "ci"
+    assert properties["$set"] == {"user_cohort": "ci"}

--- a/lightly_studio/tests/analytics/test_tracking.py
+++ b/lightly_studio/tests/analytics/test_tracking.py
@@ -6,7 +6,7 @@ from collections.abc import Generator, Mapping
 import pytest
 from pytest_mock import MockerFixture
 
-from lightly_studio.analytics import tracking
+from lightly_studio.analytics import cohort, tracking
 
 
 class FakeTracker:
@@ -119,6 +119,7 @@ def test_shutdown__when_the_backend_raises(mocker: MockerFixture) -> None:
 
 
 def test_create_tracker(mocker: MockerFixture) -> None:
+    mocker.patch.object(cohort, "is_test_run", return_value=False)
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_POSTHOG_KEY", "phc_test")
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_POSTHOG_HOST", "https://posthog.test")
@@ -133,6 +134,7 @@ def test_create_tracker(mocker: MockerFixture) -> None:
 
 def test_create_tracker__flushes_at_exit(mocker: MockerFixture) -> None:
     """Without this hook a short-lived process drops the queued event."""
+    mocker.patch.object(cohort, "is_test_run", return_value=False)
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_POSTHOG_KEY", "phc_test")
     mocker.patch.object(tracking, "PostHogTracker")
@@ -153,5 +155,14 @@ def test_create_tracker__when_analytics_are_disabled(mocker: MockerFixture) -> N
 def test_create_tracker__without_a_key(mocker: MockerFixture) -> None:
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
     mocker.patch.object(tracking, "LIGHTLY_STUDIO_POSTHOG_KEY", "")
+
+    assert isinstance(tracking._create_tracker(), tracking.NoOpTracker)
+
+
+def test_create_tracker__during_a_test_run(mocker: MockerFixture) -> None:
+    """The suite must not report events of its own, tracking being on by default."""
+    mocker.patch.object(cohort, "is_test_run", return_value=True)
+    mocker.patch.object(tracking, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
+    mocker.patch.object(tracking, "LIGHTLY_STUDIO_POSTHOG_KEY", "phc_test")
 
     assert isinstance(tracking._create_tracker(), tracking.NoOpTracker)


### PR DESCRIPTION
## What has changed and why?

Follow-up: #2029 carries the same cohort to the GUI.

A handful of devs and CI runs currently dominate the product signal, since every event we report is anonymous and indistinguishable. Each event now carries a `user_cohort`:

- `staff` from `LIGHTLY_STUDIO_INTERNAL=1`, or from a `~/.cache/lightly-studio/internal` marker file that survives recreating the virtualenv.
- `ci` from `CI` / `GITHUB_ACTIONS`. A build matrix otherwise looks like one very active user.
- `source_build` from the PEP 610 `direct_url.json` record, covering editable and plain installs from a checkout. External contributors land here too, hence its own bucket.
- `user` whenever nothing indicates otherwise, so a misdetection loses internal traffic from the internal metrics rather than polluting the product metrics.

The cohort also goes on the person via `$set`, which is what PostHog's project-wide internal user filter selects on. Test runs are now dropped rather than labelled: tracking is on by default, so the suite was free to report events of its own.

Still to do by hand in PostHog: set the internal user filter to `user_cohort is not user`, and add a static cohort of the existing internal `install_id`s to exclude the data already collected.

## How has it been tested?

Unit tests for every cohort branch and every `direct_url.json` case. `make static-checks && make test` in `lightly_studio`: 36 passed in `tests/analytics`, `ruff` clean, `mypy` unchanged at the 10 pre-existing errors in untouched files (missing optional `gcsfs`/`s3fs` stubs locally).

Manually: with the marker file present, `app_launched` reports `user_cohort: staff`; removed, an editable install reports `source_build`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @gabrielfruet, who added the backend tracking in #1914. Alternative: @IgorSusmelj.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Installations are classified as staff, CI, source-build, or regular-user cohorts.
  * Cohort information is included in analytics properties.
  * Test-run activity is excluded from product analytics.

* **Documentation**
  * Added guidance for marking a machine as internal persistently or for a single shell.

* **Tests**
  * Added coverage for cohort detection, installation types, internal markers, and test-run tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->