### PR TITLE
Report GUI events against the installation ID

### DIFF
--- a/lightly_studio/src/lightly_studio/api/analytics_config.py
+++ b/lightly_studio/src/lightly_studio/api/analytics_config.py
@@ -1,0 +1,43 @@
+"""Analytics configuration the GUI reads back from the backend.
+
+The GUI reports to the same PostHog project as the Python package, so deciding here keeps one
+source of truth for whether tracking runs, under which identity, and in which cohort.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from lightly_studio.analytics import cohort, install_id
+from lightly_studio.analytics.cohort import UserCohort
+from lightly_studio.dataset.env import LIGHTLY_STUDIO_ANALYTICS_ENABLED
+
+
+class AnalyticsConfigView(BaseModel):
+    """Analytics configuration of the running app.
+
+    Attributes:
+        enabled: Whether usage tracking is switched on.
+        distinct_id: Anonymous ID the GUI reports against, shared with the Python package so that
+            backend and browser events belong to one person. None while tracking is off.
+        user_cohort: Cohort of this installation, keeping internal usage out of the product
+            metrics. None while tracking is off.
+    """
+
+    enabled: bool
+    distinct_id: str | None
+    user_cohort: UserCohort | None
+
+
+def get_analytics_config() -> AnalyticsConfigView:
+    """Build the analytics configuration for the running app."""
+    if not LIGHTLY_STUDIO_ANALYTICS_ENABLED:
+        # Reading the installation ID writes it to disk on first use, which opting out must not
+        # trigger.
+        return AnalyticsConfigView(enabled=False, distinct_id=None, user_cohort=None)
+
+    return AnalyticsConfigView(
+        enabled=True,
+        distinct_id=str(install_id.get_install_id()),
+        user_cohort=cohort.get_cohort(),
+    )

--- a/lightly_studio/src/lightly_studio/api/app.py
+++ b/lightly_studio/src/lightly_studio/api/app.py
@@ -21,6 +21,7 @@ from lightly_studio.api.routes import (
     webapp,
 )
 from lightly_studio.api.routes.api import (
+    analytics,
     annotation,
     annotation_label,
     caption,
@@ -149,6 +150,7 @@ api_router.include_router(settings.settings_router)
 api_router.include_router(classifier.classifier_router)
 api_router.include_router(embeddings2d.embeddings2d_router)
 api_router.include_router(features.features_router)
+api_router.include_router(analytics.analytics_router)
 api_router.include_router(evaluation.evaluation_router)
 api_router.include_router(metadata.metadata_router)
 api_router.include_router(sampling.sampling_router)

--- a/lightly_studio/src/lightly_studio/api/features.py
+++ b/lightly_studio/src/lightly_studio/api/features.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_ANALYTICS_ENABLED
 
-# The GUI reads this back to decide whether to start PostHog, so that
-# LIGHTLY_STUDIO_ANALYTICS_ENABLED switches off tracking on both sides.
+# Reports whether usage tracking runs. The GUI decides whether to start PostHog from
+# /analytics/config instead, which also carries the identity to report under.
 ANALYTICS_FEATURE = "analytics"
 
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/analytics.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/analytics.py
@@ -1,0 +1,18 @@
+"""This module contains the API routes for the analytics configuration."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from lightly_studio.api import analytics_config
+from lightly_studio.api.analytics_config import AnalyticsConfigView
+
+__all__ = ["analytics_router"]
+
+analytics_router = APIRouter()
+
+
+@analytics_router.get("/analytics/config")
+def get_analytics_config() -> AnalyticsConfigView:
+    """Get the analytics configuration the GUI reports under."""
+    return analytics_config.get_analytics_config()

--- a/lightly_studio/tests/api/test_analytics_config.py
+++ b/lightly_studio/tests/api/test_analytics_config.py
@@ -1,0 +1,33 @@
+from uuid import UUID
+
+from pytest_mock import MockerFixture
+
+from lightly_studio.analytics import cohort, install_id
+from lightly_studio.analytics.cohort import UserCohort
+from lightly_studio.api import analytics_config
+
+
+def test_get_analytics_config(mocker: MockerFixture) -> None:
+    mocker.patch.object(analytics_config, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", True)
+    distinct_id = UUID("00000000-0000-4000-8000-000000000000")
+    mocker.patch.object(install_id, "get_install_id", return_value=distinct_id)
+    mocker.patch.object(cohort, "get_cohort", return_value=UserCohort.STAFF)
+
+    config = analytics_config.get_analytics_config()
+
+    assert config.enabled
+    assert config.distinct_id == str(distinct_id)
+    assert config.user_cohort == UserCohort.STAFF
+
+
+def test_get_analytics_config__with_analytics_disabled(mocker: MockerFixture) -> None:
+    """Opting out must leave no identity behind, on disk or in the response."""
+    mocker.patch.object(analytics_config, "LIGHTLY_STUDIO_ANALYTICS_ENABLED", False)
+    get_install_id = mocker.patch.object(install_id, "get_install_id")
+
+    config = analytics_config.get_analytics_config()
+
+    assert not config.enabled
+    assert config.distinct_id is None
+    assert config.user_cohort is None
+    get_install_id.assert_not_called()

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -20,6 +20,7 @@ export { useAddTagToSample } from '$lib/hooks/useAddTagToSample/useAddTagToSampl
 export { useFileDrop } from '$lib/hooks/useFileDrop/useFileDrop';
 export { useImageUpload } from '$lib/hooks/useImageUpload/useImageUpload';
 export { useFeatureFlags } from '$lib/hooks/useFeatureFlags/useFeatureFlags';
+export { useAnalyticsConfig } from '$lib/hooks/useAnalyticsConfig/useAnalyticsConfig';
 export { useSelectAll } from '$lib/hooks/useSelectAll/useSelectAll';
 export { useEmbedText } from '$lib/hooks/useEmbedText/useEmbedText';
 export { useTextEmbedding } from '$lib/hooks/useTextEmbedding/useTextEmbedding';

--- a/lightly_studio_view/src/lib/hooks/useAnalyticsConfig/useAnalyticsConfig.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnalyticsConfig/useAnalyticsConfig.test.ts
@@ -1,0 +1,42 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAnalyticsConfig } from './useAnalyticsConfig';
+
+const mockGetAnalyticsConfig = vi.fn();
+
+vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
+    getAnalyticsConfig: (...args: unknown[]) => mockGetAnalyticsConfig(...args)
+}));
+
+const config = { enabled: true, distinct_id: 'install-id', user_cohort: 'staff' };
+
+describe('useAnalyticsConfig', () => {
+    beforeEach(() => {
+        mockGetAnalyticsConfig.mockReset();
+    });
+
+    it('should expose the configuration reported by the backend', async () => {
+        mockGetAnalyticsConfig.mockResolvedValue({ data: config });
+
+        const { config: store, ready } = useAnalyticsConfig();
+        await ready;
+
+        expect(get(store)).toEqual(config);
+    });
+
+    it.each([
+        ['the request rejects', () => mockGetAnalyticsConfig.mockRejectedValue(new Error('nope'))],
+        // The client resolves with an error rather than rejecting on an HTTP failure.
+        [
+            'the response carries an error',
+            () => mockGetAnalyticsConfig.mockResolvedValue({ error: {} })
+        ]
+    ])('should leave the configuration empty when %s', async (_name, arrange) => {
+        arrange();
+
+        const { config: store, ready } = useAnalyticsConfig();
+        await ready;
+
+        expect(get(store)).toBeNull();
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useAnalyticsConfig/useAnalyticsConfig.ts
+++ b/lightly_studio_view/src/lib/hooks/useAnalyticsConfig/useAnalyticsConfig.ts
@@ -1,0 +1,28 @@
+import { getAnalyticsConfig } from '$lib/api/lightly_studio_local/sdk.gen';
+import { readonly, writable } from 'svelte/store';
+
+type AnalyticsConfig = NonNullable<Awaited<ReturnType<typeof getAnalyticsConfig>>['data']>;
+
+/**
+ * Analytics configuration reported by the backend, so that the browser reports against the same
+ * person as the Python package instead of a second anonymous one.
+ */
+export const useAnalyticsConfig = () => {
+    const config = writable<AnalyticsConfig | null>(null);
+    // Handed back as `ready` so a caller that has to act on the answer can await it instead of
+    // reading the store before the request lands. A failed request leaves the config empty, which
+    // callers treat as tracking being off, so neither a rejection nor the `error` the client
+    // resolves with on an HTTP failure is reported.
+    const ready = getAnalyticsConfig()
+        .then((response) => {
+            if (response.data) {
+                config.set(response.data);
+            }
+        })
+        .catch(() => {});
+
+    return {
+        config: readonly(config),
+        ready
+    };
+};

--- a/lightly_studio_view/src/lib/hooks/usePostHog.test.ts
+++ b/lightly_studio_view/src/lib/hooks/usePostHog.test.ts
@@ -17,30 +17,37 @@ vi.mock('$lib/version.json', () => ({
 const mockInit = vi.fn();
 const mockCapture = vi.fn();
 const mockRegister = vi.fn();
+const mockIdentify = vi.fn();
 
 vi.mock('posthog-js', () => ({
     default: {
         init: (...args: unknown[]) => mockInit(...args),
         capture: (...args: unknown[]) => mockCapture(...args),
-        register: (...args: unknown[]) => mockRegister(...args)
+        register: (...args: unknown[]) => mockRegister(...args),
+        identify: (...args: unknown[]) => mockIdentify(...args)
     }
 }));
 
 // Mocked at the module registry rather than spied on, so it survives the vi.resetModules() the
 // tests below need to get an uninitialized hook.
-const mockGetFeatures = vi.fn();
+const mockGetAnalyticsConfig = vi.fn();
 
 vi.mock('$lib/api/lightly_studio_local/sdk.gen', () => ({
-    getFeatures: (...args: unknown[]) => mockGetFeatures(...args)
+    getAnalyticsConfig: (...args: unknown[]) => mockGetAnalyticsConfig(...args)
 }));
+
+const enabledConfig = {
+    data: { enabled: true, distinct_id: 'install-id', user_cohort: 'user' }
+};
 
 describe('usePostHog', () => {
     beforeEach(() => {
         mockInit.mockClear();
         mockCapture.mockClear();
         mockRegister.mockClear();
-        mockGetFeatures.mockReset();
-        mockGetFeatures.mockResolvedValue({ data: ['analytics'] });
+        mockIdentify.mockClear();
+        mockGetAnalyticsConfig.mockReset();
+        mockGetAnalyticsConfig.mockResolvedValue(enabledConfig);
     });
 
     it('should initialize PostHog with correct configuration', async () => {
@@ -73,16 +80,28 @@ describe('usePostHog', () => {
         expect(mockInit).toHaveBeenCalledTimes(1);
     });
 
+    it('should identify with the installation id and cohort reported by the backend', async () => {
+        mockGetAnalyticsConfig.mockResolvedValue({
+            data: { enabled: true, distinct_id: 'install-id', user_cohort: 'staff' }
+        });
+
+        await (await freshPostHog()).init();
+
+        expect(mockIdentify).toHaveBeenCalledWith('install-id', { user_cohort: 'staff' });
+    });
+
     it('should not initialize when the backend reports analytics as off', async () => {
-        mockGetFeatures.mockResolvedValue({ data: [] });
+        mockGetAnalyticsConfig.mockResolvedValue({
+            data: { enabled: false, distinct_id: null, user_cohort: null }
+        });
 
         await (await freshPostHog()).init();
 
         expect(mockInit).not.toHaveBeenCalled();
     });
 
-    it('should not initialize when the features request fails', async () => {
-        mockGetFeatures.mockRejectedValue(new Error('API Error'));
+    it('should not initialize when the config request fails', async () => {
+        mockGetAnalyticsConfig.mockRejectedValue(new Error('API Error'));
 
         await (await freshPostHog()).init();
 

--- a/lightly_studio_view/src/lib/hooks/usePostHog.ts
+++ b/lightly_studio_view/src/lib/hooks/usePostHog.ts
@@ -8,12 +8,8 @@ import {
 import { version } from '$lib/version.json';
 // Imported by its own path: $lib/hooks re-exports usePostHog, so going through the barrel would
 // make the two modules import each other.
-import { useFeatureFlags } from '$lib/hooks/useFeatureFlags/useFeatureFlags';
+import { useAnalyticsConfig } from '$lib/hooks/useAnalyticsConfig/useAnalyticsConfig';
 import { get } from 'svelte/store';
-
-// The backend reports this only while LIGHTLY_STUDIO_ANALYTICS_ENABLED is set, so one variable
-// opts out of tracking in both the Python package and here.
-const ANALYTICS_FEATURE = 'analytics';
 
 let initialized = false;
 
@@ -38,11 +34,13 @@ export const usePostHog = () => {
     const init = async () => {
         if (!browser || initialized) return;
 
-        // A failed request leaves the flags empty, so a backend that cannot be reached is never
-        // tracked against.
-        const { featureFlags, ready } = useFeatureFlags();
+        // A failed request leaves the config empty, so a backend that cannot be reached is never
+        // tracked against. LIGHTLY_STUDIO_ANALYTICS_ENABLED decides there, so one variable opts
+        // out of tracking in both the Python package and here.
+        const { config, ready } = useAnalyticsConfig();
         await ready;
-        if (!get(featureFlags).includes(ANALYTICS_FEATURE)) return;
+        const analyticsConfig = get(config);
+        if (!analyticsConfig?.enabled) return;
         // Re-check: concurrent callers both get past the guard above before this resolves.
         if (initialized) return;
 
@@ -62,6 +60,14 @@ export const usePostHog = () => {
             capture_exceptions: true
         });
         posthog.register({ app_version: version });
+
+        // Report against the installation ID the Python package uses, so backend and browser
+        // events belong to one person rather than two, with the cohort on that person.
+        if (analyticsConfig.distinct_id) {
+            posthog.identify(analyticsConfig.distinct_id, {
+                user_cohort: analyticsConfig.user_cohort
+            });
+        }
 
         initialized = true;
     };


### PR DESCRIPTION
## What has changed and why?

Stacked on #2028, which adds the cohort. Part of [LIG-10435](https://linear.app/lightly/issue/LIG-10435/figure-out-track-devs-and-staff-separately-from-real-users).

`posthog.identify` was never called, and with `person_profiles: 'identified_only'` the browser had no person profile at all. Browser events therefore used a different distinct ID than the Python package, so one install counted as two people, and the cohort from #2028 could not reach the GUI.

New `GET /api/analytics/config` returns `{enabled, distinct_id, user_cohort}`, and the GUI reads it instead of the feature-flag list. It reports against the installation ID the Python package uses, so backend and browser events belong to one person and the cohort lands on that person from both sides. The endpoint deliberately does not read the installation ID while analytics are off, since reading it writes it to disk.

Known gap: Playwright e2e runs a real backend and a real browser, so the pytest guard from #2028 does not catch it. On CI the `ci` cohort covers it; run locally it reports as `staff` or `source_build`. Filterable, but not dropped.

## How has it been tested?

New tests for the endpoint with analytics on and off, for the hook, and for the `identify` call.

- `cd lightly_studio && make static-checks && make test` — 326 passed, 6 skipped in `tests/api` and `tests/analytics`; `mypy` unchanged at the pre-existing baseline.
- `cd lightly_studio_view && make static-checks && npm run test:unit -- --run` — all passing, `svelte-check` 0 errors 0 warnings.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

Suggested reviewer: @gabrielfruet, as for #2028. Alternative: @IgorSusmelj.
