### PR TITLE
Add empty DefaultEmbeddingSpace table and resolver

### DIFF
--- a/lightly_studio/src/lightly_studio/api/db_tables.py
+++ b/lightly_studio/src/lightly_studio/api/db_tables.py
@@ -19,6 +19,9 @@ from lightly_studio.models.collection import (
 from lightly_studio.models.dataset import (
     DatasetTable,  # noqa: F401, required for SQLModel to work properly
 )
+from lightly_studio.models.default_embedding_space import (
+    DefaultEmbeddingSpaceTable,  # noqa: F401, required for SQLModel to work properly
+)
 from lightly_studio.models.embedding_model import (
     EmbeddingModelTable,  # noqa: F401, required for SQLModel to work properly
 )

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787314049_a05138ab5fc4_add_default_embedding_space_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787314049_a05138ab5fc4_add_default_embedding_space_table.py
@@ -1,0 +1,57 @@
+"""add default embedding space table.
+
+Creates the empty `default_embedding_space` table (one row per collection). Nothing
+reads the table at this revision; the backfill of each collection's current default and
+the switch to reading the table land in the follow-up revision
+`b1c2d3e4f5a6_backfill_default_embedding_space`, together with the write path that keeps
+it populated. Keeping the create empty makes this revision a pure additive schema step.
+
+Downgrade drops the table.
+
+DuckDB builds its schema with `create_all`, so this migration only matters for tracked
+Postgres databases.
+
+Revision ID: a05138ab5fc4
+Revises: 4f6a7b8c9d0e
+Create Date: 2026-08-21 14:07:29.909594
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a05138ab5fc4"
+down_revision: Union[str, Sequence[str], None] = "4f6a7b8c9d0e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "default_embedding_space",
+        sa.Column("collection_id", sa.Uuid(), nullable=False),
+        sa.Column("embedding_model_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(["collection_id"], ["collection.collection_id"]),
+        sa.ForeignKeyConstraint(["embedding_model_id"], ["embedding_model.embedding_model_id"]),
+        sa.PrimaryKeyConstraint("collection_id"),
+    )
+    op.create_index(
+        op.f("ix_default_embedding_space_embedding_model_id"),
+        "default_embedding_space",
+        ["embedding_model_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        op.f("ix_default_embedding_space_embedding_model_id"),
+        table_name="default_embedding_space",
+    )
+    op.drop_table("default_embedding_space")

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787314049_a05138ab5fc4_add_default_embedding_space_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787314049_a05138ab5fc4_add_default_embedding_space_table.py
@@ -35,18 +35,8 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["embedding_model_id"], ["embedding_model.embedding_model_id"]),
         sa.PrimaryKeyConstraint("collection_id"),
     )
-    op.create_index(
-        op.f("ix_default_embedding_space_embedding_model_id"),
-        "default_embedding_space",
-        ["embedding_model_id"],
-        unique=False,
-    )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_index(
-        op.f("ix_default_embedding_space_embedding_model_id"),
-        table_name="default_embedding_space",
-    )
     op.drop_table("default_embedding_space")

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787314049_a05138ab5fc4_add_default_embedding_space_table.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787314049_a05138ab5fc4_add_default_embedding_space_table.py
@@ -1,12 +1,7 @@
 """add default embedding space table.
 
-Creates the empty `default_embedding_space` table (one row per collection). Nothing
-reads the table at this revision; the backfill of each collection's current default and
-the switch to reading the table land in the follow-up revision
-`b1c2d3e4f5a6_backfill_default_embedding_space`, together with the write path that keeps
-it populated. Keeping the create empty makes this revision a pure additive schema step.
-
-Downgrade drops the table.
+Creates the empty `default_embedding_space` table (one row per collection). No code reads
+the table at this revision.
 
 DuckDB builds its schema with `create_all`, so this migration only matters for tracked
 Postgres databases.

--- a/lightly_studio/src/lightly_studio/models/default_embedding_space.py
+++ b/lightly_studio/src/lightly_studio/models/default_embedding_space.py
@@ -1,0 +1,24 @@
+"""This module defines the DefaultEmbeddingSpace model for the application."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Field, SQLModel
+
+
+class DefaultEmbeddingSpaceTable(SQLModel, table=True):
+    """Link table: the default embedding space of a collection.
+
+    One row per collection (the ``collection_id`` primary key enforces this). The
+    embedding space is identified by the embedding model that produced it, so the row
+    points at the ``embedding_model`` used whenever a caller does not name one
+    explicitly, e.g. the 2D projection endpoints and similarity search. This is the
+    persistent record of the "default" that used to be derived on the fly as the
+    collection's oldest model.
+    """
+
+    __tablename__ = "default_embedding_space"
+
+    collection_id: UUID = Field(foreign_key="collection.collection_id", primary_key=True)
+    embedding_model_id: UUID = Field(foreign_key="embedding_model.embedding_model_id", index=True)

--- a/lightly_studio/src/lightly_studio/models/default_embedding_space.py
+++ b/lightly_studio/src/lightly_studio/models/default_embedding_space.py
@@ -13,9 +13,7 @@ class DefaultEmbeddingSpaceTable(SQLModel, table=True):
     One row per collection (the ``collection_id`` primary key enforces this). The
     embedding space is identified by the embedding model that produced it, so the row
     points at the ``embedding_model`` used whenever a caller does not name one
-    explicitly, e.g. the 2D projection endpoints and similarity search. This is the
-    persistent record of the "default" that used to be derived on the fly as the
-    collection's oldest model.
+    explicitly, e.g. the 2D projection endpoints and similarity search.
     """
 
     __tablename__ = "default_embedding_space"

--- a/lightly_studio/src/lightly_studio/models/default_embedding_space.py
+++ b/lightly_studio/src/lightly_studio/models/default_embedding_space.py
@@ -19,4 +19,4 @@ class DefaultEmbeddingSpaceTable(SQLModel, table=True):
     __tablename__ = "default_embedding_space"
 
     collection_id: UUID = Field(foreign_key="collection.collection_id", primary_key=True)
-    embedding_model_id: UUID = Field(foreign_key="embedding_model.embedding_model_id", index=True)
+    embedding_model_id: UUID = Field(foreign_key="embedding_model.embedding_model_id")

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -16,7 +16,11 @@ _HANDLED_TABLES_COUNT = 25
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)
 # - two_dim_embeddings (cached projections, regenerated as needed)
-_EXCLUDED_TABLES_COUNT = 2
+# - default_embedding_space (created empty; nothing writes it yet)
+# TODO(Michal, 08/2026): Move default_embedding_space into deep_copy and delete_dataset
+# (copy/delete its rows per collection) and shift it into _HANDLED_TABLES_COUNT once the
+# write path lands.
+_EXCLUDED_TABLES_COUNT = 3
 
 _TOTAL_TABLES_COUNT = _HANDLED_TABLES_COUNT + _EXCLUDED_TABLES_COUNT
 

--- a/lightly_studio/src/lightly_studio/resolvers/default_embedding_space_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/default_embedding_space_resolver.py
@@ -1,0 +1,71 @@
+"""Handler for database operations related to a collection's default embedding space."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session, select
+
+from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
+
+
+def set_default(
+    session: Session, collection_id: UUID, embedding_model_id: UUID
+) -> DefaultEmbeddingSpaceTable:
+    """Set (or replace) the default embedding space of a collection.
+
+    A collection has at most one default, so an existing row is updated in place rather
+    than inserted a second time.
+
+    Args:
+        session: The database session.
+        collection_id: The collection whose default is set.
+        embedding_model_id: The embedding model to record as the default.
+
+    Returns:
+        The persisted default embedding space row.
+    """
+    default = _get_by_collection_id(session=session, collection_id=collection_id)
+    if default is None:
+        default = DefaultEmbeddingSpaceTable(
+            collection_id=collection_id, embedding_model_id=embedding_model_id
+        )
+    else:
+        default.embedding_model_id = embedding_model_id
+
+    session.add(default)
+    session.commit()
+    session.refresh(default)
+    return default
+
+
+def get_by_collection_id(session: Session, collection_id: UUID) -> UUID | None:
+    """Return the collection's default embedding model id, or None if it has none."""
+    default = _get_by_collection_id(session=session, collection_id=collection_id)
+    return None if default is None else default.embedding_model_id
+
+
+def delete_by_collection_id(session: Session, collection_id: UUID) -> bool:
+    """Delete the collection's default embedding space row.
+
+    Returns:
+        True if a row was deleted, False if the collection had no default.
+    """
+    default = _get_by_collection_id(session=session, collection_id=collection_id)
+    if default is None:
+        return False
+
+    session.delete(default)
+    session.commit()
+    return True
+
+
+def _get_by_collection_id(
+    session: Session, collection_id: UUID
+) -> DefaultEmbeddingSpaceTable | None:
+    """Return the collection's default embedding space row, or None if it has none."""
+    return session.exec(
+        select(DefaultEmbeddingSpaceTable).where(
+            DefaultEmbeddingSpaceTable.collection_id == collection_id
+        )
+    ).one_or_none()

--- a/lightly_studio/tests/resolvers/test_default_embedding_space_resolver.py
+++ b/lightly_studio/tests/resolvers/test_default_embedding_space_resolver.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from lightly_studio.resolvers import default_embedding_space_resolver
+from tests.helpers_resolvers import (
+    create_collection,
+    create_embedding_model,
+)
+
+
+def test_set_default__inserts(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
+
+    default = default_embedding_space_resolver.set_default(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
+
+    assert default.collection_id == collection.collection_id
+    assert default.embedding_model_id == model.embedding_model_id
+
+
+def test_set_default__replaces_existing(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    model_1 = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="model_1",
+        embedding_model_hash="hash_1",
+    )
+    model_2 = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="model_2",
+        embedding_model_hash="hash_2",
+    )
+
+    default_embedding_space_resolver.set_default(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model_1.embedding_model_id,
+    )
+    default_embedding_space_resolver.set_default(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model_2.embedding_model_id,
+    )
+
+    # The collection still has a single default, now pointing at the second model.
+    assert (
+        default_embedding_space_resolver.get_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        == model_2.embedding_model_id
+    )
+
+
+def test_get_by_collection_id__none_when_unset(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+
+    assert (
+        default_embedding_space_resolver.get_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is None
+    )
+
+
+def test_get_by_collection_id__returns_id(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
+    default_embedding_space_resolver.set_default(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
+
+    assert (
+        default_embedding_space_resolver.get_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        == model.embedding_model_id
+    )
+
+
+def test_delete_by_collection_id__deletes(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
+    default_embedding_space_resolver.set_default(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=model.embedding_model_id,
+    )
+
+    deleted = default_embedding_space_resolver.delete_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    )
+
+    assert deleted is True
+    assert (
+        default_embedding_space_resolver.get_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is None
+    )
+
+
+def test_delete_by_collection_id__returns_false_when_absent(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+
+    assert (
+        default_embedding_space_resolver.delete_by_collection_id(
+            session=db_session, collection_id=collection.collection_id
+        )
+        is False
+    )


### PR DESCRIPTION
## What has changed and why?

Adds a `default_embedding_space` table (one row per collection) that will become the persistent source of truth for a collection's default embedding space, replacing the on-the-fly "oldest model" derivation.

A follow-up will remove `collection_id` from the `embedding_model` table.

- The space is identified by the embedding model that produced it, so the row points at an `embedding_model` row. The `embedding_model` table is unchanged; the plan is to rename it later to `embedding_space`.
- Purely additive: table created empty, nothing reads or writes it yet — runtime behaviour unchanged.
- New `DefaultEmbeddingSpaceTable` model + `default_embedding_space_resolver` (`set_default`, `get_by_collection_id`, `delete_by_collection_id`).
- Alembic revision `a05138ab5fc4`: create the table, no backfill.

First of a stack. The backfill and the switch of `get_default_by_collection_id` onto the table land in the follow-up PR.

## How has it been tested?

- `make static-checks` (ruff, mypy, format).
- `make build` + `pytest tests/resolvers/test_default_embedding_space_resolver.py` — 6 pass against the empty table.
- Verified standalone: `get_default_by_collection_id` still on the old oldest-model path, single alembic head.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for assigning, replacing, retrieving, and removing a collection’s default embedding model.
  * Added persistent storage for collection default embedding-model settings.
  * Default embedding-model selections are now retained reliably across sessions.

* **Bug Fixes**
  * Improved handling of default embedding-model deletion, including clear results when no setting exists.

* **Tests**
  * Added coverage for creating, updating, retrieving, and deleting default embedding-model settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->