### PR TITLE
Resolve the collection default from DefaultEmbeddingSpace

### DIFF
--- a/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
@@ -18,7 +18,7 @@ from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.resolvers import (
     annotation_resolver,
-    embedding_model_resolver,
+    default_embedding_space_resolver,
     image_resolver,
     twodim_embedding_resolver,
     video_resolver,
@@ -55,17 +55,17 @@ def get_2d_embeddings(
     _validate_filter_type(collection=collection, filters=body.filters)
 
     # TODO(Malte, 09/2025): Support choosing the embedding model via API parameter.
-    embedding_model = embedding_model_resolver.get_default_by_collection_id(
+    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
         session=session,
         collection_id=collection_id,
     )
-    if embedding_model is None:
+    if embedding_model_id is None:
         raise ValueError("No embedding model configured.")
 
     x_array, y_array, sample_ids = twodim_embedding_resolver.get_twodim_embeddings(
         session=session,
         collection_id=collection_id,
-        embedding_model_id=embedding_model.embedding_model_id,
+        embedding_model_id=embedding_model_id,
     )
 
     matching_sample_ids: set[UUID] | None = None

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -24,6 +24,7 @@ from lightly_studio.models.sample_embedding import SampleEmbeddingCreate
 from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
+    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -172,9 +173,22 @@ class EmbeddingManager:
         # Store the model in our dictionary
         self._models[model_id] = embedding_generator
 
-        # Set as default if requested or if it's the first model
+        # Set as default if requested or if it's the first model. The in-memory map is the
+        # runtime cache that pairs a collection with an already-loaded generator; the
+        # default_embedding_space table persists the same choice so query-layer callers
+        # (get_default_by_collection_id) survive across processes.
         if set_as_default or collection_id not in self._collection_id_to_default_model_id:
             self._collection_id_to_default_model_id[collection_id] = model_id
+        if (
+            set_as_default
+            or default_embedding_space_resolver.get_by_collection_id(
+                session=session, collection_id=collection_id
+            )
+            is None
+        ):
+            default_embedding_space_resolver.set_default(
+                session=session, collection_id=collection_id, embedding_model_id=model_id
+            )
 
         return db_model
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -174,7 +174,7 @@ class EmbeddingManager:
 
         # Record the default in two places: the in-memory map caches the loaded generator
         # for this process, and the default_embedding_space table persists the choice for
-        # query-layer callers (get_default_by_collection_id).
+        # query-layer callers (default_embedding_space_resolver.get_by_collection_id).
         if set_as_default or collection_id not in self._collection_id_to_default_model_id:
             self._collection_id_to_default_model_id[collection_id] = model_id
         if (

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -170,13 +170,11 @@ class EmbeddingManager:
         )
         model_id = db_model.embedding_model_id
 
-        # Store the model in our dictionary
         self._models[model_id] = embedding_generator
 
-        # Set as default if requested or if it's the first model. The in-memory map is the
-        # runtime cache that pairs a collection with an already-loaded generator; the
-        # default_embedding_space table persists the same choice so query-layer callers
-        # (get_default_by_collection_id) survive across processes.
+        # Record the default in two places: the in-memory map caches the loaded generator
+        # for this process, and the default_embedding_space table persists the choice for
+        # query-layer callers (get_default_by_collection_id).
         if set_as_default or collection_id not in self._collection_id_to_default_model_id:
             self._collection_id_to_default_model_id[collection_id] = model_id
         if (

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787314050_b1c2d3e4f5a6_backfill_default_embedding_space.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787314050_b1c2d3e4f5a6_backfill_default_embedding_space.py
@@ -2,7 +2,7 @@
 
 Seeds the `default_embedding_space` table (created empty in `a05138ab5fc4`) with each
 collection's default: the oldest embedding model by `created_at ASC, embedding_model_id
-ASC`. This is the same rule `get_default_by_collection_id` applies, so reading the table
+ASC`. This is the same model the query resolved before, so reading the table
 resolves the same model the query used before. Collections created after this migration
 are populated by `embedding_manager.register_embedding_model`, so no collection is left
 without a default row.

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787314050_b1c2d3e4f5a6_backfill_default_embedding_space.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787314050_b1c2d3e4f5a6_backfill_default_embedding_space.py
@@ -1,0 +1,63 @@
+"""backfill default embedding space.
+
+Seeds the `default_embedding_space` table (created empty in `a05138ab5fc4`) with each
+collection's current default: the oldest embedding model by
+`created_at ASC, embedding_model_id ASC`. This mirrors the rule the old
+`get_default_by_collection_id` resolver used, so the switch to reading the table in the
+same release is behaviour-preserving. The updated write path
+(`embedding_manager.register_embedding_model`) keeps the table populated for collections
+created after this migration runs, so there is no window where a collection is missing a
+default row.
+
+Downgrade empties the table. It is not lossy at this revision: `embedding_model` still
+carries `collection_id`, so the default can be re-derived from the same oldest-model
+rule (the column drop lands in a later revision).
+
+DuckDB builds its schema with `create_all` and has no backfill step, so this migration
+only matters for tracked Postgres databases.
+
+Revision ID: b1c2d3e4f5a6
+Revises: a05138ab5fc4
+Create Date: 2026-08-21 14:12:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, Sequence[str], None] = "a05138ab5fc4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _backfill_defaults()
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.get_bind().execute(sa.text("DELETE FROM default_embedding_space"))
+
+
+def _backfill_defaults() -> None:
+    """Seed one default per collection: its oldest embedding model.
+
+    `DISTINCT ON` keeps the first row per `collection_id` under the `ORDER BY`, which
+    reproduces the old `created_at ASC, embedding_model_id ASC` tie-break exactly.
+    """
+    op.get_bind().execute(
+        sa.text(
+            """
+            INSERT INTO default_embedding_space (collection_id, embedding_model_id)
+            SELECT DISTINCT ON (collection_id) collection_id, embedding_model_id
+            FROM embedding_model
+            ORDER BY collection_id, created_at ASC, embedding_model_id ASC
+            """
+        )
+    )

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787314050_b1c2d3e4f5a6_backfill_default_embedding_space.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787314050_b1c2d3e4f5a6_backfill_default_embedding_space.py
@@ -1,13 +1,11 @@
 """backfill default embedding space.
 
 Seeds the `default_embedding_space` table (created empty in `a05138ab5fc4`) with each
-collection's current default: the oldest embedding model by
-`created_at ASC, embedding_model_id ASC`. This mirrors the rule the old
-`get_default_by_collection_id` resolver used, so the switch to reading the table in the
-same release is behaviour-preserving. The updated write path
-(`embedding_manager.register_embedding_model`) keeps the table populated for collections
-created after this migration runs, so there is no window where a collection is missing a
-default row.
+collection's default: the oldest embedding model by `created_at ASC, embedding_model_id
+ASC`. This is the same rule `get_default_by_collection_id` applies, so reading the table
+resolves the same model the query used before. Collections created after this migration
+are populated by `embedding_manager.register_embedding_model`, so no collection is left
+without a default row.
 
 Downgrade empties the table. It is not lossy at this revision: `embedding_model` still
 carries `collection_id`, so the default can be re-derived from the same oldest-model
@@ -48,8 +46,8 @@ def downgrade() -> None:
 def _backfill_defaults() -> None:
     """Seed one default per collection: its oldest embedding model.
 
-    `DISTINCT ON` keeps the first row per `collection_id` under the `ORDER BY`, which
-    reproduces the old `created_at ASC, embedding_model_id ASC` tie-break exactly.
+    `DISTINCT ON` keeps the first row per `collection_id` under the `ORDER BY`, so the
+    `created_at ASC, embedding_model_id ASC` tie-break selects the oldest model.
     """
     op.get_bind().execute(
         sa.text(

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -16,10 +16,14 @@ _HANDLED_TABLES_COUNT = 25
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)
 # - two_dim_embeddings (cached projections, regenerated as needed)
-# - default_embedding_space (created empty; nothing writes it yet)
-# TODO(Michal, 08/2026): Move default_embedding_space into deep_copy and delete_dataset
-# (copy/delete its rows per collection) and shift it into _HANDLED_TABLES_COUNT once the
-# write path lands.
+# - default_embedding_space (excluded here, but the write path has now landed, so it is
+#   populated in Postgres — see the TODO below)
+# TODO(Michal, 08/2026): default_embedding_space is now written (backfill +
+# register_embedding_model), but deep_copy and delete_dataset still ignore it. Until PR2 wires
+# them up, on Postgres delete_dataset raises an FK error for any dataset with embeddings (its rows
+# still reference embedding_model/collection) and deep_copy silently drops the copied collection's
+# default. PR2 must: delete its rows in delete_dataset.py, copy them in deep_copy.py, and move it
+# into _HANDLED_TABLES_COUNT. This break is acceptable only because PR1b and PR2 ship together.
 _EXCLUDED_TABLES_COUNT = 3
 
 _TOTAL_TABLES_COUNT = _HANDLED_TABLES_COUNT + _EXCLUDED_TABLES_COUNT

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -16,14 +16,11 @@ _HANDLED_TABLES_COUNT = 25
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)
 # - two_dim_embeddings (cached projections, regenerated as needed)
-# - default_embedding_space (excluded here, but the write path has now landed, so it is
-#   populated in Postgres — see the TODO below)
-# TODO(Michal, 08/2026): default_embedding_space is now written (backfill +
-# register_embedding_model), but deep_copy and delete_dataset still ignore it. Until PR2 wires
-# them up, on Postgres delete_dataset raises an FK error for any dataset with embeddings (its rows
-# still reference embedding_model/collection) and deep_copy silently drops the copied collection's
-# default. PR2 must: delete its rows in delete_dataset.py, copy them in deep_copy.py, and move it
-# into _HANDLED_TABLES_COUNT. This break is acceptable only because PR1b and PR2 ship together.
+# - default_embedding_space (populated, but not yet handled by deep_copy/delete_dataset — see TODO)
+# TODO(Michal, 08/2026): wire default_embedding_space into deep_copy and delete_dataset,
+# then move it into _HANDLED_TABLES_COUNT. Until then, on Postgres delete_dataset raises an
+# FK error for any dataset with embeddings, and deep_copy silently drops the copied
+# collection's default.
 _EXCLUDED_TABLES_COUNT = 3
 
 _TOTAL_TABLES_COUNT = _HANDLED_TABLES_COUNT + _EXCLUDED_TABLES_COUNT

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from sqlmodel import Session, col, select
 
+from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import (
     EmbeddingModelCreate,
     EmbeddingModelTable,
@@ -58,20 +59,19 @@ def get_default_by_collection_id(
 ) -> EmbeddingModelTable | None:
     """Return the collection's default embedding model, or None if it has none.
 
-    The default is the oldest model (``created_at`` ascending), which makes the choice
-    deterministic when a collection has multiple embedding models. Endpoints that resolve
-    a selection against a cached 2D projection (embeddings2d, embedding regions) must all
-    agree on this same model so the projections line up. ``embedding_model_id`` breaks ties
-    when models share the same ``created_at`` (e.g. bulk-created in one transaction).
+    The default is read from the ``default_embedding_space`` table (one row per
+    collection). Endpoints that resolve a selection against a cached 2D projection
+    (embeddings2d, embedding regions) must all agree on this same model so the
+    projections line up.
     """
     return session.exec(
         select(EmbeddingModelTable)
-        .where(EmbeddingModelTable.collection_id == collection_id)
-        .order_by(
-            col(EmbeddingModelTable.created_at).asc(),
-            col(EmbeddingModelTable.embedding_model_id).asc(),
+        .join(
+            DefaultEmbeddingSpaceTable,
+            onclause=col(DefaultEmbeddingSpaceTable.embedding_model_id)
+            == col(EmbeddingModelTable.embedding_model_id),
         )
-        .limit(1)
+        .where(DefaultEmbeddingSpaceTable.collection_id == collection_id)
     ).first()
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -6,7 +6,6 @@ from uuid import UUID
 
 from sqlmodel import Session, col, select
 
-from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import (
     EmbeddingModelCreate,
     EmbeddingModelTable,
@@ -52,27 +51,6 @@ def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[Embe
         .order_by(col(EmbeddingModelTable.created_at).asc())
     ).all()
     return list(embedding_models)
-
-
-def get_default_by_collection_id(
-    session: Session, collection_id: UUID
-) -> EmbeddingModelTable | None:
-    """Return the collection's default embedding model, or None if it has none.
-
-    The default is read from the ``default_embedding_space`` table (one row per
-    collection). Endpoints that resolve a selection against a cached 2D projection
-    (embeddings2d, embedding regions) must all agree on this same model so the
-    projections line up.
-    """
-    return session.exec(
-        select(EmbeddingModelTable)
-        .join(
-            DefaultEmbeddingSpaceTable,
-            onclause=col(DefaultEmbeddingSpaceTable.embedding_model_id)
-            == col(EmbeddingModelTable.embedding_model_id),
-        )
-        .where(DefaultEmbeddingSpaceTable.collection_id == collection_id)
-    ).first()
 
 
 def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable | None:

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -15,7 +15,7 @@ from numpy.typing import NDArray
 from sqlmodel import Session
 
 from lightly_studio.models.embedding_region import EmbeddingRegion
-from lightly_studio.resolvers import embedding_model_resolver, twodim_embedding_resolver
+from lightly_studio.resolvers import default_embedding_space_resolver, twodim_embedding_resolver
 
 
 def get_sample_ids_in_region(
@@ -28,17 +28,17 @@ def get_sample_ids_in_region(
     # so the region is tested against the exact projection the user lassoed over.
     # TODO(Kondrat, 07/2026): Select the embedding model via API parameter once supported,
     # matching embeddings2d.get_2d_embeddings.
-    embedding_model = embedding_model_resolver.get_default_by_collection_id(
+    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
         session=session,
         collection_id=collection_id,
     )
-    if embedding_model is None:
+    if embedding_model_id is None:
         return []
 
     x_array, y_array, sample_ids = twodim_embedding_resolver.get_twodim_embeddings(
         session=session,
         collection_id=collection_id,
-        embedding_model_id=embedding_model.embedding_model_id,
+        embedding_model_id=embedding_model_id,
     )
     if len(sample_ids) == 0:
         return []

--- a/lightly_studio/tests/api/routes/api/test_collection_tag.py
+++ b/lightly_studio/tests/api/routes/api/test_collection_tag.py
@@ -156,6 +156,7 @@ def test_add_samples_by_filter__image_filter_with_embedding_region_tags_only_reg
         session=db_session,
         collection_id=collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
     # Two samples inside the square region [0,10]x[0,10], one far outside.
     images = create_samples_with_embeddings(
@@ -252,6 +253,7 @@ def test_add_samples_by_filter__annotations_filter_with_embedding_region_tags_on
         session=db_session,
         collection_id=annotation_collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
     create_sample_embedding(
         session=db_session,

--- a/lightly_studio/tests/api/routes/api/test_embeddings2d.py
+++ b/lightly_studio/tests/api/routes/api/test_embeddings2d.py
@@ -170,6 +170,7 @@ def test_get_embeddings2d__with_video_filter(
         collection_id=collection_id,
         embedding_model_name="model_a",
         embedding_dimension=EMBEDDING_DIMENSION,
+        set_as_default=True,
     )
 
     # Create videos

--- a/lightly_studio/tests/api/routes/api/test_embeddings2d__color_by.py
+++ b/lightly_studio/tests/api/routes/api/test_embeddings2d__color_by.py
@@ -804,7 +804,7 @@ def test_get_embeddings2d__annotation_collection_color_by_own_label(
     ]
     image = create_image(session=db_session, collection_id=collection.collection_id)
     embedding_model = create_embedding_model(
-        session=db_session, collection_id=annotation_collection_id
+        session=db_session, collection_id=annotation_collection_id, set_as_default=True
     )
     annotations = []
     for i, label in enumerate(annotation_labels):

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -38,6 +38,7 @@ from lightly_studio.resolvers import (
     annotation_resolver,
     caption_resolver,
     collection_resolver,
+    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -304,9 +305,16 @@ def create_embedding_model(  # noqa: PLR0913
     embedding_model_hash: str = "example_hash",
     parameter_count_in_mb: int = 100,
     embedding_dimension: int = 128,
+    set_as_default: bool = False,
 ) -> EmbeddingModelTable:
-    """Helper function to create a embedding model."""
-    return embedding_model_resolver.create(
+    """Helper function to create a embedding model.
+
+    With ``set_as_default`` the model is recorded as the collection's default embedding
+    model, so ``get_default_by_collection_id`` resolves to it. It is off by default to
+    avoid the ``default_embedding_space`` foreign key blocking model or collection deletes
+    in tests that do not need a default.
+    """
+    model = embedding_model_resolver.create(
         session=session,
         embedding_model=EmbeddingModelCreate(
             collection_id=collection_id,
@@ -316,6 +324,13 @@ def create_embedding_model(  # noqa: PLR0913
             embedding_dimension=embedding_dimension,
         ),
     )
+    if set_as_default:
+        default_embedding_space_resolver.set_default(
+            session=session,
+            collection_id=collection_id,
+            embedding_model_id=model.embedding_model_id,
+        )
+    return model
 
 
 def create_sample_embedding(
@@ -404,11 +419,14 @@ def fill_db_with_samples_and_embeddings(
     """Creates a collection and fills it with sample and embeddings."""
     collection = create_collection(session)
     embedding_models = []
-    for embedding_model_name in embedding_model_names:
+    for index, embedding_model_name in enumerate(embedding_model_names):
         embedding_model = create_embedding_model(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=embedding_model_name,
+            # The first model is the collection default, matching production and the
+            # queries that resolve get_default_by_collection_id (e.g. embeddings2d).
+            set_as_default=index == 0,
         )
         embedding_models.append(embedding_model)
     for i in range(n_samples):
@@ -446,11 +464,14 @@ def fill_db_with_video_samples_and_embeddings(
     """
     collection = create_collection(session=session, sample_type=SampleType.VIDEO)
     embedding_models = []
-    for embedding_model_name in embedding_model_names:
+    for index, embedding_model_name in enumerate(embedding_model_names):
         embedding_model = create_embedding_model(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=embedding_model_name,
+            # The first model is the collection default, matching production and the
+            # queries that resolve get_default_by_collection_id (e.g. embeddings2d).
+            set_as_default=index == 0,
         )
         embedding_models.append(embedding_model)
     for i in range(n_samples):

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -310,9 +310,9 @@ def create_embedding_model(  # noqa: PLR0913
     """Helper function to create a embedding model.
 
     With ``set_as_default`` the model is recorded as the collection's default embedding
-    model, so ``get_default_by_collection_id`` resolves to it. It is off by default to
-    avoid the ``default_embedding_space`` foreign key blocking model or collection deletes
-    in tests that do not need a default.
+    model, so ``default_embedding_space_resolver.get_by_collection_id`` resolves to it. It
+    is off by default to avoid the ``default_embedding_space`` foreign key blocking model
+    or collection deletes in tests that do not need a default.
     """
     model = embedding_model_resolver.create(
         session=session,
@@ -425,7 +425,7 @@ def fill_db_with_samples_and_embeddings(
             collection_id=collection.collection_id,
             embedding_model_name=embedding_model_name,
             # The first model is the collection default, matching production and the
-            # queries that resolve get_default_by_collection_id (e.g. embeddings2d).
+            # queries that resolve the default embedding space (e.g. embeddings2d).
             set_as_default=index == 0,
         )
         embedding_models.append(embedding_model)
@@ -470,7 +470,7 @@ def fill_db_with_video_samples_and_embeddings(
             collection_id=collection.collection_id,
             embedding_model_name=embedding_model_name,
             # The first model is the collection default, matching production and the
-            # queries that resolve get_default_by_collection_id (e.g. embeddings2d).
+            # queries that resolve the default embedding space (e.g. embeddings2d).
             set_as_default=index == 0,
         )
         embedding_models.append(embedding_model)

--- a/lightly_studio/tests/resolvers/collection_resolver/test_export.py
+++ b/lightly_studio/tests/resolvers/collection_resolver/test_export.py
@@ -96,6 +96,7 @@ def _setup_embedding_region(
         session=db_session,
         collection_id=collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
     image_a, image_b, image_c = create_samples_with_embeddings(
         session=db_session,

--- a/lightly_studio/tests/resolvers/image_resolver/annotation_count_helpers/test_resolve_embedding_region.py
+++ b/lightly_studio/tests/resolvers/image_resolver/annotation_count_helpers/test_resolve_embedding_region.py
@@ -105,6 +105,7 @@ def _create_collection_with_embedded_samples(
         session=session,
         collection_id=collection.collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
     images = helpers_resolvers.create_samples_with_embeddings(
         session=session,

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
@@ -1097,6 +1097,7 @@ def _setup_collection_with_2d_coordinates(
         session=session,
         collection_id=collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
     images = create_samples_with_embeddings(
         session=session,
@@ -1185,6 +1186,7 @@ def test_get_all_by_collection_id__embedding_region_combined_with_dimension_filt
         session=db_session,
         collection_id=collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
     # Two samples fall inside the region below, but only one also satisfies the width filter.
     images = create_samples_with_embeddings(

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_for_export.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_for_export.py
@@ -86,6 +86,7 @@ def test_get_for_export__with_embedding_region_filter(db_session: Session) -> No
         session=db_session,
         collection_id=collection.collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
 
     image_inside1 = create_image(

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -72,7 +72,7 @@ def test_get_default_by_collection_id__returns_recorded_default(db_session: Sess
         embedding_model_name="chosen",
         embedding_model_hash="hash_chosen",
     )
-    # The first model is the default until set_default overrides it.
+    # Distinct ids, so the assertion below confirms set_default picked this one.
     assert first.embedding_model_id != chosen.embedding_model_id
     default_embedding_space_resolver.set_default(
         session=db_session,

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -4,7 +4,7 @@ import pytest
 from sqlmodel import Session
 
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
-from lightly_studio.resolvers import default_embedding_space_resolver, embedding_model_resolver
+from lightly_studio.resolvers import embedding_model_resolver
 from tests.helpers_resolvers import (
     create_collection,
     create_embedding_model,
@@ -45,46 +45,6 @@ def test_read_embedding_models(db_session: Session) -> None:
 
     assert embedding_models[0].embedding_model_id == embedding_model_1.embedding_model_id
     assert embedding_models[1].embedding_model_id == embedding_model_2.embedding_model_id
-
-
-def test_get_default_by_collection_id__none_when_no_default(db_session: Session) -> None:
-    """A collection with no default row resolves to None."""
-    collection = create_collection(session=db_session)
-
-    default = embedding_model_resolver.get_default_by_collection_id(
-        session=db_session, collection_id=collection.collection_id
-    )
-    assert default is None
-
-
-def test_get_default_by_collection_id__returns_recorded_default(db_session: Session) -> None:
-    """The default is the model recorded in default_embedding_space."""
-    collection = create_collection(session=db_session)
-    first = create_embedding_model(
-        session=db_session,
-        collection_id=collection.collection_id,
-        embedding_model_name="first",
-        embedding_model_hash="hash_first",
-    )
-    chosen = create_embedding_model(
-        session=db_session,
-        collection_id=collection.collection_id,
-        embedding_model_name="chosen",
-        embedding_model_hash="hash_chosen",
-    )
-    # Distinct ids, so the assertion below confirms set_default picked this one.
-    assert first.embedding_model_id != chosen.embedding_model_id
-    default_embedding_space_resolver.set_default(
-        session=db_session,
-        collection_id=collection.collection_id,
-        embedding_model_id=chosen.embedding_model_id,
-    )
-
-    default = embedding_model_resolver.get_default_by_collection_id(
-        session=db_session, collection_id=collection.collection_id
-    )
-    assert default is not None
-    assert default.embedding_model_id == chosen.embedding_model_id
 
 
 def test_read_embedding_model(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -4,7 +4,7 @@ import pytest
 from sqlmodel import Session
 
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
-from lightly_studio.resolvers import embedding_model_resolver
+from lightly_studio.resolvers import default_embedding_space_resolver, embedding_model_resolver
 from tests.helpers_resolvers import (
     create_collection,
     create_embedding_model,
@@ -45,6 +45,46 @@ def test_read_embedding_models(db_session: Session) -> None:
 
     assert embedding_models[0].embedding_model_id == embedding_model_1.embedding_model_id
     assert embedding_models[1].embedding_model_id == embedding_model_2.embedding_model_id
+
+
+def test_get_default_by_collection_id__none_when_no_default(db_session: Session) -> None:
+    """A collection with no default row resolves to None."""
+    collection = create_collection(session=db_session)
+
+    default = embedding_model_resolver.get_default_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    )
+    assert default is None
+
+
+def test_get_default_by_collection_id__returns_recorded_default(db_session: Session) -> None:
+    """The default is the model recorded in default_embedding_space."""
+    collection = create_collection(session=db_session)
+    first = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="first",
+        embedding_model_hash="hash_first",
+    )
+    chosen = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="chosen",
+        embedding_model_hash="hash_chosen",
+    )
+    # The first model is the default until set_default overrides it.
+    assert first.embedding_model_id != chosen.embedding_model_id
+    default_embedding_space_resolver.set_default(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=chosen.embedding_model_id,
+    )
+
+    default = embedding_model_resolver.get_default_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    )
+    assert default is not None
+    assert default.embedding_model_id == chosen.embedding_model_id
 
 
 def test_read_embedding_model(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_region_resolver.py
@@ -132,6 +132,7 @@ def _setup_collection_with_coordinates(
         session=session,
         collection_id=collection.collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
     images = helpers_resolvers.create_samples_with_embeddings(
         session=session,


### PR DESCRIPTION
## What has changed and why?

Switches a collection's default embedding space from the on-the-fly "oldest model" derivation to the `default_embedding_space` table, and keeps the table populated. Behaviour-preserving.

- `get_default_by_collection_id` now reads the table; return type unchanged, so the embeddings2d and embedding-region callers are untouched.
- `embedding_manager.register_embedding_model` persists the default via `set_default` (in-memory generator cache stays the runtime lookup).
- Alembic revision `b1c2d3e4f5a6`: backfill each collection's current default (oldest model). Paired with the write-path change in the same release, so no collection is left without a default row.
- Downgrade empties the table; not lossy — `embedding_model.collection_id` still exists at this revision.
- Test helper `create_embedding_model` gains an opt-in `set_as_default`; default-resolving call sites opt in.

Stacked on #2030 — review/merge that first. Base retargets to `main` once #2030 lands.

## How has it been tested?

- `make static-checks` (ruff, mypy, format).
- `pytest` on the embedding resolver / manager / embeddings2d suite — 59 pass, 4 skipped.
- Single alembic head `b1c2d3e4f5a6`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent default embedding-space selection for each collection.
  * Existing collections are automatically assigned a default based on their earliest embedding model.
  * New embedding models can be explicitly designated as the collection default.

* **Bug Fixes**
  * 2D embedding and embedding-region views now consistently use the collection’s configured default embedding space.
  * Views gracefully return no results when a default embedding space is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->