### PR TITLE
Place nulls last for every sort expression

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from uuid import UUID
 
 import sqlalchemy
-from sqlalchemy import ColumnElement, and_, case, func, nullslast, or_
+from sqlalchemy import ColumnElement, and_, case, func, or_
 from sqlalchemy import Select as SQLAlchemySelect
 from sqlalchemy.engine import Row
 from sqlalchemy.orm import Mapped, aliased
@@ -75,11 +75,13 @@ class OrderByExpression(ABC):
         For use in ``query.order_by()`` or window ``over(order_by=...)``. Usually a
         single element; a sort may return several when one key cannot express the
         required ordering. Does not apply joins; call ``apply`` first when joins are
-        required.
+        required. NULLs always sort last, so DuckDB and PostgreSQL — which disagree on
+        the default placement — order nullable fields the same way.
         """
-        if self.ascending:
-            return [expr.asc() for expr in self._sort_key_expressions()]
-        return [expr.desc() for expr in self._sort_key_expressions()]
+        directed: list[ColumnElement[Any]] = [
+            expr.asc() if self.ascending else expr.desc() for expr in self._sort_key_expressions()
+        ]
+        return [sqlalchemy.nullslast(element) for element in directed]
 
     def apply(self, query: SelectOfScalar[T]) -> SelectOfScalar[T]:
         """Apply joins for this sort and append the ``ORDER BY``.
@@ -190,10 +192,6 @@ class OrderByMetadataField(OrderByExpression):
     def _sort_key_expressions(self) -> list[ColumnElement[Any]]:
         """Return the numerical key, NULL for non-numerical fields, then the text value."""
         return [self._order_value_expression(), self._extracted_value()]
-
-    def to_column_elements(self) -> list[ColumnElement[Any]]:
-        """Pin NULLs last; the two dialects disagree on where they go by default."""
-        return [sqlalchemy.nullslast(element) for element in super().to_column_elements()]
 
     def _is_numerical_field(self) -> ColumnElement[bool]:
         """Return whether ``metadata_schema`` records this field as a number.
@@ -311,10 +309,6 @@ class OrderByAnnotationEvaluationMetricField(OrderByExpression):
         self.annotation_id_column = annotation_id_column
         # Per-instance alias so this join cannot collide with a filter join on the same table.
         self._metric_alias = aliased(EvaluationAnnotationMetricTable)
-
-    def to_column_elements(self) -> list[ColumnElement[Any]]:
-        """Return the sort keys with direction applied and nulls placed last."""
-        return [nullslast(element) for element in super().to_column_elements()]
 
     def _order_value_expression(self) -> ColumnElement[Any]:
         """Return the metric value, zero when the row is unmatched, null when absent."""

--- a/lightly_studio/tests/core/dataset_query/test_order_by.py
+++ b/lightly_studio/tests/core/dataset_query/test_order_by.py
@@ -49,17 +49,17 @@ class TestOrderByField:
         returned_query = order_by.apply(query)
 
         sql = str(returned_query.compile(compile_kwargs={"literal_binds": True})).lower()
-        assert "order by image.file_name asc" in sql
+        assert "order by image.file_name asc nulls last" in sql
 
     def test_apply__descending(self) -> None:
-        """Test descending ordering via desc() method."""
+        """Descending ordering pins NULLs last, which DuckDB and PostgreSQL default differently."""
         query = select(ImageTable)
         order_by = OrderByField(ImageSampleField.file_name).desc()
 
         returned_query = order_by.apply(query)
 
         sql = str(returned_query.compile(compile_kwargs={"literal_binds": True})).lower()
-        assert "order by image.file_name desc" in sql
+        assert "order by image.file_name desc nulls last" in sql
 
     def test_apply__desc_then_asc(self) -> None:
         """Test that desc().asc() returns to ascending order."""
@@ -69,7 +69,7 @@ class TestOrderByField:
         returned_query = order_by.apply(query)
 
         sql = str(returned_query.compile(compile_kwargs={"literal_binds": True})).lower()
-        assert "order by image.file_name asc" in sql
+        assert "order by image.file_name asc nulls last" in sql
 
 
 class TestOrderByMetadataField:
@@ -206,7 +206,7 @@ class TestOrderByEvaluationMetricField:
         assert "left outer join evaluation_run" in sql
         assert "left outer join evaluation_sample_metric" in sql
         assert "evaluation_sample_metric_1.metric_name = 'score'" in sql
-        assert "order by evaluation_sample_metric_1.value asc" in sql
+        assert "order by evaluation_sample_metric_1.value asc nulls last" in sql
 
     def test_apply__descending(self) -> None:
         """Test descending ordering via desc() method."""
@@ -218,7 +218,7 @@ class TestOrderByEvaluationMetricField:
         sql = str(
             returned_query.compile(dialect=self.dialect, compile_kwargs={"literal_binds": True})
         ).lower()
-        assert "order by evaluation_sample_metric_1.value desc" in sql
+        assert "order by evaluation_sample_metric_1.value desc nulls last" in sql
 
     def test_apply__desc_then_asc(self) -> None:
         """Test that desc().asc() returns to ascending order."""
@@ -230,7 +230,7 @@ class TestOrderByEvaluationMetricField:
         sql = str(
             returned_query.compile(dialect=self.dialect, compile_kwargs={"literal_binds": True})
         ).lower()
-        assert "order by evaluation_sample_metric_1.value asc" in sql
+        assert "order by evaluation_sample_metric_1.value asc nulls last" in sql
 
     def test_to_column_elements__ascending(self) -> None:
         """Test that to_column_elements returns only the column element without any JOIN."""
@@ -239,7 +239,7 @@ class TestOrderByEvaluationMetricField:
         (col_element,) = order_by.to_column_elements()
 
         sql = str(col_element.compile(compile_kwargs={"literal_binds": True})).lower()
-        assert "evaluation_sample_metric_1.value asc" in sql
+        assert "evaluation_sample_metric_1.value asc nulls last" in sql
         assert "join" not in sql
 
 


### PR DESCRIPTION
## What has changed and why?

The base sort expression applied direction but never pinned NULL placement, so a `DESC` sort on a nullable column ordered NULLs first on PostgreSQL and last on DuckDB — the same request, two different first rows. `OrderByExpression` now pins NULLs last by default (with a `nulls_last` flag), and the two subclasses that used to paste their own `nullslast` wrapper drop it. This also fixes the evaluation-metric sort, whose docstring promised NULLs-last but never applied it.

First of a four-PR split of the video `sort_by` work. The nullable case surfaces there (video `duration_s`), but the fix is engine-level and stands alone.

## How has it been tested?

`make test` on the ordering suites. The `OrderByField` and evaluation-metric SQL-text assertions now expect `nulls last` — dialect-agnostic guards that fail if the wrapping is removed.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sorting now consistently places missing values last for ascending and descending orders.
  * Image filename and evaluation metric sorting now apply consistent missing-value behavior across ordering variations.
  * Ordering behavior is more consistent across supported database environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->