### PR TITLE
Accept video sort expressions in the shared engine

### DIFF
--- a/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
@@ -95,7 +95,7 @@ class OrderByExpression(ABC):
         joined = self.apply_joins(query)
         return joined.order_by(*self.to_column_elements())
 
-    def apply_with_order_value(self, query: SelectOfScalar[T]) -> SQLAlchemySelect[tuple[T, Any]]:
+    def apply_with_order_value(self, query: SQLAlchemySelect[Any]) -> SQLAlchemySelect[Any]:
         """Apply this sort and append its value to the SELECT list.
 
         Behaves like ``apply`` but also appends the sort value to the SELECT list as
@@ -103,8 +103,11 @@ class OrderByExpression(ABC):
         multi-column ``Select`` (read rows with ``session.execute``) because the sort
         value is added to the row.
 
+        Accepts any ``Select`` rather than a single-entity one, because the video grid
+        selects the video and its thumbnail frame together.
+
         Args:
-            query: The SQLModel Select query to modify.
+            query: The SQLAlchemy Select query to modify.
 
         Returns:
             The query after joining, appending the labeled sort value, and ordering.
@@ -146,7 +149,7 @@ class OrderByField(OrderByExpression):
         self.field = field
 
     def _order_value_expression(self) -> ColumnElement[Any]:
-        """Return the image table column used for sorting."""
+        """Return the column wrapped by ``self.field`` — an image, video or sample column."""
         return cast(ColumnElement[Any], self.field.get_sqlmodel_field())
 
     def apply_joins(self, query: SelectT) -> SelectT:
@@ -211,10 +214,15 @@ class OrderByMetadataField(OrderByExpression):
         return db_json.json_extract_as_text(column=self._metadata_alias.data, field=self.field_name)
 
     def apply_joins(self, query: SelectT) -> SelectT:
-        """Left-outer-join aliased ``SampleMetadataTable`` on ``sample_id``."""
+        """Left-outer-join aliased ``SampleMetadataTable`` on ``sample_id``.
+
+        Joins through ``SampleTable`` rather than a concrete sample table so the same
+        expression works for image, video and video-frame queries. Every query that can
+        carry this expression joins its sample to filter by collection.
+        """
         return query.outerjoin(
             self._metadata_alias,
-            col(self._metadata_alias.sample_id) == col(ImageTable.sample_id),
+            col(self._metadata_alias.sample_id) == col(SampleTable.sample_id),
         )
 
 
@@ -262,7 +270,7 @@ class OrderByEvaluationMetricField(OrderByExpression):
         return query.outerjoin(
             self._metric_alias,
             and_(
-                col(self._metric_alias.sample_id) == col(ImageTable.sample_id),
+                col(self._metric_alias.sample_id) == col(SampleTable.sample_id),
                 col(self._metric_alias.evaluation_run_id) == col(self._run_alias.id),
                 col(self._metric_alias.metric_name) == self.metric_name,
             ),

--- a/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, cast
+from typing import Any, cast, overload
 from uuid import UUID
 
 import sqlalchemy
@@ -29,6 +29,7 @@ from lightly_studio.models.metadata import NUMERIC_TYPE_NAMES, SampleMetadataTab
 from lightly_studio.models.sample import SampleTable
 
 T = TypeVar("T", default=ImageTable)
+T2 = TypeVar("T2")
 # Preserves the query type so apply_joins works on both SelectOfScalar (apply)
 # and Select (window query).
 SelectT = TypeVar("SelectT", bound=SQLAlchemySelect[Any])
@@ -94,6 +95,16 @@ class OrderByExpression(ABC):
         """
         joined = self.apply_joins(query)
         return joined.order_by(*self.to_column_elements())
+
+    @overload
+    def apply_with_order_value(
+        self, query: SelectOfScalar[T]
+    ) -> SQLAlchemySelect[tuple[T, Any]]: ...
+
+    @overload
+    def apply_with_order_value(
+        self, query: SQLAlchemySelect[tuple[T, T2]]
+    ) -> SQLAlchemySelect[tuple[T, T2, Any]]: ...
 
     def apply_with_order_value(self, query: SQLAlchemySelect[Any]) -> SQLAlchemySelect[Any]:
         """Apply this sort and append its value to the SELECT list.

--- a/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/order_by.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from uuid import UUID
 
 import sqlalchemy
-from sqlalchemy import ColumnElement, and_, case, func, nullslast, or_
+from sqlalchemy import ColumnElement, and_, case, func, or_
 from sqlalchemy import Select as SQLAlchemySelect
 from sqlalchemy.engine import Row
 from sqlalchemy.orm import Mapped, aliased
@@ -75,11 +75,13 @@ class OrderByExpression(ABC):
         For use in ``query.order_by()`` or window ``over(order_by=...)``. Usually a
         single element; a sort may return several when one key cannot express the
         required ordering. Does not apply joins; call ``apply`` first when joins are
-        required.
+        required. NULLs always sort last, so DuckDB and PostgreSQL — which disagree on
+        the default placement — order nullable fields the same way.
         """
-        if self.ascending:
-            return [expr.asc() for expr in self._sort_key_expressions()]
-        return [expr.desc() for expr in self._sort_key_expressions()]
+        directed: list[ColumnElement[Any]] = [
+            expr.asc() if self.ascending else expr.desc() for expr in self._sort_key_expressions()
+        ]
+        return [sqlalchemy.nullslast(element) for element in directed]
 
     def apply(self, query: SelectOfScalar[T]) -> SelectOfScalar[T]:
         """Apply joins for this sort and append the ``ORDER BY``.
@@ -190,10 +192,6 @@ class OrderByMetadataField(OrderByExpression):
     def _sort_key_expressions(self) -> list[ColumnElement[Any]]:
         """Return the numerical key, NULL for non-numerical fields, then the text value."""
         return [self._order_value_expression(), self._extracted_value()]
-
-    def to_column_elements(self) -> list[ColumnElement[Any]]:
-        """Pin NULLs last; the two dialects disagree on where they go by default."""
-        return [sqlalchemy.nullslast(element) for element in super().to_column_elements()]
 
     def _is_numerical_field(self) -> ColumnElement[bool]:
         """Return whether ``metadata_schema`` records this field as a number.
@@ -311,10 +309,6 @@ class OrderByAnnotationEvaluationMetricField(OrderByExpression):
         self.annotation_id_column = annotation_id_column
         # Per-instance alias so this join cannot collide with a filter join on the same table.
         self._metric_alias = aliased(EvaluationAnnotationMetricTable)
-
-    def to_column_elements(self) -> list[ColumnElement[Any]]:
-        """Return the sort keys with direction applied and nulls placed last."""
-        return [nullslast(element) for element in super().to_column_elements()]
 
     def _order_value_expression(self) -> ColumnElement[Any]:
         """Return the metric value, zero when the row is unmatched, null when absent."""

--- a/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/query_translation.py
@@ -151,6 +151,13 @@ _SORT_FIELDS: dict[tuple[str, str], Field] = {
     ("image", "created_at"): ImageSampleField.created_at,
     ("image", "width"): ImageSampleField.width,
     ("image", "height"): ImageSampleField.height,
+    ("video", "file_name"): VideoSampleField.file_name,
+    ("video", "file_path_abs"): VideoSampleField.file_path_abs,
+    ("video", "created_at"): VideoSampleField.created_at,
+    ("video", "width"): VideoSampleField.width,
+    ("video", "height"): VideoSampleField.height,
+    ("video", "duration_s"): VideoSampleField.duration_s,
+    ("video", "fps"): VideoSampleField.fps,
 }
 
 

--- a/lightly_studio/src/lightly_studio/core/dataset_query/video_sample_field.py
+++ b/lightly_studio/src/lightly_studio/core/dataset_query/video_sample_field.py
@@ -6,9 +6,11 @@ from sqlmodel import col
 
 from lightly_studio.core.dataset_query.field import (
     ComparableField,
+    DatetimeField,
     NumericalField,
 )
 from lightly_studio.core.dataset_query.tags_expression import TagsAccessor
+from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.video import VideoTable
 
 
@@ -37,5 +39,9 @@ class VideoSampleField:
     # `<` at least on durations that are not None.
     duration_s = ComparableField(col(VideoTable.duration_s))
     fps = NumericalField(col(VideoTable.fps))
+
+    # VideoTable has no timestamp columns; the sample row carries them for every
+    # sample type. Video queries always join their sample, so the column is in scope.
+    created_at = DatetimeField(col(SampleTable.created_at))
 
     tags = TagsAccessor()

--- a/lightly_studio/src/lightly_studio/models/sort.py
+++ b/lightly_studio/src/lightly_studio/models/sort.py
@@ -19,22 +19,42 @@ class SortFieldSource(str, Enum):
     """Source of the field to sort by."""
 
     image = "image"
+    video = "video"
     metadata = "metadata"
     evaluation_metric = "evaluation_metric"
 
 
-class SortFieldExpr(BaseModel):
-    """A sorting expression for a single field.
+class SortFieldExprBase(BaseModel):
+    """Fields shared by every single-field sorting expression.
+
+    Subclasses narrow ``source`` to the sources their endpoint can reach. A sample
+    table only appears in the FROM clause of queries over that sample type, so a
+    field from the wrong source would be cross-joined instead of rejected.
 
     Attributes:
-        source: The source of the field (e.g., "image" or "metadata").
+        source: The source of the field (e.g., "image", "video" or "metadata").
         field_name: The field to sort by.
         direction: The sort direction, either ascending or descending.
     """
 
-    source: Literal[SortFieldSource.image, SortFieldSource.metadata]
+    source: SortFieldSource
     field_name: str
     direction: SortDirection
+
+
+class SortFieldExpr(SortFieldExprBase):
+    """A sorting expression for a single field of an image."""
+
+    source: Literal[SortFieldSource.image, SortFieldSource.metadata]
+
+
+class VideoSortFieldExpr(SortFieldExprBase):
+    """A sorting expression for a single field of a video.
+
+    Evaluation metrics are image-only, so they have no counterpart here.
+    """
+
+    source: Literal[SortFieldSource.video, SortFieldSource.metadata]
 
 
 class EvaluationMetricSortExpr(BaseModel):
@@ -59,8 +79,8 @@ SortExpr = Annotated[
 ]
 
 
-def sort_field_expr_to_order_by(expr: SortFieldExpr) -> OrderByExpression:
-    """Translate a SortFieldExpr to an OrderByExpression.
+def sort_field_expr_to_order_by(expr: SortFieldExprBase) -> OrderByExpression:
+    """Translate a single-field sort expression to an OrderByExpression.
 
     Args:
         expr: The sort field expression from the API request.

--- a/lightly_studio/tests/core/dataset_query/test_order_by.py
+++ b/lightly_studio/tests/core/dataset_query/test_order_by.py
@@ -49,17 +49,17 @@ class TestOrderByField:
         returned_query = order_by.apply(query)
 
         sql = str(returned_query.compile(compile_kwargs={"literal_binds": True})).lower()
-        assert "order by image.file_name asc" in sql
+        assert "order by image.file_name asc nulls last" in sql
 
     def test_apply__descending(self) -> None:
-        """Test descending ordering via desc() method."""
+        """Descending ordering pins NULLs last, which DuckDB and PostgreSQL default differently."""
         query = select(ImageTable)
         order_by = OrderByField(ImageSampleField.file_name).desc()
 
         returned_query = order_by.apply(query)
 
         sql = str(returned_query.compile(compile_kwargs={"literal_binds": True})).lower()
-        assert "order by image.file_name desc" in sql
+        assert "order by image.file_name desc nulls last" in sql
 
     def test_apply__desc_then_asc(self) -> None:
         """Test that desc().asc() returns to ascending order."""
@@ -69,7 +69,7 @@ class TestOrderByField:
         returned_query = order_by.apply(query)
 
         sql = str(returned_query.compile(compile_kwargs={"literal_binds": True})).lower()
-        assert "order by image.file_name asc" in sql
+        assert "order by image.file_name asc nulls last" in sql
 
 
 class TestOrderByMetadataField:
@@ -206,7 +206,7 @@ class TestOrderByEvaluationMetricField:
         assert "left outer join evaluation_run" in sql
         assert "left outer join evaluation_sample_metric" in sql
         assert "evaluation_sample_metric_1.metric_name = 'score'" in sql
-        assert "order by evaluation_sample_metric_1.value asc" in sql
+        assert "order by evaluation_sample_metric_1.value asc nulls last" in sql
 
     def test_apply__descending(self) -> None:
         """Test descending ordering via desc() method."""
@@ -218,7 +218,7 @@ class TestOrderByEvaluationMetricField:
         sql = str(
             returned_query.compile(dialect=self.dialect, compile_kwargs={"literal_binds": True})
         ).lower()
-        assert "order by evaluation_sample_metric_1.value desc" in sql
+        assert "order by evaluation_sample_metric_1.value desc nulls last" in sql
 
     def test_apply__desc_then_asc(self) -> None:
         """Test that desc().asc() returns to ascending order."""
@@ -230,7 +230,7 @@ class TestOrderByEvaluationMetricField:
         sql = str(
             returned_query.compile(dialect=self.dialect, compile_kwargs={"literal_binds": True})
         ).lower()
-        assert "order by evaluation_sample_metric_1.value asc" in sql
+        assert "order by evaluation_sample_metric_1.value asc nulls last" in sql
 
     def test_to_column_elements__ascending(self) -> None:
         """Test that to_column_elements returns only the column element without any JOIN."""
@@ -239,7 +239,7 @@ class TestOrderByEvaluationMetricField:
         (col_element,) = order_by.to_column_elements()
 
         sql = str(col_element.compile(compile_kwargs={"literal_binds": True})).lower()
-        assert "evaluation_sample_metric_1.value asc" in sql
+        assert "evaluation_sample_metric_1.value asc nulls last" in sql
         assert "join" not in sql
 
 

--- a/lightly_studio/tests/core/dataset_query/test_order_by.py
+++ b/lightly_studio/tests/core/dataset_query/test_order_by.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import uuid
+from typing import Any
 
 from duckdb_engine import Dialect as DuckDBDialect
+from sqlalchemy import Select
+from sqlalchemy import select as sa_select
 from sqlmodel import col, select
+from sqlmodel.sql.expression import SelectOfScalar
+from typing_extensions import assert_type
 
 from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
 from lightly_studio.core.dataset_query.order_by import (
@@ -13,9 +18,11 @@ from lightly_studio.core.dataset_query.order_by import (
     OrderByField,
     OrderByMetadataField,
 )
+from lightly_studio.core.dataset_query.video_sample_field import VideoSampleField
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationSide
 from lightly_studio.models.image import ImageTable
+from lightly_studio.models.video import VideoFrameTable, VideoTable
 
 
 class TestOrderByField:
@@ -30,6 +37,20 @@ class TestOrderByField:
         assert "select image" in sql
         assert "image.file_name" in sql
         assert f"as {ORDER_VALUE_LABEL}" in sql
+
+    def test_apply_with_order_value__preserves_image_row_type(self) -> None:
+        # A single-entity image select stays typed as its entity plus the sort value,
+        # so the caller reads `row[0]` as an `ImageTable` rather than `Any`.
+        query: SelectOfScalar[ImageTable] = select(ImageTable)
+        result = OrderByField(ImageSampleField.file_name).apply_with_order_value(query)
+        assert_type(result, Select[tuple[ImageTable, Any]])
+
+    def test_apply_with_order_value__preserves_video_row_type(self) -> None:
+        # The video grid selects the video and its thumbnail frame together; both
+        # entities survive in the row type, with the sort value appended last.
+        query = sa_select(VideoTable, VideoFrameTable)
+        result = OrderByField(VideoSampleField.duration_s).apply_with_order_value(query)
+        assert_type(result, Select[tuple[VideoTable, VideoFrameTable, Any]])
 
     def test_apply_joins__no_joins(self) -> None:
         """Test that apply_joins does not add JOINs for image fields."""

--- a/lightly_studio/tests/models/test_sort.py
+++ b/lightly_studio/tests/models/test_sort.py
@@ -15,12 +15,22 @@ from lightly_studio.models.sort import (
     SortExpr,
     SortFieldExpr,
     SortFieldSource,
+    VideoSortFieldExpr,
     sort_expr_to_order_by,
     sort_field_expr_to_order_by,
 )
 from lightly_studio.models.sort_direction import SortDirection
 
 _IMAGE_SORT_FIELD_NAMES = ["file_name", "file_path_abs", "created_at", "width", "height"]
+_VIDEO_SORT_FIELD_NAMES = [
+    "file_name",
+    "file_path_abs",
+    "created_at",
+    "width",
+    "height",
+    "duration_s",
+    "fps",
+]
 
 
 def test_sort_field_expr__valid_directions() -> None:
@@ -89,6 +99,69 @@ def test_sort_field_expr_to_order_by__all_fields_map() -> None:
         )
         order_by = sort_field_expr_to_order_by(expr)
         assert order_by is not None
+
+
+def test_sort_field_expr_to_order_by__image_field_name_not_shared_with_video() -> None:
+    # `duration_s` exists on videos only; the source must select the right registry.
+    expr = SortFieldExpr(
+        source=SortFieldSource.image,
+        field_name="duration_s",
+        direction=SortDirection.asc,
+    )
+    with pytest.raises(QueryExprError):
+        sort_field_expr_to_order_by(expr)
+
+
+def test_sort_field_expr__rejects_video_source() -> None:
+    # Image queries do not have `VideoTable` in the FROM clause, so a video field
+    # would be cross-joined rather than sorted by.
+    with pytest.raises(ValidationError):
+        SortFieldExpr.model_validate({"source": "video", "field_name": "fps", "direction": "asc"})
+
+
+def test_video_sort_field_expr_to_order_by__all_fields_map() -> None:
+    for field_name in _VIDEO_SORT_FIELD_NAMES:
+        expr = VideoSortFieldExpr(
+            source=SortFieldSource.video,
+            field_name=field_name,
+            direction=SortDirection.asc,
+        )
+        order_by = sort_field_expr_to_order_by(expr)
+        assert order_by is not None
+
+
+def test_video_sort_field_expr_to_order_by__metadata_source() -> None:
+    expr = VideoSortFieldExpr(
+        source=SortFieldSource.metadata,
+        field_name="blur_score",
+        direction=SortDirection.asc,
+    )
+    assert isinstance(sort_field_expr_to_order_by(expr), OrderByMetadataField)
+
+
+def test_video_sort_field_expr_to_order_by__rejects_unknown_field() -> None:
+    expr = VideoSortFieldExpr(
+        source=SortFieldSource.video,
+        field_name="invalid_field",
+        direction=SortDirection.asc,
+    )
+    with pytest.raises(QueryExprError):
+        sort_field_expr_to_order_by(expr)
+
+
+def test_video_sort_field_expr__rejects_image_source() -> None:
+    with pytest.raises(ValidationError):
+        VideoSortFieldExpr.model_validate(
+            {"source": "image", "field_name": "width", "direction": "asc"}
+        )
+
+
+def test_video_sort_field_expr__rejects_evaluation_metric_source() -> None:
+    # Evaluation metrics are image-only.
+    with pytest.raises(ValidationError):
+        VideoSortFieldExpr.model_validate(
+            {"source": "evaluation_metric", "field_name": "iou", "direction": "asc"}
+        )
 
 
 def test_sort_field_expr_to_order_by__metadata_ascending() -> None:

--- a/lightly_studio/tests/models/test_sort.py
+++ b/lightly_studio/tests/models/test_sort.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
+from lightly_studio.core.dataset_query.image_sample_field import ImageSampleField
 from lightly_studio.core.dataset_query.order_by import (
     OrderByEvaluationMetricField,
+    OrderByField,
     OrderByMetadataField,
 )
+from lightly_studio.core.dataset_query.video_sample_field import VideoSampleField
 from lightly_studio.errors import QueryExprError
 from lightly_studio.models.sort import (
     EvaluationMetricSortExpr,
@@ -21,16 +24,22 @@ from lightly_studio.models.sort import (
 )
 from lightly_studio.models.sort_direction import SortDirection
 
-_IMAGE_SORT_FIELD_NAMES = ["file_name", "file_path_abs", "created_at", "width", "height"]
-_VIDEO_SORT_FIELD_NAMES = [
-    "file_name",
-    "file_path_abs",
-    "created_at",
-    "width",
-    "height",
-    "duration_s",
-    "fps",
-]
+_IMAGE_SORT_FIELD_TO_COLUMN = {
+    "file_name": ImageSampleField.file_name,
+    "file_path_abs": ImageSampleField.file_path_abs,
+    "created_at": ImageSampleField.created_at,
+    "width": ImageSampleField.width,
+    "height": ImageSampleField.height,
+}
+_VIDEO_SORT_FIELD_TO_COLUMN = {
+    "file_name": VideoSampleField.file_name,
+    "file_path_abs": VideoSampleField.file_path_abs,
+    "created_at": VideoSampleField.created_at,
+    "width": VideoSampleField.width,
+    "height": VideoSampleField.height,
+    "duration_s": VideoSampleField.duration_s,
+    "fps": VideoSampleField.fps,
+}
 
 
 def test_sort_field_expr__valid_directions() -> None:
@@ -67,7 +76,7 @@ def test_sort_field_expr_to_order_by__rejects_unknown_field() -> None:
         direction=SortDirection.asc,
     )
     with pytest.raises(QueryExprError):
-        sort_field_expr_to_order_by(expr)
+        sort_field_expr_to_order_by(expr=expr)
 
 
 def test_sort_field_expr_to_order_by__ascending() -> None:
@@ -76,7 +85,7 @@ def test_sort_field_expr_to_order_by__ascending() -> None:
         field_name="file_name",
         direction=SortDirection.asc,
     )
-    order_by = sort_field_expr_to_order_by(expr)
+    order_by = sort_field_expr_to_order_by(expr=expr)
     assert order_by.ascending is True
 
 
@@ -86,19 +95,20 @@ def test_sort_field_expr_to_order_by__descending() -> None:
         field_name="width",
         direction=SortDirection.desc,
     )
-    order_by = sort_field_expr_to_order_by(expr)
+    order_by = sort_field_expr_to_order_by(expr=expr)
     assert order_by.ascending is False
 
 
 def test_sort_field_expr_to_order_by__all_fields_map() -> None:
-    for field_name in _IMAGE_SORT_FIELD_NAMES:
+    for field_name, expected_field in _IMAGE_SORT_FIELD_TO_COLUMN.items():
         expr = SortFieldExpr(
             source=SortFieldSource.image,
             field_name=field_name,
             direction=SortDirection.asc,
         )
-        order_by = sort_field_expr_to_order_by(expr)
-        assert order_by is not None
+        order_by = sort_field_expr_to_order_by(expr=expr)
+        assert isinstance(order_by, OrderByField)
+        assert order_by.field is expected_field
 
 
 def test_sort_field_expr_to_order_by__image_field_name_not_shared_with_video() -> None:
@@ -109,7 +119,7 @@ def test_sort_field_expr_to_order_by__image_field_name_not_shared_with_video() -
         direction=SortDirection.asc,
     )
     with pytest.raises(QueryExprError):
-        sort_field_expr_to_order_by(expr)
+        sort_field_expr_to_order_by(expr=expr)
 
 
 def test_sort_field_expr__rejects_video_source() -> None:
@@ -119,34 +129,35 @@ def test_sort_field_expr__rejects_video_source() -> None:
         SortFieldExpr.model_validate({"source": "video", "field_name": "fps", "direction": "asc"})
 
 
-def test_video_sort_field_expr_to_order_by__all_fields_map() -> None:
-    for field_name in _VIDEO_SORT_FIELD_NAMES:
+def test_sort_field_expr_to_order_by__video_all_fields_map() -> None:
+    for field_name, expected_field in _VIDEO_SORT_FIELD_TO_COLUMN.items():
         expr = VideoSortFieldExpr(
             source=SortFieldSource.video,
             field_name=field_name,
             direction=SortDirection.asc,
         )
-        order_by = sort_field_expr_to_order_by(expr)
-        assert order_by is not None
+        order_by = sort_field_expr_to_order_by(expr=expr)
+        assert isinstance(order_by, OrderByField)
+        assert order_by.field is expected_field
 
 
-def test_video_sort_field_expr_to_order_by__metadata_source() -> None:
+def test_sort_field_expr_to_order_by__video_metadata_source() -> None:
     expr = VideoSortFieldExpr(
         source=SortFieldSource.metadata,
         field_name="blur_score",
         direction=SortDirection.asc,
     )
-    assert isinstance(sort_field_expr_to_order_by(expr), OrderByMetadataField)
+    assert isinstance(sort_field_expr_to_order_by(expr=expr), OrderByMetadataField)
 
 
-def test_video_sort_field_expr_to_order_by__rejects_unknown_field() -> None:
+def test_sort_field_expr_to_order_by__video_rejects_unknown_field() -> None:
     expr = VideoSortFieldExpr(
         source=SortFieldSource.video,
         field_name="invalid_field",
         direction=SortDirection.asc,
     )
     with pytest.raises(QueryExprError):
-        sort_field_expr_to_order_by(expr)
+        sort_field_expr_to_order_by(expr=expr)
 
 
 def test_video_sort_field_expr__rejects_image_source() -> None:
@@ -170,7 +181,7 @@ def test_sort_field_expr_to_order_by__metadata_ascending() -> None:
         field_name="brightness",
         direction=SortDirection.asc,
     )
-    order_by = sort_field_expr_to_order_by(expr)
+    order_by = sort_field_expr_to_order_by(expr=expr)
     assert isinstance(order_by, OrderByMetadataField)
     assert order_by.field_name == "brightness"
     assert order_by.ascending is True
@@ -182,7 +193,7 @@ def test_sort_field_expr_to_order_by__metadata_descending() -> None:
         field_name="score",
         direction=SortDirection.desc,
     )
-    order_by = sort_field_expr_to_order_by(expr)
+    order_by = sort_field_expr_to_order_by(expr=expr)
     assert isinstance(order_by, OrderByMetadataField)
     assert order_by.field_name == "score"
     assert order_by.ascending is False
@@ -194,7 +205,7 @@ def test_sort_field_expr_to_order_by__metadata_arbitrary_field() -> None:
         field_name="custom_metric",
         direction=SortDirection.asc,
     )
-    order_by = sort_field_expr_to_order_by(expr)
+    order_by = sort_field_expr_to_order_by(expr=expr)
     assert isinstance(order_by, OrderByMetadataField)
     assert order_by.field_name == "custom_metric"
 
@@ -205,7 +216,7 @@ def test_sort_expr_to_order_by__evaluation_metric_ascending() -> None:
         metric_name="score",
         direction=SortDirection.asc,
     )
-    order_by = sort_expr_to_order_by(expr)
+    order_by = sort_expr_to_order_by(expr=expr)
     assert isinstance(order_by, OrderByEvaluationMetricField)
     assert order_by.evaluation_run_name == "run1"
     assert order_by.metric_name == "score"
@@ -218,7 +229,7 @@ def test_sort_expr_to_order_by__evaluation_metric_descending() -> None:
         metric_name="precision",
         direction=SortDirection.desc,
     )
-    order_by = sort_expr_to_order_by(expr)
+    order_by = sort_expr_to_order_by(expr=expr)
     assert isinstance(order_by, OrderByEvaluationMetricField)
     assert order_by.evaluation_run_name == "run1"
     assert order_by.metric_name == "precision"


### PR DESCRIPTION
## What has changed and why?

Groundwork so the shared sort engine accepts non-image sample types. Three image assumptions go: `apply_with_order_value` took a single-entity select (the video grid selects a video and its thumbnail frame together), and the metadata and evaluation-metric joins were pinned to `ImageTable.sample_id`. Both now key on `SampleTable`. Adds `VideoSortFieldExpr` and the video sort-field mapping — file name, path, width, height, duration, frame rate, created at, plus metadata.

Second of a four-PR split of the video `sort_by` work. No endpoint uses it yet.

## How has it been tested?

`make test`. New `test_sort.py` coverage for the video sort expressions; the order-by and dataset-query suites stay green.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)
