### PR TITLE
Add prepare-release workflow: changelog promotion, version bump, release PR

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,174 @@
+name: Prepare Release
+
+# Replaces RELEASE.md steps 3-5 (branch, changelog promotion, version bump,
+# release PR) with one manual dispatch. Public repo, ubuntu-latest, no
+# secrets beyond the default token used to push the branch and open the PR.
+# Publishes nothing - see LIG-10552 for the full spec.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: >-
+          Semver bump. "auto" uses the suggestion computed from which
+          [Unreleased] sections are non-empty (see the job summary).
+        type: choice
+        options: [auto, patch, minor, major]
+        default: auto
+      version:
+        description: >-
+          Explicit version override, e.g. for a release candidate such as
+          1.0.0rc1. Takes precedence over "bump" when set.
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Only one release preparation at a time; never cancel one mid-flight since
+# it pushes a branch and opens a PR.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          # Full history + tags: the coverage checklist below diffs against
+          # the last tag.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set Up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.8.17"
+          enable-cache: true
+
+      - name: Guard against a git-pinned Labelformat
+        run: |
+          python3 scripts/prepare_release.py check-labelformat-pin \
+            --pyproject lightly_studio/pyproject.toml
+
+      - name: Suggest version bump
+        id: suggest
+        # Only needed when the operator left both inputs on their defaults;
+        # an explicit --version or --bump makes the suggestion moot.
+        if: inputs.version == '' && inputs.bump == 'auto'
+        run: |
+          result="$(python3 scripts/prepare_release.py suggest-bump --changelog CHANGELOG.md)"
+          bump="$(printf '%s\n' "$result" | head -n1 | sed 's/^bump=//')"
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Suggested version bump: \`$bump\`"
+            printf '%s\n' "$result" | tail -n +2
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve inputs
+        id: resolved
+        run: |
+          bump="${{ inputs.bump }}"
+          if [ "$bump" = "auto" ]; then
+            # Empty when an explicit --version was given instead (the
+            # "Suggest version bump" step above was skipped) - unused in
+            # that case, compute-version ignores --bump whenever --version
+            # is set.
+            bump="${{ steps.suggest.outputs.bump }}"
+            bump="${bump:-patch}"
+          fi
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+
+          version="$(python3 scripts/prepare_release.py compute-version \
+            --pyproject lightly_studio/pyproject.toml \
+            --bump "$bump" \
+            --version "${{ inputs.version }}")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "### Preparing release v$version" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create release branch
+        run: git checkout -b "release-v${{ steps.resolved.outputs.version }}"
+
+      - name: Promote changelog
+        run: |
+          python3 scripts/prepare_release.py promote-changelog \
+            --changelog CHANGELOG.md \
+            --version "${{ steps.resolved.outputs.version }}" \
+            --date "$(date -u +%F)"
+
+      - name: Bump pyproject.toml version
+        run: |
+          python3 scripts/prepare_release.py bump-pyproject \
+            --pyproject lightly_studio/pyproject.toml \
+            --version "${{ steps.resolved.outputs.version }}"
+
+      - name: Snapshot uv.lock before sync
+        run: cp lightly_studio/uv.lock /tmp/uv.lock.before
+
+      - name: uv sync
+        working-directory: lightly_studio
+        run: uv sync
+
+      - name: Assert uv.lock diff is narrow
+        run: |
+          python3 scripts/prepare_release.py assert-lock-diff \
+            --before /tmp/uv.lock.before \
+            --after lightly_studio/uv.lock \
+            --package lightly-studio
+
+      - name: Confirm exactly the expected files changed
+        run: |
+          changed="$(git status --porcelain | awk '{print $2}' | sort)"
+          expected="$(printf '%s\n' CHANGELOG.md lightly_studio/pyproject.toml lightly_studio/uv.lock | sort)"
+          if [ "$changed" != "$expected" ]; then
+            echo "::error::Unexpected file set changed. Got:"
+            echo "$changed"
+            exit 1
+          fi
+
+      - name: Build coverage checklist (advisory, git-derived, never published)
+        run: |
+          last_tag="$(git describe --tags --abbrev=0 origin/main 2>/dev/null || true)"
+          {
+            if [ -z "$last_tag" ]; then
+              echo "_No previous tag found; skipping coverage checklist._"
+            else
+              echo "Merged commits since \`$last_tag\` - check each has a matching CHANGELOG entry:"
+              echo
+              git log "$last_tag..origin/main" --no-merges --oneline | sed 's/^/- /'
+            fi
+          } > /tmp/coverage_checklist.md
+          cat /tmp/coverage_checklist.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Render PR body
+        run: |
+          python3 scripts/prepare_release.py render-pr-body \
+            --changelog CHANGELOG.md \
+            --version "${{ steps.resolved.outputs.version }}" \
+            --coverage-file /tmp/coverage_checklist.md \
+            --drafting-skipped-reason "the LLM drafting step from LIG-10559 is not wired in yet" \
+            --output /tmp/pr_body.md
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md lightly_studio/pyproject.toml lightly_studio/uv.lock
+          git commit -m "Bump version to ${{ steps.resolved.outputs.version }}"
+          git push origin "release-v${{ steps.resolved.outputs.version }}"
+
+      - name: Open release PR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+            --title "Bump version to ${{ steps.resolved.outputs.version }}" \
+            --body-file /tmp/pr_body.md \
+            --base main \
+            --head "release-v${{ steps.resolved.outputs.version }}"

--- a/lightly_studio/pytest.ini
+++ b/lightly_studio/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-pythonpath = src
+pythonpath =
+    src
+    scripts
 python_files = test_*.py
 
 markers =

--- a/lightly_studio/scripts/prepare_release.py
+++ b/lightly_studio/scripts/prepare_release.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Mechanical steps for preparing a LightlyStudio release.
+
+Backs the `Prepare Release` GitHub Actions workflow
+(`.github/workflows/prepare_release.yml`). Every subcommand does one small,
+independently testable piece of RELEASE.md steps 3-5: promoting the
+changelog, bumping the version, and guarding against a handful of ways that
+can quietly go wrong. See LIG-10552 for the full spec.
+
+Stdlib only, deliberately: this runs on the release-critical path before
+`uv sync`, so it must not itself depend on anything `uv` would need to
+resolve first.
+
+Usage (see `main()` for the full set of subcommands):
+    python scripts/prepare_release.py suggest-bump --changelog CHANGELOG.md
+    python scripts/prepare_release.py promote-changelog --changelog CHANGELOG.md \
+        --version 1.0.6 --date 2026-08-21
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+# Keep a Changelog subsection headings, in the fixed order RELEASE.md and the
+# existing CHANGELOG.md use.
+SUBSECTIONS = ("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security")
+
+# `## [Unreleased]` is the one heading kept unescaped; every released version
+# heading is `## \[X.Y.Z\] - YYYY-MM-DD` (see LIG-10552 for why that split
+# matters). Getting this backwards silently breaks the convention instead of
+# failing loudly, which is exactly what `assert_changelog_structure` guards.
+_UNRELEASED_RE = re.compile(r"^## \[Unreleased\][ \t]*$", re.MULTILINE)
+_ANY_H2_RE = re.compile(r"^## ", re.MULTILINE)
+_SUBSECTION_RE = re.compile(r"^### (?P<name>\w+)[ \t]*$", re.MULTILINE)
+_PYPROJECT_VERSION_RE = re.compile(r'^version = "(?P<version>[^"]+)"$', re.MULTILINE)
+_LOCK_PACKAGE_SPLIT_RE = re.compile(r"(?=^\[\[package\]\]$)", re.MULTILINE)
+_LOCK_PACKAGE_NAME_RE = re.compile(r'^name = "(?P<name>[^"]+)"$', re.MULTILINE)
+_SEMVER_PART_COUNT = 3
+
+
+class PrepareReleaseError(Exception):
+    """A release-preparation precondition failed.
+
+    Raised for anything that should fail the workflow loudly rather than
+    open a malformed or unreviewable release PR.
+    """
+
+
+def current_pyproject_version(pyproject_text: str) -> str:
+    """Reads the `[project] version` from a `pyproject.toml`'s text."""
+    match = _PYPROJECT_VERSION_RE.search(pyproject_text)
+    if match is None:
+        raise PrepareReleaseError('no `version = "..."` line found in pyproject.toml')
+    return match.group("version")
+
+
+def bump_semver(version: str, bump: str) -> str:
+    """Bumps a plain `X.Y.Z` version.
+
+    Args:
+        version: The current version. Must be exactly `X.Y.Z` with integer
+            parts; anything else (e.g. an already-released release
+            candidate) has no well-defined next bump and should be
+            overridden explicitly instead.
+        bump: One of "patch", "minor", "major".
+
+    Returns:
+        The bumped version, still in plain `X.Y.Z` form.
+    """
+    parts = version.split(".")
+    if len(parts) != _SEMVER_PART_COUNT or not all(p.isdigit() for p in parts):
+        raise PrepareReleaseError(
+            f"current version {version!r} is not a plain X.Y.Z semver; "
+            "pass --version explicitly instead of a --bump"
+        )
+    major, minor, patch = (int(p) for p in parts)
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    if bump == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    raise PrepareReleaseError(f"unknown bump kind {bump!r}")
+
+
+def check_labelformat_pin(pyproject_text: str) -> None:
+    """Fails if the Labelformat requirement is pinned by git sha.
+
+    A `git+` requirement means Labelformat itself needs a release first
+    (see the Labelformat release runbook); a plain version requirement is
+    fine.
+    """
+    match = re.search(r'^\s*"labelformat[^"]*"', pyproject_text, re.MULTILINE)
+    if match and "git+" in match.group(0):
+        raise PrepareReleaseError(
+            "labelformat is pinned by git sha in pyproject.toml "
+            f"({match.group(0).strip()}). Release Labelformat first, see "
+            "https://www.notion.so/Release-Labelformat-or-Lightly-Insights-"
+            "039ffe75cd8b4dd89dcb45a7338533b2?source=copy_link"
+        )
+
+
+def bump_pyproject_version(pyproject_text: str, new_version: str) -> str:
+    """Returns `pyproject_text` with the `[project] version` replaced."""
+    new_text, count = _PYPROJECT_VERSION_RE.subn(
+        f'version = "{new_version}"', pyproject_text, count=1
+    )
+    if count == 0:
+        raise PrepareReleaseError('no `version = "..."` line found in pyproject.toml')
+    return new_text
+
+
+def parse_unreleased_sections(changelog_text: str) -> dict[str, str]:
+    """Extracts the `[Unreleased]` section's six subsections.
+
+    Returns:
+        A mapping from subsection name (e.g. "Added") to its raw body text
+        (may be empty or whitespace-only).
+    """
+    body = _unreleased_body(changelog_text)
+    headings = list(_SUBSECTION_RE.finditer(body))
+    names = [h.group("name") for h in headings]
+    if names != list(SUBSECTIONS):
+        raise PrepareReleaseError(
+            f"[Unreleased] subsections are {names}, expected {list(SUBSECTIONS)} in that order"
+        )
+    sections = {}
+    for i, heading in enumerate(headings):
+        start = heading.end()
+        end = headings[i + 1].start() if i + 1 < len(headings) else len(body)
+        sections[heading.group("name")] = body[start:end]
+    return sections
+
+
+def suggest_bump(sections: dict[str, str]) -> tuple[str, str]:
+    """Suggests a semver bump from which [Unreleased] sections are non-empty.
+
+    Added / Changed / Removed / Deprecated entries suggest a minor bump;
+    only Fixed and/or Security entries suggest a patch. The operator still
+    confirms - this is a suggestion, not a decision.
+    """
+    non_empty = [name for name in SUBSECTIONS if sections.get(name, "").strip()]
+    if not non_empty:
+        raise PrepareReleaseError("the [Unreleased] section has no entries; nothing to release")
+    minor_triggers = [n for n in non_empty if n in ("Added", "Changed", "Removed", "Deprecated")]
+    bump = "minor" if minor_triggers else "patch"
+    reasoning = f"Non-empty [Unreleased] sections: {', '.join(non_empty)}."
+    return bump, reasoning
+
+
+def promote_changelog(changelog_text: str, version: str, date: str) -> str:
+    """Promotes `[Unreleased]` to a released version block.
+
+    Drops empty subsections from the promoted block, inserts a fresh empty
+    `[Unreleased]` skeleton above it, and leaves everything else byte-for-byte
+    unchanged. Callers must run `assert_changelog_structure` on the result
+    before trusting it - this function only constructs, it doesn't verify.
+    """
+    unreleased_match = _single_unreleased_match(changelog_text)
+    _, body_end = _unreleased_body_span(changelog_text, unreleased_match)
+    sections = parse_unreleased_sections(changelog_text)
+
+    preamble = changelog_text[: unreleased_match.start()]
+    rest = changelog_text[body_end:]
+
+    skeleton = "## [Unreleased]\n\n" + "".join(f"### {name}\n\n" for name in SUBSECTIONS)
+
+    promoted_sections = "".join(
+        f"### {name}\n\n{sections[name].strip()}\n\n"
+        for name in SUBSECTIONS
+        if sections[name].strip()
+    )
+    promoted = f"## \\[{version}\\] - {date}\n\n" + promoted_sections
+
+    return preamble + skeleton + promoted + rest
+
+
+def assert_changelog_structure(original_text: str, new_text: str, version: str) -> None:
+    r"""Verifies a changelog promotion didn't corrupt the file.
+
+    Independently re-derives the required invariants from `new_text` rather
+    than trusting how it was built, so it catches bugs in the construction
+    logic itself:
+
+    * exactly one `## [Unreleased]` heading, with all six subheadings,
+    * the new `## \\[version\\] - YYYY-MM-DD` heading exists,
+    * every previously-released version block is byte-identical to before.
+    """
+    unreleased_matches = list(_UNRELEASED_RE.finditer(new_text))
+    if len(unreleased_matches) != 1:
+        raise PrepareReleaseError(
+            f"expected exactly one [Unreleased] heading after promotion, found "
+            f"{len(unreleased_matches)}"
+        )
+    # Raises PrepareReleaseError itself if a subheading is missing/misordered.
+    parse_unreleased_sections(new_text)
+
+    released_heading = re.compile(
+        r"^## \\\[" + re.escape(version) + r"\\\] - \d{4}-\d{2}-\d{2}[ \t]*$",
+        re.MULTILINE,
+    )
+    if not released_heading.search(new_text):
+        raise PrepareReleaseError(
+            f"expected an escaped '## \\[{version}\\] - YYYY-MM-DD' heading after promotion"
+        )
+
+    original_match = _single_unreleased_match(original_text)
+    _, original_body_end = _unreleased_body_span(original_text, original_match)
+    previously_released = original_text[original_body_end:]
+    if not new_text.endswith(previously_released):
+        raise PrepareReleaseError(
+            "previously-released changelog blocks are not byte-identical after promotion"
+        )
+
+
+def extract_released_section(changelog_text: str, version: str) -> str:
+    r"""Returns the (trimmed) body of the `## \[version\] - ...` block."""
+    heading = re.compile(
+        r"^## \\\[" + re.escape(version) + r"\\\] - \d{4}-\d{2}-\d{2}[ \t]*$",
+        re.MULTILINE,
+    )
+    match = heading.search(changelog_text)
+    if match is None:
+        raise PrepareReleaseError(f"no promoted heading found for version {version!r}")
+    body_start = match.end()
+    next_heading = _ANY_H2_RE.search(changelog_text, body_start)
+    body_end = next_heading.start() if next_heading else len(changelog_text)
+    return changelog_text[body_start:body_end].strip()
+
+
+def render_pr_body(section_body: str, drafting_skipped_reason: str, coverage_checklist: str) -> str:
+    """Assembles the release PR body: draft notes + advisory coverage checklist.
+
+    The coverage checklist is git-derived and untrusted display text - it
+    must never be mistaken for reviewed release notes, hence the explicit
+    label and the blank line separating it from the draft notes.
+    """
+    checklist = coverage_checklist.strip() or "_None found._"
+    return (
+        "## Draft release notes\n\n"
+        f"> Automated drafting was skipped ({drafting_skipped_reason}). These are the "
+        "mechanically promoted CHANGELOG entries - review and edit before publishing.\n\n"
+        f"{section_body}\n\n"
+        "## Coverage checklist (advisory only - never copy into the release notes)\n\n"
+        "Merged changes since the last tag with no obviously matching CHANGELOG entry, "
+        "for a human to judge:\n\n"
+        f"{checklist}\n"
+    )
+
+
+def parse_lock_blocks(uv_lock_text: str) -> dict[str, str]:
+    """Splits a `uv.lock`'s text into per-package blocks, keyed by name.
+
+    The lockfile header (everything before the first `[[package]]`) is kept
+    under the empty-string key so it participates in the same diff check.
+    """
+    chunks = _LOCK_PACKAGE_SPLIT_RE.split(uv_lock_text)
+    blocks = {"": chunks[0]}
+    for chunk in chunks[1:]:
+        match = _LOCK_PACKAGE_NAME_RE.search(chunk)
+        if match is None:
+            raise PrepareReleaseError("a uv.lock [[package]] block has no `name` field")
+        blocks[match.group("name")] = chunk
+    return blocks
+
+
+def assert_lock_diff_narrow(before_text: str, after_text: str, package: str) -> None:
+    """Fails if `uv sync` changed more than `package`'s version line.
+
+    `uv sync` on CI can resolve transitive dependencies differently from
+    whoever last locked, producing a diff wider than the version bump. That
+    doesn't endanger the published wheel, but it makes the release PR
+    unreviewable, so treat it as a hard failure rather than something review
+    might catch.
+    """
+    before_blocks = parse_lock_blocks(before_text)
+    after_blocks = parse_lock_blocks(after_text)
+
+    unexpected = sorted(
+        name or "<lockfile header>"
+        for name in set(before_blocks) | set(after_blocks)
+        if name != package and before_blocks.get(name) != after_blocks.get(name)
+    )
+    if unexpected:
+        raise PrepareReleaseError(
+            "uv sync changed packages beyond the version bump: " + ", ".join(unexpected)
+        )
+
+    before_pkg = before_blocks.get(package)
+    after_pkg = after_blocks.get(package)
+    if before_pkg is None or after_pkg is None:
+        raise PrepareReleaseError(f"package {package!r} not found in uv.lock before/after uv sync")
+
+    diff = difflib.unified_diff(before_pkg.splitlines(), after_pkg.splitlines(), lineterm="")
+    changed_lines = [line for line in diff if line[:1] in "+-" and line[:3] not in ("+++", "---")]
+    if any(not re.match(r'^[+-]version = "', line) for line in changed_lines):
+        raise PrepareReleaseError(
+            f"uv.lock diff for {package!r} touches more than its version line:\n"
+            + "\n".join(changed_lines)
+        )
+
+
+def _single_unreleased_match(changelog_text: str) -> re.Match[str]:
+    matches = list(_UNRELEASED_RE.finditer(changelog_text))
+    if len(matches) != 1:
+        raise PrepareReleaseError(
+            f"expected exactly one [Unreleased] heading, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _unreleased_body_span(changelog_text: str, unreleased_match: re.Match[str]) -> tuple[int, int]:
+    body_start = unreleased_match.end()
+    next_heading = _ANY_H2_RE.search(changelog_text, body_start)
+    body_end = next_heading.start() if next_heading else len(changelog_text)
+    return body_start, body_end
+
+
+def _unreleased_body(changelog_text: str) -> str:
+    match = _single_unreleased_match(changelog_text)
+    start, end = _unreleased_body_span(changelog_text, match)
+    return changelog_text[start:end]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: parses `argv`, dispatches to the matching subcommand."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_pin = subparsers.add_parser(
+        "check-labelformat-pin", help="fail if labelformat is pinned by git sha"
+    )
+    check_pin.add_argument("--pyproject", type=Path, required=True)
+
+    suggest = subparsers.add_parser(
+        "suggest-bump", help="suggest a semver bump from [Unreleased]'s contents"
+    )
+    suggest.add_argument("--changelog", type=Path, required=True)
+
+    compute = subparsers.add_parser(
+        "compute-version", help="resolve the release version to bump to"
+    )
+    compute.add_argument("--pyproject", type=Path, required=True)
+    compute.add_argument("--bump", choices=["patch", "minor", "major"], required=True)
+    compute.add_argument("--version", default="", help="explicit override, empty to use --bump")
+
+    promote = subparsers.add_parser(
+        "promote-changelog", help="promote [Unreleased] to a released version block"
+    )
+    promote.add_argument("--changelog", type=Path, required=True)
+    promote.add_argument("--version", required=True)
+    promote.add_argument("--date", required=True, help="YYYY-MM-DD")
+
+    bump_pyproject = subparsers.add_parser(
+        "bump-pyproject", help="write the new version into pyproject.toml"
+    )
+    bump_pyproject.add_argument("--pyproject", type=Path, required=True)
+    bump_pyproject.add_argument("--version", required=True)
+
+    lock_diff = subparsers.add_parser(
+        "assert-lock-diff", help="fail if uv sync changed more than the version bump"
+    )
+    lock_diff.add_argument("--before", type=Path, required=True)
+    lock_diff.add_argument("--after", type=Path, required=True)
+    lock_diff.add_argument("--package", required=True)
+
+    pr_body = subparsers.add_parser("render-pr-body", help="assemble the release PR body")
+    pr_body.add_argument("--changelog", type=Path, required=True)
+    pr_body.add_argument("--version", required=True)
+    pr_body.add_argument("--drafting-skipped-reason", required=True)
+    pr_body.add_argument("--coverage-file", type=Path, required=True)
+    pr_body.add_argument("--output", type=Path, required=True)
+
+    args = parser.parse_args(argv)
+
+    try:
+        return _dispatch(args)
+    except PrepareReleaseError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    handlers = {
+        "check-labelformat-pin": _cmd_check_labelformat_pin,
+        "suggest-bump": _cmd_suggest_bump,
+        "compute-version": _cmd_compute_version,
+        "promote-changelog": _cmd_promote_changelog,
+        "bump-pyproject": _cmd_bump_pyproject,
+        "assert-lock-diff": _cmd_assert_lock_diff,
+        "render-pr-body": _cmd_render_pr_body,
+    }
+    handlers[args.command](args)
+    return 0
+
+
+def _cmd_check_labelformat_pin(args: argparse.Namespace) -> None:
+    check_labelformat_pin(args.pyproject.read_text())
+
+
+def _cmd_suggest_bump(args: argparse.Namespace) -> None:
+    sections = parse_unreleased_sections(args.changelog.read_text())
+    bump, reasoning = suggest_bump(sections)
+    print(f"bump={bump}")
+    print(reasoning)
+
+
+def _cmd_compute_version(args: argparse.Namespace) -> None:
+    if args.version:
+        print(args.version)
+        return
+    current = current_pyproject_version(args.pyproject.read_text())
+    print(bump_semver(current, args.bump))
+
+
+def _cmd_promote_changelog(args: argparse.Namespace) -> None:
+    original = args.changelog.read_text()
+    promoted = promote_changelog(original, args.version, args.date)
+    assert_changelog_structure(original, promoted, args.version)
+    args.changelog.write_text(promoted)
+
+
+def _cmd_bump_pyproject(args: argparse.Namespace) -> None:
+    original = args.pyproject.read_text()
+    args.pyproject.write_text(bump_pyproject_version(original, args.version))
+
+
+def _cmd_assert_lock_diff(args: argparse.Namespace) -> None:
+    assert_lock_diff_narrow(args.before.read_text(), args.after.read_text(), package=args.package)
+
+
+def _cmd_render_pr_body(args: argparse.Namespace) -> None:
+    section_body = extract_released_section(args.changelog.read_text(), args.version)
+    coverage_checklist = args.coverage_file.read_text() if args.coverage_file.exists() else ""
+    body = render_pr_body(section_body, args.drafting_skipped_reason, coverage_checklist)
+    args.output.write_text(body)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lightly_studio/tests/scripts/test_prepare_release.py
+++ b/lightly_studio/tests/scripts/test_prepare_release.py
@@ -1,0 +1,257 @@
+import prepare_release
+import pytest
+from prepare_release import PrepareReleaseError
+
+SAMPLE_CHANGELOG = """\
+# Changelog
+
+All notable changes to Lightly**Studio** will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Added thing one.
+
+### Changed
+
+- Changed thing one.
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## \\[1.0.5\\] - 2026-08-14
+
+### Added
+
+- Some old thing.
+
+## \\[1.0.4\\] - 2026-08-01
+
+### Fixed
+
+- An older fix.
+"""
+
+SAMPLE_PYPROJECT = """\
+[project]
+name = "lightly-studio"
+version = "1.0.5"
+description = "..."
+
+dependencies = [
+    "labelformat>=0.1.17",
+]
+"""
+
+
+def test_current_pyproject_version():
+    assert prepare_release.current_pyproject_version(SAMPLE_PYPROJECT) == "1.0.5"
+
+
+def test_current_pyproject_version__missing_raises():
+    with pytest.raises(PrepareReleaseError):
+        prepare_release.current_pyproject_version('[project]\nname = "x"\n')
+
+
+@pytest.mark.parametrize(
+    ("bump", "expected"),
+    [("patch", "1.0.6"), ("minor", "1.1.0"), ("major", "2.0.0")],
+)
+def test_bump_semver(bump, expected):
+    assert prepare_release.bump_semver("1.0.5", bump) == expected
+
+
+def test_bump_semver__non_semver_current_version_raises():
+    with pytest.raises(PrepareReleaseError):
+        prepare_release.bump_semver("1.0.0rc1", "patch")
+
+
+def test_check_labelformat_pin__version_requirement_is_fine():
+    prepare_release.check_labelformat_pin(SAMPLE_PYPROJECT)
+
+
+def test_check_labelformat_pin__git_sha_raises():
+    text = SAMPLE_PYPROJECT.replace(
+        '"labelformat>=0.1.17"',
+        '"labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"',
+    )
+    with pytest.raises(PrepareReleaseError, match="git sha"):
+        prepare_release.check_labelformat_pin(text)
+
+
+def test_bump_pyproject_version():
+    result = prepare_release.bump_pyproject_version(SAMPLE_PYPROJECT, "1.0.6")
+    assert 'version = "1.0.6"' in result
+    assert 'version = "1.0.5"' not in result
+    # Only the [project] version changes, nothing else.
+    assert result.replace("1.0.6", "1.0.5") == SAMPLE_PYPROJECT
+
+
+def test_parse_unreleased_sections():
+    sections = prepare_release.parse_unreleased_sections(SAMPLE_CHANGELOG)
+    assert list(sections) == list(prepare_release.SUBSECTIONS)
+    assert "Added thing one" in sections["Added"]
+    assert "Changed thing one" in sections["Changed"]
+    assert sections["Deprecated"].strip() == ""
+    assert sections["Removed"].strip() == ""
+
+
+def test_parse_unreleased_sections__wrong_order_raises():
+    broken = SAMPLE_CHANGELOG.replace(
+        "### Added\n\n- Added thing one.\n\n### Changed",
+        "### Changed\n\n### Added\n\n- Added thing one.",
+    )
+    with pytest.raises(PrepareReleaseError):
+        prepare_release.parse_unreleased_sections(broken)
+
+
+def test_parse_unreleased_sections__no_unreleased_heading_raises():
+    with pytest.raises(PrepareReleaseError):
+        prepare_release.parse_unreleased_sections("# Changelog\n\nnothing here\n")
+
+
+def test_suggest_bump__added_or_changed_suggests_minor():
+    sections = prepare_release.parse_unreleased_sections(SAMPLE_CHANGELOG)
+    bump, reasoning = prepare_release.suggest_bump(sections)
+    assert bump == "minor"
+    assert "Added" in reasoning
+    assert "Changed" in reasoning
+
+
+def test_suggest_bump__only_fixed_or_security_suggests_patch():
+    sections = dict.fromkeys(prepare_release.SUBSECTIONS, "")
+    sections["Fixed"] = "- Fixed a bug.\n"
+    bump, _ = prepare_release.suggest_bump(sections)
+    assert bump == "patch"
+
+
+def test_suggest_bump__nothing_unreleased_raises():
+    sections = dict.fromkeys(prepare_release.SUBSECTIONS, "")
+    with pytest.raises(PrepareReleaseError, match="nothing to release"):
+        prepare_release.suggest_bump(sections)
+
+
+def test_promote_changelog():
+    promoted = prepare_release.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+
+    # Fresh, fully-empty [Unreleased] skeleton with all six subheadings.
+    assert promoted.count("## [Unreleased]") == 1
+    for name in prepare_release.SUBSECTIONS:
+        assert f"### {name}\n\n" in promoted
+
+    # New release heading in escaped form, empty sections dropped.
+    assert "## \\[1.1.0\\] - 2026-08-21" in promoted
+    assert "Added thing one" in promoted
+    assert "Changed thing one" in promoted
+
+    # Previously-released blocks are untouched.
+    assert "## \\[1.0.5\\] - 2026-08-14" in promoted
+    assert "## \\[1.0.4\\] - 2026-08-01" in promoted
+    assert promoted.index("1.1.0") < promoted.index("1.0.5") < promoted.index("1.0.4")
+
+    prepare_release.assert_changelog_structure(SAMPLE_CHANGELOG, promoted, "1.1.0")
+
+
+def test_assert_changelog_structure__missing_unreleased_raises():
+    promoted = prepare_release.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    corrupted = promoted.replace("## [Unreleased]\n\n", "", 1)
+    with pytest.raises(PrepareReleaseError):
+        prepare_release.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+
+
+def test_assert_changelog_structure__mutated_released_block_raises():
+    promoted = prepare_release.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    corrupted = promoted.replace("An older fix.", "A DIFFERENT fix.")
+    with pytest.raises(PrepareReleaseError, match="byte-identical"):
+        prepare_release.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+
+
+def test_assert_changelog_structure__missing_new_heading_raises():
+    promoted = prepare_release.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    corrupted = promoted.replace("## \\[1.1.0\\] - 2026-08-21", "## [1.1.0] - 2026-08-21")
+    with pytest.raises(PrepareReleaseError):
+        prepare_release.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+
+
+def test_extract_released_section():
+    promoted = prepare_release.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    section = prepare_release.extract_released_section(promoted, "1.1.0")
+    assert "Added thing one" in section
+    assert "1.0.5" not in section
+
+
+def test_render_pr_body():
+    body = prepare_release.render_pr_body(
+        section_body="### Added\n\n- Added thing one.",
+        drafting_skipped_reason="LIG-10559 is not wired in yet",
+        coverage_checklist="- abc123 Some PR title (#42)",
+    )
+    assert "Draft release notes" in body
+    assert "LIG-10559 is not wired in yet" in body
+    assert "Added thing one" in body
+    assert "Coverage checklist" in body
+    assert "#42" in body
+
+
+def test_render_pr_body__empty_checklist_shows_placeholder():
+    body = prepare_release.render_pr_body(
+        section_body="### Fixed\n\n- A fix.",
+        drafting_skipped_reason="reason",
+        coverage_checklist="",
+    )
+    assert "_None found._" in body
+
+
+SAMPLE_LOCK = """\
+version = 1
+revision = 2
+
+[[package]]
+name = "alpha"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "lightly-studio"
+version = "1.0.5"
+source = { editable = "." }
+dependencies = [
+    { name = "alpha" },
+]
+"""
+
+
+def test_parse_lock_blocks():
+    blocks = prepare_release.parse_lock_blocks(SAMPLE_LOCK)
+    assert set(blocks) == {"", "alpha", "lightly-studio"}
+    assert 'version = "1.0.5"' in blocks["lightly-studio"]
+
+
+def test_assert_lock_diff_narrow__version_only_change_is_ok():
+    after = SAMPLE_LOCK.replace(
+        'name = "lightly-studio"\nversion = "1.0.5"', 'name = "lightly-studio"\nversion = "1.0.6"'
+    )
+    prepare_release.assert_lock_diff_narrow(SAMPLE_LOCK, after, package="lightly-studio")
+
+
+def test_assert_lock_diff_narrow__unrelated_package_changed_raises():
+    after = SAMPLE_LOCK.replace(
+        'name = "alpha"\nversion = "1.0.0"', 'name = "alpha"\nversion = "1.1.0"'
+    )
+    with pytest.raises(PrepareReleaseError, match="alpha"):
+        prepare_release.assert_lock_diff_narrow(SAMPLE_LOCK, after, package="lightly-studio")
+
+
+def test_assert_lock_diff_narrow__broader_change_to_target_package_raises():
+    after = SAMPLE_LOCK.replace(
+        'version = "1.0.5"\nsource = { editable = "." }',
+        'version = "1.0.6"\nsource = { editable = "./elsewhere" }',
+    )
+    with pytest.raises(PrepareReleaseError, match="more than its version line"):
+        prepare_release.assert_lock_diff_narrow(SAMPLE_LOCK, after, package="lightly-studio")


### PR DESCRIPTION
## What has changed and why?

Adds a `workflow_dispatch`-only **Prepare Release** workflow
(`.github/workflows/prepare_release.yml`) that replaces RELEASE.md steps
3-5 with one manual dispatch:

1. Create a `release-vX.Y.Z` branch off `main`.
2. Promote `CHANGELOG.md`'s `[Unreleased]` section into a released
   `## \[X.Y.Z\] - YYYY-MM-DD` block (escaped heading form, matching the
   other 22 released headings), dropping empty subsections, and insert a
   fresh empty `[Unreleased]` skeleton above it.
3. Bump the version in `lightly_studio/pyproject.toml` and run `uv sync`.
4. Open a `Bump version to X.Y.Z` PR whose body contains the promoted
   CHANGELOG entries as draft release notes, plus a clearly-labelled,
   advisory-only coverage checklist (merged commits since the last tag)
   that never flows into the notes themselves.

Runs on `ubuntu-latest` with no secrets beyond the default `GITHUB_TOKEN`
(scoped to `contents: write` / `pull-requests: write`) - nothing in
`lightly-studio-private` changes. Publishes nothing; tag / GitHub release
/ PyPI stay manual for now.

The mechanical logic lives in `lightly_studio/scripts/prepare_release.py`
(stdlib only, so it doesn't need anything `uv` would have to resolve
first) and fails the workflow loudly rather than open a bad PR:

- Guards against a git-sha-pinned `labelformat` requirement.
- Suggests a semver bump from which `[Unreleased]` sections are
  non-empty (Added/Changed/Removed/Deprecated -> minor, only
  Fixed/Security -> patch); the operator can still override it, or pass
  an explicit `version` for cases like `1.0.0rc1`.
- After promoting the changelog, asserts exactly one `[Unreleased]`
  heading with all six subsections, the new escaped heading exists, and
  every previously-released block is byte-identical to before.
- After `uv sync`, asserts the `uv.lock` diff touches only the root
  package's version line, so resolver drift on CI fails loudly instead
  of landing an unreviewable lock diff in the release PR.
- A second net: the workflow also fails if anything other than
  `CHANGELOG.md`, `pyproject.toml`, and `uv.lock` changed.

LLM-drafted release notes (LIG-10559) aren't wired in yet, so this
deliberately takes the fail-open path required by that ticket: the PR
body always contains the mechanically-promoted changelog with a note
that drafting was skipped. Wiring in LIG-10559 later is a small,
additive change to the "Render PR body" step.

The heading-escaping normalisation itself is out of scope here per the
ticket - it's flagged as a separate follow-up PR.

Linear: https://linear.app/lightly/issue/LIG-10552

## How has it been tested?

- Added unit tests (`lightly_studio/tests/scripts/test_prepare_release.py`,
  26 cases) covering the semver bump, the labelformat guard, changelog
  promotion (including the empty-subsection-dropping and
  skeleton-insertion behavior), all three structural assertions and their
  failure cases, the PR-body rendering, and the `uv.lock` diff checks
  (narrow version-only change accepted, unrelated package change
  rejected, broader change to the target package itself rejected).
- Ran `make static-checks` (ruff format/check, mypy) on the new files.
- Smoke-tested every subcommand by hand against the real
  `CHANGELOG.md` / `lightly_studio/pyproject.toml` / `lightly_studio/uv.lock`
  from this repo (promotion, version bump, lock-diff assertion, and PR
  body rendering all produced the expected output).
- Have not yet dispatched the workflow itself on GitHub (needs a run on
  `main` to fully validate branch/PR creation end-to-end) - flagging for
  reviewer awareness before merge.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided release-preparation workflow that selects or accepts a version, updates release files, and opens a pull request for review.
  * Added validation for changelog structure, version updates, dependency pins, and lockfile changes.
  * Added release summaries and an advisory coverage checklist during preparation.

* **Bug Fixes**
  * Improved test configuration so release-preparation utilities are discoverable.

* **Tests**
  * Added comprehensive coverage for versioning, changelog promotion, validation, lockfile checks, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->