### PR TITLE
Add changelog promotion for the prepare-release workflow

### DIFF
--- a/lightly_studio/pytest.ini
+++ b/lightly_studio/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-pythonpath = src
+pythonpath =
+    src
+    scripts
 python_files = test_*.py
 
 markers =

--- a/lightly_studio/scripts/prepare_release.py
+++ b/lightly_studio/scripts/prepare_release.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Mechanical steps for preparing a LightlyStudio release.
+
+Backs the `Prepare Release` GitHub Actions workflow, landing incrementally
+(see LIG-10552 for the full spec). Every subcommand does one small,
+independently testable piece of RELEASE.md steps 3-5. This first slice
+covers the highest-consequence one: promoting `CHANGELOG.md`'s
+`[Unreleased]` section into a released version block without silently
+corrupting the file.
+
+Stdlib only, deliberately: this runs on the release-critical path before
+`uv sync`, so it must not itself depend on anything `uv` would need to
+resolve first.
+
+Usage (see `main()` for the full set of subcommands):
+    python scripts/prepare_release.py suggest-bump --changelog CHANGELOG.md
+    python scripts/prepare_release.py promote-changelog --changelog CHANGELOG.md \
+        --version 1.0.6 --date 2026-08-21
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Keep a Changelog subsection headings, in the fixed order RELEASE.md and the
+# existing CHANGELOG.md use.
+SUBSECTIONS = ("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security")
+
+# `## [Unreleased]` is the one heading kept unescaped; every released version
+# heading is `## \[X.Y.Z\] - YYYY-MM-DD` (see LIG-10552 for why that split
+# matters). Getting this backwards silently breaks the convention instead of
+# failing loudly, which is exactly what `assert_changelog_structure` guards.
+_UNRELEASED_RE = re.compile(r"^## \[Unreleased\][ \t]*$", re.MULTILINE)
+_ANY_H2_RE = re.compile(r"^## ", re.MULTILINE)
+_SUBSECTION_RE = re.compile(r"^### (?P<name>\w+)[ \t]*$", re.MULTILINE)
+
+
+class PrepareReleaseError(Exception):
+    """A release-preparation precondition failed.
+
+    Raised for anything that should fail the workflow loudly rather than
+    open a malformed or unreviewable release PR.
+    """
+
+
+def parse_unreleased_sections(changelog_text: str) -> dict[str, str]:
+    """Extracts the `[Unreleased]` section's six subsections.
+
+    Returns:
+        A mapping from subsection name (e.g. "Added") to its raw body text
+        (may be empty or whitespace-only).
+    """
+    body = _unreleased_body(changelog_text)
+    headings = list(_SUBSECTION_RE.finditer(body))
+    names = [h.group("name") for h in headings]
+    if names != list(SUBSECTIONS):
+        raise PrepareReleaseError(
+            f"[Unreleased] subsections are {names}, expected {list(SUBSECTIONS)} in that order"
+        )
+    sections = {}
+    for i, heading in enumerate(headings):
+        start = heading.end()
+        end = headings[i + 1].start() if i + 1 < len(headings) else len(body)
+        sections[heading.group("name")] = body[start:end]
+    return sections
+
+
+def suggest_bump(sections: dict[str, str]) -> tuple[str, str]:
+    """Suggests a semver bump from which [Unreleased] sections are non-empty.
+
+    Added / Changed / Removed / Deprecated entries suggest a minor bump;
+    only Fixed and/or Security entries suggest a patch. The operator still
+    confirms - this is a suggestion, not a decision.
+    """
+    non_empty = [name for name in SUBSECTIONS if sections.get(name, "").strip()]
+    if not non_empty:
+        raise PrepareReleaseError("the [Unreleased] section has no entries; nothing to release")
+    minor_triggers = [n for n in non_empty if n in ("Added", "Changed", "Removed", "Deprecated")]
+    bump = "minor" if minor_triggers else "patch"
+    reasoning = f"Non-empty [Unreleased] sections: {', '.join(non_empty)}."
+    return bump, reasoning
+
+
+def promote_changelog(changelog_text: str, version: str, date: str) -> str:
+    """Promotes `[Unreleased]` to a released version block.
+
+    Drops empty subsections from the promoted block, inserts a fresh empty
+    `[Unreleased]` skeleton above it, and leaves everything else byte-for-byte
+    unchanged. Callers must run `assert_changelog_structure` on the result
+    before trusting it - this function only constructs, it doesn't verify.
+    """
+    unreleased_match = _single_unreleased_match(changelog_text)
+    _, body_end = _unreleased_body_span(changelog_text, unreleased_match)
+    sections = parse_unreleased_sections(changelog_text)
+
+    preamble = changelog_text[: unreleased_match.start()]
+    rest = changelog_text[body_end:]
+
+    skeleton = "## [Unreleased]\n\n" + "".join(f"### {name}\n\n" for name in SUBSECTIONS)
+
+    promoted_sections = "".join(
+        f"### {name}\n\n{sections[name].strip()}\n\n"
+        for name in SUBSECTIONS
+        if sections[name].strip()
+    )
+    promoted = f"## \\[{version}\\] - {date}\n\n" + promoted_sections
+
+    return preamble + skeleton + promoted + rest
+
+
+def assert_changelog_structure(original_text: str, new_text: str, version: str) -> None:
+    r"""Verifies a changelog promotion didn't corrupt the file.
+
+    Independently re-derives the required invariants from `new_text` rather
+    than trusting how it was built, so it catches bugs in the construction
+    logic itself:
+
+    * exactly one `## [Unreleased]` heading, with all six subheadings,
+    * the new `## \\[version\\] - YYYY-MM-DD` heading exists,
+    * every previously-released version block is byte-identical to before.
+    """
+    unreleased_matches = list(_UNRELEASED_RE.finditer(new_text))
+    if len(unreleased_matches) != 1:
+        raise PrepareReleaseError(
+            f"expected exactly one [Unreleased] heading after promotion, found "
+            f"{len(unreleased_matches)}"
+        )
+    # Raises PrepareReleaseError itself if a subheading is missing/misordered.
+    parse_unreleased_sections(new_text)
+
+    released_heading = re.compile(
+        r"^## \\\[" + re.escape(version) + r"\\\] - \d{4}-\d{2}-\d{2}[ \t]*$",
+        re.MULTILINE,
+    )
+    if not released_heading.search(new_text):
+        raise PrepareReleaseError(
+            f"expected an escaped '## \\[{version}\\] - YYYY-MM-DD' heading after promotion"
+        )
+
+    original_match = _single_unreleased_match(original_text)
+    _, original_body_end = _unreleased_body_span(original_text, original_match)
+    previously_released = original_text[original_body_end:]
+    if not new_text.endswith(previously_released):
+        raise PrepareReleaseError(
+            "previously-released changelog blocks are not byte-identical after promotion"
+        )
+
+
+def extract_released_section(changelog_text: str, version: str) -> str:
+    r"""Returns the (trimmed) body of the `## \[version\] - ...` block."""
+    heading = re.compile(
+        r"^## \\\[" + re.escape(version) + r"\\\] - \d{4}-\d{2}-\d{2}[ \t]*$",
+        re.MULTILINE,
+    )
+    match = heading.search(changelog_text)
+    if match is None:
+        raise PrepareReleaseError(f"no promoted heading found for version {version!r}")
+    body_start = match.end()
+    next_heading = _ANY_H2_RE.search(changelog_text, body_start)
+    body_end = next_heading.start() if next_heading else len(changelog_text)
+    return changelog_text[body_start:body_end].strip()
+
+
+def _single_unreleased_match(changelog_text: str) -> re.Match[str]:
+    matches = list(_UNRELEASED_RE.finditer(changelog_text))
+    if len(matches) != 1:
+        raise PrepareReleaseError(
+            f"expected exactly one [Unreleased] heading, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _unreleased_body_span(changelog_text: str, unreleased_match: re.Match[str]) -> tuple[int, int]:
+    body_start = unreleased_match.end()
+    next_heading = _ANY_H2_RE.search(changelog_text, body_start)
+    body_end = next_heading.start() if next_heading else len(changelog_text)
+    return body_start, body_end
+
+
+def _unreleased_body(changelog_text: str) -> str:
+    match = _single_unreleased_match(changelog_text)
+    start, end = _unreleased_body_span(changelog_text, match)
+    return changelog_text[start:end]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: parses `argv`, dispatches to the matching subcommand."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    suggest = subparsers.add_parser(
+        "suggest-bump", help="suggest a semver bump from [Unreleased]'s contents"
+    )
+    suggest.add_argument("--changelog", type=Path, required=True)
+
+    promote = subparsers.add_parser(
+        "promote-changelog", help="promote [Unreleased] to a released version block"
+    )
+    promote.add_argument("--changelog", type=Path, required=True)
+    promote.add_argument("--version", required=True)
+    promote.add_argument("--date", required=True, help="YYYY-MM-DD")
+
+    args = parser.parse_args(argv)
+
+    try:
+        return _dispatch(args)
+    except PrepareReleaseError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    handlers = {
+        "suggest-bump": _cmd_suggest_bump,
+        "promote-changelog": _cmd_promote_changelog,
+    }
+    handlers[args.command](args)
+    return 0
+
+
+def _cmd_suggest_bump(args: argparse.Namespace) -> None:
+    sections = parse_unreleased_sections(args.changelog.read_text())
+    bump, reasoning = suggest_bump(sections)
+    print(f"bump={bump}")
+    print(reasoning)
+
+
+def _cmd_promote_changelog(args: argparse.Namespace) -> None:
+    original = args.changelog.read_text()
+    promoted = promote_changelog(original, args.version, args.date)
+    assert_changelog_structure(original, promoted, args.version)
+    args.changelog.write_text(promoted)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lightly_studio/tests/scripts/test_prepare_release.py
+++ b/lightly_studio/tests/scripts/test_prepare_release.py
@@ -1,0 +1,132 @@
+import prepare_release
+import pytest
+from prepare_release import PrepareReleaseError
+
+SAMPLE_CHANGELOG = """\
+# Changelog
+
+All notable changes to Lightly**Studio** will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Added thing one.
+
+### Changed
+
+- Changed thing one.
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## \\[1.0.5\\] - 2026-08-14
+
+### Added
+
+- Some old thing.
+
+## \\[1.0.4\\] - 2026-08-01
+
+### Fixed
+
+- An older fix.
+"""
+
+
+def test_parse_unreleased_sections():
+    sections = prepare_release.parse_unreleased_sections(SAMPLE_CHANGELOG)
+    assert list(sections) == list(prepare_release.SUBSECTIONS)
+    assert "Added thing one" in sections["Added"]
+    assert "Changed thing one" in sections["Changed"]
+    assert sections["Deprecated"].strip() == ""
+    assert sections["Removed"].strip() == ""
+
+
+def test_parse_unreleased_sections__wrong_order_raises():
+    broken = SAMPLE_CHANGELOG.replace(
+        "### Added\n\n- Added thing one.\n\n### Changed",
+        "### Changed\n\n### Added\n\n- Added thing one.",
+    )
+    with pytest.raises(PrepareReleaseError):
+        prepare_release.parse_unreleased_sections(broken)
+
+
+def test_parse_unreleased_sections__no_unreleased_heading_raises():
+    with pytest.raises(PrepareReleaseError):
+        prepare_release.parse_unreleased_sections("# Changelog\n\nnothing here\n")
+
+
+def test_suggest_bump__added_or_changed_suggests_minor():
+    sections = prepare_release.parse_unreleased_sections(SAMPLE_CHANGELOG)
+    bump, reasoning = prepare_release.suggest_bump(sections)
+    assert bump == "minor"
+    assert "Added" in reasoning
+    assert "Changed" in reasoning
+
+
+def test_suggest_bump__only_fixed_or_security_suggests_patch():
+    sections = dict.fromkeys(prepare_release.SUBSECTIONS, "")
+    sections["Fixed"] = "- Fixed a bug.\n"
+    bump, _ = prepare_release.suggest_bump(sections)
+    assert bump == "patch"
+
+
+def test_suggest_bump__nothing_unreleased_raises():
+    sections = dict.fromkeys(prepare_release.SUBSECTIONS, "")
+    with pytest.raises(PrepareReleaseError, match="nothing to release"):
+        prepare_release.suggest_bump(sections)
+
+
+def test_promote_changelog():
+    promoted = prepare_release.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+
+    # Fresh, fully-empty [Unreleased] skeleton with all six subheadings.
+    assert promoted.count("## [Unreleased]") == 1
+    for name in prepare_release.SUBSECTIONS:
+        assert f"### {name}\n\n" in promoted
+
+    # New release heading in escaped form, empty sections dropped.
+    assert "## \\[1.1.0\\] - 2026-08-21" in promoted
+    assert "Added thing one" in promoted
+    assert "Changed thing one" in promoted
+
+    # Previously-released blocks are untouched.
+    assert "## \\[1.0.5\\] - 2026-08-14" in promoted
+    assert "## \\[1.0.4\\] - 2026-08-01" in promoted
+    assert promoted.index("1.1.0") < promoted.index("1.0.5") < promoted.index("1.0.4")
+
+    prepare_release.assert_changelog_structure(SAMPLE_CHANGELOG, promoted, "1.1.0")
+
+
+def test_assert_changelog_structure__missing_unreleased_raises():
+    promoted = prepare_release.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    corrupted = promoted.replace("## [Unreleased]\n\n", "", 1)
+    with pytest.raises(PrepareReleaseError):
+        prepare_release.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+
+
+def test_assert_changelog_structure__mutated_released_block_raises():
+    promoted = prepare_release.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    corrupted = promoted.replace("An older fix.", "A DIFFERENT fix.")
+    with pytest.raises(PrepareReleaseError, match="byte-identical"):
+        prepare_release.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+
+
+def test_assert_changelog_structure__missing_new_heading_raises():
+    promoted = prepare_release.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    corrupted = promoted.replace("## \\[1.1.0\\] - 2026-08-21", "## [1.1.0] - 2026-08-21")
+    with pytest.raises(PrepareReleaseError):
+        prepare_release.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+
+
+def test_extract_released_section():
+    promoted = prepare_release.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    section = prepare_release.extract_released_section(promoted, "1.1.0")
+    assert "Added thing one" in section
+    assert "1.0.5" not in section


### PR DESCRIPTION
Part of a stack for LIG-10552 ([gh-stack](https://github.github.com/gh-stack/)), 1 of 4, landing bottom-up onto `main`:

1. **#2038 - changelog promotion** (this PR)
2. #2039 - version, pyproject.toml, and uv.lock guards
3. #2040 - PR body rendering (draft notes + coverage checklist)
4. #2041 - the workflow itself

Please review/merge in order; each PR rebases onto the previous once it lands.

## What has changed and why?

First slice of the **Prepare Release** workflow (LIG-10552): the mechanical
logic to promote `CHANGELOG.md`'s `[Unreleased]` section into a released
version block, and the structural assertion that catches a corrupted
result before anything downstream trusts it - the highest-consequence
quiet failure called out in the ticket (if the fresh `[Unreleased]`
skeleton fails to get inserted, subsequent PRs have nowhere to add
entries).

`lightly_studio/scripts/prepare_release.py` (stdlib only, deliberately -
this runs before `uv sync`, so it can't itself depend on anything `uv`
would need to resolve first):

- `parse_unreleased_sections` / `suggest_bump`: read the six
  `[Unreleased]` subsections and suggest a semver bump from which ones
  are non-empty (Added/Changed/Removed/Deprecated -> minor, only
  Fixed/Security -> patch).
- `promote_changelog`: turns `[Unreleased]` into an escaped
  `## \[X.Y.Z\] - YYYY-MM-DD` heading (matching the other 22 released
  headings), drops empty subsections, and inserts a fresh empty
  `[Unreleased]` skeleton above it.
- `assert_changelog_structure`: independently re-derives the required
  invariants from the result rather than trusting how it was built -
  exactly one `[Unreleased]` heading with all six subsections, the new
  heading present, every previously-released block byte-identical to
  before - and fails loudly rather than let a malformed changelog
  through.

A minimal CLI (`suggest-bump`, `promote-changelog`) ships with this PR;
later PRs in the stack add more subcommands to the same file.

Linear: https://linear.app/lightly/issue/LIG-10552

## How has it been tested?

- 11 unit tests in `lightly_studio/tests/scripts/test_prepare_release.py`,
  covering the happy path and the failure case for each assertion
  (missing `[Unreleased]`, mutated released block, missing new heading).
- `make static-checks` (ruff format/check, mypy) passes on the new files.
- Hand-ran `promote-changelog` against this repo's real `CHANGELOG.md` to
  confirm the output looks right.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

---
Suggested reviewer: @michal-lightly (most `.github/workflows` / release-tooling history in this repo). Alternate: @lukas-lightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a release-preparation command-line tool that recommends version bumps and promotes unreleased changelog entries into versioned releases.
  - Added validation to detect missing, incomplete, incorrectly ordered, or malformed changelog sections.
  - Preserves previously released changelog content during updates.

- **Tests**
  - Added comprehensive coverage for release recommendations, changelog promotion, validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->