### PR TITLE
Render the release PR body: draft notes + coverage checklist

### DIFF
--- a/lightly_studio/scripts/prepare_release.py
+++ b/lightly_studio/scripts/prepare_release.py
@@ -4,8 +4,8 @@
 Backs the `Prepare Release` GitHub Actions workflow, landing incrementally
 (see LIG-10552 for the full spec). Every subcommand does one small,
 independently testable piece of RELEASE.md steps 3-5. This slice adds
-changelog promotion plus the version, `pyproject.toml`, and `uv.lock`
-guards RELEASE.md's steps 2-4 call for.
+changelog promotion, the version/`pyproject.toml`/`uv.lock` guards, and
+draft release-notes rendering for the release PR body.
 
 Stdlib only, deliberately: this runs on the release-critical path before
 `uv sync`, so it must not itself depend on anything `uv` would need to
@@ -232,6 +232,26 @@ def extract_released_section(changelog_text: str, version: str) -> str:
     return changelog_text[body_start:body_end].strip()
 
 
+def render_pr_body(section_body: str, drafting_skipped_reason: str, coverage_checklist: str) -> str:
+    """Assembles the release PR body: draft notes + advisory coverage checklist.
+
+    The coverage checklist is git-derived and untrusted display text - it
+    must never be mistaken for reviewed release notes, hence the explicit
+    label and the blank line separating it from the draft notes.
+    """
+    checklist = coverage_checklist.strip() or "_None found._"
+    return (
+        "## Draft release notes\n\n"
+        f"> Automated drafting was skipped ({drafting_skipped_reason}). These are the "
+        "mechanically promoted CHANGELOG entries - review and edit before publishing.\n\n"
+        f"{section_body}\n\n"
+        "## Coverage checklist (advisory only - never copy into the release notes)\n\n"
+        "Merged changes since the last tag with no obviously matching CHANGELOG entry, "
+        "for a human to judge:\n\n"
+        f"{checklist}\n"
+    )
+
+
 def parse_lock_blocks(uv_lock_text: str) -> dict[str, str]:
     """Splits a `uv.lock`'s text into per-package blocks, keyed by name.
 
@@ -348,6 +368,13 @@ def main(argv: list[str] | None = None) -> int:
     lock_diff.add_argument("--after", type=Path, required=True)
     lock_diff.add_argument("--package", required=True)
 
+    pr_body = subparsers.add_parser("render-pr-body", help="assemble the release PR body")
+    pr_body.add_argument("--changelog", type=Path, required=True)
+    pr_body.add_argument("--version", required=True)
+    pr_body.add_argument("--drafting-skipped-reason", required=True)
+    pr_body.add_argument("--coverage-file", type=Path, required=True)
+    pr_body.add_argument("--output", type=Path, required=True)
+
     args = parser.parse_args(argv)
 
     try:
@@ -365,6 +392,7 @@ def _dispatch(args: argparse.Namespace) -> int:
         "promote-changelog": _cmd_promote_changelog,
         "bump-pyproject": _cmd_bump_pyproject,
         "assert-lock-diff": _cmd_assert_lock_diff,
+        "render-pr-body": _cmd_render_pr_body,
     }
     handlers[args.command](args)
     return 0
@@ -403,6 +431,13 @@ def _cmd_bump_pyproject(args: argparse.Namespace) -> None:
 
 def _cmd_assert_lock_diff(args: argparse.Namespace) -> None:
     assert_lock_diff_narrow(args.before.read_text(), args.after.read_text(), package=args.package)
+
+
+def _cmd_render_pr_body(args: argparse.Namespace) -> None:
+    section_body = extract_released_section(args.changelog.read_text(), args.version)
+    coverage_checklist = args.coverage_file.read_text() if args.coverage_file.exists() else ""
+    body = render_pr_body(section_body, args.drafting_skipped_reason, coverage_checklist)
+    args.output.write_text(body)
 
 
 if __name__ == "__main__":

--- a/lightly_studio/tests/scripts/test_prepare_release.py
+++ b/lightly_studio/tests/scripts/test_prepare_release.py
@@ -186,6 +186,28 @@ def test_extract_released_section():
     assert "1.0.5" not in section
 
 
+def test_render_pr_body():
+    body = prepare_release.render_pr_body(
+        section_body="### Added\n\n- Added thing one.",
+        drafting_skipped_reason="LIG-10559 is not wired in yet",
+        coverage_checklist="- abc123 Some PR title (#42)",
+    )
+    assert "Draft release notes" in body
+    assert "LIG-10559 is not wired in yet" in body
+    assert "Added thing one" in body
+    assert "Coverage checklist" in body
+    assert "#42" in body
+
+
+def test_render_pr_body__empty_checklist_shows_placeholder():
+    body = prepare_release.render_pr_body(
+        section_body="### Fixed\n\n- A fix.",
+        drafting_skipped_reason="reason",
+        coverage_checklist="",
+    )
+    assert "_None found._" in body
+
+
 SAMPLE_LOCK = """\
 version = 1
 revision = 2


### PR DESCRIPTION
Part of a stack for LIG-10552 ([gh-stack](https://github.github.com/gh-stack/)), 3 of 4, landing bottom-up onto `main`:

1. #2038 - changelog promotion
2. #2039 - version, pyproject.toml, and uv.lock guards
3. **#2040 - PR body rendering (draft notes + coverage checklist)** (this PR)
4. #2041 - the workflow itself

Based on #2039 - please review/merge in order; each PR rebases onto the
previous once it lands.

## What has changed and why?

Third slice of the **Prepare Release** workflow (LIG-10552), on top of
the changelog/version/lock guards.

`lightly_studio/scripts/prepare_release.py`:

- `render_pr_body`: assembles the release PR body from the promoted
  CHANGELOG section as draft release notes, plus a clearly-labelled,
  advisory-only coverage checklist that must never be mistaken for
  reviewed release notes.

LLM-drafted release notes (LIG-10559) aren't wired in yet, so this
deliberately takes the fail-open path that ticket requires: the draft
notes are always the mechanically-promoted changelog text with a note
that drafting was skipped. Wiring in LIG-10559 later only touches this
function's `drafting_skipped_reason` input.

Wires it into the CLI as `render-pr-body`, completing the tool's full
set of subcommands - the next (and final) PR in the stack just adds the
GitHub Actions workflow that dispatches them.

Linear: https://linear.app/lightly/issue/LIG-10552

## How has it been tested?

- 2 new unit tests: the rendered body (draft notes + coverage checklist
  present, no internal reference leaking) and the empty-checklist
  placeholder.
- `make static-checks` (ruff format/check, mypy) passes.
- Hand-ran `render-pr-body` against this repo's real `CHANGELOG.md`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

---
Suggested reviewer: @michal-lightly. Alternate: @lukas-lightly.
