### PR TITLE
Add prepare-release workflow: changelog promotion, version bump, release PR

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,174 @@
+name: Prepare Release
+
+# Replaces RELEASE.md steps 3-5 (branch, changelog promotion, version bump,
+# release PR) with one manual dispatch. Public repo, ubuntu-latest, no
+# secrets beyond the default token used to push the branch and open the PR.
+# Publishes nothing - see LIG-10552 for the full spec.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: >-
+          Semver bump. "auto" uses the suggestion computed from which
+          [Unreleased] sections are non-empty (see the job summary).
+        type: choice
+        options: [auto, patch, minor, major]
+        default: auto
+      version:
+        description: >-
+          Explicit version override, e.g. for a release candidate such as
+          1.0.0rc1. Takes precedence over "bump" when set.
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Only one release preparation at a time; never cancel one mid-flight since
+# it pushes a branch and opens a PR.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          # Full history + tags: the coverage checklist below diffs against
+          # the last tag.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set Up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.8.17"
+          enable-cache: true
+
+      - name: Guard against a git-pinned Labelformat
+        run: |
+          python3 scripts/prepare_release.py check-labelformat-pin \
+            --pyproject lightly_studio/pyproject.toml
+
+      - name: Suggest version bump
+        id: suggest
+        # Only needed when the operator left both inputs on their defaults;
+        # an explicit --version or --bump makes the suggestion moot.
+        if: inputs.version == '' && inputs.bump == 'auto'
+        run: |
+          result="$(python3 scripts/prepare_release.py suggest-bump --changelog CHANGELOG.md)"
+          bump="$(printf '%s\n' "$result" | head -n1 | sed 's/^bump=//')"
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Suggested version bump: \`$bump\`"
+            printf '%s\n' "$result" | tail -n +2
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve inputs
+        id: resolved
+        run: |
+          bump="${{ inputs.bump }}"
+          if [ "$bump" = "auto" ]; then
+            # Empty when an explicit --version was given instead (the
+            # "Suggest version bump" step above was skipped) - unused in
+            # that case, compute-version ignores --bump whenever --version
+            # is set.
+            bump="${{ steps.suggest.outputs.bump }}"
+            bump="${bump:-patch}"
+          fi
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+
+          version="$(python3 scripts/prepare_release.py compute-version \
+            --pyproject lightly_studio/pyproject.toml \
+            --bump "$bump" \
+            --version "${{ inputs.version }}")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "### Preparing release v$version" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create release branch
+        run: git checkout -b "release-v${{ steps.resolved.outputs.version }}"
+
+      - name: Promote changelog
+        run: |
+          python3 scripts/prepare_release.py promote-changelog \
+            --changelog CHANGELOG.md \
+            --version "${{ steps.resolved.outputs.version }}" \
+            --date "$(date -u +%F)"
+
+      - name: Bump pyproject.toml version
+        run: |
+          python3 scripts/prepare_release.py bump-pyproject \
+            --pyproject lightly_studio/pyproject.toml \
+            --version "${{ steps.resolved.outputs.version }}"
+
+      - name: Snapshot uv.lock before sync
+        run: cp lightly_studio/uv.lock /tmp/uv.lock.before
+
+      - name: uv sync
+        working-directory: lightly_studio
+        run: uv sync
+
+      - name: Assert uv.lock diff is narrow
+        run: |
+          python3 scripts/prepare_release.py assert-lock-diff \
+            --before /tmp/uv.lock.before \
+            --after lightly_studio/uv.lock \
+            --package lightly-studio
+
+      - name: Confirm exactly the expected files changed
+        run: |
+          changed="$(git status --porcelain | awk '{print $2}' | sort)"
+          expected="$(printf '%s\n' CHANGELOG.md lightly_studio/pyproject.toml lightly_studio/uv.lock | sort)"
+          if [ "$changed" != "$expected" ]; then
+            echo "::error::Unexpected file set changed. Got:"
+            echo "$changed"
+            exit 1
+          fi
+
+      - name: Build coverage checklist (advisory, git-derived, never published)
+        run: |
+          last_tag="$(git describe --tags --abbrev=0 origin/main 2>/dev/null || true)"
+          {
+            if [ -z "$last_tag" ]; then
+              echo "_No previous tag found; skipping coverage checklist._"
+            else
+              echo "Merged commits since \`$last_tag\` - check each has a matching CHANGELOG entry:"
+              echo
+              git log "$last_tag..origin/main" --no-merges --oneline | sed 's/^/- /'
+            fi
+          } > /tmp/coverage_checklist.md
+          cat /tmp/coverage_checklist.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Render PR body
+        run: |
+          python3 scripts/prepare_release.py render-pr-body \
+            --changelog CHANGELOG.md \
+            --version "${{ steps.resolved.outputs.version }}" \
+            --coverage-file /tmp/coverage_checklist.md \
+            --drafting-skipped-reason "the LLM drafting step from LIG-10559 is not wired in yet" \
+            --output /tmp/pr_body.md
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md lightly_studio/pyproject.toml lightly_studio/uv.lock
+          git commit -m "Bump version to ${{ steps.resolved.outputs.version }}"
+          git push origin "release-v${{ steps.resolved.outputs.version }}"
+
+      - name: Open release PR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+            --title "Bump version to ${{ steps.resolved.outputs.version }}" \
+            --body-file /tmp/pr_body.md \
+            --base main \
+            --head "release-v${{ steps.resolved.outputs.version }}"

--- a/lightly_studio/scripts/prepare_release.py
+++ b/lightly_studio/scripts/prepare_release.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Mechanical steps for preparing a LightlyStudio release.
 
-Backs the `Prepare Release` GitHub Actions workflow, landing incrementally
-(see LIG-10552 for the full spec). Every subcommand does one small,
-independently testable piece of RELEASE.md steps 3-5. This slice adds
-changelog promotion, the version/`pyproject.toml`/`uv.lock` guards, and
-draft release-notes rendering for the release PR body.
+Backs the `Prepare Release` GitHub Actions workflow
+(`.github/workflows/prepare_release.yml`). Every subcommand does one small,
+independently testable piece of RELEASE.md steps 3-5: promoting the
+changelog, bumping the version, and guarding against a handful of ways that
+can quietly go wrong. See LIG-10552 for the full spec.
 
 Stdlib only, deliberately: this runs on the release-critical path before
 `uv sync`, so it must not itself depend on anything `uv` would need to


### PR DESCRIPTION
Part of a stack for LIG-10552 ([gh-stack](https://github.github.com/gh-stack/)), 4 of 4 (top), landing bottom-up onto `main`:

1. #2038 - changelog promotion
2. #2039 - version, pyproject.toml, and uv.lock guards
3. #2040 - PR body rendering (draft notes + coverage checklist)
4. **#2041 - the workflow itself** (this PR)

Based on #2040 - please review/merge in order; this is the last one, it
wires everything below it together.

## What has changed and why?

Fourth and final slice of the **Prepare Release** workflow (LIG-10552).
Adds `.github/workflows/prepare_release.yml`, a `workflow_dispatch`-only
workflow that replaces RELEASE.md steps 3-5 with one manual dispatch,
using the CLI built up across #2038-#2040:

1. Create a `release-vX.Y.Z` branch off `main`.
2. Guard against a git-pinned Labelformat; suggest/resolve the version
   bump.
3. Promote the changelog, bump `pyproject.toml`, run `uv sync`.
4. Assert the `uv.lock` diff is narrow, and that exactly the three
   expected files changed (a second net beyond the script's own
   assertion, per the ticket).
5. Build the advisory coverage checklist and render the PR body.
6. Commit, push, and open a `Bump version to X.Y.Z` PR.

Runs on `ubuntu-latest` with no secrets beyond the default `GITHUB_TOKEN`
(`contents: write` / `pull-requests: write`) - nothing in
`lightly-studio-private` changes. Publishes nothing; tag / GitHub
release / PyPI stay manual for now.

The heading-escaping normalisation itself is out of scope here per the
ticket - it's flagged as a separate follow-up.

Linear: https://linear.app/lightly/issue/LIG-10552

## How has it been tested?

- Inherits the 26 unit tests from the earlier PRs in this stack (all
  passing), plus `make static-checks` on the full script.
- Smoke-tested every subcommand by hand against this repo's real
  `CHANGELOG.md` / `pyproject.toml` / `uv.lock` (promotion, version
  bump, lock-diff assertion, and PR body rendering all produced the
  expected output).
- Have not yet dispatched the workflow itself on GitHub (needs a run on
  `main`, i.e. after this stack merges) - flagging for reviewer
  awareness before merge.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

---
Suggested reviewer: @michal-lightly. Alternate: @lukas-lightly.
