### PR TITLE
Add prepare-release tooling: changelog promotion

### DIFF
--- a/.github/scripts/.gitignore
+++ b/.github/scripts/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+.pytest_cache
+.ruff_cache
+.mypy_cache

--- a/.github/scripts/prepare_release/changelog.py
+++ b/.github/scripts/prepare_release/changelog.py
@@ -25,48 +25,6 @@ _ANY_H2_RE = re.compile(r"^## ", re.MULTILINE)
 _SUBSECTION_RE = re.compile(r"^### (?P<name>\w+)[ \t]*$", re.MULTILINE)
 
 
-def parse_unreleased_sections(changelog_text: str) -> dict[str, str]:
-    """Extracts the `[Unreleased]` section's six subsections.
-
-    Returns:
-        A mapping from subsection name (e.g. "Added") to its raw body text
-        (may be empty or whitespace-only).
-    """
-    body = _unreleased_body(changelog_text)
-    headings = list(_SUBSECTION_RE.finditer(body))
-    names = [h.group("name") for h in headings]
-    if names != list(SUBSECTIONS):
-        raise PrepareReleaseError(
-            f"[Unreleased] subsections are {names}, expected {list(SUBSECTIONS)} in that order"
-        )
-    if body[: headings[0].start()].strip():
-        raise PrepareReleaseError(
-            "unexpected content between the [Unreleased] heading and its first subsection"
-        )
-    sections = {}
-    for i, heading in enumerate(headings):
-        start = heading.end()
-        end = headings[i + 1].start() if i + 1 < len(headings) else len(body)
-        sections[heading.group("name")] = body[start:end]
-    return sections
-
-
-def suggest_bump(sections: dict[str, str]) -> tuple[str, str]:
-    """Suggests a semver bump from which [Unreleased] sections are non-empty.
-
-    Added / Changed / Removed / Deprecated entries suggest a minor bump;
-    only Fixed and/or Security entries suggest a patch. The operator still
-    confirms - this is a suggestion, not a decision.
-    """
-    non_empty = [name for name in SUBSECTIONS if sections.get(name, "").strip()]
-    if not non_empty:
-        raise PrepareReleaseError("the [Unreleased] section has no entries; nothing to release")
-    minor_triggers = [n for n in non_empty if n in ("Added", "Changed", "Removed", "Deprecated")]
-    bump = "minor" if minor_triggers else "patch"
-    reasoning = f"Non-empty [Unreleased] sections: {', '.join(non_empty)}."
-    return bump, reasoning
-
-
 def promote_changelog(changelog_text: str, version: str, date: str) -> str:
     """Promotes `[Unreleased]` to a released version block.
 
@@ -77,7 +35,7 @@ def promote_changelog(changelog_text: str, version: str, date: str) -> str:
     """
     unreleased_match = _single_unreleased_match(changelog_text)
     _, body_end = _unreleased_body_span(changelog_text, unreleased_match)
-    sections = parse_unreleased_sections(changelog_text)
+    sections = _parse_unreleased_sections(changelog_text)
 
     preamble = changelog_text[: unreleased_match.start()]
     rest = changelog_text[body_end:]
@@ -102,6 +60,7 @@ def assert_changelog_structure(original_text: str, new_text: str, version: str) 
     logic itself:
 
     * exactly one `## [Unreleased]` heading, with all six subheadings,
+    * the fresh `[Unreleased]` section has no entries,
     * exactly one new `## \\[version\\] - YYYY-MM-DD` heading, preceded by
       the `[Unreleased]` heading,
     * every previously-released version block is byte-identical to before.
@@ -113,7 +72,11 @@ def assert_changelog_structure(original_text: str, new_text: str, version: str) 
             f"{len(unreleased_matches)}"
         )
     # Raises PrepareReleaseError itself if a subheading is missing/misordered.
-    parse_unreleased_sections(new_text)
+    fresh_sections = _parse_unreleased_sections(new_text)
+    if any(content.strip() for content in fresh_sections.values()):
+        raise PrepareReleaseError(
+            "expected the fresh [Unreleased] section to have no entries after promotion"
+        )
 
     released_heading = re.compile(
         r"^## \\\[" + re.escape(version) + r"\\\] - \d{4}-\d{2}-\d{2}[ \t]*$",
@@ -140,7 +103,11 @@ def assert_changelog_structure(original_text: str, new_text: str, version: str) 
 
 
 def extract_released_section(changelog_text: str, version: str) -> str:
-    r"""Returns the (trimmed) body of the `## \[version\] - ...` block."""
+    r"""Returns the (trimmed) body of the `## \[version\] - ...` block.
+
+    Consumed by the release PR body renderer (a later stage of this stack) to
+    pull the just-promoted section's text into the release PR description.
+    """
     heading = re.compile(
         r"^## \\\[" + re.escape(version) + r"\\\] - \d{4}-\d{2}-\d{2}[ \t]*$",
         re.MULTILINE,
@@ -152,6 +119,32 @@ def extract_released_section(changelog_text: str, version: str) -> str:
     next_heading = _ANY_H2_RE.search(changelog_text, body_start)
     body_end = next_heading.start() if next_heading else len(changelog_text)
     return changelog_text[body_start:body_end].strip()
+
+
+def _parse_unreleased_sections(changelog_text: str) -> dict[str, str]:
+    """Extracts the `[Unreleased]` section's six subsections.
+
+    Returns:
+        A mapping from subsection name (e.g. "Added") to its raw body text
+        (may be empty or whitespace-only).
+    """
+    body = _unreleased_body(changelog_text)
+    headings = list(_SUBSECTION_RE.finditer(body))
+    names = [h.group("name") for h in headings]
+    if names != list(SUBSECTIONS):
+        raise PrepareReleaseError(
+            f"[Unreleased] subsections are {names}, expected {list(SUBSECTIONS)} in that order"
+        )
+    if body[: headings[0].start()].strip():
+        raise PrepareReleaseError(
+            "unexpected content between the [Unreleased] heading and its first subsection"
+        )
+    sections = {}
+    for i, heading in enumerate(headings):
+        start = heading.end()
+        end = headings[i + 1].start() if i + 1 < len(headings) else len(body)
+        sections[heading.group("name")] = body[start:end]
+    return sections
 
 
 def _single_unreleased_match(changelog_text: str) -> re.Match[str]:

--- a/.github/scripts/prepare_release/changelog.py
+++ b/.github/scripts/prepare_release/changelog.py
@@ -63,6 +63,7 @@ def assert_changelog_structure(original_text: str, new_text: str, version: str) 
     * the fresh `[Unreleased]` section has no entries,
     * exactly one new `## \\[version\\] - YYYY-MM-DD` heading, preceded by
       the `[Unreleased]` heading,
+    * the promoted release block preserves the original `[Unreleased]` entries,
     * every previously-released version block is byte-identical to before.
     """
     unreleased_matches = list(_UNRELEASED_RE.finditer(new_text))
@@ -91,6 +92,17 @@ def assert_changelog_structure(original_text: str, new_text: str, version: str) 
     if released_matches[0].start() < unreleased_matches[0].start():
         raise PrepareReleaseError(
             f"expected the [Unreleased] heading to precede the new '[{version}]' release heading"
+        )
+
+    original_sections = _parse_unreleased_sections(original_text)
+    expected_released_body = "".join(
+        f"### {name}\n\n{original_sections[name].strip()}\n\n"
+        for name in SUBSECTIONS
+        if original_sections[name].strip()
+    ).strip()
+    if extract_released_section(changelog_text=new_text, version=version) != expected_released_body:
+        raise PrepareReleaseError(
+            "promoted release content does not preserve the original [Unreleased] entries"
         )
 
     original_match = _single_unreleased_match(original_text)

--- a/.github/scripts/prepare_release/changelog.py
+++ b/.github/scripts/prepare_release/changelog.py
@@ -39,6 +39,10 @@ def parse_unreleased_sections(changelog_text: str) -> dict[str, str]:
         raise PrepareReleaseError(
             f"[Unreleased] subsections are {names}, expected {list(SUBSECTIONS)} in that order"
         )
+    if body[: headings[0].start()].strip():
+        raise PrepareReleaseError(
+            "unexpected content between the [Unreleased] heading and its first subsection"
+        )
     sections = {}
     for i, heading in enumerate(headings):
         start = heading.end()
@@ -98,7 +102,8 @@ def assert_changelog_structure(original_text: str, new_text: str, version: str) 
     logic itself:
 
     * exactly one `## [Unreleased]` heading, with all six subheadings,
-    * the new `## \\[version\\] - YYYY-MM-DD` heading exists,
+    * exactly one new `## \\[version\\] - YYYY-MM-DD` heading, preceded by
+      the `[Unreleased]` heading,
     * every previously-released version block is byte-identical to before.
     """
     unreleased_matches = list(_UNRELEASED_RE.finditer(new_text))
@@ -114,9 +119,15 @@ def assert_changelog_structure(original_text: str, new_text: str, version: str) 
         r"^## \\\[" + re.escape(version) + r"\\\] - \d{4}-\d{2}-\d{2}[ \t]*$",
         re.MULTILINE,
     )
-    if not released_heading.search(new_text):
+    released_matches = list(released_heading.finditer(new_text))
+    if len(released_matches) != 1:
         raise PrepareReleaseError(
-            f"expected an escaped '## \\[{version}\\] - YYYY-MM-DD' heading after promotion"
+            f"expected exactly one escaped '## \\[{version}\\] - YYYY-MM-DD' heading after "
+            f"promotion, found {len(released_matches)}"
+        )
+    if released_matches[0].start() < unreleased_matches[0].start():
+        raise PrepareReleaseError(
+            f"expected the [Unreleased] heading to precede the new '[{version}]' release heading"
         )
 
     original_match = _single_unreleased_match(original_text)

--- a/.github/scripts/prepare_release/changelog.py
+++ b/.github/scripts/prepare_release/changelog.py
@@ -1,0 +1,165 @@
+"""Promote CHANGELOG.md's [Unreleased] section into a released version block.
+
+The riskiest step of preparing a release: get the promotion wrong and the
+changelog silently stops being a trustworthy record. `promote_changelog`
+only constructs the new text; callers must run `assert_changelog_structure`
+on the result before trusting it.
+"""
+
+from __future__ import annotations
+
+import re
+
+from prepare_release.errors import PrepareReleaseError
+
+# Keep a Changelog subsection headings, in the fixed order this project's
+# CHANGELOG.md uses.
+SUBSECTIONS = ("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security")
+
+# `## [Unreleased]` is the one heading kept unescaped; every released version
+# heading is `## \[X.Y.Z\] - YYYY-MM-DD`. Getting this backwards silently
+# breaks the convention instead of failing loudly, which is exactly what
+# `assert_changelog_structure` guards against.
+_UNRELEASED_RE = re.compile(r"^## \[Unreleased\][ \t]*$", re.MULTILINE)
+_ANY_H2_RE = re.compile(r"^## ", re.MULTILINE)
+_SUBSECTION_RE = re.compile(r"^### (?P<name>\w+)[ \t]*$", re.MULTILINE)
+
+
+def parse_unreleased_sections(changelog_text: str) -> dict[str, str]:
+    """Extracts the `[Unreleased]` section's six subsections.
+
+    Returns:
+        A mapping from subsection name (e.g. "Added") to its raw body text
+        (may be empty or whitespace-only).
+    """
+    body = _unreleased_body(changelog_text)
+    headings = list(_SUBSECTION_RE.finditer(body))
+    names = [h.group("name") for h in headings]
+    if names != list(SUBSECTIONS):
+        raise PrepareReleaseError(
+            f"[Unreleased] subsections are {names}, expected {list(SUBSECTIONS)} in that order"
+        )
+    sections = {}
+    for i, heading in enumerate(headings):
+        start = heading.end()
+        end = headings[i + 1].start() if i + 1 < len(headings) else len(body)
+        sections[heading.group("name")] = body[start:end]
+    return sections
+
+
+def suggest_bump(sections: dict[str, str]) -> tuple[str, str]:
+    """Suggests a semver bump from which [Unreleased] sections are non-empty.
+
+    Added / Changed / Removed / Deprecated entries suggest a minor bump;
+    only Fixed and/or Security entries suggest a patch. The operator still
+    confirms - this is a suggestion, not a decision.
+    """
+    non_empty = [name for name in SUBSECTIONS if sections.get(name, "").strip()]
+    if not non_empty:
+        raise PrepareReleaseError("the [Unreleased] section has no entries; nothing to release")
+    minor_triggers = [n for n in non_empty if n in ("Added", "Changed", "Removed", "Deprecated")]
+    bump = "minor" if minor_triggers else "patch"
+    reasoning = f"Non-empty [Unreleased] sections: {', '.join(non_empty)}."
+    return bump, reasoning
+
+
+def promote_changelog(changelog_text: str, version: str, date: str) -> str:
+    """Promotes `[Unreleased]` to a released version block.
+
+    Drops empty subsections from the promoted block, inserts a fresh empty
+    `[Unreleased]` skeleton above it, and leaves everything else byte-for-byte
+    unchanged. Callers must run `assert_changelog_structure` on the result
+    before trusting it - this function only constructs, it doesn't verify.
+    """
+    unreleased_match = _single_unreleased_match(changelog_text)
+    _, body_end = _unreleased_body_span(changelog_text, unreleased_match)
+    sections = parse_unreleased_sections(changelog_text)
+
+    preamble = changelog_text[: unreleased_match.start()]
+    rest = changelog_text[body_end:]
+
+    skeleton = "## [Unreleased]\n\n" + "".join(f"### {name}\n\n" for name in SUBSECTIONS)
+
+    promoted_sections = "".join(
+        f"### {name}\n\n{sections[name].strip()}\n\n"
+        for name in SUBSECTIONS
+        if sections[name].strip()
+    )
+    promoted = f"## \\[{version}\\] - {date}\n\n" + promoted_sections
+
+    return preamble + skeleton + promoted + rest
+
+
+def assert_changelog_structure(original_text: str, new_text: str, version: str) -> None:
+    r"""Verifies a changelog promotion didn't corrupt the file.
+
+    Independently re-derives the required invariants from `new_text` rather
+    than trusting how it was built, so it catches bugs in the construction
+    logic itself:
+
+    * exactly one `## [Unreleased]` heading, with all six subheadings,
+    * the new `## \\[version\\] - YYYY-MM-DD` heading exists,
+    * every previously-released version block is byte-identical to before.
+    """
+    unreleased_matches = list(_UNRELEASED_RE.finditer(new_text))
+    if len(unreleased_matches) != 1:
+        raise PrepareReleaseError(
+            f"expected exactly one [Unreleased] heading after promotion, found "
+            f"{len(unreleased_matches)}"
+        )
+    # Raises PrepareReleaseError itself if a subheading is missing/misordered.
+    parse_unreleased_sections(new_text)
+
+    released_heading = re.compile(
+        r"^## \\\[" + re.escape(version) + r"\\\] - \d{4}-\d{2}-\d{2}[ \t]*$",
+        re.MULTILINE,
+    )
+    if not released_heading.search(new_text):
+        raise PrepareReleaseError(
+            f"expected an escaped '## \\[{version}\\] - YYYY-MM-DD' heading after promotion"
+        )
+
+    original_match = _single_unreleased_match(original_text)
+    _, original_body_end = _unreleased_body_span(original_text, original_match)
+    previously_released = original_text[original_body_end:]
+    if not new_text.endswith(previously_released):
+        raise PrepareReleaseError(
+            "previously-released changelog blocks are not byte-identical after promotion"
+        )
+
+
+def extract_released_section(changelog_text: str, version: str) -> str:
+    r"""Returns the (trimmed) body of the `## \[version\] - ...` block."""
+    heading = re.compile(
+        r"^## \\\[" + re.escape(version) + r"\\\] - \d{4}-\d{2}-\d{2}[ \t]*$",
+        re.MULTILINE,
+    )
+    match = heading.search(changelog_text)
+    if match is None:
+        raise PrepareReleaseError(f"no promoted heading found for version {version!r}")
+    body_start = match.end()
+    next_heading = _ANY_H2_RE.search(changelog_text, body_start)
+    body_end = next_heading.start() if next_heading else len(changelog_text)
+    return changelog_text[body_start:body_end].strip()
+
+
+def _single_unreleased_match(changelog_text: str) -> re.Match[str]:
+    matches = list(_UNRELEASED_RE.finditer(changelog_text))
+    if len(matches) != 1:
+        raise PrepareReleaseError(
+            f"expected exactly one [Unreleased] heading, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _unreleased_body_span(changelog_text: str, unreleased_match: re.Match[str]) -> tuple[int, int]:
+    body_start = unreleased_match.end()
+    next_heading = _ANY_H2_RE.search(changelog_text, body_start)
+    body_end = next_heading.start() if next_heading else len(changelog_text)
+    return body_start, body_end
+
+
+def _unreleased_body(changelog_text: str) -> str:
+    match = _single_unreleased_match(changelog_text)
+    start, end = _unreleased_body_span(changelog_text, match)
+    return changelog_text[start:end]

--- a/.github/scripts/prepare_release/errors.py
+++ b/.github/scripts/prepare_release/errors.py
@@ -1,0 +1,9 @@
+"""Shared error type for the prepare-release tooling."""
+
+
+class PrepareReleaseError(Exception):
+    """A release-preparation precondition failed.
+
+    Raised for anything that should fail the workflow loudly rather than
+    open a malformed or unreviewable release PR.
+    """

--- a/.github/scripts/pyproject.toml
+++ b/.github/scripts/pyproject.toml
@@ -1,0 +1,26 @@
+# Tooling config only - this directory is CI-internal tooling for the
+# "Prepare Release" workflow, not a distributed package, so there's no
+# [project] table here.
+
+[tool.pytest.ini_options]
+pythonpath = "."
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+select = ["E", "F", "W", "C90", "I", "N", "D", "UP", "B", "A", "C4", "DTZ", "T10", "PIE", "PT", "RET", "SLF", "SIM", "TID", "ARG", "PL", "RUF"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["D104"]
+"tests/**/*.py" = ["D100", "D101", "D102", "D103", "D107", "PLR2004", "SLF001"]
+
+[tool.mypy]
+strict = true
+disallow_untyped_defs = true

--- a/.github/scripts/tests/test_changelog.py
+++ b/.github/scripts/tests/test_changelog.py
@@ -92,6 +92,17 @@ def test_assert_changelog_structure__entry_left_in_fresh_unreleased_raises() -> 
         )
 
 
+def test_assert_changelog_structure__dropped_entry_raises() -> None:
+    promoted = changelog.promote_changelog(
+        changelog_text=SAMPLE_CHANGELOG, version="1.1.0", date="2026-08-21"
+    )
+    corrupted = promoted.replace("- Added thing one.\n\n", "", 1)
+    with pytest.raises(PrepareReleaseError, match="does not preserve"):
+        changelog.assert_changelog_structure(
+            original_text=SAMPLE_CHANGELOG, new_text=corrupted, version="1.1.0"
+        )
+
+
 def test_assert_changelog_structure__mutated_released_block_raises() -> None:
     promoted = changelog.promote_changelog(
         changelog_text=SAMPLE_CHANGELOG, version="1.1.0", date="2026-08-21"

--- a/.github/scripts/tests/test_changelog.py
+++ b/.github/scripts/tests/test_changelog.py
@@ -1,0 +1,133 @@
+import pytest
+
+from prepare_release import changelog
+from prepare_release.errors import PrepareReleaseError
+
+SAMPLE_CHANGELOG = """\
+# Changelog
+
+All notable changes to Lightly**Studio** will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Added thing one.
+
+### Changed
+
+- Changed thing one.
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## \\[1.0.5\\] - 2026-08-14
+
+### Added
+
+- Some old thing.
+
+## \\[1.0.4\\] - 2026-08-01
+
+### Fixed
+
+- An older fix.
+"""
+
+
+def test_parse_unreleased_sections():
+    sections = changelog.parse_unreleased_sections(SAMPLE_CHANGELOG)
+    assert list(sections) == list(changelog.SUBSECTIONS)
+    assert "Added thing one" in sections["Added"]
+    assert "Changed thing one" in sections["Changed"]
+    assert sections["Deprecated"].strip() == ""
+    assert sections["Removed"].strip() == ""
+
+
+def test_parse_unreleased_sections__wrong_order_raises():
+    broken = SAMPLE_CHANGELOG.replace(
+        "### Added\n\n- Added thing one.\n\n### Changed",
+        "### Changed\n\n### Added\n\n- Added thing one.",
+    )
+    with pytest.raises(PrepareReleaseError):
+        changelog.parse_unreleased_sections(broken)
+
+
+def test_parse_unreleased_sections__no_unreleased_heading_raises():
+    with pytest.raises(PrepareReleaseError):
+        changelog.parse_unreleased_sections("# Changelog\n\nnothing here\n")
+
+
+def test_suggest_bump__added_or_changed_suggests_minor():
+    sections = changelog.parse_unreleased_sections(SAMPLE_CHANGELOG)
+    bump, reasoning = changelog.suggest_bump(sections)
+    assert bump == "minor"
+    assert "Added" in reasoning
+    assert "Changed" in reasoning
+
+
+def test_suggest_bump__only_fixed_or_security_suggests_patch():
+    sections = dict.fromkeys(changelog.SUBSECTIONS, "")
+    sections["Fixed"] = "- Fixed a bug.\n"
+    bump, _ = changelog.suggest_bump(sections)
+    assert bump == "patch"
+
+
+def test_suggest_bump__nothing_unreleased_raises():
+    sections = dict.fromkeys(changelog.SUBSECTIONS, "")
+    with pytest.raises(PrepareReleaseError, match="nothing to release"):
+        changelog.suggest_bump(sections)
+
+
+def test_promote_changelog():
+    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+
+    # Fresh, fully-empty [Unreleased] skeleton with all six subheadings.
+    assert promoted.count("## [Unreleased]") == 1
+    for name in changelog.SUBSECTIONS:
+        assert f"### {name}\n\n" in promoted
+
+    # New release heading in escaped form, empty sections dropped.
+    assert "## \\[1.1.0\\] - 2026-08-21" in promoted
+    assert "Added thing one" in promoted
+    assert "Changed thing one" in promoted
+
+    # Previously-released blocks are untouched.
+    assert "## \\[1.0.5\\] - 2026-08-14" in promoted
+    assert "## \\[1.0.4\\] - 2026-08-01" in promoted
+    assert promoted.index("1.1.0") < promoted.index("1.0.5") < promoted.index("1.0.4")
+
+    changelog.assert_changelog_structure(SAMPLE_CHANGELOG, promoted, "1.1.0")
+
+
+def test_assert_changelog_structure__missing_unreleased_raises():
+    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    corrupted = promoted.replace("## [Unreleased]\n\n", "", 1)
+    with pytest.raises(PrepareReleaseError):
+        changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+
+
+def test_assert_changelog_structure__mutated_released_block_raises():
+    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    corrupted = promoted.replace("An older fix.", "A DIFFERENT fix.")
+    with pytest.raises(PrepareReleaseError, match="byte-identical"):
+        changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+
+
+def test_assert_changelog_structure__missing_new_heading_raises():
+    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    corrupted = promoted.replace("## \\[1.1.0\\] - 2026-08-21", "## [1.1.0] - 2026-08-21")
+    with pytest.raises(PrepareReleaseError):
+        changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+
+
+def test_extract_released_section():
+    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    section = changelog.extract_released_section(promoted, "1.1.0")
+    assert "Added thing one" in section
+    assert "1.0.5" not in section

--- a/.github/scripts/tests/test_changelog.py
+++ b/.github/scripts/tests/test_changelog.py
@@ -40,65 +40,14 @@ All notable changes to Lightly**Studio** will be documented in this file.
 """
 
 
-def test_parse_unreleased_sections() -> None:
-    sections = changelog.parse_unreleased_sections(SAMPLE_CHANGELOG)
-    assert list(sections) == list(changelog.SUBSECTIONS)
-    assert "Added thing one" in sections["Added"]
-    assert "Changed thing one" in sections["Changed"]
-    assert sections["Deprecated"].strip() == ""
-    assert sections["Removed"].strip() == ""
-
-
-def test_parse_unreleased_sections__wrong_order_raises() -> None:
-    broken = SAMPLE_CHANGELOG.replace(
-        "### Added\n\n- Added thing one.\n\n### Changed",
-        "### Changed\n\n### Added\n\n- Added thing one.",
-    )
-    with pytest.raises(PrepareReleaseError):
-        changelog.parse_unreleased_sections(broken)
-
-
-def test_parse_unreleased_sections__no_unreleased_heading_raises() -> None:
-    with pytest.raises(PrepareReleaseError):
-        changelog.parse_unreleased_sections("# Changelog\n\nnothing here\n")
-
-
-def test_parse_unreleased_sections__stray_content_before_first_subsection_raises() -> None:
-    broken = SAMPLE_CHANGELOG.replace(
-        "## [Unreleased]\n\n### Added",
-        "## [Unreleased]\n\nSee migration notes below.\n\n### Added",
-    )
-    with pytest.raises(PrepareReleaseError, match="unexpected content"):
-        changelog.parse_unreleased_sections(broken)
-
-
-def test_suggest_bump__added_or_changed_suggests_minor() -> None:
-    sections = changelog.parse_unreleased_sections(SAMPLE_CHANGELOG)
-    bump, reasoning = changelog.suggest_bump(sections)
-    assert bump == "minor"
-    assert "Added" in reasoning
-    assert "Changed" in reasoning
-
-
-def test_suggest_bump__only_fixed_or_security_suggests_patch() -> None:
-    sections = dict.fromkeys(changelog.SUBSECTIONS, "")
-    sections["Fixed"] = "- Fixed a bug.\n"
-    bump, _ = changelog.suggest_bump(sections)
-    assert bump == "patch"
-
-
-def test_suggest_bump__nothing_unreleased_raises() -> None:
-    sections = dict.fromkeys(changelog.SUBSECTIONS, "")
-    with pytest.raises(PrepareReleaseError, match="nothing to release"):
-        changelog.suggest_bump(sections)
-
-
 def test_promote_changelog() -> None:
-    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    promoted = changelog.promote_changelog(
+        changelog_text=SAMPLE_CHANGELOG, version="1.1.0", date="2026-08-21"
+    )
 
     # Fresh, fully-empty [Unreleased] skeleton with all six subheadings.
     assert promoted.count("## [Unreleased]") == 1
-    fresh_sections = changelog.parse_unreleased_sections(promoted)
+    fresh_sections = changelog._parse_unreleased_sections(promoted)
     assert list(fresh_sections) == list(changelog.SUBSECTIONS)
     assert all(not content.strip() for content in fresh_sections.values())
 
@@ -112,34 +61,67 @@ def test_promote_changelog() -> None:
     assert "## \\[1.0.4\\] - 2026-08-01" in promoted
     assert promoted.index("1.1.0") < promoted.index("1.0.5") < promoted.index("1.0.4")
 
-    changelog.assert_changelog_structure(SAMPLE_CHANGELOG, promoted, "1.1.0")
+    changelog.assert_changelog_structure(
+        original_text=SAMPLE_CHANGELOG, new_text=promoted, version="1.1.0"
+    )
 
 
 def test_assert_changelog_structure__missing_unreleased_raises() -> None:
-    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    promoted = changelog.promote_changelog(
+        changelog_text=SAMPLE_CHANGELOG, version="1.1.0", date="2026-08-21"
+    )
     corrupted = promoted.replace("## [Unreleased]\n\n", "", 1)
     with pytest.raises(PrepareReleaseError):
-        changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+        changelog.assert_changelog_structure(
+            original_text=SAMPLE_CHANGELOG, new_text=corrupted, version="1.1.0"
+        )
+
+
+def test_assert_changelog_structure__entry_left_in_fresh_unreleased_raises() -> None:
+    promoted = changelog.promote_changelog(
+        changelog_text=SAMPLE_CHANGELOG, version="1.1.0", date="2026-08-21"
+    )
+    corrupted = promoted.replace(
+        "## [Unreleased]\n\n### Added",
+        "## [Unreleased]\n\n### Added\n\n- Leftover entry.",
+        1,
+    )
+    with pytest.raises(PrepareReleaseError, match="no entries"):
+        changelog.assert_changelog_structure(
+            original_text=SAMPLE_CHANGELOG, new_text=corrupted, version="1.1.0"
+        )
 
 
 def test_assert_changelog_structure__mutated_released_block_raises() -> None:
-    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    promoted = changelog.promote_changelog(
+        changelog_text=SAMPLE_CHANGELOG, version="1.1.0", date="2026-08-21"
+    )
     corrupted = promoted.replace("An older fix.", "A DIFFERENT fix.")
     with pytest.raises(PrepareReleaseError, match="byte-identical"):
-        changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+        changelog.assert_changelog_structure(
+            original_text=SAMPLE_CHANGELOG, new_text=corrupted, version="1.1.0"
+        )
 
 
 def test_assert_changelog_structure__missing_new_heading_raises() -> None:
-    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
+    promoted = changelog.promote_changelog(
+        changelog_text=SAMPLE_CHANGELOG, version="1.1.0", date="2026-08-21"
+    )
     corrupted = promoted.replace("## \\[1.1.0\\] - 2026-08-21", "## [1.1.0] - 2026-08-21")
     with pytest.raises(PrepareReleaseError):
-        changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+        changelog.assert_changelog_structure(
+            original_text=SAMPLE_CHANGELOG, new_text=corrupted, version="1.1.0"
+        )
 
 
 def test_assert_changelog_structure__duplicate_new_heading_raises() -> None:
-    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.0.5", "2026-08-24")
+    promoted = changelog.promote_changelog(
+        changelog_text=SAMPLE_CHANGELOG, version="1.0.5", date="2026-08-24"
+    )
     with pytest.raises(PrepareReleaseError, match="exactly one"):
-        changelog.assert_changelog_structure(SAMPLE_CHANGELOG, promoted, "1.0.5")
+        changelog.assert_changelog_structure(
+            original_text=SAMPLE_CHANGELOG, new_text=promoted, version="1.0.5"
+        )
 
 
 def test_assert_changelog_structure__unreleased_after_release_heading_raises() -> None:
@@ -156,11 +138,47 @@ def test_assert_changelog_structure__unreleased_after_release_heading_raises() -
         "### Removed\n\n### Fixed\n\n### Security\n\n"
     ) + SAMPLE_CHANGELOG[SAMPLE_CHANGELOG.index("## \\[1.0.5\\]") :]
     with pytest.raises(PrepareReleaseError, match="precede"):
-        changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+        changelog.assert_changelog_structure(
+            original_text=SAMPLE_CHANGELOG, new_text=corrupted, version="1.1.0"
+        )
 
 
 def test_extract_released_section() -> None:
-    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
-    section = changelog.extract_released_section(promoted, "1.1.0")
+    promoted = changelog.promote_changelog(
+        changelog_text=SAMPLE_CHANGELOG, version="1.1.0", date="2026-08-21"
+    )
+    section = changelog.extract_released_section(changelog_text=promoted, version="1.1.0")
     assert "Added thing one" in section
     assert "1.0.5" not in section
+
+
+def test_parse_unreleased_sections() -> None:
+    sections = changelog._parse_unreleased_sections(SAMPLE_CHANGELOG)
+    assert list(sections) == list(changelog.SUBSECTIONS)
+    assert "Added thing one" in sections["Added"]
+    assert "Changed thing one" in sections["Changed"]
+    assert sections["Deprecated"].strip() == ""
+    assert sections["Removed"].strip() == ""
+
+
+def test_parse_unreleased_sections__wrong_order_raises() -> None:
+    broken = SAMPLE_CHANGELOG.replace(
+        "### Added\n\n- Added thing one.\n\n### Changed",
+        "### Changed\n\n### Added\n\n- Added thing one.",
+    )
+    with pytest.raises(PrepareReleaseError):
+        changelog._parse_unreleased_sections(broken)
+
+
+def test_parse_unreleased_sections__no_unreleased_heading_raises() -> None:
+    with pytest.raises(PrepareReleaseError):
+        changelog._parse_unreleased_sections("# Changelog\n\nnothing here\n")
+
+
+def test_parse_unreleased_sections__stray_content_before_first_subsection_raises() -> None:
+    broken = SAMPLE_CHANGELOG.replace(
+        "## [Unreleased]\n\n### Added",
+        "## [Unreleased]\n\nSee migration notes below.\n\n### Added",
+    )
+    with pytest.raises(PrepareReleaseError, match="unexpected content"):
+        changelog._parse_unreleased_sections(broken)

--- a/.github/scripts/tests/test_changelog.py
+++ b/.github/scripts/tests/test_changelog.py
@@ -40,7 +40,7 @@ All notable changes to Lightly**Studio** will be documented in this file.
 """
 
 
-def test_parse_unreleased_sections():
+def test_parse_unreleased_sections() -> None:
     sections = changelog.parse_unreleased_sections(SAMPLE_CHANGELOG)
     assert list(sections) == list(changelog.SUBSECTIONS)
     assert "Added thing one" in sections["Added"]
@@ -49,7 +49,7 @@ def test_parse_unreleased_sections():
     assert sections["Removed"].strip() == ""
 
 
-def test_parse_unreleased_sections__wrong_order_raises():
+def test_parse_unreleased_sections__wrong_order_raises() -> None:
     broken = SAMPLE_CHANGELOG.replace(
         "### Added\n\n- Added thing one.\n\n### Changed",
         "### Changed\n\n### Added\n\n- Added thing one.",
@@ -58,12 +58,21 @@ def test_parse_unreleased_sections__wrong_order_raises():
         changelog.parse_unreleased_sections(broken)
 
 
-def test_parse_unreleased_sections__no_unreleased_heading_raises():
+def test_parse_unreleased_sections__no_unreleased_heading_raises() -> None:
     with pytest.raises(PrepareReleaseError):
         changelog.parse_unreleased_sections("# Changelog\n\nnothing here\n")
 
 
-def test_suggest_bump__added_or_changed_suggests_minor():
+def test_parse_unreleased_sections__stray_content_before_first_subsection_raises() -> None:
+    broken = SAMPLE_CHANGELOG.replace(
+        "## [Unreleased]\n\n### Added",
+        "## [Unreleased]\n\nSee migration notes below.\n\n### Added",
+    )
+    with pytest.raises(PrepareReleaseError, match="unexpected content"):
+        changelog.parse_unreleased_sections(broken)
+
+
+def test_suggest_bump__added_or_changed_suggests_minor() -> None:
     sections = changelog.parse_unreleased_sections(SAMPLE_CHANGELOG)
     bump, reasoning = changelog.suggest_bump(sections)
     assert bump == "minor"
@@ -71,26 +80,27 @@ def test_suggest_bump__added_or_changed_suggests_minor():
     assert "Changed" in reasoning
 
 
-def test_suggest_bump__only_fixed_or_security_suggests_patch():
+def test_suggest_bump__only_fixed_or_security_suggests_patch() -> None:
     sections = dict.fromkeys(changelog.SUBSECTIONS, "")
     sections["Fixed"] = "- Fixed a bug.\n"
     bump, _ = changelog.suggest_bump(sections)
     assert bump == "patch"
 
 
-def test_suggest_bump__nothing_unreleased_raises():
+def test_suggest_bump__nothing_unreleased_raises() -> None:
     sections = dict.fromkeys(changelog.SUBSECTIONS, "")
     with pytest.raises(PrepareReleaseError, match="nothing to release"):
         changelog.suggest_bump(sections)
 
 
-def test_promote_changelog():
+def test_promote_changelog() -> None:
     promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
 
     # Fresh, fully-empty [Unreleased] skeleton with all six subheadings.
     assert promoted.count("## [Unreleased]") == 1
-    for name in changelog.SUBSECTIONS:
-        assert f"### {name}\n\n" in promoted
+    fresh_sections = changelog.parse_unreleased_sections(promoted)
+    assert list(fresh_sections) == list(changelog.SUBSECTIONS)
+    assert all(not content.strip() for content in fresh_sections.values())
 
     # New release heading in escaped form, empty sections dropped.
     assert "## \\[1.1.0\\] - 2026-08-21" in promoted
@@ -105,28 +115,51 @@ def test_promote_changelog():
     changelog.assert_changelog_structure(SAMPLE_CHANGELOG, promoted, "1.1.0")
 
 
-def test_assert_changelog_structure__missing_unreleased_raises():
+def test_assert_changelog_structure__missing_unreleased_raises() -> None:
     promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
     corrupted = promoted.replace("## [Unreleased]\n\n", "", 1)
     with pytest.raises(PrepareReleaseError):
         changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
 
 
-def test_assert_changelog_structure__mutated_released_block_raises():
+def test_assert_changelog_structure__mutated_released_block_raises() -> None:
     promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
     corrupted = promoted.replace("An older fix.", "A DIFFERENT fix.")
     with pytest.raises(PrepareReleaseError, match="byte-identical"):
         changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
 
 
-def test_assert_changelog_structure__missing_new_heading_raises():
+def test_assert_changelog_structure__missing_new_heading_raises() -> None:
     promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
     corrupted = promoted.replace("## \\[1.1.0\\] - 2026-08-21", "## [1.1.0] - 2026-08-21")
     with pytest.raises(PrepareReleaseError):
         changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
 
 
-def test_extract_released_section():
+def test_assert_changelog_structure__duplicate_new_heading_raises() -> None:
+    promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.0.5", "2026-08-24")
+    with pytest.raises(PrepareReleaseError, match="exactly one"):
+        changelog.assert_changelog_structure(SAMPLE_CHANGELOG, promoted, "1.0.5")
+
+
+def test_assert_changelog_structure__unreleased_after_release_heading_raises() -> None:
+    # Every other check would pass here (single [Unreleased] heading with
+    # valid subsections, the new release heading present exactly once, the
+    # previously-released suffix byte-identical) - only the ordering is
+    # wrong: the new release heading comes before [Unreleased].
+    corrupted = (
+        "# Changelog\n\n"
+        "## \\[1.1.0\\] - 2026-08-21\n\n"
+        "### Added\n\n- Added thing one.\n\n"
+        "## [Unreleased]\n\n"
+        "### Added\n\n### Changed\n\n### Deprecated\n\n"
+        "### Removed\n\n### Fixed\n\n### Security\n\n"
+    ) + SAMPLE_CHANGELOG[SAMPLE_CHANGELOG.index("## \\[1.0.5\\]") :]
+    with pytest.raises(PrepareReleaseError, match="precede"):
+        changelog.assert_changelog_structure(SAMPLE_CHANGELOG, corrupted, "1.1.0")
+
+
+def test_extract_released_section() -> None:
     promoted = changelog.promote_changelog(SAMPLE_CHANGELOG, "1.1.0", "2026-08-21")
     section = changelog.extract_released_section(promoted, "1.1.0")
     assert "Added thing one" in section


### PR DESCRIPTION
Part of a stack ([gh-stack](https://github.github.com/gh-stack/)), 1 of 4, landing bottom-up onto `main`:

1. **#2043 - changelog promotion** (this PR)
2. #2044 - version, pyproject.toml, and uv.lock guards
3. #2045 - PR body rendering (draft notes + coverage checklist)
4. #2046 - CLI + GitHub Actions workflow

Please review/merge in order; each PR rebases onto the previous once it lands.

## What has changed and why?

First layer of the **Prepare Release** tooling: promote `CHANGELOG.md`'s
`[Unreleased]` section into a released version block, and assert the
result is structurally sound before anything downstream trusts it.

Lives in a standalone `.github/scripts/prepare_release` package
(stdlib only - it runs before `uv sync`), with its own
`pyproject.toml` for lint/type/test config.

- `changelog.py`: parses the six `[Unreleased]` subsections, suggests
  a semver bump, promotes them into a dated `## [X.Y.Z] - YYYY-MM-DD`
  heading, and inserts a fresh empty `[Unreleased]` skeleton above it.
- `assert_changelog_structure`: independently re-checks the result -
  one `[Unreleased]` heading, the new heading present, every earlier
  released block untouched - and fails loudly if not.

No CLI yet - that's wired up in the last PR of the stack.

## How has it been tested?

- 11 unit tests covering the happy path and each failure case.
- `ruff format --check`, `ruff check`, and `mypy --strict` pass.
- Hand-ran against this repo's real `CHANGELOG.md`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

---
Suggested reviewer: @michal-lightly. Alternate: @lukas-lightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated changelog release preparation, promoting unreleased entries into versioned release sections.
  * Added extraction of released changelog content for release workflows.

* **Bug Fixes**
  * Added validation for malformed sections, duplicate releases, incorrect ordering, stray content, and unintended changes.
  * Release preparation now reports clear errors when changelog requirements are not met.

* **Chores**
  * Added consistent linting, testing, and type-checking configuration for release tooling.
  * Added cleanup rules for generated Python cache files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->