### PR TITLE
Add prepare-release tooling: version, pyproject.toml, and uv.lock guards

### DIFF
--- a/.github/scripts/prepare_release/lock.py
+++ b/.github/scripts/prepare_release/lock.py
@@ -19,34 +19,14 @@ _LOCK_PACKAGE_SPLIT_RE = re.compile(r"(?=^\[\[package\]\]$)", re.MULTILINE)
 _LOCK_PACKAGE_NAME_RE = re.compile(r'^name = "(?P<name>[^"]+)"$', re.MULTILINE)
 
 
-def parse_lock_blocks(uv_lock_text: str) -> dict[str, list[str]]:
-    """Splits a `uv.lock`'s text into per-package blocks, keyed by name.
-
-    `uv`'s universal resolution can emit several `[[package]]` blocks for
-    the same name - one per platform/Python-version marker, or per
-    resolution fork - so each name maps to the list of its blocks in file
-    order rather than a single block. The lockfile header (everything
-    before the first `[[package]]`) is kept under the empty-string key so
-    it participates in the same diff check.
-    """
-    chunks = _LOCK_PACKAGE_SPLIT_RE.split(uv_lock_text)
-    blocks: dict[str, list[str]] = {"": [chunks[0]]}
-    for chunk in chunks[1:]:
-        match = _LOCK_PACKAGE_NAME_RE.search(chunk)
-        if match is None:
-            raise PrepareReleaseError("a uv.lock [[package]] block has no `name` field")
-        blocks.setdefault(match.group("name"), []).append(chunk)
-    return blocks
-
-
 def assert_lock_diff_narrow(before_text: str, after_text: str, package: str) -> None:
     """Fails if `uv sync` changed more than `package`'s version line."""
-    before_blocks = parse_lock_blocks(before_text)
-    after_blocks = parse_lock_blocks(after_text)
+    before_blocks = _parse_lock_blocks(before_text)
+    after_blocks = _parse_lock_blocks(after_text)
 
     unexpected = sorted(
         name or "<lockfile header>"
-        for name in set(before_blocks) | set(after_blocks)
+        for name in set(before_blocks.keys()) | set(after_blocks.keys())
         if name != package and before_blocks.get(name) != after_blocks.get(name)
     )
     if unexpected:
@@ -74,3 +54,23 @@ def assert_lock_diff_narrow(before_text: str, after_text: str, package: str) -> 
                 f"uv.lock diff for {package!r} touches more than its version line:\n"
                 + "\n".join(changed_lines)
             )
+
+
+def _parse_lock_blocks(uv_lock_text: str) -> dict[str, list[str]]:
+    """Splits a `uv.lock`'s text into per-package blocks, keyed by name.
+
+    `uv`'s universal resolution can emit several `[[package]]` blocks for
+    the same name - one per platform/Python-version marker, or per
+    resolution fork - so each name maps to the list of its blocks in file
+    order rather than a single block. The lockfile header (everything
+    before the first `[[package]]`) is kept under the empty-string key so
+    it participates in the same diff check.
+    """
+    chunks = _LOCK_PACKAGE_SPLIT_RE.split(uv_lock_text)
+    blocks: dict[str, list[str]] = {"": [chunks[0]]}
+    for chunk in chunks[1:]:
+        match = _LOCK_PACKAGE_NAME_RE.search(chunk)
+        if match is None:
+            raise PrepareReleaseError("a uv.lock [[package]] block has no `name` field")
+        blocks.setdefault(match.group("name"), []).append(chunk)
+    return blocks

--- a/.github/scripts/prepare_release/lock.py
+++ b/.github/scripts/prepare_release/lock.py
@@ -19,19 +19,23 @@ _LOCK_PACKAGE_SPLIT_RE = re.compile(r"(?=^\[\[package\]\]$)", re.MULTILINE)
 _LOCK_PACKAGE_NAME_RE = re.compile(r'^name = "(?P<name>[^"]+)"$', re.MULTILINE)
 
 
-def parse_lock_blocks(uv_lock_text: str) -> dict[str, str]:
+def parse_lock_blocks(uv_lock_text: str) -> dict[str, list[str]]:
     """Splits a `uv.lock`'s text into per-package blocks, keyed by name.
 
-    The lockfile header (everything before the first `[[package]]`) is kept
-    under the empty-string key so it participates in the same diff check.
+    `uv`'s universal resolution can emit several `[[package]]` blocks for
+    the same name - one per platform/Python-version marker, or per
+    resolution fork - so each name maps to the list of its blocks in file
+    order rather than a single block. The lockfile header (everything
+    before the first `[[package]]`) is kept under the empty-string key so
+    it participates in the same diff check.
     """
     chunks = _LOCK_PACKAGE_SPLIT_RE.split(uv_lock_text)
-    blocks = {"": chunks[0]}
+    blocks: dict[str, list[str]] = {"": [chunks[0]]}
     for chunk in chunks[1:]:
         match = _LOCK_PACKAGE_NAME_RE.search(chunk)
         if match is None:
             raise PrepareReleaseError("a uv.lock [[package]] block has no `name` field")
-        blocks[match.group("name")] = chunk
+        blocks.setdefault(match.group("name"), []).append(chunk)
     return blocks
 
 
@@ -50,15 +54,23 @@ def assert_lock_diff_narrow(before_text: str, after_text: str, package: str) -> 
             "uv sync changed packages beyond the version bump: " + ", ".join(unexpected)
         )
 
-    before_pkg = before_blocks.get(package)
-    after_pkg = after_blocks.get(package)
-    if before_pkg is None or after_pkg is None:
+    before_pkg_blocks = before_blocks.get(package)
+    after_pkg_blocks = after_blocks.get(package)
+    if not before_pkg_blocks or not after_pkg_blocks:
         raise PrepareReleaseError(f"package {package!r} not found in uv.lock before/after uv sync")
-
-    diff = difflib.unified_diff(before_pkg.splitlines(), after_pkg.splitlines(), lineterm="")
-    changed_lines = [line for line in diff if line[:1] in "+-" and line[:3] not in ("+++", "---")]
-    if any(not re.match(r'^[+-]version = "', line) for line in changed_lines):
+    if len(before_pkg_blocks) != len(after_pkg_blocks):
         raise PrepareReleaseError(
-            f"uv.lock diff for {package!r} touches more than its version line:\n"
-            + "\n".join(changed_lines)
+            f"uv sync changed the number of {package!r} blocks in uv.lock "
+            f"({len(before_pkg_blocks)} -> {len(after_pkg_blocks)})"
         )
+
+    for before_pkg, after_pkg in zip(before_pkg_blocks, after_pkg_blocks):
+        diff = difflib.unified_diff(before_pkg.splitlines(), after_pkg.splitlines(), lineterm="")
+        changed_lines = [
+            line for line in diff if line[:1] in "+-" and line[:3] not in ("+++", "---")
+        ]
+        if any(not re.match(r'^[+-]version = "', line) for line in changed_lines):
+            raise PrepareReleaseError(
+                f"uv.lock diff for {package!r} touches more than its version line:\n"
+                + "\n".join(changed_lines)
+            )

--- a/.github/scripts/prepare_release/lock.py
+++ b/.github/scripts/prepare_release/lock.py
@@ -1,0 +1,64 @@
+"""Guard against `uv sync` widening the `uv.lock` diff beyond the version bump.
+
+`uv sync` on a CI runner can resolve transitive dependencies differently
+from whoever last locked (different Python patch, platform, or registry
+state), producing a diff wider than the version bump. That doesn't
+endanger the published wheel - dependency metadata comes from
+`pyproject.toml`, not the lock - but it makes the release PR unreviewable
+and drifts the dev/CI environment away from what was last validated.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+
+from prepare_release.errors import PrepareReleaseError
+
+_LOCK_PACKAGE_SPLIT_RE = re.compile(r"(?=^\[\[package\]\]$)", re.MULTILINE)
+_LOCK_PACKAGE_NAME_RE = re.compile(r'^name = "(?P<name>[^"]+)"$', re.MULTILINE)
+
+
+def parse_lock_blocks(uv_lock_text: str) -> dict[str, str]:
+    """Splits a `uv.lock`'s text into per-package blocks, keyed by name.
+
+    The lockfile header (everything before the first `[[package]]`) is kept
+    under the empty-string key so it participates in the same diff check.
+    """
+    chunks = _LOCK_PACKAGE_SPLIT_RE.split(uv_lock_text)
+    blocks = {"": chunks[0]}
+    for chunk in chunks[1:]:
+        match = _LOCK_PACKAGE_NAME_RE.search(chunk)
+        if match is None:
+            raise PrepareReleaseError("a uv.lock [[package]] block has no `name` field")
+        blocks[match.group("name")] = chunk
+    return blocks
+
+
+def assert_lock_diff_narrow(before_text: str, after_text: str, package: str) -> None:
+    """Fails if `uv sync` changed more than `package`'s version line."""
+    before_blocks = parse_lock_blocks(before_text)
+    after_blocks = parse_lock_blocks(after_text)
+
+    unexpected = sorted(
+        name or "<lockfile header>"
+        for name in set(before_blocks) | set(after_blocks)
+        if name != package and before_blocks.get(name) != after_blocks.get(name)
+    )
+    if unexpected:
+        raise PrepareReleaseError(
+            "uv sync changed packages beyond the version bump: " + ", ".join(unexpected)
+        )
+
+    before_pkg = before_blocks.get(package)
+    after_pkg = after_blocks.get(package)
+    if before_pkg is None or after_pkg is None:
+        raise PrepareReleaseError(f"package {package!r} not found in uv.lock before/after uv sync")
+
+    diff = difflib.unified_diff(before_pkg.splitlines(), after_pkg.splitlines(), lineterm="")
+    changed_lines = [line for line in diff if line[:1] in "+-" and line[:3] not in ("+++", "---")]
+    if any(not re.match(r'^[+-]version = "', line) for line in changed_lines):
+        raise PrepareReleaseError(
+            f"uv.lock diff for {package!r} touches more than its version line:\n"
+            + "\n".join(changed_lines)
+        )

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -61,7 +61,7 @@ def check_labelformat_pin(pyproject_text: str) -> None:
     fine.
     """
     for match in re.finditer(
-        r'^\s*(?P<quote>["\'])labelformat[^"\']*\1', pyproject_text, re.MULTILINE
+        r'^\s*(?P<quote>["\'])labelformat[^"\']*\1', pyproject_text, re.MULTILINE | re.IGNORECASE
     ):
         if "git+" in match.group(0):
             raise PrepareReleaseError(

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -60,10 +60,9 @@ def check_labelformat_pin(pyproject_text: str) -> None:
 
     A `git+` requirement means Labelformat itself needs a release first
     (see the Labelformat release runbook); a plain version requirement is
-    fine. Checked per line, comments stripped but not anchored to the
-    line's start, so an entry that isn't the first item in an inline array
-    (e.g. `dependencies = ["a", "labelformat @ git+..."]`) is still caught,
-    while a commented-out example (`# - "labelformat @ git+..."`) is not.
+    fine. Matched per line with `#`-comments stripped first (so a
+    commented-out example doesn't false-positive), not anchored to the
+    line's start (so a non-first entry in an inline array still is caught).
     """
     for line in pyproject_text.splitlines():
         active = line.split("#", 1)[0]

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -1,0 +1,74 @@
+"""Version bump math and pyproject.toml / Labelformat guards."""
+
+from __future__ import annotations
+
+import re
+
+from prepare_release.errors import PrepareReleaseError
+
+_PYPROJECT_VERSION_RE = re.compile(r'^version = "(?P<version>[^"]+)"$', re.MULTILINE)
+_SEMVER_PART_COUNT = 3
+
+
+def current_pyproject_version(pyproject_text: str) -> str:
+    """Reads the `[project] version` from a `pyproject.toml`'s text."""
+    match = _PYPROJECT_VERSION_RE.search(pyproject_text)
+    if match is None:
+        raise PrepareReleaseError('no `version = "..."` line found in pyproject.toml')
+    return match.group("version")
+
+
+def bump_semver(version: str, bump: str) -> str:
+    """Bumps a plain `X.Y.Z` version.
+
+    Args:
+        version: The current version. Must be exactly `X.Y.Z` with integer
+            parts; anything else (e.g. an already-released release
+            candidate) has no well-defined next bump and should be
+            overridden explicitly instead.
+        bump: One of "patch", "minor", "major".
+
+    Returns:
+        The bumped version, still in plain `X.Y.Z` form.
+    """
+    parts = version.split(".")
+    if len(parts) != _SEMVER_PART_COUNT or not all(p.isdigit() for p in parts):
+        raise PrepareReleaseError(
+            f"current version {version!r} is not a plain X.Y.Z semver; "
+            "pass --version explicitly instead of a --bump"
+        )
+    major, minor, patch = (int(p) for p in parts)
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    if bump == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    raise PrepareReleaseError(f"unknown bump kind {bump!r}")
+
+
+def check_labelformat_pin(pyproject_text: str) -> None:
+    """Fails if the Labelformat requirement is pinned by git sha.
+
+    A `git+` requirement means Labelformat itself needs a release first
+    (see the Labelformat release runbook); a plain version requirement is
+    fine.
+    """
+    match = re.search(r'^\s*"labelformat[^"]*"', pyproject_text, re.MULTILINE)
+    if match and "git+" in match.group(0):
+        raise PrepareReleaseError(
+            "labelformat is pinned by git sha in pyproject.toml "
+            f"({match.group(0).strip()}). Release Labelformat first, see "
+            "https://www.notion.so/Release-Labelformat-or-Lightly-Insights-"
+            "039ffe75cd8b4dd89dcb45a7338533b2?source=copy_link"
+        )
+
+
+def bump_pyproject_version(pyproject_text: str, new_version: str) -> str:
+    """Returns `pyproject_text` with the `[project] version` replaced."""
+    new_text, count = _PYPROJECT_VERSION_RE.subn(
+        f'version = "{new_version}"', pyproject_text, count=1
+    )
+    if count == 0:
+        raise PrepareReleaseError('no `version = "..."` line found in pyproject.toml')
+    return new_text

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -8,7 +8,9 @@ from prepare_release.errors import PrepareReleaseError
 
 _PROJECT_SECTION_RE = re.compile(r"^\[project\]\r?\n(?:(?!^\[).*(?:\r?\n|\Z))*", re.MULTILINE)
 _PYPROJECT_VERSION_RE = re.compile(
-    r'^[ \t]*version[ \t]*=[ \t]*"(?P<version>[^"]+)"(?=\r?$)', re.MULTILINE
+    r"^[ \t]*version[ \t]*=[ \t]*(?P<quote>[\"'])(?P<version>[^\"']+)(?P=quote)"
+    r"(?=[ \t]*(?:#.*)?\r?$)",
+    re.MULTILINE,
 )
 _SEMVER_PART_RE = re.compile(r"(?:0|[1-9][0-9]*)")
 _SEMVER_PART_COUNT = 3
@@ -60,12 +62,12 @@ def check_labelformat_pin(pyproject_text: str) -> None:
 
     A `git+` requirement means Labelformat itself needs a release first
     (see the Labelformat release runbook); a plain version requirement is
-    fine. Matched per line with `#`-comments stripped first (so a
+    fine. Matched per line with a trailing `#`-comment stripped first (so a
     commented-out example doesn't false-positive), not anchored to the
     line's start (so a non-first entry in an inline array still is caught).
     """
     for line in pyproject_text.splitlines():
-        active = line.split("#", 1)[0]
+        active = _strip_comment(line)
         for match in re.finditer(r'(?P<quote>["\'])labelformat[^"\']*\1', active, re.IGNORECASE):
             if "git+" in match.group(0):
                 raise PrepareReleaseError(
@@ -104,3 +106,20 @@ def _project_section(pyproject_text: str) -> re.Match[str]:
     if match is None:
         raise PrepareReleaseError("no `[project]` table found in pyproject.toml")
     return match
+
+
+def _strip_comment(line: str) -> str:
+    """Removes a trailing `#` comment, ignoring a `#` inside a quoted string.
+
+    E.g. a `#egg=...` URL fragment inside a `"... @ git+https://...#egg=..."`
+    dependency string is not mistaken for a comment.
+    """
+    quote = None
+    for i, char in enumerate(line):
+        if quote:
+            quote = None if char == quote else quote
+        elif char in "\"'":
+            quote = char
+        elif char == "#":
+            return line[:i]
+    return line

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -7,8 +7,8 @@ import re
 from prepare_release.errors import PrepareReleaseError
 
 _PROJECT_SECTION_RE = re.compile(r"^\[project\]\r?\n(?:(?!^\[).*(?:\r?\n|\Z))*", re.MULTILINE)
-_PYPROJECT_VERSION_RE = re.compile(r'^version = "(?P<version>[^"]+)"$', re.MULTILINE)
-_SEMVER_PART_RE = re.compile(r"^(?:0|[1-9]\d*)$")
+_PYPROJECT_VERSION_RE = re.compile(r'^version = "(?P<version>[^"]+)"(?=\r?$)', re.MULTILINE)
+_SEMVER_PART_RE = re.compile(r"(?:0|[1-9][0-9]*)")
 _SEMVER_PART_COUNT = 3
 
 
@@ -38,7 +38,7 @@ def bump_semver(version: str, bump: str) -> str:
         The bumped version, still in plain `X.Y.Z` form.
     """
     parts = version.split(".")
-    if len(parts) != _SEMVER_PART_COUNT or not all(_SEMVER_PART_RE.match(p) for p in parts):
+    if len(parts) != _SEMVER_PART_COUNT or not all(_SEMVER_PART_RE.fullmatch(p) for p in parts):
         raise PrepareReleaseError(
             f"current version {version!r} is not a plain X.Y.Z semver; "
             "pass --version explicitly instead of a --bump"
@@ -60,14 +60,16 @@ def check_labelformat_pin(pyproject_text: str) -> None:
     (see the Labelformat release runbook); a plain version requirement is
     fine.
     """
-    match = re.search(r'^\s*(?P<quote>["\'])labelformat[^"\']*\1', pyproject_text, re.MULTILINE)
-    if match and "git+" in match.group(0):
-        raise PrepareReleaseError(
-            "labelformat is pinned by git sha in pyproject.toml "
-            f"({match.group(0).strip()}). Release Labelformat first, see "
-            "https://www.notion.so/Release-Labelformat-or-Lightly-Insights-"
-            "039ffe75cd8b4dd89dcb45a7338533b2?source=copy_link"
-        )
+    for match in re.finditer(
+        r'^\s*(?P<quote>["\'])labelformat[^"\']*\1', pyproject_text, re.MULTILINE
+    ):
+        if "git+" in match.group(0):
+            raise PrepareReleaseError(
+                "labelformat is pinned by git sha in pyproject.toml "
+                f"({match.group(0).strip()}). Release Labelformat first, see "
+                "https://www.notion.so/Release-Labelformat-or-Lightly-Insights-"
+                "039ffe75cd8b4dd89dcb45a7338533b2?source=copy_link"
+            )
 
 
 def bump_pyproject_version(pyproject_text: str, new_version: str) -> str:

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -6,15 +6,33 @@ import re
 
 from prepare_release.errors import PrepareReleaseError
 
+_PROJECT_SECTION_RE = re.compile(r"^\[project\]\r?\n(?:(?!^\[).*(?:\r?\n|\Z))*", re.MULTILINE)
 _PYPROJECT_VERSION_RE = re.compile(r'^version = "(?P<version>[^"]+)"$', re.MULTILINE)
+_SEMVER_PART_RE = re.compile(r"^(?:0|[1-9]\d*)$")
 _SEMVER_PART_COUNT = 3
+
+
+def _project_section(pyproject_text: str) -> re.Match[str]:
+    """Locates the `[project]` table's text span, header included.
+
+    Scoping to this span (rather than searching the whole file) keeps a
+    `version = "..."` line in some other table, e.g. `[tool.foo]`, from
+    being mistaken for the release version.
+    """
+    match = _PROJECT_SECTION_RE.search(pyproject_text)
+    if match is None:
+        raise PrepareReleaseError("no `[project]` table found in pyproject.toml")
+    return match
 
 
 def current_pyproject_version(pyproject_text: str) -> str:
     """Reads the `[project] version` from a `pyproject.toml`'s text."""
-    match = _PYPROJECT_VERSION_RE.search(pyproject_text)
+    section = _project_section(pyproject_text).group(0)
+    match = _PYPROJECT_VERSION_RE.search(section)
     if match is None:
-        raise PrepareReleaseError('no `version = "..."` line found in pyproject.toml')
+        raise PrepareReleaseError(
+            'no `version = "..."` line found in the `[project]` table of pyproject.toml'
+        )
     return match.group("version")
 
 
@@ -23,16 +41,17 @@ def bump_semver(version: str, bump: str) -> str:
 
     Args:
         version: The current version. Must be exactly `X.Y.Z` with integer
-            parts; anything else (e.g. an already-released release
-            candidate) has no well-defined next bump and should be
-            overridden explicitly instead.
+            parts and no leading zeroes (per semver.org's grammar);
+            anything else (e.g. an already-released release candidate) has
+            no well-defined next bump and should be overridden explicitly
+            instead.
         bump: One of "patch", "minor", "major".
 
     Returns:
         The bumped version, still in plain `X.Y.Z` form.
     """
     parts = version.split(".")
-    if len(parts) != _SEMVER_PART_COUNT or not all(p.isdigit() for p in parts):
+    if len(parts) != _SEMVER_PART_COUNT or not all(_SEMVER_PART_RE.match(p) for p in parts):
         raise PrepareReleaseError(
             f"current version {version!r} is not a plain X.Y.Z semver; "
             "pass --version explicitly instead of a --bump"
@@ -54,7 +73,7 @@ def check_labelformat_pin(pyproject_text: str) -> None:
     (see the Labelformat release runbook); a plain version requirement is
     fine.
     """
-    match = re.search(r'^\s*"labelformat[^"]*"', pyproject_text, re.MULTILINE)
+    match = re.search(r'^\s*(?P<quote>["\'])labelformat[^"\']*\1', pyproject_text, re.MULTILINE)
     if match and "git+" in match.group(0):
         raise PrepareReleaseError(
             "labelformat is pinned by git sha in pyproject.toml "
@@ -66,9 +85,16 @@ def check_labelformat_pin(pyproject_text: str) -> None:
 
 def bump_pyproject_version(pyproject_text: str, new_version: str) -> str:
     """Returns `pyproject_text` with the `[project] version` replaced."""
-    new_text, count = _PYPROJECT_VERSION_RE.subn(
-        f'version = "{new_version}"', pyproject_text, count=1
+    section_match = _project_section(pyproject_text)
+    new_section, count = _PYPROJECT_VERSION_RE.subn(
+        f'version = "{new_version}"', section_match.group(0), count=1
     )
     if count == 0:
-        raise PrepareReleaseError('no `version = "..."` line found in pyproject.toml')
-    return new_text
+        raise PrepareReleaseError(
+            'no `version = "..."` line found in the `[project]` table of pyproject.toml'
+        )
+    return (
+        pyproject_text[: section_match.start()]
+        + new_section
+        + pyproject_text[section_match.end() :]
+    )

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -1,60 +1,19 @@
-"""Version bump math and pyproject.toml / Labelformat guards."""
+"""Labelformat git-pin guard.
+
+Reading, bumping, and writing the `[project]` version is left to
+`uv version --bump` (see the Prepare Release workflow) rather than
+reimplemented here - it already parses/writes real TOML and handles more
+than plain X.Y.Z (alpha/beta/rc/post/dev), which regex-based text editing
+kept getting subtly wrong in review. This module keeps only the guard that
+`uv` has no way to know about: whether Labelformat itself needs a release
+first.
+"""
 
 from __future__ import annotations
 
 import re
 
 from prepare_release.errors import PrepareReleaseError
-
-_PROJECT_SECTION_RE = re.compile(r"^\[project\]\r?\n(?:(?!^\[).*(?:\r?\n|\Z))*", re.MULTILINE)
-_PYPROJECT_VERSION_RE = re.compile(
-    r"^[ \t]*version[ \t]*=[ \t]*(?P<quote>[\"'])(?P<version>[^\"']+)(?P=quote)"
-    r"(?=[ \t]*(?:#.*)?\r?$)",
-    re.MULTILINE,
-)
-_SEMVER_PART_RE = re.compile(r"(?:0|[1-9][0-9]*)")
-_SEMVER_PART_COUNT = 3
-
-
-def current_pyproject_version(pyproject_text: str) -> str:
-    """Reads the `[project] version` from a `pyproject.toml`'s text."""
-    section = _project_section(pyproject_text).group(0)
-    match = _PYPROJECT_VERSION_RE.search(section)
-    if match is None:
-        raise PrepareReleaseError(
-            'no `version = "..."` line found in the `[project]` table of pyproject.toml'
-        )
-    return match.group("version")
-
-
-def bump_semver(version: str, bump: str) -> str:
-    """Bumps a plain `X.Y.Z` version.
-
-    Args:
-        version: The current version. Must be exactly `X.Y.Z` with integer
-            parts and no leading zeroes (per semver.org's grammar);
-            anything else (e.g. an already-released release candidate) has
-            no well-defined next bump and should be overridden explicitly
-            instead.
-        bump: One of "patch", "minor", "major".
-
-    Returns:
-        The bumped version, still in plain `X.Y.Z` form.
-    """
-    parts = version.split(".")
-    if len(parts) != _SEMVER_PART_COUNT or not all(_SEMVER_PART_RE.fullmatch(p) for p in parts):
-        raise PrepareReleaseError(
-            f"current version {version!r} is not a plain X.Y.Z semver; "
-            "pass --version explicitly instead of a --bump"
-        )
-    major, minor, patch = (int(p) for p in parts)
-    if bump == "major":
-        return f"{major + 1}.0.0"
-    if bump == "minor":
-        return f"{major}.{minor + 1}.0"
-    if bump == "patch":
-        return f"{major}.{minor}.{patch + 1}"
-    raise PrepareReleaseError(f"unknown bump kind {bump!r}")
 
 
 def check_labelformat_pin(pyproject_text: str) -> None:
@@ -76,36 +35,6 @@ def check_labelformat_pin(pyproject_text: str) -> None:
                     "https://www.notion.so/Release-Labelformat-or-Lightly-Insights-"
                     "039ffe75cd8b4dd89dcb45a7338533b2?source=copy_link"
                 )
-
-
-def bump_pyproject_version(pyproject_text: str, new_version: str) -> str:
-    """Returns `pyproject_text` with the `[project] version` replaced."""
-    section_match = _project_section(pyproject_text)
-    new_section, count = _PYPROJECT_VERSION_RE.subn(
-        f'version = "{new_version}"', section_match.group(0), count=1
-    )
-    if count == 0:
-        raise PrepareReleaseError(
-            'no `version = "..."` line found in the `[project]` table of pyproject.toml'
-        )
-    return (
-        pyproject_text[: section_match.start()]
-        + new_section
-        + pyproject_text[section_match.end() :]
-    )
-
-
-def _project_section(pyproject_text: str) -> re.Match[str]:
-    """Locates the `[project]` table's text span, header included.
-
-    Scoping to this span (rather than searching the whole file) keeps a
-    `version = "..."` line in some other table, e.g. `[tool.foo]`, from
-    being mistaken for the release version.
-    """
-    match = _PROJECT_SECTION_RE.search(pyproject_text)
-    if match is None:
-        raise PrepareReleaseError("no `[project]` table found in pyproject.toml")
-    return match
 
 
 def _strip_comment(line: str) -> str:

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -12,19 +12,6 @@ _SEMVER_PART_RE = re.compile(r"^(?:0|[1-9]\d*)$")
 _SEMVER_PART_COUNT = 3
 
 
-def _project_section(pyproject_text: str) -> re.Match[str]:
-    """Locates the `[project]` table's text span, header included.
-
-    Scoping to this span (rather than searching the whole file) keeps a
-    `version = "..."` line in some other table, e.g. `[tool.foo]`, from
-    being mistaken for the release version.
-    """
-    match = _PROJECT_SECTION_RE.search(pyproject_text)
-    if match is None:
-        raise PrepareReleaseError("no `[project]` table found in pyproject.toml")
-    return match
-
-
 def current_pyproject_version(pyproject_text: str) -> str:
     """Reads the `[project] version` from a `pyproject.toml`'s text."""
     section = _project_section(pyproject_text).group(0)
@@ -98,3 +85,16 @@ def bump_pyproject_version(pyproject_text: str, new_version: str) -> str:
         + new_section
         + pyproject_text[section_match.end() :]
     )
+
+
+def _project_section(pyproject_text: str) -> re.Match[str]:
+    """Locates the `[project]` table's text span, header included.
+
+    Scoping to this span (rather than searching the whole file) keeps a
+    `version = "..."` line in some other table, e.g. `[tool.foo]`, from
+    being mistaken for the release version.
+    """
+    match = _PROJECT_SECTION_RE.search(pyproject_text)
+    if match is None:
+        raise PrepareReleaseError("no `[project]` table found in pyproject.toml")
+    return match

--- a/.github/scripts/prepare_release/version.py
+++ b/.github/scripts/prepare_release/version.py
@@ -7,7 +7,9 @@ import re
 from prepare_release.errors import PrepareReleaseError
 
 _PROJECT_SECTION_RE = re.compile(r"^\[project\]\r?\n(?:(?!^\[).*(?:\r?\n|\Z))*", re.MULTILINE)
-_PYPROJECT_VERSION_RE = re.compile(r'^version = "(?P<version>[^"]+)"(?=\r?$)', re.MULTILINE)
+_PYPROJECT_VERSION_RE = re.compile(
+    r'^[ \t]*version[ \t]*=[ \t]*"(?P<version>[^"]+)"(?=\r?$)', re.MULTILINE
+)
 _SEMVER_PART_RE = re.compile(r"(?:0|[1-9][0-9]*)")
 _SEMVER_PART_COUNT = 3
 
@@ -58,18 +60,21 @@ def check_labelformat_pin(pyproject_text: str) -> None:
 
     A `git+` requirement means Labelformat itself needs a release first
     (see the Labelformat release runbook); a plain version requirement is
-    fine.
+    fine. Checked per line, comments stripped but not anchored to the
+    line's start, so an entry that isn't the first item in an inline array
+    (e.g. `dependencies = ["a", "labelformat @ git+..."]`) is still caught,
+    while a commented-out example (`# - "labelformat @ git+..."`) is not.
     """
-    for match in re.finditer(
-        r'^\s*(?P<quote>["\'])labelformat[^"\']*\1', pyproject_text, re.MULTILINE | re.IGNORECASE
-    ):
-        if "git+" in match.group(0):
-            raise PrepareReleaseError(
-                "labelformat is pinned by git sha in pyproject.toml "
-                f"({match.group(0).strip()}). Release Labelformat first, see "
-                "https://www.notion.so/Release-Labelformat-or-Lightly-Insights-"
-                "039ffe75cd8b4dd89dcb45a7338533b2?source=copy_link"
-            )
+    for line in pyproject_text.splitlines():
+        active = line.split("#", 1)[0]
+        for match in re.finditer(r'(?P<quote>["\'])labelformat[^"\']*\1', active, re.IGNORECASE):
+            if "git+" in match.group(0):
+                raise PrepareReleaseError(
+                    "labelformat is pinned by git sha in pyproject.toml "
+                    f"({match.group(0).strip()}). Release Labelformat first, see "
+                    "https://www.notion.so/Release-Labelformat-or-Lightly-Insights-"
+                    "039ffe75cd8b4dd89dcb45a7338533b2?source=copy_link"
+                )
 
 
 def bump_pyproject_version(pyproject_text: str, new_version: str) -> str:

--- a/.github/scripts/tests/test_lock.py
+++ b/.github/scripts/tests/test_lock.py
@@ -98,8 +98,7 @@ def test_assert_lock_diff_narrow__unchanged_duplicate_blocks_are_ok():
 
 
 def test_assert_lock_diff_narrow__change_to_first_of_duplicate_blocks_raises():
-    # Regression test: a change to the *first* of two same-named blocks must
-    # not be masked by the second, unchanged, occurrence.
+    # A change to the first duplicate block must not be masked by the second.
     after = SAMPLE_LOCK_WITH_DUPLICATE.replace(
         'name = "alpha"\nversion = "1.0.0"\nsource = { registry = "https://pypi.org/simple" }\n'
         "resolution-markers = [\n    \"python_full_version < '3.11'\",\n]",

--- a/.github/scripts/tests/test_lock.py
+++ b/.github/scripts/tests/test_lock.py
@@ -22,10 +22,47 @@ dependencies = [
 """
 
 
+SAMPLE_LOCK_WITH_DUPLICATE = """\
+version = 1
+revision = 2
+
+[[package]]
+name = "alpha"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+
+[[package]]
+name = "alpha"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+]
+
+[[package]]
+name = "lightly-studio"
+version = "1.0.5"
+source = { editable = "." }
+dependencies = [
+    { name = "alpha" },
+]
+"""
+
+
 def test_parse_lock_blocks():
     blocks = lock.parse_lock_blocks(SAMPLE_LOCK)
     assert set(blocks) == {"", "alpha", "lightly-studio"}
-    assert 'version = "1.0.5"' in blocks["lightly-studio"]
+    assert 'version = "1.0.5"' in blocks["lightly-studio"][0]
+
+
+def test_parse_lock_blocks__preserves_duplicate_package_blocks():
+    blocks = lock.parse_lock_blocks(SAMPLE_LOCK_WITH_DUPLICATE)
+    assert len(blocks["alpha"]) == 2
+    assert "< '3.11'" in blocks["alpha"][0]
+    assert ">= '3.11'" in blocks["alpha"][1]
 
 
 def test_assert_lock_diff_narrow__version_only_change_is_ok():
@@ -50,3 +87,25 @@ def test_assert_lock_diff_narrow__broader_change_to_target_package_raises():
     )
     with pytest.raises(PrepareReleaseError, match="more than its version line"):
         lock.assert_lock_diff_narrow(SAMPLE_LOCK, after, package="lightly-studio")
+
+
+def test_assert_lock_diff_narrow__unchanged_duplicate_blocks_are_ok():
+    lock.assert_lock_diff_narrow(
+        SAMPLE_LOCK_WITH_DUPLICATE,
+        SAMPLE_LOCK_WITH_DUPLICATE.replace('version = "1.0.5"', 'version = "1.0.6"'),
+        package="lightly-studio",
+    )
+
+
+def test_assert_lock_diff_narrow__change_to_first_of_duplicate_blocks_raises():
+    # Regression test: a change to the *first* of two same-named blocks must
+    # not be masked by the second, unchanged, occurrence.
+    after = SAMPLE_LOCK_WITH_DUPLICATE.replace(
+        'name = "alpha"\nversion = "1.0.0"\nsource = { registry = "https://pypi.org/simple" }\n'
+        "resolution-markers = [\n    \"python_full_version < '3.11'\",\n]",
+        'name = "alpha"\nversion = "1.1.0"\nsource = { registry = "https://pypi.org/simple" }\n'
+        "resolution-markers = [\n    \"python_full_version < '3.11'\",\n]",
+        1,
+    )
+    with pytest.raises(PrepareReleaseError, match="alpha"):
+        lock.assert_lock_diff_narrow(SAMPLE_LOCK_WITH_DUPLICATE, after, package="lightly-studio")

--- a/.github/scripts/tests/test_lock.py
+++ b/.github/scripts/tests/test_lock.py
@@ -52,19 +52,6 @@ dependencies = [
 """
 
 
-def test_parse_lock_blocks():
-    blocks = lock.parse_lock_blocks(SAMPLE_LOCK)
-    assert set(blocks) == {"", "alpha", "lightly-studio"}
-    assert 'version = "1.0.5"' in blocks["lightly-studio"][0]
-
-
-def test_parse_lock_blocks__preserves_duplicate_package_blocks():
-    blocks = lock.parse_lock_blocks(SAMPLE_LOCK_WITH_DUPLICATE)
-    assert len(blocks["alpha"]) == 2
-    assert "< '3.11'" in blocks["alpha"][0]
-    assert ">= '3.11'" in blocks["alpha"][1]
-
-
 def test_assert_lock_diff_narrow__version_only_change_is_ok():
     after = SAMPLE_LOCK.replace(
         'name = "lightly-studio"\nversion = "1.0.5"', 'name = "lightly-studio"\nversion = "1.0.6"'
@@ -108,3 +95,16 @@ def test_assert_lock_diff_narrow__change_to_first_of_duplicate_blocks_raises():
     )
     with pytest.raises(PrepareReleaseError, match="alpha"):
         lock.assert_lock_diff_narrow(SAMPLE_LOCK_WITH_DUPLICATE, after, package="lightly-studio")
+
+
+def test_parse_lock_blocks():
+    blocks = lock._parse_lock_blocks(SAMPLE_LOCK)
+    assert set(blocks) == {"", "alpha", "lightly-studio"}
+    assert 'version = "1.0.5"' in blocks["lightly-studio"][0]
+
+
+def test_parse_lock_blocks__preserves_duplicate_package_blocks():
+    blocks = lock._parse_lock_blocks(SAMPLE_LOCK_WITH_DUPLICATE)
+    assert len(blocks["alpha"]) == 2
+    assert "< '3.11'" in blocks["alpha"][0]
+    assert ">= '3.11'" in blocks["alpha"][1]

--- a/.github/scripts/tests/test_lock.py
+++ b/.github/scripts/tests/test_lock.py
@@ -1,0 +1,52 @@
+import pytest
+
+from prepare_release import lock
+from prepare_release.errors import PrepareReleaseError
+
+SAMPLE_LOCK = """\
+version = 1
+revision = 2
+
+[[package]]
+name = "alpha"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "lightly-studio"
+version = "1.0.5"
+source = { editable = "." }
+dependencies = [
+    { name = "alpha" },
+]
+"""
+
+
+def test_parse_lock_blocks():
+    blocks = lock.parse_lock_blocks(SAMPLE_LOCK)
+    assert set(blocks) == {"", "alpha", "lightly-studio"}
+    assert 'version = "1.0.5"' in blocks["lightly-studio"]
+
+
+def test_assert_lock_diff_narrow__version_only_change_is_ok():
+    after = SAMPLE_LOCK.replace(
+        'name = "lightly-studio"\nversion = "1.0.5"', 'name = "lightly-studio"\nversion = "1.0.6"'
+    )
+    lock.assert_lock_diff_narrow(SAMPLE_LOCK, after, package="lightly-studio")
+
+
+def test_assert_lock_diff_narrow__unrelated_package_changed_raises():
+    after = SAMPLE_LOCK.replace(
+        'name = "alpha"\nversion = "1.0.0"', 'name = "alpha"\nversion = "1.1.0"'
+    )
+    with pytest.raises(PrepareReleaseError, match="alpha"):
+        lock.assert_lock_diff_narrow(SAMPLE_LOCK, after, package="lightly-studio")
+
+
+def test_assert_lock_diff_narrow__broader_change_to_target_package_raises():
+    after = SAMPLE_LOCK.replace(
+        'version = "1.0.5"\nsource = { editable = "." }',
+        'version = "1.0.6"\nsource = { editable = "./elsewhere" }',
+    )
+    with pytest.raises(PrepareReleaseError, match="more than its version line"):
+        lock.assert_lock_diff_narrow(SAMPLE_LOCK, after, package="lightly-studio")

--- a/.github/scripts/tests/test_version.py
+++ b/.github/scripts/tests/test_version.py
@@ -35,6 +35,18 @@ def test_current_pyproject_version__handles_crlf_line_endings():
 
 
 @pytest.mark.parametrize(
+    "text",
+    [
+        '[project]\nname = "x"\nversion="1.0.5"\n',
+        '[project]\nname = "x"\n    version = "1.0.5"\n',
+    ],
+    ids=["no_spaces_around_equals", "indented"],
+)
+def test_current_pyproject_version__tolerates_non_canonical_spacing(text):
+    assert version.current_pyproject_version(text) == "1.0.5"
+
+
+@pytest.mark.parametrize(
     ("bump", "expected"),
     [("patch", "1.0.6"), ("minor", "1.1.0"), ("major", "2.0.0")],
 )
@@ -94,6 +106,27 @@ def test_check_labelformat_pin__mixed_case_git_sha_raises():
         version.check_labelformat_pin(text)
 
 
+def test_check_labelformat_pin__commented_out_example_is_ignored():
+    text = SAMPLE_PYPROJECT.replace(
+        '"labelformat>=0.1.17"',
+        '# - "labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"\n'
+        '    "labelformat>=0.1.17"',
+    )
+    version.check_labelformat_pin(text)
+
+
+def test_check_labelformat_pin__git_sha_inside_inline_array_raises():
+    # A git-pinned entry that isn't the array's first element must still be
+    # caught - the check isn't anchored to the start of a line.
+    text = (
+        '[project]\nname = "x"\nversion = "1.0.5"\n\n'
+        'dependencies = ["torch>=2.0", '
+        '"labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"]\n'
+    )
+    with pytest.raises(PrepareReleaseError, match="git sha"):
+        version.check_labelformat_pin(text)
+
+
 def test_check_labelformat_pin__git_sha_after_plain_entry_raises():
     # A plain entry earlier in the file must not shadow a git-pinned one later.
     text = SAMPLE_PYPROJECT.replace(
@@ -126,3 +159,10 @@ def test_bump_pyproject_version__preserves_crlf_line_endings():
     result = version.bump_pyproject_version(text, "1.0.6")
     assert 'version = "1.0.6"\r\n' in result
     assert result.replace("1.0.6", "1.0.5") == text
+
+
+def test_bump_pyproject_version__tolerates_no_spaces_around_equals():
+    text = '[project]\nname = "x"\nversion="1.0.5"\n'
+    result = version.bump_pyproject_version(text, "1.0.6")
+    assert 'version = "1.0.6"' in result
+    assert "1.0.5" not in result

--- a/.github/scripts/tests/test_version.py
+++ b/.github/scripts/tests/test_version.py
@@ -35,6 +35,10 @@ def test_current_pyproject_version__ignores_version_in_preceding_tool_table():
         pytest.param(SAMPLE_PYPROJECT.replace("\n", "\r\n"), id="crlf"),
         pytest.param('[project]\nname = "x"\nversion="1.0.5"\n', id="no_spaces_around_equals"),
         pytest.param('[project]\nname = "x"\n    version = "1.0.5"\n', id="indented"),
+        pytest.param("[project]\nname = \"x\"\nversion = '1.0.5'\n", id="single_quoted"),
+        pytest.param(
+            '[project]\nname = "x"\nversion = "1.0.5"  # release\n', id="trailing_comment"
+        ),
     ],
 )
 def test_current_pyproject_version__tolerates_format_variations(text):
@@ -90,6 +94,12 @@ _GIT_PIN = "git+https://github.com/lightly-ai/labelformat.git@325a20b"
         # Not the array's first (or only) entry on its line - the check
         # must not stop at the first match, nor anchor to a line's start.
         pytest.param(f'"labelformat>=0.1.17", "labelformat @ {_GIT_PIN}"', id="after_plain_entry"),
+        # A `#` inside a *preceding* entry's URL fragment must not be mistaken
+        # for a comment and truncate the labelformat entry off the line.
+        pytest.param(
+            f'"other @ git+https://x/y.git#subdirectory=other", "labelformat @ {_GIT_PIN}"',
+            id="hash_in_preceding_url_fragment",
+        ),
     ],
 )
 def test_check_labelformat_pin__git_sha_raises(replacement):
@@ -125,4 +135,18 @@ def test_bump_pyproject_version__tolerates_no_spaces_around_equals():
     text = '[project]\nname = "x"\nversion="1.0.5"\n'
     result = version.bump_pyproject_version(text, "1.0.6")
     assert 'version = "1.0.6"' in result
+    assert "1.0.5" not in result
+
+
+def test_bump_pyproject_version__accepts_single_quoted_version():
+    text = "[project]\nname = \"x\"\nversion = '1.0.5'\n"
+    result = version.bump_pyproject_version(text, "1.0.6")
+    assert 'version = "1.0.6"' in result
+    assert "1.0.5" not in result
+
+
+def test_bump_pyproject_version__preserves_trailing_comment():
+    text = '[project]\nname = "x"\nversion = "1.0.5"  # release\n'
+    result = version.bump_pyproject_version(text, "1.0.6")
+    assert 'version = "1.0.6"  # release\n' in result
     assert "1.0.5" not in result

--- a/.github/scripts/tests/test_version.py
+++ b/.github/scripts/tests/test_version.py
@@ -29,20 +29,15 @@ def test_current_pyproject_version__ignores_version_in_preceding_tool_table():
     assert version.current_pyproject_version(text) == "1.0.5"
 
 
-def test_current_pyproject_version__handles_crlf_line_endings():
-    text = SAMPLE_PYPROJECT.replace("\n", "\r\n")
-    assert version.current_pyproject_version(text) == "1.0.5"
-
-
 @pytest.mark.parametrize(
     "text",
     [
-        '[project]\nname = "x"\nversion="1.0.5"\n',
-        '[project]\nname = "x"\n    version = "1.0.5"\n',
+        pytest.param(SAMPLE_PYPROJECT.replace("\n", "\r\n"), id="crlf"),
+        pytest.param('[project]\nname = "x"\nversion="1.0.5"\n', id="no_spaces_around_equals"),
+        pytest.param('[project]\nname = "x"\n    version = "1.0.5"\n', id="indented"),
     ],
-    ids=["no_spaces_around_equals", "indented"],
 )
-def test_current_pyproject_version__tolerates_non_canonical_spacing(text):
+def test_current_pyproject_version__tolerates_format_variations(text):
     assert version.current_pyproject_version(text) == "1.0.5"
 
 
@@ -54,56 +49,24 @@ def test_bump_semver(bump, expected):
     assert version.bump_semver("1.0.5", bump) == expected
 
 
-def test_bump_semver__non_semver_current_version_raises():
-    with pytest.raises(PrepareReleaseError):
-        version.bump_semver("1.0.0rc1", "patch")
-
-
-@pytest.mark.parametrize("version_string", ["1.02.3", "01.2.3", "1.2.03"])
-def test_bump_semver__leading_zero_component_raises(version_string):
+@pytest.mark.parametrize(
+    "version_string",
+    [
+        pytest.param("1.0.0rc1", id="not_plain_semver"),
+        pytest.param("1.02.3", id="leading_zero"),
+        pytest.param("01.2.3", id="leading_zero_major"),
+        pytest.param("1.2.03", id="leading_zero_patch"),
+        pytest.param("1.2.3\n", id="trailing_newline"),
+        pytest.param("1.٢.3", id="non_ascii_digit"),  # "٢" is the Arabic-Indic digit two
+    ],
+)
+def test_bump_semver__invalid_version_raises(version_string):
     with pytest.raises(PrepareReleaseError):
         version.bump_semver(version_string, "patch")
 
 
-def test_bump_semver__trailing_newline_component_raises():
-    with pytest.raises(PrepareReleaseError):
-        version.bump_semver("1.2.3\n", "patch")
-
-
-def test_bump_semver__non_ascii_digit_component_raises():
-    with pytest.raises(PrepareReleaseError):
-        version.bump_semver("1.٢.3", "patch")  # "٢" is the Arabic-Indic digit two
-
-
 def test_check_labelformat_pin__version_requirement_is_fine():
     version.check_labelformat_pin(SAMPLE_PYPROJECT)
-
-
-def test_check_labelformat_pin__git_sha_raises():
-    text = SAMPLE_PYPROJECT.replace(
-        '"labelformat>=0.1.17"',
-        '"labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"',
-    )
-    with pytest.raises(PrepareReleaseError, match="git sha"):
-        version.check_labelformat_pin(text)
-
-
-def test_check_labelformat_pin__single_quoted_git_sha_raises():
-    text = SAMPLE_PYPROJECT.replace(
-        '"labelformat>=0.1.17"',
-        "'labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b'",
-    )
-    with pytest.raises(PrepareReleaseError, match="git sha"):
-        version.check_labelformat_pin(text)
-
-
-def test_check_labelformat_pin__mixed_case_git_sha_raises():
-    text = SAMPLE_PYPROJECT.replace(
-        '"labelformat>=0.1.17"',
-        '"LabelFormat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"',
-    )
-    with pytest.raises(PrepareReleaseError, match="git sha"):
-        version.check_labelformat_pin(text)
 
 
 def test_check_labelformat_pin__commented_out_example_is_ignored():
@@ -115,25 +78,22 @@ def test_check_labelformat_pin__commented_out_example_is_ignored():
     version.check_labelformat_pin(text)
 
 
-def test_check_labelformat_pin__git_sha_inside_inline_array_raises():
-    # A git-pinned entry that isn't the array's first element must still be
-    # caught - the check isn't anchored to the start of a line.
-    text = (
-        '[project]\nname = "x"\nversion = "1.0.5"\n\n'
-        'dependencies = ["torch>=2.0", '
-        '"labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"]\n'
-    )
-    with pytest.raises(PrepareReleaseError, match="git sha"):
-        version.check_labelformat_pin(text)
+_GIT_PIN = "git+https://github.com/lightly-ai/labelformat.git@325a20b"
 
 
-def test_check_labelformat_pin__git_sha_after_plain_entry_raises():
-    # A plain entry earlier in the file must not shadow a git-pinned one later.
-    text = SAMPLE_PYPROJECT.replace(
-        '"labelformat>=0.1.17"',
-        '"labelformat>=0.1.17",\n'
-        '    "labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"',
-    )
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        pytest.param(f'"labelformat @ {_GIT_PIN}"', id="double_quoted"),
+        pytest.param(f"'labelformat @ {_GIT_PIN}'", id="single_quoted"),
+        pytest.param(f'"LabelFormat @ {_GIT_PIN}"', id="mixed_case"),
+        # Not the array's first (or only) entry on its line - the check
+        # must not stop at the first match, nor anchor to a line's start.
+        pytest.param(f'"labelformat>=0.1.17", "labelformat @ {_GIT_PIN}"', id="after_plain_entry"),
+    ],
+)
+def test_check_labelformat_pin__git_sha_raises(replacement):
+    text = SAMPLE_PYPROJECT.replace('"labelformat>=0.1.17"', replacement)
     with pytest.raises(PrepareReleaseError, match="git sha"):
         version.check_labelformat_pin(text)
 

--- a/.github/scripts/tests/test_version.py
+++ b/.github/scripts/tests/test_version.py
@@ -15,60 +15,6 @@ dependencies = [
 """
 
 
-def test_current_pyproject_version():
-    assert version.current_pyproject_version(SAMPLE_PYPROJECT) == "1.0.5"
-
-
-def test_current_pyproject_version__missing_raises():
-    with pytest.raises(PrepareReleaseError):
-        version.current_pyproject_version('[project]\nname = "x"\n')
-
-
-def test_current_pyproject_version__ignores_version_in_preceding_tool_table():
-    text = '[tool.some-plugin]\nversion = "9.9.9"\n\n[project]\nname = "x"\nversion = "1.0.5"\n'
-    assert version.current_pyproject_version(text) == "1.0.5"
-
-
-@pytest.mark.parametrize(
-    "text",
-    [
-        pytest.param(SAMPLE_PYPROJECT.replace("\n", "\r\n"), id="crlf"),
-        pytest.param('[project]\nname = "x"\nversion="1.0.5"\n', id="no_spaces_around_equals"),
-        pytest.param('[project]\nname = "x"\n    version = "1.0.5"\n', id="indented"),
-        pytest.param("[project]\nname = \"x\"\nversion = '1.0.5'\n", id="single_quoted"),
-        pytest.param(
-            '[project]\nname = "x"\nversion = "1.0.5"  # release\n', id="trailing_comment"
-        ),
-    ],
-)
-def test_current_pyproject_version__tolerates_format_variations(text):
-    assert version.current_pyproject_version(text) == "1.0.5"
-
-
-@pytest.mark.parametrize(
-    ("bump", "expected"),
-    [("patch", "1.0.6"), ("minor", "1.1.0"), ("major", "2.0.0")],
-)
-def test_bump_semver(bump, expected):
-    assert version.bump_semver("1.0.5", bump) == expected
-
-
-@pytest.mark.parametrize(
-    "version_string",
-    [
-        pytest.param("1.0.0rc1", id="not_plain_semver"),
-        pytest.param("1.02.3", id="leading_zero"),
-        pytest.param("01.2.3", id="leading_zero_major"),
-        pytest.param("1.2.03", id="leading_zero_patch"),
-        pytest.param("1.2.3\n", id="trailing_newline"),
-        pytest.param("1.٢.3", id="non_ascii_digit"),  # "٢" is the Arabic-Indic digit two
-    ],
-)
-def test_bump_semver__invalid_version_raises(version_string):
-    with pytest.raises(PrepareReleaseError):
-        version.bump_semver(version_string, "patch")
-
-
 def test_check_labelformat_pin__version_requirement_is_fine():
     version.check_labelformat_pin(SAMPLE_PYPROJECT)
 
@@ -106,47 +52,3 @@ def test_check_labelformat_pin__git_sha_raises(replacement):
     text = SAMPLE_PYPROJECT.replace('"labelformat>=0.1.17"', replacement)
     with pytest.raises(PrepareReleaseError, match="git sha"):
         version.check_labelformat_pin(text)
-
-
-def test_bump_pyproject_version():
-    result = version.bump_pyproject_version(SAMPLE_PYPROJECT, "1.0.6")
-    assert 'version = "1.0.6"' in result
-    assert 'version = "1.0.5"' not in result
-    # Only the [project] version changes, nothing else.
-    assert result.replace("1.0.6", "1.0.5") == SAMPLE_PYPROJECT
-
-
-def test_bump_pyproject_version__ignores_version_in_preceding_tool_table():
-    text = '[tool.some-plugin]\nversion = "9.9.9"\n\n[project]\nname = "x"\nversion = "1.0.5"\n'
-    result = version.bump_pyproject_version(text, "1.0.6")
-    assert 'version = "9.9.9"' in result
-    assert 'version = "1.0.6"' in result
-    assert 'version = "1.0.5"' not in result
-
-
-def test_bump_pyproject_version__preserves_crlf_line_endings():
-    text = SAMPLE_PYPROJECT.replace("\n", "\r\n")
-    result = version.bump_pyproject_version(text, "1.0.6")
-    assert 'version = "1.0.6"\r\n' in result
-    assert result.replace("1.0.6", "1.0.5") == text
-
-
-def test_bump_pyproject_version__tolerates_no_spaces_around_equals():
-    text = '[project]\nname = "x"\nversion="1.0.5"\n'
-    result = version.bump_pyproject_version(text, "1.0.6")
-    assert 'version = "1.0.6"' in result
-    assert "1.0.5" not in result
-
-
-def test_bump_pyproject_version__accepts_single_quoted_version():
-    text = "[project]\nname = \"x\"\nversion = '1.0.5'\n"
-    result = version.bump_pyproject_version(text, "1.0.6")
-    assert 'version = "1.0.6"' in result
-    assert "1.0.5" not in result
-
-
-def test_bump_pyproject_version__preserves_trailing_comment():
-    text = '[project]\nname = "x"\nversion = "1.0.5"  # release\n'
-    result = version.bump_pyproject_version(text, "1.0.6")
-    assert 'version = "1.0.6"  # release\n' in result
-    assert "1.0.5" not in result

--- a/.github/scripts/tests/test_version.py
+++ b/.github/scripts/tests/test_version.py
@@ -85,6 +85,15 @@ def test_check_labelformat_pin__single_quoted_git_sha_raises():
         version.check_labelformat_pin(text)
 
 
+def test_check_labelformat_pin__mixed_case_git_sha_raises():
+    text = SAMPLE_PYPROJECT.replace(
+        '"labelformat>=0.1.17"',
+        '"LabelFormat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"',
+    )
+    with pytest.raises(PrepareReleaseError, match="git sha"):
+        version.check_labelformat_pin(text)
+
+
 def test_check_labelformat_pin__git_sha_after_plain_entry_raises():
     # A plain entry earlier in the file must not shadow a git-pinned one later.
     text = SAMPLE_PYPROJECT.replace(

--- a/.github/scripts/tests/test_version.py
+++ b/.github/scripts/tests/test_version.py
@@ -50,9 +50,37 @@ def test_check_labelformat_pin__git_sha_raises():
         version.check_labelformat_pin(text)
 
 
+def test_check_labelformat_pin__single_quoted_git_sha_raises():
+    text = SAMPLE_PYPROJECT.replace(
+        '"labelformat>=0.1.17"',
+        "'labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b'",
+    )
+    with pytest.raises(PrepareReleaseError, match="git sha"):
+        version.check_labelformat_pin(text)
+
+
 def test_bump_pyproject_version():
     result = version.bump_pyproject_version(SAMPLE_PYPROJECT, "1.0.6")
     assert 'version = "1.0.6"' in result
     assert 'version = "1.0.5"' not in result
     # Only the [project] version changes, nothing else.
     assert result.replace("1.0.6", "1.0.5") == SAMPLE_PYPROJECT
+
+
+def test_current_pyproject_version__ignores_version_in_preceding_tool_table():
+    text = '[tool.some-plugin]\nversion = "9.9.9"\n\n[project]\nname = "x"\nversion = "1.0.5"\n'
+    assert version.current_pyproject_version(text) == "1.0.5"
+
+
+def test_bump_pyproject_version__ignores_version_in_preceding_tool_table():
+    text = '[tool.some-plugin]\nversion = "9.9.9"\n\n[project]\nname = "x"\nversion = "1.0.5"\n'
+    result = version.bump_pyproject_version(text, "1.0.6")
+    assert 'version = "9.9.9"' in result
+    assert 'version = "1.0.6"' in result
+    assert 'version = "1.0.5"' not in result
+
+
+@pytest.mark.parametrize("version_string", ["1.02.3", "01.2.3", "1.2.03"])
+def test_bump_semver__leading_zero_component_raises(version_string):
+    with pytest.raises(PrepareReleaseError):
+        version.bump_semver(version_string, "patch")

--- a/.github/scripts/tests/test_version.py
+++ b/.github/scripts/tests/test_version.py
@@ -29,6 +29,11 @@ def test_current_pyproject_version__ignores_version_in_preceding_tool_table():
     assert version.current_pyproject_version(text) == "1.0.5"
 
 
+def test_current_pyproject_version__handles_crlf_line_endings():
+    text = SAMPLE_PYPROJECT.replace("\n", "\r\n")
+    assert version.current_pyproject_version(text) == "1.0.5"
+
+
 @pytest.mark.parametrize(
     ("bump", "expected"),
     [("patch", "1.0.6"), ("minor", "1.1.0"), ("major", "2.0.0")],
@@ -46,6 +51,16 @@ def test_bump_semver__non_semver_current_version_raises():
 def test_bump_semver__leading_zero_component_raises(version_string):
     with pytest.raises(PrepareReleaseError):
         version.bump_semver(version_string, "patch")
+
+
+def test_bump_semver__trailing_newline_component_raises():
+    with pytest.raises(PrepareReleaseError):
+        version.bump_semver("1.2.3\n", "patch")
+
+
+def test_bump_semver__non_ascii_digit_component_raises():
+    with pytest.raises(PrepareReleaseError):
+        version.bump_semver("1.٢.3", "patch")  # "٢" is the Arabic-Indic digit two
 
 
 def test_check_labelformat_pin__version_requirement_is_fine():
@@ -70,6 +85,17 @@ def test_check_labelformat_pin__single_quoted_git_sha_raises():
         version.check_labelformat_pin(text)
 
 
+def test_check_labelformat_pin__git_sha_after_plain_entry_raises():
+    # A plain entry earlier in the file must not shadow a git-pinned one later.
+    text = SAMPLE_PYPROJECT.replace(
+        '"labelformat>=0.1.17"',
+        '"labelformat>=0.1.17",\n'
+        '    "labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"',
+    )
+    with pytest.raises(PrepareReleaseError, match="git sha"):
+        version.check_labelformat_pin(text)
+
+
 def test_bump_pyproject_version():
     result = version.bump_pyproject_version(SAMPLE_PYPROJECT, "1.0.6")
     assert 'version = "1.0.6"' in result
@@ -84,3 +110,10 @@ def test_bump_pyproject_version__ignores_version_in_preceding_tool_table():
     assert 'version = "9.9.9"' in result
     assert 'version = "1.0.6"' in result
     assert 'version = "1.0.5"' not in result
+
+
+def test_bump_pyproject_version__preserves_crlf_line_endings():
+    text = SAMPLE_PYPROJECT.replace("\n", "\r\n")
+    result = version.bump_pyproject_version(text, "1.0.6")
+    assert 'version = "1.0.6"\r\n' in result
+    assert result.replace("1.0.6", "1.0.5") == text

--- a/.github/scripts/tests/test_version.py
+++ b/.github/scripts/tests/test_version.py
@@ -1,0 +1,58 @@
+import pytest
+
+from prepare_release import version
+from prepare_release.errors import PrepareReleaseError
+
+SAMPLE_PYPROJECT = """\
+[project]
+name = "lightly-studio"
+version = "1.0.5"
+description = "..."
+
+dependencies = [
+    "labelformat>=0.1.17",
+]
+"""
+
+
+def test_current_pyproject_version():
+    assert version.current_pyproject_version(SAMPLE_PYPROJECT) == "1.0.5"
+
+
+def test_current_pyproject_version__missing_raises():
+    with pytest.raises(PrepareReleaseError):
+        version.current_pyproject_version('[project]\nname = "x"\n')
+
+
+@pytest.mark.parametrize(
+    ("bump", "expected"),
+    [("patch", "1.0.6"), ("minor", "1.1.0"), ("major", "2.0.0")],
+)
+def test_bump_semver(bump, expected):
+    assert version.bump_semver("1.0.5", bump) == expected
+
+
+def test_bump_semver__non_semver_current_version_raises():
+    with pytest.raises(PrepareReleaseError):
+        version.bump_semver("1.0.0rc1", "patch")
+
+
+def test_check_labelformat_pin__version_requirement_is_fine():
+    version.check_labelformat_pin(SAMPLE_PYPROJECT)
+
+
+def test_check_labelformat_pin__git_sha_raises():
+    text = SAMPLE_PYPROJECT.replace(
+        '"labelformat>=0.1.17"',
+        '"labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"',
+    )
+    with pytest.raises(PrepareReleaseError, match="git sha"):
+        version.check_labelformat_pin(text)
+
+
+def test_bump_pyproject_version():
+    result = version.bump_pyproject_version(SAMPLE_PYPROJECT, "1.0.6")
+    assert 'version = "1.0.6"' in result
+    assert 'version = "1.0.5"' not in result
+    # Only the [project] version changes, nothing else.
+    assert result.replace("1.0.6", "1.0.5") == SAMPLE_PYPROJECT

--- a/.github/scripts/tests/test_version.py
+++ b/.github/scripts/tests/test_version.py
@@ -24,6 +24,11 @@ def test_current_pyproject_version__missing_raises():
         version.current_pyproject_version('[project]\nname = "x"\n')
 
 
+def test_current_pyproject_version__ignores_version_in_preceding_tool_table():
+    text = '[tool.some-plugin]\nversion = "9.9.9"\n\n[project]\nname = "x"\nversion = "1.0.5"\n'
+    assert version.current_pyproject_version(text) == "1.0.5"
+
+
 @pytest.mark.parametrize(
     ("bump", "expected"),
     [("patch", "1.0.6"), ("minor", "1.1.0"), ("major", "2.0.0")],
@@ -35,6 +40,12 @@ def test_bump_semver(bump, expected):
 def test_bump_semver__non_semver_current_version_raises():
     with pytest.raises(PrepareReleaseError):
         version.bump_semver("1.0.0rc1", "patch")
+
+
+@pytest.mark.parametrize("version_string", ["1.02.3", "01.2.3", "1.2.03"])
+def test_bump_semver__leading_zero_component_raises(version_string):
+    with pytest.raises(PrepareReleaseError):
+        version.bump_semver(version_string, "patch")
 
 
 def test_check_labelformat_pin__version_requirement_is_fine():
@@ -67,20 +78,9 @@ def test_bump_pyproject_version():
     assert result.replace("1.0.6", "1.0.5") == SAMPLE_PYPROJECT
 
 
-def test_current_pyproject_version__ignores_version_in_preceding_tool_table():
-    text = '[tool.some-plugin]\nversion = "9.9.9"\n\n[project]\nname = "x"\nversion = "1.0.5"\n'
-    assert version.current_pyproject_version(text) == "1.0.5"
-
-
 def test_bump_pyproject_version__ignores_version_in_preceding_tool_table():
     text = '[tool.some-plugin]\nversion = "9.9.9"\n\n[project]\nname = "x"\nversion = "1.0.5"\n'
     result = version.bump_pyproject_version(text, "1.0.6")
     assert 'version = "9.9.9"' in result
     assert 'version = "1.0.6"' in result
     assert 'version = "1.0.5"' not in result
-
-
-@pytest.mark.parametrize("version_string", ["1.02.3", "01.2.3", "1.2.03"])
-def test_bump_semver__leading_zero_component_raises(version_string):
-    with pytest.raises(PrepareReleaseError):
-        version.bump_semver(version_string, "patch")


### PR DESCRIPTION
Part of a stack ([gh-stack](https://github.github.com/gh-stack/)), 2 of 4, landing bottom-up onto `main`:

1. #2043 - changelog promotion
2. **#2044 - version, pyproject.toml, and uv.lock guards** (this PR)
3. #2045 - PR body rendering (draft notes + coverage checklist)
4. #2046 - CLI + GitHub Actions workflow

Based on #2043 - please review/merge in order; each PR rebases onto the
previous once it lands.

## What has changed and why?

Second layer of the **Prepare Release** tooling: version and lock-file
guards.

- `version.py`: reads and bumps the `[project]` version in
  `pyproject.toml`; also fails if `labelformat` is pinned by git sha,
  pointing at the Labelformat release runbook instead of letting the
  workflow proceed against an unreleased dependency.
- `lock.py`: fails if `uv sync` changed anything in `uv.lock` beyond
  the root package's version line, so resolver drift on transitive
  dependencies can't sneak into a release PR as a sprawling diff.

## How has it been tested?

- 13 unit tests covering the semver bump, the labelformat guard, and
  the lock-diff assertion's various cases.
- `ruff format --check`, `ruff check`, and `mypy --strict` pass.
- Hand-ran against this repo's real `pyproject.toml` / `uv.lock`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

---
Suggested reviewer: @michal-lightly. Alternate: @lukas-lightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved release preparation checks for project version updates with stricter semantic-version validation.
  - Added major, minor, and patch version bump support while preserving unrelated project configuration and line endings.
  - Strengthened lockfile safeguards for duplicate package entries and narrowly scoped version-only changes.
  - Added validation for supported Git-pinned tooling versions, including flexible formatting and single-quoted requirements.

- **Tests**
  - Expanded coverage for version updates, invalid versions, duplicate lockfile entries, and narrowly scoped lockfile changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->