### PR TITLE
Add prepare-release tooling: render the release PR body

### DIFF
--- a/.github/scripts/prepare_release/pr_body.py
+++ b/.github/scripts/prepare_release/pr_body.py
@@ -1,0 +1,23 @@
+"""Render the release PR body: draft notes + advisory coverage checklist."""
+
+from __future__ import annotations
+
+
+def render_pr_body(section_body: str, drafting_skipped_reason: str, coverage_checklist: str) -> str:
+    """Assembles the release PR body: draft notes + advisory coverage checklist.
+
+    The coverage checklist is git-derived and untrusted display text - it
+    must never be mistaken for reviewed release notes, hence the explicit
+    label and the blank line separating it from the draft notes.
+    """
+    checklist = coverage_checklist.strip() or "_None found._"
+    return (
+        "## Draft release notes\n\n"
+        f"> Automated drafting was skipped ({drafting_skipped_reason}). These are the "
+        "mechanically promoted CHANGELOG entries - review and edit before publishing.\n\n"
+        f"{section_body}\n\n"
+        "## Coverage checklist (advisory only - never copy into the release notes)\n\n"
+        "Merged changes since the last tag with no obviously matching CHANGELOG entry, "
+        "for a human to judge:\n\n"
+        f"{checklist}\n"
+    )

--- a/.github/scripts/tests/test_pr_body.py
+++ b/.github/scripts/tests/test_pr_body.py
@@ -1,0 +1,23 @@
+from prepare_release import pr_body
+
+
+def test_render_pr_body():
+    body = pr_body.render_pr_body(
+        section_body="### Added\n\n- Added thing one.",
+        drafting_skipped_reason="automated drafting is not wired in yet",
+        coverage_checklist="- abc123 Some PR title (#42)",
+    )
+    assert "Draft release notes" in body
+    assert "automated drafting is not wired in yet" in body
+    assert "Added thing one" in body
+    assert "Coverage checklist" in body
+    assert "#42" in body
+
+
+def test_render_pr_body__empty_checklist_shows_placeholder():
+    body = pr_body.render_pr_body(
+        section_body="### Fixed\n\n- A fix.",
+        drafting_skipped_reason="reason",
+        coverage_checklist="",
+    )
+    assert "_None found._" in body


### PR DESCRIPTION
Part of a stack ([gh-stack](https://github.github.com/gh-stack/)), 3 of 4, landing bottom-up onto `main`:

1. #2043 - changelog promotion
2. #2044 - version, pyproject.toml, and uv.lock guards
3. **#2045 - PR body rendering (draft notes + coverage checklist)** (this PR)
4. #2046 - CLI + GitHub Actions workflow

Based on #2044 - please review/merge in order; each PR rebases onto the
previous once it lands.

## What has changed and why?

Third layer of the **Prepare Release** tooling: `pr_body.py` renders
the release PR body from the promoted `CHANGELOG.md` section as draft
release notes, plus an advisory-only coverage checklist that's clearly
labelled so it's never mistaken for reviewed release notes.

Automated (LLM) drafting of the release notes isn't wired in yet
(tracked separately), so this fails open: the draft notes are always
the mechanically-promoted changelog text, with a note that drafting
was skipped. A release must never be blocked by that step being
unavailable.

## How has it been tested?

- 2 unit tests: the rendered body (notes + checklist present) and the
  empty-checklist placeholder.
- `ruff format --check`, `ruff check`, and `mypy --strict` pass.
- Hand-ran against this repo's real `CHANGELOG.md`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

---
Suggested reviewer: @michal-lightly. Alternate: @lukas-lightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added standardized release-note formatting with skipped-drafting notices and advisory information.
  - Added coverage checklist rendering, including a placeholder when no checklist items are available.

- **Tests**
  - Added coverage for populated release notes, skipped-drafting reasons, checklist content, and empty-checklist behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->