### PR TITLE
Add prepare-release workflow: wire up the CLI and GitHub Actions

### DIFF
--- a/.github/scripts/prepare_release/__main__.py
+++ b/.github/scripts/prepare_release/__main__.py
@@ -1,0 +1,8 @@
+"""Allows invocation as `python -m prepare_release <subcommand> ...`."""
+
+import sys
+
+from prepare_release.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -7,7 +7,6 @@ changelog, bumping the version, and guarding against a handful of ways
 that can quietly go wrong.
 
 Usage:
-    python -m prepare_release suggest-bump --changelog CHANGELOG.md
     python -m prepare_release promote-changelog --changelog CHANGELOG.md \
         --version 1.0.6 --date 2026-08-21
 """
@@ -31,11 +30,6 @@ def main(argv: list[str] | None = None) -> int:
         "check-labelformat-pin", help="fail if labelformat is pinned by git sha"
     )
     check_pin.add_argument("--pyproject", type=Path, required=True)
-
-    suggest = subparsers.add_parser(
-        "suggest-bump", help="suggest a semver bump from [Unreleased]'s contents"
-    )
-    suggest.add_argument("--changelog", type=Path, required=True)
 
     compute = subparsers.add_parser(
         "compute-version", help="resolve the release version to bump to"
@@ -83,7 +77,6 @@ def main(argv: list[str] | None = None) -> int:
 def _dispatch(args: argparse.Namespace) -> int:
     handlers = {
         "check-labelformat-pin": _cmd_check_labelformat_pin,
-        "suggest-bump": _cmd_suggest_bump,
         "compute-version": _cmd_compute_version,
         "promote-changelog": _cmd_promote_changelog,
         "bump-pyproject": _cmd_bump_pyproject,
@@ -98,43 +91,50 @@ def _cmd_check_labelformat_pin(args: argparse.Namespace) -> None:
     version.check_labelformat_pin(args.pyproject.read_text())
 
 
-def _cmd_suggest_bump(args: argparse.Namespace) -> None:
-    sections = changelog.parse_unreleased_sections(args.changelog.read_text())
-    bump, reasoning = changelog.suggest_bump(sections)
-    print(f"bump={bump}")
-    print(reasoning)
-
-
 def _cmd_compute_version(args: argparse.Namespace) -> None:
     if args.version:
         print(args.version)
         return
     current = version.current_pyproject_version(args.pyproject.read_text())
-    print(version.bump_semver(current, args.bump))
+    print(version.bump_semver(version=current, bump=args.bump))
 
 
 def _cmd_promote_changelog(args: argparse.Namespace) -> None:
     original = args.changelog.read_text()
-    promoted = changelog.promote_changelog(original, args.version, args.date)
-    changelog.assert_changelog_structure(original, promoted, args.version)
+    promoted = changelog.promote_changelog(
+        changelog_text=original, version=args.version, date=args.date
+    )
+    changelog.assert_changelog_structure(
+        original_text=original, new_text=promoted, version=args.version
+    )
     args.changelog.write_text(promoted)
 
 
 def _cmd_bump_pyproject(args: argparse.Namespace) -> None:
     original = args.pyproject.read_text()
-    args.pyproject.write_text(version.bump_pyproject_version(original, args.version))
+    args.pyproject.write_text(
+        version.bump_pyproject_version(pyproject_text=original, new_version=args.version)
+    )
 
 
 def _cmd_assert_lock_diff(args: argparse.Namespace) -> None:
     lock.assert_lock_diff_narrow(
-        args.before.read_text(), args.after.read_text(), package=args.package
+        before_text=args.before.read_text(),
+        after_text=args.after.read_text(),
+        package=args.package,
     )
 
 
 def _cmd_render_pr_body(args: argparse.Namespace) -> None:
-    section_body = changelog.extract_released_section(args.changelog.read_text(), args.version)
+    section_body = changelog.extract_released_section(
+        changelog_text=args.changelog.read_text(), version=args.version
+    )
     coverage_checklist = args.coverage_file.read_text() if args.coverage_file.exists() else ""
-    body = pr_body.render_pr_body(section_body, args.drafting_skipped_reason, coverage_checklist)
+    body = pr_body.render_pr_body(
+        section_body=section_body,
+        drafting_skipped_reason=args.drafting_skipped_reason,
+        coverage_checklist=coverage_checklist,
+    )
     args.output.write_text(body)
 
 

--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -3,8 +3,9 @@
 Backs the "Prepare Release" GitHub Actions workflow
 (`.github/workflows/prepare_release.yml`). Each subcommand does one small,
 independently testable piece of preparing a release: promoting the
-changelog, bumping the version, and guarding against a handful of ways
-that can quietly go wrong.
+changelog and guarding against a handful of ways that can quietly go
+wrong. Reading/bumping/writing the `[project]` version itself is left to
+`uv version --bump` directly in the workflow (see version.py's docstring).
 
 Usage:
     python -m prepare_release promote-changelog --changelog CHANGELOG.md \
@@ -31,25 +32,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     check_pin.add_argument("--pyproject", type=Path, required=True)
 
-    compute = subparsers.add_parser(
-        "compute-version", help="resolve the release version to bump to"
-    )
-    compute.add_argument("--pyproject", type=Path, required=True)
-    compute.add_argument("--bump", choices=["patch", "minor", "major"], required=True)
-    compute.add_argument("--version", default="", help="explicit override, empty to use --bump")
-
     promote = subparsers.add_parser(
         "promote-changelog", help="promote [Unreleased] to a released version block"
     )
     promote.add_argument("--changelog", type=Path, required=True)
     promote.add_argument("--version", required=True)
     promote.add_argument("--date", required=True, help="YYYY-MM-DD")
-
-    bump_pyproject = subparsers.add_parser(
-        "bump-pyproject", help="write the new version into pyproject.toml"
-    )
-    bump_pyproject.add_argument("--pyproject", type=Path, required=True)
-    bump_pyproject.add_argument("--version", required=True)
 
     lock_diff = subparsers.add_parser(
         "assert-lock-diff", help="fail if uv sync changed more than the version bump"
@@ -77,9 +65,7 @@ def main(argv: list[str] | None = None) -> int:
 def _dispatch(args: argparse.Namespace) -> int:
     handlers = {
         "check-labelformat-pin": _cmd_check_labelformat_pin,
-        "compute-version": _cmd_compute_version,
         "promote-changelog": _cmd_promote_changelog,
-        "bump-pyproject": _cmd_bump_pyproject,
         "assert-lock-diff": _cmd_assert_lock_diff,
         "render-pr-body": _cmd_render_pr_body,
     }
@@ -91,14 +77,6 @@ def _cmd_check_labelformat_pin(args: argparse.Namespace) -> None:
     version.check_labelformat_pin(args.pyproject.read_text())
 
 
-def _cmd_compute_version(args: argparse.Namespace) -> None:
-    if args.version:
-        print(args.version)
-        return
-    current = version.current_pyproject_version(args.pyproject.read_text())
-    print(version.bump_semver(version=current, bump=args.bump))
-
-
 def _cmd_promote_changelog(args: argparse.Namespace) -> None:
     original = args.changelog.read_text()
     promoted = changelog.promote_changelog(
@@ -108,13 +86,6 @@ def _cmd_promote_changelog(args: argparse.Namespace) -> None:
         original_text=original, new_text=promoted, version=args.version
     )
     args.changelog.write_text(promoted)
-
-
-def _cmd_bump_pyproject(args: argparse.Namespace) -> None:
-    original = args.pyproject.read_text()
-    args.pyproject.write_text(
-        version.bump_pyproject_version(pyproject_text=original, new_version=args.version)
-    )
 
 
 def _cmd_assert_lock_diff(args: argparse.Namespace) -> None:

--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -21,6 +21,11 @@ from pathlib import Path
 from prepare_release import changelog, lock, pr_body, version
 from prepare_release.errors import PrepareReleaseError
 
+CHECK_LABELFORMAT_PIN = "check-labelformat-pin"
+PROMOTE_CHANGELOG = "promote-changelog"
+ASSERT_LOCK_DIFF = "assert-lock-diff"
+RENDER_PR_BODY = "render-pr-body"
+
 
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point: parses `argv`, dispatches to the matching subcommand."""
@@ -28,25 +33,25 @@ def main(argv: list[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     check_pin = subparsers.add_parser(
-        "check-labelformat-pin", help="fail if labelformat is pinned by git sha"
+        CHECK_LABELFORMAT_PIN, help="fail if labelformat is pinned by git sha"
     )
     check_pin.add_argument("--pyproject", type=Path, required=True)
 
     promote = subparsers.add_parser(
-        "promote-changelog", help="promote [Unreleased] to a released version block"
+        PROMOTE_CHANGELOG, help="promote [Unreleased] to a released version block"
     )
     promote.add_argument("--changelog", type=Path, required=True)
     promote.add_argument("--version", required=True)
     promote.add_argument("--date", required=True, help="YYYY-MM-DD")
 
     lock_diff = subparsers.add_parser(
-        "assert-lock-diff", help="fail if uv sync changed more than the version bump"
+        ASSERT_LOCK_DIFF, help="fail if uv sync changed more than the version bump"
     )
     lock_diff.add_argument("--before", type=Path, required=True)
     lock_diff.add_argument("--after", type=Path, required=True)
     lock_diff.add_argument("--package", required=True)
 
-    pr_body_parser = subparsers.add_parser("render-pr-body", help="assemble the release PR body")
+    pr_body_parser = subparsers.add_parser(RENDER_PR_BODY, help="assemble the release PR body")
     pr_body_parser.add_argument("--changelog", type=Path, required=True)
     pr_body_parser.add_argument("--version", required=True)
     pr_body_parser.add_argument("--drafting-skipped-reason", required=True)
@@ -64,10 +69,10 @@ def main(argv: list[str] | None = None) -> int:
 
 def _dispatch(args: argparse.Namespace) -> int:
     handlers = {
-        "check-labelformat-pin": _cmd_check_labelformat_pin,
-        "promote-changelog": _cmd_promote_changelog,
-        "assert-lock-diff": _cmd_assert_lock_diff,
-        "render-pr-body": _cmd_render_pr_body,
+        CHECK_LABELFORMAT_PIN: _cmd_check_labelformat_pin,
+        PROMOTE_CHANGELOG: _cmd_promote_changelog,
+        ASSERT_LOCK_DIFF: _cmd_assert_lock_diff,
+        RENDER_PR_BODY: _cmd_render_pr_body,
     }
     handlers[args.command](args)
     return 0

--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -1,0 +1,142 @@
+"""Command-line entry point for the prepare-release tooling.
+
+Backs the "Prepare Release" GitHub Actions workflow
+(`.github/workflows/prepare_release.yml`). Each subcommand does one small,
+independently testable piece of preparing a release: promoting the
+changelog, bumping the version, and guarding against a handful of ways
+that can quietly go wrong.
+
+Usage:
+    python -m prepare_release suggest-bump --changelog CHANGELOG.md
+    python -m prepare_release promote-changelog --changelog CHANGELOG.md \
+        --version 1.0.6 --date 2026-08-21
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from prepare_release import changelog, lock, pr_body, version
+from prepare_release.errors import PrepareReleaseError
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: parses `argv`, dispatches to the matching subcommand."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_pin = subparsers.add_parser(
+        "check-labelformat-pin", help="fail if labelformat is pinned by git sha"
+    )
+    check_pin.add_argument("--pyproject", type=Path, required=True)
+
+    suggest = subparsers.add_parser(
+        "suggest-bump", help="suggest a semver bump from [Unreleased]'s contents"
+    )
+    suggest.add_argument("--changelog", type=Path, required=True)
+
+    compute = subparsers.add_parser(
+        "compute-version", help="resolve the release version to bump to"
+    )
+    compute.add_argument("--pyproject", type=Path, required=True)
+    compute.add_argument("--bump", choices=["patch", "minor", "major"], required=True)
+    compute.add_argument("--version", default="", help="explicit override, empty to use --bump")
+
+    promote = subparsers.add_parser(
+        "promote-changelog", help="promote [Unreleased] to a released version block"
+    )
+    promote.add_argument("--changelog", type=Path, required=True)
+    promote.add_argument("--version", required=True)
+    promote.add_argument("--date", required=True, help="YYYY-MM-DD")
+
+    bump_pyproject = subparsers.add_parser(
+        "bump-pyproject", help="write the new version into pyproject.toml"
+    )
+    bump_pyproject.add_argument("--pyproject", type=Path, required=True)
+    bump_pyproject.add_argument("--version", required=True)
+
+    lock_diff = subparsers.add_parser(
+        "assert-lock-diff", help="fail if uv sync changed more than the version bump"
+    )
+    lock_diff.add_argument("--before", type=Path, required=True)
+    lock_diff.add_argument("--after", type=Path, required=True)
+    lock_diff.add_argument("--package", required=True)
+
+    pr_body_parser = subparsers.add_parser("render-pr-body", help="assemble the release PR body")
+    pr_body_parser.add_argument("--changelog", type=Path, required=True)
+    pr_body_parser.add_argument("--version", required=True)
+    pr_body_parser.add_argument("--drafting-skipped-reason", required=True)
+    pr_body_parser.add_argument("--coverage-file", type=Path, required=True)
+    pr_body_parser.add_argument("--output", type=Path, required=True)
+
+    args = parser.parse_args(argv)
+
+    try:
+        return _dispatch(args)
+    except PrepareReleaseError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    handlers = {
+        "check-labelformat-pin": _cmd_check_labelformat_pin,
+        "suggest-bump": _cmd_suggest_bump,
+        "compute-version": _cmd_compute_version,
+        "promote-changelog": _cmd_promote_changelog,
+        "bump-pyproject": _cmd_bump_pyproject,
+        "assert-lock-diff": _cmd_assert_lock_diff,
+        "render-pr-body": _cmd_render_pr_body,
+    }
+    handlers[args.command](args)
+    return 0
+
+
+def _cmd_check_labelformat_pin(args: argparse.Namespace) -> None:
+    version.check_labelformat_pin(args.pyproject.read_text())
+
+
+def _cmd_suggest_bump(args: argparse.Namespace) -> None:
+    sections = changelog.parse_unreleased_sections(args.changelog.read_text())
+    bump, reasoning = changelog.suggest_bump(sections)
+    print(f"bump={bump}")
+    print(reasoning)
+
+
+def _cmd_compute_version(args: argparse.Namespace) -> None:
+    if args.version:
+        print(args.version)
+        return
+    current = version.current_pyproject_version(args.pyproject.read_text())
+    print(version.bump_semver(current, args.bump))
+
+
+def _cmd_promote_changelog(args: argparse.Namespace) -> None:
+    original = args.changelog.read_text()
+    promoted = changelog.promote_changelog(original, args.version, args.date)
+    changelog.assert_changelog_structure(original, promoted, args.version)
+    args.changelog.write_text(promoted)
+
+
+def _cmd_bump_pyproject(args: argparse.Namespace) -> None:
+    original = args.pyproject.read_text()
+    args.pyproject.write_text(version.bump_pyproject_version(original, args.version))
+
+
+def _cmd_assert_lock_diff(args: argparse.Namespace) -> None:
+    lock.assert_lock_diff_narrow(
+        args.before.read_text(), args.after.read_text(), package=args.package
+    )
+
+
+def _cmd_render_pr_body(args: argparse.Namespace) -> None:
+    section_body = changelog.extract_released_section(args.changelog.read_text(), args.version)
+    coverage_checklist = args.coverage_file.read_text() if args.coverage_file.exists() else ""
+    body = pr_body.render_pr_body(section_body, args.drafting_skipped_reason, coverage_checklist)
+    args.output.write_text(body)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -54,7 +54,6 @@ def main(argv: list[str] | None = None) -> int:
     pr_body_parser = subparsers.add_parser(RENDER_PR_BODY, help="assemble the release PR body")
     pr_body_parser.add_argument("--changelog", type=Path, required=True)
     pr_body_parser.add_argument("--version", required=True)
-    pr_body_parser.add_argument("--drafting-skipped-reason", required=True)
     pr_body_parser.add_argument("--coverage-file", type=Path, required=True)
     pr_body_parser.add_argument("--output", type=Path, required=True)
 
@@ -108,7 +107,6 @@ def _cmd_render_pr_body(args: argparse.Namespace) -> None:
     coverage_checklist = args.coverage_file.read_text() if args.coverage_file.exists() else ""
     body = pr_body.render_pr_body(
         section_body=section_body,
-        drafting_skipped_reason=args.drafting_skipped_reason,
         coverage_checklist=coverage_checklist,
     )
     args.output.write_text(body)

--- a/.github/scripts/prepare_release/cli.py
+++ b/.github/scripts/prepare_release/cli.py
@@ -54,7 +54,6 @@ def main(argv: list[str] | None = None) -> int:
     pr_body_parser = subparsers.add_parser(RENDER_PR_BODY, help="assemble the release PR body")
     pr_body_parser.add_argument("--changelog", type=Path, required=True)
     pr_body_parser.add_argument("--version", required=True)
-    pr_body_parser.add_argument("--coverage-file", type=Path, required=True)
     pr_body_parser.add_argument("--output", type=Path, required=True)
 
     args = parser.parse_args(argv)
@@ -104,11 +103,7 @@ def _cmd_render_pr_body(args: argparse.Namespace) -> None:
     section_body = changelog.extract_released_section(
         changelog_text=args.changelog.read_text(), version=args.version
     )
-    coverage_checklist = args.coverage_file.read_text() if args.coverage_file.exists() else ""
-    body = pr_body.render_pr_body(
-        section_body=section_body,
-        coverage_checklist=coverage_checklist,
-    )
+    body = pr_body.render_pr_body(section_body=section_body)
     args.output.write_text(body)
 
 

--- a/.github/scripts/prepare_release/pr_body.py
+++ b/.github/scripts/prepare_release/pr_body.py
@@ -1,22 +1,15 @@
-"""Render the release PR body: draft notes + advisory coverage checklist."""
+"""Render the release PR body: the draft release notes."""
 
 from __future__ import annotations
 
 
-def render_pr_body(section_body: str, coverage_checklist: str) -> str:
-    """Assembles the release PR body: draft notes + advisory coverage checklist.
+def render_pr_body(section_body: str) -> str:
+    """Assembles the release PR body: the draft release notes.
 
-    The coverage checklist is git-derived and untrusted display text - it
-    must never be mistaken for reviewed release notes, hence the explicit
-    label and the blank line separating it from the draft notes.
+    section_body is the CHANGELOG section already promoted for this version.
     """
-    checklist = coverage_checklist.strip() or "_None found._"
     return (
         "## Draft release notes\n\n"
         "> Mechanically promoted from CHANGELOG.md - review and edit before publishing.\n\n"
-        f"{section_body}\n\n"
-        "## Coverage checklist (advisory only - never copy into the release notes)\n\n"
-        "Merged changes since the last tag with no obviously matching CHANGELOG entry, "
-        "for a human to judge:\n\n"
-        f"{checklist}\n"
+        f"{section_body}\n"
     )

--- a/.github/scripts/prepare_release/pr_body.py
+++ b/.github/scripts/prepare_release/pr_body.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-def render_pr_body(section_body: str, drafting_skipped_reason: str, coverage_checklist: str) -> str:
+def render_pr_body(section_body: str, coverage_checklist: str) -> str:
     """Assembles the release PR body: draft notes + advisory coverage checklist.
 
     The coverage checklist is git-derived and untrusted display text - it
@@ -13,8 +13,7 @@ def render_pr_body(section_body: str, drafting_skipped_reason: str, coverage_che
     checklist = coverage_checklist.strip() or "_None found._"
     return (
         "## Draft release notes\n\n"
-        f"> Automated drafting was skipped ({drafting_skipped_reason}). These are the "
-        "mechanically promoted CHANGELOG entries - review and edit before publishing.\n\n"
+        "> Mechanically promoted from CHANGELOG.md - review and edit before publishing.\n\n"
         f"{section_body}\n\n"
         "## Coverage checklist (advisory only - never copy into the release notes)\n\n"
         "Merged changes since the last tag with no obviously matching CHANGELOG entry, "

--- a/.github/scripts/tests/test_cli.py
+++ b/.github/scripts/tests/test_cli.py
@@ -149,8 +149,6 @@ def test_main__render_pr_body__writes_file(tmp_path: Path):
                 str(changelog_file),
                 "--version",
                 "1.1.0",
-                "--drafting-skipped-reason",
-                "automated drafting is not wired in yet",
                 "--coverage-file",
                 str(tmp_path / "missing_coverage_file.md"),
                 "--output",
@@ -161,4 +159,3 @@ def test_main__render_pr_body__writes_file(tmp_path: Path):
     )
     body = output.read_text()
     assert "Added thing one" in body
-    assert "automated drafting is not wired in yet" in body

--- a/.github/scripts/tests/test_cli.py
+++ b/.github/scripts/tests/test_cli.py
@@ -149,8 +149,6 @@ def test_main__render_pr_body__writes_file(tmp_path: Path):
                 str(changelog_file),
                 "--version",
                 "1.1.0",
-                "--coverage-file",
-                str(tmp_path / "missing_coverage_file.md"),
                 "--output",
                 str(output),
             ]

--- a/.github/scripts/tests/test_cli.py
+++ b/.github/scripts/tests/test_cli.py
@@ -69,32 +69,6 @@ def test_main__check_labelformat_pin__git_sha_fails(tmp_path: Path, capsys: pyte
     assert "git sha" in capsys.readouterr().err
 
 
-def test_main__compute_version__from_bump(tmp_path: Path, capsys: pytest.CaptureFixture):
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text(SAMPLE_PYPROJECT)
-    cli.main(["compute-version", "--pyproject", str(pyproject), "--bump", "minor"])
-    assert capsys.readouterr().out.strip() == "1.1.0"
-
-
-def test_main__compute_version__explicit_version_overrides_bump(
-    tmp_path: Path, capsys: pytest.CaptureFixture
-):
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text(SAMPLE_PYPROJECT)
-    cli.main(
-        [
-            "compute-version",
-            "--pyproject",
-            str(pyproject),
-            "--bump",
-            "minor",
-            "--version",
-            "1.0.0rc1",
-        ]
-    )
-    assert capsys.readouterr().out.strip() == "1.0.0rc1"
-
-
 def test_main__promote_changelog__writes_file(tmp_path: Path):
     changelog_file = tmp_path / "CHANGELOG.md"
     changelog_file.write_text(SAMPLE_CHANGELOG)
@@ -115,13 +89,6 @@ def test_main__promote_changelog__writes_file(tmp_path: Path):
     promoted = changelog_file.read_text()
     assert "## \\[1.1.0\\] - 2026-08-25" in promoted
     assert "Added thing one" in promoted
-
-
-def test_main__bump_pyproject__writes_file(tmp_path: Path):
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text(SAMPLE_PYPROJECT)
-    assert cli.main(["bump-pyproject", "--pyproject", str(pyproject), "--version", "1.0.6"]) == 0
-    assert 'version = "1.0.6"' in pyproject.read_text()
 
 
 def test_main__assert_lock_diff__narrow_diff_passes(tmp_path: Path):

--- a/.github/scripts/tests/test_cli.py
+++ b/.github/scripts/tests/test_cli.py
@@ -1,0 +1,197 @@
+from pathlib import Path
+
+import pytest
+
+from prepare_release import changelog, cli
+
+SAMPLE_PYPROJECT = """\
+[project]
+name = "lightly-studio"
+version = "1.0.5"
+description = "..."
+
+dependencies = [
+    "labelformat>=0.1.17",
+]
+"""
+
+SAMPLE_CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Added thing one.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+"""
+
+SAMPLE_LOCK = """\
+version = 1
+revision = 2
+
+[[package]]
+name = "lightly-studio"
+version = "1.0.5"
+source = { editable = "." }
+"""
+
+
+def test_main__unknown_command_exits_nonzero():
+    with pytest.raises(SystemExit):
+        cli.main(["suggest-bump", "--changelog", "CHANGELOG.md"])
+
+
+def test_main__check_labelformat_pin__passes(tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(SAMPLE_PYPROJECT)
+    assert cli.main(["check-labelformat-pin", "--pyproject", str(pyproject)]) == 0
+
+
+def test_main__check_labelformat_pin__git_sha_fails(tmp_path: Path, capsys: pytest.CaptureFixture):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        SAMPLE_PYPROJECT.replace(
+            '"labelformat>=0.1.17"',
+            '"labelformat @ git+https://github.com/lightly-ai/labelformat.git@325a20b"',
+        )
+    )
+    assert cli.main(["check-labelformat-pin", "--pyproject", str(pyproject)]) == 1
+    assert "git sha" in capsys.readouterr().err
+
+
+def test_main__compute_version__from_bump(tmp_path: Path, capsys: pytest.CaptureFixture):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(SAMPLE_PYPROJECT)
+    cli.main(["compute-version", "--pyproject", str(pyproject), "--bump", "minor"])
+    assert capsys.readouterr().out.strip() == "1.1.0"
+
+
+def test_main__compute_version__explicit_version_overrides_bump(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(SAMPLE_PYPROJECT)
+    cli.main(
+        [
+            "compute-version",
+            "--pyproject",
+            str(pyproject),
+            "--bump",
+            "minor",
+            "--version",
+            "1.0.0rc1",
+        ]
+    )
+    assert capsys.readouterr().out.strip() == "1.0.0rc1"
+
+
+def test_main__promote_changelog__writes_file(tmp_path: Path):
+    changelog_file = tmp_path / "CHANGELOG.md"
+    changelog_file.write_text(SAMPLE_CHANGELOG)
+    assert (
+        cli.main(
+            [
+                "promote-changelog",
+                "--changelog",
+                str(changelog_file),
+                "--version",
+                "1.1.0",
+                "--date",
+                "2026-08-25",
+            ]
+        )
+        == 0
+    )
+    promoted = changelog_file.read_text()
+    assert "## \\[1.1.0\\] - 2026-08-25" in promoted
+    assert "Added thing one" in promoted
+
+
+def test_main__bump_pyproject__writes_file(tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(SAMPLE_PYPROJECT)
+    assert cli.main(["bump-pyproject", "--pyproject", str(pyproject), "--version", "1.0.6"]) == 0
+    assert 'version = "1.0.6"' in pyproject.read_text()
+
+
+def test_main__assert_lock_diff__narrow_diff_passes(tmp_path: Path):
+    before = tmp_path / "before.lock"
+    after = tmp_path / "after.lock"
+    before.write_text(SAMPLE_LOCK)
+    after.write_text(SAMPLE_LOCK.replace('version = "1.0.5"', 'version = "1.0.6"'))
+    assert (
+        cli.main(
+            [
+                "assert-lock-diff",
+                "--before",
+                str(before),
+                "--after",
+                str(after),
+                "--package",
+                "lightly-studio",
+            ]
+        )
+        == 0
+    )
+
+
+def test_main__assert_lock_diff__wide_diff_fails(tmp_path: Path, capsys: pytest.CaptureFixture):
+    before = tmp_path / "before.lock"
+    after = tmp_path / "after.lock"
+    before.write_text(SAMPLE_LOCK)
+    after.write_text(SAMPLE_LOCK.replace('source = { editable = "." }', 'source = { path = "." }'))
+    assert (
+        cli.main(
+            [
+                "assert-lock-diff",
+                "--before",
+                str(before),
+                "--after",
+                str(after),
+                "--package",
+                "lightly-studio",
+            ]
+        )
+        == 1
+    )
+    assert "more than its version line" in capsys.readouterr().err
+
+
+def test_main__render_pr_body__writes_file(tmp_path: Path):
+    changelog_file = tmp_path / "CHANGELOG.md"
+    output = tmp_path / "pr_body.md"
+    promoted = changelog.promote_changelog(
+        changelog_text=SAMPLE_CHANGELOG, version="1.1.0", date="2026-08-25"
+    )
+    changelog_file.write_text(promoted)
+    assert (
+        cli.main(
+            [
+                "render-pr-body",
+                "--changelog",
+                str(changelog_file),
+                "--version",
+                "1.1.0",
+                "--drafting-skipped-reason",
+                "automated drafting is not wired in yet",
+                "--coverage-file",
+                str(tmp_path / "missing_coverage_file.md"),
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    body = output.read_text()
+    assert "Added thing one" in body
+    assert "automated drafting is not wired in yet" in body

--- a/.github/scripts/tests/test_pr_body.py
+++ b/.github/scripts/tests/test_pr_body.py
@@ -2,19 +2,6 @@ from prepare_release import pr_body
 
 
 def test_render_pr_body():
-    body = pr_body.render_pr_body(
-        section_body="### Added\n\n- Added thing one.",
-        coverage_checklist="- abc123 Some PR title (#42)",
-    )
+    body = pr_body.render_pr_body(section_body="### Added\n\n- Added thing one.")
     assert "Draft release notes" in body
     assert "Added thing one" in body
-    assert "Coverage checklist" in body
-    assert "#42" in body
-
-
-def test_render_pr_body__empty_checklist_shows_placeholder():
-    body = pr_body.render_pr_body(
-        section_body="### Fixed\n\n- A fix.",
-        coverage_checklist="",
-    )
-    assert "_None found._" in body

--- a/.github/scripts/tests/test_pr_body.py
+++ b/.github/scripts/tests/test_pr_body.py
@@ -4,11 +4,9 @@ from prepare_release import pr_body
 def test_render_pr_body():
     body = pr_body.render_pr_body(
         section_body="### Added\n\n- Added thing one.",
-        drafting_skipped_reason="automated drafting is not wired in yet",
         coverage_checklist="- abc123 Some PR title (#42)",
     )
     assert "Draft release notes" in body
-    assert "automated drafting is not wired in yet" in body
     assert "Added thing one" in body
     assert "Coverage checklist" in body
     assert "#42" in body
@@ -17,7 +15,6 @@ def test_render_pr_body():
 def test_render_pr_body__empty_checklist_shows_placeholder():
     body = pr_body.render_pr_body(
         section_body="### Fixed\n\n- A fix.",
-        drafting_skipped_reason="reason",
         coverage_checklist="",
     )
     assert "_None found._" in body

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -134,7 +134,6 @@ jobs:
             --changelog CHANGELOG.md \
             --version "${{ steps.resolved.outputs.version }}" \
             --coverage-file /tmp/coverage_checklist.md \
-            --drafting-skipped-reason "automated LLM drafting is not wired in yet" \
             --output /tmp/pr_body.md
 
       - name: Commit changes

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -39,8 +39,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Set Up uv
         uses: astral-sh/setup-uv@v10.0.1
@@ -114,26 +112,11 @@ jobs:
             exit 1
           fi
 
-      - name: Build coverage checklist (advisory, git-derived, never published)
-        run: |
-          last_tag="$(git describe --tags --abbrev=0 origin/main 2>/dev/null || true)"
-          {
-            if [ -z "$last_tag" ]; then
-              echo "_No previous tag found; skipping coverage checklist._"
-            else
-              echo "Merged commits since \`$last_tag\` - check each has a matching CHANGELOG entry:"
-              echo
-              git log "$last_tag..origin/main" --no-merges --oneline | sed 's/^/- /'
-            fi
-          } > /tmp/coverage_checklist.md
-          cat /tmp/coverage_checklist.md >> "$GITHUB_STEP_SUMMARY"
-
       - name: Render PR body
         run: |
           python3 -m prepare_release render-pr-body \
             --changelog CHANGELOG.md \
             --version "${{ steps.resolved.outputs.version }}" \
-            --coverage-file /tmp/coverage_checklist.md \
             --output /tmp/pr_body.md
 
       - name: Commit changes

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -77,12 +77,20 @@ jobs:
       - name: Resolve inputs
         id: resolved
         working-directory: lightly_studio
+        # Read the workflow_dispatch inputs via env instead of interpolating them
+        # into the script - INPUT_VERSION is a free-form string, and substituting
+        # it directly into `run:` would let it inject shell commands.
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BUMP: ${{ inputs.bump }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            version="${{ inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            # --dry-run --frozen: validate/normalize the explicit override only,
+            # no write, no re-lock. Also rejects a version that isn't valid semver.
+            version="$(uv version "$INPUT_VERSION" --dry-run --frozen --short)"
           else
             # --dry-run --frozen: compute the bumped version only, no write, no re-lock.
-            version="$(uv version --bump "${{ inputs.bump }}" --dry-run --frozen --short)"
+            version="$(uv version --bump "$INPUT_BUMP" --dry-run --frozen --short)"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "### Preparing release v$version" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,8 +1,5 @@
 name: Prepare Release
 
-# Creates a release branch, promotes the changelog, bumps the version, and
-# opens a review-ready release PR - the mechanical half of preparing a
-# LightlyStudio release. Publishes nothing.
 on:
   workflow_dispatch:
     inputs:
@@ -26,15 +23,11 @@ permissions:
   contents: write
   pull-requests: write
 
-# Only one release preparation at a time; never cancel one mid-flight since
-# it pushes a branch and opens a PR.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
 env:
-  # prepare_release lives outside lightly_studio (CI-internal, not shipped);
-  # run as `python3 -m prepare_release` with this on PYTHONPATH.
   PYTHONPATH: ${{ github.workspace }}/.github/scripts
 
 jobs:
@@ -46,8 +39,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
-          # Full history + tags: the coverage checklist below diffs against
-          # the last tag.
           fetch-depth: 0
           fetch-tags: true
 
@@ -73,13 +64,10 @@ jobs:
       - name: Resolve inputs
         id: resolved
         working-directory: lightly_studio
-        # Passed via env, not interpolated into the script: inputs.version is
-        # free-form, and used raw it would let a crafted value inject shell code.
         env:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_BUMP: ${{ inputs.bump }}
         run: |
-          # --dry-run --frozen: validate/normalize only, no write, no re-lock.
           if [ -n "$INPUT_VERSION" ]; then
             version="$(uv version "$INPUT_VERSION" --dry-run --frozen --short)"
           else
@@ -100,8 +88,6 @@ jobs:
 
       - name: Bump pyproject.toml version
         working-directory: lightly_studio
-        # --frozen: write the version only, no re-lock - the explicit uv sync
-        # below (and its narrow-diff check) is the one deliberate lock step.
         run: uv version "${{ steps.resolved.outputs.version }}" --frozen
 
       - name: Snapshot uv.lock before sync

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -10,11 +10,12 @@ on:
     inputs:
       bump:
         description: >-
-          Semver bump. "auto" uses the suggestion computed from which
-          [Unreleased] sections are non-empty (see the job summary).
+          Semver bump to apply. Nothing is inferred from the changelog -
+          pick "minor" deliberately when you know the [Unreleased] entries
+          add or change something notable, "patch" otherwise.
         type: choice
-        options: [auto, patch, minor, major]
-        default: auto
+        options: [patch, minor, major]
+        default: patch
       version:
         description: >-
           Explicit version override, e.g. for a release candidate such as
@@ -73,37 +74,12 @@ jobs:
           python3 -m prepare_release check-labelformat-pin \
             --pyproject lightly_studio/pyproject.toml
 
-      - name: Suggest version bump
-        id: suggest
-        # Only needed when the operator left both inputs on their defaults;
-        # an explicit --version or --bump makes the suggestion moot.
-        if: inputs.version == '' && inputs.bump == 'auto'
-        run: |
-          result="$(python3 -m prepare_release suggest-bump --changelog CHANGELOG.md)"
-          bump="$(printf '%s\n' "$result" | head -n1 | sed 's/^bump=//')"
-          echo "bump=$bump" >> "$GITHUB_OUTPUT"
-          {
-            echo "### Suggested version bump: \`$bump\`"
-            printf '%s\n' "$result" | tail -n +2
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Resolve inputs
         id: resolved
         run: |
-          bump="${{ inputs.bump }}"
-          if [ "$bump" = "auto" ]; then
-            # Empty when an explicit --version was given instead (the
-            # "Suggest version bump" step above was skipped) - unused in
-            # that case, compute-version ignores --bump whenever --version
-            # is set.
-            bump="${{ steps.suggest.outputs.bump }}"
-            bump="${bump:-patch}"
-          fi
-          echo "bump=$bump" >> "$GITHUB_OUTPUT"
-
           version="$(python3 -m prepare_release compute-version \
             --pyproject lightly_studio/pyproject.toml \
-            --bump "$bump" \
+            --bump "${{ inputs.bump }}" \
             --version "${{ inputs.version }}")"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "### Preparing release v$version" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,190 @@
+name: Prepare Release
+
+# Creates a release branch, promotes the changelog, bumps the version, and
+# opens a review-ready release PR - the mechanical half of preparing a
+# LightlyStudio release, in one manual dispatch. Public repo, ubuntu-latest,
+# no secrets beyond the default token used to push the branch and open the
+# PR. Publishes nothing.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: >-
+          Semver bump. "auto" uses the suggestion computed from which
+          [Unreleased] sections are non-empty (see the job summary).
+        type: choice
+        options: [auto, patch, minor, major]
+        default: auto
+      version:
+        description: >-
+          Explicit version override, e.g. for a release candidate such as
+          1.0.0rc1. Takes precedence over "bump" when set.
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Only one release preparation at a time; never cancel one mid-flight since
+# it pushes a branch and opens a PR.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  # The prepare_release tooling lives outside the lightly_studio package -
+  # it's CI-internal, not something shipped or user-facing - so it's run
+  # as `python3 -m prepare_release` with this on PYTHONPATH rather than
+  # from inside lightly_studio's own environment.
+  PYTHONPATH: ${{ github.workspace }}/.github/scripts
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          # Full history + tags: the coverage checklist below diffs against
+          # the last tag.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set Up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.8.17"
+          enable-cache: true
+
+      - name: Lint and test the prepare_release tooling
+        working-directory: .github/scripts
+        run: |
+          uv run --with ruff --no-project ruff format --check .
+          uv run --with ruff --no-project ruff check .
+          uv run --with mypy --no-project mypy prepare_release
+          uv run --with pytest --no-project pytest -q
+
+      - name: Guard against a git-pinned Labelformat
+        run: |
+          python3 -m prepare_release check-labelformat-pin \
+            --pyproject lightly_studio/pyproject.toml
+
+      - name: Suggest version bump
+        id: suggest
+        # Only needed when the operator left both inputs on their defaults;
+        # an explicit --version or --bump makes the suggestion moot.
+        if: inputs.version == '' && inputs.bump == 'auto'
+        run: |
+          result="$(python3 -m prepare_release suggest-bump --changelog CHANGELOG.md)"
+          bump="$(printf '%s\n' "$result" | head -n1 | sed 's/^bump=//')"
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Suggested version bump: \`$bump\`"
+            printf '%s\n' "$result" | tail -n +2
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve inputs
+        id: resolved
+        run: |
+          bump="${{ inputs.bump }}"
+          if [ "$bump" = "auto" ]; then
+            # Empty when an explicit --version was given instead (the
+            # "Suggest version bump" step above was skipped) - unused in
+            # that case, compute-version ignores --bump whenever --version
+            # is set.
+            bump="${{ steps.suggest.outputs.bump }}"
+            bump="${bump:-patch}"
+          fi
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+
+          version="$(python3 -m prepare_release compute-version \
+            --pyproject lightly_studio/pyproject.toml \
+            --bump "$bump" \
+            --version "${{ inputs.version }}")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "### Preparing release v$version" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create release branch
+        run: git checkout -b "release-v${{ steps.resolved.outputs.version }}"
+
+      - name: Promote changelog
+        run: |
+          python3 -m prepare_release promote-changelog \
+            --changelog CHANGELOG.md \
+            --version "${{ steps.resolved.outputs.version }}" \
+            --date "$(date -u +%F)"
+
+      - name: Bump pyproject.toml version
+        run: |
+          python3 -m prepare_release bump-pyproject \
+            --pyproject lightly_studio/pyproject.toml \
+            --version "${{ steps.resolved.outputs.version }}"
+
+      - name: Snapshot uv.lock before sync
+        run: cp lightly_studio/uv.lock /tmp/uv.lock.before
+
+      - name: uv sync
+        working-directory: lightly_studio
+        run: uv sync
+
+      - name: Assert uv.lock diff is narrow
+        run: |
+          python3 -m prepare_release assert-lock-diff \
+            --before /tmp/uv.lock.before \
+            --after lightly_studio/uv.lock \
+            --package lightly-studio
+
+      - name: Confirm exactly the expected files changed
+        run: |
+          changed="$(git status --porcelain | awk '{print $2}' | sort)"
+          expected="$(printf '%s\n' CHANGELOG.md lightly_studio/pyproject.toml lightly_studio/uv.lock | sort)"
+          if [ "$changed" != "$expected" ]; then
+            echo "::error::Unexpected file set changed. Got:"
+            echo "$changed"
+            exit 1
+          fi
+
+      - name: Build coverage checklist (advisory, git-derived, never published)
+        run: |
+          last_tag="$(git describe --tags --abbrev=0 origin/main 2>/dev/null || true)"
+          {
+            if [ -z "$last_tag" ]; then
+              echo "_No previous tag found; skipping coverage checklist._"
+            else
+              echo "Merged commits since \`$last_tag\` - check each has a matching CHANGELOG entry:"
+              echo
+              git log "$last_tag..origin/main" --no-merges --oneline | sed 's/^/- /'
+            fi
+          } > /tmp/coverage_checklist.md
+          cat /tmp/coverage_checklist.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Render PR body
+        run: |
+          python3 -m prepare_release render-pr-body \
+            --changelog CHANGELOG.md \
+            --version "${{ steps.resolved.outputs.version }}" \
+            --coverage-file /tmp/coverage_checklist.md \
+            --drafting-skipped-reason "automated LLM drafting is not wired in yet" \
+            --output /tmp/pr_body.md
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md lightly_studio/pyproject.toml lightly_studio/uv.lock
+          git commit -m "Bump version to ${{ steps.resolved.outputs.version }}"
+          git push origin "release-v${{ steps.resolved.outputs.version }}"
+
+      - name: Open release PR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+            --title "Bump version to ${{ steps.resolved.outputs.version }}" \
+            --body-file /tmp/pr_body.md \
+            --base main \
+            --head "release-v${{ steps.resolved.outputs.version }}"

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-tags: true
 
       - name: Set Up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.8.17"
           enable-cache: true

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -2,9 +2,7 @@ name: Prepare Release
 
 # Creates a release branch, promotes the changelog, bumps the version, and
 # opens a review-ready release PR - the mechanical half of preparing a
-# LightlyStudio release, in one manual dispatch. Public repo, ubuntu-latest,
-# no secrets beyond the default token used to push the branch and open the
-# PR. Publishes nothing.
+# LightlyStudio release. Publishes nothing.
 on:
   workflow_dispatch:
     inputs:
@@ -35,10 +33,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # The prepare_release tooling lives outside the lightly_studio package -
-  # it's CI-internal, not something shipped or user-facing - so it's run
-  # as `python3 -m prepare_release` with this on PYTHONPATH rather than
-  # from inside lightly_studio's own environment.
+  # prepare_release lives outside lightly_studio (CI-internal, not shipped);
+  # run as `python3 -m prepare_release` with this on PYTHONPATH.
   PYTHONPATH: ${{ github.workspace }}/.github/scripts
 
 jobs:
@@ -77,19 +73,16 @@ jobs:
       - name: Resolve inputs
         id: resolved
         working-directory: lightly_studio
-        # Read the workflow_dispatch inputs via env instead of interpolating them
-        # into the script - INPUT_VERSION is a free-form string, and substituting
-        # it directly into `run:` would let it inject shell commands.
+        # Passed via env, not interpolated into the script: inputs.version is
+        # free-form, and used raw it would let a crafted value inject shell code.
         env:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_BUMP: ${{ inputs.bump }}
         run: |
+          # --dry-run --frozen: validate/normalize only, no write, no re-lock.
           if [ -n "$INPUT_VERSION" ]; then
-            # --dry-run --frozen: validate/normalize the explicit override only,
-            # no write, no re-lock. Also rejects a version that isn't valid semver.
             version="$(uv version "$INPUT_VERSION" --dry-run --frozen --short)"
           else
-            # --dry-run --frozen: compute the bumped version only, no write, no re-lock.
             version="$(uv version --bump "$INPUT_BUMP" --dry-run --frozen --short)"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -76,11 +76,14 @@ jobs:
 
       - name: Resolve inputs
         id: resolved
+        working-directory: lightly_studio
         run: |
-          version="$(python3 -m prepare_release compute-version \
-            --pyproject lightly_studio/pyproject.toml \
-            --bump "${{ inputs.bump }}" \
-            --version "${{ inputs.version }}")"
+          if [ -n "${{ inputs.version }}" ]; then
+            version="${{ inputs.version }}"
+          else
+            # --dry-run --frozen: compute the bumped version only, no write, no re-lock.
+            version="$(uv version --bump "${{ inputs.bump }}" --dry-run --frozen --short)"
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "### Preparing release v$version" >> "$GITHUB_STEP_SUMMARY"
 
@@ -95,10 +98,10 @@ jobs:
             --date "$(date -u +%F)"
 
       - name: Bump pyproject.toml version
-        run: |
-          python3 -m prepare_release bump-pyproject \
-            --pyproject lightly_studio/pyproject.toml \
-            --version "${{ steps.resolved.outputs.version }}"
+        working-directory: lightly_studio
+        # --frozen: write the version only, no re-lock - the explicit uv sync
+        # below (and its narrow-diff check) is the one deliberate lock step.
+        run: uv version "${{ steps.resolved.outputs.version }}" --frozen
 
       - name: Snapshot uv.lock before sync
         run: cp lightly_studio/uv.lock /tmp/uv.lock.before


### PR DESCRIPTION
Part of a stack ([gh-stack](https://github.github.com/gh-stack/)), 4 of 4 (top), landing bottom-up onto `main`:

1. #2043 - changelog promotion
2. #2044 - version, pyproject.toml, and uv.lock guards
3. #2045 - PR body rendering (draft notes + coverage checklist)
4. **#2046 - CLI + GitHub Actions workflow** (this PR)

Based on #2045 - please review/merge in order; this is the last one,
it wires everything below it together.

## What has changed and why?

Final layer: `cli.py` / `__main__.py` wire the changelog/version/lock/
pr_body modules from the earlier PRs into `python -m prepare_release`.

`.github/workflows/prepare_release.yml` (`workflow_dispatch` only)
uses that CLI to replace the manual "branch, promote the changelog,
bump the version, open a release PR" steps:

1. Branch off `main` as `release-vX.Y.Z`.
2. Guard against a git-pinned Labelformat; resolve the version bump.
3. Promote the changelog, bump `pyproject.toml`, run `uv sync`.
4. Assert the `uv.lock` diff is narrow and only the expected files
   changed.
5. Render the PR body from the promoted CHANGELOG section.
6. Commit, push, open a `Bump version to X.Y.Z` PR.

`.github/scripts/prepare_release` sits outside `lightly_studio`, so
`make static-checks` / `make test` don't cover it - the workflow
lints/type-checks/tests it itself first.

## How has it been tested?

- Inherits the 26 unit tests from the earlier PRs, run via the new
  lint/test step's exact commands.
- Smoke-tested every subcommand by hand, invoked the same way the
  workflow does, against this repo's real files.
- Haven't dispatched the workflow itself yet (needs a run on `main`) -
  flagging for reviewer awareness before merge.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Not needed (internal change)

---
Suggested reviewer: @michal-lightly. Alternate: @lukas-lightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered release workflow that prepares release branches, updates release metadata, validates lockfile changes, and opens release pull requests.
  * Added command-line tools for changelog promotion, lockfile validation, Labelformat configuration checks, and pull request body generation.
  * Supports explicit release versions or automatic version bumps.
  * Added convenient module-based execution for release preparation commands.

* **Bug Fixes**
  * Added safeguards for unexpected lockfile changes and unsupported pinned tooling.

* **Tests**
  * Added automated coverage for release commands, file updates, validation errors, and workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

