### PR TITLE
Remind agents to load the matching guideline skill before edits

### DIFF
--- a/.claude/hooks/skill-reminder.py
+++ b/.claude/hooks/skill-reminder.py
@@ -30,13 +30,19 @@ def skills_for(rel_path: str) -> list[str]:
 
 
 def first_time(session_id: str, skill: str) -> bool:
-    """True the first time this session touches this skill; records it for next time."""
+    """True the first time this session touches this skill; records it for next time.
+
+    Fails open: on any filesystem error (including an existing marker) it returns
+    False, so a marker problem never produces a reminder. `touch(exist_ok=False)`
+    makes the create atomic against a concurrent hook.
+    """
     marker_dir = Path(tempfile.gettempdir()) / "claude-skill-reminder"
     marker = marker_dir / f"{session_id}-{skill}"
-    if marker.exists():
+    try:
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        marker.touch(exist_ok=False)
+    except OSError:
         return False
-    marker_dir.mkdir(parents=True, exist_ok=True)
-    marker.touch()
     return True
 
 

--- a/.claude/hooks/skill-reminder.py
+++ b/.claude/hooks/skill-reminder.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: remind the agent to load the guideline skill for the file it edits.
+
+Maps the edited path to the matching guide skill(s) and injects a reminder the first time
+each guide's area is touched in a session. Fails open: on any error it exits 0 with no
+output, so an edit is never blocked.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+# Path prefix + file suffixes -> guide skills to load. First match wins, so the backend
+# package (a subdirectory) comes before the general lightly_studio rule.
+SKILLS_BY_PATH = [
+    ("lightly_studio/src/lightly_studio/", (".py",), ["python-guide", "backend-guide"]),
+    ("lightly_studio/", (".py",), ["python-guide"]),
+    ("lightly_studio_view/", (".ts", ".svelte", ".js"), ["frontend-guide"]),
+]
+
+
+def skills_for(rel_path: str) -> list[str]:
+    for prefix, suffixes, skills in SKILLS_BY_PATH:
+        if rel_path.startswith(prefix) and rel_path.endswith(suffixes):
+            return skills
+    return []
+
+
+def first_time(session_id: str, skill: str) -> bool:
+    """True the first time this session touches this skill; records it for next time."""
+    marker = Path(tempfile.gettempdir()) / "claude-skill-reminder" / f"{session_id}-{skill}"
+    if marker.exists():
+        return False
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.touch()
+    return True
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        root = Path(payload["cwd"]).resolve()
+        rel_path = str(Path(payload["tool_input"]["file_path"]).resolve().relative_to(root))
+    except Exception:
+        return 0  # Fail open: never block an edit.
+
+    session_id = payload.get("session_id", "session")
+    skills = [s for s in skills_for(rel_path) if first_time(session_id=session_id, skill=s)]
+    if not skills:
+        return 0
+
+    context = (
+        f"You are editing {rel_path}. Load the {', '.join(skills)} skill(s) with the "
+        f"Skill tool before continuing. See AGENTS.md for the path-to-skill map."
+    )
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": context,
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/skill-reminder.py
+++ b/.claude/hooks/skill-reminder.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """PreToolUse hook: remind the agent to load the guideline skill for the file it edits.
 
-Maps the edited path to the matching guide skill(s) and injects a reminder the first time
-each guide's area is touched in a session. Fails open: on any error it exits 0 with no
-output, so an edit is never blocked.
+Maps the edited path to the matching guide skill(s). Reminds once per session per area.
+Fails open: on any error it exits 0 with no output, so an edit is never blocked.
 """
+
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -17,7 +18,7 @@ from pathlib import Path
 SKILLS_BY_PATH = [
     ("lightly_studio/src/lightly_studio/", (".py",), ["python-guide", "backend-guide"]),
     ("lightly_studio/", (".py",), ["python-guide"]),
-    ("lightly_studio_view/", (".ts", ".svelte", ".js"), ["frontend-guide"]),
+    ("lightly_studio_view/", (".ts", ".svelte"), ["frontend-guide"]),
 ]
 
 
@@ -30,10 +31,11 @@ def skills_for(rel_path: str) -> list[str]:
 
 def first_time(session_id: str, skill: str) -> bool:
     """True the first time this session touches this skill; records it for next time."""
-    marker = Path(tempfile.gettempdir()) / "claude-skill-reminder" / f"{session_id}-{skill}"
+    marker_dir = Path(tempfile.gettempdir()) / "claude-skill-reminder"
+    marker = marker_dir / f"{session_id}-{skill}"
     if marker.exists():
         return False
-    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker_dir.mkdir(parents=True, exist_ok=True)
     marker.touch()
     return True
 
@@ -41,13 +43,17 @@ def first_time(session_id: str, skill: str) -> bool:
 def main() -> int:
     try:
         payload = json.load(sys.stdin)
-        root = Path(payload["cwd"]).resolve()
-        rel_path = str(Path(payload["tool_input"]["file_path"]).resolve().relative_to(root))
+        root = Path(os.environ.get("CLAUDE_PROJECT_DIR") or payload["cwd"]).resolve()
+        file_path = Path(payload["tool_input"]["file_path"]).resolve()
+        rel_path = str(file_path.relative_to(root))
     except Exception:
         return 0  # Fail open: never block an edit.
 
     session_id = payload.get("session_id", "session")
-    skills = [s for s in skills_for(rel_path) if first_time(session_id=session_id, skill=s)]
+    skills = []
+    for skill in skills_for(rel_path):
+        if first_time(session_id=session_id, skill=skill):
+            skills.append(skill)
     if not skills:
         return 0
 
@@ -55,12 +61,13 @@ def main() -> int:
         f"You are editing {rel_path}. Load the {', '.join(skills)} skill(s) with the "
         f"Skill tool before continuing. See AGENTS.md for the path-to-skill map."
     )
-    print(json.dumps({
+    output = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "additionalContext": context,
         }
-    }))
+    }
+    print(json.dumps(output))
     return 0
 
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/skill-reminder.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ lightly_studio/.env
 dataset_examples_studio
 
 .claude/settings.local.json
-.claude/settings.json
 
 # Top-level tmp dir.
 /tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,16 +3,24 @@
 ## Coding Guidelines
 
 Our coding guidelines are [Agent Skills](https://agentskills.io) in [`.agents/skills`](./.agents/skills).
-Claude Code, Codex and Gemini CLI load them automatically when a task matches. If your tool does not
-support skills, read the relevant `SKILL.md` yourself before changing code:
+Skills do not load automatically. Before you edit a file, load the skill for its path. If your
+tool cannot load skills, read that `SKILL.md` first.
 
-- [Frontend](./.agents/skills/frontend-guide/SKILL.md): TypeScript and SvelteKit standards. Read before touching `lightly_studio_view`.
-- [Python](./.agents/skills/python-guide/SKILL.md): Python style. Read before touching any Python file.
-- [Backend](./.agents/skills/backend-guide/SKILL.md): FastAPI and SQLModel architecture. Read before touching `lightly_studio`.
-- [Best Practices](./.agents/skills/best-practices/SKILL.md): General principles for readability, maintainability, and performance.
-- [Glossary](./.agents/skills/glossary/SKILL.md): Terminology and naming conventions.
-- [Pull Requests](./.agents/skills/pull-requests/SKILL.md): Guidelines for submitting a pull request.
-- [Contributing](./CONTRIBUTING.md): Development setup and testing instructions.
+Load the skill that matches the path you edit:
+
+- `lightly_studio/**/*.py` → [python-guide](./.agents/skills/python-guide/SKILL.md): Python style.
+- `lightly_studio/src/lightly_studio/**` → also [backend-guide](./.agents/skills/backend-guide/SKILL.md): FastAPI and SQLModel.
+- `lightly_studio_view/**` (`.ts`, `.svelte`) → [frontend-guide](./.agents/skills/frontend-guide/SKILL.md): TypeScript and SvelteKit.
+
+When the task matches, also load:
+
+- [best-practices](./.agents/skills/best-practices/SKILL.md): a new function, module, or component.
+- [glossary](./.agents/skills/glossary/SKILL.md): names for anything that users see.
+- [pull-requests](./.agents/skills/pull-requests/SKILL.md): a pull request.
+- [Contributing](./CONTRIBUTING.md): setup and tests.
+
+Claude Code gives you a reminder. A `PreToolUse` hook (`.claude/settings.json` and
+`.claude/hooks/skill-reminder.py`) shows the matching skill when you edit these paths.
 
 ## Validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,9 @@ make static-checks
 make test
 ```
 
-When updating the code please follow our coding guidelines in [.agents/skills](./.agents/skills).
-They are [Agent Skills](https://agentskills.io), so Claude Code, Codex and Gemini CLI load the
-relevant one automatically as you work.
+When you update the code, follow our coding guidelines in [.agents/skills](./.agents/skills).
+They are [Agent Skills](https://agentskills.io). Skills do not load automatically. Load the
+skill that matches the file you edit. See [AGENTS.md](./AGENTS.md) for the path-to-skill map.
 
 ### End-to-End Testing
 


### PR DESCRIPTION
## What has changed and why?

AGENTS.md and CONTRIBUTING.md told agents that Claude Code, Codex and Gemini CLI load the coding-guideline skills automatically. They don't, so edits landed without the matching guide.

This drops the false claim and replaces it with an explicit path-to-skill map, then backs the map with a `PreToolUse` hook so the reminder actually fires.

- Docs (`AGENTS.md`, `CONTRIBUTING.md`): map each path to its guide. `lightly_studio/**/*.py` to python-guide, the backend package also to backend-guide, `lightly_studio_view/**` to frontend-guide.
- Hook (`.claude/hooks/skill-reminder.py`): on Edit/Write/MultiEdit, injects a reminder to load the matching guide the first time a session touches that area.
- Config: commit `.claude/settings.json` to register the hook; drop it from `.gitignore`.

## How has it been tested?

Manually: piped `PreToolUse` payloads for backend, frontend, unmapped, and malformed inputs through the hook and confirmed the reminder JSON, and silence where expected. No automated tests. The hook fails open — any error exits 0, so a failed reminder never blocks an edit.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated contribution and coding guidelines with clearer instructions for applying relevant project skills based on file paths.
  - Added guidance covering best practices, glossary usage, pull requests, and contribution documentation.

- **Developer Experience**
  - Added automatic reminders during file edits to help ensure applicable skills are loaded.
  - Reminders appear once per skill and fail safely without interrupting editing.
  - Added version-controlled configuration for the editing workflow, including improved support for Python, backend, TypeScript, and Svelte files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->