### PR TITLE
Keep PG idle connections alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix requests failing intermittently while the GUI is under load, caused by concurrent access to a shared database session.
 - Hide every bounding box and its annotation counts when all annotation sources are unchecked, instead of showing them all.
+- Keep long-lived PostgreSQL connections alive.
 
 ### Security
 

--- a/lightly_studio/src/lightly_studio/database/db_manager.py
+++ b/lightly_studio/src/lightly_studio/database/db_manager.py
@@ -121,18 +121,18 @@ class DatabaseEngine:
                 # A middlebox (e.g., firewalls, VPNs) can silently drop idle connections,
                 # and the next statement will fail with "server closed the connection unexpectedly".
                 # TCP keepalives keep the socket warm so the flow is never reaped.
-                # pre_ping and recycle replace a pooled connection that died before it is
+                # Pre_ping and recycle replace a pooled connection that died before it is
                 # handed out again.
 
-                # test a pooled connection before handing it out, so a dead one is never reused
+                # Test a pooled connection before handing it out, so a dead one is never reused.
                 engine_kwargs["pool_pre_ping"] = True
-                # discard & reopen any connection older than 1800s
+                # Discard & reopen any connection older than 1800s.
                 engine_kwargs["pool_recycle"] = 1800
                 engine_kwargs["connect_args"] = {
-                    "keepalives": 1,           # setting this explicitly so the intent is visible
-                    "keepalives_idle": 30,     # send a probe after 30s of idleness
-                    "keepalives_interval": 10, # 10s gap between probes once one goes unanswered
-                    "keepalives_count": 5,     # 5 unanswered probes declare the socket dead
+                    "keepalives": 1,  # Setting this explicitly so the intent is visible.
+                    "keepalives_idle": 30,  # Send a probe after 30s of idleness.
+                    "keepalives_interval": 10,  # 10s gap between probes once one goes unanswered.
+                    "keepalives_count": 5,  # 5 unanswered probes declare the socket dead.
                 }
             self._engine = create_engine(url=self._engine_url, **engine_kwargs)
 

--- a/lightly_studio/src/lightly_studio/database/db_manager.py
+++ b/lightly_studio/src/lightly_studio/database/db_manager.py
@@ -115,12 +115,26 @@ class DatabaseEngine:
                 connect_args=connect_args,
             )
         else:
-            # TODO(Mihnea, 02/2026): Consider adding Postgres-specific pool options
-            self._engine = create_engine(
-                url=self._engine_url,
-                pool_size=10,
-                max_overflow=40,
-            )
+            engine_kwargs: dict[str, Any] = {"pool_size": 10, "max_overflow": 40}
+            if self._backend == DatabaseBackend.POSTGRESQL:
+                # A session can hold one Postgres connection open and idle across a long stretch.
+                # A middlebox (e.g., firewalls, VPNs) can silently drop idle connections,
+                # and the next statement will fail with "server closed the connection unexpectedly".
+                # TCP keepalives keep the socket warm so the flow is never reaped.
+                # pre_ping and recycle replace a pooled connection that died before it is
+                # handed out again.
+
+                # test a pooled connection before handing it out, so a dead one is never reused
+                engine_kwargs["pool_pre_ping"] = True
+                # discard & reopen any connection older than 1800s
+                engine_kwargs["pool_recycle"] = 1800
+                engine_kwargs["connect_args"] = {
+                    "keepalives": 1,           # setting this explicitly so the intent is visible
+                    "keepalives_idle": 30,     # send a probe after 30s of idleness
+                    "keepalives_interval": 10, # 10s gap between probes once one goes unanswered
+                    "keepalives_count": 5,     # 5 unanswered probes declare the socket dead
+                }
+            self._engine = create_engine(url=self._engine_url, **engine_kwargs)
 
         # For DuckDB, create_engine will create the database file if it does not exist.
         # For Postgres, we need to create the database.

--- a/lightly_studio/tests/database/test_db_manager.py
+++ b/lightly_studio/tests/database/test_db_manager.py
@@ -455,6 +455,54 @@ def test_connect__cleanup_existing(
     db_manager.close()
 
 
+def test_database_engine__postgres_sets_keepalive_and_pool_options(
+    mocker: MockerFixture,
+) -> None:
+    create_engine_mock = mocker.patch.object(db_manager, "create_engine")
+    mocker.patch.object(db_manager, "_database_exists", return_value=True)
+    mocker.patch.object(db_manager, "_initialize_postgres_schema")
+
+    DatabaseEngine(engine_url="postgresql://user:pass@host:5432/db")
+
+    kwargs = create_engine_mock.call_args.kwargs
+    assert kwargs["pool_pre_ping"] is True
+    assert kwargs["pool_recycle"] == 1800
+    assert kwargs["connect_args"] == {
+        "keepalives": 1,
+        "keepalives_idle": 30,
+        "keepalives_interval": 10,
+        "keepalives_count": 5,
+    }
+
+
+def test_database_engine__duckdb_omits_postgres_pool_options(
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    create_engine_mock = mocker.patch.object(db_manager, "create_engine")
+    mocker.patch.object(db_manager, "_create_duckdb_schema")
+
+    DatabaseEngine(engine_url=f"duckdb:///{tmp_path / 'test.db'}")
+
+    kwargs = create_engine_mock.call_args.kwargs
+    assert "connect_args" not in kwargs
+    assert "pool_pre_ping" not in kwargs
+    assert "pool_recycle" not in kwargs
+
+
+@pytest.mark.postgres_only
+def test_database_engine__postgres_pool_options_applied_on_real_engine(
+    postgres_url: str | None,
+) -> None:
+    assert postgres_url is not None
+    engine = DatabaseEngine(engine_url=postgres_url)
+    try:
+        assert engine._engine.pool._pre_ping is True
+        assert engine._engine.pool._recycle == 1800
+    finally:
+        engine.close()
+
+
 def test_get_backend(
     tmp_path: Path,
     patch_engine_singleton: None,  # noqa: ARG001


### PR DESCRIPTION
## What has changed and why?

Configure TCP keepalives (+ `pool_pre_ping`/`pool_recycle`) on Postgres engines. Connections can be held idle through long compute phases that can be dropped (by firewalls, for example). Check the comments for more details.

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of long-lived PostgreSQL connections by detecting stale connections and keeping active connections alive.
  * Added connection recycling to help prevent failures during extended operation.
  * Existing DuckDB and single-threaded behavior remains unchanged.

* **Documentation**
  * Updated the changelog with the PostgreSQL connection reliability improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->