### PR TITLE
Validate embedding vectors before writing to sample_embedding

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -540,9 +540,9 @@ def _store_embeddings(
     so a failure leaves no partially embedded dataset behind.
 
     Raises:
-        ValueError: If the embeddings fail validation. See `_validate_embeddings_for_storage`.
+        ValueError: If the embeddings fail validation. See `_validate_and_coerce_embeddings`.
     """
-    _validate_embeddings_for_storage(
+    embeddings = _validate_and_coerce_embeddings(
         session=session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
     )
 
@@ -572,19 +572,22 @@ def _store_embeddings(
     session.commit()
 
 
-def _validate_embeddings_for_storage(
+def _validate_and_coerce_embeddings(
     session: Session,
     model_id: UUID,
     sample_ids: list[UUID],
     embeddings: NDArray[np.float32],
-) -> None:
-    """Validate embeddings before they are written to sample_embedding.
+) -> NDArray[np.float32]:
+    """Validate embeddings and coerce them to float32 before they are written to sample_embedding.
+
+    Any numeric dtype (e.g. float64, int32) is safely cast to float32. Losing precision
+    beyond float32 is expected and fine; overflowing to Inf is not.
 
     Raises:
         ValueError: If the number of embeddings does not match the number of sample
-            IDs, the embeddings are not a 2-D float32 array free of NaN/Inf, or their
-            dimension does not match the embedding model's declared
-            `embedding_dimension`.
+            IDs, the embeddings are not a 2-D numeric array free of NaN/Inf (before or
+            after the float32 cast), or their dimension does not match the embedding
+            model's declared `embedding_dimension`.
     """
     if len(embeddings) != len(sample_ids):
         raise ValueError(
@@ -592,12 +595,16 @@ def _validate_embeddings_for_storage(
             f"sample IDs ({len(sample_ids)})."
         )
     if len(embeddings) == 0:
-        return
+        return embeddings
 
     if embeddings.ndim != 2:  # noqa: PLR2004
         raise ValueError(f"Embeddings must be a 2-D array, got {embeddings.ndim}-D.")
-    if embeddings.dtype != np.float32:
-        raise ValueError(f"Embeddings must be float32, got dtype {embeddings.dtype}.")
+    if not (
+        np.issubdtype(embeddings.dtype, np.floating) or np.issubdtype(embeddings.dtype, np.integer)
+    ):
+        raise ValueError(f"Embeddings must be numeric, got dtype {embeddings.dtype}.")
+
+    embeddings = embeddings.astype(np.float32, copy=False)
     if not np.isfinite(embeddings).all():
         raise ValueError("Embeddings must not contain NaN or infinite values.")
 
@@ -613,6 +620,7 @@ def _validate_embeddings_for_storage(
             f"Embedding dimension ({actual_dimension}) does not match the embedding "
             f"model's declared dimension ({embedding_model.embedding_dimension})."
         )
+    return embeddings
 
 
 def _load_embedding_generator_from_env(sample_type: SampleType) -> EmbeddingGenerator | None:

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -589,16 +589,16 @@ def _validate_and_coerce_embeddings(
             after the float32 cast), or their dimension does not match the embedding
             model's declared `embedding_dimension`.
     """
-    if len(embeddings) != len(sample_ids):
-        raise ValueError(
-            f"Number of embeddings ({len(embeddings)}) does not match number of "
-            f"sample IDs ({len(sample_ids)})."
-        )
-    if len(embeddings) == 0:
-        return embeddings
-
     if embeddings.ndim != 2:  # noqa: PLR2004
         raise ValueError(f"Embeddings must be a 2-D array, got {embeddings.ndim}-D.")
+    if embeddings.shape[0] != len(sample_ids):
+        raise ValueError(
+            f"Number of embeddings ({embeddings.shape[0]}) does not match number of "
+            f"sample IDs ({len(sample_ids)})."
+        )
+    if embeddings.shape[0] == 0:
+        return embeddings
+
     if not (
         np.issubdtype(embeddings.dtype, np.floating) or np.issubdtype(embeddings.dtype, np.integer)
     ):

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -538,7 +538,14 @@ def _store_embeddings(
 
     Insertion is batched to reduce peak memory. All batches are committed together
     so a failure leaves no partially embedded dataset behind.
+
+    Raises:
+        ValueError: If the embeddings fail validation. See `_validate_embeddings_for_storage`.
     """
+    _validate_embeddings_for_storage(
+        session=session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
+    )
+
     with tqdm(
         total=len(sample_ids),
         desc="Storing embeddings",
@@ -563,6 +570,49 @@ def _store_embeddings(
             progress.update(len(sample_embeddings))
 
     session.commit()
+
+
+def _validate_embeddings_for_storage(
+    session: Session,
+    model_id: UUID,
+    sample_ids: list[UUID],
+    embeddings: NDArray[np.float32],
+) -> None:
+    """Validate embeddings before they are written to sample_embedding.
+
+    Raises:
+        ValueError: If the number of embeddings does not match the number of sample
+            IDs, the embeddings are not a 2-D float32 array free of NaN/Inf, or their
+            dimension does not match the embedding model's declared
+            `embedding_dimension`.
+    """
+    if len(embeddings) != len(sample_ids):
+        raise ValueError(
+            f"Number of embeddings ({len(embeddings)}) does not match number of "
+            f"sample IDs ({len(sample_ids)})."
+        )
+    if len(embeddings) == 0:
+        return
+
+    if embeddings.ndim != 2:  # noqa: PLR2004
+        raise ValueError(f"Embeddings must be a 2-D array, got {embeddings.ndim}-D.")
+    if embeddings.dtype != np.float32:
+        raise ValueError(f"Embeddings must be float32, got dtype {embeddings.dtype}.")
+    if not np.isfinite(embeddings).all():
+        raise ValueError("Embeddings must not contain NaN or infinite values.")
+
+    embedding_model = embedding_model_resolver.get_by_id(
+        session=session, embedding_model_id=model_id
+    )
+    if embedding_model is None:
+        raise ValueError(f"No embedding model found with ID {model_id}")
+
+    actual_dimension = embeddings.shape[1]
+    if actual_dimension != embedding_model.embedding_dimension:
+        raise ValueError(
+            f"Embedding dimension ({actual_dimension}) does not match the embedding "
+            f"model's declared dimension ({embedding_model.embedding_dimension})."
+        )
 
 
 def _load_embedding_generator_from_env(sample_type: SampleType) -> EmbeddingGenerator | None:

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -590,7 +590,10 @@ def _validate_and_coerce_embeddings(
             model's declared `embedding_dimension`.
     """
     if embeddings.ndim != 2:  # noqa: PLR2004
-        raise ValueError(f"Embeddings must be a 2-D array, got {embeddings.ndim}-D.")
+        raise ValueError(
+            "Embeddings must be a 2-D array (one row per sample: shape "
+            f"(num_samples, embedding_dimension)), got a {embeddings.ndim}-D array."
+        )
     if embeddings.shape[0] != len(sample_ids):
         raise ValueError(
             f"Number of embeddings ({embeddings.shape[0]}) does not match number of "

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -848,12 +848,17 @@ def test_compute_image_embedding(
     assert len(stored_embeddings) == 0
 
 
+# Dimension of the model registered by _register_random_model, used to build
+# well-formed test embeddings below.
+_RANDOM_MODEL_DIMENSION = 3
+
+
 def _register_random_model(session: Session, collection: CollectionTable) -> UUID:
-    """Register a RandomEmbeddingGenerator (dimension=3) and return its model ID."""
+    """Register a RandomEmbeddingGenerator with dimension `_RANDOM_MODEL_DIMENSION`."""
     manager = EmbeddingManager()
     return manager.register_embedding_model(
         session=session,
-        embedding_generator=RandomEmbeddingGenerator(),
+        embedding_generator=RandomEmbeddingGenerator(dimension=_RANDOM_MODEL_DIMENSION),
         collection_id=collection.collection_id,
         set_as_default=True,
     ).embedding_model_id
@@ -866,7 +871,7 @@ def test_validate_and_coerce_embeddings(
     """A well-formed batch of embeddings passes validation unchanged."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4(), uuid4()]
-    embeddings = np.zeros((2, 3), dtype=np.float32)
+    embeddings = np.zeros((2, _RANDOM_MODEL_DIMENSION), dtype=np.float32)
 
     result = embedding_manager._validate_and_coerce_embeddings(
         session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
@@ -887,7 +892,7 @@ def test_validate_and_coerce_embeddings__empty_is_valid(
         session=db_session,
         model_id=model_id,
         sample_ids=[],
-        embeddings=np.zeros((0, 3), dtype=np.float32),
+        embeddings=np.zeros((0, _RANDOM_MODEL_DIMENSION), dtype=np.float32),
     )
 
     assert len(result) == 0
@@ -900,7 +905,7 @@ def test_validate_and_coerce_embeddings__count_mismatch(
     """A different number of embeddings and sample IDs raises a clear error."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4(), uuid4()]
-    embeddings = np.zeros((1, 3), dtype=np.float32)
+    embeddings = np.zeros((1, _RANDOM_MODEL_DIMENSION), dtype=np.float32)
 
     with pytest.raises(ValueError, match=r"does not match number of sample IDs"):
         embedding_manager._validate_and_coerce_embeddings(
@@ -915,9 +920,10 @@ def test_validate_and_coerce_embeddings__wrong_dimension(
     """A vector whose length doesn't match embedding_dimension raises a clear error."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4()]
-    embeddings = np.zeros((1, 4), dtype=np.float32)  # model dimension is 3
+    wrong_dimension = _RANDOM_MODEL_DIMENSION + 1
+    embeddings = np.zeros((1, wrong_dimension), dtype=np.float32)
 
-    with pytest.raises(ValueError, match=r"Embedding dimension \(4\)"):
+    with pytest.raises(ValueError, match=rf"Embedding dimension \({wrong_dimension}\)"):
         embedding_manager._validate_and_coerce_embeddings(
             session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
         )
@@ -930,7 +936,9 @@ def test_validate_and_coerce_embeddings__casts_float64_to_float32(
     """A float64 array (the numpy default) is safely cast down to float32, not rejected."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4()]
-    embeddings = np.array([[0.1, 0.2, 0.3]], dtype=np.float64)
+    embeddings = np.array(
+        [[0.1 * (i + 1) for i in range(_RANDOM_MODEL_DIMENSION)]], dtype=np.float64
+    )
 
     result = embedding_manager._validate_and_coerce_embeddings(
         session=db_session,
@@ -950,7 +958,7 @@ def test_validate_and_coerce_embeddings__rejects_non_numeric_dtype(
     """A non-numeric dtype (e.g. strings) is rejected."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4()]
-    embeddings = np.array([["a", "b", "c"]])
+    embeddings = np.array([[f"s{i}" for i in range(_RANDOM_MODEL_DIMENSION)]])
 
     with pytest.raises(ValueError, match=r"must be numeric"):
         embedding_manager._validate_and_coerce_embeddings(
@@ -968,7 +976,8 @@ def test_validate_and_coerce_embeddings__rejects_overflow_from_cast(
     """A float64 value too large for float32 overflows to Inf and is rejected."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4()]
-    embeddings = np.array([[1e308, 0.0, 0.0]], dtype=np.float64)
+    embeddings = np.zeros((1, _RANDOM_MODEL_DIMENSION), dtype=np.float64)
+    embeddings[0, 0] = 1e308  # Too large to represent as float32.
 
     with pytest.raises(ValueError, match=r"NaN or infinite"):
         embedding_manager._validate_and_coerce_embeddings(
@@ -986,7 +995,7 @@ def test_validate_and_coerce_embeddings__nan(
     """A NaN value in an embedding raises a clear error."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4()]
-    embeddings = np.full((1, 3), np.nan, dtype=np.float32)
+    embeddings = np.full((1, _RANDOM_MODEL_DIMENSION), np.nan, dtype=np.float32)
 
     with pytest.raises(ValueError, match=r"NaN or infinite"):
         embedding_manager._validate_and_coerce_embeddings(
@@ -1001,7 +1010,7 @@ def test_validate_and_coerce_embeddings__inf(
     """An infinite value in an embedding raises a clear error."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4()]
-    embeddings = np.full((1, 3), np.inf, dtype=np.float32)
+    embeddings = np.full((1, _RANDOM_MODEL_DIMENSION), np.inf, dtype=np.float32)
 
     with pytest.raises(ValueError, match=r"NaN or infinite"):
         embedding_manager._validate_and_coerce_embeddings(
@@ -1016,7 +1025,7 @@ def test_store_embeddings__rejects_invalid_embeddings_before_write(
     """_store_embeddings raises before writing anything to the database."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4()]
-    embeddings = np.full((1, 3), np.nan, dtype=np.float32)
+    embeddings = np.full((1, _RANDOM_MODEL_DIMENSION), np.nan, dtype=np.float32)
 
     with pytest.raises(ValueError, match=r"NaN or infinite"):
         embedding_manager._store_embeddings(
@@ -1041,7 +1050,9 @@ def test_store_embeddings__casts_float64_embeddings(
     model_id = _register_random_model(session=db_session, collection=collection)
     image = create_image(session=db_session, collection_id=collection.collection_id)
     sample_ids = [image.sample_id]
-    embeddings = np.array([[0.1, 0.2, 0.3]], dtype=np.float64)
+    embeddings = np.array(
+        [[0.1 * (i + 1) for i in range(_RANDOM_MODEL_DIMENSION)]], dtype=np.float64
+    )
 
     embedding_manager._store_embeddings(
         session=db_session,
@@ -1055,4 +1066,4 @@ def test_store_embeddings__casts_float64_embeddings(
         select(SampleEmbeddingTable).where(SampleEmbeddingTable.embedding_model_id == model_id)
     ).all()
     assert len(stored_embeddings) == 1
-    assert len(stored_embeddings[0].embedding) == 3
+    assert len(stored_embeddings[0].embedding) == _RANDOM_MODEL_DIMENSION

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -898,6 +898,24 @@ def test_validate_and_coerce_embeddings__empty_is_valid(
     assert len(result) == 0
 
 
+def test_validate_and_coerce_embeddings__rejects_non_2d_array(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A 0-D array raises a clear ValueError instead of TypeError from `len()`."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    sample_ids = [uuid4()]
+    embeddings = np.array(1.0, dtype=np.float32)
+
+    with pytest.raises(ValueError, match=r"must be a 2-D array, got 0-D"):
+        embedding_manager._validate_and_coerce_embeddings(
+            session=db_session,
+            model_id=model_id,
+            sample_ids=sample_ids,
+            embeddings=embeddings,
+        )
+
+
 def test_validate_and_coerce_embeddings__count_mismatch(
     db_session: Session,
     collection: CollectionTable,

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -907,7 +907,7 @@ def test_validate_and_coerce_embeddings__rejects_non_2d_array(
     sample_ids = [uuid4()]
     embeddings = np.array(1.0, dtype=np.float32)
 
-    with pytest.raises(ValueError, match=r"must be a 2-D array, got 0-D"):
+    with pytest.raises(ValueError, match=r"must be a 2-D array .* got a 0-D array"):
         embedding_manager._validate_and_coerce_embeddings(
             session=db_session,
             model_id=model_id,

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -846,3 +846,145 @@ def test_compute_image_embedding(
         select(SampleEmbeddingTable).where(SampleEmbeddingTable.embedding_model_id == model_id)
     ).all()
     assert len(stored_embeddings) == 0
+
+
+def _register_random_model(session: Session, collection: CollectionTable) -> UUID:
+    """Register a RandomEmbeddingGenerator (dimension=3) and return its model ID."""
+    manager = EmbeddingManager()
+    return manager.register_embedding_model(
+        session=session,
+        embedding_generator=RandomEmbeddingGenerator(),
+        collection_id=collection.collection_id,
+        set_as_default=True,
+    ).embedding_model_id
+
+
+def test_validate_embeddings_for_storage(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A well-formed batch of embeddings passes validation without error."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    sample_ids = [uuid4(), uuid4()]
+    embeddings = np.zeros((2, 3), dtype=np.float32)
+
+    embedding_manager._validate_embeddings_for_storage(
+        session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
+    )
+
+
+def test_validate_embeddings_for_storage__empty_is_valid(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """An empty batch passes validation without touching the embedding model."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+
+    embedding_manager._validate_embeddings_for_storage(
+        session=db_session,
+        model_id=model_id,
+        sample_ids=[],
+        embeddings=np.zeros((0, 3), dtype=np.float32),
+    )
+
+
+def test_validate_embeddings_for_storage__count_mismatch(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A different number of embeddings and sample IDs raises a clear error."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    sample_ids = [uuid4(), uuid4()]
+    embeddings = np.zeros((1, 3), dtype=np.float32)
+
+    with pytest.raises(ValueError, match=r"does not match number of sample IDs"):
+        embedding_manager._validate_embeddings_for_storage(
+            session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
+        )
+
+
+def test_validate_embeddings_for_storage__wrong_dimension(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A vector whose length doesn't match embedding_dimension raises a clear error."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    sample_ids = [uuid4()]
+    embeddings = np.zeros((1, 4), dtype=np.float32)  # model dimension is 3
+
+    with pytest.raises(ValueError, match=r"Embedding dimension \(4\)"):
+        embedding_manager._validate_embeddings_for_storage(
+            session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
+        )
+
+
+def test_validate_embeddings_for_storage__wrong_dtype(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A non-float32 array is rejected instead of being silently coerced."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    sample_ids = [uuid4()]
+    embeddings = np.zeros((1, 3), dtype=np.float64)
+
+    with pytest.raises(ValueError, match=r"must be float32"):
+        embedding_manager._validate_embeddings_for_storage(
+            session=db_session,
+            model_id=model_id,
+            sample_ids=sample_ids,
+            embeddings=embeddings,  # type: ignore[arg-type]
+        )
+
+
+def test_validate_embeddings_for_storage__nan(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A NaN value in an embedding raises a clear error."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    sample_ids = [uuid4()]
+    embeddings = np.full((1, 3), np.nan, dtype=np.float32)
+
+    with pytest.raises(ValueError, match=r"NaN or infinite"):
+        embedding_manager._validate_embeddings_for_storage(
+            session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
+        )
+
+
+def test_validate_embeddings_for_storage__inf(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """An infinite value in an embedding raises a clear error."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    sample_ids = [uuid4()]
+    embeddings = np.full((1, 3), np.inf, dtype=np.float32)
+
+    with pytest.raises(ValueError, match=r"NaN or infinite"):
+        embedding_manager._validate_embeddings_for_storage(
+            session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
+        )
+
+
+def test_store_embeddings__rejects_invalid_embeddings_before_write(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """_store_embeddings raises before writing anything to the database."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    sample_ids = [uuid4()]
+    embeddings = np.full((1, 3), np.nan, dtype=np.float32)
+
+    with pytest.raises(ValueError, match=r"NaN or infinite"):
+        embedding_manager._store_embeddings(
+            session=db_session,
+            model_id=model_id,
+            sample_ids=sample_ids,
+            embeddings=embeddings,
+            show_progress=False,
+        )
+
+    stored_embeddings = db_session.exec(
+        select(SampleEmbeddingTable).where(SampleEmbeddingTable.embedding_model_id == model_id)
+    ).all()
+    assert len(stored_embeddings) == 0

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -853,17 +853,6 @@ def test_compute_image_embedding(
 _RANDOM_MODEL_DIMENSION = 3
 
 
-def _register_random_model(session: Session, collection: CollectionTable) -> UUID:
-    """Register a RandomEmbeddingGenerator with dimension `_RANDOM_MODEL_DIMENSION`."""
-    manager = EmbeddingManager()
-    return manager.register_embedding_model(
-        session=session,
-        embedding_generator=RandomEmbeddingGenerator(dimension=_RANDOM_MODEL_DIMENSION),
-        collection_id=collection.collection_id,
-        set_as_default=True,
-    ).embedding_model_id
-
-
 def test_validate_and_coerce_embeddings(
     db_session: Session,
     collection: CollectionTable,
@@ -1085,3 +1074,14 @@ def test_store_embeddings__casts_float64_embeddings(
     ).all()
     assert len(stored_embeddings) == 1
     assert len(stored_embeddings[0].embedding) == _RANDOM_MODEL_DIMENSION
+
+
+def _register_random_model(session: Session, collection: CollectionTable) -> UUID:
+    """Register a RandomEmbeddingGenerator with dimension `_RANDOM_MODEL_DIMENSION`."""
+    manager = EmbeddingManager()
+    return manager.register_embedding_model(
+        session=session,
+        embedding_generator=RandomEmbeddingGenerator(dimension=_RANDOM_MODEL_DIMENSION),
+        collection_id=collection.collection_id,
+        set_as_default=True,
+    ).embedding_model_id

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -859,36 +859,41 @@ def _register_random_model(session: Session, collection: CollectionTable) -> UUI
     ).embedding_model_id
 
 
-def test_validate_embeddings_for_storage(
+def test_validate_and_coerce_embeddings(
     db_session: Session,
     collection: CollectionTable,
 ) -> None:
-    """A well-formed batch of embeddings passes validation without error."""
+    """A well-formed batch of embeddings passes validation unchanged."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4(), uuid4()]
     embeddings = np.zeros((2, 3), dtype=np.float32)
 
-    embedding_manager._validate_embeddings_for_storage(
+    result = embedding_manager._validate_and_coerce_embeddings(
         session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
     )
 
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result, embeddings)
 
-def test_validate_embeddings_for_storage__empty_is_valid(
+
+def test_validate_and_coerce_embeddings__empty_is_valid(
     db_session: Session,
     collection: CollectionTable,
 ) -> None:
     """An empty batch passes validation without touching the embedding model."""
     model_id = _register_random_model(session=db_session, collection=collection)
 
-    embedding_manager._validate_embeddings_for_storage(
+    result = embedding_manager._validate_and_coerce_embeddings(
         session=db_session,
         model_id=model_id,
         sample_ids=[],
         embeddings=np.zeros((0, 3), dtype=np.float32),
     )
 
+    assert len(result) == 0
 
-def test_validate_embeddings_for_storage__count_mismatch(
+
+def test_validate_and_coerce_embeddings__count_mismatch(
     db_session: Session,
     collection: CollectionTable,
 ) -> None:
@@ -898,12 +903,12 @@ def test_validate_embeddings_for_storage__count_mismatch(
     embeddings = np.zeros((1, 3), dtype=np.float32)
 
     with pytest.raises(ValueError, match=r"does not match number of sample IDs"):
-        embedding_manager._validate_embeddings_for_storage(
+        embedding_manager._validate_and_coerce_embeddings(
             session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
         )
 
 
-def test_validate_embeddings_for_storage__wrong_dimension(
+def test_validate_and_coerce_embeddings__wrong_dimension(
     db_session: Session,
     collection: CollectionTable,
 ) -> None:
@@ -913,22 +918,60 @@ def test_validate_embeddings_for_storage__wrong_dimension(
     embeddings = np.zeros((1, 4), dtype=np.float32)  # model dimension is 3
 
     with pytest.raises(ValueError, match=r"Embedding dimension \(4\)"):
-        embedding_manager._validate_embeddings_for_storage(
+        embedding_manager._validate_and_coerce_embeddings(
             session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
         )
 
 
-def test_validate_embeddings_for_storage__wrong_dtype(
+def test_validate_and_coerce_embeddings__casts_float64_to_float32(
     db_session: Session,
     collection: CollectionTable,
 ) -> None:
-    """A non-float32 array is rejected instead of being silently coerced."""
+    """A float64 array (the numpy default) is safely cast down to float32, not rejected."""
     model_id = _register_random_model(session=db_session, collection=collection)
     sample_ids = [uuid4()]
-    embeddings = np.zeros((1, 3), dtype=np.float64)
+    embeddings = np.array([[0.1, 0.2, 0.3]], dtype=np.float64)
 
-    with pytest.raises(ValueError, match=r"must be float32"):
-        embedding_manager._validate_embeddings_for_storage(
+    result = embedding_manager._validate_and_coerce_embeddings(
+        session=db_session,
+        model_id=model_id,
+        sample_ids=sample_ids,
+        embeddings=embeddings,  # type: ignore[arg-type]
+    )
+
+    assert result.dtype == np.float32
+    np.testing.assert_allclose(result, embeddings, rtol=1e-6)
+
+
+def test_validate_and_coerce_embeddings__rejects_non_numeric_dtype(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A non-numeric dtype (e.g. strings) is rejected."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    sample_ids = [uuid4()]
+    embeddings = np.array([["a", "b", "c"]])
+
+    with pytest.raises(ValueError, match=r"must be numeric"):
+        embedding_manager._validate_and_coerce_embeddings(
+            session=db_session,
+            model_id=model_id,
+            sample_ids=sample_ids,
+            embeddings=embeddings,
+        )
+
+
+def test_validate_and_coerce_embeddings__rejects_overflow_from_cast(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """A float64 value too large for float32 overflows to Inf and is rejected."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    sample_ids = [uuid4()]
+    embeddings = np.array([[1e308, 0.0, 0.0]], dtype=np.float64)
+
+    with pytest.raises(ValueError, match=r"NaN or infinite"):
+        embedding_manager._validate_and_coerce_embeddings(
             session=db_session,
             model_id=model_id,
             sample_ids=sample_ids,
@@ -936,7 +979,7 @@ def test_validate_embeddings_for_storage__wrong_dtype(
         )
 
 
-def test_validate_embeddings_for_storage__nan(
+def test_validate_and_coerce_embeddings__nan(
     db_session: Session,
     collection: CollectionTable,
 ) -> None:
@@ -946,12 +989,12 @@ def test_validate_embeddings_for_storage__nan(
     embeddings = np.full((1, 3), np.nan, dtype=np.float32)
 
     with pytest.raises(ValueError, match=r"NaN or infinite"):
-        embedding_manager._validate_embeddings_for_storage(
+        embedding_manager._validate_and_coerce_embeddings(
             session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
         )
 
 
-def test_validate_embeddings_for_storage__inf(
+def test_validate_and_coerce_embeddings__inf(
     db_session: Session,
     collection: CollectionTable,
 ) -> None:
@@ -961,7 +1004,7 @@ def test_validate_embeddings_for_storage__inf(
     embeddings = np.full((1, 3), np.inf, dtype=np.float32)
 
     with pytest.raises(ValueError, match=r"NaN or infinite"):
-        embedding_manager._validate_embeddings_for_storage(
+        embedding_manager._validate_and_coerce_embeddings(
             session=db_session, model_id=model_id, sample_ids=sample_ids, embeddings=embeddings
         )
 
@@ -988,3 +1031,28 @@ def test_store_embeddings__rejects_invalid_embeddings_before_write(
         select(SampleEmbeddingTable).where(SampleEmbeddingTable.embedding_model_id == model_id)
     ).all()
     assert len(stored_embeddings) == 0
+
+
+def test_store_embeddings__casts_float64_embeddings(
+    db_session: Session,
+    collection: CollectionTable,
+) -> None:
+    """_store_embeddings accepts and stores embeddings passed in as float64."""
+    model_id = _register_random_model(session=db_session, collection=collection)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    sample_ids = [image.sample_id]
+    embeddings = np.array([[0.1, 0.2, 0.3]], dtype=np.float64)
+
+    embedding_manager._store_embeddings(
+        session=db_session,
+        model_id=model_id,
+        sample_ids=sample_ids,
+        embeddings=embeddings,  # type: ignore[arg-type]
+        show_progress=False,
+    )
+
+    stored_embeddings = db_session.exec(
+        select(SampleEmbeddingTable).where(SampleEmbeddingTable.embedding_model_id == model_id)
+    ).all()
+    assert len(stored_embeddings) == 1
+    assert len(stored_embeddings[0].embedding) == 3


### PR DESCRIPTION
## What has changed and why?

Adds validation before embeddings are written to `sample_embedding`, in the shared `_store_embeddings` write path used by both image/annotation/video generators and the precomputed-embeddings import path. Rejects with a clear `ValueError` before any DB write:

- count mismatch between embeddings and sample IDs
- non-numeric dtype (e.g. strings), or a cast to float32 that overflows to Inf
- NaN/Inf values
- vector dimension not matching the embedding model's declared `embedding_dimension`

Non-float32 numeric dtypes (float64, ints) are safely cast to float32 rather than rejected outright — float64 is numpy's default, so real precomputed-embedding imports commonly arrive that way, and losing precision beyond float32 is expected for embedding storage.

Previously none of this was checked; bad rows landed in the DB and only failed later, at query time, with an opaque DuckDB error.


## How has it been tested?

- Added unit tests in `test_embedding_manager.py` covering each rejected case (count mismatch, non-numeric dtype, overflow-on-cast, NaN, Inf, dimension mismatch), the float64-safe-cast case, and a test confirming `_store_embeddings` writes nothing when validation fails.
- `make static-checks` and `make test` pass; existing built-in generator tests pass unchanged.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)

Reviewer: @JonasWurst (most history on this file), alt: @horacio-almasan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved embedding validation and storage reliability.
* Numeric embeddings are consistently converted to the supported format, including higher-precision values.
* Invalid, non-numeric, non-finite, mismatched, incorrectly sized, or non-2-D embeddings are rejected before storage.
* Prevented invalid embedding data from being written.
* Clarified errors for embeddings with an invalid shape.

## Tests

* Expanded coverage for valid, empty, higher-precision, overflowing, non-finite, and invalid embedding batches.
* Added coverage for dimensionality checks, consistent embedding shapes, and reliable persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->