### PR TITLE
Mark evaluation runs stale on annotation mutations

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/add_annotations.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_annotations.py
@@ -28,6 +28,7 @@ from lightly_studio.resolvers import (
     annotation_collection_coverage_resolver,
     annotation_resolver,
     collection_resolver,
+    evaluation_run_resolver,
     image_resolver,
 )
 from lightly_studio.type_definitions import PathLike
@@ -230,5 +231,10 @@ def _process_annotation_batch(  # noqa: PLR0913
             annotation_collection_id=annotation_collection_id,
             parent_sample_ids=matched_sample_ids,
         )
+        if annotations_to_create:
+            evaluation_run_resolver.mark_stale_by_collection_id(
+                session=session,
+                collection_id=annotation_collection_id,
+            )
 
     return missing_paths

--- a/lightly_studio/src/lightly_studio/core/sample.py
+++ b/lightly_studio/src/lightly_studio/core/sample.py
@@ -13,11 +13,13 @@ from sqlmodel import Session
 from lightly_studio.core.annotation import CreateAnnotation
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.caption import CaptionCreate
+from lightly_studio.models.collection import SampleType
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.resolvers import (
     annotation_resolver,
     caption_resolver,
     collection_resolver,
+    evaluation_run_resolver,
     metadata_resolver,
     tag_resolver,
 )
@@ -305,6 +307,16 @@ class Sample(ABC):
             annotations=annotation_creates,
             collection_name=annotation_source,
         )
+        annotation_collection_id = collection_resolver.get_or_create_child_collection(
+            session=session,
+            collection_id=self.collection_id,
+            sample_type=SampleType.ANNOTATION,
+            name=annotation_source,
+        )
+        evaluation_run_resolver.mark_stale_by_collection_id(
+            session=session,
+            collection_id=annotation_collection_id,
+        )
 
     def delete_annotation(self, annotation: Annotation) -> None:
         """Delete an annotation from this sample.
@@ -314,9 +326,14 @@ class Sample(ABC):
         """
         session = self.get_object_session()
         annotation_id = annotation.annotation_base.sample_id
+        collection_id = annotation.annotation_base.annotation_collection_id
         annotation_resolver.delete_annotation(
             session=session,
             annotation_id=annotation_id,
+        )
+        evaluation_run_resolver.mark_stale_by_collection_id(
+            session=session,
+            collection_id=collection_id,
         )
 
 

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787097600_d1e2f3a4b5c6_add_evaluation_run_stale_since.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787097600_d1e2f3a4b5c6_add_evaluation_run_stale_since.py
@@ -1,0 +1,33 @@
+"""add_evaluation_run_stale_since.
+
+Adds nullable ``stale_since`` column to ``evaluation_run``.  The column is
+``NULL`` for runs that are up-to-date and set to a UTC timestamp when the
+underlying annotation collection changes.
+
+Revision ID: d1e2f3a4b5c6
+Revises: 4f6a7b8c9d0e
+Create Date: 2026-08-20 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d1e2f3a4b5c6"
+down_revision: Union[str, Sequence[str], None] = "4f6a7b8c9d0e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("evaluation_run", sa.Column("stale_since", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("evaluation_run", "stale_since")

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787400000_d1e2f3a4b5c6_add_evaluation_run_stale_since.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787400000_d1e2f3a4b5c6_add_evaluation_run_stale_since.py
@@ -5,8 +5,8 @@ Adds nullable ``stale_since`` column to ``evaluation_run``.  The column is
 underlying annotation collection changes.
 
 Revision ID: d1e2f3a4b5c6
-Revises: 4f6a7b8c9d0e
-Create Date: 2026-08-20 00:00:00.000000
+Revises: b1c2d3e4f5a6
+Create Date: 2026-08-24 00:00:00.000000
 
 """
 
@@ -18,7 +18,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "d1e2f3a4b5c6"
-down_revision: Union[str, Sequence[str], None] = "4f6a7b8c9d0e"
+down_revision: Union[str, Sequence[str], None] = "b1c2d3e4f5a6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787846600_d1e2f3a4b5c6_add_evaluation_run_stale_since.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787846600_d1e2f3a4b5c6_add_evaluation_run_stale_since.py
@@ -5,8 +5,8 @@ Adds nullable ``stale_since`` column to ``evaluation_run``.  The column is
 underlying annotation collection changes.
 
 Revision ID: d1e2f3a4b5c6
-Revises: b1c2d3e4f5a6
-Create Date: 2026-08-24 00:00:00.000000
+Revises: e5f6a7b8c9d0
+Create Date: 2026-08-28 00:00:00.000000
 
 """
 
@@ -18,7 +18,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "d1e2f3a4b5c6"
-down_revision: Union[str, Sequence[str], None] = "b1c2d3e4f5a6"
+down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/lightly_studio/src/lightly_studio/models/evaluation_run.py
+++ b/lightly_studio/src/lightly_studio/models/evaluation_run.py
@@ -48,6 +48,7 @@ class EvaluationRunTable(EvaluationRunBase, table=True):
     )
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    stale_since: datetime | None = None
 
 
 class EvaluationRunCreate(EvaluationRunBase):
@@ -61,5 +62,6 @@ class EvaluationRunView(BaseModel):
     name: str
     evaluation_run_configuration: dict[str, Any]
     created_at: datetime
+    stale_since: datetime | None
     gt_annotation_source: str | None
     pred_annotation_source: str | None

--- a/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/__init__.py
@@ -6,10 +6,14 @@ from lightly_studio.resolvers.evaluation_run_resolver.get_by_id import get_by_id
 from lightly_studio.resolvers.evaluation_run_resolver.list_views_by_dataset_id import (
     list_views_by_dataset_id,
 )
+from lightly_studio.resolvers.evaluation_run_resolver.mark_stale_by_collection_id import (
+    mark_stale_by_collection_id,
+)
 
 __all__ = [
     "create",
     "get_all_by_dataset_id",
     "get_by_id",
     "list_views_by_dataset_id",
+    "mark_stale_by_collection_id",
 ]

--- a/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/list_views_by_dataset_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/list_views_by_dataset_id.py
@@ -43,6 +43,7 @@ def list_views_by_dataset_id(
             created_at=run.created_at,
             gt_annotation_source=collection_name_by_id.get(run.gt_annotation_collection_id),
             pred_annotation_source=collection_name_by_id.get(run.pred_annotation_collection_id),
+            stale_since=run.stale_since,
         )
         for run in runs
     ]

--- a/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/mark_stale_by_collection_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/mark_stale_by_collection_id.py
@@ -1,0 +1,31 @@
+"""Mark evaluation runs as stale when their annotation collections change."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import update
+from sqlmodel import Session, col
+
+from lightly_studio.models.evaluation_run import EvaluationRunTable
+
+
+def mark_stale_by_collection_id(session: Session, collection_id: UUID) -> None:
+    """Set ``stale_since`` on every evaluation run referencing *collection_id*.
+
+    Matches runs whose ``gt_annotation_collection_id`` or
+    ``pred_annotation_collection_id`` equals the given collection.  Calling this
+    function multiple times updates ``stale_since`` to the latest timestamp.
+    """
+    now = datetime.now(timezone.utc)
+    stmt = (
+        update(EvaluationRunTable)
+        .where(
+            (col(EvaluationRunTable.gt_annotation_collection_id) == collection_id)
+            | (col(EvaluationRunTable.pred_annotation_collection_id) == collection_id)
+        )
+        .values(stale_since=now)
+    )
+    session.execute(stmt)
+    session.commit()

--- a/lightly_studio/src/lightly_studio/services/annotations_service/create_annotation.py
+++ b/lightly_studio/src/lightly_studio/services/annotations_service/create_annotation.py
@@ -12,7 +12,7 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
     AnnotationType,
 )
-from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.resolvers import annotation_resolver, evaluation_run_resolver
 
 
 class AnnotationCreateParams(BaseModel):
@@ -68,5 +68,10 @@ def create_annotation(session: Session, annotation: AnnotationCreateParams) -> A
 
     if created_annotation is None:
         raise ValueError(f"Failed to create annotation: {annotation}")
+
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=session,
+        collection_id=created_annotation.annotation_collection_id,
+    )
 
     return created_annotation

--- a/lightly_studio/src/lightly_studio/services/annotations_service/delete_annotation.py
+++ b/lightly_studio/src/lightly_studio/services/annotations_service/delete_annotation.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from sqlmodel import Session
 
-from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.resolvers import annotation_resolver, evaluation_run_resolver
 
 
 def delete_annotation(session: Session, annotation_id: UUID) -> None:
@@ -19,4 +19,12 @@ def delete_annotation(session: Session, annotation_id: UUID) -> None:
     Raises:
         ValueError: If the annotation with the given ID is not found.
     """
+    annotation = annotation_resolver.get_by_id(session=session, annotation_id=annotation_id)
+    if annotation is None:
+        raise ValueError(f"Annotation {annotation_id} not found")
+    collection_id = annotation.annotation_collection_id
     annotation_resolver.delete_annotation(session=session, annotation_id=annotation_id)
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=session,
+        collection_id=collection_id,
+    )

--- a/lightly_studio/src/lightly_studio/services/annotations_service/update_annotation_bounding_box.py
+++ b/lightly_studio/src/lightly_studio/services/annotations_service/update_annotation_bounding_box.py
@@ -11,6 +11,7 @@ from lightly_studio.models.annotation.annotation_base import (
 )
 from lightly_studio.resolvers import (
     annotation_resolver,
+    evaluation_run_resolver,
 )
 from lightly_studio.resolvers.annotation_resolver.update_bounding_box import BoundingBoxCoordinates
 
@@ -29,8 +30,13 @@ def update_annotation_bounding_box(
         The updated annotation with the new bounding box assigned.
 
     """
-    return annotation_resolver.update_bounding_box(
+    result = annotation_resolver.update_bounding_box(
         session,
         annotation_id,
         bounding_box,
     )
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=session,
+        collection_id=result.annotation_collection_id,
+    )
+    return result

--- a/lightly_studio/src/lightly_studio/services/annotations_service/update_annotation_label.py
+++ b/lightly_studio/src/lightly_studio/services/annotations_service/update_annotation_label.py
@@ -13,6 +13,7 @@ from lightly_studio.models.annotation_label import AnnotationLabelCreate
 from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
+    evaluation_run_resolver,
 )
 
 
@@ -34,6 +35,9 @@ def update_annotation_label(
     if annotation is None:
         raise ValueError(f"Annotation with id {annotation_id} does not exist.")
 
+    # Capture collection_id before the update; the resolver returns a detached copy.
+    collection_id = annotation.annotation_collection_id
+
     # Get dataset ID from the annotation's current label
     dataset_id = annotation.annotation_label.dataset_id
     annotation_label = annotation_label_resolver.get_by_label_name(
@@ -51,8 +55,13 @@ def update_annotation_label(
             ),
         )
 
-    return annotation_resolver.update_annotation_label(
+    result = annotation_resolver.update_annotation_label(
         session,
         annotation_id,
         annotation_label.annotation_label_id,
     )
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=session,
+        collection_id=collection_id,
+    )
+    return result

--- a/lightly_studio/src/lightly_studio/services/annotations_service/update_segmentation_mask.py
+++ b/lightly_studio/src/lightly_studio/services/annotations_service/update_segmentation_mask.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from sqlmodel import Session
 
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
-from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.resolvers import annotation_resolver, evaluation_run_resolver
 
 
 def update_segmentation_mask(
@@ -23,8 +23,13 @@ def update_segmentation_mask(
     Returns:
         The updated AnnotationBaseTable instance.
     """
-    return annotation_resolver.update_segmentation_mask(
+    result = annotation_resolver.update_segmentation_mask(
         session=session,
         annotation_id=annotation_id,
         segmentation_mask=segmentation_mask,
     )
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=session,
+        collection_id=result.annotation_collection_id,
+    )
+    return result

--- a/lightly_studio/tests/api/routes/api/evaluation/test_get_runs.py
+++ b/lightly_studio/tests/api/routes/api/evaluation/test_get_runs.py
@@ -21,6 +21,7 @@ def test_get_evaluation_runs(test_client: TestClient, mocker: MockerFixture) -> 
             created_at=datetime(2026, 5, 18, 10, 0, 0, tzinfo=timezone.utc),
             gt_annotation_source="gt_v1",
             pred_annotation_source="pred_v1",
+            stale_since=None,
         ),
         EvaluationRunView(
             id=run_2_id,
@@ -29,6 +30,7 @@ def test_get_evaluation_runs(test_client: TestClient, mocker: MockerFixture) -> 
             created_at=datetime(2026, 5, 17, 9, 30, 0, tzinfo=timezone.utc),
             gt_annotation_source="gt_v2",
             pred_annotation_source="pred_v2",
+            stale_since=None,
         ),
     ]
     list_views = mocker.patch(

--- a/lightly_studio/tests/api/routes/api/evaluation/test_get_runs.py
+++ b/lightly_studio/tests/api/routes/api/evaluation/test_get_runs.py
@@ -49,6 +49,7 @@ def test_get_evaluation_runs(test_client: TestClient, mocker: MockerFixture) -> 
             "created_at": "2026-05-18T10:00:00Z",
             "gt_annotation_source": "gt_v1",
             "pred_annotation_source": "pred_v1",
+            "stale_since": None,
         },
         {
             "id": str(run_2_id),
@@ -57,6 +58,7 @@ def test_get_evaluation_runs(test_client: TestClient, mocker: MockerFixture) -> 
             "created_at": "2026-05-17T09:30:00Z",
             "gt_annotation_source": "gt_v2",
             "pred_annotation_source": "pred_v2",
+            "stale_since": None,
         },
     ]
 

--- a/lightly_studio/tests/core/image/test_add_annotations.py
+++ b/lightly_studio/tests/core/image/test_add_annotations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+import posixpath
 
 import pytest
 from labelformat.formats.labelformat import LabelformatObjectDetectionInput
@@ -13,7 +14,14 @@ from labelformat.utils import ImageDimensionError
 from sqlmodel import Session
 
 from lightly_studio.core.image import add_annotations
-from lightly_studio.resolvers import annotation_resolver, image_resolver
+from lightly_studio.models.collection import CollectionCreate, SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    collection_resolver,
+    evaluation_run_resolver,
+    image_resolver,
+)
 from tests import helpers_resolvers
 from tests.helpers_resolvers import ImageStub
 
@@ -91,6 +99,87 @@ def test_add_annotations_from_labelformat__missing_images(db_session: Session) -
     images_root = Path("/images").absolute().as_posix()
     assert missing_paths == [f"{images_root}/nonexistent.jpg"]
     assert len(samples) == 0
+
+
+def test_normalize_images_root__local_path_is_posix() -> None:
+    # On Windows, `str(Path(...).absolute())` returns backslashes which, when
+    # joined with posix-separated labelformat filenames via `posixpath.join`,
+    # produce mixed-separator strings that fail to match ingested paths.
+    # The normalized root must therefore be in posix form.
+    result = add_annotations.normalize_images_root(Path("some") / "images")
+
+    assert "\\" not in result
+    assert result.endswith("some/images")
+    assert Path(result).is_absolute()
+
+
+def test_normalize_images_root__joins_cleanly_with_posix_filename() -> None:
+    root = add_annotations.normalize_images_root(Path("data") / "coco")
+    joined = posixpath.join(root, "images/0001.jpg")
+
+    assert "\\" not in joined
+    assert joined.endswith("data/coco/images/0001.jpg")
+
+
+def test_normalize_images_root__preserves_remote_protocol() -> None:
+    result = add_annotations.normalize_images_root("s3://bucket/path")
+
+    assert result == "s3://bucket/path"
+
+
+def test_add_annotations_from_labelformat__marks_evaluation_run_stale(
+    db_session: Session,
+) -> None:
+    collection = helpers_resolvers.create_collection(db_session)
+    helpers_resolvers.create_images(
+        db_session,
+        collection.collection_id,
+        [
+            ImageStub(
+                path=Path("images/image.jpg").absolute().as_posix(),
+                width=100,
+                height=200,
+            ),
+        ],
+    )
+    gt_collection = collection_resolver.create(
+        session=db_session,
+        collection=CollectionCreate(
+            name="gt",
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=collection.collection_id,
+        ),
+    )
+    pred_collection = helpers_resolvers.create_collection(
+        db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=collection.collection_id,
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=collection.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    assert run.stale_since is None
+
+    add_annotations.add_annotations_from_labelformat(
+        session=db_session,
+        root_collection_id=collection.collection_id,
+        input_labels=_get_labelformat_input_obj_det(filename="image.jpg"),
+        images_root="images",
+        collection_name="gt",
+    )
+
+    refreshed = evaluation_run_resolver.get_by_id(
+        session=db_session, evaluation_id=run.id
+    )
+    assert refreshed is not None
+    assert refreshed.stale_since is not None
 
 
 def _get_labelformat_input_obj_det(filename: str) -> LabelformatObjectDetectionInput:

--- a/lightly_studio/tests/core/image/test_add_annotations.py
+++ b/lightly_studio/tests/core/image/test_add_annotations.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-import posixpath
 
 import pytest
 from labelformat.formats.labelformat import LabelformatObjectDetectionInput
@@ -99,32 +98,6 @@ def test_add_annotations_from_labelformat__missing_images(db_session: Session) -
     images_root = Path("/images").absolute().as_posix()
     assert missing_paths == [f"{images_root}/nonexistent.jpg"]
     assert len(samples) == 0
-
-
-def test_normalize_images_root__local_path_is_posix() -> None:
-    # On Windows, `str(Path(...).absolute())` returns backslashes which, when
-    # joined with posix-separated labelformat filenames via `posixpath.join`,
-    # produce mixed-separator strings that fail to match ingested paths.
-    # The normalized root must therefore be in posix form.
-    result = add_annotations.normalize_images_root(Path("some") / "images")
-
-    assert "\\" not in result
-    assert result.endswith("some/images")
-    assert Path(result).is_absolute()
-
-
-def test_normalize_images_root__joins_cleanly_with_posix_filename() -> None:
-    root = add_annotations.normalize_images_root(Path("data") / "coco")
-    joined = posixpath.join(root, "images/0001.jpg")
-
-    assert "\\" not in joined
-    assert joined.endswith("data/coco/images/0001.jpg")
-
-
-def test_normalize_images_root__preserves_remote_protocol() -> None:
-    result = add_annotations.normalize_images_root("s3://bucket/path")
-
-    assert result == "s3://bucket/path"
 
 
 def test_add_annotations_from_labelformat__marks_evaluation_run_stale(

--- a/lightly_studio/tests/core/image/test_add_annotations.py
+++ b/lightly_studio/tests/core/image/test_add_annotations.py
@@ -175,9 +175,7 @@ def test_add_annotations_from_labelformat__marks_evaluation_run_stale(
         collection_name="gt",
     )
 
-    refreshed = evaluation_run_resolver.get_by_id(
-        session=db_session, evaluation_id=run.id
-    )
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
     assert refreshed is not None
     assert refreshed.stale_since is not None
 

--- a/lightly_studio/tests/core/image/test_image_sample.py
+++ b/lightly_studio/tests/core/image/test_image_sample.py
@@ -684,9 +684,7 @@ class TestImageSample:
             annotation_source="gt",
         )
 
-        refreshed = evaluation_run_resolver.get_by_id(
-            session=db_session, evaluation_id=run.id
-        )
+        refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
         assert refreshed is not None
         assert refreshed.stale_since is not None
 
@@ -730,8 +728,6 @@ class TestImageSample:
         annotation = image.annotations[0]
         image.delete_annotation(annotation)
 
-        refreshed = evaluation_run_resolver.get_by_id(
-            session=db_session, evaluation_id=run.id
-        )
+        refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
         assert refreshed is not None
         assert refreshed.stale_since is not None

--- a/lightly_studio/tests/core/image/test_image_sample.py
+++ b/lightly_studio/tests/core/image/test_image_sample.py
@@ -13,7 +13,9 @@ from lightly_studio.core.annotation.object_detection import ObjectDetectionAnnot
 from lightly_studio.core.annotation.segmentation_mask import SegmentationMaskAnnotation
 from lightly_studio.core.image.image_sample import ImageSample
 from lightly_studio.models.annotation.annotation_base import AnnotationType
-from lightly_studio.resolvers import image_resolver
+from lightly_studio.models.collection import CollectionCreate, SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
+from lightly_studio.resolvers import collection_resolver, evaluation_run_resolver, image_resolver
 from tests.helpers_resolvers import (
     create_annotation,
     create_annotation_label,
@@ -641,3 +643,95 @@ class TestImageSample:
 
         # Verify it's gone.
         assert len(image.annotations) == 0
+
+    def test_add_annotations__marks_evaluation_run_stale(
+        self,
+        db_session: Session,
+    ) -> None:
+        collection = create_collection(session=db_session)
+        image_table = create_image(
+            session=db_session,
+            collection_id=collection.collection_id,
+        )
+        image = ImageSample(inner=image_table)
+        gt_collection = collection_resolver.create(
+            session=db_session,
+            collection=CollectionCreate(
+                name="gt",
+                sample_type=SampleType.ANNOTATION,
+                parent_collection_id=collection.collection_id,
+            ),
+        )
+        pred_collection = create_collection(
+            session=db_session,
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=collection.collection_id,
+        )
+        run = evaluation_run_resolver.create(
+            session=db_session,
+            evaluation_run_input=EvaluationRunCreate(
+                name="run",
+                gt_annotation_collection_id=gt_collection.collection_id,
+                pred_annotation_collection_id=pred_collection.collection_id,
+                dataset_id=collection.dataset_id,
+                task_type=EvaluationTaskType.OBJECT_DETECTION,
+            ),
+        )
+        assert run.stale_since is None
+
+        image.add_annotations(
+            [CreateClassification(class_name="cat")],
+            annotation_source="gt",
+        )
+
+        refreshed = evaluation_run_resolver.get_by_id(
+            session=db_session, evaluation_id=run.id
+        )
+        assert refreshed is not None
+        assert refreshed.stale_since is not None
+
+    def test_delete_annotation__marks_evaluation_run_stale(
+        self,
+        db_session: Session,
+    ) -> None:
+        collection = create_collection(session=db_session)
+        image_table = create_image(
+            session=db_session,
+            collection_id=collection.collection_id,
+        )
+        image = ImageSample(inner=image_table)
+        image.add_annotation(
+            CreateClassification(class_name="cat"),
+            annotation_source="gt",
+        )
+        gt_collection_id = collection_resolver.get_or_create_child_collection(
+            session=db_session,
+            collection_id=collection.collection_id,
+            sample_type=SampleType.ANNOTATION,
+            name="gt",
+        )
+        pred_collection = create_collection(
+            session=db_session,
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=collection.collection_id,
+        )
+        run = evaluation_run_resolver.create(
+            session=db_session,
+            evaluation_run_input=EvaluationRunCreate(
+                name="run",
+                gt_annotation_collection_id=gt_collection_id,
+                pred_annotation_collection_id=pred_collection.collection_id,
+                dataset_id=collection.dataset_id,
+                task_type=EvaluationTaskType.OBJECT_DETECTION,
+            ),
+        )
+        assert run.stale_since is None
+
+        annotation = image.annotations[0]
+        image.delete_annotation(annotation)
+
+        refreshed = evaluation_run_resolver.get_by_id(
+            session=db_session, evaluation_id=run.id
+        )
+        assert refreshed is not None
+        assert refreshed.stale_since is not None

--- a/lightly_studio/tests/resolvers/evaluation_run_resolver/test_evaluation_run_mark_stale_by_collection_id.py
+++ b/lightly_studio/tests/resolvers/evaluation_run_resolver/test_evaluation_run_mark_stale_by_collection_id.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.evaluation_run import (
+    EvaluationRunCreate,
+    EvaluationTaskType,
+)
+from lightly_studio.resolvers import evaluation_run_resolver
+from tests.helpers_resolvers import create_collection
+
+
+def test_marks_runs_matching_gt_collection(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    gt_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_gt",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=db_session, collection_id=gt_collection.collection_id
+    )
+
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed is not None
+    assert refreshed.stale_since is not None
+
+
+def test_marks_runs_matching_pred_collection(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    gt_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_pred",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=db_session, collection_id=pred_collection.collection_id
+    )
+
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed is not None
+    assert refreshed.stale_since is not None
+
+
+def test_does_not_mark_unrelated_runs(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    target_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    other_gt = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    other_pred = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    # Run referencing target_collection as GT.
+    run_matching = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_match",
+            gt_annotation_collection_id=target_collection.collection_id,
+            pred_annotation_collection_id=other_pred.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    # Unrelated run.
+    run_unrelated = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_unrelated",
+            gt_annotation_collection_id=other_gt.collection_id,
+            pred_annotation_collection_id=other_pred.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.CLASSIFICATION,
+        ),
+    )
+
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=db_session, collection_id=target_collection.collection_id
+    )
+
+    assert (
+        evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_matching.id)
+    ).stale_since is not None
+    assert (
+        evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_unrelated.id)
+    ).stale_since is None
+
+
+def test_marks_both_gt_and_pred_matches(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    shared_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    other_collection_a = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    other_collection_b = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    other_collection_c = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    # Run with shared_collection as GT.
+    run_gt = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_as_gt",
+            gt_annotation_collection_id=shared_collection.collection_id,
+            pred_annotation_collection_id=other_collection_a.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    # Run with shared_collection as pred.
+    run_pred = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_as_pred",
+            gt_annotation_collection_id=other_collection_b.collection_id,
+            pred_annotation_collection_id=shared_collection.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    # Unrelated run.
+    run_unrelated = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_none",
+            gt_annotation_collection_id=other_collection_b.collection_id,
+            pred_annotation_collection_id=other_collection_c.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.CLASSIFICATION,
+        ),
+    )
+
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=db_session, collection_id=shared_collection.collection_id
+    )
+
+    assert (
+        evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_gt.id)
+    ).stale_since is not None
+    assert (
+        evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_pred.id)
+    ).stale_since is not None
+    assert (
+        evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_unrelated.id)
+    ).stale_since is None
+
+
+def test_calling_twice_updates_stale_since(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    gt_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_twice",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=db_session, collection_id=gt_collection.collection_id
+    )
+    first_stale_since = evaluation_run_resolver.get_by_id(
+        session=db_session, evaluation_id=run.id
+    ).stale_since
+
+    evaluation_run_resolver.mark_stale_by_collection_id(
+        session=db_session, collection_id=gt_collection.collection_id
+    )
+    second_stale_since = evaluation_run_resolver.get_by_id(
+        session=db_session, evaluation_id=run.id
+    ).stale_since
+
+    assert first_stale_since is not None
+    assert second_stale_since is not None
+    assert second_stale_since >= first_stale_since
+
+
+def test_stale_since_defaults_to_none(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    gt_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_fresh",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+
+    assert run.stale_since is None

--- a/lightly_studio/tests/resolvers/evaluation_run_resolver/test_evaluation_run_mark_stale_by_collection_id.py
+++ b/lightly_studio/tests/resolvers/evaluation_run_resolver/test_evaluation_run_mark_stale_by_collection_id.py
@@ -11,7 +11,9 @@ from lightly_studio.resolvers import evaluation_run_resolver
 from tests.helpers_resolvers import create_collection
 
 
-def test_marks_runs_matching_gt_collection(db_session: Session) -> None:
+def test_mark_stale_by_collection_id__marks_runs_matching_gt_collection(
+    db_session: Session,
+) -> None:
     dataset = create_collection(session=db_session)
     gt_collection = create_collection(
         session=db_session,
@@ -43,7 +45,9 @@ def test_marks_runs_matching_gt_collection(db_session: Session) -> None:
     assert refreshed.stale_since is not None
 
 
-def test_marks_runs_matching_pred_collection(db_session: Session) -> None:
+def test_mark_stale_by_collection_id__marks_runs_matching_pred_collection(
+    db_session: Session,
+) -> None:
     dataset = create_collection(session=db_session)
     gt_collection = create_collection(
         session=db_session,
@@ -75,7 +79,7 @@ def test_marks_runs_matching_pred_collection(db_session: Session) -> None:
     assert refreshed.stale_since is not None
 
 
-def test_does_not_mark_unrelated_runs(db_session: Session) -> None:
+def test_mark_stale_by_collection_id__does_not_mark_unrelated_runs(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     target_collection = create_collection(
         session=db_session,
@@ -127,7 +131,7 @@ def test_does_not_mark_unrelated_runs(db_session: Session) -> None:
     ).stale_since is None
 
 
-def test_marks_both_gt_and_pred_matches(db_session: Session) -> None:
+def test_mark_stale_by_collection_id__marks_both_gt_and_pred_matches(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     shared_collection = create_collection(
         session=db_session,
@@ -198,7 +202,9 @@ def test_marks_both_gt_and_pred_matches(db_session: Session) -> None:
     ).stale_since is None
 
 
-def test_calling_twice_updates_stale_since(db_session: Session) -> None:
+def test_mark_stale_by_collection_id__calling_twice_updates_stale_since(
+    db_session: Session,
+) -> None:
     dataset = create_collection(session=db_session)
     gt_collection = create_collection(
         session=db_session,
@@ -240,7 +246,7 @@ def test_calling_twice_updates_stale_since(db_session: Session) -> None:
     assert second_stale_since >= first_stale_since
 
 
-def test_stale_since_defaults_to_none(db_session: Session) -> None:
+def test_mark_stale_by_collection_id__stale_since_defaults_to_none(db_session: Session) -> None:
     dataset = create_collection(session=db_session)
     gt_collection = create_collection(
         session=db_session,

--- a/lightly_studio/tests/resolvers/evaluation_run_resolver/test_evaluation_run_mark_stale_by_collection_id.py
+++ b/lightly_studio/tests/resolvers/evaluation_run_resolver/test_evaluation_run_mark_stale_by_collection_id.py
@@ -123,12 +123,16 @@ def test_mark_stale_by_collection_id__does_not_mark_unrelated_runs(db_session: S
         session=db_session, collection_id=target_collection.collection_id
     )
 
-    assert (
-        evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_matching.id)
-    ).stale_since is not None
-    assert (
-        evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_unrelated.id)
-    ).stale_since is None
+    refreshed_matching = evaluation_run_resolver.get_by_id(
+        session=db_session, evaluation_id=run_matching.id
+    )
+    assert refreshed_matching is not None
+    assert refreshed_matching.stale_since is not None
+    refreshed_unrelated = evaluation_run_resolver.get_by_id(
+        session=db_session, evaluation_id=run_unrelated.id
+    )
+    assert refreshed_unrelated is not None
+    assert refreshed_unrelated.stale_since is None
 
 
 def test_mark_stale_by_collection_id__marks_both_gt_and_pred_matches(db_session: Session) -> None:
@@ -191,15 +195,19 @@ def test_mark_stale_by_collection_id__marks_both_gt_and_pred_matches(db_session:
         session=db_session, collection_id=shared_collection.collection_id
     )
 
-    assert (
-        evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_gt.id)
-    ).stale_since is not None
-    assert (
-        evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_pred.id)
-    ).stale_since is not None
-    assert (
-        evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_unrelated.id)
-    ).stale_since is None
+    refreshed_gt = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run_gt.id)
+    assert refreshed_gt is not None
+    assert refreshed_gt.stale_since is not None
+    refreshed_pred = evaluation_run_resolver.get_by_id(
+        session=db_session, evaluation_id=run_pred.id
+    )
+    assert refreshed_pred is not None
+    assert refreshed_pred.stale_since is not None
+    refreshed_unrelated = evaluation_run_resolver.get_by_id(
+        session=db_session, evaluation_id=run_unrelated.id
+    )
+    assert refreshed_unrelated is not None
+    assert refreshed_unrelated.stale_since is None
 
 
 def test_mark_stale_by_collection_id__calling_twice_updates_stale_since(
@@ -230,16 +238,16 @@ def test_mark_stale_by_collection_id__calling_twice_updates_stale_since(
     evaluation_run_resolver.mark_stale_by_collection_id(
         session=db_session, collection_id=gt_collection.collection_id
     )
-    first_stale_since = evaluation_run_resolver.get_by_id(
-        session=db_session, evaluation_id=run.id
-    ).stale_since
+    refreshed_first = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed_first is not None
+    first_stale_since = refreshed_first.stale_since
 
     evaluation_run_resolver.mark_stale_by_collection_id(
         session=db_session, collection_id=gt_collection.collection_id
     )
-    second_stale_since = evaluation_run_resolver.get_by_id(
-        session=db_session, evaluation_id=run.id
-    ).stale_since
+    refreshed_second = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed_second is not None
+    second_stale_since = refreshed_second.stale_since
 
     assert first_stale_since is not None
     assert second_stale_since is not None

--- a/lightly_studio/tests/services/annotations_service/test_create_annotation.py
+++ b/lightly_studio/tests/services/annotations_service/test_create_annotation.py
@@ -192,7 +192,7 @@ def test_create_annotation_classification_with_temporal_span(
     assert result.temporal_span_details.end_time_s == 8.0
 
 
-def test_create_annotation_marks_evaluation_run_stale(db_session: Session) -> None:
+def test_create_annotation__marks_evaluation_run_stale(db_session: Session) -> None:
     image_collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=image_collection.collection_id)
     label = create_annotation_label(

--- a/lightly_studio/tests/services/annotations_service/test_create_annotation.py
+++ b/lightly_studio/tests/services/annotations_service/test_create_annotation.py
@@ -13,12 +13,15 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationType,
 )
 from lightly_studio.models.annotation_label import AnnotationLabelTable
-from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.collection import CollectionCreate, CollectionTable, SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
 from lightly_studio.models.image import ImageTable
+from lightly_studio.resolvers import collection_resolver, evaluation_run_resolver
 from lightly_studio.services.annotations_service.create_annotation import (
     AnnotationCreateParams,
     create_annotation,
 )
+from tests.helpers_resolvers import create_annotation_label, create_collection, create_image
 
 
 def test_create_annotation_object_detection(
@@ -187,3 +190,56 @@ def test_create_annotation_classification_with_temporal_span(
     assert result.temporal_span_details is not None
     assert result.temporal_span_details.start_time_s == 2.5
     assert result.temporal_span_details.end_time_s == 8.0
+
+
+def test_create_annotation_marks_evaluation_run_stale(db_session: Session) -> None:
+    image_collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=image_collection.collection_id)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=image_collection.collection_id,
+        label_name="cat",
+    )
+    gt_collection = collection_resolver.create(
+        session=db_session,
+        collection=CollectionCreate(
+            name="gt",
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=image_collection.collection_id,
+        ),
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=image_collection.collection_id,
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=image_collection.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    assert run.stale_since is None
+
+    create_annotation(
+        session=db_session,
+        annotation=AnnotationCreateParams(
+            annotation_label_id=label.annotation_label_id,
+            annotation_type=AnnotationType.OBJECT_DETECTION,
+            collection_id=image_collection.collection_id,
+            parent_sample_id=image.sample_id,
+            annotation_collection_name="gt",
+            x=10,
+            y=10,
+            width=20,
+            height=20,
+        ),
+    )
+
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed is not None
+    assert refreshed.stale_since is not None

--- a/lightly_studio/tests/services/annotations_service/test_delete_annotation.py
+++ b/lightly_studio/tests/services/annotations_service/test_delete_annotation.py
@@ -59,7 +59,7 @@ def test_delete_annotation__raises_error_when_annotation_not_found(
         delete_annotation(session=db_session, annotation_id=non_existent_annotation_id)
 
 
-def test_delete_annotation_marks_evaluation_run_stale(db_session: Session) -> None:
+def test_delete_annotation__marks_evaluation_run_stale(db_session: Session) -> None:
     image_collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=image_collection.collection_id)
     label = create_annotation_label(

--- a/lightly_studio/tests/services/annotations_service/test_delete_annotation.py
+++ b/lightly_studio/tests/services/annotations_service/test_delete_annotation.py
@@ -7,11 +7,23 @@ from uuid import UUID
 import pytest
 from sqlmodel import Session
 
-from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.models.collection import CollectionCreate, SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    collection_resolver,
+    evaluation_run_resolver,
+)
 from lightly_studio.services.annotations_service.delete_annotation import (
     delete_annotation,
 )
 from tests.conftest import AnnotationsTestData
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
 
 
 def test_delete_annotation__success(
@@ -45,3 +57,50 @@ def test_delete_annotation__raises_error_when_annotation_not_found(
     # Call the service and expect ValueError
     with pytest.raises(ValueError, match=f"Annotation {non_existent_annotation_id} not found"):
         delete_annotation(session=db_session, annotation_id=non_existent_annotation_id)
+
+
+def test_delete_annotation_marks_evaluation_run_stale(db_session: Session) -> None:
+    image_collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=image_collection.collection_id)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=image_collection.collection_id,
+        label_name="cat",
+    )
+    gt_collection = collection_resolver.create(
+        session=db_session,
+        collection=CollectionCreate(
+            name="gt",
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=image_collection.collection_id,
+        ),
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=image_collection.collection_id,
+    )
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=image_collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name="gt",
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=image_collection.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    assert run.stale_since is None
+
+    delete_annotation(session=db_session, annotation_id=annotation.sample_id)
+
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed is not None
+    assert refreshed.stale_since is not None

--- a/lightly_studio/tests/services/annotations_service/test_update_annotation.py
+++ b/lightly_studio/tests/services/annotations_service/test_update_annotation.py
@@ -8,14 +8,24 @@ from uuid import UUID
 import pytest
 from sqlmodel import Session
 
+from lightly_studio.models.collection import CollectionCreate, SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
 from lightly_studio.resolvers import (
     annotation_resolver,
+    collection_resolver,
+    evaluation_run_resolver,
 )
 from lightly_studio.services import annotations_service
 from lightly_studio.services.annotations_service.update_annotation import (
     AnnotationUpdate,
 )
 from tests.conftest import AnnotationsTestData
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
 
 
 def test_update_annotation__calls_update_annotation_label(
@@ -138,3 +148,57 @@ def test_update_annotation__calls_update_temporal_span_when_both_times_provided(
             start_time_s=1.0,
             end_time_s=5.0,
         )
+
+
+def test_update_annotation_marks_evaluation_run_stale(db_session: Session) -> None:
+    image_collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=image_collection.collection_id)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=image_collection.collection_id,
+        label_name="cat",
+    )
+    gt_collection = collection_resolver.create(
+        session=db_session,
+        collection=CollectionCreate(
+            name="gt",
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=image_collection.collection_id,
+        ),
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=image_collection.collection_id,
+    )
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=image_collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name="gt",
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=image_collection.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    assert run.stale_since is None
+
+    annotations_service.update_annotation(
+        session=db_session,
+        annotation_update=AnnotationUpdate(
+            annotation_id=annotation.sample_id,
+            collection_id=gt_collection.collection_id,
+            label_name="dog",
+        ),
+    )
+
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed is not None
+    assert refreshed.stale_since is not None

--- a/lightly_studio/tests/services/annotations_service/test_update_annotation.py
+++ b/lightly_studio/tests/services/annotations_service/test_update_annotation.py
@@ -150,7 +150,7 @@ def test_update_annotation__calls_update_temporal_span_when_both_times_provided(
         )
 
 
-def test_update_annotation_marks_evaluation_run_stale(db_session: Session) -> None:
+def test_update_annotation__marks_evaluation_run_stale(db_session: Session) -> None:
     image_collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=image_collection.collection_id)
     label = create_annotation_label(

--- a/lightly_studio/tests/services/annotations_service/test_update_annotation_label.py
+++ b/lightly_studio/tests/services/annotations_service/test_update_annotation_label.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 from sqlmodel import Session
 
+from lightly_studio.models.collection import CollectionCreate, SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
 from lightly_studio.resolvers import (
     annotation_resolver,
+    collection_resolver,
+    evaluation_run_resolver,
 )
 from lightly_studio.services.annotations_service.update_annotation_label import (
     update_annotation_label,
 )
 from tests.conftest import AnnotationsTestData
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
 
 
 def test_update_annotation_label_with_existing_label(
@@ -64,3 +74,54 @@ def test_update_annotation_label_creates_new_label(
 
     assert persisted_annotation is not None
     assert persisted_annotation.annotation_label.annotation_label_name == new_label_name
+
+
+def test_update_annotation_label_marks_evaluation_run_stale(db_session: Session) -> None:
+    image_collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=image_collection.collection_id)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=image_collection.collection_id,
+        label_name="cat",
+    )
+    pred_collection = collection_resolver.create(
+        session=db_session,
+        collection=CollectionCreate(
+            name="pred",
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=image_collection.collection_id,
+        ),
+    )
+    gt_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=image_collection.collection_id,
+    )
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=image_collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name="pred",
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=image_collection.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    assert run.stale_since is None
+
+    update_annotation_label(
+        session=db_session,
+        annotation_id=annotation.sample_id,
+        label_name="dog",
+    )
+
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed is not None
+    assert refreshed.stale_since is not None

--- a/lightly_studio/tests/services/annotations_service/test_update_annotation_label.py
+++ b/lightly_studio/tests/services/annotations_service/test_update_annotation_label.py
@@ -76,7 +76,7 @@ def test_update_annotation_label_creates_new_label(
     assert persisted_annotation.annotation_label.annotation_label_name == new_label_name
 
 
-def test_update_annotation_label_marks_evaluation_run_stale(db_session: Session) -> None:
+def test_update_annotation_label__marks_evaluation_run_stale(db_session: Session) -> None:
     image_collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=image_collection.collection_id)
     label = create_annotation_label(

--- a/lightly_studio/tests/services/annotations_service/test_update_annotation_object_detection.py
+++ b/lightly_studio/tests/services/annotations_service/test_update_annotation_object_detection.py
@@ -4,15 +4,28 @@ from __future__ import annotations
 
 from sqlmodel import Session
 
+from lightly_studio.models.collection import CollectionCreate, SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
 from lightly_studio.resolvers import (
     annotation_resolver,
+    collection_resolver,
+    evaluation_run_resolver,
 )
 from lightly_studio.resolvers.annotation_resolver.update_bounding_box import BoundingBoxCoordinates
 from lightly_studio.services import (
     annotations_service,
 )
 from lightly_studio.services.annotations_service.update_annotation import AnnotationUpdate
+from lightly_studio.services.annotations_service.update_annotation_bounding_box import (
+    update_annotation_bounding_box,
+)
 from tests.conftest import AnnotationsTestData, assert_contains_properties
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
 
 
 def test_update_annotation_object_detection(
@@ -58,3 +71,54 @@ def test_update_annotation_object_detection(
             "height": bounding_box["height"],
         },
     )
+
+
+def test_update_annotation_bounding_box_marks_evaluation_run_stale(db_session: Session) -> None:
+    image_collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=image_collection.collection_id)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=image_collection.collection_id,
+        label_name="cat",
+    )
+    gt_collection = collection_resolver.create(
+        session=db_session,
+        collection=CollectionCreate(
+            name="gt",
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=image_collection.collection_id,
+        ),
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=image_collection.collection_id,
+    )
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=image_collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name="gt",
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=image_collection.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    assert run.stale_since is None
+
+    update_annotation_bounding_box(
+        session=db_session,
+        annotation_id=annotation.sample_id,
+        bounding_box=BoundingBoxCoordinates(x=1, y=2, width=3, height=4),
+    )
+
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed is not None
+    assert refreshed.stale_since is not None

--- a/lightly_studio/tests/services/annotations_service/test_update_annotation_object_detection.py
+++ b/lightly_studio/tests/services/annotations_service/test_update_annotation_object_detection.py
@@ -16,9 +16,6 @@ from lightly_studio.services import (
     annotations_service,
 )
 from lightly_studio.services.annotations_service.update_annotation import AnnotationUpdate
-from lightly_studio.services.annotations_service.update_annotation_bounding_box import (
-    update_annotation_bounding_box,
-)
 from tests.conftest import AnnotationsTestData, assert_contains_properties
 from tests.helpers_resolvers import (
     create_annotation,
@@ -73,7 +70,7 @@ def test_update_annotation_object_detection(
     )
 
 
-def test_update_annotation_bounding_box_marks_evaluation_run_stale(db_session: Session) -> None:
+def test_update_annotation_bounding_box__marks_evaluation_run_stale(db_session: Session) -> None:
     image_collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=image_collection.collection_id)
     label = create_annotation_label(
@@ -113,7 +110,7 @@ def test_update_annotation_bounding_box_marks_evaluation_run_stale(db_session: S
     )
     assert run.stale_since is None
 
-    update_annotation_bounding_box(
+    annotations_service.update_annotation_bounding_box(
         session=db_session,
         annotation_id=annotation.sample_id,
         bounding_box=BoundingBoxCoordinates(x=1, y=2, width=3, height=4),

--- a/lightly_studio/tests/services/annotations_service/test_update_annotations.py
+++ b/lightly_studio/tests/services/annotations_service/test_update_annotations.py
@@ -112,7 +112,7 @@ def test_update_annotations__updates_label_for_all_track_annotations(
     assert outside_after.annotation_label_id == label_before.annotation_label_id
 
 
-def test_update_annotations_marks_evaluation_run_stale(db_session: Session) -> None:
+def test_update_annotations__marks_evaluation_run_stale(db_session: Session) -> None:
     image_collection = create_collection(session=db_session)
     image = create_image(session=db_session, collection_id=image_collection.collection_id)
     label = create_annotation_label(

--- a/lightly_studio/tests/services/annotations_service/test_update_annotations.py
+++ b/lightly_studio/tests/services/annotations_service/test_update_annotations.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 from sqlmodel import Session
 
 from lightly_studio.models.annotation.object_track import ObjectTrackCreate
-from lightly_studio.resolvers import annotation_resolver, object_track_resolver
+from lightly_studio.models.collection import CollectionCreate, SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    collection_resolver,
+    evaluation_run_resolver,
+    object_track_resolver,
+)
 from lightly_studio.services import annotations_service
 from lightly_studio.services.annotations_service.update_annotation import AnnotationUpdate
 from tests.helpers_resolvers import (
     AnnotationDetails,
+    create_annotation,
     create_annotation_label,
     create_annotations,
     create_collection,
@@ -102,3 +110,59 @@ def test_update_annotations__updates_label_for_all_track_annotations(
     outside_after = annotation_resolver.get_by_id(db_session, track_b_annotations[0].sample_id)
     assert outside_after is not None
     assert outside_after.annotation_label_id == label_before.annotation_label_id
+
+
+def test_update_annotations_marks_evaluation_run_stale(db_session: Session) -> None:
+    image_collection = create_collection(session=db_session)
+    image = create_image(session=db_session, collection_id=image_collection.collection_id)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=image_collection.collection_id,
+        label_name="cat",
+    )
+    pred_collection = collection_resolver.create(
+        session=db_session,
+        collection=CollectionCreate(
+            name="pred",
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=image_collection.collection_id,
+        ),
+    )
+    gt_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=image_collection.collection_id,
+    )
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=image_collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_collection_name="pred",
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=image_collection.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    assert run.stale_since is None
+
+    annotations_service.update_annotations(
+        session=db_session,
+        annotation_updates=[
+            AnnotationUpdate(
+                annotation_id=annotation.sample_id,
+                collection_id=pred_collection.collection_id,
+                label_name="dog",
+            ),
+        ],
+    )
+
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed is not None
+    assert refreshed.stale_since is not None

--- a/lightly_studio/tests/services/annotations_service/test_update_segmentation_mask.py
+++ b/lightly_studio/tests/services/annotations_service/test_update_segmentation_mask.py
@@ -6,10 +6,20 @@ from lightly_studio.models.annotation.annotation_base import (
     AnnotationCreate,
     AnnotationType,
 )
-from lightly_studio.models.collection import SampleType
-from lightly_studio.resolvers import annotation_resolver
+from lightly_studio.models.collection import CollectionCreate, SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
+from lightly_studio.resolvers import (
+    annotation_resolver,
+    collection_resolver,
+    evaluation_run_resolver,
+)
 from lightly_studio.services import annotations_service
-from tests.helpers_resolvers import create_annotation_label, create_collection, create_image
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
 
 
 def test_update_segmentation_mask(db_session: Session) -> None:
@@ -52,3 +62,56 @@ def test_update_segmentation_mask(db_session: Session) -> None:
     assert annotation.sample_id == annotation_id
     assert annotation.segmentation_details is not None
     assert annotation.segmentation_details.segmentation_mask == [1, 2, 3, 4]
+
+
+def test_update_segmentation_mask_marks_evaluation_run_stale(db_session: Session) -> None:
+    image_collection = create_collection(session=db_session, sample_type=SampleType.IMAGE)
+    image = create_image(session=db_session, collection_id=image_collection.collection_id)
+    label = create_annotation_label(
+        session=db_session,
+        root_collection_id=image_collection.collection_id,
+        label_name="car",
+    )
+    gt_collection = collection_resolver.create(
+        session=db_session,
+        collection=CollectionCreate(
+            name="gt",
+            sample_type=SampleType.ANNOTATION,
+            parent_collection_id=image_collection.collection_id,
+        ),
+    )
+    pred_collection = create_collection(
+        session=db_session,
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=image_collection.collection_id,
+    )
+    annotation = create_annotation(
+        session=db_session,
+        collection_id=image_collection.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=label.annotation_label_id,
+        annotation_type=AnnotationType.SEGMENTATION_MASK,
+        annotation_data={"segmentation_mask": [0, 1, 2]},
+        annotation_collection_name="gt",
+    )
+    run = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=image_collection.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    assert run.stale_since is None
+
+    annotations_service.update_segmentation_mask(
+        session=db_session,
+        annotation_id=annotation.sample_id,
+        segmentation_mask=[1, 2, 3, 4],
+    )
+
+    refreshed = evaluation_run_resolver.get_by_id(session=db_session, evaluation_id=run.id)
+    assert refreshed is not None
+    assert refreshed.stale_since is not None

--- a/lightly_studio/tests/services/annotations_service/test_update_segmentation_mask.py
+++ b/lightly_studio/tests/services/annotations_service/test_update_segmentation_mask.py
@@ -64,7 +64,7 @@ def test_update_segmentation_mask(db_session: Session) -> None:
     assert annotation.segmentation_details.segmentation_mask == [1, 2, 3, 4]
 
 
-def test_update_segmentation_mask_marks_evaluation_run_stale(db_session: Session) -> None:
+def test_update_segmentation_mask__marks_evaluation_run_stale(db_session: Session) -> None:
     image_collection = create_collection(session=db_session, sample_type=SampleType.IMAGE)
     image = create_image(session=db_session, collection_id=image_collection.collection_id)
     label = create_annotation_label(

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunItem/EvaluationRunItem.test.ts
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunItem/EvaluationRunItem.test.ts
@@ -22,6 +22,7 @@ const baseRun: EvaluationRunView = {
         classwise: true
     },
     created_at: new Date('2026-01-15T10:30:00Z'),
+    stale_since: null,
     gt_annotation_source: 'ground_truth_v1',
     pred_annotation_source: 'predictions_v2'
 };

--- a/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunsPanel.test.ts
+++ b/lightly_studio_view/src/lib/components/EvaluationRunsPanel/EvaluationRunsPanel.test.ts
@@ -24,6 +24,7 @@ const makeRun = (
 ): EvaluationRunView => ({
     evaluation_run_configuration: {},
     created_at: new Date('2026-01-01T00:00:00Z'),
+    stale_since: null,
     gt_annotation_source: 'gt_v1',
     pred_annotation_source: 'pred_v1',
     ...overrides


### PR DESCRIPTION
## What has changed and why?

Automatically marks affected evaluation runs as stale whenever annotations change through the annotation service layer. When a user creates, deletes, or updates an annotation in a collection used as a GT or prediction source by an evaluation run, that run’s `stale_since` is set.

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>