### PR TITLE
Remove collection_id from embedding_model

### DIFF
--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import random
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
-from uuid import UUID
 
 import numpy as np
 from numpy.typing import NDArray
@@ -59,7 +58,7 @@ class EmbeddingGenerator(Protocol):
     before you add a dataset or start the GUI.
     """
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(self) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
 
         <span class="doc-badge doc-badge--beta">Beta</span>
@@ -67,9 +66,6 @@ class EmbeddingGenerator(Protocol):
         Returns metadata about the model to be stored in the database.
         The `embedding_model_hash` field is used to match the same EmbeddingGenerator
         across multiple LightlyStudio runs.
-
-        Args:
-            collection_id: The ID of the collection.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -197,11 +193,8 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         """
         self._dimension = dimension
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(self) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
-
-        Args:
-            collection_id: The ID of the collection.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -210,7 +203,6 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
             name="Random",
             embedding_model_hash="random_model",
             embedding_dimension=self._dimension,
-            collection_id=collection_id,
         )
 
     def embed_text(self, _text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -164,9 +164,7 @@ class EmbeddingManager:
         # Get or create embedding model record in the database.
         db_model = embedding_model_resolver.get_or_create(
             session=session,
-            embedding_model=embedding_generator.get_embedding_model_input(
-                collection_id=collection_id
-            ),
+            embedding_model=embedding_generator.get_embedding_model_input(),
         )
         model_id = db_model.embedding_model_id
 

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import UUID
 
 import numpy as np
 import torch
@@ -53,11 +52,8 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
         self._model_hash = file_utils.get_file_xxhash(model_path)
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(self) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
-
-        Args:
-            collection_id: The ID of the collection.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -66,7 +62,6 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             name=MODEL_NAME,
             embedding_model_hash=self._model_hash,
             embedding_dimension=EMBEDDING_DIMENSION,
-            collection_id=collection_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from uuid import UUID
 
 import fsspec
 import numpy as np
@@ -63,11 +62,8 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         self._model = self._model.to(self._device)
         self._model_hash = file_utils.get_file_xxhash(Path(model_path))
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(self) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
-
-        Args:
-            collection_id: The ID of the collection.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -76,7 +72,6 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             name=MODEL_NAME,
             embedding_model_hash=self._model_hash,
             embedding_dimension=self._model.output_dim,
-            collection_id=collection_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
@@ -12,7 +12,6 @@ so ingestion uses your generator instead of the environment default.
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import UUID
 
 import numpy as np
 import torch
@@ -66,7 +65,7 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
         self._model_hash = file_utils.get_file_xxhash(model_path)
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(self) -> EmbeddingModelCreate:
         """Describe the model so it can be recorded in the database.
 
         The name shows up in the GUI and the hash lets Lightly Studio detect when
@@ -76,7 +75,6 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
             name="Custom Embedding Model",
             embedding_model_hash=self._model_hash,
             embedding_dimension=EMBEDDING_DIMENSION,
-            collection_id=collection_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
+++ b/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
@@ -11,7 +11,6 @@ video model.
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import UUID
 
 import numpy as np
 from environs import Env
@@ -56,13 +55,12 @@ class LoadExistingEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
         """
         self._embeddings_by_filepath = embeddings_by_filepath
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(self) -> EmbeddingModelCreate:
         """Describe the model so it can be recorded in the database."""
         return EmbeddingModelCreate(
             name="Precomputed Embeddings",
             embedding_model_hash="precomputed",
             embedding_dimension=EMBEDDING_DIMENSION,
-            collection_id=collection_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -168,7 +168,6 @@ class ClassifierManager:
         embedding_model = embedding_model_resolver.get_by_model_hash(
             session=session,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
-            collection_id=classifier.collection_id,
         )
         if embedding_model is None:
             raise ValueError(
@@ -258,7 +257,6 @@ class ClassifierManager:
         embedding_model = embedding_model_resolver.get_by_model_hash(
             session=session,
             embedding_model_hash=classifier.embedding_model_hash,
-            collection_id=collection_id,
         )
         if embedding_model is None:
             raise ValueError(
@@ -393,7 +391,6 @@ class ClassifierManager:
         embedding_model = embedding_model_resolver.get_by_model_hash(
             session=session,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
-            collection_id=classifier.collection_id,
         )
         if embedding_model is None:
             raise ValueError(
@@ -456,7 +453,6 @@ class ClassifierManager:
         embedding_model = embedding_model_resolver.get_by_model_hash(
             session=session,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
-            collection_id=classifier.collection_id,
         )
         if embedding_model is None:
             raise ValueError(
@@ -592,7 +588,6 @@ class ClassifierManager:
         embedding_model = embedding_model_resolver.get_by_model_hash(
             session=session,
             embedding_model_hash=classifier.embedding_model_hash,
-            collection_id=collection_id,
         )
         if embedding_model is None:
             raise ValueError(

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787575504_5855d824582d_drop_embedding_model_collection_id.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787575504_5855d824582d_drop_embedding_model_collection_id.py
@@ -1,0 +1,88 @@
+"""drop embedding_model collection_id.
+
+Removes the `collection_id` column (and its index and foreign key) from the
+`embedding_model` table. Embedding models become a shared global registry, deduplicated
+by hash and no longer scoped to a collection; a collection's default is resolved through
+`default_embedding_space` instead.
+
+Before dropping the column, this reruns the `default_embedding_space` backfill from
+`b1c2d3e4f5a6` (idempotent via `ON CONFLICT DO NOTHING`), so any collection whose default
+row is still missing is seeded from its oldest model while `collection_id` is available.
+
+Downgrade re-adds the column, its foreign key, and its index, but is lossy: the column is
+re-added nullable and left empty (no backfill), because the per-collection scoping cannot
+be reconstructed once the column is dropped.
+
+DuckDB builds its schema with `create_all`, so this migration only matters for tracked
+Postgres databases.
+
+Revision ID: 5855d824582d
+Revises: b1c2d3e4f5a6
+Create Date: 2026-08-24 14:45:04.339061
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "5855d824582d"
+down_revision: Union[str, Sequence[str], None] = "b1c2d3e4f5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _backfill_defaults()
+    op.drop_index(op.f("ix_embedding_model_collection_id"), table_name="embedding_model")
+    op.drop_constraint(
+        op.f("embedding_model_collection_id_fkey"), "embedding_model", type_="foreignkey"
+    )
+    op.drop_column("embedding_model", "collection_id")
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Lossy: the column is re-added nullable and left empty. The old per-collection scoping
+    cannot be reconstructed, so there is no backfill.
+    """
+    op.add_column("embedding_model", sa.Column("collection_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        op.f("embedding_model_collection_id_fkey"),
+        "embedding_model",
+        "collection",
+        ["collection_id"],
+        ["collection_id"],
+    )
+    op.create_index(
+        op.f("ix_embedding_model_collection_id"),
+        "embedding_model",
+        ["collection_id"],
+        unique=False,
+    )
+
+
+def _backfill_defaults() -> None:
+    """Seed one default per collection that still lacks one: its oldest embedding model.
+
+    Mirrors the backfill in `b1c2d3e4f5a6`. `DISTINCT ON` keeps the first row per
+    `collection_id` under the `ORDER BY`, so the `created_at ASC, embedding_model_id ASC`
+    tie-break selects the oldest model. `ON CONFLICT DO NOTHING` makes the rerun
+    idempotent: collections already seeded by PR1b or the write path are left untouched.
+    """
+    op.get_bind().execute(
+        sa.text(
+            """
+            INSERT INTO default_embedding_space (collection_id, embedding_model_id)
+            SELECT DISTINCT ON (collection_id) collection_id, embedding_model_id
+            FROM embedding_model
+            ORDER BY collection_id, created_at ASC, embedding_model_id ASC
+            ON CONFLICT (collection_id) DO NOTHING
+            """
+        )
+    )

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -15,7 +15,6 @@ class EmbeddingModelBase(SQLModel):
     parameter_count_in_mb: int | None = None
     embedding_model_hash: str = Field(default="", sa_column=Column(VARCHAR(128)))
     embedding_dimension: int
-    collection_id: UUID = Field(default=None, foreign_key="collection.collection_id", index=True)
 
 
 class EmbeddingModelCreate(EmbeddingModelBase):

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -44,7 +44,7 @@ from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.embedding_model import EmbeddingModelTable
+from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.evaluation_annotation_metric import (
     EvaluationAnnotationMetricTable,
 )
@@ -68,6 +68,10 @@ _MAP_SAMPLE = "deep_copy_map_sample"
 _MAP_TAG = "deep_copy_map_tag"
 _MAP_OBJECT_TRACK = "deep_copy_map_object_track"
 _MAP_ANNOTATION_LABEL = "deep_copy_map_annotation_label"
+# Embedding models are a shared global registry, so they are not duplicated. This map is
+# an identity map (old_id == new_id) scoped to the models with an embedding in the copied
+# samples; it lets _copy_sample_embeddings keep its embedding_model_id FK pointing at the
+# existing shared row.
 _MAP_EMBEDDING_MODEL = "deep_copy_map_embedding_model"
 _MAP_EVALUATION_RUN = "deep_copy_map_evaluation_run"
 
@@ -117,7 +121,7 @@ def deep_copy(
     _copy_tags(session=session, now=now)
     _copy_object_tracks(session=session, new_dataset_id=new_dataset_id)
     _copy_annotation_labels(session=session, new_dataset_id=new_dataset_id)
-    _copy_embedding_models(session=session, now=now)
+    _copy_default_embedding_space(session=session)
     _copy_samples(session=session, now=now)
     _copy_evaluation_runs(session=session, new_dataset_id=new_dataset_id, now=now)
 
@@ -190,11 +194,16 @@ def _build_id_maps(session: Session, old_dataset_id: UUID) -> None:
         where_sql="dataset_id = :old_dataset_id",
         params=dataset_params,
     )
+    # Identity map: embedding models are shared and not duplicated, so old_id == new_id.
+    # Scoped from sample_embedding (models with an embedding in the copied samples) since
+    # embedding_model no longer carries a collection_id.
     _create_id_map(
         session=session,
-        source_table="embedding_model",
+        source_table="sample_embedding",
         id_column="embedding_model_id",
-        where_sql=in_collection_map,
+        where_sql=f"sample_id IN (SELECT old_id FROM {_MAP_SAMPLE})",
+        map_table_name=_MAP_EMBEDDING_MODEL,
+        identity=True,
     )
     _create_id_map(
         session=session,
@@ -204,12 +213,14 @@ def _build_id_maps(session: Session, old_dataset_id: UUID) -> None:
     )
 
 
-def _create_id_map(
+def _create_id_map(  # noqa: PLR0913
     session: Session,
     source_table: str,
     id_column: str,
     where_sql: str,
     params: dict[str, Any] | None = None,
+    map_table_name: str | None = None,
+    identity: bool = False,
 ) -> None:
     """Create a temporary ``(old_id, new_id)`` table for in-scope rows of a source table.
 
@@ -219,17 +230,26 @@ def _create_id_map(
 
     Args:
         session: Database session.
-        source_table: Table to map ids for; also determines the temp table name.
-        id_column: Primary-key column whose values become ``old_id``.
+        source_table: Table to select the ids from; also determines the temp table name
+            unless ``map_table_name`` overrides it.
+        id_column: Column whose values become ``old_id``.
         where_sql: SQL predicate selecting the in-scope rows. An internal constant; any
             values are bound through ``params``.
         params: Bind parameters referenced by ``where_sql``.
+        map_table_name: Explicit temp table name, needed when it must not follow the
+            source table (e.g. a map built from ``sample_embedding`` but named for
+            embedding models).
+        identity: When True, ``new_id`` equals ``old_id`` (the entity is shared, not
+            duplicated) and ``SELECT DISTINCT`` deduplicates the ids; otherwise a fresh
+            ``gen_random_uuid()`` is assigned per row.
     """
-    map_name = f"deep_copy_map_{source_table}"
+    map_name = map_table_name or f"deep_copy_map_{source_table}"
+    new_id_expr = id_column if identity else "gen_random_uuid()"
+    distinct = "DISTINCT " if identity else ""
     session.execute(
         text(
             f"CREATE TEMPORARY TABLE {map_name} ON COMMIT DROP AS "
-            f"SELECT {id_column} AS old_id, gen_random_uuid() AS new_id "
+            f"SELECT {distinct}{id_column} AS old_id, {new_id_expr} AS new_id "
             f"FROM {source_table} WHERE {where_sql}"
         ),
         params or {},
@@ -436,22 +456,22 @@ def _copy_annotation_labels(session: Session, new_dataset_id: UUID) -> None:
     )
 
 
-def _copy_embedding_models(session: Session, now: datetime) -> None:
-    """Copy embedding models, remapping collection_id."""
-    src = _table(EmbeddingModelTable).alias("src")
-    map_model = _map(_MAP_EMBEDDING_MODEL)
+def _copy_default_embedding_space(session: Session) -> None:
+    """Copy each collection's default embedding space, remapping collection_id.
+
+    Embedding models are shared, so ``embedding_model_id`` is copied verbatim and points
+    at the same global row; only ``collection_id`` is remapped to the copied collection.
+    """
+    src = _table(DefaultEmbeddingSpaceTable).alias("src")
     map_collection = _map(_MAP_COLLECTION)
-    from_clause = src.join(map_model, map_model.c.old_id == src.c["embedding_model_id"]).join(
-        map_collection, map_collection.c.old_id == src.c["collection_id"]
-    )
+    from_clause = src.join(map_collection, map_collection.c.old_id == src.c["collection_id"])
     overrides = {
-        "embedding_model_id": map_model.c.new_id,
         "collection_id": map_collection.c.new_id,
-        "created_at": literal(now),
+        "embedding_model_id": src.c["embedding_model_id"],
     }
     _copy_table(
         session=session,
-        target=EmbeddingModelTable,
+        target=DefaultEmbeddingSpaceTable,
         source=src,
         from_clause=from_clause,
         overrides=overrides,

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -37,7 +37,7 @@ from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.embedding_model import EmbeddingModelTable
+from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricTable
@@ -119,7 +119,10 @@ def delete_dataset(
     _delete_samples(session=session, dataset_id=dataset_id)
     _delete_annotation_labels(session=session, dataset_id=dataset_id)
     _delete_tags(session=session, dataset_id=dataset_id)
-    _delete_embedding_models(session=session, dataset_id=dataset_id)
+    # Embedding models are a shared global registry and survive the delete (only the
+    # per-collection default association is removed). The default_embedding_space rows
+    # must go before the collections they reference.
+    _delete_default_embedding_spaces(session=session, dataset_id=dataset_id)
     _delete_object_tracks(session=session, dataset_id=dataset_id)
     _delete_evaluation_runs(session=session, dataset_id=dataset_id)
     _delete_export_jobs(session=session, dataset_id=dataset_id)
@@ -317,11 +320,15 @@ def _delete_tags(session: Session, dataset_id: UUID) -> None:
     )
 
 
-def _delete_embedding_models(session: Session, dataset_id: UUID) -> None:
-    """Delete embedding models for the dataset's collections."""
+def _delete_default_embedding_spaces(session: Session, dataset_id: UUID) -> None:
+    """Delete the default embedding space rows for the dataset's collections.
+
+    The referenced embedding models are shared and left in place (they may be the default
+    of other collections); only the per-collection association is removed.
+    """
     session.exec(
-        delete(EmbeddingModelTable).where(
-            col(EmbeddingModelTable.collection_id).in_(_collection_ids_subquery(dataset_id))
+        delete(DefaultEmbeddingSpaceTable).where(
+            col(DefaultEmbeddingSpaceTable.collection_id).in_(_collection_ids_subquery(dataset_id))
         ),
         execution_options=_DELETE_EXECUTION_OPTIONS,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -11,16 +11,15 @@ from sqlmodel import SQLModel
 # - export_job is handled by delete_dataset only (its collection_id FK must be cleared
 #   before the collection is deleted); deep_copy intentionally leaves it alone since a job
 #   is a transient download token, not data worth duplicating.
+# - default_embedding_space is handled by both (its collection_id is remapped on copy and
+#   its rows are deleted before the collections they reference).
 _HANDLED_TABLES_COUNT = 25
 
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)
 # - two_dim_embeddings (cached projections, regenerated as needed)
-# - default_embedding_space (populated, but not yet handled by deep_copy/delete_dataset — see TODO)
-# TODO(Michal, 08/2026): wire default_embedding_space into deep_copy and delete_dataset,
-# then move it into _HANDLED_TABLES_COUNT. Until then, on Postgres delete_dataset raises an
-# FK error for any dataset with embeddings, and deep_copy silently drops the copied
-# collection's default.
+# - embedding_model (a shared global registry, not scoped to a collection: deep_copy reuses
+#   the existing rows and delete_dataset leaves them in place)
 _EXCLUDED_TABLES_COUNT = 3
 
 _TOTAL_TABLES_COUNT = _HANDLED_TABLES_COUNT + _EXCLUDED_TABLES_COUNT

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -10,6 +10,8 @@ from lightly_studio.models.embedding_model import (
     EmbeddingModelCreate,
     EmbeddingModelTable,
 )
+from lightly_studio.models.sample import SampleTable
+from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 
 
 def create(session: Session, embedding_model: EmbeddingModelCreate) -> EmbeddingModelTable:
@@ -25,7 +27,6 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
     """Retrieve an existing EmbeddingModel by hash or create a new one if it does not exist."""
     db_model = get_by_model_hash(
         session=session,
-        collection_id=embedding_model.collection_id,
         embedding_model_hash=embedding_model.embedding_model_hash,
     )
     if db_model is None:
@@ -44,10 +45,23 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
 
 
 def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[EmbeddingModelTable]:
-    """Retrieve all embedding models."""
+    """Retrieve the embedding models that have an embedding in the collection.
+
+    Embedding models are a global registry shared across collections, so a model belongs
+    to a collection only through the samples it has embedded. This joins
+    ``sample_embedding`` to ``sample`` and keeps the distinct models whose embeddings
+    belong to a sample in the collection.
+    """
     embedding_models = session.exec(
         select(EmbeddingModelTable)
-        .where(EmbeddingModelTable.collection_id == collection_id)
+        .join(
+            SampleEmbeddingTable,
+            col(SampleEmbeddingTable.embedding_model_id)
+            == col(EmbeddingModelTable.embedding_model_id),
+        )
+        .join(SampleTable, col(SampleTable.sample_id) == col(SampleEmbeddingTable.sample_id))
+        .where(col(SampleTable.collection_id) == collection_id)
+        .distinct()
         .order_by(col(EmbeddingModelTable.created_at).asc())
     ).all()
     return list(embedding_models)
@@ -62,14 +76,15 @@ def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable
     ).one_or_none()
 
 
-def get_by_model_hash(
-    session: Session, collection_id: UUID, embedding_model_hash: str
-) -> EmbeddingModelTable | None:
-    """Retrieve a single embedding model by hash and collection."""
+def get_by_model_hash(session: Session, embedding_model_hash: str) -> EmbeddingModelTable | None:
+    """Retrieve a single embedding model by hash.
+
+    Embedding models are deduplicated globally by hash, so the same weights map to a
+    single shared row regardless of collection.
+    """
     query = select(EmbeddingModelTable).where(
         EmbeddingModelTable.embedding_model_hash == embedding_model_hash
     )
-    query = query.where(EmbeddingModelTable.collection_id == collection_id)
     return session.exec(query).one_or_none()
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
@@ -6,11 +6,11 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import ColumnElement
-from sqlmodel import Session, col, select
+from sqlmodel import Session, col
 
 from lightly_studio.database import db_vector
-from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.resolvers import default_embedding_space_resolver
 from lightly_studio.type_definitions import QueryType
 
 
@@ -27,11 +27,9 @@ def get_distance_expression(
     if not text_embedding:
         return None, None
 
-    embedding_model_id = session.exec(
-        select(EmbeddingModelTable.embedding_model_id)
-        .where(EmbeddingModelTable.collection_id == collection_id)
-        .limit(1)
-    ).first()
+    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+        session=session, collection_id=collection_id
+    )
 
     if not embedding_model_id:
         return None, None

--- a/lightly_studio/tests/benchmarks/deep_copy_benchmark.py
+++ b/lightly_studio/tests/benchmarks/deep_copy_benchmark.py
@@ -160,7 +160,6 @@ def _generate_dataset(config: GenerationConfig) -> UUID:
         embedding_model = embedding_model_resolver.create(
             session=session,
             embedding_model=EmbeddingModelCreate(
-                collection_id=collection.collection_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/benchmarks/delete_dataset_benchmark.py
+++ b/lightly_studio/tests/benchmarks/delete_dataset_benchmark.py
@@ -169,7 +169,6 @@ def _generate_dataset(config: GenerationConfig) -> UUID:
         embedding_model = embedding_model_resolver.create(
             session=session,
             embedding_model=EmbeddingModelCreate(
-                collection_id=collection.collection_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/benchmarks/embedding_io_benchmark.py
+++ b/lightly_studio/tests/benchmarks/embedding_io_benchmark.py
@@ -185,7 +185,6 @@ def _setup(config: BenchmarkConfig) -> tuple[list[UUID], UUID]:
         embedding_model = embedding_model_resolver.create(
             session=session,
             embedding_model=EmbeddingModelCreate(
-                collection_id=collection.collection_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/benchmarks/gui_benchmark.py
+++ b/lightly_studio/tests/benchmarks/gui_benchmark.py
@@ -398,7 +398,6 @@ def _resolve_embedding_model(session: Session, collection_id: UUID) -> tuple[UUI
     synthetic_model = embedding_model_resolver.create(
         session=session,
         embedding_model=EmbeddingModelCreate(
-            collection_id=collection_id,
             name=DEFAULT_EMBEDDING_MODEL_NAME,
             embedding_dimension=DEFAULT_EMBEDDING_DIM,
         ),

--- a/lightly_studio/tests/benchmarks/sample_embedding_lookup_benchmark.py
+++ b/lightly_studio/tests/benchmarks/sample_embedding_lookup_benchmark.py
@@ -224,7 +224,6 @@ def _setup(config: BenchmarkConfig) -> tuple[list[UUID], UUID, UUID]:
         embedding_model = embedding_model_resolver.create(
             session=session,
             embedding_model=EmbeddingModelCreate(
-                collection_id=collection.collection_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -231,10 +231,9 @@ def collections(db_session: Session) -> list[CollectionTable]:
 
 
 @pytest.fixture
-def embedding_model_input(collection: CollectionTable) -> EmbeddingModelCreate:
+def embedding_model_input() -> EmbeddingModelCreate:
     """Create an EmbeddingModelCreate instance."""
     return EmbeddingModelCreate(
-        collection_id=collection.collection_id,
         embedding_dimension=3,
         name="test_model",
     )

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import numpy as np
 import pytest
@@ -88,10 +88,9 @@ def test_register_multiple_models(
 
     # Register a second model.
     class FakeEmbeddingGenerator(ImageEmbeddingGenerator):
-        def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+        def get_embedding_model_input(self) -> EmbeddingModelCreate:
             return EmbeddingModelCreate(
                 name="Fake",
-                collection_id=collection_id,
                 embedding_model_hash="fake_hash",
                 parameter_count_in_mb=50,
                 embedding_dimension=5,
@@ -132,8 +131,6 @@ def test_register_multiple_models(
     assert len(stored_models) == 2
     model_names = {model.name for model in stored_models}
     assert model_names == {"Random", "Fake"}
-    # Verify both models are associated with the same collection
-    assert all(model.collection_id == collection.collection_id for model in stored_models)
 
 
 def test_embed_text_with_default_model(
@@ -514,8 +511,8 @@ def test_load_or_get_default_model__shares_generator_across_collections(
 ) -> None:
     """An annotation child collection reuses the parent's loaded generator.
 
-    The generator weights are loaded once, but each collection still gets its
-    own embedding-model record and id.
+    The generator weights are loaded once. Embedding models are deduplicated globally by
+    hash, so both collections resolve to the same shared embedding-model record and id.
     """
     image_collection = create_collection(session=db_session, sample_type=SampleType.IMAGE)
     annotation_collection = create_collection(
@@ -544,8 +541,8 @@ def test_load_or_get_default_model__shares_generator_across_collections(
     mock_load.assert_called_once_with(sample_type=SampleType.IMAGE)
     assert manager._models[image_model_id] is manager._models[annotation_model_id]
 
-    # Each collection still owns a distinct embedding-model record.
-    assert image_model_id != annotation_model_id
+    # Global dedup by hash: both collections share the same embedding-model record.
+    assert image_model_id == annotation_model_id
 
 
 def test_load_or_get_default_model__cant_load(
@@ -613,10 +610,9 @@ def test_set_default_embedding_model_falls_back_to_env_for_unregistered_slot(
     class ImageOnlyGenerator:
         # Implements the image protocol but not embed_videos, so only the image
         # slot is overridden.
-        def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+        def get_embedding_model_input(self) -> EmbeddingModelCreate:
             return EmbeddingModelCreate(
                 name="ImageOnly",
-                collection_id=collection_id,
                 embedding_dimension=3,
                 embedding_model_hash="image_only_model",
             )
@@ -806,10 +802,9 @@ class TextOnlyEmbeddingGenerator:
     def __init__(self, dimension: int = 3) -> None:
         self._dimension = dimension
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(self) -> EmbeddingModelCreate:
         return EmbeddingModelCreate(
             name="TextOnly",
-            collection_id=collection_id,
             embedding_dimension=self._dimension,
             embedding_model_hash="text_only_model",
         )

--- a/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import uuid
 from pathlib import Path
 
 import numpy as np
@@ -18,12 +17,10 @@ FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 class TestMobileCLIPEmbeddingGenerator:
     def test_get_embedding_model_input(self) -> None:
         mobileclip = MobileCLIPEmbeddingGenerator()
-        collection_id = uuid.uuid4()
-        embedding_model_input = mobileclip.get_embedding_model_input(collection_id=collection_id)
+        embedding_model_input = mobileclip.get_embedding_model_input()
 
         assert embedding_model_input.name == "mobileclip_s0"
         assert embedding_model_input.embedding_dimension == 512
-        assert embedding_model_input.collection_id == collection_id
         assert embedding_model_input.embedding_model_hash != ""
 
     def test_embed_text(self) -> None:

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import uuid
 from pathlib import Path
 
 import numpy as np
@@ -20,14 +19,10 @@ FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 class TestPerceptionEncoderEmbeddingGenerator:
     def test_get_embedding_model_input(self) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
-        collection_id = uuid.uuid4()
-        embedding_model_input = perception_encoder.get_embedding_model_input(
-            collection_id=collection_id
-        )
+        embedding_model_input = perception_encoder.get_embedding_model_input()
 
         assert embedding_model_input.name == "PE-Core-T16-384"
         assert embedding_model_input.embedding_dimension == 512
-        assert embedding_model_input.collection_id == collection_id
         assert embedding_model_input.embedding_model_hash != ""
 
     def test_embed_text(self) -> None:

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -22,6 +22,7 @@ from lightly_studio.models.embedding_model import (
 )
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import embedding_model_resolver
+from tests.helpers_resolvers import create_image, create_sample_embedding
 
 
 @pytest.fixture
@@ -53,14 +54,28 @@ def fine_tuning_embeddings() -> list[SampleEmbeddingTable]:
 
 @pytest.fixture
 def embedding_model(db_session: Session, collection: CollectionTable) -> EmbeddingModelTable:
-    """Fixture to create an embedding model."""
-    embedding_model = EmbeddingModelCreate(
-        embedding_model_hash="mock_hash",
-        name="test_model",
-        collection_id=collection.collection_id,
-        embedding_dimension=3,
+    """Fixture to create an embedding model with an embedding in the collection.
+
+    Embedding models are a shared global registry; they belong to a collection only
+    through the samples they embedded, so the model is given one embedding in the
+    collection to make ``get_all_by_collection_id`` resolve it.
+    """
+    embedding_model = embedding_model_resolver.create(
+        session=db_session,
+        embedding_model=EmbeddingModelCreate(
+            embedding_model_hash="mock_hash",
+            name="test_model",
+            embedding_dimension=3,
+        ),
     )
-    return embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)
+    image = create_image(session=db_session, collection_id=collection.collection_id)
+    create_sample_embedding(
+        session=db_session,
+        sample_id=image.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[0.1, 0.2, 0.3],
+    )
+    return embedding_model
 
 
 @pytest.fixture

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -307,24 +307,28 @@ def create_embedding_model(  # noqa: PLR0913
     embedding_dimension: int = 128,
     set_as_default: bool = False,
 ) -> EmbeddingModelTable:
-    """Helper function to create a embedding model.
+    """Helper function to create an embedding model.
 
-    With ``set_as_default`` the model is recorded as the collection's default embedding
-    model, so ``default_embedding_space_resolver.get_by_collection_id`` resolves to it. It
-    is off by default to avoid the ``default_embedding_space`` foreign key blocking model
-    or collection deletes in tests that do not need a default.
+    Mirrors ``embedding_manager.register_embedding_model``: the model is recorded as the
+    collection's default embedding space when ``set_as_default`` is set or the collection
+    has no default yet, so the first model created for a collection becomes its default.
     """
     model = embedding_model_resolver.create(
         session=session,
         embedding_model=EmbeddingModelCreate(
-            collection_id=collection_id,
             name=embedding_model_name,
             embedding_model_hash=embedding_model_hash,
             parameter_count_in_mb=parameter_count_in_mb,
             embedding_dimension=embedding_dimension,
         ),
     )
-    if set_as_default:
+    has_default = (
+        default_embedding_space_resolver.get_by_collection_id(
+            session=session, collection_id=collection_id
+        )
+        is not None
+    )
+    if set_as_default or not has_default:
         default_embedding_space_resolver.set_default(
             session=session,
             collection_id=collection_id,
@@ -419,14 +423,11 @@ def fill_db_with_samples_and_embeddings(
     """Creates a collection and fills it with sample and embeddings."""
     collection = create_collection(session)
     embedding_models = []
-    for index, embedding_model_name in enumerate(embedding_model_names):
+    for embedding_model_name in embedding_model_names:
         embedding_model = create_embedding_model(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=embedding_model_name,
-            # The first model is the collection default, matching production and the
-            # queries that resolve the default embedding space (e.g. embeddings2d).
-            set_as_default=index == 0,
         )
         embedding_models.append(embedding_model)
     for i in range(n_samples):
@@ -464,14 +465,11 @@ def fill_db_with_video_samples_and_embeddings(
     """
     collection = create_collection(session=session, sample_type=SampleType.VIDEO)
     embedding_models = []
-    for index, embedding_model_name in enumerate(embedding_model_names):
+    for embedding_model_name in embedding_model_names:
         embedding_model = create_embedding_model(
             session=session,
             collection_id=collection.collection_id,
             embedding_model_name=embedding_model_name,
-            # The first model is the collection default, matching production and the
-            # queries that resolve the default embedding space (e.g. embeddings2d).
-            set_as_default=index == 0,
         )
         embedding_models.append(embedding_model)
     for i in range(n_samples):

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -316,14 +316,15 @@ def test_deep_copy__with_embeddings(db_session: Session) -> None:
         copy_name="copied",
     )
 
-    # Assert - embedding model is copied with new ID
+    # Assert - the embedding model is a shared global row, reused (not duplicated) by the
+    # copy, so the copied collection resolves the very same embedding_model_id.
     copied_embedding_models = embedding_model_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=copied.collection_id,
     )
     assert len(copied_embedding_models) == 1
     copied_model = copied_embedding_models[0]
-    assert copied_model.embedding_model_id != embedding_model.embedding_model_id
+    assert copied_model.embedding_model_id == embedding_model.embedding_model_id
     assert copied_model.name == embedding_model.name
     assert copied_model.embedding_model_hash == embedding_model.embedding_model_hash
     assert copied_model.embedding_dimension == embedding_model.embedding_dimension

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -21,7 +21,7 @@ from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.embedding_model import EmbeddingModelTable
+from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
 from lightly_studio.models.evaluation_sample_metric import (
@@ -107,8 +107,12 @@ def _dataset_table_counts(session: Session, dataset_id: UUID) -> dict[str, int]:
             SampleGroupLinkTable, col(SampleGroupLinkTable.sample_id).in_(sample_ids)
         ),
         "tag": count(TagTable, col(TagTable.collection_id).in_(collection_ids)),
-        "embedding_model": count(
-            EmbeddingModelTable, col(EmbeddingModelTable.collection_id).in_(collection_ids)
+        # Embedding models are a shared global registry (not scoped to a dataset), so they
+        # are not counted here. The per-collection default_embedding_space rows are what
+        # deep_copy duplicates and delete_dataset removes.
+        "default_embedding_space": count(
+            DefaultEmbeddingSpaceTable,
+            col(DefaultEmbeddingSpaceTable.collection_id).in_(collection_ids),
         ),
         "annotation_collection_coverage": count(
             AnnotationCollectionCoverageTable,
@@ -263,7 +267,7 @@ def test_deep_copy_then_delete_round_trip(db_session: Session) -> None:
         "metadata",
         "tag",
         "sample_tag_link",
-        "embedding_model",
+        "default_embedding_space",
         "annotation_label",
         "object_track",
         "evaluation_run",

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -1,14 +1,42 @@
 from __future__ import annotations
 
+from uuid import UUID
+
 import pytest
 from sqlmodel import Session
 
 from lightly_studio.models.embedding_model import EmbeddingModelCreate
-from lightly_studio.resolvers import embedding_model_resolver
+from lightly_studio.resolvers import (
+    default_embedding_space_resolver,
+    embedding_model_resolver,
+)
 from tests.helpers_resolvers import (
     create_collection,
     create_embedding_model,
+    create_image,
+    create_sample_embedding,
 )
+
+
+def _attach_model_to_collection(
+    session: Session,
+    collection_id: UUID,
+    embedding_model_id: UUID,
+    file_path_abs: str,
+) -> None:
+    """Give an embedding model an embedding in a collection.
+
+    Embedding models are a shared global registry; they belong to a collection only
+    through the samples they embedded. This creates one image sample and one embedding so
+    ``get_all_by_collection_id`` and ``get_by_name`` see the model in the collection.
+    """
+    image = create_image(session=session, collection_id=collection_id, file_path_abs=file_path_abs)
+    create_sample_embedding(
+        session=session,
+        sample_id=image.sample_id,
+        embedding_model_id=embedding_model_id,
+        embedding=[0.0, 0.0],
+    )
 
 
 def test_create_embedding_model(db_session: Session) -> None:
@@ -30,21 +58,61 @@ def test_read_embedding_models(db_session: Session) -> None:
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_1",
+        embedding_model_hash="hash_1",
     )
     embedding_model_2 = create_embedding_model(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_2",
+        embedding_model_hash="hash_2",
+    )
+    _attach_model_to_collection(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model_1.embedding_model_id,
+        file_path_abs="sample_1.jpg",
+    )
+    _attach_model_to_collection(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model_2.embedding_model_id,
+        file_path_abs="sample_2.jpg",
     )
 
-    # Get all embedding models of a collection.
+    # Get all embedding models with an embedding in the collection, oldest first.
     embedding_models = embedding_model_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection_id
     )
     assert len(embedding_models) == 2
-
     assert embedding_models[0].embedding_model_id == embedding_model_1.embedding_model_id
     assert embedding_models[1].embedding_model_id == embedding_model_2.embedding_model_id
+
+
+def test_read_embedding_models__scoped_to_collection(db_session: Session) -> None:
+    """A model is listed for a collection only if it has an embedding there."""
+    collection_1 = create_collection(session=db_session, collection_name="collection_1")
+    collection_2 = create_collection(session=db_session, collection_name="collection_2")
+
+    model = create_embedding_model(
+        session=db_session,
+        collection_id=collection_1.collection_id,
+        embedding_model_name="shared_model",
+    )
+    _attach_model_to_collection(
+        session=db_session,
+        collection_id=collection_1.collection_id,
+        embedding_model_id=model.embedding_model_id,
+        file_path_abs="sample_1.jpg",
+    )
+
+    models_1 = embedding_model_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection_1.collection_id
+    )
+    models_2 = embedding_model_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection_2.collection_id
+    )
+    assert [m.embedding_model_id for m in models_1] == [model.embedding_model_id]
+    assert models_2 == []
 
 
 def test_read_embedding_model(db_session: Session) -> None:
@@ -67,12 +135,16 @@ def test_delete_embedding_model(db_session: Session) -> None:
 
     embedding_model = create_embedding_model(session=db_session, collection_id=collection_id)
 
-    # Delete the embedding model.
+    # The first model becomes the collection default; its default_embedding_space row must
+    # be removed before the model can be deleted (foreign key).
+    default_embedding_space_resolver.delete_by_collection_id(
+        session=db_session, collection_id=collection_id
+    )
+
     embedding_model_resolver.delete(
         session=db_session, embedding_model_id=embedding_model.embedding_model_id
     )
 
-    # Assert the embedding model was deleted.
     embedding_model_deleted = embedding_model_resolver.get_by_id(
         session=db_session, embedding_model_id=embedding_model.embedding_model_id
     )
@@ -97,64 +169,54 @@ def test_get_by_model_hash(db_session: Session) -> None:
     )
 
     embedding_model = embedding_model_resolver.get_by_model_hash(
-        session=db_session, embedding_model_hash="hash_1", collection_id=collection_id
+        session=db_session, embedding_model_hash="hash_1"
     )
     assert embedding_model is not None
     assert embedding_model.name == embedding_model_1.name
 
     embedding_model = embedding_model_resolver.get_by_model_hash(
-        session=db_session, embedding_model_hash="hash_3", collection_id=collection_id
+        session=db_session, embedding_model_hash="hash_3"
     )
     assert embedding_model is None
 
 
-def test_get_by_model_hash__with_collection_id(db_session: Session) -> None:
+def test_get_by_model_hash__dedup_across_collections(db_session: Session) -> None:
+    """Models are deduplicated globally by hash: same weights map to one shared row."""
     collection_1 = create_collection(session=db_session, collection_name="collection_1")
     collection_2 = create_collection(session=db_session, collection_name="collection_2")
 
-    # Create models with same hash in different collections
-    model_1 = create_embedding_model(
+    model = create_embedding_model(
         session=db_session,
         collection_id=collection_1.collection_id,
-        embedding_model_name="model_in_collection_1",
-        embedding_model_hash="same_hash",
-    )
-    model_2 = create_embedding_model(
-        session=db_session,
-        collection_id=collection_2.collection_id,
-        embedding_model_name="model_in_collection_2",
+        embedding_model_name="shared_model",
         embedding_model_hash="same_hash",
     )
 
-    # With collection_id, returns the correct model
-    result = embedding_model_resolver.get_by_model_hash(
+    # A second collection re-using the same hash resolves the same shared row.
+    reused = embedding_model_resolver.get_or_create(
         session=db_session,
-        embedding_model_hash="same_hash",
-        collection_id=collection_1.collection_id,
+        embedding_model=EmbeddingModelCreate(
+            name="shared_model",
+            embedding_model_hash="same_hash",
+            parameter_count_in_mb=model.parameter_count_in_mb,
+            embedding_dimension=model.embedding_dimension,
+        ),
     )
-    assert result is not None
-    assert result.embedding_model_id == model_1.embedding_model_id
-    assert result.embedding_model_hash == "same_hash"
-    assert result.collection_id == collection_1.collection_id
+    assert reused.embedding_model_id == model.embedding_model_id
 
     result = embedding_model_resolver.get_by_model_hash(
-        session=db_session,
-        embedding_model_hash="same_hash",
-        collection_id=collection_2.collection_id,
+        session=db_session, embedding_model_hash="same_hash"
     )
     assert result is not None
-    assert result.embedding_model_id == model_2.embedding_model_id
-    assert result.embedding_model_hash == "same_hash"
-    assert result.collection_id == collection_2.collection_id
+    assert result.embedding_model_id == model.embedding_model_id
 
-    # With non-matching collection_id, returns None
-    collection_3 = create_collection(session=db_session, collection_name="collection_3")
-    result_3 = embedding_model_resolver.get_by_model_hash(
+    # The collections share a single embedding model row.
+    default_1 = default_embedding_space_resolver.set_default(
         session=db_session,
-        embedding_model_hash="same_hash",
-        collection_id=collection_3.collection_id,
+        collection_id=collection_2.collection_id,
+        embedding_model_id=reused.embedding_model_id,
     )
-    assert result_3 is None
+    assert default_1.embedding_model_id == model.embedding_model_id
 
 
 def test_get_by_name__none_with_single_model(db_session: Session) -> None:
@@ -166,6 +228,12 @@ def test_get_by_name__none_with_single_model(db_session: Session) -> None:
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_1",
+    )
+    _attach_model_to_collection(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        file_path_abs="sample_1.jpg",
     )
 
     result = embedding_model_resolver.get_by_name(
@@ -180,15 +248,29 @@ def test_get_by_name__none_with_multiple_models(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    create_embedding_model(
+    model_1 = create_embedding_model(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_1",
+        embedding_model_hash="hash_1",
     )
-    create_embedding_model(
+    model_2 = create_embedding_model(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_2",
+        embedding_model_hash="hash_2",
+    )
+    _attach_model_to_collection(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=model_1.embedding_model_id,
+        file_path_abs="sample_1.jpg",
+    )
+    _attach_model_to_collection(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=model_2.embedding_model_id,
+        file_path_abs="sample_2.jpg",
     )
 
     with pytest.raises(
@@ -223,11 +305,25 @@ def test_get_by_name__existing_name(db_session: Session) -> None:
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_1",
+        embedding_model_hash="hash_1",
     )
     embedding_model_2 = create_embedding_model(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_2",
+        embedding_model_hash="hash_2",
+    )
+    _attach_model_to_collection(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model_1.embedding_model_id,
+        file_path_abs="sample_1.jpg",
+    )
+    _attach_model_to_collection(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model_2.embedding_model_id,
+        file_path_abs="sample_2.jpg",
     )
 
     result = embedding_model_resolver.get_by_name(
@@ -248,10 +344,16 @@ def test_get_by_name__nonexistent_name(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    create_embedding_model(
+    model = create_embedding_model(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_1",
+    )
+    _attach_model_to_collection(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_id=model.embedding_model_id,
+        file_path_abs="sample_1.jpg",
     )
 
     with pytest.raises(ValueError, match=r"Embedding model with name `nonexistent` not found."):
@@ -262,10 +364,7 @@ def test_get_by_name__nonexistent_name(db_session: Session) -> None:
 
 def test_get_or_create__creates_new_model(db_session: Session) -> None:
     """get_or_create should insert a model when none exists for the hash."""
-    collection = create_collection(session=db_session)
-
     model_create = EmbeddingModelCreate(
-        collection_id=collection.collection_id,
         name="Model Name",
         embedding_model_hash="model_hash",
         parameter_count_in_mb=200,
@@ -279,7 +378,6 @@ def test_get_or_create__creates_new_model(db_session: Session) -> None:
     assert created.name == "Model Name"
     assert created.parameter_count_in_mb == 200
     assert created.embedding_dimension == 768
-    assert created.collection_id == collection.collection_id
 
 
 def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
@@ -295,7 +393,6 @@ def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
     )
 
     model_create = EmbeddingModelCreate(
-        collection_id=collection.collection_id,
         name="Model Name",
         embedding_model_hash="model_hash",
         parameter_count_in_mb=10,
@@ -307,10 +404,6 @@ def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
     )
 
     assert reused.embedding_model_id == existing.embedding_model_id
-    models = embedding_model_resolver.get_all_by_collection_id(
-        session=db_session, collection_id=collection.collection_id
-    )
-    assert len(models) == 1
 
 
 def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:
@@ -326,7 +419,6 @@ def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:
     )
 
     conflicting_model_create = EmbeddingModelCreate(
-        collection_id=collection.collection_id,
         name="Model Name",
         embedding_model_hash="model_hash",
         parameter_count_in_mb=2000,
@@ -342,12 +434,9 @@ def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:
         )
 
 
-def test_get_or_create__same_hash_different_collections(db_session: Session) -> None:
-    collection_1 = create_collection(session=db_session, collection_name="collection_1")
-    collection_2 = create_collection(session=db_session, collection_name="collection_2")
-
+def test_get_or_create__same_hash_shared_across_collections(db_session: Session) -> None:
+    """Same hash used from two collections resolves to a single shared model row."""
     model_create_1 = EmbeddingModelCreate(
-        collection_id=collection_1.collection_id,
         name="Test Model",
         embedding_model_hash="same_hash",
         parameter_count_in_mb=10,
@@ -358,7 +447,6 @@ def test_get_or_create__same_hash_different_collections(db_session: Session) -> 
     )
 
     model_create_2 = EmbeddingModelCreate(
-        collection_id=collection_2.collection_id,
         name="Test Model",
         embedding_model_hash="same_hash",
         parameter_count_in_mb=10,
@@ -368,17 +456,5 @@ def test_get_or_create__same_hash_different_collections(db_session: Session) -> 
         session=db_session, embedding_model=model_create_2
     )
 
-    # Should be different models
-    assert model_1.embedding_model_id != model_2.embedding_model_id
-    assert model_1.collection_id == collection_1.collection_id
-    assert model_2.collection_id == collection_2.collection_id
-
-    # Each collection should have exactly one model
-    models_1 = embedding_model_resolver.get_all_by_collection_id(
-        session=db_session, collection_id=collection_1.collection_id
-    )
-    models_2 = embedding_model_resolver.get_all_by_collection_id(
-        session=db_session, collection_id=collection_2.collection_id
-    )
-    assert len(models_1) == 1
-    assert len(models_2) == 1
+    # The same weights map to one shared row.
+    assert model_1.embedding_model_id == model_2.embedding_model_id


### PR DESCRIPTION
## What has changed and why?

Remove `collection_id` from `embedding_model`. Models become a shared global registry, deduplicated by hash. A collection's default embedding space lives only in `default_embedding_space` (added in #2030, backfilled in #2031). Completes LIG-10548.

- Dedup is global by hash — same weights, one shared row.
- `get_all_by_collection_id` re-derived from `sample_embedding`; similarity resolves the model via `default_embedding_space`.
- Deep-copy shares model rows (identity-mapped) and copies the default mapping instead of duplicating models.
- Delete-cascade drops the collection's default row; shared models survive (orphans acceptable, GC deferred).
- Migration re-verifies the backfill, then drops the column + index. Downgrade is lossy (non-default associations not reconstructable).

## How has it been tested?

- `make static-checks`, `make test` (DuckDB) — pass.
- `make migration-check-postgresql` — no new upgrade operations.
- `make test-postgres` — pass, except one pre-existing failure unrelated to this change (verified identical on `main`).

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)