### PR TITLE
Expose path->sample-id mapping from media ingestion

### DIFF
--- a/lightly_studio/src/lightly_studio/core/image/add_annotations.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_annotations.py
@@ -8,7 +8,6 @@ from collections.abc import Mapping
 from pathlib import Path
 from uuid import UUID
 
-import fsspec
 import yaml
 from labelformat.model.instance_segmentation import (
     ImageInstanceSegmentation,
@@ -22,7 +21,7 @@ from labelformat.utils import ImageDimensionError
 from sqlmodel import Session
 from tqdm import tqdm
 
-from lightly_studio.core import labelformat_helpers
+from lightly_studio.core import labelformat_helpers, path_utils
 from lightly_studio.models.annotation.annotation_base import AnnotationCreate
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import (
@@ -81,7 +80,7 @@ def add_annotations_from_labelformat(  # noqa: PLR0913
         A list of file_path_abs values from input_labels that had no matching sample in
         the collection. An empty list means all images were found.
     """
-    images_root_abs = normalize_images_root(images_root=images_root)
+    images_root_abs = path_utils.normalize_path_root(images_root)
 
     # Some formats (e.g. YOLO) open every image during the get_labels() scan. Set a skip+log hook so
     # a broken image is skipped instead of aborting the ingest.
@@ -126,24 +125,6 @@ def add_annotations_from_labelformat(  # noqa: PLR0913
         )
 
     return missing_paths
-
-
-def normalize_images_root(images_root: PathLike) -> str:
-    """Return absolute local roots and preserve remote roots.
-
-    Local paths are returned in posix form (forward slashes) so they can be
-    safely joined with `posixpath.join` and compared across platforms. On
-    Windows, `str(Path(...).absolute())` yields backslashes that, when joined
-    with posix-separated relative paths, produce mixed-separator strings that
-    fail to match what was stored at ingestion time.
-    """
-    images_root_str = str(images_root)
-    protocol, _ = fsspec.core.split_protocol(images_root_str)
-    if protocol is None:
-        return Path(images_root_str).absolute().as_posix()
-    if protocol == "file":
-        return Path(fsspec.core.strip_protocol(images_root_str)).absolute().as_posix()
-    return images_root_str
 
 
 def resolve_yolo_splits(data_yaml: Path, input_split: str | None) -> list[str]:

--- a/lightly_studio/src/lightly_studio/core/image/add_images.py
+++ b/lightly_studio/src/lightly_studio/core/image/add_images.py
@@ -22,6 +22,7 @@ from labelformat.utils import ImageDimensionError
 from sqlmodel import Session
 from tqdm import tqdm
 
+from lightly_studio.core import path_utils
 from lightly_studio.core.file_outcome_report import (
     BROKEN_IMAGE_ERRORS,
     AlreadyPresentInputFileError,
@@ -76,7 +77,7 @@ def load_into_dataset_from_paths(
     root_collection_id: UUID,
     image_paths: Iterable[str],
     show_progress: bool = True,
-) -> list[UUID]:
+) -> dict[str, UUID]:
     """Load images from file paths into the dataset.
 
     Args:
@@ -86,7 +87,9 @@ def load_into_dataset_from_paths(
         show_progress: Whether to display a progress bar and final summary of loading results.
 
     Returns:
-        A list of UUIDs of the created samples.
+        A mapping from normalized `file_path_abs` to the UUID of the created sample. A
+        path that was skipped (already present, missing, or broken) has no entry, so the
+        mapping is not guaranteed to cover every input path.
 
     Raises:
         AllInputFilesFailedError: If at least one file was attempted and every
@@ -94,9 +97,7 @@ def load_into_dataset_from_paths(
     """
     # Normalize all paths up front so the database check can happen once, before the
     # main processing loop, instead of once per batch.
-    normalized_paths = [
-        add_annotations.normalize_images_root(image_path) for image_path in image_paths
-    ]
+    normalized_paths = [path_utils.normalize_path_root(image_path) for image_path in image_paths]
     # The set starts with paths already in the database and grows with paths seen in this
     # call, so both already-present and in-run duplicate paths are skipped before batching.
     seen_or_existing_paths = _get_existing_paths_set(
@@ -106,7 +107,7 @@ def load_into_dataset_from_paths(
     )
 
     samples_to_create: list[ImageCreate] = []
-    created_sample_ids: list[UUID] = []
+    created_path_to_id: dict[str, UUID] = {}
 
     report = FileOutcomeReport()
 
@@ -152,22 +153,26 @@ def load_into_dataset_from_paths(
 
             # Process batch when it reaches SAMPLE_BATCH_SIZE
             if len(samples_to_create) >= SAMPLE_BATCH_SIZE:
-                created_path_to_id = _create_batch_samples(
-                    session=session, collection_id=root_collection_id, samples=samples_to_create
+                created_path_to_id.update(
+                    _create_batch_samples(
+                        session=session,
+                        collection_id=root_collection_id,
+                        samples=samples_to_create,
+                    )
                 )
-                created_sample_ids.extend(created_path_to_id.values())
                 samples_to_create = []
 
     # Handle remaining samples
     if samples_to_create:
-        created_path_to_id = _create_batch_samples(
-            session=session, collection_id=root_collection_id, samples=samples_to_create
+        created_path_to_id.update(
+            _create_batch_samples(
+                session=session, collection_id=root_collection_id, samples=samples_to_create
+            )
         )
-        created_sample_ids.extend(created_path_to_id.values())
 
     report.log_summary()
     report.raise_if_all_failed()
-    return created_sample_ids
+    return created_path_to_id
 
 
 def load_into_dataset_from_labelformat(  # noqa: PLR0913
@@ -199,7 +204,7 @@ def load_into_dataset_from_labelformat(  # noqa: PLR0913
             attempted file was missing or broken.
 
     """
-    images_root_abs = add_annotations.normalize_images_root(images_root=images_path)
+    images_root_abs = path_utils.normalize_path_root(images_path)
 
     # Some formats open images to read the dimensions during the get_images() and get_labels() scans
     # Collector is used to record BROKEN images and skip, preventing abort of the ingest. Pascal VOC
@@ -429,7 +434,7 @@ def tag_samples_by_directory(
     if tag_depth == 0:
         return
 
-    input_path_abs = add_annotations.normalize_images_root(input_path)
+    input_path_abs = path_utils.normalize_path_root(input_path)
 
     newly_created_images = image_resolver.get_many_by_id(
         session=session,

--- a/lightly_studio/src/lightly_studio/core/image/create_image.py
+++ b/lightly_studio/src/lightly_studio/core/image/create_image.py
@@ -31,15 +31,15 @@ class CreateImage(CreateSample):
             AllInputFilesFailedError: If the image is missing or broken.
             ValueError: If the image could not be added for any other reason.
         """
-        sample_ids = add_images.load_into_dataset_from_paths(
+        path_to_sample_id = add_images.load_into_dataset_from_paths(
             session=session,
             root_collection_id=collection_id,
             image_paths=[self.path],
             show_progress=False,
         )
-        if len(sample_ids) != 1:
+        if len(path_to_sample_id) != 1:
             raise ValueError("Failed to create image sample.")
-        return sample_ids[0]
+        return next(iter(path_to_sample_id.values()))
 
     def sample_type(self) -> SampleType:
         """Return the sample type."""

--- a/lightly_studio/src/lightly_studio/core/image/image_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/image/image_dataset.py
@@ -172,11 +172,12 @@ class ImageDataset(BaseSampleDataset[ImageSample]):
         logger.info(f"Found {len(image_paths)} images in {path}.")
 
         # Process images
-        created_sample_ids = add_images.load_into_dataset_from_paths(
+        path_to_sample_id = add_images.load_into_dataset_from_paths(
             session=self.session,
             root_collection_id=self.collection_id,
             image_paths=image_paths,
         )
+        created_sample_ids = list(path_to_sample_id.values())
 
         if created_sample_ids:
             add_images.tag_samples_by_directory(

--- a/lightly_studio/src/lightly_studio/core/path_utils.py
+++ b/lightly_studio/src/lightly_studio/core/path_utils.py
@@ -1,0 +1,30 @@
+"""Shared file path helpers for media ingestion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import fsspec
+
+from lightly_studio.type_definitions import PathLike
+
+
+def normalize_path_root(path: PathLike) -> str:
+    """Return an absolute local path and preserve a remote path as-is.
+
+    Local paths are returned in posix form (forward slashes) so they can be
+    safely joined with `posixpath.join` and compared across platforms. On
+    Windows, `str(Path(...).absolute())` yields backslashes that, when joined
+    with posix-separated relative paths, produce mixed-separator strings that
+    fail to match what was stored at ingestion time.
+
+    Shared by image and video ingestion so both modalities store and compare
+    `file_path_abs` values consistently.
+    """
+    path_str = str(path)
+    protocol, _ = fsspec.core.split_protocol(path_str)
+    if protocol is None:
+        return Path(path_str).absolute().as_posix()
+    if protocol == "file":
+        return Path(fsspec.core.strip_protocol(path_str)).absolute().as_posix()
+    return path_str

--- a/lightly_studio/src/lightly_studio/core/video/add_videos.py
+++ b/lightly_studio/src/lightly_studio/core/video/add_videos.py
@@ -34,7 +34,7 @@ from PIL import Image
 from sqlmodel import Session
 from tqdm import tqdm
 
-from lightly_studio.core import labelformat_helpers
+from lightly_studio.core import labelformat_helpers, path_utils
 from lightly_studio.core.file_outcome_report import (
     AlreadyPresentInputFileError,
     BrokenInputFileError,
@@ -110,7 +110,7 @@ def load_into_collection_from_paths(  # noqa: PLR0913
     show_progress: bool = True,
     target_fps: float | None = None,
     embed_frames: bool = False,
-) -> tuple[list[UUID], list[UUID]]:
+) -> tuple[dict[str, UUID], list[UUID]]:
     """Load video samples from file paths into the dataset using PyAV.
 
     Args:
@@ -130,15 +130,19 @@ def load_into_collection_from_paths(  # noqa: PLR0913
 
     Returns:
         A tuple containing:
-            - List of UUIDs of the created video samples
+            - A mapping from normalized `file_path_abs` to the UUID of the created video
+              sample. A path that was skipped (already present, missing, or broken) has
+              no entry, so the mapping is not guaranteed to cover every input path.
             - List of UUIDs of the created video frame samples
     """
     if target_fps is not None and target_fps <= 0:
         raise ValueError(f"target_fps must be greater than 0, got {target_fps}.")
 
-    created_video_sample_ids: list[UUID] = []
+    created_video_path_to_id: dict[str, UUID] = {}
     created_video_frame_sample_ids: list[UUID] = []
-    video_paths_list = list(video_paths)
+    # Normalize up front so the returned mapping is keyed consistently with images, and so
+    # a relative single-file path is not stored as a relative `file_path_abs`.
+    video_paths_list = [path_utils.normalize_path_root(video_path) for video_path in video_paths]
     # The set starts with paths already in the database and grows with paths seen in this
     # call, so both already-present and in-run duplicate paths are skipped.
     _, existing_paths = sample_resolver.filter_new_paths(
@@ -191,13 +195,13 @@ def load_into_collection_from_paths(  # noqa: PLR0913
                 video_path=video_path,
                 seen_or_existing_paths=seen_or_existing_paths,
             )
-            created_video_sample_ids.append(video_sample_id)
+            created_video_path_to_id[video_path] = video_sample_id
             created_video_frame_sample_ids.extend(frame_sample_ids)
 
     report.log_summary()
     report.raise_if_all_failed()
 
-    return created_video_sample_ids, created_video_frame_sample_ids
+    return created_video_path_to_id, created_video_frame_sample_ids
 
 
 def _load_single_video(
@@ -345,24 +349,24 @@ def load_video_annotations_from_labelformat(  # noqa: PLR0913
         input_labels=input_labels, root_path=root_path, video_paths=video_paths, limit=limit
     )
 
-    created_sample_ids, created_video_frame_sample_ids = load_into_collection_from_paths(
+    created_video_path_to_id, created_video_frame_sample_ids = load_into_collection_from_paths(
         session=session,
         collection_id=collection_id,
         video_paths=video_paths_labelformat,
         embed_frames=embed_frames,
     )
+    created_sample_ids = list(created_video_path_to_id.values())
 
     # In YouTube-VIS, the file extension is typically missing. Hence we fallback to the path
     # without suffix. This method is assuming that we have no files with same path without suffix in
     # the dataset. E.g. /root/my_video.mp4 and /root/my_video.mov will not be present in the dataset
     # at the same time.
-    # Construct the mapping from path without suffix to sample id.
-    video_path_without_suffix_to_sample_id: dict[str, UUID] = {}
-    for sample_id in created_sample_ids:
-        video = video_resolver.get_by_id(session=session, sample_id=sample_id)
-        if video is not None:
-            video_path_without_suffix = str(Path(video.file_path_abs).absolute().with_suffix(""))
-            video_path_without_suffix_to_sample_id[video_path_without_suffix] = sample_id
+    # Construct the mapping from path without suffix to sample id, straight from the paths
+    # just returned instead of re-fetching each video from the database.
+    video_path_without_suffix_to_sample_id = {
+        str(Path(video_path).absolute().with_suffix("")): sample_id
+        for video_path, sample_id in created_video_path_to_id.items()
+    }
 
     label_map = labelformat_helpers.create_label_map(
         session=session,

--- a/lightly_studio/src/lightly_studio/core/video/create_video.py
+++ b/lightly_studio/src/lightly_studio/core/video/create_video.py
@@ -37,7 +37,7 @@ class CreateVideo(CreateSample):
         Raises:
             ValueError: If the video could not be added.
         """
-        video_ids, _ = add_videos.load_into_collection_from_paths(
+        video_path_to_id, _ = add_videos.load_into_collection_from_paths(
             session=session,
             collection_id=collection_id,
             video_paths=[self.path],
@@ -45,9 +45,9 @@ class CreateVideo(CreateSample):
             num_decode_threads=self.num_decode_threads,
             show_progress=False,
         )
-        if len(video_ids) != 1:
+        if len(video_path_to_id) != 1:
             raise ValueError("Failed to create video sample.")
-        return video_ids[0]
+        return next(iter(video_path_to_id.values()))
 
     def sample_type(self) -> SampleType:
         """Return the sample type."""

--- a/lightly_studio/src/lightly_studio/core/video/video_dataset.py
+++ b/lightly_studio/src/lightly_studio/core/video/video_dataset.py
@@ -153,7 +153,7 @@ class VideoDataset(BaseSampleDataset[VideoSample]):
         logger.info(f"Found {len(video_paths)} videos in {path}.")
 
         # Process videos.
-        created_sample_ids, _ = add_videos.load_into_collection_from_paths(
+        video_path_to_id, _ = add_videos.load_into_collection_from_paths(
             session=self.session,
             collection_id=self.collection_id,
             video_paths=video_paths,
@@ -161,6 +161,7 @@ class VideoDataset(BaseSampleDataset[VideoSample]):
             target_fps=target_fps,
             embed_frames=embed_frames,
         )
+        created_sample_ids = list(video_path_to_id.values())
 
         if embed:
             _generate_embeddings_video(

--- a/lightly_studio/tests/core/image/test_add_annotations.py
+++ b/lightly_studio/tests/core/image/test_add_annotations.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import posixpath
 from pathlib import Path
 
 import pytest
@@ -92,32 +91,6 @@ def test_add_annotations_from_labelformat__missing_images(db_session: Session) -
     images_root = Path("/images").absolute().as_posix()
     assert missing_paths == [f"{images_root}/nonexistent.jpg"]
     assert len(samples) == 0
-
-
-def test_normalize_images_root__local_path_is_posix() -> None:
-    # On Windows, `str(Path(...).absolute())` returns backslashes which, when
-    # joined with posix-separated labelformat filenames via `posixpath.join`,
-    # produce mixed-separator strings that fail to match ingested paths.
-    # The normalized root must therefore be in posix form.
-    result = add_annotations.normalize_images_root(Path("some") / "images")
-
-    assert "\\" not in result
-    assert result.endswith("some/images")
-    assert Path(result).is_absolute()
-
-
-def test_normalize_images_root__joins_cleanly_with_posix_filename() -> None:
-    root = add_annotations.normalize_images_root(Path("data") / "coco")
-    joined = posixpath.join(root, "images/0001.jpg")
-
-    assert "\\" not in joined
-    assert joined.endswith("data/coco/images/0001.jpg")
-
-
-def test_normalize_images_root__preserves_remote_protocol() -> None:
-    result = add_annotations.normalize_images_root("s3://bucket/path")
-
-    assert result == "s3://bucket/path"
 
 
 def _get_labelformat_input_obj_det(filename: str) -> LabelformatObjectDetectionInput:

--- a/lightly_studio/tests/core/image/test_add_images.py
+++ b/lightly_studio/tests/core/image/test_add_images.py
@@ -107,7 +107,7 @@ def test_load_into_collection_from_paths(db_session: Session, tmp_path: Path) ->
     PILImage.new("RGB", (100, 100)).save(image_paths[0])
 
     # Act
-    sample_ids = add_images.load_into_dataset_from_paths(
+    path_to_sample_id = add_images.load_into_dataset_from_paths(
         session=db_session,
         root_collection_id=collection.collection_id,
         image_paths=image_paths,
@@ -119,7 +119,7 @@ def test_load_into_collection_from_paths(db_session: Session, tmp_path: Path) ->
     ).samples
     assert len(samples) == 1
 
-    assert samples[0].sample_id == sample_ids[0]
+    assert samples[0].sample_id == path_to_sample_id[image_paths[0]]
     assert samples[0].file_name == "image1.jpg"
     assert samples[0].file_path_abs == str(image_paths[0])
     assert samples[0].width == 100
@@ -159,7 +159,7 @@ def test_load_into_dataset_from_paths__records_missing_broken_already_present_ou
 
     # Act
     with caplog.at_level("INFO"):
-        sample_ids = add_images.load_into_dataset_from_paths(
+        path_to_sample_id = add_images.load_into_dataset_from_paths(
             session=db_session,
             root_collection_id=collection.collection_id,
             image_paths=[
@@ -168,12 +168,16 @@ def test_load_into_dataset_from_paths__records_missing_broken_already_present_ou
             ],
         )
 
-    # Assert: only the good files are added.
-    assert len(sample_ids) == len(good_paths)
+    # Assert: the mapping only contains entries for the newly-created (good) files, correctly
+    # matched to the sample actually created for that path. Already-present, missing, and
+    # broken paths have no entry.
+    assert set(path_to_sample_id.keys()) == {str(path) for path in good_paths}
     samples = image_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     ).samples
     assert {sample.file_name for sample in samples} == {"good0.jpg", "present0.jpg", "present1.jpg"}
+    good_sample = next(sample for sample in samples if sample.file_name == "good0.jpg")
+    assert path_to_sample_id[str(good_paths[0])] == good_sample.sample_id
 
     # Assert: the end-of-run summary records the distinct per-outcome counts.
     assert "added=1" in caplog.text
@@ -198,13 +202,13 @@ def test_load_into_dataset_from_paths__records_decompression_bomb_as_broken(
     monkeypatch.setattr(PILImage, "MAX_IMAGE_PIXELS", 20_000)
 
     with caplog.at_level("INFO"):
-        sample_ids = add_images.load_into_dataset_from_paths(
+        path_to_sample_id = add_images.load_into_dataset_from_paths(
             session=db_session,
             root_collection_id=collection.collection_id,
             image_paths=[str(good_path), str(bomb_path)],
         )
 
-    assert len(sample_ids) == 1
+    assert set(path_to_sample_id.keys()) == {str(good_path)}
     samples = image_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     ).samples
@@ -223,18 +227,18 @@ def test_load_into_collection_from_paths__deduplicates_in_run_duplicates(
     image_paths = [image_path, image_path, image_path]
 
     # Act
-    sample_ids = add_images.load_into_dataset_from_paths(
+    path_to_sample_id = add_images.load_into_dataset_from_paths(
         session=db_session,
         root_collection_id=collection.collection_id,
         image_paths=image_paths,
     )
 
-    # Assert: the duplicated path is only created once.
+    # Assert: the duplicated path is only created once, with a single mapping entry.
     samples = image_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     ).samples
     assert len(samples) == 1
-    assert len(sample_ids) == 1
+    assert path_to_sample_id == {image_path: samples[0].sample_id}
 
 
 def test_load_into_dataset_from_labelformat__records_missing_already_present_added_outcomes(
@@ -938,20 +942,22 @@ def test_load_into_dataset_from_paths__file_url_normalization(
 
     # Act: Load with file:// directory URL
     file_url = f"file://{tmp_path}"
-    sample_ids = add_images.load_into_dataset_from_paths(
+    path_to_sample_id = add_images.load_into_dataset_from_paths(
         session=db_session,
         root_collection_id=collection.collection_id,
         image_paths=[file_url + "/image.jpg"],
     )
 
-    # Assert: Sample was created with normalized path
-    assert len(sample_ids) == 1
+    # Assert: Sample was created with normalized path, and the mapping is keyed by it.
+    normalized_path = str(image_path.absolute())
+    assert path_to_sample_id.keys() == {normalized_path}
     samples = image_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     ).samples
     assert len(samples) == 1
     # Path should be absolute (file:// stripped and normalized)
-    assert samples[0].file_path_abs == str(image_path.absolute())
+    assert samples[0].file_path_abs == normalized_path
+    assert path_to_sample_id[normalized_path] == samples[0].sample_id
 
     # Act: Now add annotations using the same file:// directory root
     # (Without path normalization, this would fail to match)

--- a/lightly_studio/tests/core/test_path_utils.py
+++ b/lightly_studio/tests/core/test_path_utils.py
@@ -52,7 +52,9 @@ def test_normalize_path_root__unprefixed_path_is_resolved_relative_to_cwd(
     assert result == (tmp_path / "images/0001.jpg").as_posix()
 
 
-def test_normalize_path_root__absolute_path_is_left_unchanged() -> None:
-    result = path_utils.normalize_path_root("/images/0001.jpg")
+def test_normalize_path_root__absolute_path_is_left_unchanged(tmp_path: Path) -> None:
+    absolute_path = tmp_path / "images" / "0001.jpg"
 
-    assert result == "/images/0001.jpg"
+    result = path_utils.normalize_path_root(str(absolute_path))
+
+    assert result == absolute_path.as_posix()

--- a/lightly_studio/tests/core/test_path_utils.py
+++ b/lightly_studio/tests/core/test_path_utils.py
@@ -1,0 +1,30 @@
+import posixpath
+from pathlib import Path
+
+from lightly_studio.core import path_utils
+
+
+def test_normalize_path_root__local_path_is_posix() -> None:
+    # On Windows, `str(Path(...).absolute())` returns backslashes which, when
+    # joined with posix-separated labelformat filenames via `posixpath.join`,
+    # produce mixed-separator strings that fail to match ingested paths.
+    # The normalized path must therefore be in posix form.
+    result = path_utils.normalize_path_root(Path("some") / "images")
+
+    assert "\\" not in result
+    assert result.endswith("some/images")
+    assert Path(result).is_absolute()
+
+
+def test_normalize_path_root__joins_cleanly_with_posix_filename() -> None:
+    root = path_utils.normalize_path_root(Path("data") / "coco")
+    joined = posixpath.join(root, "images/0001.jpg")
+
+    assert "\\" not in joined
+    assert joined.endswith("data/coco/images/0001.jpg")
+
+
+def test_normalize_path_root__preserves_remote_protocol() -> None:
+    result = path_utils.normalize_path_root("s3://bucket/path")
+
+    assert result == "s3://bucket/path"

--- a/lightly_studio/tests/core/test_path_utils.py
+++ b/lightly_studio/tests/core/test_path_utils.py
@@ -1,6 +1,8 @@
 import posixpath
 from pathlib import Path
 
+import pytest
+
 from lightly_studio.core import path_utils
 
 
@@ -28,3 +30,29 @@ def test_normalize_path_root__preserves_remote_protocol() -> None:
     result = path_utils.normalize_path_root("s3://bucket/path")
 
     assert result == "s3://bucket/path"
+
+
+def test_normalize_path_root__dot_prefixed_path_is_resolved_relative_to_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = path_utils.normalize_path_root("./images/0001.jpg")
+
+    assert result == (tmp_path / "images/0001.jpg").as_posix()
+
+
+def test_normalize_path_root__unprefixed_path_is_resolved_relative_to_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = path_utils.normalize_path_root("images/0001.jpg")
+
+    assert result == (tmp_path / "images/0001.jpg").as_posix()
+
+
+def test_normalize_path_root__absolute_path_is_left_unchanged() -> None:
+    result = path_utils.normalize_path_root("/images/0001.jpg")
+
+    assert result == "/images/0001.jpg"

--- a/lightly_studio/tests/core/video/test_add_videos.py
+++ b/lightly_studio/tests/core/video/test_add_videos.py
@@ -64,12 +64,12 @@ def test_load_into_collection_from_paths(db_session: Session, tmp_path: Path) ->
         num_frames=30,
         fps=2,
     )
-    video_sample_ids, frame_sample_ids = add_videos.load_into_collection_from_paths(
+    video_path_to_id, frame_sample_ids = add_videos.load_into_collection_from_paths(
         session=db_session,
         collection_id=collection.collection_id,
         video_paths=[str(first_video_path), str(second_video_path)],
     )
-    assert len(video_sample_ids) == 2
+    assert len(video_path_to_id) == 2
     assert len(frame_sample_ids) == 60
 
     # Check that video samples are created.
@@ -83,9 +83,11 @@ def test_load_into_collection_from_paths(db_session: Session, tmp_path: Path) ->
     assert video.file_path_abs == str(second_video_path)
     assert video.frame is not None
     assert video.frame.frame_number == 0
+    assert video_path_to_id[str(second_video_path)] == video.sample_id
     video = videos[1]
     assert video.file_name == "test_video_1.mp4"
     assert video.file_path_abs == str(first_video_path)
+    assert video_path_to_id[str(first_video_path)] == video.sample_id
 
     # Check the correct collection hierarchy was created. There should be one extra collection
     # created with the video frames.
@@ -102,6 +104,30 @@ def test_load_into_collection_from_paths(db_session: Session, tmp_path: Path) ->
         collection_id=collection_hierarchy[1].collection_id,
     ).samples
     assert len(video_frames) == 60
+
+
+def test_load_into_collection_from_paths__normalizes_relative_path(
+    db_session: Session, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A relative video path is normalized to an absolute file_path_abs, matching images."""
+    collection = create_collection(db_session, sample_type=SampleType.VIDEO)
+    video_path = create_video_file(output_path=tmp_path / "video.mp4", num_frames=2, fps=1)
+    monkeypatch.chdir(tmp_path)
+
+    video_path_to_id, _ = add_videos.load_into_collection_from_paths(
+        session=db_session,
+        collection_id=collection.collection_id,
+        video_paths=["video.mp4"],
+    )
+
+    normalized_path = str(video_path.absolute())
+    assert video_path_to_id.keys() == {normalized_path}
+    videos = video_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    ).samples
+    assert len(videos) == 1
+    assert videos[0].file_path_abs == normalized_path
+    assert video_path_to_id[normalized_path] == videos[0].sample_id
 
 
 def test_load_into_collection_from_paths__records_missing_broken_already_present_outcomes(
@@ -136,7 +162,7 @@ def test_load_into_collection_from_paths__records_missing_broken_already_present
 
     # Act
     with caplog.at_level("INFO"):
-        video_sample_ids, _ = add_videos.load_into_collection_from_paths(
+        video_path_to_id, _ = add_videos.load_into_collection_from_paths(
             session=db_session,
             collection_id=collection.collection_id,
             video_paths=[
@@ -145,8 +171,10 @@ def test_load_into_collection_from_paths__records_missing_broken_already_present
             ],
         )
 
-    # Assert: only the good video is added.
-    assert len(video_sample_ids) == len(good_paths)
+    # Assert: the mapping only contains entries for the newly-created (good) video, correctly
+    # matched to the sample actually created for that path. Already-present, missing, and
+    # broken paths have no entry.
+    assert set(video_path_to_id.keys()) == {str(path) for path in good_paths}
     videos = video_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     ).samples
@@ -155,6 +183,8 @@ def test_load_into_collection_from_paths__records_missing_broken_already_present
         "present0.mp4",
         "present1.mp4",
     }
+    good_video = next(video for video in videos if video.file_name == "good0.mp4")
+    assert video_path_to_id[str(good_paths[0])] == good_video.sample_id
 
     # Assert: the end-of-run summary records the distinct per-outcome counts.
     assert "added=1" in caplog.text
@@ -175,7 +205,7 @@ def test_load_into_collection_from_paths__mid_decode_failure_is_cleaned_up(
     _fail_after_frame_creation(mocker=mocker, failing_file_name=broken_path.name)
 
     with caplog.at_level("INFO"):
-        video_sample_ids, _ = add_videos.load_into_collection_from_paths(
+        video_path_to_id, _ = add_videos.load_into_collection_from_paths(
             session=db_session,
             collection_id=collection.collection_id,
             video_paths=[str(broken_path), str(good_path)],
@@ -185,7 +215,7 @@ def test_load_into_collection_from_paths__mid_decode_failure_is_cleaned_up(
         session=db_session, collection_id=collection.collection_id
     ).samples
     assert [video.file_name for video in videos] == [good_path.name]
-    assert video_sample_ids == [videos[0].sample_id]
+    assert video_path_to_id == {str(good_path): videos[0].sample_id}
     assert "added=1" in caplog.text
     assert "broken=1" in caplog.text
 


### PR DESCRIPTION
## What has changed and why?


`load_into_dataset_from_paths` / `load_into_collection_from_paths` returned a flat
`list[UUID]` that can be shorter than the input path list (skipped duplicate/missing/broken
files). A caller zipping input paths to the returned ids gets silent misalignment from the
first skip onward.

- Both functions now return `dict[str, UUID]` keyed by normalized `file_path_abs` instead of
  a flat list, so a skipped path just has no entry instead of shifting everything after it.
- Extracted `normalize_images_root` into `core/path_utils.normalize_path_root` and applied it
  to video paths too, so a relative single-file video path is no longer stored as a relative
  `file_path_abs` (previously only images normalized paths).
- Updated all internal callers to use the mapping. One caller
  (`load_video_annotations_from_labelformat`) now builds its path-without-suffix lookup
  directly from the returned mapping instead of re-fetching each video from the database.

## How has it been tested?

- Added/extended tests asserting the returned mapping only contains entries for
  actually-created samples, correctly matched, when duplicate/missing/broken files are mixed
  in with valid ones (both image and video).
- Added a test for video relative-path normalization.
- `make static-checks` and `make test` pass.

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change; public SDK method signatures are unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Image and video imports now consistently normalize local and `file://` paths.
  * Import results retain the relationship between each normalized file path and its created sample.
  * Annotation processing reuses imported media information for more efficient processing.
  * Relative paths resolve consistently, while remote paths remain unchanged.

* **Bug Fixes**
  * Improved handling of duplicate, missing, broken, and partially failed media imports.
  * Results now include only successfully imported files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->