### PR TITLE
Open embedding plot by default

### DIFF
--- a/lightly_studio_view/e2e/general/annotation-grid.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/annotation-grid.e2e-test.ts
@@ -95,7 +95,7 @@ test('We can see clicked element when navigating back from details', async ({
     page,
     annotationsPage
 }) => {
-    await page.setViewportSize({ width: 800, height: 400 });
+    await page.setViewportSize({ width: 1024, height: 400 });
 
     const viewport = page.getByTestId('annotations-grid');
     await expect(viewport).toBeVisible();

--- a/lightly_studio_view/e2e/general/bussines-flow-1.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/bussines-flow-1.e2e-test.ts
@@ -8,8 +8,10 @@ test.describe('bussines-flow1', () => {
     test('User Opens UI', async ({ page, samplesPage }) => {
         // samplesPage fixture automatically navigates and loads samples
 
-        // Expect first page of samples to be loaded (default page size from COCO collection)
-        expect(await samplesPage.getSamples().count()).toBe(cocoDataset.defaultPageSize);
+        // Infinite scroll may preload additional pages, so only require one full page.
+        await expect
+            .poll(() => samplesPage.getSamples().count())
+            .toBeGreaterThanOrEqual(cocoDataset.defaultPageSize);
 
         // Check if we have some annotations on screen.
         const annotations = page.getByTestId('sample-annotation-item');
@@ -104,7 +106,9 @@ test.describe('bussines-flow1', () => {
 
         // Clear tag filter to see all samples again
         await samplesPage.pressTag(catsTagName);
-        expect(await samplesPage.getSamples().count()).toBe(cocoDataset.defaultPageSize);
+        await expect
+            .poll(() => samplesPage.getSamples().count())
+            .toBeGreaterThanOrEqual(cocoDataset.defaultPageSize);
 
         // We need to wait after clicking the clear button for the grid view to be updated
         const clearResponsePromise = page.waitForResponse(
@@ -140,7 +144,9 @@ test.describe('bussines-flow1', () => {
         // Unfilter by clicking dog label again.
         // 2 of the 5 selected dogs are beyond the first 100 samples -> not visible
         await samplesPage.clickLabel(cocoDataset.labels.dog.name);
-        expect(await samplesPage.getSamples().count()).toBe(cocoDataset.defaultPageSize);
+        await expect
+            .poll(() => samplesPage.getSamples().count())
+            .toBeGreaterThanOrEqual(cocoDataset.defaultPageSize);
 
         // Create tag to verify all 5 selections persisted (including those not visible).
         await samplesPage.createTag(dogsTagName);

--- a/lightly_studio_view/e2e/general/sample-details/navigate-to-sample-details.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/sample-details/navigate-to-sample-details.e2e-test.ts
@@ -4,9 +4,10 @@ import { cocoDataset } from '../fixtures';
 test('user can navigate to sample details', async ({ page, samplesPage, sampleDetailsPage }) => {
     // samplesPage fixture automatically navigates and loads samples
 
-    // Expect first page of samples to be loaded (default page size from COCO collection)
-    const sampleCount = await samplesPage.getSamples().count();
-    expect(sampleCount).toBe(cocoDataset.defaultPageSize);
+    // Infinite scroll may preload additional pages, so only require one full page.
+    await expect
+        .poll(() => samplesPage.getSamples().count())
+        .toBeGreaterThanOrEqual(cocoDataset.defaultPageSize);
 
     // Wait for labels menu to load
     await expect(page.getByTestId('labels-menu-item').first()).toBeVisible();

--- a/lightly_studio_view/e2e/general/select-all.e2e-test.ts
+++ b/lightly_studio_view/e2e/general/select-all.e2e-test.ts
@@ -30,9 +30,9 @@ test('select all images with label filter via keyboard shortcut', async ({ page,
 
     // Remove the label filter and select all again
     await samplesPage.clickLabel(cocoDataset.labels.dog.name);
-    await expect(samplesPage.getSamples()).toHaveCount(cocoDataset.defaultPageSize, {
-        timeout: 10000
-    });
+    await expect
+        .poll(() => samplesPage.getSamples().count(), { timeout: 10000 })
+        .toBeGreaterThanOrEqual(cocoDataset.defaultPageSize);
 
     await page.click('body');
     const allSampleIdsResponse = page.waitForResponse(

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.test.ts
@@ -19,6 +19,20 @@ describe('useGlobalStorage', () => {
         storage.clearSelectedSampleAnnotationCrops(testCollectionId2);
     });
 
+    describe('Active panel', () => {
+        it('defaults to the embedding plot', () => {
+            expect(get(storage.activePanel)).toBe('embeddingPlot');
+        });
+
+        it('shares a manual close across consumers', () => {
+            storage.setActivePanel('none');
+
+            expect(get(useGlobalStorage().activePanel)).toBe('none');
+
+            storage.setActivePanel('embeddingPlot');
+        });
+    });
+
     describe('Sample selection', () => {
         it('should select a sample', () => {
             storage.toggleSampleSelection('sample1', testCollectionId);

--- a/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
+++ b/lightly_studio_view/src/lib/hooks/useGlobalStorage.ts
@@ -121,7 +121,7 @@ export type PanelType =
     | 'queryEditor'
     | 'distribution';
 
-const activePanel = writable<PanelType>('none');
+const activePanel = writable<PanelType>('embeddingPlot');
 const showEmbeddingPlot = derived(activePanel, ($p) => $p === 'embeddingPlot');
 const showEvaluationRuns = derived(activePanel, ($p) => $p === 'evaluationRuns');
 

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/layout.workspace.test.ts
@@ -194,7 +194,7 @@ function setPageRoute(routeId: string | null): void {
 beforeEach(() => {
     vi.clearAllMocks();
 
-    mockActivePanel = writable<PanelType>('none');
+    mockActivePanel = writable<PanelType>('embeddingPlot');
     mockFilterPanelCollapsed = writable(false);
 
     vi.mocked(useGlobalStorageModule.useGlobalStorage).mockReturnValue({


### PR DESCRIPTION
## What has changed and why?

- Select the embedding plot as the initial active panel so the first compatible collection opens it by default.
- Preserve the shared panel state so a manual close remains closed across collection switches.

## How has it been tested?

- Added tests for the initial panel default and shared manual-close state.
- Ran focused Vitest, Prettier, ESLint, and svelte-check.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Suggested reviewer: @ikondrat
Alternative: @LeonardoRosaa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The embedding plot panel now opens by default when viewing datasets.

- **Bug Fixes**
  - Improved consistency when closing the active panel across different parts of the application.

- **Tests**
  - Added coverage for the default embedding plot state and shared panel-close behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->