### PR TITLE
Add API keys link to admin menu

### DIFF
--- a/lightly_studio_view/src/lib/components/UserAvatar/UserAvatar.svelte
+++ b/lightly_studio_view/src/lib/components/UserAvatar/UserAvatar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import * as Popover from '$lib/components/ui/popover';
     import { Button } from '$lib/components';
-    import { LogOut, Users } from '@lucide/svelte';
+    import { KeyRound, LogOut, Users } from '@lucide/svelte';
     import { cn } from '$lib/utils/shadcn';
     import { useLogout } from '$lib/hooks/useLogout/useLogout';
     import { Separator } from '../ui/separator';
@@ -62,6 +62,16 @@
                 >
                     <Users class="size-4" />
                     Users
+                </Button>
+                <Button
+                    variant="ghost"
+                    buttonProps={{
+                        class: 'w-full justify-start gap-2',
+                        href: '/workspace/api-keys'
+                    }}
+                >
+                    <KeyRound class="size-4" />
+                    API keys
                 </Button>
             {/if}
             <Separator />

--- a/lightly_studio_view/src/lib/components/UserAvatar/UserAvatar.test.ts
+++ b/lightly_studio_view/src/lib/components/UserAvatar/UserAvatar.test.ts
@@ -62,6 +62,15 @@ describe('UserAvatar', () => {
         expect(usersButton.getAttribute('href')).toBe('/workspace/users');
     });
 
+    it('should render API keys menu item for admin user', async () => {
+        const { getByTitle, getByRole } = render(UserAvatar, { props: { user: mockUser } });
+
+        await fireEvent.click(getByTitle('admin'));
+
+        const apiKeysButton = getByRole('link', { name: /api keys/i });
+        expect(apiKeysButton.getAttribute('href')).toBe('/workspace/api-keys');
+    });
+
     it('should not render users menu item for editor user', async () => {
         const editorUser = {
             username: 'editor',
@@ -105,5 +114,6 @@ describe('UserAvatar', () => {
 
         const usersButton = queryByRole('link', { name: /users/i });
         expect(usersButton).toBeNull();
+        expect(queryByRole('link', { name: /api keys/i })).toBeNull();
     });
 });

--- a/lightly_studio_view/src/lib/components/UserAvatar/UserAvatar.test.ts
+++ b/lightly_studio_view/src/lib/components/UserAvatar/UserAvatar.test.ts
@@ -51,7 +51,7 @@ describe('UserAvatar', () => {
         ).toBeInTheDocument();
     });
 
-    it('should render users menu item for admin user', async () => {
+    it('should render admin menu items for admin user', async () => {
         const { getByTitle, getByRole } = render(UserAvatar, { props: { user: mockUser } });
         const avatarButton = getByTitle('admin');
 
@@ -60,12 +60,6 @@ describe('UserAvatar', () => {
         const usersButton = getByRole('link', { name: /users/i });
         expect(usersButton).toBeTruthy();
         expect(usersButton.getAttribute('href')).toBe('/workspace/users');
-    });
-
-    it('should render API keys menu item for admin user', async () => {
-        const { getByTitle, getByRole } = render(UserAvatar, { props: { user: mockUser } });
-
-        await fireEvent.click(getByTitle('admin'));
 
         const apiKeysButton = getByRole('link', { name: /api keys/i });
         expect(apiKeysButton.getAttribute('href')).toBe('/workspace/api-keys');
@@ -101,7 +95,7 @@ describe('UserAvatar', () => {
         expect(usersButton).toBeNull();
     });
 
-    it('should not render users menu item for viewer user', async () => {
+    it('should not render admin menu items for viewer user', async () => {
         const viewerUser = {
             username: 'viewer',
             email: 'viewer@example.com',


### PR DESCRIPTION
## What has changed and why?
This mirrors the ad95f986e0d53c5cf1e08d7888b2b32d9848be5e commit in the self hosted repository.

## How has it been tested?
Added a test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **API keys** option to the user avatar menu for administrators.
  * Selecting the option opens the API keys workspace page.

* **Bug Fixes**
  * Ensured viewers cannot see the API keys menu option.
  * Updated menu behavior checks to distinguish administrator and viewer access correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->