### PR TITLE
Add dataset ID to embedding models

### DIFF
--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -139,15 +139,13 @@ to list which input positions those rows belong to. This lets you skip any file 
 that has no vector.
 
 ```python
-from uuid import UUID
-
 import numpy as np
 from numpy.typing import NDArray
 from PIL import Image
 
 import lightly_studio as ls
 from lightly_studio.dataset.embedding_result import EmbeddingResult
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 
 EMBEDDING_DIMENSION = 512
 
@@ -156,7 +154,7 @@ class CustomEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
     def __init__(self) -> None:
         self._filepath_to_embedding: dict[str, NDArray[np.float32]] = ...  # Implement the loading logic here.
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate: ...
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription: ...
 
     def embed_text(self, text: str) -> list[float]: ...
 
@@ -200,15 +198,13 @@ Use this when you want a different model than the built-ins. Load your model in
 `__init__` and run it inside `embed_images`.
 
 ```python
-from uuid import UUID
-
 import numpy as np
 from numpy.typing import NDArray
 from PIL import Image
 
 import lightly_studio as ls
 from lightly_studio.dataset.embedding_result import EmbeddingResult
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 
 EMBEDDING_DIMENSION = 512
 
@@ -217,7 +213,7 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
     def __init__(self) -> None:
         ...  # Load your model and preprocessing here.
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate: ...
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription: ...
 
     def embed_text(self, text: str) -> list[float]: ...
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -59,7 +59,9 @@ class EmbeddingGenerator(Protocol):
     before you add a dataset or start the GUI.
     """
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
 
         <span class="doc-badge doc-badge--beta">Beta</span>
@@ -70,6 +72,7 @@ class EmbeddingGenerator(Protocol):
 
         Args:
             collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -197,11 +200,14 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         """
         self._dimension = dimension
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
 
         Args:
             collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -211,6 +217,7 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
             embedding_model_hash="random_model",
             embedding_dimension=self._dimension,
             collection_id=collection_id,
+            dataset_id=dataset_id,
         )
 
     def embed_text(self, _text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import random
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
-from uuid import UUID
 
 import numpy as np
 from numpy.typing import NDArray
 from PIL import Image
 
 from lightly_studio.dataset.embedding_result import EmbeddingResult
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 
 
 @dataclass(frozen=True)
@@ -59,10 +58,8 @@ class EmbeddingGenerator(Protocol):
     before you add a dataset or start the GUI.
     """
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        """Generate an EmbeddingModelCreate instance.
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        """Describe the embedding space produced by this generator.
 
         <span class="doc-badge doc-badge--beta">Beta</span>
 
@@ -70,12 +67,8 @@ class EmbeddingGenerator(Protocol):
         The `embedding_model_hash` field is used to match the same EmbeddingGenerator
         across multiple LightlyStudio runs.
 
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
-
         Returns:
-            An EmbeddingModelCreate instance with the model details.
+            A description of the embedding space.
         """
 
     def embed_text(self, text: str) -> list[float]:
@@ -200,24 +193,16 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         """
         self._dimension = dimension
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        """Generate an EmbeddingModelCreate instance.
-
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        """Describe the embedding space produced by this generator.
 
         Returns:
-            An EmbeddingModelCreate instance with the model details.
+            A description of the embedding space.
         """
-        return EmbeddingModelCreate(
+        return EmbeddingSpaceDescription(
             name="Random",
             embedding_model_hash="random_model",
             embedding_dimension=self._dimension,
-            collection_id=collection_id,
-            dataset_id=dataset_id,
         )
 
     def embed_text(self, _text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -161,12 +161,15 @@ class EmbeddingManager:
         Returns:
             The created EmbeddingModel.
         """
-        # Get or create embedding model record in the database.
+        collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+        if collection is None:
+            raise ValueError("Provided collection_id could not be found.")
+
+        embedding_model = embedding_generator.get_embedding_model_input(collection_id=collection_id)
+        embedding_model.dataset_id = collection.dataset_id
         db_model = embedding_model_resolver.get_or_create(
             session=session,
-            embedding_model=embedding_generator.get_embedding_model_input(
-                collection_id=collection_id
-            ),
+            embedding_model=embedding_model,
         )
         model_id = db_model.embedding_model_id
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -167,7 +167,10 @@ class EmbeddingManager:
 
         embedding_space = embedding_generator.get_embedding_model_input()
         embedding_model = EmbeddingModelCreate(
-            **embedding_space.model_dump(),
+            name=embedding_space.name,
+            parameter_count_in_mb=embedding_space.parameter_count_in_mb,
+            embedding_model_hash=embedding_space.embedding_model_hash,
+            embedding_dimension=embedding_space.embedding_dimension,
             collection_id=collection_id,
             dataset_id=collection.dataset_id,
         )

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -19,7 +19,7 @@ from lightly_studio.dataset.embedding_generator import (
     VideoEmbeddingGenerator,
 )
 from lightly_studio.models.collection import SampleType
-from lightly_studio.models.embedding_model import EmbeddingModelTable
+from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingCreate
 from lightly_studio.resolvers import (
     annotation_resolver,
@@ -165,12 +165,15 @@ class EmbeddingManager:
         if collection is None:
             raise ValueError("Provided collection_id could not be found.")
 
+        embedding_space = embedding_generator.get_embedding_model_input()
+        embedding_model = EmbeddingModelCreate(
+            **embedding_space.model_dump(),
+            collection_id=collection_id,
+            dataset_id=collection.dataset_id,
+        )
         db_model = embedding_model_resolver.get_or_create(
             session=session,
-            embedding_model=embedding_generator.get_embedding_model_input(
-                collection_id=collection_id,
-                dataset_id=collection.dataset_id,
-            ),
+            embedding_model=embedding_model,
         )
         model_id = db_model.embedding_model_id
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -165,11 +165,12 @@ class EmbeddingManager:
         if collection is None:
             raise ValueError("Provided collection_id could not be found.")
 
-        embedding_model = embedding_generator.get_embedding_model_input(collection_id=collection_id)
-        embedding_model.dataset_id = collection.dataset_id
         db_model = embedding_model_resolver.get_or_create(
             session=session,
-            embedding_model=embedding_model,
+            embedding_model=embedding_generator.get_embedding_model_input(
+                collection_id=collection_id,
+                dataset_id=collection.dataset_id,
+            ),
         )
         model_id = db_model.embedding_model_id
 

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -53,11 +53,14 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
         self._model_hash = file_utils.get_file_xxhash(model_path)
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
 
         Args:
             collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -67,6 +70,7 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             embedding_model_hash=self._model_hash,
             embedding_dimension=EMBEDDING_DIMENSION,
             collection_id=collection_id,
+            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import UUID
 
 import numpy as np
 import torch
@@ -11,7 +10,7 @@ from numpy.typing import NDArray
 from PIL import Image
 
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 from lightly_studio.vendor import mobileclip
 
 from . import file_utils, image_crop_embedding, image_embedding
@@ -53,24 +52,16 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
         self._model_hash = file_utils.get_file_xxhash(model_path)
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        """Generate an EmbeddingModelCreate instance.
-
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        """Describe the embedding space produced by this generator.
 
         Returns:
-            An EmbeddingModelCreate instance with the model details.
+            A description of the embedding space.
         """
-        return EmbeddingModelCreate(
+        return EmbeddingSpaceDescription(
             name=MODEL_NAME,
             embedding_model_hash=self._model_hash,
             embedding_dimension=EMBEDDING_DIMENSION,
-            collection_id=collection_id,
-            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -63,11 +63,14 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         self._model = self._model.to(self._device)
         self._model_hash = file_utils.get_file_xxhash(Path(model_path))
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
 
         Args:
             collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -77,6 +80,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             embedding_model_hash=self._model_hash,
             embedding_dimension=self._model.output_dim,
             collection_id=collection_id,
+            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from uuid import UUID
 
 import fsspec
 import numpy as np
@@ -21,7 +20,7 @@ from lightly_studio.core.file_outcome_report import (
     MissingInputFileError,
 )
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 from lightly_studio.utils import batching
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
 
@@ -63,24 +62,16 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         self._model = self._model.to(self._device)
         self._model_hash = file_utils.get_file_xxhash(Path(model_path))
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        """Generate an EmbeddingModelCreate instance.
-
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        """Describe the embedding space produced by this generator.
 
         Returns:
-            An EmbeddingModelCreate instance with the model details.
+            A description of the embedding space.
         """
-        return EmbeddingModelCreate(
+        return EmbeddingSpaceDescription(
             name=MODEL_NAME,
             embedding_model_hash=self._model_hash,
             embedding_dimension=self._model.output_dim,
-            collection_id=collection_id,
-            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
@@ -66,17 +66,24 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
         self._model_hash = file_utils.get_file_xxhash(model_path)
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         """Describe the model so it can be recorded in the database.
 
         The name shows up in the GUI and the hash lets Lightly Studio detect when
         the same model has been used before.
+
+        Args:
+            collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
         """
         return EmbeddingModelCreate(
             name="Custom Embedding Model",
             embedding_model_hash=self._model_hash,
             embedding_dimension=EMBEDDING_DIMENSION,
             collection_id=collection_id,
+            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
@@ -12,7 +12,6 @@ so ingestion uses your generator instead of the environment default.
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import UUID
 
 import numpy as np
 import torch
@@ -26,7 +25,7 @@ from lightly_studio.dataset import file_utils, image_crop_embedding, image_embed
 from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.dataset.image_embedding import EmbeddingContext
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 from lightly_studio.vendor import mobileclip
 
 MODEL_NAME = "mobileclip_s0"
@@ -66,24 +65,16 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
         self._model_hash = file_utils.get_file_xxhash(model_path)
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
         """Describe the model so it can be recorded in the database.
 
         The name shows up in the GUI and the hash lets Lightly Studio detect when
         the same model has been used before.
-
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
         """
-        return EmbeddingModelCreate(
+        return EmbeddingSpaceDescription(
             name="Custom Embedding Model",
             embedding_model_hash=self._model_hash,
             embedding_dimension=EMBEDDING_DIMENSION,
-            collection_id=collection_id,
-            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
+++ b/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
@@ -11,7 +11,6 @@ video model.
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import UUID
 
 import numpy as np
 from environs import Env
@@ -21,7 +20,7 @@ from PIL import Image
 import lightly_studio as ls
 from lightly_studio.database import db_manager
 from lightly_studio.dataset.embedding_result import EmbeddingResult
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 
 IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
 EMBEDDING_DIMENSION = 64
@@ -56,21 +55,12 @@ class LoadExistingEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
         """
         self._embeddings_by_filepath = embeddings_by_filepath
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        """Describe the model so it can be recorded in the database.
-
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
-        """
-        return EmbeddingModelCreate(
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        """Describe the model so it can be recorded in the database."""
+        return EmbeddingSpaceDescription(
             name="Precomputed Embeddings",
             embedding_model_hash="precomputed",
             embedding_dimension=EMBEDDING_DIMENSION,
-            collection_id=collection_id,
-            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
+++ b/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
@@ -56,13 +56,21 @@ class LoadExistingEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
         """
         self._embeddings_by_filepath = embeddings_by_filepath
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
-        """Describe the model so it can be recorded in the database."""
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
+        """Describe the model so it can be recorded in the database.
+
+        Args:
+            collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
+        """
         return EmbeddingModelCreate(
             name="Precomputed Embeddings",
             embedding_model_hash="precomputed",
             embedding_dimension=EMBEDDING_DIMENSION,
             collection_id=collection_id,
+            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787582284_c2d3e4f5a6b7_add_embedding_model_dataset_id.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787582284_c2d3e4f5a6b7_add_embedding_model_dataset_id.py
@@ -1,0 +1,62 @@
+"""add embedding model dataset id.
+
+Adds a nullable ``dataset_id`` to ``embedding_model`` and backfills it through the
+existing collection relationship. The column remains nullable while ``collection_id``
+is still the source of truth; a later migration can make it required when it removes
+``collection_id``.
+
+DuckDB builds its schema with ``create_all``, so this migration only matters for tracked
+Postgres databases.
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2026-08-24 16:38:04.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c2d3e4f5a6b7"
+down_revision: Union[str, Sequence[str], None] = "b1c2d3e4f5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("embedding_model", sa.Column("dataset_id", sa.Uuid(), nullable=True))
+    op.create_index(
+        op.f("ix_embedding_model_dataset_id"),
+        "embedding_model",
+        ["dataset_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "fk_embedding_model_dataset_id",
+        "embedding_model",
+        "dataset",
+        ["dataset_id"],
+        ["dataset_id"],
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE embedding_model
+            SET dataset_id = collection.dataset_id
+            FROM collection
+            WHERE embedding_model.collection_id = collection.collection_id
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("fk_embedding_model_dataset_id", "embedding_model", type_="foreignkey")
+    op.drop_index(op.f("ix_embedding_model_dataset_id"), table_name="embedding_model")
+    op.drop_column("embedding_model", "dataset_id")

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787582284_c2d3e4f5a6b7_add_embedding_model_dataset_id.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787582284_c2d3e4f5a6b7_add_embedding_model_dataset_id.py
@@ -1,9 +1,8 @@
 """add embedding model dataset id.
 
-Adds a nullable ``dataset_id`` to ``embedding_model`` and backfills it through the
-existing collection relationship. The column remains nullable while ``collection_id``
-is still the source of truth; a later migration can make it required when it removes
-``collection_id``.
+Adds ``dataset_id`` to ``embedding_model`` and backfills it through the existing
+collection relationship. The column is added as nullable for the backfill and then made
+required.
 
 DuckDB builds its schema with ``create_all``, so this migration only matters for tracked
 Postgres databases.
@@ -53,6 +52,7 @@ def upgrade() -> None:
             """
         )
     )
+    op.alter_column("embedding_model", "dataset_id", nullable=False)
 
 
 def downgrade() -> None:

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -8,13 +8,18 @@ from uuid import UUID, uuid4
 from sqlmodel import VARCHAR, Column, Field, SQLModel
 
 
-class EmbeddingModelBase(SQLModel):
-    """Base class for the EmbeddingModel."""
+class EmbeddingSpaceDescription(SQLModel):
+    """Description of an embedding space."""
 
     name: str
     parameter_count_in_mb: int | None = None
     embedding_model_hash: str = Field(default="", sa_column=Column(VARCHAR(128)))
     embedding_dimension: int
+
+
+class EmbeddingModelBase(EmbeddingSpaceDescription):
+    """Base class for the EmbeddingModel."""
+
     collection_id: UUID = Field(default=None, foreign_key="collection.collection_id", index=True)
     dataset_id: UUID = Field(foreign_key="dataset.dataset_id", index=True)
 

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -16,7 +16,7 @@ class EmbeddingModelBase(SQLModel):
     embedding_model_hash: str = Field(default="", sa_column=Column(VARCHAR(128)))
     embedding_dimension: int
     collection_id: UUID = Field(default=None, foreign_key="collection.collection_id", index=True)
-    dataset_id: UUID | None = Field(default=None, foreign_key="dataset.dataset_id", index=True)
+    dataset_id: UUID = Field(foreign_key="dataset.dataset_id", index=True)
 
 
 class EmbeddingModelCreate(EmbeddingModelBase):

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -16,6 +16,7 @@ class EmbeddingModelBase(SQLModel):
     embedding_model_hash: str = Field(default="", sa_column=Column(VARCHAR(128)))
     embedding_dimension: int
     collection_id: UUID = Field(default=None, foreign_key="collection.collection_id", index=True)
+    dataset_id: UUID | None = Field(default=None, foreign_key="dataset.dataset_id", index=True)
 
 
 class EmbeddingModelCreate(EmbeddingModelBase):

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -117,7 +117,7 @@ def deep_copy(
     _copy_tags(session=session, now=now)
     _copy_object_tracks(session=session, new_dataset_id=new_dataset_id)
     _copy_annotation_labels(session=session, new_dataset_id=new_dataset_id)
-    _copy_embedding_models(session=session, now=now)
+    _copy_embedding_models(session=session, new_dataset_id=new_dataset_id, now=now)
     _copy_samples(session=session, now=now)
     _copy_evaluation_runs(session=session, new_dataset_id=new_dataset_id, now=now)
 
@@ -436,8 +436,8 @@ def _copy_annotation_labels(session: Session, new_dataset_id: UUID) -> None:
     )
 
 
-def _copy_embedding_models(session: Session, now: datetime) -> None:
-    """Copy embedding models, remapping collection_id."""
+def _copy_embedding_models(session: Session, new_dataset_id: UUID, now: datetime) -> None:
+    """Copy embedding models, remapping collection_id and dataset_id."""
     src = _table(EmbeddingModelTable).alias("src")
     map_model = _map(_MAP_EMBEDDING_MODEL)
     map_collection = _map(_MAP_COLLECTION)
@@ -447,6 +447,7 @@ def _copy_embedding_models(session: Session, now: datetime) -> None:
     overrides = {
         "embedding_model_id": map_model.c.new_id,
         "collection_id": map_collection.c.new_id,
+        "dataset_id": literal(new_dataset_id),
         "created_at": literal(now),
     }
     _copy_table(

--- a/lightly_studio/tests/benchmarks/deep_copy_benchmark.py
+++ b/lightly_studio/tests/benchmarks/deep_copy_benchmark.py
@@ -161,6 +161,7 @@ def _generate_dataset(config: GenerationConfig) -> UUID:
             session=session,
             embedding_model=EmbeddingModelCreate(
                 collection_id=collection.collection_id,
+                dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/benchmarks/delete_dataset_benchmark.py
+++ b/lightly_studio/tests/benchmarks/delete_dataset_benchmark.py
@@ -170,6 +170,7 @@ def _generate_dataset(config: GenerationConfig) -> UUID:
             session=session,
             embedding_model=EmbeddingModelCreate(
                 collection_id=collection.collection_id,
+                dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/benchmarks/embedding_io_benchmark.py
+++ b/lightly_studio/tests/benchmarks/embedding_io_benchmark.py
@@ -186,6 +186,7 @@ def _setup(config: BenchmarkConfig) -> tuple[list[UUID], UUID]:
             session=session,
             embedding_model=EmbeddingModelCreate(
                 collection_id=collection.collection_id,
+                dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/benchmarks/gui_benchmark.py
+++ b/lightly_studio/tests/benchmarks/gui_benchmark.py
@@ -395,10 +395,13 @@ def _resolve_embedding_model(session: Session, collection_id: UUID) -> tuple[UUI
         "model: the embeddings view will appear in this process's GUI but not on a separate or "
         "deployed server."
     )
+    collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+    assert collection is not None
     synthetic_model = embedding_model_resolver.create(
         session=session,
         embedding_model=EmbeddingModelCreate(
             collection_id=collection_id,
+            dataset_id=collection.dataset_id,
             name=DEFAULT_EMBEDDING_MODEL_NAME,
             embedding_dimension=DEFAULT_EMBEDDING_DIM,
         ),

--- a/lightly_studio/tests/benchmarks/sample_embedding_lookup_benchmark.py
+++ b/lightly_studio/tests/benchmarks/sample_embedding_lookup_benchmark.py
@@ -225,6 +225,7 @@ def _setup(config: BenchmarkConfig) -> tuple[list[UUID], UUID, UUID]:
             session=session,
             embedding_model=EmbeddingModelCreate(
                 collection_id=collection.collection_id,
+                dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -235,6 +235,7 @@ def embedding_model_input(collection: CollectionTable) -> EmbeddingModelCreate:
     """Create an EmbeddingModelCreate instance."""
     return EmbeddingModelCreate(
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         embedding_dimension=3,
         name="test_model",
     )

--- a/lightly_studio/tests/database/test_db_migrations.py
+++ b/lightly_studio/tests/database/test_db_migrations.py
@@ -164,6 +164,11 @@ def test_postgres_embedding_model_dataset_id__backfilled(
                 statement=text("SELECT dataset_id FROM embedding_model")
             ).scalar_one()
         assert str(backfilled_dataset_id) == dataset_id
+        columns = db_migrations._get_inspector(engine=engine).get_columns(
+            table_name="embedding_model"
+        )
+        dataset_id_column = next(column for column in columns if column["name"] == "dataset_id")
+        assert dataset_id_column["nullable"] is False
 
         config.attributes.pop("connection", None)
         command.check(config)

--- a/lightly_studio/tests/database/test_db_migrations.py
+++ b/lightly_studio/tests/database/test_db_migrations.py
@@ -99,3 +99,73 @@ def test_postgres_fresh_database__upgrade_head(
         assert version == head_revision
     finally:
         engine.close()
+
+
+def test_postgres_embedding_model_dataset_id__backfilled(
+    postgres_url: str | None,
+) -> None:
+    """The dataset ID migration backfills embedding models from their collection."""
+    if postgres_url is None:
+        pytest.skip("Requires --postgres")
+
+    _reset_postgres_database(engine_url=postgres_url)
+    normalized_url = db_url.ensure_psycopg3_driver(engine_url=postgres_url)
+    engine = create_engine(normalized_url)
+    config = db_migrations.get_alembic_config(engine_url=postgres_url)
+    dataset_id = "00000000-0000-0000-0000-000000000001"
+    collection_id = "00000000-0000-0000-0000-000000000002"
+
+    try:
+        db_migrations._run_alembic_command(
+            engine=engine,
+            config=config,
+            fn=command.upgrade,
+            revision="b1c2d3e4f5a6",
+        )
+        with engine.begin() as connection:
+            connection.execute(
+                statement=text("INSERT INTO dataset (dataset_id) VALUES (:dataset_id)"),
+                parameters={"dataset_id": dataset_id},
+            )
+            connection.execute(
+                statement=text(
+                    """
+                    INSERT INTO collection (
+                        name, sample_type, collection_id, dataset_id, created_at, updated_at
+                    ) VALUES (
+                        'collection', 'IMAGE', :collection_id, :dataset_id, NOW(), NOW()
+                    )
+                    """
+                ),
+                parameters={"collection_id": collection_id, "dataset_id": dataset_id},
+            )
+            connection.execute(
+                statement=text(
+                    """
+                    INSERT INTO embedding_model (
+                        name, embedding_dimension, collection_id, embedding_model_id, created_at
+                    ) VALUES (
+                        'model', 128, :collection_id,
+                        '00000000-0000-0000-0000-000000000003', NOW()
+                    )
+                    """
+                ),
+                parameters={"collection_id": collection_id},
+            )
+
+        db_migrations._run_alembic_command(
+            engine=engine,
+            config=config,
+            fn=command.upgrade,
+            revision="head",
+        )
+        with engine.connect() as connection:
+            backfilled_dataset_id = connection.execute(
+                statement=text("SELECT dataset_id FROM embedding_model")
+            ).scalar_one()
+        assert str(backfilled_dataset_id) == dataset_id
+
+        config.attributes.pop("connection", None)
+        command.check(config)
+    finally:
+        engine.dispose()

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -24,7 +24,10 @@ from lightly_studio.dataset.embedding_manager import (
 from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import CollectionTable, SampleType
-from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
+from lightly_studio.models.embedding_model import (
+    EmbeddingModelTable,
+    EmbeddingSpaceDescription,
+)
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import (
@@ -101,13 +104,9 @@ def test_register_multiple_models(
 
     # Register a second model.
     class FakeEmbeddingGenerator(ImageEmbeddingGenerator):
-        def get_embedding_model_input(
-            self, collection_id: UUID, dataset_id: UUID
-        ) -> EmbeddingModelCreate:
-            return EmbeddingModelCreate(
+        def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+            return EmbeddingSpaceDescription(
                 name="Fake",
-                collection_id=collection_id,
-                dataset_id=dataset_id,
                 embedding_model_hash="fake_hash",
                 parameter_count_in_mb=50,
                 embedding_dimension=5,
@@ -630,13 +629,9 @@ def test_set_default_embedding_model_falls_back_to_env_for_unregistered_slot(
     class ImageOnlyGenerator:
         # Implements the image protocol but not embed_videos, so only the image
         # slot is overridden.
-        def get_embedding_model_input(
-            self, collection_id: UUID, dataset_id: UUID
-        ) -> EmbeddingModelCreate:
-            return EmbeddingModelCreate(
+        def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+            return EmbeddingSpaceDescription(
                 name="ImageOnly",
-                collection_id=collection_id,
-                dataset_id=dataset_id,
                 embedding_dimension=3,
                 embedding_model_hash="image_only_model",
             )
@@ -826,13 +821,9 @@ class TextOnlyEmbeddingGenerator:
     def __init__(self, dimension: int = 3) -> None:
         self._dimension = dimension
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        return EmbeddingModelCreate(
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        return EmbeddingSpaceDescription(
             name="TextOnly",
-            collection_id=collection_id,
-            dataset_id=dataset_id,
             embedding_dimension=self._dimension,
             embedding_model_hash="text_only_model",
         )

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -101,10 +101,13 @@ def test_register_multiple_models(
 
     # Register a second model.
     class FakeEmbeddingGenerator(ImageEmbeddingGenerator):
-        def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+        def get_embedding_model_input(
+            self, collection_id: UUID, dataset_id: UUID
+        ) -> EmbeddingModelCreate:
             return EmbeddingModelCreate(
                 name="Fake",
                 collection_id=collection_id,
+                dataset_id=dataset_id,
                 embedding_model_hash="fake_hash",
                 parameter_count_in_mb=50,
                 embedding_dimension=5,
@@ -627,10 +630,13 @@ def test_set_default_embedding_model_falls_back_to_env_for_unregistered_slot(
     class ImageOnlyGenerator:
         # Implements the image protocol but not embed_videos, so only the image
         # slot is overridden.
-        def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+        def get_embedding_model_input(
+            self, collection_id: UUID, dataset_id: UUID
+        ) -> EmbeddingModelCreate:
             return EmbeddingModelCreate(
                 name="ImageOnly",
                 collection_id=collection_id,
+                dataset_id=dataset_id,
                 embedding_dimension=3,
                 embedding_model_hash="image_only_model",
             )
@@ -820,10 +826,13 @@ class TextOnlyEmbeddingGenerator:
     def __init__(self, dimension: int = 3) -> None:
         self._dimension = dimension
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         return EmbeddingModelCreate(
             name="TextOnly",
             collection_id=collection_id,
+            dataset_id=dataset_id,
             embedding_dimension=self._dimension,
             embedding_model_hash="text_only_model",
         )

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -70,6 +70,19 @@ def test_register_embedding_model(
     assert stored_model is not None
     assert stored_model.name == "Random"
     assert stored_model.embedding_dimension == 3
+    assert stored_model.dataset_id == collection.dataset_id
+
+
+def test_register_embedding_model__collection_not_found(db_session: Session) -> None:
+    manager = EmbeddingManager()
+    collection_id = UUID(int=0)
+
+    with pytest.raises(ValueError, match="Provided collection_id could not be found"):
+        manager.register_embedding_model(
+            session=db_session,
+            embedding_generator=RandomEmbeddingGenerator(),
+            collection_id=collection_id,
+        )
 
 
 def test_register_multiple_models(
@@ -132,8 +145,9 @@ def test_register_multiple_models(
     assert len(stored_models) == 2
     model_names = {model.name for model in stored_models}
     assert model_names == {"Random", "Fake"}
-    # Verify both models are associated with the same collection
+    # Verify both models are associated with the same collection and dataset
     assert all(model.collection_id == collection.collection_id for model in stored_models)
+    assert all(model.dataset_id == collection.dataset_id for model in stored_models)
 
 
 def test_embed_text_with_default_model(

--- a/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
@@ -19,11 +19,15 @@ class TestMobileCLIPEmbeddingGenerator:
     def test_get_embedding_model_input(self) -> None:
         mobileclip = MobileCLIPEmbeddingGenerator()
         collection_id = uuid.uuid4()
-        embedding_model_input = mobileclip.get_embedding_model_input(collection_id=collection_id)
+        dataset_id = uuid.uuid4()
+        embedding_model_input = mobileclip.get_embedding_model_input(
+            collection_id=collection_id, dataset_id=dataset_id
+        )
 
         assert embedding_model_input.name == "mobileclip_s0"
         assert embedding_model_input.embedding_dimension == 512
         assert embedding_model_input.collection_id == collection_id
+        assert embedding_model_input.dataset_id == dataset_id
         assert embedding_model_input.embedding_model_hash != ""
 
     def test_embed_text(self) -> None:

--- a/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import uuid
 from pathlib import Path
 
 import numpy as np
@@ -18,16 +17,10 @@ FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 class TestMobileCLIPEmbeddingGenerator:
     def test_get_embedding_model_input(self) -> None:
         mobileclip = MobileCLIPEmbeddingGenerator()
-        collection_id = uuid.uuid4()
-        dataset_id = uuid.uuid4()
-        embedding_model_input = mobileclip.get_embedding_model_input(
-            collection_id=collection_id, dataset_id=dataset_id
-        )
+        embedding_model_input = mobileclip.get_embedding_model_input()
 
         assert embedding_model_input.name == "mobileclip_s0"
         assert embedding_model_input.embedding_dimension == 512
-        assert embedding_model_input.collection_id == collection_id
-        assert embedding_model_input.dataset_id == dataset_id
         assert embedding_model_input.embedding_model_hash != ""
 
     def test_embed_text(self) -> None:

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import uuid
 from pathlib import Path
 
 import numpy as np
@@ -20,16 +19,10 @@ FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 class TestPerceptionEncoderEmbeddingGenerator:
     def test_get_embedding_model_input(self) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
-        collection_id = uuid.uuid4()
-        dataset_id = uuid.uuid4()
-        embedding_model_input = perception_encoder.get_embedding_model_input(
-            collection_id=collection_id, dataset_id=dataset_id
-        )
+        embedding_model_input = perception_encoder.get_embedding_model_input()
 
         assert embedding_model_input.name == "PE-Core-T16-384"
         assert embedding_model_input.embedding_dimension == 512
-        assert embedding_model_input.collection_id == collection_id
-        assert embedding_model_input.dataset_id == dataset_id
         assert embedding_model_input.embedding_model_hash != ""
 
     def test_embed_text(self) -> None:

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -21,13 +21,15 @@ class TestPerceptionEncoderEmbeddingGenerator:
     def test_get_embedding_model_input(self) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
         collection_id = uuid.uuid4()
+        dataset_id = uuid.uuid4()
         embedding_model_input = perception_encoder.get_embedding_model_input(
-            collection_id=collection_id
+            collection_id=collection_id, dataset_id=dataset_id
         )
 
         assert embedding_model_input.name == "PE-Core-T16-384"
         assert embedding_model_input.embedding_dimension == 512
         assert embedding_model_input.collection_id == collection_id
+        assert embedding_model_input.dataset_id == dataset_id
         assert embedding_model_input.embedding_model_hash != ""
 
     def test_embed_text(self) -> None:

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -58,6 +58,7 @@ def embedding_model(db_session: Session, collection: CollectionTable) -> Embeddi
         embedding_model_hash="mock_hash",
         name="test_model",
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         embedding_dimension=3,
     )
     return embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -314,10 +314,15 @@ def create_embedding_model(  # noqa: PLR0913
     is off by default to avoid the ``default_embedding_space`` foreign key blocking model
     or collection deletes in tests that do not need a default.
     """
+    collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+    if collection is None:
+        raise ValueError(f"Collection with id {collection_id} not found.")
+
     model = embedding_model_resolver.create(
         session=session,
         embedding_model=EmbeddingModelCreate(
             collection_id=collection_id,
+            dataset_id=collection.dataset_id,
             name=embedding_model_name,
             embedding_model_hash=embedding_model_hash,
             parameter_count_in_mb=parameter_count_in_mb,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -324,6 +324,7 @@ def test_deep_copy__with_embeddings(db_session: Session) -> None:
     assert len(copied_embedding_models) == 1
     copied_model = copied_embedding_models[0]
     assert copied_model.embedding_model_id != embedding_model.embedding_model_id
+    assert copied_model.dataset_id == copied.dataset_id
     assert copied_model.name == embedding_model.name
     assert copied_model.embedding_model_hash == embedding_model.embedding_model_hash
     assert copied_model.embedding_dimension == embedding_model.embedding_dimension

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -266,6 +266,7 @@ def test_get_or_create__creates_new_model(db_session: Session) -> None:
 
     model_create = EmbeddingModelCreate(
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         name="Model Name",
         embedding_model_hash="model_hash",
         parameter_count_in_mb=200,
@@ -296,6 +297,7 @@ def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
 
     model_create = EmbeddingModelCreate(
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         name="Model Name",
         embedding_model_hash="model_hash",
         parameter_count_in_mb=10,
@@ -327,6 +329,7 @@ def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:
 
     conflicting_model_create = EmbeddingModelCreate(
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         name="Model Name",
         embedding_model_hash="model_hash",
         parameter_count_in_mb=2000,
@@ -348,6 +351,7 @@ def test_get_or_create__same_hash_different_collections(db_session: Session) -> 
 
     model_create_1 = EmbeddingModelCreate(
         collection_id=collection_1.collection_id,
+        dataset_id=collection_1.dataset_id,
         name="Test Model",
         embedding_model_hash="same_hash",
         parameter_count_in_mb=10,
@@ -359,6 +363,7 @@ def test_get_or_create__same_hash_different_collections(db_session: Session) -> 
 
     model_create_2 = EmbeddingModelCreate(
         collection_id=collection_2.collection_id,
+        dataset_id=collection_2.dataset_id,
         name="Test Model",
         embedding_model_hash="same_hash",
         parameter_count_in_mb=10,


### PR DESCRIPTION
## What has changed and why?

Adds a required `dataset_id` foreign key to embedding models as the next step toward removing their collection ownership.

- Backfills existing rows before enforcing `NOT NULL`.
- Introduces `EmbeddingSpaceDescription` so embedding generators return persistence-agnostic metadata; `EmbeddingManager` attaches collection and dataset IDs.
- Remaps deep-copied models while retaining `collection_id` temporarily for the follow-up removal.

## How has it been tested?

- `make static-checks`
- Generator, embedding manager, and resolver tests: 45 passed.
- PostgreSQL migration backfill, nullability, and Alembic schema check.
- PostgreSQL deep-copy and delete round-trip tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Suggested reviewer: @iunir. Alternative: @JonasWurst.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dataset association for embedding models, improving organization and traceability.
  * Added shared embedding-space descriptions for custom and precomputed embedding workflows.
* **Bug Fixes**
  * Embedding model registration now validates the collection and assigns the correct dataset.
  * Deep-copied embedding models are correctly linked to the copied dataset.
  * Existing embedding records are automatically updated with dataset associations.
* **Documentation**
  * Updated embedding examples and guidance to reflect the streamlined embedding metadata workflow.
* **Tests**
  * Expanded coverage for dataset assignment, migration backfills, validation, and deep-copy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->