### PR TITLE
LIG-8961 Verify and document Azure Blob Storage support

### DIFF
--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -103,6 +103,24 @@ start-e2e-distribution: build
 start-e2e-video-groups: build
 	uv run e2e-tests/index_videos_groups.py
 
+# See e2e-tests/README.md for S3 setup and credential instructions
+.PHONY: start-e2e-s3
+start-e2e-s3: build
+	@echo "Starting server for e2e tests with remote S3 dataset..."
+	uv run e2e-tests/index_s3.py
+
+# Requires GOOGLE_APPLICATION_CREDENTIALS or FSSPEC_GCS env var to be set
+.PHONY: start-e2e-gcs
+start-e2e-gcs: build
+	@echo "Starting server for e2e tests with remote GCS dataset..."
+	uv run e2e-tests/index_gcs.py
+
+# See e2e-tests/README.md for Azure setup and credential instructions
+.PHONY: start-e2e-azure
+start-e2e-azure: build
+	@echo "Starting server for e2e tests with remote Azure dataset..."
+	uv run e2e-tests/index_azure.py
+
 .PHONY: start-postgres
 start-postgres: stop-postgres
 	@echo "Starting PostgreSQL container ($(POSTGRES_IMAGE))..."

--- a/lightly_studio/Makefile
+++ b/lightly_studio/Makefile
@@ -109,7 +109,7 @@ start-e2e-s3: build
 	@echo "Starting server for e2e tests with remote S3 dataset..."
 	uv run e2e-tests/index_s3.py
 
-# Requires GOOGLE_APPLICATION_CREDENTIALS or FSSPEC_GCS env var to be set
+# Uses gcsfs default authentication; see e2e-tests/README.md for alternatives
 .PHONY: start-e2e-gcs
 start-e2e-gcs: build
 	@echo "Starting server for e2e tests with remote GCS dataset..."

--- a/lightly_studio/docs/docs/dataset_setup/cloud_storage.md
+++ b/lightly_studio/docs/docs/dataset_setup/cloud_storage.md
@@ -1,6 +1,6 @@
 # Cloud Storage
 
-To load images or videos directly from a cloud storage provider (like AWS S3, GCS, etc.), first install the required dependencies:
+To load images or videos directly from AWS S3, Google Cloud Storage, or Azure Blob Storage, first install the required dependencies:
 
 ```shell
 pip install "lightly-studio[cloud-storage]"
@@ -29,6 +29,7 @@ import lightly_studio as ls
 dataset = ls.ImageDataset.load_or_create()
 dataset.add_images_from_path(path="s3://my-bucket/images/")
 dataset.add_images_from_path(path="gcs://other-bucket/more-images/")
+dataset.add_images_from_path(path="abfs://my-container/azure-images/")
 dataset.add_images_from_path(path="/data/images/not-in-the-cloud-yet")
 ```
 

--- a/lightly_studio/docs/docs/enterprise/cloud_storage/azure.md
+++ b/lightly_studio/docs/docs/enterprise/cloud_storage/azure.md
@@ -27,8 +27,9 @@ Do not grant write, create, add, or delete permissions.
 6. Store the generated **Blob SAS token** securely. It is a credential and must
    not be committed to source control or pasted into logs.
 
-Repeat these steps for another container if it requires a separate credential.
 LightlyStudio currently stores one deployment-wide Azure credential set.
+Configure the SAS token for the container that the deployment uses. Configuring
+credentials for a second container replaces the existing credentials.
 
 ## Step 2: Record the Storage Account Name
 

--- a/lightly_studio/docs/docs/enterprise/cloud_storage/azure.md
+++ b/lightly_studio/docs/docs/enterprise/cloud_storage/azure.md
@@ -1,0 +1,43 @@
+# Azure Blob Storage Setup
+
+This guide creates a read-only shared access signature (SAS) for an Azure Blob
+Storage container. After creating the token, follow
+[Cloud Storage](index.md#step-2-add-credentials-in-the-gui) to add it in the
+LightlyStudio Enterprise GUI.
+
+## Required Permissions
+
+LightlyStudio needs these permissions on the container:
+
+- **Read** — read images and videos
+- **List** — discover objects under dataset paths
+
+Do not grant write, create, add, or delete permissions.
+
+## Step 1: Create a Container SAS Token
+
+1. Open the storage account in the
+   [Azure portal](https://portal.azure.com/) and select **Data storage** →
+   **Containers**.
+2. Select the container LightlyStudio needs to read.
+3. Open **Shared access tokens**.
+4. Select only **Read** and **List** permissions.
+5. Choose an expiration time that follows your organization's credential
+   rotation policy, then generate the SAS token.
+6. Store the generated **Blob SAS token** securely. It is a credential and must
+   not be committed to source control or pasted into logs.
+
+Repeat these steps for another container if it requires a separate credential.
+LightlyStudio currently stores one deployment-wide Azure credential set.
+
+## Step 2: Record the Storage Account Name
+
+Copy the storage account name from the Azure portal. Use only the name, such as
+`mystorageaccount`, rather than the full `blob.core.windows.net` URL.
+
+## Next Step
+
+Open [Cloud Storage — Step 2](index.md#step-2-add-credentials-in-the-gui),
+select **Azure Blob Storage**, and enter the storage account name and SAS token.
+After saving, Python clients can call `ls.connect()` and use paths such as
+`abfs://my-container/images/`.

--- a/lightly_studio/docs/docs/enterprise/cloud_storage/index.md
+++ b/lightly_studio/docs/docs/enterprise/cloud_storage/index.md
@@ -5,14 +5,13 @@ Once set up, every Python client that calls `ls.connect()` receives the credenti
 automatically, no per-user setup is needed. Cloud storage is read-only, LightlyStudio
 will not write any data to your buckets or need write permissions.
 
-Currently supported: **AWS S3** and **Google Cloud Storage (GCS)**. Azure support
-is planned.
+Currently supported: **AWS S3**, **Google Cloud Storage (GCS)**, and
+**Azure Blob Storage**.
 
 ## How It Works
 
 1. **Admin creates cloud provider credentials** with read access to the storage bucket.
-   See [AWS S3 Setup](aws.md) or [Google Cloud Storage Setup](gcs.md) for a
-   step-by-step guide.
+   See the provider-specific setup guides below for step-by-step instructions.
 2. **Admin saves the credentials** in the LightlyStudio Enterprise GUI.
 3. **Python clients call `ls.connect()`** and receive the credentials automatically.
 
@@ -22,6 +21,7 @@ Follow the guide for your cloud provider to create credentials with the required
 
 - [AWS S3](aws.md)
 - [Google Cloud Storage](gcs.md)
+- [Azure Blob Storage](azure.md)
 
 ## Step 2: Add Credentials in the GUI
 
@@ -29,8 +29,8 @@ Follow the guide for your cloud provider to create credentials with the required
 2. Go to the **Datasets** page and click the **Cloud Storage Credentials** button.
    This button is only visible to admins.
 3. Select your provider.
-4. For Amazon S3, enter the **Access Key ID** and **Secret Access Key**. For
-   Google Cloud Storage, paste the complete service-account JSON object.
+4. Enter the credentials requested for the selected provider. For Azure Blob
+   Storage, enter the storage account name and a read-only container SAS token.
 5. Click **Save Credentials**.
 
 The credentials are now stored on the server and shared with all Python client connections.
@@ -62,6 +62,17 @@ ls.connect()
 
 dataset = ls.ImageDataset.load_or_create(name="gcs_dataset")
 dataset.add_images_from_path(path="gcs://my-bucket/images/")
+```
+
+For Azure Blob Storage, use an `abfs://` path:
+
+```python title="enterprise_azure_storage.py"
+import lightly_studio as ls
+
+ls.connect()
+
+dataset = ls.ImageDataset.load_or_create(name="azure_dataset")
+dataset.add_images_from_path(path="abfs://my-container/images/")
 ```
 
 !!! note

--- a/lightly_studio/docs/mkdocs.yml
+++ b/lightly_studio/docs/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - enterprise/cloud_storage/index.md
       - AWS S3: enterprise/cloud_storage/aws.md
       - Google Cloud Storage: enterprise/cloud_storage/gcs.md
+      - Azure Blob Storage: enterprise/cloud_storage/azure.md
   - Tutorials:
     - tutorials/index.md
     - "Tutorial 1: Curate a Traffic CCTV Dataset for YOLO Training": tutorials/yolo-traffic-cctv-object-detection.md
@@ -127,6 +128,7 @@ plugins:
           - enterprise/cloud_storage/index.md
           - enterprise/cloud_storage/aws.md
           - enterprise/cloud_storage/gcs.md
+          - enterprise/cloud_storage/azure.md
         Tutorials:
           - tutorials/index.md
           - tutorials/yolo-traffic-cctv-object-detection.md

--- a/lightly_studio/e2e-tests/README.md
+++ b/lightly_studio/e2e-tests/README.md
@@ -123,8 +123,9 @@ gcloud auth application-default login
 ```
 
 This writes credentials to `~/.config/gcloud/application_default_credentials.json`,
-which GCS clients pick up automatically via the `GOOGLE_APPLICATION_CREDENTIALS`
-environment variable convention.
+which gcsfs discovers from the ADC well-known file through its default
+authentication. This option does not require `GOOGLE_APPLICATION_CREDENTIALS`
+or `FSSPEC_GCS` to be set.
 
 **Option B — Service account key file:**
 
@@ -181,7 +182,7 @@ Never commit service-account key files.
 
 The Azure E2E test indexes the COCO example dataset directly from a private
 Azure Blob Storage container. Use separate SAS tokens for uploading the test
-data and for running LightlyStudio. LightlyStudio only needs read and list
+data and for running LightlyStudio. LightlyStudio only requires read and list
 permissions.
 
 ### Prerequisites
@@ -216,7 +217,8 @@ Generate a short-lived SAS token with upload permissions (`racwdl`) from the
 copy the **Blob SAS token** (starts with `sv=`).
 
 ```shell
-UPLOAD_SAS="<paste-sas-token-here>"
+read -r -s -p "Upload SAS: " UPLOAD_SAS
+printf '\n'
 UPLOAD_URL="https://${ACCOUNT}.blob.core.windows.net/${CONTAINER}?${UPLOAD_SAS}"
 
 azcopy copy \
@@ -229,7 +231,7 @@ azcopy copy \
 The container must have this layout because `index_azure.py` uses these paths:
 
 ```text
-test/
+# Container root: test
 ├── images/
 │   ├── 000000565296.jpg
 │   └── ...
@@ -243,7 +245,8 @@ Generate a separate SAS with only read and list permissions (`rl`) from the
 **Read** and **List**, set expiry to a few days ahead, and copy the token.
 
 ```shell
-READ_SAS="<paste-read-only-sas-token-here>"
+read -r -s -p "Read-only SAS: " READ_SAS
+printf '\n'
 READ_URL="https://${ACCOUNT}.blob.core.windows.net/${CONTAINER}?${READ_SAS}"
 
 # Verify access before running the test:

--- a/lightly_studio/e2e-tests/README.md
+++ b/lightly_studio/e2e-tests/README.md
@@ -1,0 +1,307 @@
+# Cloud Storage E2E Tests
+
+Three e2e scripts test remote cloud storage connectivity:
+
+| Provider | Script | Makefile target |
+|---|---|---|
+| Amazon S3 | `e2e-tests/index_s3.py` | `make start-e2e-s3` |
+| Google Cloud Storage | `e2e-tests/index_gcs.py` | `make start-e2e-gcs` |
+| Azure Blob Storage | `e2e-tests/index_azure.py` | `make start-e2e-azure` |
+
+---
+
+## Amazon S3
+
+The S3 e2e test indexes a dataset directly from a private S3 bucket using
+standard AWS credentials.
+
+### Prerequisites
+
+- AWS CLI configured (`aws configure` or environment variables)
+- An S3 bucket with the `coco_subset_128_images` dataset uploaded
+- The `cloud-storage` extra installed
+
+```shell
+cd lightly_studio
+uv sync --extra cloud-storage
+```
+
+### 1. Upload the Dataset
+
+```shell
+BUCKET="<your-bucket-name>"
+PREFIX="coco_subset_128_images"
+SOURCE_DIR="<absolute-path-to-coco_subset_128_images>"
+
+aws s3 cp "$SOURCE_DIR/" "s3://$BUCKET/$PREFIX/" --recursive
+```
+
+### 2. Configure Credentials
+
+Use any of the standard AWS credential mechanisms. The simplest is environment
+variables:
+
+```shell
+export AWS_ACCESS_KEY_ID="<access-key-id>"
+export AWS_SECRET_ACCESS_KEY="<secret-access-key>"
+# For temporary credentials also set:
+export AWS_SESSION_TOKEN="<session-token>"
+export AWS_DEFAULT_REGION="<region>"   # e.g. us-east-1
+```
+
+Alternatively, `aws configure` writes `~/.aws/credentials` which is picked up
+automatically.
+
+### 3. Run the Test
+
+Edit the bucket path in `e2e-tests/index_s3.py`:
+
+```python
+# Change this line to point at your bucket:
+dataset.add_images_from_path(path="s3://<your-bucket>/coco_subset_128_images/", embed=False)
+```
+
+Then run:
+
+```shell
+make start-e2e-s3
+# or, after the first build:
+uv run e2e-tests/index_s3.py
+```
+
+The test should create the `s3_dataset` dataset, index 128 images, and start
+LightlyStudio at <http://localhost:8001>.
+
+### Troubleshooting
+
+- `NoCredentialsError`: export `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+  in the same terminal.
+- `AccessDenied`: the IAM principal needs `s3:GetObject` and `s3:ListBucket`
+  on the target bucket and prefix.
+- Missing `s3fs`: run `uv sync --extra cloud-storage`.
+
+### Clean Up Credentials
+
+```shell
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+```
+
+Never commit AWS credentials.
+
+---
+
+## Google Cloud Storage
+
+The GCS e2e test indexes a dataset directly from a private GCS bucket.
+
+### Prerequisites
+
+- `gcloud` CLI authenticated (`gcloud auth application-default login`)
+- A GCS bucket with the `coco_subset_128_images` dataset uploaded
+- The `cloud-storage` extra installed
+
+```shell
+cd lightly_studio
+uv sync --extra cloud-storage
+```
+
+### 1. Upload the Dataset
+
+```shell
+BUCKET="<your-bucket-name>"
+SOURCE_DIR="<absolute-path-to-coco_subset_128_images>"
+
+gsutil -m cp -r "$SOURCE_DIR" "gs://$BUCKET/"
+```
+
+### 2. Configure Credentials
+
+**Option A — Application Default Credentials (recommended for local dev):**
+
+```shell
+gcloud auth application-default login
+```
+
+This writes credentials to `~/.config/gcloud/application_default_credentials.json`,
+which GCS clients pick up automatically via the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable convention.
+
+**Option B — Service account key file:**
+
+```shell
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account-key.json"
+```
+
+**Option C — fsspec inline config:**
+
+```shell
+export FSSPEC_GCS='{"token": "/path/to/service-account-key.json"}'
+```
+
+### 3. Run the Test
+
+The `index_gcs.py` script currently hard-codes a specific bucket path. Edit it
+to point at your bucket before running:
+
+```python
+# index_gcs.py — change this line:
+dataset.add_images_from_path(path="gs://<your-bucket>/coco_subset_128_images/", embed=False)
+```
+
+Then run:
+
+```shell
+make start-e2e-gcs
+# or, after the first build:
+uv run e2e-tests/index_gcs.py
+```
+
+The test should create the `gcs_dataset` dataset, index 128 images, and start
+LightlyStudio at <http://localhost:8001>.
+
+### Troubleshooting
+
+- `DefaultCredentialsError`: run `gcloud auth application-default login` or set
+  `GOOGLE_APPLICATION_CREDENTIALS`.
+- `403 Forbidden`: the service account needs `storage.objects.get` and
+  `storage.objects.list` on the bucket.
+- Missing `gcsfs`: run `uv sync --extra cloud-storage`.
+
+### Clean Up Credentials
+
+```shell
+unset GOOGLE_APPLICATION_CREDENTIALS FSSPEC_GCS
+```
+
+Never commit service-account key files.
+
+---
+
+## Azure Blob Storage
+
+The Azure E2E test indexes the COCO example dataset directly from a private
+Azure Blob Storage container. Use separate SAS tokens for uploading the test
+data and for running LightlyStudio. LightlyStudio only needs read and list
+permissions.
+
+### Prerequisites
+
+- [AzCopy](https://learn.microsoft.com/azure/storage/common/storage-use-azcopy-v10)
+- An Azure Storage account with a private container named `test`
+  (create via the [Azure portal](https://portal.azure.com) if it does not exist)
+- The local `coco_subset_128_images` example dataset
+
+Install the project dependencies, including Azure filesystem support:
+
+```shell
+cd lightly_studio
+uv sync --extra cloud-storage
+```
+
+### 1. Configure the Test Resources
+
+Set the storage account name and local dataset path:
+
+```shell
+ACCOUNT="<storage-account-name>"
+CONTAINER="test"
+SOURCE_DIR="<absolute-path-to-coco_subset_128_images>"
+```
+
+### 2. Upload the Dataset
+
+Generate a short-lived SAS token with upload permissions (`racwdl`) from the
+[Azure portal](https://portal.azure.com): navigate to the storage account →
+**Containers** → `test` → **Generate SAS**, set the expiry to tomorrow, and
+copy the **Blob SAS token** (starts with `sv=`).
+
+```shell
+UPLOAD_SAS="<paste-sas-token-here>"
+UPLOAD_URL="https://${ACCOUNT}.blob.core.windows.net/${CONTAINER}?${UPLOAD_SAS}"
+
+azcopy copy \
+  "${SOURCE_DIR}/*" \
+  "$UPLOAD_URL" \
+  --recursive=true \
+  --from-to=LocalBlob
+```
+
+The container must have this layout because `index_azure.py` uses these paths:
+
+```text
+test/
+├── images/
+│   ├── 000000565296.jpg
+│   └── ...
+└── instances_train2017.json
+```
+
+### 3. Configure Read-Only Credentials
+
+Generate a separate SAS with only read and list permissions (`rl`) from the
+[Azure portal](https://portal.azure.com): same path as above but tick only
+**Read** and **List**, set expiry to a few days ahead, and copy the token.
+
+```shell
+READ_SAS="<paste-read-only-sas-token-here>"
+READ_URL="https://${ACCOUNT}.blob.core.windows.net/${CONTAINER}?${READ_SAS}"
+
+# Verify access before running the test:
+azcopy list "$READ_URL"
+```
+
+Configure the fsspec credentials consumed by `index_azure.py`. Do not print the
+value because it contains the SAS token.
+
+```shell
+export FSSPEC_ABFS="$(
+  printf '{"account_name":"%s","sas_token":"%s"}' "$ACCOUNT" "$READ_SAS"
+)"
+
+printenv FSSPEC_ABFS >/dev/null \
+  && echo "FSSPEC_ABFS is configured" \
+  || echo "FSSPEC_ABFS is missing"
+```
+
+### 4. Run the Test
+
+From the `lightly_studio` backend directory, build and start the Azure E2E
+environment:
+
+```shell
+make start-e2e-azure
+```
+
+After the first build, use the following command for faster retries:
+
+```shell
+uv run e2e-tests/index_azure.py
+```
+
+The test should create the `azure_coco_dataset` dataset, index 128 images and
+their instance-segmentation annotations, and start LightlyStudio at
+<http://localhost:8001>. Embedding generation is disabled to keep the test
+focused on Azure connectivity and remote indexing.
+
+### Troubleshooting
+
+- `Set FSSPEC_ABFS...`: export `FSSPEC_ABFS` in the same terminal that runs
+  `make`.
+- `AuthorizationPermissionMismatch`: regenerate the read-only SAS with both
+  `r` and `l` permissions and confirm that it has not expired.
+- `ContainerNotFound` or missing COCO JSON: run `azcopy list "$READ_URL"` and
+  confirm that `images/` and `instances_train2017.json` are at the container
+  root.
+- Missing `adlfs`: run `uv sync --extra cloud-storage`.
+
+### Clean Up Credentials
+
+Remove credentials from the shell after testing:
+
+```shell
+unset UPLOAD_SAS UPLOAD_URL
+unset READ_SAS READ_URL
+unset FSSPEC_ABFS
+```
+
+Never commit SAS tokens or the populated `FSSPEC_ABFS` value.

--- a/lightly_studio/e2e-tests/index_azure.py
+++ b/lightly_studio/e2e-tests/index_azure.py
@@ -1,0 +1,25 @@
+"""Index the remote COCO example dataset from Azure Blob Storage."""
+
+import os
+
+import lightly_studio as ls
+from lightly_studio import cloud_credentials
+
+azure_credentials = os.environ.get("FSSPEC_ABFS")
+if azure_credentials is None:
+    raise RuntimeError("Set FSSPEC_ABFS to JSON containing the Azure account name and SAS token.")
+
+cloud_credentials.apply_cloud_credentials(credentials={"FSSPEC_ABFS": azure_credentials})
+
+ls.db_manager.connect(cleanup_existing=True)
+
+dataset = ls.ImageDataset.create(name="azure_coco_dataset")
+dataset.add_samples_from_coco(
+    annotations_json="abfs://test/instances_train2017.json",
+    images_path="abfs://test/images/",
+    annotation_type=ls.AnnotationType.SEGMENTATION_MASK,
+    embed=False,
+    embed_annotations=False,
+)
+
+ls.start_gui()

--- a/lightly_studio/e2e-tests/index_gcs.py
+++ b/lightly_studio/e2e-tests/index_gcs.py
@@ -7,8 +7,8 @@ from lightly_studio.database import db_manager
 # Connect to the database
 db_manager.connect(cleanup_existing=True)
 
-# Create dataset with images from GCS
-# Requires GOOGLE_APPLICATION_CREDENTIALS or FSSPEC_GCS env var to be set
+# Create a dataset with images from GCS.
+# By default, gcsfs discovers credentials from the ADC well-known file.
 dataset = ImageDataset.create(name="gcs_dataset")
 dataset.add_images_from_path(path="gs://kondrat-test-bucket/coco_subset_128_images/", embed=False)
 

--- a/lightly_studio/e2e-tests/index_gcs.py
+++ b/lightly_studio/e2e-tests/index_gcs.py
@@ -1,0 +1,15 @@
+"""End-to-end demonstration of indexing a remote GCS dataset."""
+
+import lightly_studio as ls
+from lightly_studio.core.image.image_dataset import ImageDataset
+from lightly_studio.database import db_manager
+
+# Connect to the database
+db_manager.connect(cleanup_existing=True)
+
+# Create dataset with images from GCS
+# Requires GOOGLE_APPLICATION_CREDENTIALS or FSSPEC_GCS env var to be set
+dataset = ImageDataset.create(name="gcs_dataset")
+dataset.add_images_from_path(path="gs://kondrat-test-bucket/coco_subset_128_images/", embed=False)
+
+ls.start_gui()

--- a/lightly_studio/e2e-tests/index_s3.py
+++ b/lightly_studio/e2e-tests/index_s3.py
@@ -1,0 +1,13 @@
+"""End-to-end demonstration of indexing a remote S3 dataset."""
+
+import lightly_studio as ls
+from lightly_studio.core.image.image_dataset import ImageDataset
+from lightly_studio.database import db_manager
+
+db_manager.connect(cleanup_existing=True)
+
+# Requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or ~/.aws/credentials.
+dataset = ImageDataset.create(name="s3_dataset")
+dataset.add_images_from_path(path="s3://<your-bucket>/coco_subset_128_images/", embed=False)
+
+ls.start_gui()

--- a/lightly_studio/src/lightly_studio/dataset/fsspec_lister.py
+++ b/lightly_studio/src/lightly_studio/dataset/fsspec_lister.py
@@ -22,7 +22,7 @@ PATH_SEPARATOR = "/"
 GLOB_CHARS = ["*", "?", "[", "]"]
 
 # Cloud storage protocols
-CLOUD_PROTOCOLS = ("s3", "gs", "gcs", "azure", "abfs")
+CLOUD_PROTOCOLS = ("s3", "gs", "gcs", "abfs", "abfss", "az")
 
 # Image file extensions
 IMAGE_EXTENSIONS = {

--- a/lightly_studio/tests/api/routes/api/test_enterprise.py
+++ b/lightly_studio/tests/api/routes/api/test_enterprise.py
@@ -2,6 +2,7 @@ import json
 import os
 
 import fsspec
+from adlfs import AzureBlobFileSystem  # type: ignore[import-untyped]
 from fastapi.testclient import TestClient
 from gcsfs import GCSFileSystem  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
@@ -59,6 +60,27 @@ def test_refresh_cloud_credentials__applies_gcs_config(
 
     assert response.status_code == 204
     assert fsspec.config.conf["gcs"] == storage_options
+    clear_cache.assert_called_once_with()
+
+
+def test_refresh_cloud_credentials__applies_azure_config(
+    test_client: TestClient,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch.dict(os.environ, clear=False)
+    mocker.patch.dict(fsspec.config.conf, {}, clear=True)
+    clear_cache = mocker.spy(AzureBlobFileSystem, "clear_instance_cache")
+    storage_options = {"account_name": "test-account", "account_key": "test-key"}
+    serialized_options = json.dumps(storage_options)
+
+    response = test_client.put(
+        "/api/cloud-credentials",
+        json={"FSSPEC_ABFS": serialized_options},
+    )
+
+    assert response.status_code == 204
+    assert os.environ["FSSPEC_ABFS"] == serialized_options
+    assert fsspec.config.conf["abfs"] == storage_options
     clear_cache.assert_called_once_with()
 
 

--- a/lightly_studio/tests/dataset/test_fsspec_lister.py
+++ b/lightly_studio/tests/dataset/test_fsspec_lister.py
@@ -268,3 +268,8 @@ def test_validate_limit(limit: int | None) -> None:
 def test_validate_limit__invalid(limit: int) -> None:
     with pytest.raises(ValueError, match=r"limit must be greater than 0"):
         fsspec_lister.validate_limit(limit)
+
+
+def test_cloud_protocols__include_azure_blob_aliases() -> None:
+    assert {"abfs", "abfss", "az"} <= set(fsspec_lister.CLOUD_PROTOCOLS)
+    assert "azure" not in fsspec_lister.CLOUD_PROTOCOLS

--- a/lightly_studio/tests/test_cloud_credentials.py
+++ b/lightly_studio/tests/test_cloud_credentials.py
@@ -13,7 +13,6 @@ from gcsfs import GCSFileSystem  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
 
 from lightly_studio import cloud_credentials
-from lightly_studio.cloud_credentials import apply_cloud_credentials
 
 
 @pytest.fixture(autouse=True)
@@ -40,7 +39,7 @@ def test_apply_cloud_credentials__applies_gcs_runtime_config(
     serialized_options = json.dumps(storage_options)
     clear_cache = mocker.spy(GCSFileSystem, "clear_instance_cache")
 
-    apply_cloud_credentials(credentials={"FSSPEC_GCS": serialized_options})
+    cloud_credentials.apply_cloud_credentials(credentials={"FSSPEC_GCS": serialized_options})
 
     assert os.environ["FSSPEC_GCS"] == serialized_options
     assert fsspec.config.conf["gcs"] == storage_options
@@ -48,14 +47,14 @@ def test_apply_cloud_credentials__applies_gcs_runtime_config(
 
 
 def test_apply_cloud_credentials__invalidates_cached_gcs_filesystem() -> None:
-    apply_cloud_credentials(
+    cloud_credentials.apply_cloud_credentials(
         credentials={"FSSPEC_GCS": json.dumps({"project": "old-project", "token": "anon"})}
     )
     old_filesystem = fsspec.filesystem("gcs")
     assert GCSFileSystem._cache
     assert fsspec.filesystem("gcs") is old_filesystem
 
-    apply_cloud_credentials(
+    cloud_credentials.apply_cloud_credentials(
         credentials={"FSSPEC_GCS": json.dumps({"project": "new-project", "token": "anon"})}
     )
 
@@ -71,7 +70,9 @@ def test_apply_cloud_credentials__replaces_removed_gcs_options() -> None:
         "token": "old-token",
     }
 
-    apply_cloud_credentials(credentials={"FSSPEC_GCS": json.dumps({"token": "new-token"})})
+    cloud_credentials.apply_cloud_credentials(
+        credentials={"FSSPEC_GCS": json.dumps({"token": "new-token"})}
+    )
 
     assert fsspec.config.conf["gcs"] == {"token": "new-token"}
 
@@ -83,7 +84,7 @@ def test_apply_cloud_credentials__applies_azure_runtime_config(
     serialized_options = json.dumps(storage_options)
     clear_cache = mocker.spy(AzureBlobFileSystem, "clear_instance_cache")
 
-    apply_cloud_credentials(credentials={"FSSPEC_ABFS": serialized_options})
+    cloud_credentials.apply_cloud_credentials(credentials={"FSSPEC_ABFS": serialized_options})
 
     assert os.environ["FSSPEC_ABFS"] == serialized_options
     assert fsspec.config.conf["abfs"] == storage_options
@@ -92,7 +93,7 @@ def test_apply_cloud_credentials__applies_azure_runtime_config(
 
 
 def test_apply_cloud_credentials__invalidates_cached_azure_filesystem() -> None:
-    apply_cloud_credentials(
+    cloud_credentials.apply_cloud_credentials(
         credentials={
             "FSSPEC_ABFS": json.dumps({"account_name": "old-account", "account_key": "old-key"})
         }
@@ -101,7 +102,7 @@ def test_apply_cloud_credentials__invalidates_cached_azure_filesystem() -> None:
     assert AzureBlobFileSystem._cache
     assert fsspec.filesystem("az") is old_filesystem
 
-    apply_cloud_credentials(
+    cloud_credentials.apply_cloud_credentials(
         credentials={
             "FSSPEC_ABFS": json.dumps({"account_name": "new-account", "account_key": "new-key"})
         }
@@ -116,7 +117,7 @@ def test_apply_cloud_credentials__invalidates_cached_azure_filesystem() -> None:
 @pytest.mark.parametrize("value", ["not-json", "[]"])
 def test_apply_cloud_credentials__rejects_invalid_fsspec_config(value: str) -> None:
     with pytest.raises(ValueError, match="Invalid FSSPEC cloud credential configuration"):
-        apply_cloud_credentials(credentials={"FSSPEC_GCS": value})
+        cloud_credentials.apply_cloud_credentials(credentials={"FSSPEC_GCS": value})
 
     assert "FSSPEC_GCS" not in os.environ
     assert "gcs" not in fsspec.config.conf
@@ -132,7 +133,9 @@ def test_apply_cloud_credentials__missing_filesystem_dependency(
     )
 
     with pytest.raises(ImportError, match="lightly-studio"):
-        apply_cloud_credentials(credentials={"FSSPEC_GCS": json.dumps({"token": "anon"})})
+        cloud_credentials.apply_cloud_credentials(
+            credentials={"FSSPEC_GCS": json.dumps({"token": "anon"})}
+        )
 
     assert "FSSPEC_GCS" not in os.environ
     assert "gcs" not in fsspec.config.conf

--- a/lightly_studio/tests/test_cloud_credentials.py
+++ b/lightly_studio/tests/test_cloud_credentials.py
@@ -8,6 +8,7 @@ from collections.abc import Generator
 
 import fsspec
 import pytest
+from adlfs import AzureBlobFileSystem  # type: ignore[import-untyped]
 from gcsfs import GCSFileSystem  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
 
@@ -19,8 +20,10 @@ from lightly_studio.cloud_credentials import apply_cloud_credentials
 def _reset_cloud_configuration(mocker: MockerFixture) -> Generator[None, None, None]:
     mocker.patch.dict(os.environ, {}, clear=True)
     mocker.patch.dict(fsspec.config.conf, {}, clear=True)
+    AzureBlobFileSystem.clear_instance_cache()
     GCSFileSystem.clear_instance_cache()
     yield
+    AzureBlobFileSystem.clear_instance_cache()
     GCSFileSystem.clear_instance_cache()
 
 
@@ -71,6 +74,43 @@ def test_apply_cloud_credentials__replaces_removed_gcs_options() -> None:
     apply_cloud_credentials(credentials={"FSSPEC_GCS": json.dumps({"token": "new-token"})})
 
     assert fsspec.config.conf["gcs"] == {"token": "new-token"}
+
+
+def test_apply_cloud_credentials__applies_azure_runtime_config(
+    mocker: MockerFixture,
+) -> None:
+    storage_options = {"account_name": "test-account", "account_key": "test-key"}
+    serialized_options = json.dumps(storage_options)
+    clear_cache = mocker.spy(AzureBlobFileSystem, "clear_instance_cache")
+
+    apply_cloud_credentials(credentials={"FSSPEC_ABFS": serialized_options})
+
+    assert os.environ["FSSPEC_ABFS"] == serialized_options
+    assert fsspec.config.conf["abfs"] == storage_options
+    assert fsspec.filesystem("az").account_name == "test-account"
+    clear_cache.assert_called_once_with()
+
+
+def test_apply_cloud_credentials__invalidates_cached_azure_filesystem() -> None:
+    apply_cloud_credentials(
+        credentials={
+            "FSSPEC_ABFS": json.dumps({"account_name": "old-account", "account_key": "old-key"})
+        }
+    )
+    old_filesystem = fsspec.filesystem("abfs")
+    assert AzureBlobFileSystem._cache
+    assert fsspec.filesystem("az") is old_filesystem
+
+    apply_cloud_credentials(
+        credentials={
+            "FSSPEC_ABFS": json.dumps({"account_name": "new-account", "account_key": "new-key"})
+        }
+    )
+
+    assert not AzureBlobFileSystem._cache
+    new_filesystem = fsspec.filesystem("az")
+    assert new_filesystem is not old_filesystem
+    assert new_filesystem.account_name == "new-account"
 
 
 @pytest.mark.parametrize("value", ["not-json", "[]"])

--- a/lightly_studio/tests/test_enterprise.py
+++ b/lightly_studio/tests/test_enterprise.py
@@ -8,6 +8,7 @@ import os
 import fsspec
 import pytest
 import requests
+from adlfs import AzureBlobFileSystem  # type: ignore[import-untyped]
 from gcsfs import GCSFileSystem  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture, MockType
 
@@ -322,6 +323,30 @@ def test_connect__applies_gcs_runtime_config(
 
     assert os.environ["FSSPEC_GCS"] == serialized_options
     assert fsspec.config.conf["gcs"] == storage_options
+    clear_cache.assert_called_once_with()
+
+
+def test_connect__applies_azure_runtime_config(
+    mocker: MockerFixture,
+    patch_db_connect: MockType,  # noqa: ARG001
+) -> None:
+    mocker.patch.dict(fsspec.config.conf, {}, clear=True)
+    clear_cache = mocker.spy(AzureBlobFileSystem, "clear_instance_cache")
+    storage_options = {"account_name": "test-account", "account_key": "test-key"}
+    serialized_options = json.dumps(storage_options)
+    mock_response = mocker.MagicMock()
+    mock_response.status_code = 200
+    mock_response.ok = True
+    mock_response.json.return_value = {
+        "engine_url": "postgresql://lightly:secret@10.0.0.5:5433/lightly_studio",
+        "cloud_credentials": {"FSSPEC_ABFS": serialized_options},
+    }
+    mocker.patch.object(requests, "get", return_value=mock_response)
+
+    enterprise.connect(api_url="http://10.0.0.5:8100", token="token")
+
+    assert os.environ["FSSPEC_ABFS"] == serialized_options
+    assert fsspec.config.conf["abfs"] == storage_options
     clear_cache.assert_called_once_with()
 
 


### PR DESCRIPTION
## What has changed and why?

Verifies and documents Azure Blob Storage support in LightlyStudio.

- Covers Azure credentials delivered as `FSSPEC_ABFS` in the shared credential helper, backend refresh endpoint, and `lightly_studio.enterprise.connect()`.
- Verifies credential rotation invalidates cached `AzureBlobFileSystem` instances.
- Supports the valid `adlfs` aliases `abfs://`, `abfss://`, and `az://`.
- Adds the Enterprise Azure setup guide using a read-only container SAS token.
- Adds Azure examples and updates the cloud-storage support matrix.

The companion Enterprise implementation is split into:

- [lightly-studio-self-hosted#261](https://github.com/lightly-ai/lightly-studio-self-hosted/pull/261) — credential validation, bootstrap delivery, and runtime dependency
- [lightly-studio-self-hosted#262](https://github.com/lightly-ai/lightly-studio-self-hosted/pull/262) — stacked credential UI and onboarding

Part of [LIG-8961](https://linear.app/lightly/issue/LIG-8961/enterprise-cloud-storage-add-and-test-azure-blob-storage-support).

## How has it been tested?

- `uv run pytest tests/dataset/test_fsspec_lister.py tests/test_cloud_credentials.py tests/test_enterprise.py tests/api/routes/api/test_enterprise.py` — 72 passed
- `make static-checks` — lock check, Ruff, mypy, and formatting passed
- `make docs` — strict MkDocs build passed

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

Suggested reviewer: @mihnea-necsulescu, based on recent ownership of the Enterprise cloud-storage credential flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Azure Blob Storage support, including `abfs://` paths and Azure protocol aliases.
  - Added end-to-end examples for Azure Blob Storage, Amazon S3, and Google Cloud Storage.

- **Bug Fixes**
  - Improved Azure credential updates during connection and refresh operations.
  - Prevented stale filesystem sessions after credential changes.

- **Documentation**
  - Added Azure setup guidance using read-only SAS tokens and cloud storage examples.

- **Tests**
  - Expanded coverage for Azure configuration, runtime updates, and credential rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->