### PR TITLE
Allow existig tag for preselected_tag_name sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sort the annotations grid by a per-annotation evaluation metric, such as IoU.
 - Python SDK: Order video queries by `VideoSampleField.created_at`.
 - Python SDK: Continue sampling from an existing tagged selection with the
-  `preselected_tag_name` parameter.
+  `preselected_tag_name` parameter. Passing the same name as `sampling_result_tag_name`
+  grows that tag with the newly selected samples instead of requiring a fresh tag.
 - Python SDK: Select video-frame sequences with `selected_sequence_length` on `Sampling.diverse()`. It defaults to `None`, which selects individual frames. `n_samples_to_select` still counts frames and must be a multiple of the sequence length.
 - Compare the annotation class distribution of any sample tag against the current view in the Distribution panel.
 

--- a/lightly_studio/docs/docs/concepts_and_tools/sampling.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/sampling.md
@@ -310,7 +310,7 @@ combine them.
 
 ### In Python
 
-Each strategy is configured directly from a [`DatasetQuery`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery) via [`sampling()`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery.sampling). This works for image datasets, video datasets, and video-frame datasets returned by [`VideoDataset.frames()`](../api/dataset.md#lightly_studio.VideoDataset.frames). The sampled items are stored under the tag passed as `sampling_result_tag_name`, so you can filter or export them later. `sampling_result_tag_name` must be a tag name that does not yet exist in the dataset.
+Each strategy is configured directly from a [`DatasetQuery`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery) via [`sampling()`](../api/dataset_query.md#lightly_studio.core.dataset_query.dataset_query.DatasetQuery.sampling). This works for image datasets, video datasets, and video-frame datasets returned by [`VideoDataset.frames()`](../api/dataset.md#lightly_studio.VideoDataset.frames). The sampled items are stored under the tag passed as `sampling_result_tag_name`, so you can filter or export them later. `sampling_result_tag_name` must be a tag name that does not yet exist in the dataset, unless it is the `preselected_tag_name` of the same run (see [Continuing from preselected samples](#continuing-from-preselected-samples)).
 
 ### Filtering before sampling
 
@@ -373,6 +373,27 @@ sampling.diverse(
 The preselected tag must belong to the sampled collection, and all of its samples must
 be part of the query being sampled. The option is available on every sampling method,
 including `multi_strategies()`.
+
+To grow one tag instead of creating a new one per batch, pass the same name as both
+`preselected_tag_name` and `sampling_result_tag_name`. The newly selected samples are
+added to the existing tag, so it holds the whole selection after every run:
+
+```py
+sampling = dataset.query().sampling()
+
+sampling.diverse(
+    n_samples_to_select=100,
+    sampling_result_tag_name="training_set",
+)
+# "training_set" holds 100 samples.
+
+sampling.diverse(
+    n_samples_to_select=100,
+    sampling_result_tag_name="training_set",
+    preselected_tag_name="training_set",
+)
+# "training_set" holds 200 samples.
+```
 
 ### Video sequence sampling
 

--- a/lightly_studio/src/lightly_studio/sampling/sample.py
+++ b/lightly_studio/src/lightly_studio/sampling/sample.py
@@ -29,7 +29,9 @@ class Sampling:
     combined to form more complex sampling strategies.
 
     The result of a sampling is stored as a tag on the selected samples in the database.
-    The `sampling_result_tag_name` must be a unique tag name that is not used yet.
+    The `sampling_result_tag_name` must be a tag name that is not used yet, with one
+    exception: reusing the `preselected_tag_name` adds the newly selected samples to
+    that tag, which lets a selection grow over repeated runs.
 
     # Creation of a Sampling instance.
 
@@ -145,6 +147,8 @@ class Sampling:
             metadata_key: Metadata key used as weights (float or int values).
             preselected_tag_name: Optional tag containing samples that should be treated
                 as already selected. These samples are excluded from the result tag.
+                Pass the same name as `sampling_result_tag_name` to instead grow that
+                tag with the newly selected samples.
         """
         strategy = MetadataWeightingStrategy(metadata_key=metadata_key)
         self.multi_strategies(
@@ -171,6 +175,8 @@ class Sampling:
                 available model or raises if multiple exist.
             preselected_tag_name: Optional tag containing samples that should be treated
                 as already selected. These samples are excluded from the result tag.
+                Pass the same name as `sampling_result_tag_name` to instead grow that
+                tag with the newly selected samples.
             selected_sequence_length: Number of frames per selected sequence, at least
                 2. ``None`` selects individual samples. When set, selection happens over
                 video-frame sequences formed per video from the candidate frames in
@@ -212,6 +218,8 @@ class Sampling:
                 available model or raises if multiple exist.
             preselected_tag_name: Optional tag containing samples that should be treated
                 as already selected. These samples are excluded from the result tag.
+                Pass the same name as `sampling_result_tag_name` to instead grow that
+                tag with the newly selected samples.
         """
         strategy = EmbeddingDeduplicationStrategy(
             embedding_model_name=embedding_model_name,
@@ -240,6 +248,8 @@ class Sampling:
                 or a dictionary mapping class names to target ratios.
             preselected_tag_name: Optional tag containing samples that should be treated
                 as already selected. These samples are excluded from the result tag.
+                Pass the same name as `sampling_result_tag_name` to instead grow that
+                tag with the newly selected samples.
         """
         strategy = AnnotationClassBalancingStrategy(target_distribution=target_distribution)
         self.multi_strategies(
@@ -265,6 +275,8 @@ class Sampling:
             sampling_strategies: Strategies to compose for sampling.
             preselected_tag_name: Optional tag containing samples that should be treated
                 as already selected. These samples are excluded from the result tag.
+                Pass the same name as `sampling_result_tag_name` to instead grow that
+                tag with the newly selected samples.
             selected_sequence_length: Number of frames per selected sequence, at least
                 2. ``None`` selects individual samples. When set, selection happens over
                 video-frame sequences formed per video from the candidate frames in

--- a/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
@@ -8,7 +8,6 @@ from uuid import UUID
 from sqlmodel import Session
 
 from lightly_studio.database.db_vector import Embedding
-from lightly_studio.models.tag import TagCreate
 from lightly_studio.resolvers import (
     embedding_model_resolver,
     sample_embedding_resolver,
@@ -45,14 +44,16 @@ def create_result_tag(
     tag_name: str,
     selected_sample_ids: Sequence[UUID],
 ) -> None:
-    """Create a sample tag and attach the selected sample ids."""
-    tag = tag_resolver.create(
+    """Attach the selected sample ids to the result sample tag, creating it if needed.
+
+    An existing tag is extended rather than replaced, which is how a run that reuses
+    its preselected tag name grows that tag. Callers must have rejected any other
+    name collision beforehand.
+    """
+    tag = tag_resolver.get_or_create_sample_tag_by_name(
         session=session,
-        tag=TagCreate(
-            collection_id=collection_id,
-            name=tag_name,
-            kind="sample",
-        ),
+        collection_id=collection_id,
+        tag_name=tag_name,
     )
     tag_resolver.add_sample_ids_to_tag_id(
         session=session, tag_id=tag.tag_id, sample_ids=list(selected_sample_ids)

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -226,7 +226,9 @@ def sampling_via_database(
 
     First resolves the sampling config to concrete database values.
     Then calls Mundig to run the sampling with pure values.
-    Finally creates a tag for the selected set.
+    Finally creates a tag for the selected set. Passing the preselected tag as
+    ``config.sampling_result_tag_name`` grows that tag in place instead, so the
+    selection accumulates over repeated runs.
 
     When ``config.selected_sequence_length`` is set, sampling runs over mean-pooled
     sequence proxies and the tag contains every frame of each selected sequence.
@@ -237,8 +239,9 @@ def sampling_via_database(
         input_sample_ids: Candidate sample IDs.
 
     Raises:
-        ValueError: If the preselected tag does not exist or its sample IDs are
-            not a subset of the input sample IDs.
+        ValueError: If the preselected tag does not exist, if its sample IDs are
+            not a subset of the input sample IDs, or if the result tag name is
+            taken by a tag other than the preselected one.
     """
     preselected_sample_ids = _get_preselected_sample_ids(
         session=session,
@@ -246,20 +249,7 @@ def sampling_via_database(
         preselected_tag_name=config.preselected_tag_name,
     )
 
-    # Check if the tag name is already used
-    existing_tag = tag_resolver.get_by_name(
-        session=session,
-        tag_name=config.sampling_result_tag_name,
-        collection_id=config.collection_id,
-    )
-    if existing_tag:
-        # TODO(Lukas, 08/2026): drop this requirement when `preselected_tag_name` is the same as
-        # `sampling_result_tag_name`.
-        msg = (
-            f"Tag with name {config.sampling_result_tag_name} already exists in the "
-            f"collection {config.collection_id}. Please use a different tag name."
-        )
-        raise ValueError(msg)
+    _check_result_tag_name_free(session=session, config=config)
 
     if config.selected_sequence_length is not None:
         sequence_sampling.sampling_via_database_sequences(
@@ -334,6 +324,32 @@ def _get_preselected_sample_ids(
         session=session,
         tag_id=preselected_tag.tag_id,
     )
+
+
+def _check_result_tag_name_free(session: Session, config: SamplingConfig) -> None:
+    """Reject a result tag name that is taken by a tag other than the preselected one.
+
+    Reusing the preselected tag name is allowed: the run extends the preselection it
+    started from. Any other existing tag would silently mix unrelated samples into the
+    sampling result.
+
+    Raises:
+        ValueError: If the result tag name is taken by another tag.
+    """
+    if config.sampling_result_tag_name == config.preselected_tag_name:
+        return
+
+    existing_tag = tag_resolver.get_by_name(
+        session=session,
+        tag_name=config.sampling_result_tag_name,
+        collection_id=config.collection_id,
+    )
+    if existing_tag is not None:
+        msg = (
+            f"Tag with name {config.sampling_result_tag_name} already exists in the "
+            f"collection {config.collection_id}. Please use a different tag name."
+        )
+        raise ValueError(msg)
 
 
 def _prepare_preselection(

--- a/lightly_studio/tests/sampling/test_sampling_via_db.py
+++ b/lightly_studio/tests/sampling/test_sampling_via_db.py
@@ -29,6 +29,7 @@ from lightly_studio.sampling.sampling_config import (
 )
 from lightly_studio.sampling.sampling_via_db import (
     _aggregate_class_distributions,
+    _check_result_tag_name_free,
     sampling_via_database,
 )
 from tests.helpers_resolvers import (
@@ -552,6 +553,56 @@ def test_sampling_via_database__preselection_matches_single_sampling(
 
     assert set(first_batch).isdisjoint(second_batch)
     assert set(first_batch + second_batch) == set(single_batch)
+
+
+def test_sampling_via_database__result_tag_name_equals_preselected_tag_name(
+    db_session: Session,
+) -> None:
+    """Reusing the preselected tag name grows that tag instead of raising."""
+    collection_id = fill_db_with_samples_and_embeddings(
+        db_session, n_samples=10, embedding_model_names=["embedding_model_1"]
+    )
+    sample_ids = _all_sample_ids(db_session, collection_id)
+    strategy = EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1")
+
+    sampling_via_database(
+        session=db_session,
+        config=SamplingConfig(
+            collection_id=collection_id,
+            n_samples_to_select=2,
+            sampling_result_tag_name="growing_batch",
+            strategies=[strategy],
+        ),
+        input_sample_ids=sample_ids,
+    )
+    tag = tag_resolver.get_by_name(
+        session=db_session, tag_name="growing_batch", collection_id=collection_id
+    )
+    assert tag is not None
+    first_batch = _sample_ids_by_tag(
+        session=db_session, collection_id=collection_id, tag_id=tag.tag_id
+    )
+    assert len(first_batch) == 2
+
+    sampling_via_database(
+        session=db_session,
+        config=SamplingConfig(
+            collection_id=collection_id,
+            n_samples_to_select=2,
+            sampling_result_tag_name="growing_batch",
+            preselected_tag_name="growing_batch",
+            strategies=[strategy],
+        ),
+        input_sample_ids=sample_ids,
+    )
+
+    tags = tag_resolver.get_all_by_collection_id(db_session, collection_id=collection_id)
+    assert [existing_tag.name for existing_tag in tags] == ["growing_batch"]
+    grown_batch = _sample_ids_by_tag(
+        session=db_session, collection_id=collection_id, tag_id=tag.tag_id
+    )
+    assert set(first_batch) < set(grown_batch)
+    assert len(grown_batch) == 4
 
 
 def test_sampling_via_database__preselected_tag_name_not_found(
@@ -1161,6 +1212,28 @@ def test_sampling_via_database_with_annotation_class_balancing_input(
     assert len(samples_in_tag) == 1
     # Pick the first sample, because it resembles the input distribution the best.
     assert samples_in_tag[0].sample_id == sample_ids[0]
+
+
+def test_check_result_tag_name_free__existing_tag_is_not_the_preselected_one(
+    db_session: Session,
+) -> None:
+    """Raises when the result tag exists and a different tag is preselected."""
+    collection_id = fill_db_with_samples_and_embeddings(
+        db_session, n_samples=1, embedding_model_names=[]
+    )
+    create_tag(session=db_session, collection_id=collection_id, tag_name="result")
+
+    with pytest.raises(ValueError, match="Tag with name result already exists"):
+        _check_result_tag_name_free(
+            session=db_session,
+            config=SamplingConfig(
+                collection_id=collection_id,
+                n_samples_to_select=1,
+                sampling_result_tag_name="result",
+                preselected_tag_name="preselected",
+                strategies=[],
+            ),
+        )
 
 
 def test_aggregate_class_distributions() -> None:

--- a/lightly_studio/tests/sampling/test_sequence_sampling.py
+++ b/lightly_studio/tests/sampling/test_sequence_sampling.py
@@ -429,6 +429,41 @@ def test_sampling_via_database__sequence_preselection_matches_single_sampling(
     assert set(first_batch + second_batch) == set(single_batch)
 
 
+def test_sampling_via_database__sequence_result_tag_name_equals_preselected_tag_name(
+    db_session: Session,
+) -> None:
+    """Reusing the preselected tag name grows that tag by another sequence."""
+    frame_collection_id, frame_sample_ids = _fill_db_with_video_frames_and_embeddings(
+        session=db_session,
+        n_frames=15,
+    )
+    strategy = EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1")
+
+    def sample_sequences(preselected_tag_name: str | None) -> list[int]:
+        sampling_via_database(
+            session=db_session,
+            config=SamplingConfig(
+                collection_id=frame_collection_id,
+                n_samples_to_select=5,
+                sampling_result_tag_name="growing_batch",
+                preselected_tag_name=preselected_tag_name,
+                strategies=[strategy],
+                selected_sequence_length=5,
+            ),
+            input_sample_ids=frame_sample_ids,
+        )
+        return _tagged_frame_numbers(
+            session=db_session, collection_id=frame_collection_id, tag_name="growing_batch"
+        )
+
+    first_batch = sample_sequences(preselected_tag_name=None)
+    grown_batch = sample_sequences(preselected_tag_name="growing_batch")
+
+    assert len(first_batch) == 5
+    assert set(first_batch) < set(grown_batch)
+    assert len(grown_batch) == 10
+
+
 def _tagged_frame_numbers(session: Session, collection_id: UUID, tag_name: str) -> list[int]:
     """Return the ascending frame numbers carrying the tag with the given name."""
     tag = tag_resolver.get_by_name(session=session, tag_name=tag_name, collection_id=collection_id)


### PR DESCRIPTION
## What has changed and why?

When continuing sampling from an existing tagged selection with the `preselected_tag_name` parameter you can add the same tag name as both input and output. This allows the tag to grow obtaining the same functionality as the data pool from lightly one.

## How has it been tested?

Existing tests pass and new tests added.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sampling results can now reuse the preselected tag, appending newly selected samples across repeated runs.
  * Existing result tags are extended when appropriate, while conflicts with unrelated tags are rejected.

* **Documentation**
  * Updated sampling guidance, API documentation, and changelog to explain tag reuse and conflict behavior.

* **Tests**
  * Added coverage for accumulating samples and validating conflicting tag names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->