### PR TITLE
feat: read evaluation runs and the confusion matrix from the Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compare the annotation class distribution of any sample tag against the current view in the Distribution panel.
 - Azure Blob Storage is supported in the LightlyStudio Enterprise version.
 - Make annotation classes selectable in distribution plot.
+- Python SDK: Read stored evaluation runs and their confusion matrix with `dataset.evaluate().list_runs()` and `dataset.evaluate().confusion_matrix(run_id)`.
 
 ### Changed
 

--- a/lightly_studio/docs/docs/api/evaluation.md
+++ b/lightly_studio/docs/docs/api/evaluation.md
@@ -29,3 +29,15 @@
 ::: lightly_studio.evaluation.image_dataset_evaluate
     options:
         members: [ImageDatasetEvaluate]
+
+## EvaluationRunView
+
+::: lightly_studio.models.evaluation_run
+    options:
+        members: [EvaluationRunView]
+
+## ConfusionMatrix
+
+::: lightly_studio.models.evaluation_confusion_matrix
+    options:
+        members: [ConfusionMatrix]

--- a/lightly_studio/docs/docs/concepts_and_tools/evaluation.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/evaluation.md
@@ -155,4 +155,28 @@ result = dataset.evaluate(query=val_query).object_detection(
 Only samples that appear in both annotation sources **and** in the query are included. Samples
 missing from either source are silently skipped.
 
+### Reading evaluation results
+
+`evaluate()` also reads back the runs that were already stored. This lets a script assert model
+quality without the GUI.
+
+Use `list_runs()` to get the stored runs, newest first. Each run is an
+[`EvaluationRunView`](../api/evaluation.md#evaluationrunview) with its id, name, configuration,
+creation time, and source names. Use `confusion_matrix()` to get the confusion matrix of a run by
+its id.
+
+```python
+evaluator = dataset.evaluate()
+
+runs = evaluator.list_runs()
+for run in runs:
+    print(run.name, run.created_at, run.evaluation_run_configuration)
+
+matrix = evaluator.confusion_matrix(run_id=runs[0].id)
+print(matrix.row_labels, matrix.col_labels, matrix.counts)
+```
+
+`confusion_matrix()` supports object-detection and classification runs. It does not support
+segmentation runs.
+
 See [Evaluation API Reference](../api/evaluation.md) for the full API surface.

--- a/lightly_studio/src/lightly_studio/api/routes/api/evaluation/get_confusion_matrix.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/evaluation/get_confusion_matrix.py
@@ -13,7 +13,6 @@ from lightly_studio.api.routes.api.status import (
 )
 from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.evaluation_confusion_matrix import ConfusionMatrix
-from lightly_studio.models.evaluation_run import EvaluationTaskType
 from lightly_studio.resolvers import (
     evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
@@ -54,10 +53,7 @@ def get_evaluation_confusion_matrix(
             status_code=HTTP_STATUS_NOT_FOUND,
             detail=f"Evaluation run {evaluation_run_id} not found.",
         )
-    if run.task_type in (
-        EvaluationTaskType.OBJECT_DETECTION,
-        EvaluationTaskType.CLASSIFICATION,
-    ):
+    if evaluation_annotation_metric_resolver.supports_confusion_matrix(run.task_type):
         return evaluation_annotation_metric_resolver.get_confusion_matrix(
             session=session,
             evaluation_run_id=evaluation_run_id,

--- a/lightly_studio/src/lightly_studio/api/routes/api/evaluation/get_runs.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/evaluation/get_runs.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Path
 
 from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.evaluation_run import EvaluationRunView
-from lightly_studio.resolvers import collection_resolver, evaluation_run_resolver
+from lightly_studio.resolvers import evaluation_run_resolver
 
 get_runs_router = APIRouter()
 
@@ -31,24 +31,7 @@ def get_evaluation_runs(
     Returns:
         List of evaluation runs, each with id, name, and run configuration.
     """
-    runs = evaluation_run_resolver.get_all_by_dataset_id(
+    return evaluation_run_resolver.list_views_by_dataset_id(
         session=session,
         dataset_id=dataset_id,
     )
-    collection_name_by_id = collection_resolver.get_names_by_ids(
-        session=session,
-        collection_ids={run.gt_annotation_collection_id for run in runs}
-        | {run.pred_annotation_collection_id for run in runs},
-    )
-
-    return [
-        EvaluationRunView(
-            id=run.id,
-            name=run.name,
-            evaluation_run_configuration=run.config_json,
-            created_at=run.created_at,
-            gt_annotation_source=collection_name_by_id[run.gt_annotation_collection_id],
-            pred_annotation_source=collection_name_by_id[run.pred_annotation_collection_id],
-        )
-        for run in runs
-    ]

--- a/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
+++ b/lightly_studio/src/lightly_studio/evaluation/image_dataset_evaluate.py
@@ -17,15 +17,18 @@ from lightly_studio.evaluation import (
 )
 from lightly_studio.evaluation.evaluation_data import EvaluationData
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
+from lightly_studio.models.evaluation_confusion_matrix import ConfusionMatrix
 from lightly_studio.models.evaluation_run import (
     EvaluationRunCreate,
     EvaluationRunTable,
+    EvaluationRunView,
     EvaluationTaskType,
 )
 from lightly_studio.resolvers import (
     annotation_collection_coverage_resolver,
     annotation_resolver,
     collection_resolver,
+    evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
 )
 
@@ -211,6 +214,57 @@ class ImageDatasetEvaluate:
         )
         return EvaluationResult.from_evaluation_data(data)
 
+    def list_runs(self) -> list[EvaluationRunView]:
+        """List the evaluation runs stored for this dataset, newest first.
+
+        Returns:
+            A view per run, with its id, name, configuration, creation time, and
+            resolved ground-truth and prediction source names.
+        """
+        return evaluation_run_resolver.list_views_by_dataset_id(
+            session=self.session,
+            dataset_id=self._dataset_id(),
+        )
+
+    def confusion_matrix(self, run_id: UUID) -> ConfusionMatrix:
+        """Return the confusion matrix of an evaluation run.
+
+        The matrix aggregates the run's persisted ground-truth/prediction
+        annotation pairings by label. Object detection and classification are
+        supported; segmentation tasks do not produce a confusion matrix.
+
+        Args:
+            run_id: ID of the evaluation run.
+
+        Returns:
+            The confusion matrix, with a shared class axis and synthetic
+            false-positive and false-negative axes.
+
+        Raises:
+            ValueError: If no run with ``run_id`` exists in this dataset.
+            NotImplementedError: If the run's task type has no confusion matrix.
+        """
+        run = evaluation_run_resolver.get_by_id(session=self.session, evaluation_id=run_id)
+        if run is None or run.dataset_id != self._dataset_id():
+            raise ValueError(f"Evaluation run {run_id} not found in this dataset.")
+        if not evaluation_annotation_metric_resolver.supports_confusion_matrix(run.task_type):
+            raise NotImplementedError(
+                f"Evaluation task type {run.task_type.value!r} has no confusion matrix."
+            )
+        return evaluation_annotation_metric_resolver.get_confusion_matrix(
+            session=self.session,
+            evaluation_run_id=run_id,
+        )
+
+    def _dataset_id(self) -> UUID:
+        """Resolve the dataset ID of the evaluated collection."""
+        collection = collection_resolver.get_by_id(
+            session=self.session, collection_id=self.collection_id
+        )
+        if collection is None:
+            raise ValueError(f"Collection {self.collection_id} not found.")
+        return collection.dataset_id
+
     def _prepare_evaluation_data(
         self,
         name: str,
@@ -312,19 +366,13 @@ class ImageDatasetEvaluate:
             collection_name=pred_annotation_source,
             task_type=task_type,
         )
-        collection = collection_resolver.get_by_id(
-            session=self.session, collection_id=self.collection_id
-        )
-        if collection is None:
-            raise ValueError(f"Collection {self.collection_id} not found")
-
         evaluation_run = evaluation_run_resolver.create(
             session=self.session,
             evaluation_run_input=EvaluationRunCreate(
                 name=name,
                 gt_annotation_collection_id=gt_collection_id,
                 pred_annotation_collection_id=pred_collection_id,
-                dataset_id=collection.dataset_id,
+                dataset_id=self._dataset_id(),
                 task_type=task_type,
                 config_json=config_json,
             ),

--- a/lightly_studio/src/lightly_studio/resolvers/evaluation_annotation_metric_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/evaluation_annotation_metric_resolver/__init__.py
@@ -10,10 +10,14 @@ from lightly_studio.resolvers.evaluation_annotation_metric_resolver.get_confusio
 from lightly_studio.resolvers.evaluation_annotation_metric_resolver.get_metrics_info_by_collection_id import (  # noqa: E501
     get_metrics_info_by_collection_id,
 )
+from lightly_studio.resolvers.evaluation_annotation_metric_resolver.supports_confusion_matrix import (  # noqa: E501
+    supports_confusion_matrix,
+)
 
 __all__ = [
     "create_many",
     "get_all_by_evaluation_run_id",
     "get_confusion_matrix",
     "get_metrics_info_by_collection_id",
+    "supports_confusion_matrix",
 ]

--- a/lightly_studio/src/lightly_studio/resolvers/evaluation_annotation_metric_resolver/supports_confusion_matrix.py
+++ b/lightly_studio/src/lightly_studio/resolvers/evaluation_annotation_metric_resolver/supports_confusion_matrix.py
@@ -1,0 +1,17 @@
+"""Decide which evaluation task types have a confusion matrix."""
+
+from __future__ import annotations
+
+from lightly_studio.models.evaluation_run import EvaluationTaskType
+
+# Task types whose per-annotation pairings (ground-truth label x prediction
+# label) aggregate into a confusion matrix. Segmentation tasks are not included.
+_TASK_TYPES_WITH_CONFUSION_MATRIX = (
+    EvaluationTaskType.OBJECT_DETECTION,
+    EvaluationTaskType.CLASSIFICATION,
+)
+
+
+def supports_confusion_matrix(task_type: EvaluationTaskType) -> bool:
+    """Return True if the task type aggregates into a confusion matrix."""
+    return task_type in _TASK_TYPES_WITH_CONFUSION_MATRIX

--- a/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/__init__.py
+++ b/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/__init__.py
@@ -3,9 +3,13 @@ from lightly_studio.resolvers.evaluation_run_resolver.get_all_by_dataset_id impo
     get_all_by_dataset_id,
 )
 from lightly_studio.resolvers.evaluation_run_resolver.get_by_id import get_by_id
+from lightly_studio.resolvers.evaluation_run_resolver.list_views_by_dataset_id import (
+    list_views_by_dataset_id,
+)
 
 __all__ = [
     "create",
     "get_all_by_dataset_id",
     "get_by_id",
+    "list_views_by_dataset_id",
 ]

--- a/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/list_views_by_dataset_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/list_views_by_dataset_id.py
@@ -41,8 +41,8 @@ def list_views_by_dataset_id(
             name=run.name,
             evaluation_run_configuration=run.config_json,
             created_at=run.created_at,
-            gt_annotation_source=collection_name_by_id[run.gt_annotation_collection_id],
-            pred_annotation_source=collection_name_by_id[run.pred_annotation_collection_id],
+            gt_annotation_source=collection_name_by_id.get(run.gt_annotation_collection_id),
+            pred_annotation_source=collection_name_by_id.get(run.pred_annotation_collection_id),
         )
         for run in runs
     ]

--- a/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/list_views_by_dataset_id.py
+++ b/lightly_studio/src/lightly_studio/resolvers/evaluation_run_resolver/list_views_by_dataset_id.py
@@ -1,0 +1,48 @@
+"""Build API views of a dataset's evaluation runs."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlmodel import Session
+
+from lightly_studio.models.evaluation_run import EvaluationRunView
+from lightly_studio.resolvers import collection_resolver
+from lightly_studio.resolvers.evaluation_run_resolver.get_all_by_dataset_id import (
+    get_all_by_dataset_id,
+)
+
+
+def list_views_by_dataset_id(
+    session: Session,
+    dataset_id: UUID,
+) -> list[EvaluationRunView]:
+    """Return API views of all evaluation runs for a dataset, newest first.
+
+    Resolves each run's ground-truth and prediction collection IDs to their
+    source names so the view is self-describing.
+
+    Args:
+        session: Database session used by resolver calls.
+        dataset_id: The dataset whose evaluation runs are listed.
+
+    Returns:
+        Views of the runs, newest first.
+    """
+    runs = get_all_by_dataset_id(session=session, dataset_id=dataset_id)
+    collection_name_by_id = collection_resolver.get_names_by_ids(
+        session=session,
+        collection_ids={run.gt_annotation_collection_id for run in runs}
+        | {run.pred_annotation_collection_id for run in runs},
+    )
+    return [
+        EvaluationRunView(
+            id=run.id,
+            name=run.name,
+            evaluation_run_configuration=run.config_json,
+            created_at=run.created_at,
+            gt_annotation_source=collection_name_by_id[run.gt_annotation_collection_id],
+            pred_annotation_source=collection_name_by_id[run.pred_annotation_collection_id],
+        )
+        for run in runs
+    ]

--- a/lightly_studio/tests/api/routes/api/evaluation/test_get_runs.py
+++ b/lightly_studio/tests/api/routes/api/evaluation/test_get_runs.py
@@ -5,64 +5,43 @@ from uuid import uuid4
 
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
-from sqlmodel import Session
 
 from lightly_studio.api.routes.api.status import HTTP_STATUS_OK
-from lightly_studio.models.collection import SampleType
-from tests.api.routes.api.evaluation import helpers
-from tests.helpers_resolvers import create_collection
+from lightly_studio.models.evaluation_run import EvaluationRunView
 
 
-def test_get_evaluation_runs(
-    test_client: TestClient, db_session: Session, mocker: MockerFixture
-) -> None:
-    collection_ids = {
-        name: create_collection(
-            session=db_session,
-            collection_name=name,
-            sample_type=SampleType.ANNOTATION,
-        ).collection_id
-        for name in ("gt_v1", "pred_v1", "gt_v2", "pred_v2")
-    }
-    gt_1_id = collection_ids["gt_v1"]
-    pred_1_id = collection_ids["pred_v1"]
-    gt_2_id = collection_ids["gt_v2"]
-    pred_2_id = collection_ids["pred_v2"]
-
+def test_get_evaluation_runs(test_client: TestClient, mocker: MockerFixture) -> None:
     run_1_id = uuid4()
     run_2_id = uuid4()
-    run_1_created_at = datetime(2026, 5, 18, 10, 0, 0, tzinfo=timezone.utc)
-    run_2_created_at = datetime(2026, 5, 17, 9, 30, 0, tzinfo=timezone.utc)
-    mock_runs = [
-        helpers.make_evaluation_run(
-            run_id=run_1_id,
+    views = [
+        EvaluationRunView(
+            id=run_1_id,
             name="run_1",
-            config_json={"iou_threshold": 0.5, "classwise": True},
-            created_at=run_1_created_at,
-            gt_annotation_collection_id=gt_1_id,
-            pred_annotation_collection_id=pred_1_id,
+            evaluation_run_configuration={"iou_threshold": 0.5, "classwise": True},
+            created_at=datetime(2026, 5, 18, 10, 0, 0, tzinfo=timezone.utc),
+            gt_annotation_source="gt_v1",
+            pred_annotation_source="pred_v1",
         ),
-        helpers.make_evaluation_run(
-            run_id=run_2_id,
+        EvaluationRunView(
+            id=run_2_id,
             name="run_2",
-            config_json={},
-            created_at=run_2_created_at,
-            gt_annotation_collection_id=gt_2_id,
-            pred_annotation_collection_id=pred_2_id,
+            evaluation_run_configuration={},
+            created_at=datetime(2026, 5, 17, 9, 30, 0, tzinfo=timezone.utc),
+            gt_annotation_source="gt_v2",
+            pred_annotation_source="pred_v2",
         ),
     ]
-    get_all_by_dataset_id = mocker.patch(
-        "lightly_studio.api.routes.api.evaluation.get_runs.evaluation_run_resolver.get_all_by_dataset_id",
-        return_value=mock_runs,
+    list_views = mocker.patch(
+        "lightly_studio.api.routes.api.evaluation.get_runs.evaluation_run_resolver.list_views_by_dataset_id",
+        return_value=views,
     )
 
     dataset_id = uuid4()
     response = test_client.get(f"/api/datasets/{dataset_id}/evaluation/runs")
 
-    assert get_all_by_dataset_id.call_args.kwargs["dataset_id"] == dataset_id
+    assert list_views.call_args.kwargs["dataset_id"] == dataset_id
     assert response.status_code == HTTP_STATUS_OK
-    data = response.json()
-    assert data == [
+    assert response.json() == [
         {
             "id": str(run_1_id),
             "name": "run_1",
@@ -87,7 +66,7 @@ def test_get_evaluation_runs__empty_response(
 ) -> None:
     dataset_id = uuid4()
     mocker.patch(
-        "lightly_studio.api.routes.api.evaluation.get_runs.evaluation_run_resolver.get_all_by_dataset_id",
+        "lightly_studio.api.routes.api.evaluation.get_runs.evaluation_run_resolver.list_views_by_dataset_id",
         return_value=[],
     )
 

--- a/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
+++ b/lightly_studio/tests/evaluation/test_image_dataset_evaluate.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from sqlmodel import Session
@@ -12,14 +12,23 @@ from lightly_studio.evaluation.image_dataset_evaluate import (
 )
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import SampleType
-from lightly_studio.models.evaluation_run import EvaluationTaskType
+from lightly_studio.models.evaluation_confusion_matrix import (
+    NO_GROUND_TRUTH_ROW_LABEL,
+    NO_PREDICTION_COL_LABEL,
+)
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
 from lightly_studio.resolvers import (
     collection_resolver,
     evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
     evaluation_sample_metric_resolver,
 )
-from tests.helpers_resolvers import create_annotation, create_annotation_label, create_image
+from tests.helpers_resolvers import (
+    create_annotation,
+    create_annotation_label,
+    create_collection,
+    create_image,
+)
 
 
 def test_object_detection_evaluation(
@@ -524,6 +533,169 @@ def test_segmentation_evaluation__raises_on_wrong_annotation_type(
             gt_annotation_source="gt",
             pred_annotation_source="pred",
         )
+
+
+def test_list_runs(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Returns a view per run, with resolved source names and the run configuration."""
+    dataset = ImageDataset.create(name="test_dataset")
+    label = create_annotation_label(
+        session=dataset.session,
+        root_collection_id=dataset.collection_id,
+    )
+    image = create_image(session=dataset.session, collection_id=dataset.collection_id)
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
+    for source_name in ("gt", "pred"):
+        create_annotation(
+            session=dataset.session,
+            collection_id=dataset.collection_id,
+            sample_id=image.sample_id,
+            annotation_label_id=label.annotation_label_id,
+            annotation_collection_name=source_name,
+        )
+    for run_name in ("run-a", "run-b"):
+        dataset.evaluate().object_detection(
+            name=run_name,
+            gt_annotation_source="gt",
+            pred_annotation_source="pred",
+        )
+
+    views = dataset.evaluate().list_runs()
+
+    assert len(views) == 2
+    assert {view.name for view in views} == {"run-a", "run-b"}
+    view = next(view for view in views if view.name == "run-a")
+    assert view.gt_annotation_source == "gt"
+    assert view.pred_annotation_source == "pred"
+    assert set(view.evaluation_run_configuration) == {"iou_threshold", "classwise"}
+
+
+def test_list_runs__no_runs_returns_empty(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Returns an empty list when the dataset has no evaluation runs."""
+    dataset = ImageDataset.create(name="test_dataset")
+
+    assert dataset.evaluate().list_runs() == []
+
+
+def test_confusion_matrix(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Returns the confusion matrix for a run from its persisted annotation pairings."""
+    dataset = ImageDataset.create(name="test_dataset")
+    gt_label = create_annotation_label(
+        session=dataset.session,
+        root_collection_id=dataset.collection_id,
+        label_name="cat",
+    )
+    pred_label = create_annotation_label(
+        session=dataset.session,
+        root_collection_id=dataset.collection_id,
+        label_name="dog",
+    )
+    image = create_image(session=dataset.session, collection_id=dataset.collection_id)
+    _create_gt_and_pred_collections(session=dataset.session, collection_id=dataset.collection_id)
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=gt_label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_collection_name="gt",
+    )
+    create_annotation(
+        session=dataset.session,
+        collection_id=dataset.collection_id,
+        sample_id=image.sample_id,
+        annotation_label_id=pred_label.annotation_label_id,
+        annotation_type=AnnotationType.CLASSIFICATION,
+        annotation_collection_name="pred",
+    )
+    dataset.evaluate().classification(
+        name="run-1",
+        gt_annotation_source="gt",
+        pred_annotation_source="pred",
+    )
+    run_id = dataset.evaluate().list_runs()[0].id
+
+    matrix = dataset.evaluate().confusion_matrix(run_id=run_id)
+
+    assert matrix.row_labels == ["cat", "dog", NO_GROUND_TRUTH_ROW_LABEL]
+    assert matrix.col_labels == ["cat", "dog", NO_PREDICTION_COL_LABEL]
+    assert matrix.counts == [[0, 1, 0], [0, 0, 0], [0, 0, 0]]
+
+
+def test_confusion_matrix__run_not_found_raises(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Raises ValueError when the run does not exist."""
+    dataset = ImageDataset.create(name="test_dataset")
+
+    with pytest.raises(ValueError, match="not found"):
+        dataset.evaluate().confusion_matrix(run_id=uuid4())
+
+
+def test_confusion_matrix__unsupported_task_type_raises(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Raises NotImplementedError for a task type without a confusion matrix."""
+    dataset = ImageDataset.create(name="test_dataset")
+    gt_collection = create_collection(
+        session=dataset.session,
+        parent_collection_id=dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    pred_collection = create_collection(
+        session=dataset.session,
+        parent_collection_id=dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    run = evaluation_run_resolver.create(
+        session=dataset.session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="seg-run",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.SEMANTIC_SEGMENTATION,
+        ),
+    )
+
+    with pytest.raises(NotImplementedError, match="semantic_segmentation"):
+        dataset.evaluate().confusion_matrix(run_id=run.id)
+
+
+def test_confusion_matrix__run_from_another_dataset_raises(
+    patch_collection: None,  # noqa: ARG001
+) -> None:
+    """Rejects a run that belongs to a different dataset."""
+    other_dataset = ImageDataset.create(name="other_dataset")
+    gt_collection = create_collection(
+        session=other_dataset.session,
+        parent_collection_id=other_dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    pred_collection = create_collection(
+        session=other_dataset.session,
+        parent_collection_id=other_dataset.collection_id,
+        sample_type=SampleType.ANNOTATION,
+    )
+    run = evaluation_run_resolver.create(
+        session=other_dataset.session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run-1",
+            gt_annotation_collection_id=gt_collection.collection_id,
+            pred_annotation_collection_id=pred_collection.collection_id,
+            dataset_id=other_dataset.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+        ),
+    )
+    dataset = ImageDataset.create(name="test_dataset")
+
+    with pytest.raises(ValueError, match="not found in this dataset"):
+        dataset.evaluate().confusion_matrix(run_id=run.id)
 
 
 def _create_gt_and_pred_collections(session: Session, collection_id: UUID) -> None:

--- a/lightly_studio/tests/resolvers/evaluation_run_resolver/test_evaluation_run_list_views.py
+++ b/lightly_studio/tests/resolvers/evaluation_run_resolver/test_evaluation_run_list_views.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlmodel import Session
+
+from lightly_studio.models.collection import SampleType
+from lightly_studio.models.evaluation_run import EvaluationRunCreate, EvaluationTaskType
+from lightly_studio.resolvers import evaluation_run_resolver
+from tests.helpers_resolvers import create_collection
+
+
+def test_list_views_by_dataset_id(db_session: Session) -> None:
+    dataset = create_collection(session=db_session)
+    gt = create_collection(
+        session=db_session,
+        collection_name="gt",
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    pred = create_collection(
+        session=db_session,
+        collection_name="pred",
+        sample_type=SampleType.ANNOTATION,
+        parent_collection_id=dataset.collection_id,
+    )
+    run_1 = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_1",
+            gt_annotation_collection_id=gt.collection_id,
+            pred_annotation_collection_id=pred.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.OBJECT_DETECTION,
+            config_json={"iou_threshold": 0.5, "classwise": True},
+        ),
+    )
+    run_2 = evaluation_run_resolver.create(
+        session=db_session,
+        evaluation_run_input=EvaluationRunCreate(
+            name="run_2",
+            gt_annotation_collection_id=gt.collection_id,
+            pred_annotation_collection_id=pred.collection_id,
+            dataset_id=dataset.dataset_id,
+            task_type=EvaluationTaskType.CLASSIFICATION,
+        ),
+    )
+
+    views = evaluation_run_resolver.list_views_by_dataset_id(
+        session=db_session, dataset_id=dataset.dataset_id
+    )
+
+    # Newest first, ground-truth and prediction collection IDs resolved to names.
+    assert [view.id for view in views] == [run_2.id, run_1.id]
+    view_1 = next(view for view in views if view.id == run_1.id)
+    assert view_1.name == "run_1"
+    assert view_1.gt_annotation_source == "gt"
+    assert view_1.pred_annotation_source == "pred"
+    assert view_1.evaluation_run_configuration == {"iou_threshold": 0.5, "classwise": True}
+
+
+def test_list_views_by_dataset_id__returns_empty_for_unknown_dataset(db_session: Session) -> None:
+    views = evaluation_run_resolver.list_views_by_dataset_id(
+        session=db_session, dataset_id=uuid.uuid4()
+    )
+
+    assert views == []


### PR DESCRIPTION
## What has changed and why?

`dataset.evaluate()` can create evaluation runs, but the Python SDK cannot read the results. The runs, their configuration, and the confusion matrix are reachable only through the GUI or internal resolvers. This adds two read methods to `ImageDatasetEvaluate`:

- `evaluate().list_runs()` returns the stored runs, newest first, as `EvaluationRunView` objects (id, name, configuration, creation time, and resolved source names).
- `evaluate().confusion_matrix(run_id)` returns the confusion matrix of a run. Object detection and classification are supported; segmentation runs raise `NotImplementedError`.

A user can now assert model quality from a script or in CI, without the GUI.

This is the first of three staged PRs for #2019, in the order confirmed on the issue (readback → confusion-derived aggregates → mean average precision). It needs no schema change and no new dependency.

The first commit is a behavior-preserving refactor: it moves the run-to-view listing and the confusion-matrix task-type check into the resolvers, so the REST routes and the Python SDK share one implementation. The second commit adds the two read methods.

Part of #2019.

## How has it been tested?

- New unit tests for both methods and the shared resolver: `list_runs()` (populated and empty), `confusion_matrix()` (populated, run not found, unsupported task type), and the run-view resolver.
- `make static-checks` (ruff, ruff format, mypy) passes.
- The evaluation, service, and route test suites pass.
- The docs build passes with `--strict`; the new methods and the `EvaluationRunView` and `ConfusionMatrix` models render in the API reference.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Python SDK support for listing stored evaluation runs, ordered newest first.
  * Added confusion matrix retrieval for classification and object detection evaluations.
  * Confusion matrices include labels for missing ground-truth or prediction annotations.
  * Evaluation run results include source names and configuration details.
  * Added validation for missing runs, runs from another dataset, and unsupported segmentation confusion matrices.

* **Documentation**
  * Documented evaluation run listing, confusion matrix retrieval, supported task types, and related API models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->