### PR TITLE
Stop reading embedding_model.collection_id

### DIFF
--- a/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
+++ b/lightly_studio/docs/docs/concepts_and_tools/embeddings.md
@@ -139,15 +139,13 @@ to list which input positions those rows belong to. This lets you skip any file 
 that has no vector.
 
 ```python
-from uuid import UUID
-
 import numpy as np
 from numpy.typing import NDArray
 from PIL import Image
 
 import lightly_studio as ls
 from lightly_studio.dataset.embedding_result import EmbeddingResult
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 
 EMBEDDING_DIMENSION = 512
 
@@ -156,7 +154,7 @@ class CustomEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
     def __init__(self) -> None:
         self._filepath_to_embedding: dict[str, NDArray[np.float32]] = ...  # Implement the loading logic here.
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate: ...
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription: ...
 
     def embed_text(self, text: str) -> list[float]: ...
 
@@ -200,15 +198,13 @@ Use this when you want a different model than the built-ins. Load your model in
 `__init__` and run it inside `embed_images`.
 
 ```python
-from uuid import UUID
-
 import numpy as np
 from numpy.typing import NDArray
 from PIL import Image
 
 import lightly_studio as ls
 from lightly_studio.dataset.embedding_result import EmbeddingResult
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 
 EMBEDDING_DIMENSION = 512
 
@@ -217,7 +213,7 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
     def __init__(self) -> None:
         ...  # Load your model and preprocessing here.
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate: ...
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription: ...
 
     def embed_text(self, text: str) -> list[float]: ...
 

--- a/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/annotation.py
@@ -28,7 +28,7 @@ from lightly_studio.models.embedding_region import EmbeddingRegion
 from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
-    embedding_model_resolver,
+    default_embedding_space_resolver,
     sample_embedding_resolver,
 )
 from lightly_studio.resolvers.annotation_resolver.get_all import (
@@ -207,11 +207,11 @@ def read_annotation_embedding(
     Used for drag-to-search self-similarity: searching with an annotation's own
     stored embedding.
     """
-    embedding_models = embedding_model_resolver.get_all_by_collection_id(
+    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
         session=session,
         collection_id=collection_id,
     )
-    if not embedding_models:
+    if embedding_model_id is None:
         raise HTTPException(
             status_code=HTTP_STATUS_NOT_FOUND,
             detail="No embedding model is registered for this collection.",
@@ -220,7 +220,7 @@ def read_annotation_embedding(
     embeddings = sample_embedding_resolver.get_by_sample_ids(
         session=session,
         sample_ids=[sample_id],
-        embedding_model_id=embedding_models[0].embedding_model_id,
+        embedding_model_id=embedding_model_id,
     )
     if not embeddings:
         raise HTTPException(

--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -59,7 +59,9 @@ class EmbeddingGenerator(Protocol):
     before you add a dataset or start the GUI.
     """
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
 
         <span class="doc-badge doc-badge--beta">Beta</span>
@@ -70,6 +72,7 @@ class EmbeddingGenerator(Protocol):
 
         Args:
             collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -197,11 +200,14 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         """
         self._dimension = dimension
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
 
         Args:
             collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -211,6 +217,7 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
             embedding_model_hash="random_model",
             embedding_dimension=self._dimension,
             collection_id=collection_id,
+            dataset_id=dataset_id,
         )
 
     def embed_text(self, _text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_generator.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import random
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
-from uuid import UUID
 
 import numpy as np
 from numpy.typing import NDArray
 from PIL import Image
 
 from lightly_studio.dataset.embedding_result import EmbeddingResult
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 
 
 @dataclass(frozen=True)
@@ -59,10 +58,8 @@ class EmbeddingGenerator(Protocol):
     before you add a dataset or start the GUI.
     """
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        """Generate an EmbeddingModelCreate instance.
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        """Describe the embedding space produced by this generator.
 
         <span class="doc-badge doc-badge--beta">Beta</span>
 
@@ -70,12 +67,8 @@ class EmbeddingGenerator(Protocol):
         The `embedding_model_hash` field is used to match the same EmbeddingGenerator
         across multiple LightlyStudio runs.
 
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
-
         Returns:
-            An EmbeddingModelCreate instance with the model details.
+            A description of the embedding space.
         """
 
     def embed_text(self, text: str) -> list[float]:
@@ -200,24 +193,16 @@ class RandomEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddingGenerator)
         """
         self._dimension = dimension
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        """Generate an EmbeddingModelCreate instance.
-
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        """Describe the embedding space produced by this generator.
 
         Returns:
-            An EmbeddingModelCreate instance with the model details.
+            A description of the embedding space.
         """
-        return EmbeddingModelCreate(
+        return EmbeddingSpaceDescription(
             name="Random",
             embedding_model_hash="random_model",
             embedding_dimension=self._dimension,
-            collection_id=collection_id,
-            dataset_id=dataset_id,
         )
 
     def embed_text(self, _text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -161,12 +161,15 @@ class EmbeddingManager:
         Returns:
             The created EmbeddingModel.
         """
-        # Get or create embedding model record in the database.
+        collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+        if collection is None:
+            raise ValueError("Provided collection_id could not be found.")
+
+        embedding_model = embedding_generator.get_embedding_model_input(collection_id=collection_id)
+        embedding_model.dataset_id = collection.dataset_id
         db_model = embedding_model_resolver.get_or_create(
             session=session,
-            embedding_model=embedding_generator.get_embedding_model_input(
-                collection_id=collection_id
-            ),
+            embedding_model=embedding_model,
         )
         model_id = db_model.embedding_model_id
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -167,7 +167,10 @@ class EmbeddingManager:
 
         embedding_space = embedding_generator.get_embedding_model_input()
         embedding_model = EmbeddingModelCreate(
-            **embedding_space.model_dump(),
+            name=embedding_space.name,
+            parameter_count_in_mb=embedding_space.parameter_count_in_mb,
+            embedding_model_hash=embedding_space.embedding_model_hash,
+            embedding_dimension=embedding_space.embedding_dimension,
             collection_id=collection_id,
             dataset_id=collection.dataset_id,
         )

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -19,7 +19,7 @@ from lightly_studio.dataset.embedding_generator import (
     VideoEmbeddingGenerator,
 )
 from lightly_studio.models.collection import SampleType
-from lightly_studio.models.embedding_model import EmbeddingModelTable
+from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingCreate
 from lightly_studio.resolvers import (
     annotation_resolver,
@@ -165,12 +165,15 @@ class EmbeddingManager:
         if collection is None:
             raise ValueError("Provided collection_id could not be found.")
 
+        embedding_space = embedding_generator.get_embedding_model_input()
+        embedding_model = EmbeddingModelCreate(
+            **embedding_space.model_dump(),
+            collection_id=collection_id,
+            dataset_id=collection.dataset_id,
+        )
         db_model = embedding_model_resolver.get_or_create(
             session=session,
-            embedding_model=embedding_generator.get_embedding_model_input(
-                collection_id=collection_id,
-                dataset_id=collection.dataset_id,
-            ),
+            embedding_model=embedding_model,
         )
         model_id = db_model.embedding_model_id
 

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -165,11 +165,12 @@ class EmbeddingManager:
         if collection is None:
             raise ValueError("Provided collection_id could not be found.")
 
-        embedding_model = embedding_generator.get_embedding_model_input(collection_id=collection_id)
-        embedding_model.dataset_id = collection.dataset_id
         db_model = embedding_model_resolver.get_or_create(
             session=session,
-            embedding_model=embedding_model,
+            embedding_model=embedding_generator.get_embedding_model_input(
+                collection_id=collection_id,
+                dataset_id=collection.dataset_id,
+            ),
         )
         model_id = db_model.embedding_model_id
 

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -53,11 +53,14 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
         self._model_hash = file_utils.get_file_xxhash(model_path)
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
 
         Args:
             collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -67,6 +70,7 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
             embedding_model_hash=self._model_hash,
             embedding_dimension=EMBEDDING_DIMENSION,
             collection_id=collection_id,
+            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/mobileclip_embedding_generator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import UUID
 
 import numpy as np
 import torch
@@ -11,7 +10,7 @@ from numpy.typing import NDArray
 from PIL import Image
 
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 from lightly_studio.vendor import mobileclip
 
 from . import file_utils, image_crop_embedding, image_embedding
@@ -53,24 +52,16 @@ class MobileCLIPEmbeddingGenerator(ImageEmbeddingGenerator):
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
         self._model_hash = file_utils.get_file_xxhash(model_path)
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        """Generate an EmbeddingModelCreate instance.
-
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        """Describe the embedding space produced by this generator.
 
         Returns:
-            An EmbeddingModelCreate instance with the model details.
+            A description of the embedding space.
         """
-        return EmbeddingModelCreate(
+        return EmbeddingSpaceDescription(
             name=MODEL_NAME,
             embedding_model_hash=self._model_hash,
             embedding_dimension=EMBEDDING_DIMENSION,
-            collection_id=collection_id,
-            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -63,11 +63,14 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         self._model = self._model.to(self._device)
         self._model_hash = file_utils.get_file_xxhash(Path(model_path))
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         """Generate an EmbeddingModelCreate instance.
 
         Args:
             collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
 
         Returns:
             An EmbeddingModelCreate instance with the model details.
@@ -77,6 +80,7 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
             embedding_model_hash=self._model_hash,
             embedding_dimension=self._model.output_dim,
             collection_id=collection_id,
+            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
+++ b/lightly_studio/src/lightly_studio/dataset/perception_encoder_embedding_generator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from uuid import UUID
 
 import fsspec
 import numpy as np
@@ -21,7 +20,7 @@ from lightly_studio.core.file_outcome_report import (
     MissingInputFileError,
 )
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 from lightly_studio.utils import batching
 from lightly_studio.vendor.perception_encoder.vision_encoder import pe, transforms
 
@@ -63,24 +62,16 @@ class PerceptionEncoderEmbeddingGenerator(ImageEmbeddingGenerator, VideoEmbeddin
         self._model = self._model.to(self._device)
         self._model_hash = file_utils.get_file_xxhash(Path(model_path))
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        """Generate an EmbeddingModelCreate instance.
-
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        """Describe the embedding space produced by this generator.
 
         Returns:
-            An EmbeddingModelCreate instance with the model details.
+            A description of the embedding space.
         """
-        return EmbeddingModelCreate(
+        return EmbeddingSpaceDescription(
             name=MODEL_NAME,
             embedding_model_hash=self._model_hash,
             embedding_dimension=self._model.output_dim,
-            collection_id=collection_id,
-            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
@@ -66,17 +66,24 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
         self._model_hash = file_utils.get_file_xxhash(model_path)
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         """Describe the model so it can be recorded in the database.
 
         The name shows up in the GUI and the hash lets Lightly Studio detect when
         the same model has been used before.
+
+        Args:
+            collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
         """
         return EmbeddingModelCreate(
             name="Custom Embedding Model",
             embedding_model_hash=self._model_hash,
             embedding_dimension=EMBEDDING_DIMENSION,
             collection_id=collection_id,
+            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/examples/example_custom_embedding_model.py
@@ -12,7 +12,6 @@ so ingestion uses your generator instead of the environment default.
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import UUID
 
 import numpy as np
 import torch
@@ -26,7 +25,7 @@ from lightly_studio.dataset import file_utils, image_crop_embedding, image_embed
 from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.dataset.env import LIGHTLY_STUDIO_MODEL_CACHE_DIR
 from lightly_studio.dataset.image_embedding import EmbeddingContext
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 from lightly_studio.vendor import mobileclip
 
 MODEL_NAME = "mobileclip_s0"
@@ -66,24 +65,16 @@ class CustomEmbeddingGenerator(ls.ImageEmbeddingGenerator):
         self._tokenizer = mobileclip.get_tokenizer(model_name=MODEL_NAME)
         self._model_hash = file_utils.get_file_xxhash(model_path)
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
         """Describe the model so it can be recorded in the database.
 
         The name shows up in the GUI and the hash lets Lightly Studio detect when
         the same model has been used before.
-
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
         """
-        return EmbeddingModelCreate(
+        return EmbeddingSpaceDescription(
             name="Custom Embedding Model",
             embedding_model_hash=self._model_hash,
             embedding_dimension=EMBEDDING_DIMENSION,
-            collection_id=collection_id,
-            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
+++ b/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
@@ -11,7 +11,6 @@ video model.
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import UUID
 
 import numpy as np
 from environs import Env
@@ -21,7 +20,7 @@ from PIL import Image
 import lightly_studio as ls
 from lightly_studio.database import db_manager
 from lightly_studio.dataset.embedding_result import EmbeddingResult
-from lightly_studio.models.embedding_model import EmbeddingModelCreate
+from lightly_studio.models.embedding_model import EmbeddingSpaceDescription
 
 IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
 EMBEDDING_DIMENSION = 64
@@ -56,21 +55,12 @@ class LoadExistingEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
         """
         self._embeddings_by_filepath = embeddings_by_filepath
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        """Describe the model so it can be recorded in the database.
-
-        Args:
-            collection_id: The ID of the collection.
-            dataset_id: The ID of the dataset.
-        """
-        return EmbeddingModelCreate(
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        """Describe the model so it can be recorded in the database."""
+        return EmbeddingSpaceDescription(
             name="Precomputed Embeddings",
             embedding_model_hash="precomputed",
             embedding_dimension=EMBEDDING_DIMENSION,
-            collection_id=collection_id,
-            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
+++ b/lightly_studio/src/lightly_studio/examples/example_load_existing_embeddings.py
@@ -56,13 +56,21 @@ class LoadExistingEmbeddingsGenerator(ls.ImageEmbeddingGenerator):
         """
         self._embeddings_by_filepath = embeddings_by_filepath
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
-        """Describe the model so it can be recorded in the database."""
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
+        """Describe the model so it can be recorded in the database.
+
+        Args:
+            collection_id: The ID of the collection.
+            dataset_id: The ID of the dataset.
+        """
         return EmbeddingModelCreate(
             name="Precomputed Embeddings",
             embedding_model_hash="precomputed",
             embedding_dimension=EMBEDDING_DIMENSION,
             collection_id=collection_id,
+            dataset_id=dataset_id,
         )
 
     def embed_text(self, text: str) -> list[float]:

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -123,17 +123,12 @@ class ClassifierManager:
         Returns:
             The created classifier name and ID.
         """
-        embedding_models = embedding_model_resolver.get_all_by_collection_id(
+        embedding_model = embedding_model_resolver.get_default_by_collection_id(
             session=session,
             collection_id=collection_id,
         )
-        if len(embedding_models) == 0:
+        if embedding_model is None:
             raise ValueError("No embedding model found for the given collection ID.")
-        # TODO(Horatiu, 05/2025): Handle multiple models correctly when
-        # available
-        if len(embedding_models) > 1:
-            raise ValueError("Multiple embedding models found for the given collection ID.")
-        embedding_model = embedding_models[0]
         classifier = RandomForest(
             name=name,
             classes=class_list,

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -28,6 +28,7 @@ from lightly_studio.models.annotation_label import (
     AnnotationLabelCreate,
 )
 from lightly_studio.models.classifier import EmbeddingClassifier
+from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.image import ImageTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
@@ -165,10 +166,10 @@ class ClassifierManager:
         if classifier is None:
             raise ValueError(f"Classifier with ID {classifier_id} not found.")
 
-        embedding_model = embedding_model_resolver.get_by_collection_id_and_hash(
+        embedding_model = _get_embedding_model_by_hash(
             session=session,
-            embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
             collection_id=classifier.collection_id,
+            embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
         )
         if embedding_model is None:
             raise ValueError(
@@ -255,10 +256,10 @@ class ClassifierManager:
         classifier = random_forest_classifier.load_random_forest_classifier(
             classifier_path=file_path, buffer=None
         )
-        embedding_model = embedding_model_resolver.get_by_collection_id_and_hash(
+        embedding_model = _get_embedding_model_by_hash(
             session=session,
-            embedding_model_hash=classifier.embedding_model_hash,
             collection_id=collection_id,
+            embedding_model_hash=classifier.embedding_model_hash,
         )
         if embedding_model is None:
             raise ValueError(
@@ -390,10 +391,10 @@ class ClassifierManager:
         annotations = classifier.annotations
         used_samples = {sample_id for samples in annotations.values() for sample_id in samples}
 
-        embedding_model = embedding_model_resolver.get_by_collection_id_and_hash(
+        embedding_model = _get_embedding_model_by_hash(
             session=session,
-            embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
             collection_id=classifier.collection_id,
+            embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
         )
         if embedding_model is None:
             raise ValueError(
@@ -453,10 +454,10 @@ class ClassifierManager:
             raise ValueError(
                 f"Classifier with ID {classifier_id} is not active and cannot be used."
             )
-        embedding_model = embedding_model_resolver.get_by_collection_id_and_hash(
+        embedding_model = _get_embedding_model_by_hash(
             session=session,
-            embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
             collection_id=classifier.collection_id,
+            embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
         )
         if embedding_model is None:
             raise ValueError(
@@ -589,10 +590,10 @@ class ClassifierManager:
         classifier = random_forest_classifier.load_random_forest_classifier(
             buffer=buffer, classifier_path=None
         )
-        embedding_model = embedding_model_resolver.get_by_collection_id_and_hash(
+        embedding_model = _get_embedding_model_by_hash(
             session=session,
-            embedding_model_hash=classifier.embedding_model_hash,
             collection_id=collection_id,
+            embedding_model_hash=classifier.embedding_model_hash,
         )
         if embedding_model is None:
             raise ValueError(
@@ -609,6 +610,25 @@ class ClassifierManager:
             annotations={class_name: [] for class_name in classifier.classes},
         )
         return self._classifiers[classifier_id]
+
+
+def _get_embedding_model_by_hash(
+    session: Session, collection_id: UUID, embedding_model_hash: str
+) -> EmbeddingModelTable | None:
+    """Resolve the embedding model with the given hash within the collection's dataset.
+
+    A classifier stores the hash of the model it was trained on. The model is looked up by
+    ``(dataset_id, embedding_model_hash)`` so it resolves regardless of whether it is the
+    collection's default embedding space.
+    """
+    collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+    if collection is None:
+        raise ValueError(f"Collection {collection_id} not found.")
+    return embedding_model_resolver.get_by_model_hash(
+        session=session,
+        dataset_id=collection.dataset_id,
+        embedding_model_hash=embedding_model_hash,
+    )
 
 
 def _create_annotation_labels_for_classifier(

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -34,6 +34,7 @@ from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
     collection_resolver,
+    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -123,9 +124,16 @@ class ClassifierManager:
         Returns:
             The created classifier name and ID.
         """
-        embedding_model = embedding_model_resolver.get_default_by_collection_id(
+        embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
             session=session,
             collection_id=collection_id,
+        )
+        embedding_model = (
+            embedding_model_resolver.get_by_id(
+                session=session, embedding_model_id=embedding_model_id
+            )
+            if embedding_model_id is not None
+            else None
         )
         if embedding_model is None:
             raise ValueError("No embedding model found for the given collection ID.")

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -165,7 +165,7 @@ class ClassifierManager:
         if classifier is None:
             raise ValueError(f"Classifier with ID {classifier_id} not found.")
 
-        embedding_model = embedding_model_resolver.get_by_model_hash(
+        embedding_model = embedding_model_resolver.get_by_collection_id_and_hash(
             session=session,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
             collection_id=classifier.collection_id,
@@ -255,7 +255,7 @@ class ClassifierManager:
         classifier = random_forest_classifier.load_random_forest_classifier(
             classifier_path=file_path, buffer=None
         )
-        embedding_model = embedding_model_resolver.get_by_model_hash(
+        embedding_model = embedding_model_resolver.get_by_collection_id_and_hash(
             session=session,
             embedding_model_hash=classifier.embedding_model_hash,
             collection_id=collection_id,
@@ -390,7 +390,7 @@ class ClassifierManager:
         annotations = classifier.annotations
         used_samples = {sample_id for samples in annotations.values() for sample_id in samples}
 
-        embedding_model = embedding_model_resolver.get_by_model_hash(
+        embedding_model = embedding_model_resolver.get_by_collection_id_and_hash(
             session=session,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
             collection_id=classifier.collection_id,
@@ -453,7 +453,7 @@ class ClassifierManager:
             raise ValueError(
                 f"Classifier with ID {classifier_id} is not active and cannot be used."
             )
-        embedding_model = embedding_model_resolver.get_by_model_hash(
+        embedding_model = embedding_model_resolver.get_by_collection_id_and_hash(
             session=session,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
             collection_id=classifier.collection_id,
@@ -589,7 +589,7 @@ class ClassifierManager:
         classifier = random_forest_classifier.load_random_forest_classifier(
             buffer=buffer, classifier_path=None
         )
-        embedding_model = embedding_model_resolver.get_by_model_hash(
+        embedding_model = embedding_model_resolver.get_by_collection_id_and_hash(
             session=session,
             embedding_model_hash=classifier.embedding_model_hash,
             collection_id=collection_id,

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -168,8 +168,8 @@ class ClassifierManager:
 
         embedding_model = _get_embedding_model_by_hash(
             session=session,
-            collection_id=classifier.collection_id,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
+            collection_id=classifier.collection_id,
         )
         if embedding_model is None:
             raise ValueError(
@@ -258,8 +258,8 @@ class ClassifierManager:
         )
         embedding_model = _get_embedding_model_by_hash(
             session=session,
-            collection_id=collection_id,
             embedding_model_hash=classifier.embedding_model_hash,
+            collection_id=collection_id,
         )
         if embedding_model is None:
             raise ValueError(
@@ -393,8 +393,8 @@ class ClassifierManager:
 
         embedding_model = _get_embedding_model_by_hash(
             session=session,
-            collection_id=classifier.collection_id,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
+            collection_id=classifier.collection_id,
         )
         if embedding_model is None:
             raise ValueError(
@@ -456,8 +456,8 @@ class ClassifierManager:
             )
         embedding_model = _get_embedding_model_by_hash(
             session=session,
-            collection_id=classifier.collection_id,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
+            collection_id=classifier.collection_id,
         )
         if embedding_model is None:
             raise ValueError(
@@ -592,8 +592,8 @@ class ClassifierManager:
         )
         embedding_model = _get_embedding_model_by_hash(
             session=session,
-            collection_id=collection_id,
             embedding_model_hash=classifier.embedding_model_hash,
+            collection_id=collection_id,
         )
         if embedding_model is None:
             raise ValueError(
@@ -613,7 +613,7 @@ class ClassifierManager:
 
 
 def _get_embedding_model_by_hash(
-    session: Session, collection_id: UUID, embedding_model_hash: str
+    session: Session, embedding_model_hash: str, collection_id: UUID
 ) -> EmbeddingModelTable | None:
     """Resolve the embedding model with the given hash within the collection's dataset.
 

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787582284_c2d3e4f5a6b7_add_embedding_model_dataset_id.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787582284_c2d3e4f5a6b7_add_embedding_model_dataset_id.py
@@ -1,0 +1,62 @@
+"""add embedding model dataset id.
+
+Adds a nullable ``dataset_id`` to ``embedding_model`` and backfills it through the
+existing collection relationship. The column remains nullable while ``collection_id``
+is still the source of truth; a later migration can make it required when it removes
+``collection_id``.
+
+DuckDB builds its schema with ``create_all``, so this migration only matters for tracked
+Postgres databases.
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2026-08-24 16:38:04.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c2d3e4f5a6b7"
+down_revision: Union[str, Sequence[str], None] = "b1c2d3e4f5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("embedding_model", sa.Column("dataset_id", sa.Uuid(), nullable=True))
+    op.create_index(
+        op.f("ix_embedding_model_dataset_id"),
+        "embedding_model",
+        ["dataset_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "fk_embedding_model_dataset_id",
+        "embedding_model",
+        "dataset",
+        ["dataset_id"],
+        ["dataset_id"],
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE embedding_model
+            SET dataset_id = collection.dataset_id
+            FROM collection
+            WHERE embedding_model.collection_id = collection.collection_id
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("fk_embedding_model_dataset_id", "embedding_model", type_="foreignkey")
+    op.drop_index(op.f("ix_embedding_model_dataset_id"), table_name="embedding_model")
+    op.drop_column("embedding_model", "dataset_id")

--- a/lightly_studio/src/lightly_studio/migrations/versions/1787582284_c2d3e4f5a6b7_add_embedding_model_dataset_id.py
+++ b/lightly_studio/src/lightly_studio/migrations/versions/1787582284_c2d3e4f5a6b7_add_embedding_model_dataset_id.py
@@ -1,9 +1,8 @@
 """add embedding model dataset id.
 
-Adds a nullable ``dataset_id`` to ``embedding_model`` and backfills it through the
-existing collection relationship. The column remains nullable while ``collection_id``
-is still the source of truth; a later migration can make it required when it removes
-``collection_id``.
+Adds ``dataset_id`` to ``embedding_model`` and backfills it through the existing
+collection relationship. The column is added as nullable for the backfill and then made
+required.
 
 DuckDB builds its schema with ``create_all``, so this migration only matters for tracked
 Postgres databases.
@@ -53,6 +52,7 @@ def upgrade() -> None:
             """
         )
     )
+    op.alter_column("embedding_model", "dataset_id", nullable=False)
 
 
 def downgrade() -> None:

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -8,13 +8,18 @@ from uuid import UUID, uuid4
 from sqlmodel import VARCHAR, Column, Field, SQLModel
 
 
-class EmbeddingModelBase(SQLModel):
-    """Base class for the EmbeddingModel."""
+class EmbeddingSpaceDescription(SQLModel):
+    """Description of an embedding space."""
 
     name: str
     parameter_count_in_mb: int | None = None
     embedding_model_hash: str = Field(default="", sa_column=Column(VARCHAR(128)))
     embedding_dimension: int
+
+
+class EmbeddingModelBase(EmbeddingSpaceDescription):
+    """Base class for the EmbeddingModel."""
+
     collection_id: UUID = Field(default=None, foreign_key="collection.collection_id", index=True)
     dataset_id: UUID = Field(foreign_key="dataset.dataset_id", index=True)
 

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -18,7 +18,12 @@ class EmbeddingSpaceDescription(SQLModel):
 
 
 class EmbeddingModelBase(EmbeddingSpaceDescription):
-    """Base class for the EmbeddingModel."""
+    """Base class for the EmbeddingModel.
+
+    ``collection_id`` is kept for backwards compatibility while the schema still requires
+    it, but it is no longer read: default resolution goes through ``default_embedding_space``
+    and ownership through ``dataset_id``. It is dropped in a follow-up migration.
+    """
 
     collection_id: UUID = Field(default=None, foreign_key="collection.collection_id", index=True)
     dataset_id: UUID = Field(foreign_key="dataset.dataset_id", index=True)

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -16,7 +16,7 @@ class EmbeddingModelBase(SQLModel):
     embedding_model_hash: str = Field(default="", sa_column=Column(VARCHAR(128)))
     embedding_dimension: int
     collection_id: UUID = Field(default=None, foreign_key="collection.collection_id", index=True)
-    dataset_id: UUID | None = Field(default=None, foreign_key="dataset.dataset_id", index=True)
+    dataset_id: UUID = Field(foreign_key="dataset.dataset_id", index=True)
 
 
 class EmbeddingModelCreate(EmbeddingModelBase):

--- a/lightly_studio/src/lightly_studio/models/embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/embedding_model.py
@@ -16,6 +16,7 @@ class EmbeddingModelBase(SQLModel):
     embedding_model_hash: str = Field(default="", sa_column=Column(VARCHAR(128)))
     embedding_dimension: int
     collection_id: UUID = Field(default=None, foreign_key="collection.collection_id", index=True)
+    dataset_id: UUID | None = Field(default=None, foreign_key="dataset.dataset_id", index=True)
 
 
 class EmbeddingModelCreate(EmbeddingModelBase):

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -44,6 +44,7 @@ from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.dataset import DatasetTable
+from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import (
     EvaluationAnnotationMetricTable,
@@ -118,6 +119,8 @@ def deep_copy(
     _copy_object_tracks(session=session, new_dataset_id=new_dataset_id)
     _copy_annotation_labels(session=session, new_dataset_id=new_dataset_id)
     _copy_embedding_models(session=session, new_dataset_id=new_dataset_id, now=now)
+    # Depends on the copied collections and embedding models above.
+    _copy_default_embedding_space(session=session)
     _copy_samples(session=session, now=now)
     _copy_evaluation_runs(session=session, new_dataset_id=new_dataset_id, now=now)
 
@@ -437,7 +440,11 @@ def _copy_annotation_labels(session: Session, new_dataset_id: UUID) -> None:
 
 
 def _copy_embedding_models(session: Session, new_dataset_id: UUID, now: datetime) -> None:
-    """Copy embedding models, remapping collection_id and dataset_id."""
+    """Copy embedding models, remapping collection_id and dataset_id.
+
+    ``collection_id`` is still remapped because the column remains NOT NULL until the
+    follow-up migration drops it; it is not read anywhere.
+    """
     src = _table(EmbeddingModelTable).alias("src")
     map_model = _map(_MAP_EMBEDDING_MODEL)
     map_collection = _map(_MAP_COLLECTION)
@@ -453,6 +460,27 @@ def _copy_embedding_models(session: Session, new_dataset_id: UUID, now: datetime
     _copy_table(
         session=session,
         target=EmbeddingModelTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_default_embedding_space(session: Session) -> None:
+    """Copy default embedding space rows, remapping collection_id and embedding_model_id."""
+    src = _table(DefaultEmbeddingSpaceTable).alias("src")
+    map_collection = _map(_MAP_COLLECTION)
+    map_model = _map(_MAP_EMBEDDING_MODEL)
+    from_clause = src.join(map_collection, map_collection.c.old_id == src.c["collection_id"]).join(
+        map_model, map_model.c.old_id == src.c["embedding_model_id"]
+    )
+    overrides = {
+        "collection_id": map_collection.c.new_id,
+        "embedding_model_id": map_model.c.new_id,
+    }
+    _copy_table(
+        session=session,
+        target=DefaultEmbeddingSpaceTable,
         source=src,
         from_clause=from_clause,
         overrides=overrides,

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -117,7 +117,7 @@ def deep_copy(
     _copy_tags(session=session, now=now)
     _copy_object_tracks(session=session, new_dataset_id=new_dataset_id)
     _copy_annotation_labels(session=session, new_dataset_id=new_dataset_id)
-    _copy_embedding_models(session=session, now=now)
+    _copy_embedding_models(session=session, new_dataset_id=new_dataset_id, now=now)
     _copy_samples(session=session, now=now)
     _copy_evaluation_runs(session=session, new_dataset_id=new_dataset_id, now=now)
 
@@ -436,8 +436,8 @@ def _copy_annotation_labels(session: Session, new_dataset_id: UUID) -> None:
     )
 
 
-def _copy_embedding_models(session: Session, now: datetime) -> None:
-    """Copy embedding models, remapping collection_id."""
+def _copy_embedding_models(session: Session, new_dataset_id: UUID, now: datetime) -> None:
+    """Copy embedding models, remapping collection_id and dataset_id."""
     src = _table(EmbeddingModelTable).alias("src")
     map_model = _map(_MAP_EMBEDDING_MODEL)
     map_collection = _map(_MAP_COLLECTION)
@@ -447,6 +447,7 @@ def _copy_embedding_models(session: Session, now: datetime) -> None:
     overrides = {
         "embedding_model_id": map_model.c.new_id,
         "collection_id": map_collection.c.new_id,
+        "dataset_id": literal(new_dataset_id),
         "created_at": literal(now),
     }
     _copy_table(

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -37,6 +37,7 @@ from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.dataset import DatasetTable
+from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
@@ -119,6 +120,9 @@ def delete_dataset(
     _delete_samples(session=session, dataset_id=dataset_id)
     _delete_annotation_labels(session=session, dataset_id=dataset_id)
     _delete_tags(session=session, dataset_id=dataset_id)
+    # Must precede embedding models (DefaultEmbeddingSpaceTable.embedding_model_id ->
+    # EmbeddingModelTable) and collections (its collection_id -> CollectionTable).
+    _delete_default_embedding_spaces(session=session, dataset_id=dataset_id)
     _delete_embedding_models(session=session, dataset_id=dataset_id)
     _delete_object_tracks(session=session, dataset_id=dataset_id)
     _delete_evaluation_runs(session=session, dataset_id=dataset_id)
@@ -317,12 +321,20 @@ def _delete_tags(session: Session, dataset_id: UUID) -> None:
     )
 
 
-def _delete_embedding_models(session: Session, dataset_id: UUID) -> None:
-    """Delete embedding models for the dataset's collections."""
+def _delete_default_embedding_spaces(session: Session, dataset_id: UUID) -> None:
+    """Delete the default embedding space rows for the dataset's collections."""
     session.exec(
-        delete(EmbeddingModelTable).where(
-            col(EmbeddingModelTable.collection_id).in_(_collection_ids_subquery(dataset_id))
+        delete(DefaultEmbeddingSpaceTable).where(
+            col(DefaultEmbeddingSpaceTable.collection_id).in_(_collection_ids_subquery(dataset_id))
         ),
+        execution_options=_DELETE_EXECUTION_OPTIONS,
+    )
+
+
+def _delete_embedding_models(session: Session, dataset_id: UUID) -> None:
+    """Delete embedding models owned by the dataset."""
+    session.exec(
+        delete(EmbeddingModelTable).where(col(EmbeddingModelTable.dataset_id) == dataset_id),
         execution_options=_DELETE_EXECUTION_OPTIONS,
     )
 

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -11,17 +11,12 @@ from sqlmodel import SQLModel
 # - export_job is handled by delete_dataset only (its collection_id FK must be cleared
 #   before the collection is deleted); deep_copy intentionally leaves it alone since a job
 #   is a transient download token, not data worth duplicating.
-_HANDLED_TABLES_COUNT = 25
+_HANDLED_TABLES_COUNT = 26
 
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)
 # - two_dim_embeddings (cached projections, regenerated as needed)
-# - default_embedding_space (populated, but not yet handled by deep_copy/delete_dataset — see TODO)
-# TODO(Michal, 08/2026): wire default_embedding_space into deep_copy and delete_dataset,
-# then move it into _HANDLED_TABLES_COUNT. Until then, on Postgres delete_dataset raises an
-# FK error for any dataset with embeddings, and deep_copy silently drops the copied
-# collection's default.
-_EXCLUDED_TABLES_COUNT = 3
+_EXCLUDED_TABLES_COUNT = 2
 
 _TOTAL_TABLES_COUNT = _HANDLED_TABLES_COUNT + _EXCLUDED_TABLES_COUNT
 

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -90,20 +90,6 @@ def get_by_model_hash(
     return session.exec(query).first()
 
 
-def get_by_collection_id_and_hash(
-    session: Session, collection_id: UUID, embedding_model_hash: str
-) -> EmbeddingModelTable | None:
-    """Return the collection's embedding model if it carries the given hash.
-
-    A collection maps to a single model through ``default_embedding_space``; this returns it
-    only when its hash matches, and None otherwise.
-    """
-    models = get_all_by_collection_id(session=session, collection_id=collection_id)
-    return next(
-        (model for model in models if model.embedding_model_hash == embedding_model_hash), None
-    )
-
-
 def get_by_name(
     session: Session, collection_id: UUID, embedding_model_name: str | None
 ) -> EmbeddingModelTable:

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -44,21 +44,6 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
     return db_model
 
 
-def get_default_by_collection_id(
-    session: Session, collection_id: UUID
-) -> EmbeddingModelTable | None:
-    """Retrieve the collection's default embedding model, or None if it has none.
-
-    A collection is associated with a single model through ``default_embedding_space``.
-    """
-    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
-        session=session, collection_id=collection_id
-    )
-    if embedding_model_id is None:
-        return None
-    return get_by_id(session=session, embedding_model_id=embedding_model_id)
-
-
 def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable | None:
     """Retrieve a single embedding model by ID."""
     return session.exec(
@@ -107,7 +92,14 @@ def get_by_name(
         ValueError: If the collection has no default model, or its name does not match
             ``embedding_model_name``.
     """
-    embedding_model = get_default_by_collection_id(session=session, collection_id=collection_id)
+    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+        session=session, collection_id=collection_id
+    )
+    embedding_model = (
+        get_by_id(session=session, embedding_model_id=embedding_model_id)
+        if embedding_model_id is not None
+        else None
+    )
 
     if embedding_model_name is None:
         if embedding_model is None:

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -59,17 +59,6 @@ def get_default_by_collection_id(
     return get_by_id(session=session, embedding_model_id=embedding_model_id)
 
 
-def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[EmbeddingModelTable]:
-    """Retrieve the collection's embedding model(s).
-
-    A collection is associated with a single model through ``default_embedding_space``, so
-    this returns that model as a one-element list, or an empty list if the collection has
-    no default.
-    """
-    embedding_model = get_default_by_collection_id(session=session, collection_id=collection_id)
-    return [embedding_model] if embedding_model is not None else []
-
-
 def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable | None:
     """Retrieve a single embedding model by ID."""
     return session.exec(
@@ -103,41 +92,32 @@ def get_by_model_hash(
 def get_by_name(
     session: Session, collection_id: UUID, embedding_model_name: str | None
 ) -> EmbeddingModelTable:
-    """Helper function to resolve the embedding model name to its ID.
+    """Resolve the collection's default embedding model, optionally checking its name.
 
     Args:
         session: The database session.
         collection_id: The ID of the collection.
-        embedding_model_name: The name of the embedding model.
-            If None, expects the collection to have exactly one embedding model and
-            returns it. Otherwise raises a ValueError.
-            If set, expects the collection to have an embedding model with the given name.
-            Otherwise raises a ValueError.
+        embedding_model_name: The expected name of the default model. If None, the default
+            is returned as is. If set, the default is returned only when its name matches.
 
     Returns:
-        The embedding model with the given name.
+        The collection's default embedding model.
+
+    Raises:
+        ValueError: If the collection has no default model, or its name does not match
+            ``embedding_model_name``.
     """
-    embedding_models = get_all_by_collection_id(
-        session=session,
-        collection_id=collection_id,
-    )
+    embedding_model = get_default_by_collection_id(session=session, collection_id=collection_id)
 
     if embedding_model_name is None:
-        if len(embedding_models) != 1:
-            raise ValueError(
-                f"Expected exactly one embedding model, "
-                f"but found {len(embedding_models)} with names "
-                f"{[model.name for model in embedding_models]}."
-            )
-        return embedding_models[0]
+        if embedding_model is None:
+            raise ValueError("The collection has no default embedding model.")
+        return embedding_model
 
-    embedding_model_with_name = next(
-        (model for model in embedding_models if model.name == embedding_model_name), None
-    )
-    if embedding_model_with_name is None:
+    if embedding_model is None or embedding_model.name != embedding_model_name:
         raise ValueError(f"Embedding model with name `{embedding_model_name}` not found.")
 
-    return embedding_model_with_name
+    return embedding_model
 
 
 def delete(session: Session, embedding_model_id: UUID) -> bool:

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -44,6 +44,21 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
     return db_model
 
 
+def get_default_by_collection_id(
+    session: Session, collection_id: UUID
+) -> EmbeddingModelTable | None:
+    """Retrieve the collection's default embedding model, or None if it has none.
+
+    A collection is associated with a single model through ``default_embedding_space``.
+    """
+    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+        session=session, collection_id=collection_id
+    )
+    if embedding_model_id is None:
+        return None
+    return get_by_id(session=session, embedding_model_id=embedding_model_id)
+
+
 def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[EmbeddingModelTable]:
     """Retrieve the collection's embedding model(s).
 
@@ -51,12 +66,7 @@ def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[Embe
     this returns that model as a one-element list, or an empty list if the collection has
     no default.
     """
-    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
-        session=session, collection_id=collection_id
-    )
-    if embedding_model_id is None:
-        return []
-    embedding_model = get_by_id(session=session, embedding_model_id=embedding_model_id)
+    embedding_model = get_default_by_collection_id(session=session, collection_id=collection_id)
     return [embedding_model] if embedding_model is not None else []
 
 

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -10,6 +10,7 @@ from lightly_studio.models.embedding_model import (
     EmbeddingModelCreate,
     EmbeddingModelTable,
 )
+from lightly_studio.resolvers import default_embedding_space_resolver
 
 
 def create(session: Session, embedding_model: EmbeddingModelCreate) -> EmbeddingModelTable:
@@ -25,7 +26,7 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
     """Retrieve an existing EmbeddingModel by hash or create a new one if it does not exist."""
     db_model = get_by_model_hash(
         session=session,
-        collection_id=embedding_model.collection_id,
+        dataset_id=embedding_model.dataset_id,
         embedding_model_hash=embedding_model.embedding_model_hash,
     )
     if db_model is None:
@@ -44,13 +45,19 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
 
 
 def get_all_by_collection_id(session: Session, collection_id: UUID) -> list[EmbeddingModelTable]:
-    """Retrieve all embedding models."""
-    embedding_models = session.exec(
-        select(EmbeddingModelTable)
-        .where(EmbeddingModelTable.collection_id == collection_id)
-        .order_by(col(EmbeddingModelTable.created_at).asc())
-    ).all()
-    return list(embedding_models)
+    """Retrieve the collection's embedding model(s).
+
+    A collection is associated with a single model through ``default_embedding_space``, so
+    this returns that model as a one-element list, or an empty list if the collection has
+    no default.
+    """
+    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+        session=session, collection_id=collection_id
+    )
+    if embedding_model_id is None:
+        return []
+    embedding_model = get_by_id(session=session, embedding_model_id=embedding_model_id)
+    return [embedding_model] if embedding_model is not None else []
 
 
 def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable | None:
@@ -63,14 +70,38 @@ def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable
 
 
 def get_by_model_hash(
+    session: Session, dataset_id: UUID, embedding_model_hash: str
+) -> EmbeddingModelTable | None:
+    """Retrieve a single embedding model by hash within a dataset.
+
+    The write path deduplicates per ``(dataset_id, embedding_model_hash)``, but no unique
+    constraint enforces it yet (it lands with the ``collection_id`` drop). The oldest match
+    is returned so legacy duplicates resolve deterministically to the canonical row.
+    """
+    query = (
+        select(EmbeddingModelTable)
+        .where(EmbeddingModelTable.embedding_model_hash == embedding_model_hash)
+        .where(EmbeddingModelTable.dataset_id == dataset_id)
+        .order_by(
+            col(EmbeddingModelTable.created_at).asc(),
+            col(EmbeddingModelTable.embedding_model_id).asc(),
+        )
+    )
+    return session.exec(query).first()
+
+
+def get_by_collection_id_and_hash(
     session: Session, collection_id: UUID, embedding_model_hash: str
 ) -> EmbeddingModelTable | None:
-    """Retrieve a single embedding model by hash and collection."""
-    query = select(EmbeddingModelTable).where(
-        EmbeddingModelTable.embedding_model_hash == embedding_model_hash
+    """Return the collection's embedding model if it carries the given hash.
+
+    A collection maps to a single model through ``default_embedding_space``; this returns it
+    only when its hash matches, and None otherwise.
+    """
+    models = get_all_by_collection_id(session=session, collection_id=collection_id)
+    return next(
+        (model for model in models if model.embedding_model_hash == embedding_model_hash), None
     )
-    query = query.where(EmbeddingModelTable.collection_id == collection_id)
-    return session.exec(query).one_or_none()
 
 
 def get_by_name(

--- a/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
@@ -6,11 +6,11 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import ColumnElement
-from sqlmodel import Session, col, select
+from sqlmodel import Session, col
 
 from lightly_studio.database import db_vector
-from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.resolvers import default_embedding_space_resolver
 from lightly_studio.type_definitions import QueryType
 
 
@@ -27,11 +27,9 @@ def get_distance_expression(
     if not text_embedding:
         return None, None
 
-    embedding_model_id = session.exec(
-        select(EmbeddingModelTable.embedding_model_id)
-        .where(EmbeddingModelTable.collection_id == collection_id)
-        .limit(1)
-    ).first()
+    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+        session=session, collection_id=collection_id
+    )
 
     if not embedding_model_id:
         return None, None

--- a/lightly_studio/tests/api/routes/api/test_annotation.py
+++ b/lightly_studio/tests/api/routes/api/test_annotation.py
@@ -319,6 +319,7 @@ def test_read_annotation_embedding__returns_stored_vector(
         session=db_session,
         collection_id=annotation_collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
     create_sample_embedding(
         session=db_session,
@@ -355,6 +356,7 @@ def test_read_annotation_embedding__missing_returns_404(
         session=db_session,
         collection_id=annotation_collection_id,
         embedding_dimension=3,
+        set_as_default=True,
     )
 
     response = test_client.get(

--- a/lightly_studio/tests/api/routes/api/test_sampling.py
+++ b/lightly_studio/tests/api/routes/api/test_sampling.py
@@ -237,6 +237,7 @@ def test_create_combination_sampling__metadata_weighting_success(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="test_embedding_model",
+        set_as_default=True,
     )
 
     samples_with_embeddings = [
@@ -308,6 +309,7 @@ def test_create_combination_sampling__metadata_weighting_success_videos(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="test_embedding_model",
+        set_as_default=True,
     )
 
     videos_with_embeddings = [
@@ -586,6 +588,7 @@ def test_create_combination_sampling__image_filter_success(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="test_embedding_model",
+        set_as_default=True,
     )
     helpers_resolvers.create_samples_with_embeddings(
         session=db_session,
@@ -637,6 +640,7 @@ def test_create_combination_sampling__video_filter_success(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="test_embedding_model",
+        set_as_default=True,
     )
     narrow_video = video_helpers.create_video(
         session=db_session,

--- a/lightly_studio/tests/benchmarks/deep_copy_benchmark.py
+++ b/lightly_studio/tests/benchmarks/deep_copy_benchmark.py
@@ -161,6 +161,7 @@ def _generate_dataset(config: GenerationConfig) -> UUID:
             session=session,
             embedding_model=EmbeddingModelCreate(
                 collection_id=collection.collection_id,
+                dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/benchmarks/delete_dataset_benchmark.py
+++ b/lightly_studio/tests/benchmarks/delete_dataset_benchmark.py
@@ -170,6 +170,7 @@ def _generate_dataset(config: GenerationConfig) -> UUID:
             session=session,
             embedding_model=EmbeddingModelCreate(
                 collection_id=collection.collection_id,
+                dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/benchmarks/embedding_io_benchmark.py
+++ b/lightly_studio/tests/benchmarks/embedding_io_benchmark.py
@@ -186,6 +186,7 @@ def _setup(config: BenchmarkConfig) -> tuple[list[UUID], UUID]:
             session=session,
             embedding_model=EmbeddingModelCreate(
                 collection_id=collection.collection_id,
+                dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/benchmarks/gui_benchmark.py
+++ b/lightly_studio/tests/benchmarks/gui_benchmark.py
@@ -395,10 +395,13 @@ def _resolve_embedding_model(session: Session, collection_id: UUID) -> tuple[UUI
         "model: the embeddings view will appear in this process's GUI but not on a separate or "
         "deployed server."
     )
+    collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+    assert collection is not None
     synthetic_model = embedding_model_resolver.create(
         session=session,
         embedding_model=EmbeddingModelCreate(
             collection_id=collection_id,
+            dataset_id=collection.dataset_id,
             name=DEFAULT_EMBEDDING_MODEL_NAME,
             embedding_dimension=DEFAULT_EMBEDDING_DIM,
         ),

--- a/lightly_studio/tests/benchmarks/sample_embedding_lookup_benchmark.py
+++ b/lightly_studio/tests/benchmarks/sample_embedding_lookup_benchmark.py
@@ -225,6 +225,7 @@ def _setup(config: BenchmarkConfig) -> tuple[list[UUID], UUID, UUID]:
             session=session,
             embedding_model=EmbeddingModelCreate(
                 collection_id=collection.collection_id,
+                dataset_id=collection.dataset_id,
                 name=DEFAULT_EMBEDDING_MODEL_NAME,
                 embedding_dimension=config.embedding_dim,
             ),

--- a/lightly_studio/tests/conftest.py
+++ b/lightly_studio/tests/conftest.py
@@ -235,6 +235,7 @@ def embedding_model_input(collection: CollectionTable) -> EmbeddingModelCreate:
     """Create an EmbeddingModelCreate instance."""
     return EmbeddingModelCreate(
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         embedding_dimension=3,
         name="test_model",
     )

--- a/lightly_studio/tests/database/test_db_migrations.py
+++ b/lightly_studio/tests/database/test_db_migrations.py
@@ -164,6 +164,11 @@ def test_postgres_embedding_model_dataset_id__backfilled(
                 statement=text("SELECT dataset_id FROM embedding_model")
             ).scalar_one()
         assert str(backfilled_dataset_id) == dataset_id
+        columns = db_migrations._get_inspector(engine=engine).get_columns(
+            table_name="embedding_model"
+        )
+        dataset_id_column = next(column for column in columns if column["name"] == "dataset_id")
+        assert dataset_id_column["nullable"] is False
 
         config.attributes.pop("connection", None)
         command.check(config)

--- a/lightly_studio/tests/database/test_db_migrations.py
+++ b/lightly_studio/tests/database/test_db_migrations.py
@@ -99,3 +99,73 @@ def test_postgres_fresh_database__upgrade_head(
         assert version == head_revision
     finally:
         engine.close()
+
+
+def test_postgres_embedding_model_dataset_id__backfilled(
+    postgres_url: str | None,
+) -> None:
+    """The dataset ID migration backfills embedding models from their collection."""
+    if postgres_url is None:
+        pytest.skip("Requires --postgres")
+
+    _reset_postgres_database(engine_url=postgres_url)
+    normalized_url = db_url.ensure_psycopg3_driver(engine_url=postgres_url)
+    engine = create_engine(normalized_url)
+    config = db_migrations.get_alembic_config(engine_url=postgres_url)
+    dataset_id = "00000000-0000-0000-0000-000000000001"
+    collection_id = "00000000-0000-0000-0000-000000000002"
+
+    try:
+        db_migrations._run_alembic_command(
+            engine=engine,
+            config=config,
+            fn=command.upgrade,
+            revision="b1c2d3e4f5a6",
+        )
+        with engine.begin() as connection:
+            connection.execute(
+                statement=text("INSERT INTO dataset (dataset_id) VALUES (:dataset_id)"),
+                parameters={"dataset_id": dataset_id},
+            )
+            connection.execute(
+                statement=text(
+                    """
+                    INSERT INTO collection (
+                        name, sample_type, collection_id, dataset_id, created_at, updated_at
+                    ) VALUES (
+                        'collection', 'IMAGE', :collection_id, :dataset_id, NOW(), NOW()
+                    )
+                    """
+                ),
+                parameters={"collection_id": collection_id, "dataset_id": dataset_id},
+            )
+            connection.execute(
+                statement=text(
+                    """
+                    INSERT INTO embedding_model (
+                        name, embedding_dimension, collection_id, embedding_model_id, created_at
+                    ) VALUES (
+                        'model', 128, :collection_id,
+                        '00000000-0000-0000-0000-000000000003', NOW()
+                    )
+                    """
+                ),
+                parameters={"collection_id": collection_id},
+            )
+
+        db_migrations._run_alembic_command(
+            engine=engine,
+            config=config,
+            fn=command.upgrade,
+            revision="head",
+        )
+        with engine.connect() as connection:
+            backfilled_dataset_id = connection.execute(
+                statement=text("SELECT dataset_id FROM embedding_model")
+            ).scalar_one()
+        assert str(backfilled_dataset_id) == dataset_id
+
+        config.attributes.pop("connection", None)
+        command.check(config)
+    finally:
+        engine.dispose()

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -530,8 +530,8 @@ def test_load_or_get_default_model__shares_generator_across_collections(
 ) -> None:
     """An annotation child collection reuses the parent's loaded generator.
 
-    The generator weights are loaded once, but each collection still gets its
-    own embedding-model record and id.
+    The generator weights are loaded once, and because both collections belong to the same
+    dataset with the same generator hash, they resolve to a single embedding-model record.
     """
     image_collection = create_collection(session=db_session, sample_type=SampleType.IMAGE)
     annotation_collection = create_collection(
@@ -560,8 +560,8 @@ def test_load_or_get_default_model__shares_generator_across_collections(
     mock_load.assert_called_once_with(sample_type=SampleType.IMAGE)
     assert manager._models[image_model_id] is manager._models[annotation_model_id]
 
-    # Each collection still owns a distinct embedding-model record.
-    assert image_model_id != annotation_model_id
+    # Both collections share the same dataset-scoped embedding-model record.
+    assert image_model_id == annotation_model_id
 
 
 def test_load_or_get_default_model__cant_load(

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -24,7 +24,10 @@ from lightly_studio.dataset.embedding_manager import (
 from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.models.annotation.annotation_base import AnnotationType
 from lightly_studio.models.collection import CollectionTable, SampleType
-from lightly_studio.models.embedding_model import EmbeddingModelCreate, EmbeddingModelTable
+from lightly_studio.models.embedding_model import (
+    EmbeddingModelTable,
+    EmbeddingSpaceDescription,
+)
 from lightly_studio.models.image import ImageTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import (
@@ -101,13 +104,9 @@ def test_register_multiple_models(
 
     # Register a second model.
     class FakeEmbeddingGenerator(ImageEmbeddingGenerator):
-        def get_embedding_model_input(
-            self, collection_id: UUID, dataset_id: UUID
-        ) -> EmbeddingModelCreate:
-            return EmbeddingModelCreate(
+        def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+            return EmbeddingSpaceDescription(
                 name="Fake",
-                collection_id=collection_id,
-                dataset_id=dataset_id,
                 embedding_model_hash="fake_hash",
                 parameter_count_in_mb=50,
                 embedding_dimension=5,
@@ -630,13 +629,9 @@ def test_set_default_embedding_model_falls_back_to_env_for_unregistered_slot(
     class ImageOnlyGenerator:
         # Implements the image protocol but not embed_videos, so only the image
         # slot is overridden.
-        def get_embedding_model_input(
-            self, collection_id: UUID, dataset_id: UUID
-        ) -> EmbeddingModelCreate:
-            return EmbeddingModelCreate(
+        def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+            return EmbeddingSpaceDescription(
                 name="ImageOnly",
-                collection_id=collection_id,
-                dataset_id=dataset_id,
                 embedding_dimension=3,
                 embedding_model_hash="image_only_model",
             )
@@ -826,13 +821,9 @@ class TextOnlyEmbeddingGenerator:
     def __init__(self, dimension: int = 3) -> None:
         self._dimension = dimension
 
-    def get_embedding_model_input(
-        self, collection_id: UUID, dataset_id: UUID
-    ) -> EmbeddingModelCreate:
-        return EmbeddingModelCreate(
+    def get_embedding_model_input(self) -> EmbeddingSpaceDescription:
+        return EmbeddingSpaceDescription(
             name="TextOnly",
-            collection_id=collection_id,
-            dataset_id=dataset_id,
             embedding_dimension=self._dimension,
             embedding_model_hash="text_only_model",
         )

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -101,10 +101,13 @@ def test_register_multiple_models(
 
     # Register a second model.
     class FakeEmbeddingGenerator(ImageEmbeddingGenerator):
-        def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+        def get_embedding_model_input(
+            self, collection_id: UUID, dataset_id: UUID
+        ) -> EmbeddingModelCreate:
             return EmbeddingModelCreate(
                 name="Fake",
                 collection_id=collection_id,
+                dataset_id=dataset_id,
                 embedding_model_hash="fake_hash",
                 parameter_count_in_mb=50,
                 embedding_dimension=5,
@@ -627,10 +630,13 @@ def test_set_default_embedding_model_falls_back_to_env_for_unregistered_slot(
     class ImageOnlyGenerator:
         # Implements the image protocol but not embed_videos, so only the image
         # slot is overridden.
-        def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+        def get_embedding_model_input(
+            self, collection_id: UUID, dataset_id: UUID
+        ) -> EmbeddingModelCreate:
             return EmbeddingModelCreate(
                 name="ImageOnly",
                 collection_id=collection_id,
+                dataset_id=dataset_id,
                 embedding_dimension=3,
                 embedding_model_hash="image_only_model",
             )
@@ -820,10 +826,13 @@ class TextOnlyEmbeddingGenerator:
     def __init__(self, dimension: int = 3) -> None:
         self._dimension = dimension
 
-    def get_embedding_model_input(self, collection_id: UUID) -> EmbeddingModelCreate:
+    def get_embedding_model_input(
+        self, collection_id: UUID, dataset_id: UUID
+    ) -> EmbeddingModelCreate:
         return EmbeddingModelCreate(
             name="TextOnly",
             collection_id=collection_id,
+            dataset_id=dataset_id,
             embedding_dimension=self._dimension,
             embedding_model_hash="text_only_model",
         )

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -70,6 +70,19 @@ def test_register_embedding_model(
     assert stored_model is not None
     assert stored_model.name == "Random"
     assert stored_model.embedding_dimension == 3
+    assert stored_model.dataset_id == collection.dataset_id
+
+
+def test_register_embedding_model__collection_not_found(db_session: Session) -> None:
+    manager = EmbeddingManager()
+    collection_id = UUID(int=0)
+
+    with pytest.raises(ValueError, match="Provided collection_id could not be found"):
+        manager.register_embedding_model(
+            session=db_session,
+            embedding_generator=RandomEmbeddingGenerator(),
+            collection_id=collection_id,
+        )
 
 
 def test_register_multiple_models(
@@ -132,8 +145,9 @@ def test_register_multiple_models(
     assert len(stored_models) == 2
     model_names = {model.name for model in stored_models}
     assert model_names == {"Random", "Fake"}
-    # Verify both models are associated with the same collection
+    # Verify both models are associated with the same collection and dataset
     assert all(model.collection_id == collection.collection_id for model in stored_models)
+    assert all(model.dataset_id == collection.dataset_id for model in stored_models)
 
 
 def test_embed_text_with_default_model(

--- a/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
@@ -19,11 +19,15 @@ class TestMobileCLIPEmbeddingGenerator:
     def test_get_embedding_model_input(self) -> None:
         mobileclip = MobileCLIPEmbeddingGenerator()
         collection_id = uuid.uuid4()
-        embedding_model_input = mobileclip.get_embedding_model_input(collection_id=collection_id)
+        dataset_id = uuid.uuid4()
+        embedding_model_input = mobileclip.get_embedding_model_input(
+            collection_id=collection_id, dataset_id=dataset_id
+        )
 
         assert embedding_model_input.name == "mobileclip_s0"
         assert embedding_model_input.embedding_dimension == 512
         assert embedding_model_input.collection_id == collection_id
+        assert embedding_model_input.dataset_id == dataset_id
         assert embedding_model_input.embedding_model_hash != ""
 
     def test_embed_text(self) -> None:

--- a/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_mobileclip_embedding_generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import uuid
 from pathlib import Path
 
 import numpy as np
@@ -18,16 +17,10 @@ FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 class TestMobileCLIPEmbeddingGenerator:
     def test_get_embedding_model_input(self) -> None:
         mobileclip = MobileCLIPEmbeddingGenerator()
-        collection_id = uuid.uuid4()
-        dataset_id = uuid.uuid4()
-        embedding_model_input = mobileclip.get_embedding_model_input(
-            collection_id=collection_id, dataset_id=dataset_id
-        )
+        embedding_model_input = mobileclip.get_embedding_model_input()
 
         assert embedding_model_input.name == "mobileclip_s0"
         assert embedding_model_input.embedding_dimension == 512
-        assert embedding_model_input.collection_id == collection_id
-        assert embedding_model_input.dataset_id == dataset_id
         assert embedding_model_input.embedding_model_hash != ""
 
     def test_embed_text(self) -> None:

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import uuid
 from pathlib import Path
 
 import numpy as np
@@ -20,16 +19,10 @@ FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 class TestPerceptionEncoderEmbeddingGenerator:
     def test_get_embedding_model_input(self) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
-        collection_id = uuid.uuid4()
-        dataset_id = uuid.uuid4()
-        embedding_model_input = perception_encoder.get_embedding_model_input(
-            collection_id=collection_id, dataset_id=dataset_id
-        )
+        embedding_model_input = perception_encoder.get_embedding_model_input()
 
         assert embedding_model_input.name == "PE-Core-T16-384"
         assert embedding_model_input.embedding_dimension == 512
-        assert embedding_model_input.collection_id == collection_id
-        assert embedding_model_input.dataset_id == dataset_id
         assert embedding_model_input.embedding_model_hash != ""
 
     def test_embed_text(self) -> None:

--- a/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
+++ b/lightly_studio/tests/dataset/test_perception_encoder_embedding_generator.py
@@ -21,13 +21,15 @@ class TestPerceptionEncoderEmbeddingGenerator:
     def test_get_embedding_model_input(self) -> None:
         perception_encoder = PerceptionEncoderEmbeddingGenerator()
         collection_id = uuid.uuid4()
+        dataset_id = uuid.uuid4()
         embedding_model_input = perception_encoder.get_embedding_model_input(
-            collection_id=collection_id
+            collection_id=collection_id, dataset_id=dataset_id
         )
 
         assert embedding_model_input.name == "PE-Core-T16-384"
         assert embedding_model_input.embedding_dimension == 512
         assert embedding_model_input.collection_id == collection_id
+        assert embedding_model_input.dataset_id == dataset_id
         assert embedding_model_input.embedding_model_hash != ""
 
     def test_embed_text(self) -> None:

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -65,7 +65,7 @@ def embedding_model(db_session: Session, collection: CollectionTable) -> Embeddi
         embedding_dimension=3,
     )
     created = embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)
-    # Register it as the collection's default so get_all_by_collection_id resolves it.
+    # Register it as the collection's default so it resolves as the collection's model.
     default_embedding_space_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -21,7 +21,10 @@ from lightly_studio.models.embedding_model import (
     EmbeddingModelTable,
 )
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
-from lightly_studio.resolvers import embedding_model_resolver
+from lightly_studio.resolvers import (
+    default_embedding_space_resolver,
+    embedding_model_resolver,
+)
 
 
 @pytest.fixture
@@ -61,7 +64,14 @@ def embedding_model(db_session: Session, collection: CollectionTable) -> Embeddi
         dataset_id=collection.dataset_id,
         embedding_dimension=3,
     )
-    return embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)
+    created = embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)
+    # Register it as the collection's default so get_all_by_collection_id resolves it.
+    default_embedding_space_resolver.set_default(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=created.embedding_model_id,
+    )
+    return created
 
 
 @pytest.fixture

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -58,6 +58,7 @@ def embedding_model(db_session: Session, collection: CollectionTable) -> Embeddi
         embedding_model_hash="mock_hash",
         name="test_model",
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         embedding_dimension=3,
     )
     return embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -52,8 +52,8 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_default_by_collection_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         # Create input data with two classes.
         input_classes = ["class1", "class2"]
@@ -75,12 +75,10 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[
-                EmbeddingModelTable(
-                    name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
-                )
-            ],
+            "get_default_by_collection_id",
+            return_value=EmbeddingModelTable(
+                name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
+            ),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -139,12 +137,10 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[
-                EmbeddingModelTable(
-                    name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
-                )
-            ],
+            "get_default_by_collection_id",
+            return_value=EmbeddingModelTable(
+                name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
+            ),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -191,8 +187,8 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_default_by_collection_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -324,8 +320,8 @@ class TestClassifierManager:
         # Setup: Create a classifier first
         mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_default_by_collection_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -382,8 +378,8 @@ class TestClassifierManager:
         # Setup: Create a classifier with initial samples
         mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_default_by_collection_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -494,8 +490,8 @@ class TestClassifierManager:
         )
         mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_default_by_collection_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -572,8 +568,8 @@ class TestClassifierManager:
         )
         mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_default_by_collection_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -656,12 +652,10 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[
-                EmbeddingModelTable(
-                    name="test", embedding_dimension=3, embedding_model_hash="mock_hash"
-                )
-            ],
+            "get_default_by_collection_id",
+            return_value=EmbeddingModelTable(
+                name="test", embedding_dimension=3, embedding_model_hash="mock_hash"
+            ),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -83,8 +83,8 @@ class TestClassifierManager:
             ],
         )
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_by_collection_id_and_hash",
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -147,8 +147,8 @@ class TestClassifierManager:
             ],
         )
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_by_collection_id_and_hash",
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -289,8 +289,8 @@ class TestClassifierManager:
             classifier_id=classifier.classifier_id, file_path=save_path
         )
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_by_collection_id_and_hash",
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=None,
         )
         with pytest.raises(
@@ -488,8 +488,8 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
 
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_by_collection_id_and_hash",
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -566,8 +566,8 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
 
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_by_collection_id_and_hash",
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -664,8 +664,8 @@ class TestClassifierManager:
             ],
         )
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_by_collection_id_and_hash",
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -31,6 +31,7 @@ from lightly_studio.models.sample_embedding import (
 from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
+    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -51,8 +52,13 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_default_by_collection_id",
+            "get_by_id",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         # Create input data with two classes.
@@ -74,8 +80,13 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_default_by_collection_id",
+            "get_by_id",
             return_value=EmbeddingModelTable(
                 name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
             ),
@@ -136,8 +147,13 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_default_by_collection_id",
+            "get_by_id",
             return_value=EmbeddingModelTable(
                 name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
             ),
@@ -186,8 +202,13 @@ class TestClassifierManager:
         """Test dropping a classifier in the finetuning step."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_default_by_collection_id",
+            "get_by_id",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -319,8 +340,13 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         # Setup: Create a classifier first
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_default_by_collection_id",
+            "get_by_id",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -377,8 +403,13 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         # Setup: Create a classifier with initial samples
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_default_by_collection_id",
+            "get_by_id",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -489,8 +520,13 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_default_by_collection_id",
+            "get_by_id",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -567,8 +603,13 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_default_by_collection_id",
+            "get_by_id",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -651,8 +692,13 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_default_by_collection_id",
+            "get_by_id",
             return_value=EmbeddingModelTable(
                 name="test", embedding_dimension=3, embedding_model_hash="mock_hash"
             ),

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -84,7 +84,7 @@ class TestClassifierManager:
         )
         mocker.patch.object(
             embedding_model_resolver,
-            "get_by_model_hash",
+            "get_by_collection_id_and_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -148,7 +148,7 @@ class TestClassifierManager:
         )
         mocker.patch.object(
             embedding_model_resolver,
-            "get_by_model_hash",
+            "get_by_collection_id_and_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -290,7 +290,7 @@ class TestClassifierManager:
         )
         mocker.patch.object(
             embedding_model_resolver,
-            "get_by_model_hash",
+            "get_by_collection_id_and_hash",
             return_value=None,
         )
         with pytest.raises(
@@ -489,7 +489,7 @@ class TestClassifierManager:
 
         mocker.patch.object(
             embedding_model_resolver,
-            "get_by_model_hash",
+            "get_by_collection_id_and_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -567,7 +567,7 @@ class TestClassifierManager:
 
         mocker.patch.object(
             embedding_model_resolver,
-            "get_by_model_hash",
+            "get_by_collection_id_and_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -665,7 +665,7 @@ class TestClassifierManager:
         )
         mocker.patch.object(
             embedding_model_resolver,
-            "get_by_model_hash",
+            "get_by_collection_id_and_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -314,10 +314,15 @@ def create_embedding_model(  # noqa: PLR0913
     is off by default to avoid the ``default_embedding_space`` foreign key blocking model
     or collection deletes in tests that do not need a default.
     """
+    collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+    if collection is None:
+        raise ValueError(f"Collection with id {collection_id} not found.")
+
     model = embedding_model_resolver.create(
         session=session,
         embedding_model=EmbeddingModelCreate(
             collection_id=collection_id,
+            dataset_id=collection.dataset_id,
             name=embedding_model_name,
             embedding_model_hash=embedding_model_hash,
             parameter_count_in_mb=parameter_count_in_mb,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -317,12 +317,11 @@ def test_deep_copy__with_embeddings(db_session: Session) -> None:
     )
 
     # Assert - embedding model is copied with new ID
-    copied_embedding_models = embedding_model_resolver.get_all_by_collection_id(
+    copied_model = embedding_model_resolver.get_default_by_collection_id(
         session=db_session,
         collection_id=copied.collection_id,
     )
-    assert len(copied_embedding_models) == 1
-    copied_model = copied_embedding_models[0]
+    assert copied_model is not None
     assert copied_model.embedding_model_id != embedding_model.embedding_model_id
     assert copied_model.dataset_id == copied.dataset_id
     assert copied_model.name == embedding_model.name
@@ -433,15 +432,15 @@ def test_deep_copy__can_delete_original_after_copy(db_session: Session) -> None:
     )
 
     # Assert - copied collection still has embeddings
-    copied_embedding_models = embedding_model_resolver.get_all_by_collection_id(
+    copied_embedding_model = embedding_model_resolver.get_default_by_collection_id(
         session=db_session,
         collection_id=copied.collection_id,
     )
-    assert len(copied_embedding_models) == 1
+    assert copied_embedding_model is not None
     copied_embeddings = sample_embedding_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=copied.collection_id,
-        embedding_model_id=copied_embedding_models[0].embedding_model_id,
+        embedding_model_id=copied_embedding_model.embedding_model_id,
     )
     assert len(copied_embeddings) == 1
 

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -324,6 +324,7 @@ def test_deep_copy__with_embeddings(db_session: Session) -> None:
     assert len(copied_embedding_models) == 1
     copied_model = copied_embedding_models[0]
     assert copied_model.embedding_model_id != embedding_model.embedding_model_id
+    assert copied_model.dataset_id == copied.dataset_id
     assert copied_model.name == embedding_model.name
     assert copied_model.embedding_model_hash == embedding_model.embedding_model_hash
     assert copied_model.embedding_dimension == embedding_model.embedding_dimension

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -317,11 +317,11 @@ def test_deep_copy__with_embeddings(db_session: Session) -> None:
     )
 
     # Assert - embedding model is copied with new ID
-    copied_model = embedding_model_resolver.get_default_by_collection_id(
+    copied_model = embedding_model_resolver.get_by_name(
         session=db_session,
         collection_id=copied.collection_id,
+        embedding_model_name=None,
     )
-    assert copied_model is not None
     assert copied_model.embedding_model_id != embedding_model.embedding_model_id
     assert copied_model.dataset_id == copied.dataset_id
     assert copied_model.name == embedding_model.name
@@ -432,11 +432,11 @@ def test_deep_copy__can_delete_original_after_copy(db_session: Session) -> None:
     )
 
     # Assert - copied collection still has embeddings
-    copied_embedding_model = embedding_model_resolver.get_default_by_collection_id(
+    copied_embedding_model = embedding_model_resolver.get_by_name(
         session=db_session,
         collection_id=copied.collection_id,
+        embedding_model_name=None,
     )
-    assert copied_embedding_model is not None
     copied_embeddings = sample_embedding_resolver.get_all_by_collection_id(
         session=db_session,
         collection_id=copied.collection_id,

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -22,8 +22,8 @@ def test_create_embedding_model(db_session: Session) -> None:
     assert embedding_model.name == "example_embedding_model"
 
 
-def test_get_all_by_collection_id__returns_default(db_session: Session) -> None:
-    """get_all_by_collection_id returns the collection's default model as a one-element list."""
+def test_get_default_by_collection_id__returns_default(db_session: Session) -> None:
+    """get_default_by_collection_id returns the collection's default model."""
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
@@ -34,15 +34,15 @@ def test_get_all_by_collection_id__returns_default(db_session: Session) -> None:
         set_as_default=True,
     )
 
-    embedding_models = embedding_model_resolver.get_all_by_collection_id(
+    default_model = embedding_model_resolver.get_default_by_collection_id(
         session=db_session, collection_id=collection_id
     )
-    assert len(embedding_models) == 1
-    assert embedding_models[0].embedding_model_id == embedding_model.embedding_model_id
+    assert default_model is not None
+    assert default_model.embedding_model_id == embedding_model.embedding_model_id
 
 
-def test_get_all_by_collection_id__empty_without_default(db_session: Session) -> None:
-    """Without a default embedding space, the collection resolves to no models."""
+def test_get_default_by_collection_id__none_without_default(db_session: Session) -> None:
+    """Without a default embedding space, the collection resolves to no model."""
     collection = create_collection(session=db_session)
 
     create_embedding_model(
@@ -51,10 +51,10 @@ def test_get_all_by_collection_id__empty_without_default(db_session: Session) ->
         embedding_model_name="embedding_model_1",
     )
 
-    embedding_models = embedding_model_resolver.get_all_by_collection_id(
+    default_model = embedding_model_resolver.get_default_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     )
-    assert embedding_models == []
+    assert default_model is None
 
 
 def test_read_embedding_model(db_session: Session) -> None:
@@ -190,9 +190,7 @@ def test_get_by_name__none_with_no_models(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    with pytest.raises(
-        ValueError, match=r"Expected exactly one embedding model, but found 0 with names \[\]\."
-    ):
+    with pytest.raises(ValueError, match=r"The collection has no default embedding model\."):
         embedding_model_resolver.get_by_name(
             session=db_session, collection_id=collection_id, embedding_model_name=None
         )
@@ -285,10 +283,11 @@ def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
     )
 
     assert reused.embedding_model_id == existing.embedding_model_id
-    models = embedding_model_resolver.get_all_by_collection_id(
+    default_model = embedding_model_resolver.get_default_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     )
-    assert len(models) == 1
+    assert default_model is not None
+    assert default_model.embedding_model_id == existing.embedding_model_id
 
 
 def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -266,6 +266,7 @@ def test_get_or_create__creates_new_model(db_session: Session) -> None:
 
     model_create = EmbeddingModelCreate(
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         name="Model Name",
         embedding_model_hash="model_hash",
         parameter_count_in_mb=200,
@@ -296,6 +297,7 @@ def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
 
     model_create = EmbeddingModelCreate(
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         name="Model Name",
         embedding_model_hash="model_hash",
         parameter_count_in_mb=10,
@@ -327,6 +329,7 @@ def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:
 
     conflicting_model_create = EmbeddingModelCreate(
         collection_id=collection.collection_id,
+        dataset_id=collection.dataset_id,
         name="Model Name",
         embedding_model_hash="model_hash",
         parameter_count_in_mb=2000,
@@ -348,6 +351,7 @@ def test_get_or_create__same_hash_different_collections(db_session: Session) -> 
 
     model_create_1 = EmbeddingModelCreate(
         collection_id=collection_1.collection_id,
+        dataset_id=collection_1.dataset_id,
         name="Test Model",
         embedding_model_hash="same_hash",
         parameter_count_in_mb=10,
@@ -359,6 +363,7 @@ def test_get_or_create__same_hash_different_collections(db_session: Session) -> 
 
     model_create_2 = EmbeddingModelCreate(
         collection_id=collection_2.collection_id,
+        dataset_id=collection_2.dataset_id,
         name="Test Model",
         embedding_model_hash="same_hash",
         parameter_count_in_mb=10,

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -22,29 +22,39 @@ def test_create_embedding_model(db_session: Session) -> None:
     assert embedding_model.name == "example_embedding_model"
 
 
-def test_read_embedding_models(db_session: Session) -> None:
+def test_get_all_by_collection_id__returns_default(db_session: Session) -> None:
+    """get_all_by_collection_id returns the collection's default model as a one-element list."""
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    embedding_model_1 = create_embedding_model(
+    embedding_model = create_embedding_model(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_1",
-    )
-    embedding_model_2 = create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_2",
+        set_as_default=True,
     )
 
-    # Get all embedding models of a collection.
     embedding_models = embedding_model_resolver.get_all_by_collection_id(
         session=db_session, collection_id=collection_id
     )
-    assert len(embedding_models) == 2
+    assert len(embedding_models) == 1
+    assert embedding_models[0].embedding_model_id == embedding_model.embedding_model_id
 
-    assert embedding_models[0].embedding_model_id == embedding_model_1.embedding_model_id
-    assert embedding_models[1].embedding_model_id == embedding_model_2.embedding_model_id
+
+def test_get_all_by_collection_id__empty_without_default(db_session: Session) -> None:
+    """Without a default embedding space, the collection resolves to no models."""
+    collection = create_collection(session=db_session)
+
+    create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_name="embedding_model_1",
+    )
+
+    embedding_models = embedding_model_resolver.get_all_by_collection_id(
+        session=db_session, collection_id=collection.collection_id
+    )
+    assert embedding_models == []
 
 
 def test_read_embedding_model(db_session: Session) -> None:
@@ -97,62 +107,61 @@ def test_get_by_model_hash(db_session: Session) -> None:
     )
 
     embedding_model = embedding_model_resolver.get_by_model_hash(
-        session=db_session, embedding_model_hash="hash_1", collection_id=collection_id
+        session=db_session, embedding_model_hash="hash_1", dataset_id=collection.dataset_id
     )
     assert embedding_model is not None
     assert embedding_model.name == embedding_model_1.name
 
     embedding_model = embedding_model_resolver.get_by_model_hash(
-        session=db_session, embedding_model_hash="hash_3", collection_id=collection_id
+        session=db_session, embedding_model_hash="hash_3", dataset_id=collection.dataset_id
     )
     assert embedding_model is None
 
 
-def test_get_by_model_hash__with_collection_id(db_session: Session) -> None:
+def test_get_by_model_hash__scoped_by_dataset(db_session: Session) -> None:
+    # Root collections each get their own dataset, so these models live in different datasets.
     collection_1 = create_collection(session=db_session, collection_name="collection_1")
     collection_2 = create_collection(session=db_session, collection_name="collection_2")
 
-    # Create models with same hash in different collections
+    # Create models with the same hash in different datasets.
     model_1 = create_embedding_model(
         session=db_session,
         collection_id=collection_1.collection_id,
-        embedding_model_name="model_in_collection_1",
+        embedding_model_name="model_in_dataset_1",
         embedding_model_hash="same_hash",
     )
     model_2 = create_embedding_model(
         session=db_session,
         collection_id=collection_2.collection_id,
-        embedding_model_name="model_in_collection_2",
+        embedding_model_name="model_in_dataset_2",
         embedding_model_hash="same_hash",
     )
 
-    # With collection_id, returns the correct model
+    # With dataset_id, returns the model owned by that dataset.
     result = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        collection_id=collection_1.collection_id,
+        dataset_id=collection_1.dataset_id,
     )
     assert result is not None
     assert result.embedding_model_id == model_1.embedding_model_id
     assert result.embedding_model_hash == "same_hash"
-    assert result.collection_id == collection_1.collection_id
 
     result = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        collection_id=collection_2.collection_id,
+        dataset_id=collection_2.dataset_id,
     )
     assert result is not None
     assert result.embedding_model_id == model_2.embedding_model_id
     assert result.embedding_model_hash == "same_hash"
-    assert result.collection_id == collection_2.collection_id
 
-    # With non-matching collection_id, returns None
+    # A dataset without a matching model returns None.
     collection_3 = create_collection(session=db_session, collection_name="collection_3")
     result_3 = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        collection_id=collection_3.collection_id,
+        dataset_id=collection_3.dataset_id,
     )
     assert result_3 is None
 
@@ -166,6 +175,7 @@ def test_get_by_name__none_with_single_model(db_session: Session) -> None:
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_1",
+        set_as_default=True,
     )
 
     result = embedding_model_resolver.get_by_name(
@@ -173,32 +183,6 @@ def test_get_by_name__none_with_single_model(db_session: Session) -> None:
     )
     assert result.embedding_model_id == embedding_model.embedding_model_id
     assert result.name == "embedding_model_1"
-
-
-def test_get_by_name__none_with_multiple_models(db_session: Session) -> None:
-    """Test get_by_name when embedding_model_name is None but multiple models exist."""
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-
-    create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_1",
-    )
-    create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_2",
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r"Expected exactly one embedding model, but found 2 with names "
-        r"\['embedding_model_1', 'embedding_model_2'\]\.",
-    ):
-        embedding_model_resolver.get_by_name(
-            session=db_session, collection_id=collection_id, embedding_model_name=None
-        )
 
 
 def test_get_by_name__none_with_no_models(db_session: Session) -> None:
@@ -215,32 +199,22 @@ def test_get_by_name__none_with_no_models(db_session: Session) -> None:
 
 
 def test_get_by_name__existing_name(db_session: Session) -> None:
-    """Test get_by_name when embedding_model_name is provided and exists."""
+    """get_by_name resolves the collection's default model by its name."""
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
 
-    embedding_model_1 = create_embedding_model(
+    embedding_model = create_embedding_model(
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_1",
-    )
-    embedding_model_2 = create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_2",
+        set_as_default=True,
     )
 
     result = embedding_model_resolver.get_by_name(
         session=db_session, collection_id=collection_id, embedding_model_name="embedding_model_1"
     )
-    assert result.embedding_model_id == embedding_model_1.embedding_model_id
+    assert result.embedding_model_id == embedding_model.embedding_model_id
     assert result.name == "embedding_model_1"
-
-    result = embedding_model_resolver.get_by_name(
-        session=db_session, collection_id=collection_id, embedding_model_name="embedding_model_2"
-    )
-    assert result.embedding_model_id == embedding_model_2.embedding_model_id
-    assert result.name == "embedding_model_2"
 
 
 def test_get_by_name__nonexistent_name(db_session: Session) -> None:
@@ -252,6 +226,7 @@ def test_get_by_name__nonexistent_name(db_session: Session) -> None:
         session=db_session,
         collection_id=collection_id,
         embedding_model_name="embedding_model_1",
+        set_as_default=True,
     )
 
     with pytest.raises(ValueError, match=r"Embedding model with name `nonexistent` not found."):
@@ -293,6 +268,7 @@ def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
         embedding_model_hash="model_hash",
         parameter_count_in_mb=10,
         embedding_dimension=32,
+        set_as_default=True,
     )
 
     model_create = EmbeddingModelCreate(
@@ -345,7 +321,8 @@ def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:
         )
 
 
-def test_get_or_create__same_hash_different_collections(db_session: Session) -> None:
+def test_get_or_create__same_hash_different_datasets(db_session: Session) -> None:
+    # Root collections each get their own dataset, so dedup does not span them.
     collection_1 = create_collection(session=db_session, collection_name="collection_1")
     collection_2 = create_collection(session=db_session, collection_name="collection_2")
 
@@ -373,17 +350,21 @@ def test_get_or_create__same_hash_different_collections(db_session: Session) -> 
         session=db_session, embedding_model=model_create_2
     )
 
-    # Should be different models
+    # Different datasets never share a row, even with the same hash.
     assert model_1.embedding_model_id != model_2.embedding_model_id
-    assert model_1.collection_id == collection_1.collection_id
-    assert model_2.collection_id == collection_2.collection_id
+    assert model_1.dataset_id == collection_1.dataset_id
+    assert model_2.dataset_id == collection_2.dataset_id
 
-    # Each collection should have exactly one model
-    models_1 = embedding_model_resolver.get_all_by_collection_id(
-        session=db_session, collection_id=collection_1.collection_id
+    # Each dataset resolves the hash to its own model.
+    assert (
+        embedding_model_resolver.get_by_model_hash(
+            session=db_session, dataset_id=collection_1.dataset_id, embedding_model_hash="same_hash"
+        )
+        == model_1
     )
-    models_2 = embedding_model_resolver.get_all_by_collection_id(
-        session=db_session, collection_id=collection_2.collection_id
+    assert (
+        embedding_model_resolver.get_by_model_hash(
+            session=db_session, dataset_id=collection_2.dataset_id, embedding_model_hash="same_hash"
+        )
+        == model_2
     )
-    assert len(models_1) == 1
-    assert len(models_2) == 1

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -22,41 +22,6 @@ def test_create_embedding_model(db_session: Session) -> None:
     assert embedding_model.name == "example_embedding_model"
 
 
-def test_get_default_by_collection_id__returns_default(db_session: Session) -> None:
-    """get_default_by_collection_id returns the collection's default model."""
-    collection = create_collection(session=db_session)
-    collection_id = collection.collection_id
-
-    embedding_model = create_embedding_model(
-        session=db_session,
-        collection_id=collection_id,
-        embedding_model_name="embedding_model_1",
-        set_as_default=True,
-    )
-
-    default_model = embedding_model_resolver.get_default_by_collection_id(
-        session=db_session, collection_id=collection_id
-    )
-    assert default_model is not None
-    assert default_model.embedding_model_id == embedding_model.embedding_model_id
-
-
-def test_get_default_by_collection_id__none_without_default(db_session: Session) -> None:
-    """Without a default embedding space, the collection resolves to no model."""
-    collection = create_collection(session=db_session)
-
-    create_embedding_model(
-        session=db_session,
-        collection_id=collection.collection_id,
-        embedding_model_name="embedding_model_1",
-    )
-
-    default_model = embedding_model_resolver.get_default_by_collection_id(
-        session=db_session, collection_id=collection.collection_id
-    )
-    assert default_model is None
-
-
 def test_read_embedding_model(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id
@@ -283,11 +248,11 @@ def test_get_or_create__reuses_existing_model(db_session: Session) -> None:
     )
 
     assert reused.embedding_model_id == existing.embedding_model_id
-    default_model = embedding_model_resolver.get_default_by_collection_id(
-        session=db_session, collection_id=collection.collection_id
+    model_by_hash = embedding_model_resolver.get_by_model_hash(
+        session=db_session, dataset_id=collection.dataset_id, embedding_model_hash="model_hash"
     )
-    assert default_model is not None
-    assert default_model.embedding_model_id == existing.embedding_model_id
+    assert model_by_hash is not None
+    assert model_by_hash.embedding_model_id == existing.embedding_model_id
 
 
 def test_get_or_create__conflicting_model_raises(db_session: Session) -> None:

--- a/lightly_studio/tests/sampling/test_sampling.py
+++ b/lightly_studio/tests/sampling/test_sampling.py
@@ -74,6 +74,7 @@ class TestSampling:
             session=dataset.session,
             collection_id=frames.collection_id,
             embedding_model_name="embedding_model_1",
+            set_as_default=True,
         )
         for i, frame in enumerate(frames):
             helpers_resolvers.create_sample_embedding(
@@ -118,6 +119,7 @@ class TestSampling:
             session=dataset.session,
             collection_id=frames.collection_id,
             embedding_model_name="embedding_model_1",
+            set_as_default=True,
         )
         for i, frame in enumerate(frames):
             helpers_resolvers.create_sample_embedding(
@@ -356,7 +358,7 @@ class TestSampling:
 
     def test_multi_strategies(self, db_session: Session, mocker: MockerFixture) -> None:
         collection_id = helpers_resolvers.fill_db_with_samples_and_embeddings(
-            session=db_session, n_samples=5, embedding_model_names=["model_1", "model_2"]
+            session=db_session, n_samples=5, embedding_model_names=["model_1"]
         )
         helpers_sampling.fill_db_metadata(
             session=db_session,
@@ -374,7 +376,6 @@ class TestSampling:
             sampling_result_tag_name="multi_strategies_sampling",
             sampling_strategies=[
                 EmbeddingDiversityStrategy(embedding_model_name="model_1"),
-                EmbeddingDiversityStrategy(embedding_model_name="model_2"),
                 MetadataWeightingStrategy(metadata_key="speed"),
             ],
         )
@@ -390,7 +391,6 @@ class TestSampling:
                 sampling_result_tag_name="multi_strategies_sampling",
                 strategies=[
                     EmbeddingDiversityStrategy(embedding_model_name="model_1"),
-                    EmbeddingDiversityStrategy(embedding_model_name="model_2"),
                     MetadataWeightingStrategy(metadata_key="speed"),
                 ],
             ),

--- a/lightly_studio/tests/sampling/test_sampling_via_db.py
+++ b/lightly_studio/tests/sampling/test_sampling_via_db.py
@@ -145,7 +145,7 @@ def test_sampling_via_database__multi_embedding_diversity(
     collection_id = fill_db_with_samples_and_embeddings(
         db_session,
         n_samples=20,
-        embedding_model_names=["embedding_model_1", "embedding_model_2"],
+        embedding_model_names=["embedding_model_1"],
     )
 
     sampling_config = SamplingConfig(
@@ -154,7 +154,7 @@ def test_sampling_via_database__multi_embedding_diversity(
         sampling_result_tag_name="sampling_1",
         strategies=[
             EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1"),
-            EmbeddingDiversityStrategy(embedding_model_name="embedding_model_2"),
+            EmbeddingDiversityStrategy(embedding_model_name="embedding_model_1"),
         ],
     )
     sampling_via_database(

--- a/lightly_studio/tests/sampling/test_sequence_sampling.py
+++ b/lightly_studio/tests/sampling/test_sequence_sampling.py
@@ -474,6 +474,7 @@ def _fill_db_with_video_frames_and_embeddings(
         collection_id=frame_collection_id,
         embedding_model_name=embedding_model_name,
         embedding_dimension=2,
+        set_as_default=True,
     )
     for i, frame_sample_id in enumerate(frame_sample_ids):
         helpers_resolvers.create_sample_embedding(


### PR DESCRIPTION
## What has changed and why?

Stops reading `EmbeddingModel.collection_id`. Resolution now goes through:
- `default_embedding_space` — the collection's default model
- `dataset_id` — model ownership (dedup, lookup by hash, delete)

The `collection_id` column stays (still NOT NULL) and is dropped in a follow-up migration.

Key points:
- `get_all_by_collection_id` resolves the single default via `default_embedding_space`
- `get_by_model_hash` / `get_or_create` key and dedup per `dataset_id`
- classifier manager and `similarity_utils` use the new resolution paths
- `deep_copy` / `delete_dataset` now handle `default_embedding_space`
- one embedding model per collection; multi-model-per-collection test setups removed

Stacks on #2062.

## How has it been tested?

- Updated tests record a collection default; sampling suites green.
- `make static-checks` and `make test`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
