### PR TITLE
Resolve classifier embedding model by dataset_id

### DIFF
--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -133,7 +133,8 @@ class ClassifierManager:
         embedding_model = embedding_model_resolver.get_by_id(
             session=session, embedding_model_id=embedding_model_id
         )
-        assert embedding_model is not None, "Default embedding space references a missing model."
+        if embedding_model is None:
+            raise ValueError("Default embedding space references a missing model.")
         classifier = RandomForest(
             name=name,
             classes=class_list,
@@ -632,7 +633,8 @@ def _get_embedding_model_by_hash(
         default_embedding_model = embedding_model_resolver.get_by_id(
             session=session, embedding_model_id=default_embedding_model_id
         )
-        assert default_embedding_model is not None
+        if default_embedding_model is None:
+            raise ValueError("Default embedding space references a missing model.")
         if default_embedding_model.embedding_model_hash == embedding_model_hash:
             return default_embedding_model
 

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -615,21 +615,12 @@ class ClassifierManager:
 def _get_embedding_model_by_hash(
     session: Session, embedding_model_hash: str, collection_id: UUID
 ) -> EmbeddingModelTable | None:
-    """Resolve the embedding model with the given hash for a classifier's collection.
+    """Resolve the embedding model with the given hash within the collection's dataset.
 
-    Sample embeddings are keyed to the collection's own model row, so match that row first
-    and fall back to the dataset only when the collection has none.
+    A classifier stores the hash of the model it was trained on. The model is looked up by
+    ``(dataset_id, embedding_model_hash)`` so it resolves regardless of whether it is the
+    collection's default embedding space.
     """
-    # TODO(Michal, 08/2026): Drop the collection-local lookup once the write path
-    # deduplicates per dataset. Until then a dataset can hold one row per collection for the
-    # same hash, and the dataset fallback returns the oldest, which may match no embeddings.
-    collection_model = embedding_model_resolver.get_by_model_hash_deprecated(
-        session=session,
-        collection_id=collection_id,
-        embedding_model_hash=embedding_model_hash,
-    )
-    if collection_model is not None:
-        return collection_model
     collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
     if collection is None:
         raise ValueError(f"Collection {collection_id} not found.")

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -28,11 +28,13 @@ from lightly_studio.models.annotation_label import (
     AnnotationLabelCreate,
 )
 from lightly_studio.models.classifier import EmbeddingClassifier
+from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.image import ImageTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
     collection_resolver,
+    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -122,17 +124,19 @@ class ClassifierManager:
         Returns:
             The created classifier name and ID.
         """
-        embedding_models = embedding_model_resolver.get_all_by_collection_id(
+        embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
             session=session,
             collection_id=collection_id,
         )
-        if len(embedding_models) == 0:
+        embedding_model = (
+            embedding_model_resolver.get_by_id(
+                session=session, embedding_model_id=embedding_model_id
+            )
+            if embedding_model_id is not None
+            else None
+        )
+        if embedding_model is None:
             raise ValueError("No embedding model found for the given collection ID.")
-        # TODO(Horatiu, 05/2025): Handle multiple models correctly when
-        # available
-        if len(embedding_models) > 1:
-            raise ValueError("Multiple embedding models found for the given collection ID.")
-        embedding_model = embedding_models[0]
         classifier = RandomForest(
             name=name,
             classes=class_list,
@@ -165,7 +169,7 @@ class ClassifierManager:
         if classifier is None:
             raise ValueError(f"Classifier with ID {classifier_id} not found.")
 
-        embedding_model = embedding_model_resolver.get_by_model_hash(
+        embedding_model = _get_embedding_model_by_hash(
             session=session,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
             collection_id=classifier.collection_id,
@@ -255,7 +259,7 @@ class ClassifierManager:
         classifier = random_forest_classifier.load_random_forest_classifier(
             classifier_path=file_path, buffer=None
         )
-        embedding_model = embedding_model_resolver.get_by_model_hash(
+        embedding_model = _get_embedding_model_by_hash(
             session=session,
             embedding_model_hash=classifier.embedding_model_hash,
             collection_id=collection_id,
@@ -390,7 +394,7 @@ class ClassifierManager:
         annotations = classifier.annotations
         used_samples = {sample_id for samples in annotations.values() for sample_id in samples}
 
-        embedding_model = embedding_model_resolver.get_by_model_hash(
+        embedding_model = _get_embedding_model_by_hash(
             session=session,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
             collection_id=classifier.collection_id,
@@ -453,7 +457,7 @@ class ClassifierManager:
             raise ValueError(
                 f"Classifier with ID {classifier_id} is not active and cannot be used."
             )
-        embedding_model = embedding_model_resolver.get_by_model_hash(
+        embedding_model = _get_embedding_model_by_hash(
             session=session,
             embedding_model_hash=classifier.few_shot_classifier.embedding_model_hash,
             collection_id=classifier.collection_id,
@@ -589,7 +593,7 @@ class ClassifierManager:
         classifier = random_forest_classifier.load_random_forest_classifier(
             buffer=buffer, classifier_path=None
         )
-        embedding_model = embedding_model_resolver.get_by_model_hash(
+        embedding_model = _get_embedding_model_by_hash(
             session=session,
             embedding_model_hash=classifier.embedding_model_hash,
             collection_id=collection_id,
@@ -609,6 +613,25 @@ class ClassifierManager:
             annotations={class_name: [] for class_name in classifier.classes},
         )
         return self._classifiers[classifier_id]
+
+
+def _get_embedding_model_by_hash(
+    session: Session, embedding_model_hash: str, collection_id: UUID
+) -> EmbeddingModelTable | None:
+    """Resolve the embedding model with the given hash within the collection's dataset.
+
+    A classifier stores the hash of the model it was trained on. The model is looked up by
+    ``(dataset_id, embedding_model_hash)`` so it resolves regardless of whether it is the
+    collection's default embedding space.
+    """
+    collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
+    if collection is None:
+        raise ValueError(f"Collection {collection_id} not found.")
+    return embedding_model_resolver.get_by_model_hash(
+        session=session,
+        dataset_id=collection.dataset_id,
+        embedding_model_hash=embedding_model_hash,
+    )
 
 
 def _create_annotation_labels_for_classifier(

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -617,13 +617,25 @@ def _get_embedding_model_by_hash(
 ) -> EmbeddingModelTable | None:
     """Resolve the embedding model with the given hash within the collection's dataset.
 
-    A classifier stores the hash of the model it was trained on. The model is looked up by
-    ``(dataset_id, embedding_model_hash)`` so it resolves regardless of whether it is the
-    collection's default embedding space.
+    The default is preferred while a dataset can contain one model row per collection.
+    The dataset-scoped fallback supports the final deduplicated state.
     """
     collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
     if collection is None:
         raise ValueError(f"Collection {collection_id} not found.")
+
+    # TODO(Michal, 08/2026): Remove once embedding models are unique per dataset and hash.
+    default_embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+        session=session, collection_id=collection_id
+    )
+    if default_embedding_model_id is not None:
+        default_embedding_model = embedding_model_resolver.get_by_id(
+            session=session, embedding_model_id=default_embedding_model_id
+        )
+        assert default_embedding_model is not None
+        if default_embedding_model.embedding_model_hash == embedding_model_hash:
+            return default_embedding_model
+
     return embedding_model_resolver.get_by_model_hash(
         session=session,
         dataset_id=collection.dataset_id,

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -617,14 +617,25 @@ def _get_embedding_model_by_hash(
 ) -> EmbeddingModelTable | None:
     """Resolve the embedding model with the given hash within the collection's dataset.
 
-    A classifier stores the hash of the model it was trained on. The model is looked up by
-    ``(dataset_id, embedding_model_hash)`` so it resolves regardless of whether it is the
-    collection's default embedding space.
+    A classifier stores the hash of the model it was trained on. The model is resolved by
+    ``(dataset_id, embedding_model_hash)`` so it is found regardless of which collection in
+    the dataset owns the row.
+
+    Args:
+        session: The database session.
+        embedding_model_hash: The hash of the model the classifier was trained on.
+        collection_id: The collection the classifier belongs to.
+
+    Returns:
+        The matching embedding model, or ``None`` if the dataset has no model with the hash.
+
+    Raises:
+        ValueError: If the collection does not exist.
     """
     collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
     if collection is None:
         raise ValueError(f"Collection {collection_id} not found.")
-    return embedding_model_resolver.get_by_model_hash(
+    return embedding_model_resolver.get_by_dataset_id_and_model_hash(
         session=session,
         dataset_id=collection.dataset_id,
         embedding_model_hash=embedding_model_hash,

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -615,12 +615,21 @@ class ClassifierManager:
 def _get_embedding_model_by_hash(
     session: Session, embedding_model_hash: str, collection_id: UUID
 ) -> EmbeddingModelTable | None:
-    """Resolve the embedding model with the given hash within the collection's dataset.
+    """Resolve the embedding model with the given hash for a classifier's collection.
 
-    A classifier stores the hash of the model it was trained on. The model is looked up by
-    ``(dataset_id, embedding_model_hash)`` so it resolves regardless of whether it is the
-    collection's default embedding space.
+    Sample embeddings are keyed to the collection's own model row, so match that row first
+    and fall back to the dataset only when the collection has none.
     """
+    # TODO(Michal, 08/2026): Drop the collection-local lookup once the write path
+    # deduplicates per dataset. Until then a dataset can hold one row per collection for the
+    # same hash, and the dataset fallback returns the oldest, which may match no embeddings.
+    collection_model = embedding_model_resolver.get_by_model_hash_deprecated(
+        session=session,
+        collection_id=collection_id,
+        embedding_model_hash=embedding_model_hash,
+    )
+    if collection_model is not None:
+        return collection_model
     collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
     if collection is None:
         raise ValueError(f"Collection {collection_id} not found.")

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -617,25 +617,14 @@ def _get_embedding_model_by_hash(
 ) -> EmbeddingModelTable | None:
     """Resolve the embedding model with the given hash within the collection's dataset.
 
-    A classifier stores the hash of the model it was trained on. The model is resolved by
-    ``(dataset_id, embedding_model_hash)`` so it is found regardless of which collection in
-    the dataset owns the row.
-
-    Args:
-        session: The database session.
-        embedding_model_hash: The hash of the model the classifier was trained on.
-        collection_id: The collection the classifier belongs to.
-
-    Returns:
-        The matching embedding model, or ``None`` if the dataset has no model with the hash.
-
-    Raises:
-        ValueError: If the collection does not exist.
+    A classifier stores the hash of the model it was trained on. The model is looked up by
+    ``(dataset_id, embedding_model_hash)`` so it resolves regardless of whether it is the
+    collection's default embedding space.
     """
     collection = collection_resolver.get_by_id(session=session, collection_id=collection_id)
     if collection is None:
         raise ValueError(f"Collection {collection_id} not found.")
-    return embedding_model_resolver.get_by_dataset_id_and_model_hash(
+    return embedding_model_resolver.get_by_model_hash(
         session=session,
         dataset_id=collection.dataset_id,
         embedding_model_hash=embedding_model_hash,

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -128,15 +128,12 @@ class ClassifierManager:
             session=session,
             collection_id=collection_id,
         )
-        embedding_model = (
-            embedding_model_resolver.get_by_id(
-                session=session, embedding_model_id=embedding_model_id
-            )
-            if embedding_model_id is not None
-            else None
-        )
-        if embedding_model is None:
+        if embedding_model_id is None:
             raise ValueError("No embedding model found for the given collection ID.")
+        embedding_model = embedding_model_resolver.get_by_id(
+            session=session, embedding_model_id=embedding_model_id
+        )
+        assert embedding_model is not None, "Default embedding space references a missing model."
         classifier = RandomForest(
             name=name,
             classes=class_list,

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -25,7 +25,7 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
     """Retrieve an existing EmbeddingModel by hash or create a new one if it does not exist."""
     db_model = get_by_model_hash(
         session=session,
-        dataset_id=embedding_model.dataset_id,
+        collection_id=embedding_model.collection_id,
         embedding_model_hash=embedding_model.embedding_model_hash,
     )
     if db_model is None:
@@ -63,13 +63,33 @@ def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable
 
 
 def get_by_model_hash(
+    session: Session, collection_id: UUID, embedding_model_hash: str
+) -> EmbeddingModelTable | None:
+    """Retrieve a single embedding model by hash and collection."""
+    query = select(EmbeddingModelTable).where(
+        EmbeddingModelTable.embedding_model_hash == embedding_model_hash
+    )
+    query = query.where(EmbeddingModelTable.collection_id == collection_id)
+    return session.exec(query).one_or_none()
+
+
+def get_by_dataset_id_and_model_hash(
     session: Session, dataset_id: UUID, embedding_model_hash: str
 ) -> EmbeddingModelTable | None:
     """Retrieve a single embedding model by hash within a dataset.
 
-    The write path deduplicates per ``(dataset_id, embedding_model_hash)``, but no unique
-    constraint enforces it yet (it lands with the ``collection_id`` drop). The oldest match
-    is returned so legacy duplicates resolve deterministically to the canonical row.
+    Models are still stored per collection, so several collections in the same dataset can
+    hold a row for the same model (identical hash). This resolves the model for the dataset
+    regardless of which collection owns the row.
+
+    Args:
+        session: The database session.
+        dataset_id: The ID of the dataset that owns the model.
+        embedding_model_hash: The hash of the embedding model to resolve.
+
+    Returns:
+        The oldest embedding model in the dataset with the given hash, or ``None`` if none
+        matches. The oldest match is returned so duplicate rows resolve deterministically.
     """
     query = (
         select(EmbeddingModelTable)

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -25,7 +25,7 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
     """Retrieve an existing EmbeddingModel by hash or create a new one if it does not exist."""
     db_model = get_by_model_hash(
         session=session,
-        collection_id=embedding_model.collection_id,
+        dataset_id=embedding_model.dataset_id,
         embedding_model_hash=embedding_model.embedding_model_hash,
     )
     if db_model is None:
@@ -63,14 +63,24 @@ def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable
 
 
 def get_by_model_hash(
-    session: Session, collection_id: UUID, embedding_model_hash: str
+    session: Session, dataset_id: UUID, embedding_model_hash: str
 ) -> EmbeddingModelTable | None:
-    """Retrieve a single embedding model by hash and collection."""
-    query = select(EmbeddingModelTable).where(
-        EmbeddingModelTable.embedding_model_hash == embedding_model_hash
+    """Retrieve a single embedding model by hash within a dataset.
+
+    The write path deduplicates per ``(dataset_id, embedding_model_hash)``, but no unique
+    constraint enforces it yet (it lands with the ``collection_id`` drop). The oldest match
+    is returned so legacy duplicates resolve deterministically to the canonical row.
+    """
+    query = (
+        select(EmbeddingModelTable)
+        .where(EmbeddingModelTable.embedding_model_hash == embedding_model_hash)
+        .where(EmbeddingModelTable.dataset_id == dataset_id)
+        .order_by(
+            col(EmbeddingModelTable.created_at).asc(),
+            col(EmbeddingModelTable.embedding_model_id).asc(),
+        )
     )
-    query = query.where(EmbeddingModelTable.collection_id == collection_id)
-    return session.exec(query).one_or_none()
+    return session.exec(query).first()
 
 
 def get_by_name(

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -25,7 +25,7 @@ def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> Em
     """Retrieve an existing EmbeddingModel by hash or create a new one if it does not exist."""
     db_model = get_by_model_hash(
         session=session,
-        collection_id=embedding_model.collection_id,
+        dataset_id=embedding_model.dataset_id,
         embedding_model_hash=embedding_model.embedding_model_hash,
     )
     if db_model is None:
@@ -63,33 +63,13 @@ def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable
 
 
 def get_by_model_hash(
-    session: Session, collection_id: UUID, embedding_model_hash: str
-) -> EmbeddingModelTable | None:
-    """Retrieve a single embedding model by hash and collection."""
-    query = select(EmbeddingModelTable).where(
-        EmbeddingModelTable.embedding_model_hash == embedding_model_hash
-    )
-    query = query.where(EmbeddingModelTable.collection_id == collection_id)
-    return session.exec(query).one_or_none()
-
-
-def get_by_dataset_id_and_model_hash(
     session: Session, dataset_id: UUID, embedding_model_hash: str
 ) -> EmbeddingModelTable | None:
     """Retrieve a single embedding model by hash within a dataset.
 
-    Models are still stored per collection, so several collections in the same dataset can
-    hold a row for the same model (identical hash). This resolves the model for the dataset
-    regardless of which collection owns the row.
-
-    Args:
-        session: The database session.
-        dataset_id: The ID of the dataset that owns the model.
-        embedding_model_hash: The hash of the embedding model to resolve.
-
-    Returns:
-        The oldest embedding model in the dataset with the given hash, or ``None`` if none
-        matches. The oldest match is returned so duplicate rows resolve deterministically.
+    The write path deduplicates per ``(dataset_id, embedding_model_hash)``, but no unique
+    constraint enforces it yet (it lands with the ``collection_id`` drop). The oldest match
+    is returned so legacy duplicates resolve deterministically to the canonical row.
     """
     query = (
         select(EmbeddingModelTable)

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -23,9 +23,9 @@ def create(session: Session, embedding_model: EmbeddingModelCreate) -> Embedding
 
 def get_or_create(session: Session, embedding_model: EmbeddingModelCreate) -> EmbeddingModelTable:
     """Retrieve an existing EmbeddingModel by hash or create a new one if it does not exist."""
-    db_model = get_by_model_hash(
+    db_model = get_by_model_hash_deprecated(
         session=session,
-        dataset_id=embedding_model.dataset_id,
+        collection_id=embedding_model.collection_id,
         embedding_model_hash=embedding_model.embedding_model_hash,
     )
     if db_model is None:
@@ -62,14 +62,32 @@ def get_by_id(session: Session, embedding_model_id: UUID) -> EmbeddingModelTable
     ).one_or_none()
 
 
+# TODO(Michal, 08/2026): Remove once the write path deduplicates per dataset and the readers
+# no longer resolve embedding models by collection.
+def get_by_model_hash_deprecated(
+    session: Session, collection_id: UUID, embedding_model_hash: str
+) -> EmbeddingModelTable | None:
+    """Retrieve a single embedding model by hash and collection.
+
+    Kept for the write path, which still deduplicates per collection until the readers move
+    to dataset scope. Prefer :func:`get_by_model_hash` for new reads.
+    """
+    query = select(EmbeddingModelTable).where(
+        EmbeddingModelTable.embedding_model_hash == embedding_model_hash
+    )
+    query = query.where(EmbeddingModelTable.collection_id == collection_id)
+    return session.exec(query).one_or_none()
+
+
 def get_by_model_hash(
     session: Session, dataset_id: UUID, embedding_model_hash: str
 ) -> EmbeddingModelTable | None:
     """Retrieve a single embedding model by hash within a dataset.
 
-    The write path deduplicates per ``(dataset_id, embedding_model_hash)``, but no unique
-    constraint enforces it yet (it lands with the ``collection_id`` drop). The oldest match
-    is returned so legacy duplicates resolve deterministically to the canonical row.
+    The same hash can appear once per collection because the write path still deduplicates
+    per collection (see :func:`get_by_model_hash_deprecated`), so a dataset can hold
+    duplicates. The oldest match is returned so they resolve deterministically to the
+    canonical row.
     """
     query = (
         select(EmbeddingModelTable)

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_model_resolver.py
@@ -88,6 +88,14 @@ def get_by_model_hash(
     per collection (see :func:`get_by_model_hash_deprecated`), so a dataset can hold
     duplicates. The oldest match is returned so they resolve deterministically to the
     canonical row.
+
+    Args:
+        session: The database session.
+        dataset_id: The dataset in which to search for the embedding model.
+        embedding_model_hash: The hash identifying the embedding model.
+
+    Returns:
+        The oldest matching embedding model, or None if no matching model exists.
     """
     query = (
         select(EmbeddingModelTable)

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -530,8 +530,8 @@ def test_load_or_get_default_model__shares_generator_across_collections(
 ) -> None:
     """An annotation child collection reuses the parent's loaded generator.
 
-    The generator weights are loaded once, but each collection still gets its
-    own embedding-model record and id.
+    The generator weights are loaded once, and because both collections belong to the same
+    dataset with the same generator hash, they resolve to a single embedding-model record.
     """
     image_collection = create_collection(session=db_session, sample_type=SampleType.IMAGE)
     annotation_collection = create_collection(
@@ -560,8 +560,8 @@ def test_load_or_get_default_model__shares_generator_across_collections(
     mock_load.assert_called_once_with(sample_type=SampleType.IMAGE)
     assert manager._models[image_model_id] is manager._models[annotation_model_id]
 
-    # Each collection still owns a distinct embedding-model record.
-    assert image_model_id != annotation_model_id
+    # Both collections share the same dataset-scoped embedding-model record.
+    assert image_model_id == annotation_model_id
 
 
 def test_load_or_get_default_model__cant_load(

--- a/lightly_studio/tests/dataset/test_embedding_manager.py
+++ b/lightly_studio/tests/dataset/test_embedding_manager.py
@@ -530,8 +530,8 @@ def test_load_or_get_default_model__shares_generator_across_collections(
 ) -> None:
     """An annotation child collection reuses the parent's loaded generator.
 
-    The generator weights are loaded once, and because both collections belong to the same
-    dataset with the same generator hash, they resolve to a single embedding-model record.
+    The generator weights are loaded once, but each collection still gets its
+    own embedding-model record and id.
     """
     image_collection = create_collection(session=db_session, sample_type=SampleType.IMAGE)
     annotation_collection = create_collection(
@@ -560,8 +560,8 @@ def test_load_or_get_default_model__shares_generator_across_collections(
     mock_load.assert_called_once_with(sample_type=SampleType.IMAGE)
     assert manager._models[image_model_id] is manager._models[annotation_model_id]
 
-    # Both collections share the same dataset-scoped embedding-model record.
-    assert image_model_id == annotation_model_id
+    # Each collection still owns a distinct embedding-model record.
+    assert image_model_id != annotation_model_id
 
 
 def test_load_or_get_default_model__cant_load(

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -21,7 +21,10 @@ from lightly_studio.models.embedding_model import (
     EmbeddingModelTable,
 )
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
-from lightly_studio.resolvers import embedding_model_resolver
+from lightly_studio.resolvers import (
+    default_embedding_space_resolver,
+    embedding_model_resolver,
+)
 
 
 @pytest.fixture
@@ -61,7 +64,14 @@ def embedding_model(db_session: Session, collection: CollectionTable) -> Embeddi
         dataset_id=collection.dataset_id,
         embedding_dimension=3,
     )
-    return embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)
+    created = embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)
+    # Register it as the collection's default so it resolves as the collection's model.
+    default_embedding_space_resolver.set_default(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_id=created.embedding_model_id,
+    )
+    return created
 
 
 @pytest.fixture

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -31,6 +31,7 @@ from lightly_studio.models.sample_embedding import (
 from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
+    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -51,9 +52,14 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_by_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         # Create input data with two classes.
         input_classes = ["class1", "class2"]
@@ -74,17 +80,20 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[
-                EmbeddingModelTable(
-                    name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
-                )
-            ],
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
         )
         mocker.patch.object(
             embedding_model_resolver,
-            "get_by_model_hash",
+            "get_by_id",
+            return_value=EmbeddingModelTable(
+                name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
+            ),
+        )
+        mocker.patch.object(
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -138,17 +147,20 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[
-                EmbeddingModelTable(
-                    name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
-                )
-            ],
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
         )
         mocker.patch.object(
             embedding_model_resolver,
-            "get_by_model_hash",
+            "get_by_id",
+            return_value=EmbeddingModelTable(
+                name="test", embedding_dimension=3, embedding_model_hash=str(uuid4())
+            ),
+        )
+        mocker.patch.object(
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
@@ -190,9 +202,14 @@ class TestClassifierManager:
         """Test dropping a classifier in the finetuning step."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_by_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -289,8 +306,8 @@ class TestClassifierManager:
             classifier_id=classifier.classifier_id, file_path=save_path
         )
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_by_model_hash",
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=None,
         )
         with pytest.raises(
@@ -323,9 +340,14 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         # Setup: Create a classifier first
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_by_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -381,9 +403,14 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         # Setup: Create a classifier with initial samples
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_by_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -488,14 +515,19 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
 
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_by_model_hash",
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_by_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -566,14 +598,19 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
 
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_by_model_hash",
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
+        )
+        mocker.patch.object(
             embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[EmbeddingModelTable(name="test", embedding_dimension=3)],
+            "get_by_id",
+            return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
             few_shot_classifier.classifier_manager,
@@ -655,17 +692,20 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            embedding_model_resolver,
-            "get_all_by_collection_id",
-            return_value=[
-                EmbeddingModelTable(
-                    name="test", embedding_dimension=3, embedding_model_hash="mock_hash"
-                )
-            ],
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=uuid4(),
         )
         mocker.patch.object(
             embedding_model_resolver,
-            "get_by_model_hash",
+            "get_by_id",
+            return_value=EmbeddingModelTable(
+                name="test", embedding_dimension=3, embedding_model_hash="mock_hash"
+            ),
+        )
+        mocker.patch.object(
+            few_shot_classifier.classifier_manager,
+            "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -8,14 +8,13 @@ import pytest
 from pytest_mock import MockerFixture
 from sqlmodel import Session
 
-from lightly_studio import few_shot_classifier
+from lightly_studio.few_shot_classifier import classifier_manager as classifier_manager_module
 from lightly_studio.few_shot_classifier.classifier import AnnotatedEmbedding
 from lightly_studio.few_shot_classifier.classifier_manager import (
     HIGH_CONFIDENCE_SAMPLES_NEEDED,
     LOW_CONFIDENCE_SAMPLES_NEEDED,
     ClassifierEntry,
     ClassifierManager,
-    _get_embedding_model_by_hash,
 )
 from lightly_studio.few_shot_classifier.random_forest_classifier import (
     RandomForest,
@@ -122,12 +121,12 @@ class TestClassifierManager:
             ),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_create_annotated_embeddings",
             return_value=[
                 AnnotatedEmbedding(
@@ -189,12 +188,12 @@ class TestClassifierManager:
             ),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_create_annotated_embeddings",
             return_value=[
                 AnnotatedEmbedding(
@@ -242,7 +241,7 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_create_annotated_embeddings",
             return_value=[
                 AnnotatedEmbedding(
@@ -336,7 +335,7 @@ class TestClassifierManager:
             classifier_id=classifier.classifier_id, file_path=save_path
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_get_embedding_model_by_hash",
             return_value=None,
         )
@@ -380,7 +379,7 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_create_annotated_embeddings",
             return_value=[
                 AnnotatedEmbedding(
@@ -443,7 +442,7 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_create_annotated_embeddings",
             return_value=[
                 AnnotatedEmbedding(
@@ -545,7 +544,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
 
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
@@ -560,7 +559,7 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_create_annotated_embeddings",
             return_value=[
                 AnnotatedEmbedding(
@@ -628,7 +627,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
 
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
@@ -643,7 +642,7 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_create_annotated_embeddings",
             return_value=[
                 AnnotatedEmbedding(
@@ -734,12 +733,12 @@ class TestClassifierManager:
             ),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_get_embedding_model_by_hash",
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_create_annotated_embeddings",
             return_value=[
                 AnnotatedEmbedding(
@@ -780,7 +779,7 @@ class TestClassifierManager:
             },
         )
         mocker.patch.object(
-            few_shot_classifier.classifier_manager,
+            classifier_manager_module,
             "_create_annotated_embeddings",
             return_value=[
                 AnnotatedEmbedding(
@@ -997,30 +996,8 @@ def test_get_embedding_model_by_hash__prefers_collection_local(db_session: Sessi
         embedding_model_hash="same_hash",
     )
 
-    result = _get_embedding_model_by_hash(
+    result = classifier_manager_module._get_embedding_model_by_hash(
         session=db_session, embedding_model_hash="same_hash", collection_id=child.collection_id
     )
     assert result is not None
     assert result.embedding_model_id == child_model.embedding_model_id
-
-
-def test_get_embedding_model_by_hash__falls_back_to_dataset(db_session: Session) -> None:
-    # When the collection has no row of its own, the lookup falls back to the dataset-scoped
-    # row. This is how a deduplicated dataset resolves once the write path stops creating a
-    # row per collection.
-    parent = create_collection(session=db_session, collection_name="parent")
-    child = create_collection(
-        session=db_session, collection_name="child", parent_collection_id=parent.collection_id
-    )
-    parent_model = create_embedding_model(
-        session=db_session,
-        collection_id=parent.collection_id,
-        embedding_model_name="model_in_parent",
-        embedding_model_hash="same_hash",
-    )
-
-    result = _get_embedding_model_by_hash(
-        session=db_session, embedding_model_hash="same_hash", collection_id=child.collection_id
-    )
-    assert result is not None
-    assert result.embedding_model_id == parent_model.embedding_model_id

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -967,6 +967,12 @@ class TestClassifierManager:
             )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="Dataset-scoped lookup returns the oldest row for a hash; while the write path "
+    "still deduplicates per collection this can be another collection's row and match no "
+    "embeddings. Fixed when the readers move to dataset scope with the unique constraint.",
+)
 def test_get_embedding_model_by_hash__prefers_collection_local(db_session: Session) -> None:
     # A child collection shares its parent's dataset, so both can hold a row for the same
     # hash while the write path deduplicates per collection. Sample embeddings are keyed to

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -15,6 +15,7 @@ from lightly_studio.few_shot_classifier.classifier_manager import (
     LOW_CONFIDENCE_SAMPLES_NEEDED,
     ClassifierEntry,
     ClassifierManager,
+    _get_embedding_model_by_hash,
 )
 from lightly_studio.few_shot_classifier.random_forest_classifier import (
     RandomForest,
@@ -38,6 +39,10 @@ from lightly_studio.resolvers import (
 )
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
+)
+from tests.helpers_resolvers import (
+    create_collection,
+    create_embedding_model,
 )
 
 
@@ -960,3 +965,56 @@ class TestClassifierManager:
                 classifier_id=classifier.classifier_id,
                 collection_id=collection_id,
             )
+
+
+def test_get_embedding_model_by_hash__prefers_collection_local(db_session: Session) -> None:
+    # A child collection shares its parent's dataset, so both can hold a row for the same
+    # hash while the write path deduplicates per collection. Sample embeddings are keyed to
+    # the collection's own row, so the lookup must return that row and not the oldest one in
+    # the dataset.
+    parent = create_collection(session=db_session, collection_name="parent")
+    child = create_collection(
+        session=db_session, collection_name="child", parent_collection_id=parent.collection_id
+    )
+    assert child.dataset_id == parent.dataset_id
+    # The parent's row is created first, so it is the oldest in the dataset.
+    create_embedding_model(
+        session=db_session,
+        collection_id=parent.collection_id,
+        embedding_model_name="model_in_parent",
+        embedding_model_hash="same_hash",
+    )
+    child_model = create_embedding_model(
+        session=db_session,
+        collection_id=child.collection_id,
+        embedding_model_name="model_in_child",
+        embedding_model_hash="same_hash",
+    )
+
+    result = _get_embedding_model_by_hash(
+        session=db_session, embedding_model_hash="same_hash", collection_id=child.collection_id
+    )
+    assert result is not None
+    assert result.embedding_model_id == child_model.embedding_model_id
+
+
+def test_get_embedding_model_by_hash__falls_back_to_dataset(db_session: Session) -> None:
+    # When the collection has no row of its own, the lookup falls back to the dataset-scoped
+    # row. This is how a deduplicated dataset resolves once the write path stops creating a
+    # row per collection.
+    parent = create_collection(session=db_session, collection_name="parent")
+    child = create_collection(
+        session=db_session, collection_name="child", parent_collection_id=parent.collection_id
+    )
+    parent_model = create_embedding_model(
+        session=db_session,
+        collection_id=parent.collection_id,
+        embedding_model_name="model_in_parent",
+        embedding_model_hash="same_hash",
+    )
+
+    result = _get_embedding_model_by_hash(
+        session=db_session, embedding_model_hash="same_hash", collection_id=child.collection_id
+    )
+    assert result is not None
+    assert result.embedding_model_id == parent_model.embedding_model_id

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -966,13 +966,7 @@ class TestClassifierManager:
             )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Dataset-scoped lookup returns the oldest row for a hash; while the write path "
-    "still deduplicates per collection this can be another collection's row and match no "
-    "embeddings. Fixed when the readers move to dataset scope with the unique constraint.",
-)
-def test_get_embedding_model_by_hash__prefers_collection_local(db_session: Session) -> None:
+def test_get_embedding_model_by_hash__prefers_default(db_session: Session) -> None:
     # A child collection shares its parent's dataset, so both can hold a row for the same
     # hash while the write path deduplicates per collection. Sample embeddings are keyed to
     # the collection's own row, so the lookup must return that row and not the oldest one in
@@ -994,6 +988,11 @@ def test_get_embedding_model_by_hash__prefers_collection_local(db_session: Sessi
         collection_id=child.collection_id,
         embedding_model_name="model_in_child",
         embedding_model_hash="same_hash",
+    )
+    default_embedding_space_resolver.set_default(
+        session=db_session,
+        collection_id=child.collection_id,
+        embedding_model_id=child_model.embedding_model_id,
     )
 
     result = classifier_manager_module._get_embedding_model_by_hash(

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -72,6 +72,31 @@ class TestClassifierManager:
         )
         assert not classifier.is_active
 
+    def test_create_classifier__no_default_embedding_model(
+        self,
+        db_session: Session,
+        mocker: MockerFixture,
+    ) -> None:
+        """create_classifier raises when the collection has no default embedding model."""
+        classifier_manager = ClassifierManager()
+        mocker.patch.object(
+            default_embedding_space_resolver,
+            "get_by_collection_id",
+            return_value=None,
+        )
+        get_by_id = mocker.patch.object(embedding_model_resolver, "get_by_id")
+
+        with pytest.raises(
+            ValueError, match=r"No embedding model found for the given collection ID\."
+        ):
+            classifier_manager.create_classifier(
+                session=db_session,
+                name="test_classifier",
+                class_list=["class1", "class2"],
+                collection_id=uuid4(),
+            )
+        get_by_id.assert_not_called()
+
     def test_commit_temp_classifier(
         self,
         db_session: Session,

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -97,62 +97,61 @@ def test_get_by_model_hash(db_session: Session) -> None:
     )
 
     embedding_model = embedding_model_resolver.get_by_model_hash(
-        session=db_session, embedding_model_hash="hash_1", collection_id=collection_id
+        session=db_session, embedding_model_hash="hash_1", dataset_id=collection.dataset_id
     )
     assert embedding_model is not None
     assert embedding_model.name == embedding_model_1.name
 
     embedding_model = embedding_model_resolver.get_by_model_hash(
-        session=db_session, embedding_model_hash="hash_3", collection_id=collection_id
+        session=db_session, embedding_model_hash="hash_3", dataset_id=collection.dataset_id
     )
     assert embedding_model is None
 
 
-def test_get_by_model_hash__with_collection_id(db_session: Session) -> None:
+def test_get_by_model_hash__scoped_by_dataset(db_session: Session) -> None:
+    # Root collections each get their own dataset, so these models live in different datasets.
     collection_1 = create_collection(session=db_session, collection_name="collection_1")
     collection_2 = create_collection(session=db_session, collection_name="collection_2")
 
-    # Create models with same hash in different collections
+    # Create models with the same hash in different datasets.
     model_1 = create_embedding_model(
         session=db_session,
         collection_id=collection_1.collection_id,
-        embedding_model_name="model_in_collection_1",
+        embedding_model_name="model_in_dataset_1",
         embedding_model_hash="same_hash",
     )
     model_2 = create_embedding_model(
         session=db_session,
         collection_id=collection_2.collection_id,
-        embedding_model_name="model_in_collection_2",
+        embedding_model_name="model_in_dataset_2",
         embedding_model_hash="same_hash",
     )
 
-    # With collection_id, returns the correct model
+    # With dataset_id, returns the model owned by that dataset.
     result = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        collection_id=collection_1.collection_id,
+        dataset_id=collection_1.dataset_id,
     )
     assert result is not None
     assert result.embedding_model_id == model_1.embedding_model_id
     assert result.embedding_model_hash == "same_hash"
-    assert result.collection_id == collection_1.collection_id
 
     result = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        collection_id=collection_2.collection_id,
+        dataset_id=collection_2.dataset_id,
     )
     assert result is not None
     assert result.embedding_model_id == model_2.embedding_model_id
     assert result.embedding_model_hash == "same_hash"
-    assert result.collection_id == collection_2.collection_id
 
-    # With non-matching collection_id, returns None
+    # A dataset without a matching model returns None.
     collection_3 = create_collection(session=db_session, collection_name="collection_3")
     result_3 = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        collection_id=collection_3.collection_id,
+        dataset_id=collection_3.dataset_id,
     )
     assert result_3 is None
 

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -97,119 +97,63 @@ def test_get_by_model_hash(db_session: Session) -> None:
     )
 
     embedding_model = embedding_model_resolver.get_by_model_hash(
-        session=db_session, embedding_model_hash="hash_1", collection_id=collection_id
+        session=db_session, embedding_model_hash="hash_1", dataset_id=collection.dataset_id
     )
     assert embedding_model is not None
     assert embedding_model.name == embedding_model_1.name
 
     embedding_model = embedding_model_resolver.get_by_model_hash(
-        session=db_session, embedding_model_hash="hash_3", collection_id=collection_id
+        session=db_session, embedding_model_hash="hash_3", dataset_id=collection.dataset_id
     )
     assert embedding_model is None
 
 
-def test_get_by_model_hash__with_collection_id(db_session: Session) -> None:
+def test_get_by_model_hash__scoped_by_dataset(db_session: Session) -> None:
+    # Root collections each get their own dataset, so these models live in different datasets.
     collection_1 = create_collection(session=db_session, collection_name="collection_1")
     collection_2 = create_collection(session=db_session, collection_name="collection_2")
 
-    # Create models with same hash in different collections
+    # Create models with the same hash in different datasets.
     model_1 = create_embedding_model(
         session=db_session,
         collection_id=collection_1.collection_id,
-        embedding_model_name="model_in_collection_1",
+        embedding_model_name="model_in_dataset_1",
         embedding_model_hash="same_hash",
     )
     model_2 = create_embedding_model(
         session=db_session,
         collection_id=collection_2.collection_id,
-        embedding_model_name="model_in_collection_2",
+        embedding_model_name="model_in_dataset_2",
         embedding_model_hash="same_hash",
     )
 
-    # With collection_id, returns the correct model
+    # With dataset_id, returns the model owned by that dataset.
     result = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        collection_id=collection_1.collection_id,
+        dataset_id=collection_1.dataset_id,
     )
     assert result is not None
     assert result.embedding_model_id == model_1.embedding_model_id
     assert result.embedding_model_hash == "same_hash"
-    assert result.collection_id == collection_1.collection_id
 
     result = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        collection_id=collection_2.collection_id,
+        dataset_id=collection_2.dataset_id,
     )
     assert result is not None
     assert result.embedding_model_id == model_2.embedding_model_id
     assert result.embedding_model_hash == "same_hash"
-    assert result.collection_id == collection_2.collection_id
 
-    # With non-matching collection_id, returns None
+    # A dataset without a matching model returns None.
     collection_3 = create_collection(session=db_session, collection_name="collection_3")
     result_3 = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        collection_id=collection_3.collection_id,
+        dataset_id=collection_3.dataset_id,
     )
     assert result_3 is None
-
-
-def test_get_by_dataset_id_and_model_hash(db_session: Session) -> None:
-    collection = create_collection(session=db_session)
-    model = create_embedding_model(
-        session=db_session,
-        collection_id=collection.collection_id,
-        embedding_model_hash="hash_1",
-    )
-
-    result = embedding_model_resolver.get_by_dataset_id_and_model_hash(
-        session=db_session, dataset_id=collection.dataset_id, embedding_model_hash="hash_1"
-    )
-    assert result is not None
-    assert result.embedding_model_id == model.embedding_model_id
-
-    # A hash the dataset has no model for returns None.
-    result = embedding_model_resolver.get_by_dataset_id_and_model_hash(
-        session=db_session, dataset_id=collection.dataset_id, embedding_model_hash="hash_2"
-    )
-    assert result is None
-
-
-def test_get_by_dataset_id_and_model_hash__resolves_across_collections(db_session: Session) -> None:
-    # A child collection shares the parent's dataset, so both models live in one dataset.
-    parent = create_collection(session=db_session, collection_name="parent")
-    child = create_collection(
-        session=db_session, collection_name="child", parent_collection_id=parent.collection_id
-    )
-    parent_model = create_embedding_model(
-        session=db_session,
-        collection_id=parent.collection_id,
-        embedding_model_name="model_in_parent",
-        embedding_model_hash="same_hash",
-    )
-    create_embedding_model(
-        session=db_session,
-        collection_id=child.collection_id,
-        embedding_model_name="model_in_child",
-        embedding_model_hash="same_hash",
-    )
-
-    # The oldest matching row (the parent's) resolves for the dataset.
-    result = embedding_model_resolver.get_by_dataset_id_and_model_hash(
-        session=db_session, dataset_id=parent.dataset_id, embedding_model_hash="same_hash"
-    )
-    assert result is not None
-    assert result.embedding_model_id == parent_model.embedding_model_id
-
-    # A different dataset without the hash returns None.
-    other = create_collection(session=db_session, collection_name="other")
-    result = embedding_model_resolver.get_by_dataset_id_and_model_hash(
-        session=db_session, dataset_id=other.dataset_id, embedding_model_hash="same_hash"
-    )
-    assert result is None
 
 
 def test_get_by_name__none_with_single_model(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -79,6 +79,84 @@ def test_delete_embedding_model(db_session: Session) -> None:
     assert embedding_model_deleted is None
 
 
+def test_get_by_model_hash_deprecated(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    collection_id = collection.collection_id
+
+    embedding_model_1 = create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_name="embedding_model_1",
+        embedding_model_hash="hash_1",
+    )
+    create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_name="embedding_model_2",
+        embedding_model_hash="hash_2",
+    )
+
+    embedding_model = embedding_model_resolver.get_by_model_hash_deprecated(
+        session=db_session, embedding_model_hash="hash_1", collection_id=collection_id
+    )
+    assert embedding_model is not None
+    assert embedding_model.name == embedding_model_1.name
+
+    embedding_model = embedding_model_resolver.get_by_model_hash_deprecated(
+        session=db_session, embedding_model_hash="hash_3", collection_id=collection_id
+    )
+    assert embedding_model is None
+
+
+def test_get_by_model_hash_deprecated__with_collection_id(db_session: Session) -> None:
+    collection_1 = create_collection(session=db_session, collection_name="collection_1")
+    collection_2 = create_collection(session=db_session, collection_name="collection_2")
+
+    # Create models with same hash in different collections
+    model_1 = create_embedding_model(
+        session=db_session,
+        collection_id=collection_1.collection_id,
+        embedding_model_name="model_in_collection_1",
+        embedding_model_hash="same_hash",
+    )
+    model_2 = create_embedding_model(
+        session=db_session,
+        collection_id=collection_2.collection_id,
+        embedding_model_name="model_in_collection_2",
+        embedding_model_hash="same_hash",
+    )
+
+    # With collection_id, returns the correct model
+    result = embedding_model_resolver.get_by_model_hash_deprecated(
+        session=db_session,
+        embedding_model_hash="same_hash",
+        collection_id=collection_1.collection_id,
+    )
+    assert result is not None
+    assert result.embedding_model_id == model_1.embedding_model_id
+    assert result.embedding_model_hash == "same_hash"
+    assert result.collection_id == collection_1.collection_id
+
+    result = embedding_model_resolver.get_by_model_hash_deprecated(
+        session=db_session,
+        embedding_model_hash="same_hash",
+        collection_id=collection_2.collection_id,
+    )
+    assert result is not None
+    assert result.embedding_model_id == model_2.embedding_model_id
+    assert result.embedding_model_hash == "same_hash"
+    assert result.collection_id == collection_2.collection_id
+
+    # With non-matching collection_id, returns None
+    collection_3 = create_collection(session=db_session, collection_name="collection_3")
+    result_3 = embedding_model_resolver.get_by_model_hash_deprecated(
+        session=db_session,
+        embedding_model_hash="same_hash",
+        collection_id=collection_3.collection_id,
+    )
+    assert result_3 is None
+
+
 def test_get_by_model_hash(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     collection_id = collection.collection_id

--- a/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_embedding_model_resolver.py
@@ -97,63 +97,119 @@ def test_get_by_model_hash(db_session: Session) -> None:
     )
 
     embedding_model = embedding_model_resolver.get_by_model_hash(
-        session=db_session, embedding_model_hash="hash_1", dataset_id=collection.dataset_id
+        session=db_session, embedding_model_hash="hash_1", collection_id=collection_id
     )
     assert embedding_model is not None
     assert embedding_model.name == embedding_model_1.name
 
     embedding_model = embedding_model_resolver.get_by_model_hash(
-        session=db_session, embedding_model_hash="hash_3", dataset_id=collection.dataset_id
+        session=db_session, embedding_model_hash="hash_3", collection_id=collection_id
     )
     assert embedding_model is None
 
 
-def test_get_by_model_hash__scoped_by_dataset(db_session: Session) -> None:
-    # Root collections each get their own dataset, so these models live in different datasets.
+def test_get_by_model_hash__with_collection_id(db_session: Session) -> None:
     collection_1 = create_collection(session=db_session, collection_name="collection_1")
     collection_2 = create_collection(session=db_session, collection_name="collection_2")
 
-    # Create models with the same hash in different datasets.
+    # Create models with same hash in different collections
     model_1 = create_embedding_model(
         session=db_session,
         collection_id=collection_1.collection_id,
-        embedding_model_name="model_in_dataset_1",
+        embedding_model_name="model_in_collection_1",
         embedding_model_hash="same_hash",
     )
     model_2 = create_embedding_model(
         session=db_session,
         collection_id=collection_2.collection_id,
-        embedding_model_name="model_in_dataset_2",
+        embedding_model_name="model_in_collection_2",
         embedding_model_hash="same_hash",
     )
 
-    # With dataset_id, returns the model owned by that dataset.
+    # With collection_id, returns the correct model
     result = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        dataset_id=collection_1.dataset_id,
+        collection_id=collection_1.collection_id,
     )
     assert result is not None
     assert result.embedding_model_id == model_1.embedding_model_id
     assert result.embedding_model_hash == "same_hash"
+    assert result.collection_id == collection_1.collection_id
 
     result = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        dataset_id=collection_2.dataset_id,
+        collection_id=collection_2.collection_id,
     )
     assert result is not None
     assert result.embedding_model_id == model_2.embedding_model_id
     assert result.embedding_model_hash == "same_hash"
+    assert result.collection_id == collection_2.collection_id
 
-    # A dataset without a matching model returns None.
+    # With non-matching collection_id, returns None
     collection_3 = create_collection(session=db_session, collection_name="collection_3")
     result_3 = embedding_model_resolver.get_by_model_hash(
         session=db_session,
         embedding_model_hash="same_hash",
-        dataset_id=collection_3.dataset_id,
+        collection_id=collection_3.collection_id,
     )
     assert result_3 is None
+
+
+def test_get_by_dataset_id_and_model_hash(db_session: Session) -> None:
+    collection = create_collection(session=db_session)
+    model = create_embedding_model(
+        session=db_session,
+        collection_id=collection.collection_id,
+        embedding_model_hash="hash_1",
+    )
+
+    result = embedding_model_resolver.get_by_dataset_id_and_model_hash(
+        session=db_session, dataset_id=collection.dataset_id, embedding_model_hash="hash_1"
+    )
+    assert result is not None
+    assert result.embedding_model_id == model.embedding_model_id
+
+    # A hash the dataset has no model for returns None.
+    result = embedding_model_resolver.get_by_dataset_id_and_model_hash(
+        session=db_session, dataset_id=collection.dataset_id, embedding_model_hash="hash_2"
+    )
+    assert result is None
+
+
+def test_get_by_dataset_id_and_model_hash__resolves_across_collections(db_session: Session) -> None:
+    # A child collection shares the parent's dataset, so both models live in one dataset.
+    parent = create_collection(session=db_session, collection_name="parent")
+    child = create_collection(
+        session=db_session, collection_name="child", parent_collection_id=parent.collection_id
+    )
+    parent_model = create_embedding_model(
+        session=db_session,
+        collection_id=parent.collection_id,
+        embedding_model_name="model_in_parent",
+        embedding_model_hash="same_hash",
+    )
+    create_embedding_model(
+        session=db_session,
+        collection_id=child.collection_id,
+        embedding_model_name="model_in_child",
+        embedding_model_hash="same_hash",
+    )
+
+    # The oldest matching row (the parent's) resolves for the dataset.
+    result = embedding_model_resolver.get_by_dataset_id_and_model_hash(
+        session=db_session, dataset_id=parent.dataset_id, embedding_model_hash="same_hash"
+    )
+    assert result is not None
+    assert result.embedding_model_id == parent_model.embedding_model_id
+
+    # A different dataset without the hash returns None.
+    other = create_collection(session=db_session, collection_name="other")
+    result = embedding_model_resolver.get_by_dataset_id_and_model_hash(
+        session=db_session, dataset_id=other.dataset_id, embedding_model_hash="same_hash"
+    )
+    assert result is None
 
 
 def test_get_by_name__none_with_single_model(db_session: Session) -> None:


### PR DESCRIPTION
## What has changed and why?

The long-term goal is to remove `embedding_model.collection_id` and enforce one embedding-model row per `(dataset_id, embedding_model_hash)`. This needs a staged rollout: dataset-scoped creators would break collection-scoped readers, while dataset-scoped readers must tolerate the existing per-collection duplicate rows until the data migration.

This PR moves the classifier reader to the new scope without changing the shared write contract:

- `create_classifier` resolves the collection default through `default_embedding_space`.
- Classifier hash lookups resolve within the dataset. While duplicate rows exist, the collection default is preferred so classifier-created sample embeddings keep using the matching physical row; dataset scope remains the fallback and final state.
- `get_or_create` keeps deduplicating per collection through `get_by_model_hash_deprecated`, so the remaining collection-scoped readers continue to work.

Follow-ups will migrate the remaining readers and creators, deduplicate embedding-model rows while repointing foreign keys, add the unique constraint, and remove `embedding_model.collection_id` plus the temporary compatibility path.

Extracted from #2067. Depends on the dataset-ID and default-embedding-space groundwork in `michal-lig-10548-add-dataset-id-to-model-table`.

## How has it been tested?

- `make static-checks`
- `pytest tests/few_shot_classifier tests/resolvers/test_embedding_model_resolver.py tests/dataset/test_embedding_manager.py`
- Focused regression rerun: 39 passed

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding model resolution for few-shot classifiers.
  * Classifiers now consistently use the collection’s default embedding model when available.
  * Prevented incorrect model selection when related collections share a dataset.
  * Improved handling of missing or unmatched embedding models across training, loading, fine-tuning, and inference.

* **Tests**
  * Added regression coverage for collection-scoped model lookup, collection isolation, and default model prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->