### PR TITLE
Stub HTMLMediaElement.pause/play in global test setup

### DIFF
--- a/lightly_studio_view/src/setupTests.ts
+++ b/lightly_studio_view/src/setupTests.ts
@@ -20,6 +20,17 @@ vi.mock('$env/static/public', () => ({
     PUBLIC_LIGHTLY_STUDIO_API_URL: 'http://mock-url.com/api'
 }));
 
+// jsdom does not implement HTMLMediaElement playback methods. Stub them so
+// components that call pause()/play() in effects don't throw "Not implemented".
+Object.defineProperty(window.HTMLMediaElement.prototype, 'pause', {
+    writable: true,
+    value: vi.fn()
+});
+Object.defineProperty(window.HTMLMediaElement.prototype, 'play', {
+    writable: true,
+    value: vi.fn().mockResolvedValue(undefined)
+});
+
 // jsdom has no ResizeObserver. Track instances so tests can trigger the callback manually
 // (jsdom reports scrollWidth/clientWidth as 0, so observers never fire on their own).
 class MockResizeObserver implements ResizeObserver {


### PR DESCRIPTION
## What has changed and why?

jsdom does not implement `HTMLMediaElement.prototype.pause` or `play`, causing a  "Not implemented" warning in any test that renders a component with a `<video>` or `<audio>` element. Added no-op stubs for both methods to `setupTests.ts`, following the same pattern already used for `matchMedia`, `ResizeObserver`, `scrollIntoView`, and `animate`. 

## How has it been tested?

Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for components that control media playback.
  * Prevented unsupported media play and pause operations from causing test errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->