### PR TITLE
Thread the grid sort store through the video list

### DIFF
--- a/lightly_studio_view/src/lib/components/ExportSamples/AnnotationsTab/AnnotationsTab.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/AnnotationsTab/AnnotationsTab.test.ts
@@ -47,7 +47,9 @@ describe('AnnotationsTab', () => {
             videoFilter: writable(null),
             filterParams: writable(null),
             updateFilterParams: vi.fn(),
-            updateSampleIds: vi.fn()
+            updateSampleIds: vi.fn(),
+            videoSortBy: writable(null),
+            updateSortBy: vi.fn()
         });
     });
 
@@ -103,7 +105,9 @@ describe('AnnotationsTab', () => {
             videoFilter: writable(activeFilter),
             filterParams: writable(null),
             updateFilterParams: vi.fn(),
-            updateSampleIds: vi.fn()
+            updateSampleIds: vi.fn(),
+            videoSortBy: writable(null),
+            updateSortBy: vi.fn()
         });
         render(AnnotationsTab, {
             props: {

--- a/lightly_studio_view/src/lib/components/ExportSamples/YoutubeVisTab/YoutubeVisTab.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/YoutubeVisTab/YoutubeVisTab.test.ts
@@ -37,7 +37,9 @@ describe('YoutubeVisTab', () => {
             videoFilter: writable(null),
             filterParams: writable(null),
             updateFilterParams: vi.fn(),
-            updateSampleIds: vi.fn()
+            updateSampleIds: vi.fn(),
+            videoSortBy: writable(null),
+            updateSortBy: vi.fn()
         });
     });
 
@@ -74,7 +76,9 @@ describe('YoutubeVisTab', () => {
             videoFilter: writable(activeFilter),
             filterParams: writable(null),
             updateFilterParams: vi.fn(),
-            updateSampleIds: vi.fn()
+            updateSampleIds: vi.fn(),
+            videoSortBy: writable(null),
+            updateSortBy: vi.fn()
         });
         render(YoutubeVisTab);
         await fireEvent.click(

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 import { useVideoFilters } from './useVideoFilters';
 import { waitFor } from '@testing-library/svelte';
+import { SortDirection } from '$lib/api/lightly_studio_local';
 
 vi.mock('../useMetadataFilters/useMetadataFilters', () => ({
     createMetadataFilters: vi.fn(() => [])
@@ -191,6 +192,40 @@ describe('useVideoFilters', () => {
 
             const { filterParams } = useVideoFilters();
             expect(get(filterParams)?.filters?.sample_ids).toEqual(['existing']);
+        });
+    });
+
+    describe('videoSortBy and updateSortBy', () => {
+        it('defaults to ascending file_path_abs', () => {
+            const { videoSortBy } = useVideoFilters();
+
+            expect(get(videoSortBy)).toEqual([
+                {
+                    source: 'video',
+                    field_name: 'file_path_abs',
+                    direction: SortDirection.ASC
+                }
+            ]);
+        });
+
+        it('replaces the sort with the provided expression', () => {
+            const { videoSortBy, updateSortBy } = useVideoFilters();
+
+            updateSortBy([
+                { source: 'video', field_name: 'duration_s', direction: SortDirection.DESC }
+            ]);
+
+            expect(get(videoSortBy)).toEqual([
+                { source: 'video', field_name: 'duration_s', direction: SortDirection.DESC }
+            ]);
+        });
+
+        it('clears the sort when given null', () => {
+            const { videoSortBy, updateSortBy } = useVideoFilters();
+
+            updateSortBy(null);
+
+            expect(get(videoSortBy)).toBeNull();
         });
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
@@ -1,10 +1,12 @@
 import { derived, get, writable } from 'svelte/store';
 import { createMetadataFilters } from '../useMetadataFilters/useMetadataFilters';
+import { SortDirection } from '$lib/api/lightly_studio_local';
 import type {
     AnnotationsFilter,
     SampleFilter,
     VideoFilter,
-    VideoFieldsBoundsView
+    VideoFieldsBoundsView,
+    VideoSortFieldExpr
 } from '$lib/api/lightly_studio_local/types.gen';
 import type { CategoricalMetadataValues } from '$lib/services/types';
 type MetadataValues = Record<string, { min: number; max: number }>;
@@ -102,6 +104,14 @@ const videoFilter = derived(filterParams, ($filterParams): VideoFilter | null =>
     buildVideoFilter($filterParams)
 );
 
+const videoSortBy = writable<VideoSortFieldExpr[] | null>([
+    {
+        source: 'video',
+        field_name: 'file_path_abs',
+        direction: SortDirection.ASC
+    }
+]);
+
 export const useVideoFilters = () => {
     const updateFilterParams = (params: VideoFilterParams) => {
         filterParams.set(params);
@@ -123,10 +133,16 @@ export const useVideoFilters = () => {
         filterParams.set(newParams);
     };
 
+    const updateSortBy = (sort: VideoSortFieldExpr[] | null) => {
+        videoSortBy.set(sort);
+    };
+
     return {
         filterParams,
         videoFilter,
+        videoSortBy,
         updateFilterParams,
-        updateSampleIds
+        updateSampleIds,
+        updateSortBy
     };
 };

--- a/lightly_studio_view/src/lib/hooks/useVideos/useVideos.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideos/useVideos.svelte.ts
@@ -2,7 +2,11 @@ import { getAllVideosInfiniteOptions } from '$lib/api/lightly_studio_local/@tans
 
 import { createInfiniteQuery, useQueryClient } from '@tanstack/svelte-query';
 import { writable } from 'svelte/store';
-import type { VideoFilter, VideoView } from '$lib/api/lightly_studio_local/types.gen';
+import type {
+    VideoFilter,
+    VideoSortFieldExpr,
+    VideoView
+} from '$lib/api/lightly_studio_local/types.gen';
 import { GRID_PAGE_SIZE } from '$lib/constants';
 
 export const useVideos = (
@@ -10,26 +14,27 @@ export const useVideos = (
         collection_id: string;
         filter: VideoFilter;
         text_embedding?: Array<number>;
+        sort_by?: VideoSortFieldExpr[] | null;
     }
 ) => {
     const query = createInfiniteQuery(() => {
-        const { collection_id, filter, text_embedding } = getParams();
+        const { collection_id, filter, text_embedding, sort_by } = getParams();
         return {
             ...getAllVideosInfiniteOptions({
                 path: { collection_id },
                 query: { limit: GRID_PAGE_SIZE },
-                body: { filter, text_embedding }
+                body: { filter, text_embedding, sort_by }
             }),
             getNextPageParam: (lastPage) => lastPage.nextCursor || undefined
         };
     });
     const client = useQueryClient();
     const refresh = () => {
-        const { collection_id, filter, text_embedding } = getParams();
+        const { collection_id, filter, text_embedding, sort_by } = getParams();
         const options = getAllVideosInfiniteOptions({
             path: { collection_id },
             query: { limit: GRID_PAGE_SIZE },
-            body: { filter, text_embedding }
+            body: { filter, text_embedding, sort_by }
         });
         client.invalidateQueries({ queryKey: options.queryKey });
     };

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
@@ -55,7 +55,7 @@
         };
     };
 
-    const { filterParams, updateFilterParams } = useVideoFilters();
+    const { filterParams, videoSortBy, updateFilterParams } = useVideoFilters();
 
     $effect(() => {
         // Synchronize the global filter parameters with the local videos parameters
@@ -118,7 +118,8 @@
     const { data, query, loadMore, totalCount } = useVideos(() => ({
         collection_id: collectionId,
         filter: currentVideoFilter,
-        text_embedding: $textEmbedding?.embedding
+        text_embedding: $textEmbedding?.embedding,
+        sort_by: $textEmbedding ? undefined : ($videoSortBy ?? undefined)
     }));
     const { setfilteredSampleCount } = useGlobalStorage();
 
@@ -160,7 +161,7 @@
         handleSampleSelect({ sampleId, index, shiftKey: event.shiftKey });
     }
 
-    const filterHash = $derived(JSON.stringify($filterParams));
+    const filterHash = $derived(JSON.stringify({ filters: $filterParams, sortBy: $videoSortBy }));
     const { initialize, savePosition, getRestoredPosition } = useScrollRestoration('frames_scroll');
     onMount(async () => {
         initialize();


### PR DESCRIPTION
Lands the sort plumbing for the Videos grid so the next PR only has to add the control. Behavior-neutral: the default sort is `file_path_abs` ascending, the same implicit order the grid uses today, so nothing renders differently.

`useVideoFilters` gains a `videoSortBy` store and `updateSortBy`, mirroring `useImageFilters`. `useVideos` accepts `sort_by` and includes it in both request bodies. The videos page passes the sort through, guarded so a text-embedding similarity search still wins and skips the sort. Changing the sort also resets grid scroll, since it now folds into the scroll-reset hash.

First of five PRs finishing video-grid sorting. The next one adds the control.

Testing: `useVideoFilters` unit tests cover the store default and `updateSortBy`. Frontend `make static-checks` and unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video sorting with ascending file-path order by default.
  * Sorting can be updated or cleared while browsing videos.
  * Video queries and scroll restoration now respect the selected sort order.
  * Text-embedding searches continue without additional sorting.

* **Tests**
  * Added coverage for default, updated, and cleared video sorting states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->