### PR TITLE
Add the Videos-grid order-by control

### DIFF
--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-    import { AnnotationOrderBy, CollectionSearch, GridHeader, ImageOrderBy } from '$lib/components';
+    import {
+        AnnotationOrderBy,
+        CollectionSearch,
+        GridHeader,
+        ImageOrderBy,
+        VideoOrderBy
+    } from '$lib/components';
     import GridHeaderSelectAllButton from '$lib/components/GridHeaderSelectAllButton/GridHeaderSelectAllButton.svelte';
 
     type SearchImage = { name: string; previewUrl: string };
@@ -9,6 +15,7 @@
         canSelectAll: boolean;
         isSelectionActive: boolean;
         isImages: boolean;
+        isVideos: boolean;
         isAnnotations: boolean;
         hasMediaWithEmbeddings: boolean;
         collectionDatasetId: string;
@@ -29,6 +36,7 @@
         canSelectAll,
         isSelectionActive,
         isImages,
+        isVideos,
         isAnnotations,
         hasMediaWithEmbeddings,
         onSelectAll,
@@ -59,6 +67,8 @@
     {#snippet auxControls()}
         {#if isImages}
             <ImageOrderBy {collectionId} datasetId={collectionDatasetId} />
+        {:else if isVideos}
+            <VideoOrderBy {collectionId} />
         {:else if isAnnotations}
             <AnnotationOrderBy {collectionId} />
         {/if}

--- a/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
+++ b/lightly_studio_view/src/lib/components/DatasetGridHeader/DatasetGridHeader.test.ts
@@ -43,6 +43,7 @@ const defaultProps = {
     canSelectAll: false,
     isSelectionActive: false,
     isImages: false,
+    isVideos: false,
     isAnnotations: false,
     hasMediaWithEmbeddings: false,
     collectionDatasetId: 'dataset-1',

--- a/lightly_studio_view/src/lib/components/ExportSamples/AnnotationsTab/AnnotationsTab.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/AnnotationsTab/AnnotationsTab.test.ts
@@ -47,7 +47,9 @@ describe('AnnotationsTab', () => {
             videoFilter: writable(null),
             filterParams: writable(null),
             updateFilterParams: vi.fn(),
-            updateSampleIds: vi.fn()
+            updateSampleIds: vi.fn(),
+            videoSortBy: writable(null),
+            updateSortBy: vi.fn()
         });
     });
 
@@ -103,7 +105,9 @@ describe('AnnotationsTab', () => {
             videoFilter: writable(activeFilter),
             filterParams: writable(null),
             updateFilterParams: vi.fn(),
-            updateSampleIds: vi.fn()
+            updateSampleIds: vi.fn(),
+            videoSortBy: writable(null),
+            updateSortBy: vi.fn()
         });
         render(AnnotationsTab, {
             props: {

--- a/lightly_studio_view/src/lib/components/ExportSamples/YoutubeVisTab/YoutubeVisTab.test.ts
+++ b/lightly_studio_view/src/lib/components/ExportSamples/YoutubeVisTab/YoutubeVisTab.test.ts
@@ -37,7 +37,9 @@ describe('YoutubeVisTab', () => {
             videoFilter: writable(null),
             filterParams: writable(null),
             updateFilterParams: vi.fn(),
-            updateSampleIds: vi.fn()
+            updateSampleIds: vi.fn(),
+            videoSortBy: writable(null),
+            updateSortBy: vi.fn()
         });
     });
 
@@ -74,7 +76,9 @@ describe('YoutubeVisTab', () => {
             videoFilter: writable(activeFilter),
             filterParams: writable(null),
             updateFilterParams: vi.fn(),
-            updateSampleIds: vi.fn()
+            updateSampleIds: vi.fn(),
+            videoSortBy: writable(null),
+            updateSortBy: vi.fn()
         });
         render(YoutubeVisTab);
         await fireEvent.click(

--- a/lightly_studio_view/src/lib/components/OrderBy/VideoOrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/VideoOrderBy.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-    import { useVideoOrderBy } from '$lib/hooks/useVideoOrderBy/useVideoOrderBy';
-    import { useGlobalStorage, usePostHog } from '$lib/hooks';
+    import { useGlobalStorage, usePostHog, useVideoOrderBy } from '$lib/hooks';
     import { type SelectItem } from '$lib/components/Select';
     import OrderByControl from './OrderByControl.svelte';
 

--- a/lightly_studio_view/src/lib/components/OrderBy/VideoOrderBy.svelte
+++ b/lightly_studio_view/src/lib/components/OrderBy/VideoOrderBy.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+    import { useVideoOrderBy } from '$lib/hooks/useVideoOrderBy/useVideoOrderBy';
+    import { useGlobalStorage, usePostHog } from '$lib/hooks';
+    import { type SelectItem } from '$lib/components/Select';
+    import OrderByControl from './OrderByControl.svelte';
+
+    interface Props {
+        collectionId: string;
+    }
+
+    const { collectionId }: Props = $props();
+
+    const { textEmbedding } = useGlobalStorage();
+    const { trackEvent } = usePostHog();
+    const isSimilaritySearchActive = $derived(!!$textEmbedding);
+
+    const {
+        allSortFields,
+        selectedDirection,
+        selectedLabel,
+        isFieldSelected,
+        handleFieldClick,
+        toggleDirection
+    } = useVideoOrderBy({ collectionId: () => collectionId });
+
+    const selectValue = $derived.by(() => {
+        const idx = $allSortFields.findIndex((field) => $isFieldSelected(field));
+        return idx >= 0 ? String(idx) : '';
+    });
+
+    const sortItems = $derived<SelectItem[]>(
+        $allSortFields.map((field, i) => ({
+            value: String(i),
+            label: field.label,
+            testId: `sort-field-${field.value}`
+        }))
+    );
+
+    const handleValueChange = (value: string) => {
+        if (value === '') {
+            const idx = $allSortFields.findIndex((field) => $isFieldSelected(field));
+            if (idx >= 0) handleFieldClick($allSortFields[idx]);
+            return;
+        }
+        const field = $allSortFields[Number(value)];
+        if (field) handleFieldClick(field);
+    };
+</script>
+
+<OrderByControl
+    items={sortItems}
+    selectedValue={selectValue}
+    triggerLabel={$selectedLabel ?? undefined}
+    direction={$selectedDirection}
+    disabled={isSimilaritySearchActive}
+    allowDeselect
+    onValueChange={handleValueChange}
+    onOpen={() => trackEvent('sort_by_opened', { collection_id: collectionId })}
+    onToggleDirection={toggleDirection}
+/>

--- a/lightly_studio_view/src/lib/components/index.ts
+++ b/lightly_studio_view/src/lib/components/index.ts
@@ -67,6 +67,7 @@ export { default as CollectionSearch } from '$lib/components/CollectionSearch/Co
 export { default as CollectionSearchImage } from '$lib/components/CollectionSearch/CollectionSearchImage/CollectionSearchImage.svelte';
 export { default as CollectionSearchInput } from '$lib/components/CollectionSearch/SearchInput/CollectionSearchInput.svelte';
 export { default as ImageOrderBy } from '$lib/components/OrderBy/ImageOrderBy.svelte';
+export { default as VideoOrderBy } from '$lib/components/OrderBy/VideoOrderBy.svelte';
 export { default as AnnotationOrderBy } from '$lib/components/OrderBy/AnnotationOrderBy.svelte';
 export { default as SamplingCombinationDialog } from '$lib/components/Sampling/SamplingCombinationDialog.svelte';
 export { default as MetadataFilterChips } from '$lib/components/MetadataFilterChips/MetadataFilterChips.svelte';

--- a/lightly_studio_view/src/lib/hooks/index.ts
+++ b/lightly_studio_view/src/lib/hooks/index.ts
@@ -63,6 +63,8 @@ export {
 } from '$lib/hooks/useImageAnnotationCounts/useImageAnnotationCounts';
 export { useImageFilters } from '$lib/hooks/useImageFilters/useImageFilters';
 export { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
+export { useVideoOrderBy } from '$lib/hooks/useVideoOrderBy/useVideoOrderBy';
+export { useVideoSortFields } from '$lib/hooks/useVideoSortFields/useVideoSortFields';
 export {
     createOperatorFromMetadata,
     type Operator,

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 import { useVideoFilters } from './useVideoFilters';
 import { waitFor } from '@testing-library/svelte';
+import { SortDirection } from '$lib/api/lightly_studio_local';
 
 vi.mock('../useMetadataFilters/useMetadataFilters', () => ({
     createMetadataFilters: vi.fn(() => [])
@@ -191,6 +192,40 @@ describe('useVideoFilters', () => {
 
             const { filterParams } = useVideoFilters();
             expect(get(filterParams)?.filters?.sample_ids).toEqual(['existing']);
+        });
+    });
+
+    describe('videoSortBy and updateSortBy', () => {
+        it('defaults to ascending file_path_abs', () => {
+            const { videoSortBy } = useVideoFilters();
+
+            expect(get(videoSortBy)).toEqual([
+                {
+                    source: 'video',
+                    field_name: 'file_path_abs',
+                    direction: SortDirection.ASC
+                }
+            ]);
+        });
+
+        it('replaces the sort with the provided expression', () => {
+            const { videoSortBy, updateSortBy } = useVideoFilters();
+
+            updateSortBy([
+                { source: 'video', field_name: 'duration_s', direction: SortDirection.DESC }
+            ]);
+
+            expect(get(videoSortBy)).toEqual([
+                { source: 'video', field_name: 'duration_s', direction: SortDirection.DESC }
+            ]);
+        });
+
+        it('clears the sort when given null', () => {
+            const { videoSortBy, updateSortBy } = useVideoFilters();
+
+            updateSortBy(null);
+
+            expect(get(videoSortBy)).toBeNull();
         });
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
@@ -1,10 +1,12 @@
 import { derived, get, writable } from 'svelte/store';
 import { createMetadataFilters } from '../useMetadataFilters/useMetadataFilters';
+import { SortDirection } from '$lib/api/lightly_studio_local';
 import type {
     AnnotationsFilter,
     SampleFilter,
     VideoFilter,
-    VideoFieldsBoundsView
+    VideoFieldsBoundsView,
+    VideoSortFieldExpr
 } from '$lib/api/lightly_studio_local/types.gen';
 import type { CategoricalMetadataValues } from '$lib/services/types';
 type MetadataValues = Record<string, { min: number; max: number }>;
@@ -102,6 +104,14 @@ const videoFilter = derived(filterParams, ($filterParams): VideoFilter | null =>
     buildVideoFilter($filterParams)
 );
 
+const videoSortBy = writable<VideoSortFieldExpr[] | null>([
+    {
+        source: 'video',
+        field_name: 'file_path_abs',
+        direction: SortDirection.ASC
+    }
+]);
+
 export const useVideoFilters = () => {
     const updateFilterParams = (params: VideoFilterParams) => {
         filterParams.set(params);
@@ -123,10 +133,16 @@ export const useVideoFilters = () => {
         filterParams.set(newParams);
     };
 
+    const updateSortBy = (sort: VideoSortFieldExpr[] | null) => {
+        videoSortBy.set(sort);
+    };
+
     return {
         filterParams,
         videoFilter,
+        videoSortBy,
         updateFilterParams,
-        updateSampleIds
+        updateSampleIds,
+        updateSortBy
     };
 };

--- a/lightly_studio_view/src/lib/hooks/useVideoOrderBy/useVideoOrderBy.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoOrderBy/useVideoOrderBy.test.ts
@@ -1,0 +1,196 @@
+import { get, writable } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SortDirection } from '$lib/api/lightly_studio_local';
+import type { VideoSortFieldExpr } from '$lib/api/lightly_studio_local';
+import type { SortField } from '$lib/hooks/useVideoSortFields/useVideoSortFields';
+import { VIDEO_SORT_FIELDS } from '$lib/hooks/useVideoSortFields/useVideoSortFields';
+import { useVideoOrderBy } from './useVideoOrderBy';
+
+const videoSortBy = writable<VideoSortFieldExpr[] | null>(null);
+const allSortFields = writable<SortField[]>([...VIDEO_SORT_FIELDS]);
+const updateSortBy = vi.fn();
+
+vi.mock('$lib/hooks/useVideoFilters/useVideoFilters', () => ({
+    useVideoFilters: () => ({ videoSortBy, updateSortBy })
+}));
+
+vi.mock('$lib/hooks/useVideoSortFields/useVideoSortFields', async (importOriginal) => {
+    const original =
+        await importOriginal<typeof import('$lib/hooks/useVideoSortFields/useVideoSortFields')>();
+    return {
+        ...original,
+        useVideoSortFields: () => ({ allSortFields })
+    };
+});
+
+describe('useVideoOrderBy', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        videoSortBy.set(null);
+        allSortFields.set([...VIDEO_SORT_FIELDS]);
+    });
+
+    describe('selectedDirection', () => {
+        it('returns ASC when no sort is active', () => {
+            const { selectedDirection } = useVideoOrderBy({ collectionId: () => 'col1' });
+            expect(get(selectedDirection)).toBe(SortDirection.ASC);
+        });
+
+        it('returns the direction of the active sort', () => {
+            videoSortBy.set([
+                { source: 'video', field_name: 'file_name', direction: SortDirection.DESC }
+            ]);
+            const { selectedDirection } = useVideoOrderBy({ collectionId: () => 'col1' });
+            expect(get(selectedDirection)).toBe(SortDirection.DESC);
+        });
+    });
+
+    describe('selectedLabel', () => {
+        it('returns null when no sort is active', () => {
+            const { selectedLabel } = useVideoOrderBy({ collectionId: () => 'col1' });
+            expect(get(selectedLabel)).toBeNull();
+        });
+
+        it('returns the label for an active video sort field', () => {
+            videoSortBy.set([
+                { source: 'video', field_name: 'duration_s', direction: SortDirection.ASC }
+            ]);
+            const { selectedLabel } = useVideoOrderBy({ collectionId: () => 'col1' });
+            expect(get(selectedLabel)).toBe('duration');
+        });
+
+        it('returns the metadata label when a metadata field is active', () => {
+            allSortFields.set([
+                ...VIDEO_SORT_FIELDS,
+                { source: 'metadata', value: 'brightness', label: 'metadata.brightness' }
+            ]);
+            videoSortBy.set([
+                { source: 'metadata', field_name: 'brightness', direction: SortDirection.ASC }
+            ]);
+            const { selectedLabel } = useVideoOrderBy({ collectionId: () => 'col1' });
+            expect(get(selectedLabel)).toBe('metadata.brightness');
+        });
+    });
+
+    describe('isFieldSelected', () => {
+        it('returns false for any field when no sort is active', () => {
+            const { isFieldSelected } = useVideoOrderBy({ collectionId: () => 'col1' });
+            const check = get(isFieldSelected);
+
+            expect(check({ source: 'video', value: 'file_name', label: 'file name' })).toBe(false);
+        });
+
+        it('returns true for the matching video field', () => {
+            videoSortBy.set([
+                { source: 'video', field_name: 'width', direction: SortDirection.ASC }
+            ]);
+            const { isFieldSelected } = useVideoOrderBy({ collectionId: () => 'col1' });
+            const check = get(isFieldSelected);
+
+            expect(check({ source: 'video', value: 'width', label: 'width' })).toBe(true);
+            expect(check({ source: 'video', value: 'height', label: 'height' })).toBe(false);
+        });
+
+        it('updates reactively when videoSortBy changes', () => {
+            const { isFieldSelected } = useVideoOrderBy({ collectionId: () => 'col1' });
+            const field = { source: 'video' as const, value: 'width', label: 'width' };
+
+            expect(get(isFieldSelected)(field)).toBe(false);
+
+            videoSortBy.set([
+                { source: 'video', field_name: 'width', direction: SortDirection.ASC }
+            ]);
+
+            expect(get(isFieldSelected)(field)).toBe(true);
+        });
+    });
+
+    describe('handleFieldClick', () => {
+        it('selects a video field with ASC direction by default', () => {
+            const { handleFieldClick } = useVideoOrderBy({ collectionId: () => 'col1' });
+
+            handleFieldClick({ source: 'video', value: 'file_name', label: 'file name' });
+
+            expect(updateSortBy).toHaveBeenCalledWith([
+                { source: 'video', field_name: 'file_name', direction: SortDirection.ASC }
+            ]);
+        });
+
+        it('deselects the field when clicking the already selected field', () => {
+            videoSortBy.set([
+                { source: 'video', field_name: 'file_name', direction: SortDirection.ASC }
+            ]);
+            const { handleFieldClick } = useVideoOrderBy({ collectionId: () => 'col1' });
+
+            handleFieldClick({ source: 'video', value: 'file_name', label: 'file name' });
+
+            expect(updateSortBy).toHaveBeenCalledWith(null);
+        });
+
+        it('switches to a different field while preserving the current direction', () => {
+            videoSortBy.set([
+                { source: 'video', field_name: 'file_name', direction: SortDirection.DESC }
+            ]);
+            const { handleFieldClick } = useVideoOrderBy({ collectionId: () => 'col1' });
+
+            handleFieldClick({ source: 'video', value: 'width', label: 'width' });
+
+            expect(updateSortBy).toHaveBeenCalledWith([
+                { source: 'video', field_name: 'width', direction: SortDirection.DESC }
+            ]);
+        });
+
+        it('selects a metadata field', () => {
+            const { handleFieldClick } = useVideoOrderBy({ collectionId: () => 'col1' });
+
+            handleFieldClick({ source: 'metadata', value: 'score', label: 'metadata.score' });
+
+            expect(updateSortBy).toHaveBeenCalledWith([
+                { source: 'metadata', field_name: 'score', direction: SortDirection.ASC }
+            ]);
+        });
+    });
+
+    describe('toggleDirection', () => {
+        it('does nothing when no sort is active', () => {
+            const { toggleDirection } = useVideoOrderBy({ collectionId: () => 'col1' });
+
+            toggleDirection();
+
+            expect(updateSortBy).not.toHaveBeenCalled();
+        });
+
+        it('toggles direction for a video field', () => {
+            videoSortBy.set([
+                { source: 'video', field_name: 'file_name', direction: SortDirection.ASC }
+            ]);
+            const { toggleDirection } = useVideoOrderBy({ collectionId: () => 'col1' });
+
+            toggleDirection();
+            expect(updateSortBy).toHaveBeenCalledWith([
+                { source: 'video', field_name: 'file_name', direction: SortDirection.DESC }
+            ]);
+
+            videoSortBy.set([
+                { source: 'video', field_name: 'file_name', direction: SortDirection.DESC }
+            ]);
+            toggleDirection();
+            expect(updateSortBy).toHaveBeenCalledWith([
+                { source: 'video', field_name: 'file_name', direction: SortDirection.ASC }
+            ]);
+        });
+
+        it('toggles direction for a metadata field', () => {
+            videoSortBy.set([
+                { source: 'metadata', field_name: 'score', direction: SortDirection.ASC }
+            ]);
+            const { toggleDirection } = useVideoOrderBy({ collectionId: () => 'col1' });
+
+            toggleDirection();
+
+            expect(updateSortBy).toHaveBeenCalledWith([
+                { source: 'metadata', field_name: 'score', direction: SortDirection.DESC }
+            ]);
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useVideoOrderBy/useVideoOrderBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoOrderBy/useVideoOrderBy.ts
@@ -1,0 +1,114 @@
+import { derived, get, type Readable } from 'svelte/store';
+import { SortDirection } from '$lib/api/lightly_studio_local';
+import type { VideoSortFieldExpr } from '$lib/api/lightly_studio_local';
+import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
+import { usePostHog } from '$lib/hooks';
+import {
+    useVideoSortFields,
+    type SortField
+} from '$lib/hooks/useVideoSortFields/useVideoSortFields';
+
+interface UseVideoOrderByParams {
+    collectionId: () => string;
+}
+
+interface UseVideoOrderByReturn {
+    allSortFields: Readable<SortField[]>;
+    selectedDirection: Readable<SortDirection>;
+    selectedLabel: Readable<string | null>;
+    isFieldSelected: Readable<(field: SortField) => boolean>;
+    handleFieldClick: (field: SortField) => void;
+    toggleDirection: () => void;
+}
+
+function checkIsFieldSelected(field: SortField, current: VideoSortFieldExpr | undefined): boolean {
+    if (!current) return false;
+    return current.field_name === field.value && current.source === field.source;
+}
+
+function sortExprAnalytics(expr: VideoSortFieldExpr): { sort_source: string; field_name: string } {
+    return {
+        sort_source: expr.source === 'metadata' ? 'metadata_field' : 'video_field',
+        field_name: expr.field_name
+    };
+}
+
+export function useVideoOrderBy({ collectionId }: UseVideoOrderByParams): UseVideoOrderByReturn {
+    const { videoSortBy, updateSortBy } = useVideoFilters();
+    const { allSortFields } = useVideoSortFields();
+    const { trackEvent } = usePostHog();
+
+    const selectedDirection = derived(
+        videoSortBy,
+        ($videoSortBy) => $videoSortBy?.[0]?.direction ?? SortDirection.ASC
+    );
+
+    const selectedLabel = derived(
+        [videoSortBy, allSortFields],
+        ([$videoSortBy, $allSortFields]) => {
+            const current = $videoSortBy?.[0];
+            if (!current) return null;
+            return (
+                $allSortFields.find(
+                    (field) => field.source === current.source && field.value === current.field_name
+                )?.label ?? null
+            );
+        }
+    );
+
+    // Returns a checker function so the template can call $isFieldSelected(field)
+    // and reactively update when videoSortBy changes.
+    const isFieldSelected = derived(
+        videoSortBy,
+        ($videoSortBy) =>
+            (field: SortField): boolean =>
+                checkIsFieldSelected(field, $videoSortBy?.[0])
+    );
+
+    function handleFieldClick(field: SortField) {
+        const current = get(videoSortBy)?.[0];
+        if (checkIsFieldSelected(field, current)) {
+            updateSortBy(null);
+            return;
+        }
+        const direction = get(selectedDirection);
+        const next: VideoSortFieldExpr = {
+            source: field.source,
+            field_name: field.value,
+            direction
+        };
+        updateSortBy([next]);
+        const { sort_source, field_name } = sortExprAnalytics(next);
+        trackEvent('grid_sorted', {
+            collection_id: collectionId(),
+            sort_source,
+            field_name,
+            direction
+        });
+    }
+
+    function toggleDirection() {
+        const current = get(videoSortBy)?.[0];
+        if (!current) return;
+        const direction =
+            get(selectedDirection) === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC;
+        const next: VideoSortFieldExpr = { ...current, direction };
+        updateSortBy([next]);
+        const { sort_source, field_name } = sortExprAnalytics(next);
+        trackEvent('grid_sorted', {
+            collection_id: collectionId(),
+            sort_source,
+            field_name,
+            direction
+        });
+    }
+
+    return {
+        allSortFields,
+        selectedDirection,
+        selectedLabel,
+        isFieldSelected,
+        handleFieldClick,
+        toggleDirection
+    };
+}

--- a/lightly_studio_view/src/lib/hooks/useVideoOrderBy/useVideoOrderBy.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoOrderBy/useVideoOrderBy.ts
@@ -1,12 +1,8 @@
 import { derived, get, type Readable } from 'svelte/store';
 import { SortDirection } from '$lib/api/lightly_studio_local';
 import type { VideoSortFieldExpr } from '$lib/api/lightly_studio_local';
-import { useVideoFilters } from '$lib/hooks/useVideoFilters/useVideoFilters';
-import { usePostHog } from '$lib/hooks';
-import {
-    useVideoSortFields,
-    type SortField
-} from '$lib/hooks/useVideoSortFields/useVideoSortFields';
+import { usePostHog, useVideoFilters, useVideoSortFields } from '$lib/hooks';
+import type { SortField } from '$lib/hooks/useVideoSortFields/useVideoSortFields';
 
 interface UseVideoOrderByParams {
     collectionId: () => string;

--- a/lightly_studio_view/src/lib/hooks/useVideoSortFields/useVideoSortFields.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoSortFields/useVideoSortFields.test.ts
@@ -1,0 +1,94 @@
+import { get, writable } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MetadataInfoView } from '$lib/api/lightly_studio_local';
+import { useVideoSortFields } from './useVideoSortFields';
+
+const metadataInfo = writable<MetadataInfoView[]>([]);
+
+vi.mock('$lib/hooks/useMetadataFilters/useMetadataFilters', () => ({
+    useMetadataFilters: () => ({ metadataInfo })
+}));
+
+describe('useVideoSortFields', () => {
+    beforeEach(() => {
+        metadataInfo.set([]);
+    });
+
+    describe('allSortFields', () => {
+        it('contains the seven base video sort fields', () => {
+            const { allSortFields } = useVideoSortFields();
+            const fields = get(allSortFields);
+
+            expect(fields).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ source: 'video', value: 'file_name' }),
+                    expect.objectContaining({ source: 'video', value: 'file_path_abs' }),
+                    expect.objectContaining({ source: 'video', value: 'created_at' }),
+                    expect.objectContaining({ source: 'video', value: 'width' }),
+                    expect.objectContaining({ source: 'video', value: 'height' }),
+                    expect.objectContaining({ source: 'video', value: 'duration_s' }),
+                    expect.objectContaining({ source: 'video', value: 'fps' })
+                ])
+            );
+        });
+
+        it('includes metadata fields of supported types with metadata. prefix label', () => {
+            metadataInfo.set([
+                { name: 'score', type: 'float' },
+                { name: 'count', type: 'integer' },
+                { name: 'label', type: 'string' },
+                { name: 'active', type: 'boolean' }
+            ]);
+            const { allSortFields } = useVideoSortFields();
+            const fields = get(allSortFields);
+
+            expect(fields).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        source: 'metadata',
+                        value: 'score',
+                        label: 'metadata.score'
+                    }),
+                    expect.objectContaining({
+                        source: 'metadata',
+                        value: 'count',
+                        label: 'metadata.count'
+                    }),
+                    expect.objectContaining({
+                        source: 'metadata',
+                        value: 'label',
+                        label: 'metadata.label'
+                    }),
+                    expect.objectContaining({
+                        source: 'metadata',
+                        value: 'active',
+                        label: 'metadata.active'
+                    })
+                ])
+            );
+        });
+
+        it('excludes list and dict metadata fields', () => {
+            metadataInfo.set([
+                { name: 'tags', type: 'list' },
+                { name: 'nested', type: 'dict' },
+                { name: 'score', type: 'float' }
+            ]);
+            const { allSortFields } = useVideoSortFields();
+            const fields = get(allSortFields);
+
+            expect(fields.map((f) => f.value)).not.toContain('tags');
+            expect(fields.map((f) => f.value)).not.toContain('nested');
+        });
+
+        it('updates reactively when metadataInfo changes', () => {
+            const { allSortFields } = useVideoSortFields();
+
+            expect(get(allSortFields).find((f) => f.value === 'brightness')).toBeUndefined();
+
+            metadataInfo.set([{ name: 'brightness', type: 'float' }]);
+
+            expect(get(allSortFields).find((f) => f.value === 'brightness')).toBeDefined();
+        });
+    });
+});

--- a/lightly_studio_view/src/lib/hooks/useVideoSortFields/useVideoSortFields.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoSortFields/useVideoSortFields.ts
@@ -1,0 +1,51 @@
+import { derived, type Readable } from 'svelte/store';
+import type { VideoSortFieldExpr } from '$lib/api/lightly_studio_local';
+import { useMetadataFilters } from '$lib/hooks/useMetadataFilters/useMetadataFilters';
+
+export interface ColumnSortField {
+    source: VideoSortFieldExpr['source'];
+    value: string;
+    label: string;
+}
+
+export type SortField = ColumnSortField;
+
+interface UseVideoSortFieldsReturn {
+    allSortFields: Readable<SortField[]>;
+}
+
+// Videos have no evaluation metrics, so the field list is the plain columns plus
+// every sortable metadata key. The `value`s are the backend sort field names
+// (see query_translation._SORT_FIELDS).
+export const VIDEO_SORT_FIELDS: ColumnSortField[] = [
+    { source: 'video', value: 'file_name', label: 'file name' },
+    { source: 'video', value: 'file_path_abs', label: 'file path' },
+    { source: 'video', value: 'created_at', label: 'created at' },
+    { source: 'video', value: 'width', label: 'width' },
+    { source: 'video', value: 'height', label: 'height' },
+    { source: 'video', value: 'duration_s', label: 'duration' },
+    { source: 'video', value: 'fps', label: 'frame rate' }
+];
+
+export function useVideoSortFields(): UseVideoSortFieldsReturn {
+    const { metadataInfo } = useMetadataFilters();
+
+    const metadataSortFields = derived(metadataInfo, ($metadataInfo) =>
+        ($metadataInfo ?? [])
+            .filter((info) => ['integer', 'float', 'string', 'boolean'].includes(info.type))
+            .map(
+                (info): ColumnSortField => ({
+                    source: 'metadata' as VideoSortFieldExpr['source'],
+                    value: info.name,
+                    label: `metadata.${info.name}`
+                })
+            )
+    );
+
+    const allSortFields = derived(metadataSortFields, ($metadataSortFields) => [
+        ...VIDEO_SORT_FIELDS,
+        ...$metadataSortFields
+    ]);
+
+    return { allSortFields };
+}

--- a/lightly_studio_view/src/lib/hooks/useVideos/useVideos.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideos/useVideos.svelte.ts
@@ -2,7 +2,11 @@ import { getAllVideosInfiniteOptions } from '$lib/api/lightly_studio_local/@tans
 
 import { createInfiniteQuery, useQueryClient } from '@tanstack/svelte-query';
 import { writable } from 'svelte/store';
-import type { VideoFilter, VideoView } from '$lib/api/lightly_studio_local/types.gen';
+import type {
+    VideoFilter,
+    VideoSortFieldExpr,
+    VideoView
+} from '$lib/api/lightly_studio_local/types.gen';
 import { GRID_PAGE_SIZE } from '$lib/constants';
 
 export const useVideos = (
@@ -10,26 +14,27 @@ export const useVideos = (
         collection_id: string;
         filter: VideoFilter;
         text_embedding?: Array<number>;
+        sort_by?: VideoSortFieldExpr[] | null;
     }
 ) => {
     const query = createInfiniteQuery(() => {
-        const { collection_id, filter, text_embedding } = getParams();
+        const { collection_id, filter, text_embedding, sort_by } = getParams();
         return {
             ...getAllVideosInfiniteOptions({
                 path: { collection_id },
                 query: { limit: GRID_PAGE_SIZE },
-                body: { filter, text_embedding }
+                body: { filter, text_embedding, sort_by }
             }),
             getNextPageParam: (lastPage) => lastPage.nextCursor || undefined
         };
     });
     const client = useQueryClient();
     const refresh = () => {
-        const { collection_id, filter, text_embedding } = getParams();
+        const { collection_id, filter, text_embedding, sort_by } = getParams();
         const options = getAllVideosInfiniteOptions({
             path: { collection_id },
             query: { limit: GRID_PAGE_SIZE },
-            body: { filter, text_embedding }
+            body: { filter, text_embedding, sort_by }
         });
         client.invalidateQueries({ queryKey: options.queryKey });
     };

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/+layout.svelte
@@ -929,6 +929,7 @@
                                 {canSelectAll}
                                 isSelectionActive={$selectedCount > 0}
                                 {isImages}
+                                {isVideos}
                                 {isAnnotations}
                                 {hasMediaWithEmbeddings}
                                 collectionDatasetId={collection.dataset_id}

--- a/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
+++ b/lightly_studio_view/src/routes/datasets/[dataset_id]/[collection_type]/[collection_id]/videos/+page.svelte
@@ -55,7 +55,7 @@
         };
     };
 
-    const { filterParams, updateFilterParams } = useVideoFilters();
+    const { filterParams, videoSortBy, updateFilterParams } = useVideoFilters();
 
     $effect(() => {
         // Synchronize the global filter parameters with the local videos parameters
@@ -118,7 +118,8 @@
     const { data, query, loadMore, totalCount } = useVideos(() => ({
         collection_id: collectionId,
         filter: currentVideoFilter,
-        text_embedding: $textEmbedding?.embedding
+        text_embedding: $textEmbedding?.embedding,
+        sort_by: $textEmbedding ? undefined : ($videoSortBy ?? undefined)
     }));
     const { setfilteredSampleCount } = useGlobalStorage();
 
@@ -160,7 +161,7 @@
         handleSampleSelect({ sampleId, index, shiftKey: event.shiftKey });
     }
 
-    const filterHash = $derived(JSON.stringify($filterParams));
+    const filterHash = $derived(JSON.stringify({ filters: $filterParams, sortBy: $videoSortBy }));
     const { initialize, savePosition, getRestoredPosition } = useScrollRestoration('frames_scroll');
     onMount(async () => {
         initialize();


### PR DESCRIPTION
Adds the order-by control to the Videos grid. Videos get their own sibling components feeding the shared `OrderByControl`, the pattern images and annotations already use (#1898). A media-type flag on the shared hook would fetch and discard image-only state: the stores differ, and videos have no evaluation metrics.

New: `VideoOrderBy.svelte` and two matching hooks, copied from the image trio with the `datasetId` argument and evaluation-metric branch removed. Sort fields are file name, file path, created at, width, height, duration, frame rate, and every metadata key of a sortable type. `DatasetGridHeader` gains an `isVideos` branch fed from the collection layout, plus a barrel export. The control is disabled during a text-embedding similarity search.

Size is copy-derived from the reviewed image code and its tests. It ships as one unit because the hooks have no caller without the component, and the component stays hidden without the header gate.

PostHog: column sorts now report `sort_source: video_field`, while metadata sorts still report `metadata_field`. Whoever owns the dashboards should add the new value.

Testing: unit tests for `useVideoOrderBy` and `useVideoSortFields`; frontend `make static-checks` and unit tests pass.

Stacked on #2075.