### PR TITLE
Order video prev/next by the grid sort

### DIFF
--- a/lightly_studio/src/lightly_studio/models/sort.py
+++ b/lightly_studio/src/lightly_studio/models/sort.py
@@ -79,6 +79,16 @@ ImageSortExpr = Annotated[
 ]
 
 
+# Image and video field expressions both allow ``source="metadata"``, so a
+# discriminated union on ``source`` cannot build. Match left to right instead: a
+# metadata expression resolves to ``ImageSortFieldExpr``, which is harmless since
+# both translate through the same ``(source, field_name)`` key.
+AdjacentSortExpr = Annotated[
+    Union[ImageSortFieldExpr, VideoSortFieldExpr, EvaluationMetricSortExpr],
+    Field(union_mode="left_to_right"),
+]
+
+
 def sort_field_expr_to_order_by(expr: SortFieldExprBase) -> OrderByExpression:
     """Translate a single-field sort expression to an OrderByExpression.
 
@@ -96,6 +106,27 @@ def sort_field_expr_to_order_by(expr: SortFieldExprBase) -> OrderByExpression:
 
 def image_sort_expr_to_order_by(expr: ImageSortExpr) -> OrderByExpression:
     """Translate an ImageSortExpr (image, metadata, or evaluation metric) to an OrderByExpression.
+
+    Args:
+        expr: The sort expression from the API request.
+
+    Returns:
+        An OrderByExpression ready to be applied to a database query.
+    """
+    if isinstance(expr, EvaluationMetricSortExpr):
+        return evaluation_metric_sort_to_order_by(
+            evaluation_run_name=expr.evaluation_run_name,
+            metric_name=expr.metric_name,
+            direction=expr.direction,
+        )
+    return sort_field_expr_to_order_by(expr)
+
+
+def adjacent_sort_expr_to_order_by(expr: AdjacentSortExpr) -> OrderByExpression:
+    """Translate an adjacency sort expression to an OrderByExpression.
+
+    Handles image, video, metadata, and evaluation-metric expressions, so the
+    shared adjacent-samples request can carry the sort of either grid.
 
     Args:
         expr: The sort expression from the API request.

--- a/lightly_studio/src/lightly_studio/models/sort.py
+++ b/lightly_studio/src/lightly_studio/models/sort.py
@@ -80,6 +80,10 @@ ImageSortExpr = Annotated[
 # discriminated union on ``source`` cannot build. Match left to right instead: a
 # metadata expression resolves to ``ImageSortFieldExpr``, which is harmless since
 # both translate through the same ``(source, field_name)`` key.
+# TODO(gabriel, 08/2026): Replace this left-to-right union with a source-discriminated one;
+# tracked in LIG-10605. Safe only while ImageSortFieldExpr and VideoSortFieldExpr stay
+# structurally identical, guarded by
+# tests/models/test_sort.py::test_image_and_video_sort_field_exprs_stay_structurally_identical.
 AdjacentSortExpr = Annotated[
     Union[ImageSortFieldExpr, VideoSortFieldExpr, EvaluationMetricSortExpr],
     Field(union_mode="left_to_right"),

--- a/lightly_studio/src/lightly_studio/models/sort.py
+++ b/lightly_studio/src/lightly_studio/models/sort.py
@@ -7,11 +7,8 @@ from typing import Annotated, Literal, Union
 
 from pydantic import BaseModel, Field
 
+from lightly_studio.core.dataset_query import query_translation
 from lightly_studio.core.dataset_query.order_by import OrderByExpression
-from lightly_studio.core.dataset_query.query_translation import (
-    evaluation_metric_sort_to_order_by,
-    sort_to_order_by,
-)
 from lightly_studio.models.sort_direction import SortDirection
 
 
@@ -98,7 +95,7 @@ def sort_field_expr_to_order_by(expr: SortFieldExprBase) -> OrderByExpression:
     Returns:
         An OrderByExpression ready to be applied to a database query.
     """
-    return sort_to_order_by(
+    return query_translation.sort_to_order_by(
         key=(expr.source, expr.field_name),
         direction=expr.direction,
     )
@@ -113,13 +110,8 @@ def image_sort_expr_to_order_by(expr: ImageSortExpr) -> OrderByExpression:
     Returns:
         An OrderByExpression ready to be applied to a database query.
     """
-    if isinstance(expr, EvaluationMetricSortExpr):
-        return evaluation_metric_sort_to_order_by(
-            evaluation_run_name=expr.evaluation_run_name,
-            metric_name=expr.metric_name,
-            direction=expr.direction,
-        )
-    return sort_field_expr_to_order_by(expr)
+    # ImageSortExpr is a subset of AdjacentSortExpr, so the shared translator handles it.
+    return adjacent_sort_expr_to_order_by(expr)
 
 
 def adjacent_sort_expr_to_order_by(expr: AdjacentSortExpr) -> OrderByExpression:
@@ -135,7 +127,7 @@ def adjacent_sort_expr_to_order_by(expr: AdjacentSortExpr) -> OrderByExpression:
         An OrderByExpression ready to be applied to a database query.
     """
     if isinstance(expr, EvaluationMetricSortExpr):
-        return evaluation_metric_sort_to_order_by(
+        return query_translation.evaluation_metric_sort_to_order_by(
             evaluation_run_name=expr.evaluation_run_name,
             metric_name=expr.metric_name,
             direction=expr.direction,

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_adjacent_videos.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_adjacent_videos.py
@@ -37,6 +37,10 @@ def get_adjacent_videos(  # noqa: PLR0913
             ordering and ``order_by`` is ignored.
         order_by: Requested grid sort so prev/next follows it; empty for the
             default ``file_path_abs`` order.
+
+    Returns:
+        The adjacency result with the previous/next sample IDs and the anchor's
+        position, or ``None`` when the anchor is not in the (filtered) collection.
     """
     base_query = _base_query(order_by=order_by)
     base_query = base_query.where(col(SampleTable.collection_id) == collection_id)
@@ -66,6 +70,9 @@ def get_adjacent_videos(  # noqa: PLR0913
     )
 
 
+# TODO(Horatiu, 06/2026): This window/tiebreaker builder duplicates
+# get_adjacent_images_window; fold both into the shared adjacency-ordering unification
+# tracked there rather than maintaining two copies.
 def _base_query(
     ordering_expression: Any | None = None,
     order_by: list[OrderByExpression] | None = None,
@@ -127,14 +134,10 @@ def _window_order_columns(
     else:
         tiebreaker = []
 
+    # Similarity and grid sort never arrive together: the similarity call passes only
+    # ``ordering_expression``, the grid call passes only ``order_by``.
     if ordering_expression is not None:
-        return (
-            ordering_expression
-            + [e for expr in order_by for e in expr.to_column_elements()]
-            + tiebreaker
-            if order_by
-            else [*ordering_expression, *tiebreaker]
-        )
+        return [*ordering_expression, *tiebreaker]
     if order_by:
         return [e for expr in order_by for e in expr.to_column_elements()] + tiebreaker
     return col(VideoTable.file_path_abs).asc()

--- a/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_adjacent_videos.py
+++ b/lightly_studio/src/lightly_studio/resolvers/video_resolver/get_adjacent_videos.py
@@ -9,6 +9,8 @@ from sqlalchemy import func
 from sqlmodel import Session, col, select
 from sqlmodel.sql.expression import Select
 
+from lightly_studio.core.dataset_query.order_by import OrderByExpression, OrderByField
+from lightly_studio.core.dataset_query.video_sample_field import VideoSampleField
 from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.models.video import VideoTable
@@ -16,15 +18,27 @@ from lightly_studio.resolvers import adjacents, similarity_utils
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
 
 
-def get_adjacent_videos(
+def get_adjacent_videos(  # noqa: PLR0913
     session: Session,
     sample_id: UUID,
     collection_id: UUID,
     filters: VideoFilter | None = None,
     text_embedding: list[float] | None = None,
+    order_by: list[OrderByExpression] | None = None,
 ) -> AdjacentResultView | None:
-    """Get the adjacent videos for a given sample ID."""
-    base_query = _base_query()
+    """Get the adjacent videos for a given sample ID.
+
+    Args:
+        session: Database session.
+        sample_id: The anchor sample whose neighbours we want.
+        collection_id: Collection the anchor and neighbours belong to.
+        filters: Optional video filters constraining the collection.
+        text_embedding: Optional similarity query; when present it drives the
+            ordering and ``order_by`` is ignored.
+        order_by: Requested grid sort so prev/next follows it; empty for the
+            default ``file_path_abs`` order.
+    """
+    base_query = _base_query(order_by=order_by)
     base_query = base_query.where(col(SampleTable.collection_id) == collection_id)
 
     embedding_model_id, distance_expr = similarity_utils.get_distance_expression(
@@ -52,22 +66,75 @@ def get_adjacent_videos(
     )
 
 
-def _base_query(ordering_expression: Any | None = None) -> Select[Any]:
-    ordering_expression = ordering_expression or col(VideoTable.file_path_abs).asc()
+def _base_query(
+    ordering_expression: Any | None = None,
+    order_by: list[OrderByExpression] | None = None,
+) -> Select[Any]:
+    """Return a per-video window query for adjacency lookup.
 
-    # Build the base query that orders samples by absolute file path and
-    # annotates each row with its previous/next sample_id and row number
-    return (
+    Rows are ordered by ``ordering_expression`` (similarity), then the requested
+    ``order_by``, then a ``file_path_abs`` tiebreaker. Each row is annotated with its
+    previous/next ``sample_id`` and row number via ``lag`` / ``lead`` / ``row_number``.
+
+    Args:
+        ordering_expression: Extra sort keys for the window ``ORDER BY`` (e.g. the
+            similarity distance). The caller must add any JOINs these need.
+        order_by: Grid sort expressions; their JOINs are applied via ``apply_joins``.
+    """
+    order_col = _window_order_columns(ordering_expression=ordering_expression, order_by=order_by)
+
+    query: Select[Any] = (
         select(
             col(VideoTable.sample_id).label("sample_id"),
             func.lag(col(VideoTable.sample_id))
-            .over(order_by=ordering_expression)
+            .over(order_by=order_col)
             .label("previous_sample_id"),
-            func.lead(col(VideoTable.sample_id))
-            .over(order_by=ordering_expression)
-            .label("next_sample_id"),
-            func.row_number().over(order_by=ordering_expression).label("row_number"),
+            func.lead(col(VideoTable.sample_id)).over(order_by=order_col).label("next_sample_id"),
+            func.row_number().over(order_by=order_col).label("row_number"),
         )
         .select_from(VideoTable)
         .join(VideoTable.sample)
     )
+
+    if order_by:
+        for expr in order_by:
+            query = expr.apply_joins(query)
+
+    return query
+
+
+def _window_order_columns(
+    ordering_expression: Any | None,
+    order_by: list[OrderByExpression] | None,
+) -> Any:
+    """Assemble the window ``ORDER BY`` from similarity, grid sort, and tiebreaker.
+
+    A ``file_path_abs`` tiebreaker (following the primary sort direction) is appended
+    unless the grid sort already sorts by ``file_path_abs``. With no explicit ordering,
+    falls back to ``file_path_abs`` ascending. Mirrors the video grid resolver's
+    tiebreaker rather than sharing a builder with the image window.
+    """
+    needs_tiebreaker = not order_by or not any(
+        isinstance(expr, OrderByField) and expr.field is VideoSampleField.file_path_abs
+        for expr in order_by
+    )
+    if needs_tiebreaker:
+        file_path_col = col(VideoTable.file_path_abs)
+        tiebreaker_col = (
+            file_path_col.asc() if (not order_by or order_by[0].ascending) else file_path_col.desc()
+        )
+        tiebreaker = [tiebreaker_col]
+    else:
+        tiebreaker = []
+
+    if ordering_expression is not None:
+        return (
+            ordering_expression
+            + [e for expr in order_by for e in expr.to_column_elements()]
+            + tiebreaker
+            if order_by
+            else [*ordering_expression, *tiebreaker]
+        )
+    if order_by:
+        return [e for expr in order_by for e in expr.to_column_elements()] + tiebreaker
+    return col(VideoTable.file_path_abs).asc()

--- a/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
+++ b/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
@@ -144,7 +144,7 @@ def get_adjacent_samples(
                 "Invalid filter provided. Expected ImageFilter"
                 f" for sample type '{request.sample_type.value}'."
             )
-        order_by = _build_sort_order_by(request.sort_by, SampleType.IMAGE)
+        order_by = _build_sort_order_by(sort_by=request.sort_by, sample_type=SampleType.IMAGE)
         return image_resolver.get_adjacent_images(
             session=session,
             sample_id=sample_id,
@@ -159,7 +159,7 @@ def get_adjacent_samples(
                 "Invalid filter provided. Expected VideoFilter"
                 f" for sample type '{request.sample_type.value}'."
             )
-        order_by = _build_sort_order_by(request.sort_by, SampleType.VIDEO)
+        order_by = _build_sort_order_by(sort_by=request.sort_by, sample_type=SampleType.VIDEO)
         return video_resolver.get_adjacent_videos(
             session=session,
             sample_id=sample_id,

--- a/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
+++ b/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
@@ -14,7 +14,7 @@ from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
 from lightly_studio.models.collection import SampleType
-from lightly_studio.models.sort import ImageSortExpr
+from lightly_studio.models.sort import AdjacentSortExpr
 from lightly_studio.resolvers import (
     annotation_resolver,
     image_resolver,
@@ -43,7 +43,7 @@ class AdjacentRequest(BaseModel):
         | None
     ) = None
     text_embedding: list[float] | None = None
-    sort_by: list[ImageSortExpr] | None = None
+    sort_by: list[AdjacentSortExpr] | None = None
     annotation_sort_by: AnnotationEvaluationMetricSortExpr | None = None
 
 
@@ -101,7 +101,7 @@ def get_adjacent_samples(
                 f" for sample type '{request.sample_type.value}'."
             )
         order_by = (
-            [sort.image_sort_expr_to_order_by(expr) for expr in request.sort_by]
+            [sort.adjacent_sort_expr_to_order_by(expr) for expr in request.sort_by]
             if request.sort_by
             else None
         )
@@ -119,12 +119,18 @@ def get_adjacent_samples(
                 "Invalid filter provided. Expected VideoFilter"
                 f" for sample type '{request.sample_type.value}'."
             )
+        order_by = (
+            [sort.adjacent_sort_expr_to_order_by(expr) for expr in request.sort_by]
+            if request.sort_by
+            else None
+        )
         return video_resolver.get_adjacent_videos(
             session=session,
             sample_id=sample_id,
             collection_id=request.collection_id,
             filters=request.filters,
             text_embedding=request.text_embedding,
+            order_by=order_by,
         )
     if request.sample_type == SampleType.VIDEO_FRAME:
         if not isinstance(request.filters, VideoFrameAdjacentFilter):

--- a/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
+++ b/lightly_studio/src/lightly_studio/services/sample_services/sample_adjacents_service.py
@@ -8,13 +8,16 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 from sqlmodel import Session, col
 
-from lightly_studio.core.dataset_query.order_by import OrderByAnnotationEvaluationMetricField
+from lightly_studio.core.dataset_query.order_by import (
+    OrderByAnnotationEvaluationMetricField,
+    OrderByExpression,
+)
 from lightly_studio.models import sort
 from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
 from lightly_studio.models.collection import SampleType
-from lightly_studio.models.sort import AdjacentSortExpr
+from lightly_studio.models.sort import AdjacentSortExpr, SortFieldSource
 from lightly_studio.resolvers import (
     annotation_resolver,
     image_resolver,
@@ -81,6 +84,47 @@ def _build_annotation_order_by(
     )
 
 
+# Field sources each sample type can sort by. The shared request accepts any source, so
+# one the target grid cannot reach must be rejected rather than translated to a field on
+# a table absent from the query (see the SortFieldExprBase docstring).
+_ALLOWED_SORT_SOURCES: dict[SampleType, set[SortFieldSource]] = {
+    SampleType.IMAGE: {
+        SortFieldSource.image,
+        SortFieldSource.metadata,
+        SortFieldSource.evaluation_metric,
+    },
+    SampleType.VIDEO: {SortFieldSource.video, SortFieldSource.metadata},
+}
+
+
+def _build_sort_order_by(
+    sort_by: list[AdjacentSortExpr] | None,
+    sample_type: SampleType,
+) -> list[OrderByExpression] | None:
+    """Translate the requested sort, rejecting sources the sample type cannot reach.
+
+    Args:
+        sort_by: The sort expressions from the request, or None.
+        sample_type: The sample type whose grid ordering the adjacency must match.
+
+    Returns:
+        The translated order-by expressions, or None when no sort was requested.
+
+    Raises:
+        ValueError: If a sort expression uses a source the sample type cannot sort by.
+    """
+    if not sort_by:
+        return None
+    allowed = _ALLOWED_SORT_SOURCES[sample_type]
+    for expr in sort_by:
+        if expr.source not in allowed:
+            raise ValueError(
+                f"Sort field source '{expr.source.value}' is not valid"
+                f" for sample type '{sample_type.value}'."
+            )
+    return [sort.adjacent_sort_expr_to_order_by(expr) for expr in sort_by]
+
+
 def get_adjacent_samples(
     session: Session, sample_id: UUID, request: AdjacentRequest
 ) -> AdjacentResultView | None:
@@ -100,11 +144,7 @@ def get_adjacent_samples(
                 "Invalid filter provided. Expected ImageFilter"
                 f" for sample type '{request.sample_type.value}'."
             )
-        order_by = (
-            [sort.adjacent_sort_expr_to_order_by(expr) for expr in request.sort_by]
-            if request.sort_by
-            else None
-        )
+        order_by = _build_sort_order_by(request.sort_by, SampleType.IMAGE)
         return image_resolver.get_adjacent_images(
             session=session,
             sample_id=sample_id,
@@ -119,11 +159,7 @@ def get_adjacent_samples(
                 "Invalid filter provided. Expected VideoFilter"
                 f" for sample type '{request.sample_type.value}'."
             )
-        order_by = (
-            [sort.adjacent_sort_expr_to_order_by(expr) for expr in request.sort_by]
-            if request.sort_by
-            else None
-        )
+        order_by = _build_sort_order_by(request.sort_by, SampleType.VIDEO)
         return video_resolver.get_adjacent_videos(
             session=session,
             sample_id=sample_id,

--- a/lightly_studio/tests/models/test_sort.py
+++ b/lightly_studio/tests/models/test_sort.py
@@ -177,6 +177,13 @@ def test_video_sort_field_expr__rejects_evaluation_metric_source() -> None:
         )
 
 
+def test_image_and_video_sort_field_exprs_stay_structurally_identical() -> None:
+    # AdjacentSortExpr resolves a ``metadata`` source to ImageSortFieldExpr via left-to-right
+    # (LIG-10605). That is only safe while the two models carry the same fields; if one gains a
+    # field the other lacks, metadata sorts silently drop it.
+    assert ImageSortFieldExpr.model_fields.keys() == VideoSortFieldExpr.model_fields.keys()
+
+
 def test_sort_field_expr_to_order_by__image_metadata_ascending() -> None:
     expr = ImageSortFieldExpr(
         source=SortFieldSource.metadata,

--- a/lightly_studio/tests/models/test_sort.py
+++ b/lightly_studio/tests/models/test_sort.py
@@ -179,9 +179,22 @@ def test_video_sort_field_expr__rejects_evaluation_metric_source() -> None:
 
 def test_image_and_video_sort_field_exprs_stay_structurally_identical() -> None:
     # AdjacentSortExpr resolves a ``metadata`` source to ImageSortFieldExpr via left-to-right
-    # (LIG-10605). That is only safe while the two models carry the same fields; if one gains a
-    # field the other lacks, metadata sorts silently drop it.
-    assert ImageSortFieldExpr.model_fields.keys() == VideoSortFieldExpr.model_fields.keys()
+    # (LIG-10605). That is only safe while the two models share identical field definitions: a
+    # drift in ``field_name`` or ``direction`` (a new field, a changed type, an added
+    # constraint) would make the same payload validate differently depending on which model
+    # wins. ``source`` is narrowed per model on purpose, so exclude it. FieldInfo has no value
+    # equality, so compare its repr, which reflects the annotation, default, and metadata.
+    image_fields = {
+        name: repr(field)
+        for name, field in ImageSortFieldExpr.model_fields.items()
+        if name != "source"
+    }
+    video_fields = {
+        name: repr(field)
+        for name, field in VideoSortFieldExpr.model_fields.items()
+        if name != "source"
+    }
+    assert image_fields == video_fields
 
 
 def test_sort_field_expr_to_order_by__image_metadata_ascending() -> None:

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_get_adjacent_videos.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_get_adjacent_videos.py
@@ -317,6 +317,7 @@ def test_get_adjacent_videos__similarity_ignores_order_by(db_session: Session) -
         collection_id=collection_id,
         embedding_model_name="embedding-for-adjacency",
         embedding_dimension=2,
+        set_as_default=True,
     )
 
     # Widths are chosen so a width-desc sort (a, b, c) disagrees with the similarity

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_get_adjacent_videos.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_get_adjacent_videos.py
@@ -1,5 +1,7 @@
 from sqlmodel import Session
 
+from lightly_studio.core.dataset_query.order_by import OrderByField
+from lightly_studio.core.dataset_query.video_sample_field import VideoSampleField
 from lightly_studio.models.collection import SampleType
 from lightly_studio.resolvers import video_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
@@ -41,6 +43,45 @@ def test_get_adjacent_videos__orders_by_path(db_session: Session) -> None:
     assert result.previous_sample_id == video_a.sample_id
     assert result.sample_id == video_b.sample_id
     assert result.next_sample_id == video_c.sample_id
+    assert result.current_sample_position == 2
+    assert result.total_count == 3
+
+
+def test_get_adjacent_videos__orders_by_requested_sort(db_session: Session) -> None:
+    collection = helpers_resolvers.create_collection(
+        session=db_session, sample_type=SampleType.VIDEO
+    )
+    collection_id = collection.collection_id
+
+    # Widths deliberately disagree with path order so the sort is observable.
+    video_a = video_helpers.create_video(
+        session=db_session,
+        collection_id=collection_id,
+        video=video_helpers.VideoStub(path="/videos/a.mp4", width=100),
+    )
+    video_b = video_helpers.create_video(
+        session=db_session,
+        collection_id=collection_id,
+        video=video_helpers.VideoStub(path="/videos/b.mp4", width=300),
+    )
+    video_c = video_helpers.create_video(
+        session=db_session,
+        collection_id=collection_id,
+        video=video_helpers.VideoStub(path="/videos/c.mp4", width=200),
+    )
+
+    result = video_resolver.get_adjacent_videos(
+        session=db_session,
+        sample_id=video_c.sample_id,
+        collection_id=collection_id,
+        order_by=[OrderByField(field=VideoSampleField.width).desc()],
+    )
+
+    # Width descending gives b (300), c (200), a (100).
+    assert result is not None
+    assert result.previous_sample_id == video_b.sample_id
+    assert result.sample_id == video_c.sample_id
+    assert result.next_sample_id == video_a.sample_id
     assert result.current_sample_position == 2
     assert result.total_count == 3
 

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_get_adjacent_videos.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_get_adjacent_videos.py
@@ -1,9 +1,9 @@
 from sqlmodel import Session
 
-from lightly_studio.core.dataset_query.order_by import OrderByField
+from lightly_studio.core.dataset_query.order_by import OrderByField, OrderByMetadataField
 from lightly_studio.core.dataset_query.video_sample_field import VideoSampleField
 from lightly_studio.models.collection import SampleType
-from lightly_studio.resolvers import video_resolver
+from lightly_studio.resolvers import metadata_resolver, video_resolver
 from lightly_studio.resolvers.annotations.annotations_filter import AnnotationsFilter
 from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from lightly_studio.resolvers.video_resolver.video_filter import VideoFilter
@@ -78,6 +78,53 @@ def test_get_adjacent_videos__orders_by_requested_sort(db_session: Session) -> N
     )
 
     # Width descending gives b (300), c (200), a (100).
+    assert result is not None
+    assert result.previous_sample_id == video_b.sample_id
+    assert result.sample_id == video_c.sample_id
+    assert result.next_sample_id == video_a.sample_id
+    assert result.current_sample_position == 2
+    assert result.total_count == 3
+
+
+def test_get_adjacent_videos__orders_by_metadata_sort(db_session: Session) -> None:
+    collection = helpers_resolvers.create_collection(
+        session=db_session, sample_type=SampleType.VIDEO
+    )
+    collection_id = collection.collection_id
+
+    video_a = video_helpers.create_video(
+        session=db_session,
+        collection_id=collection_id,
+        video=video_helpers.VideoStub(path="/videos/a.mp4"),
+    )
+    video_b = video_helpers.create_video(
+        session=db_session,
+        collection_id=collection_id,
+        video=video_helpers.VideoStub(path="/videos/b.mp4"),
+    )
+    video_c = video_helpers.create_video(
+        session=db_session,
+        collection_id=collection_id,
+        video=video_helpers.VideoStub(path="/videos/c.mp4"),
+    )
+    # Blur scores deliberately disagree with path order so the metadata sort is observable.
+    for video, blur_score in [(video_a, 0.9), (video_b, 0.1), (video_c, 0.5)]:
+        metadata_resolver.set_value_for_sample(
+            session=db_session,
+            sample_id=video.sample_id,
+            key="blur_score",
+            value=blur_score,
+        )
+
+    # Metadata sort adds an outer join to the window query; a multiplied join would
+    # corrupt lag/lead/row_number and total_count. Ascending blur gives b, c, a.
+    result = video_resolver.get_adjacent_videos(
+        session=db_session,
+        sample_id=video_c.sample_id,
+        collection_id=collection_id,
+        order_by=[OrderByMetadataField(field_name="blur_score")],
+    )
+
     assert result is not None
     assert result.previous_sample_id == video_b.sample_id
     assert result.sample_id == video_c.sample_id
@@ -251,6 +298,73 @@ def test_get_adjacent_videos__with_similarity(db_session: Session) -> None:
         text_embedding=[1.0, 1.0],
     )
 
+    assert result is not None
+    assert result.previous_sample_id is None
+    assert result.sample_id == video_c.sample_id
+    assert result.next_sample_id == video_b.sample_id
+    assert result.current_sample_position == 1
+    assert result.total_count == 3
+
+
+def test_get_adjacent_videos__similarity_ignores_order_by(db_session: Session) -> None:
+    collection = helpers_resolvers.create_collection(
+        session=db_session, sample_type=SampleType.VIDEO
+    )
+    collection_id = collection.collection_id
+
+    embedding_model = helpers_resolvers.create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_name="embedding-for-adjacency",
+        embedding_dimension=2,
+    )
+
+    # Widths are chosen so a width-desc sort (a, b, c) disagrees with the similarity
+    # order (c, b, a); the anchor's neighbours reveal which one the resolver applies.
+    video_a = video_helpers.create_video(
+        session=db_session,
+        collection_id=collection_id,
+        video=video_helpers.VideoStub(path="/videos/a.mp4", width=300),
+    )
+    video_b = video_helpers.create_video(
+        session=db_session,
+        collection_id=collection_id,
+        video=video_helpers.VideoStub(path="/videos/b.mp4", width=200),
+    )
+    video_c = video_helpers.create_video(
+        session=db_session,
+        collection_id=collection_id,
+        video=video_helpers.VideoStub(path="/videos/c.mp4", width=100),
+    )
+
+    helpers_resolvers.create_sample_embedding(
+        session=db_session,
+        sample_id=video_a.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[0.0, 1.0],
+    )
+    helpers_resolvers.create_sample_embedding(
+        session=db_session,
+        sample_id=video_b.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[0.5, 1.0],
+    )
+    helpers_resolvers.create_sample_embedding(
+        session=db_session,
+        sample_id=video_c.sample_id,
+        embedding_model_id=embedding_model.embedding_model_id,
+        embedding=[1.0, 1.0],
+    )
+
+    result = video_resolver.get_adjacent_videos(
+        session=db_session,
+        sample_id=video_c.sample_id,
+        collection_id=collection_id,
+        text_embedding=[1.0, 1.0],
+        order_by=[OrderByField(field=VideoSampleField.width).desc()],
+    )
+
+    # Similarity wins: neighbours follow distance (c, b, a), not width-desc (a, b, c).
     assert result is not None
     assert result.previous_sample_id is None
     assert result.sample_id == video_c.sample_id

--- a/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
+++ b/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
@@ -11,7 +11,12 @@ from sqlmodel import Session
 from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
 from lightly_studio.models.collection import SampleType
-from lightly_studio.models.sort import AdjacentSortExpr, SortFieldSource, VideoSortFieldExpr
+from lightly_studio.models.sort import (
+    AdjacentSortExpr,
+    ImageSortFieldExpr,
+    SortFieldSource,
+    VideoSortFieldExpr,
+)
 from lightly_studio.models.sort_direction import SortDirection
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
@@ -401,3 +406,43 @@ def test_get_adjacent_samples__raises_not_implemented_for_unsupported_type(
             sample_id=uuid4(),
             request=request,
         )
+
+
+def test_get_adjacent_samples__raises_for_video_with_image_sort_source(
+    db_session: Session,
+) -> None:
+    request = AdjacentRequest(
+        sample_type=SampleType.VIDEO,
+        collection_id=uuid4(),
+        filters=VideoFilter(),
+        sort_by=[
+            ImageSortFieldExpr(
+                source=SortFieldSource.image,
+                field_name="file_name",
+                direction=SortDirection.asc,
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match=r"Sort field source 'image' is not valid"):
+        get_adjacent_samples(session=db_session, sample_id=uuid4(), request=request)
+
+
+def test_get_adjacent_samples__raises_for_image_with_video_sort_source(
+    db_session: Session,
+) -> None:
+    request = AdjacentRequest(
+        sample_type=SampleType.IMAGE,
+        collection_id=uuid4(),
+        filters=ImageFilter(),
+        sort_by=[
+            VideoSortFieldExpr(
+                source=SortFieldSource.video,
+                field_name="duration_s",
+                direction=SortDirection.asc,
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match=r"Sort field source 'video' is not valid"):
+        get_adjacent_samples(session=db_session, sample_id=uuid4(), request=request)

--- a/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
+++ b/lightly_studio/tests/services/sample_services/test_sample_adjacents_service.py
@@ -11,6 +11,7 @@ from sqlmodel import Session
 from lightly_studio.models.adjacents import AdjacentResultView
 from lightly_studio.models.annotation_sort import AnnotationEvaluationMetricSortExpr
 from lightly_studio.models.collection import SampleType
+from lightly_studio.models.sort import AdjacentSortExpr, SortFieldSource, VideoSortFieldExpr
 from lightly_studio.models.sort_direction import SortDirection
 from lightly_studio.resolvers.annotations.annotations_filter import (
     AnnotationsFilter,
@@ -110,6 +111,57 @@ def test_get_adjacent_samples__delegates_to_video_resolver(
         collection_id=collection_id,
         filters=filters,
         text_embedding=text_embedding,
+        order_by=None,
+    )
+
+
+def test_get_adjacent_samples__translates_video_sort_by_before_delegating(
+    db_session: Session,
+    mocker: MockerFixture,
+) -> None:
+    expected = _make_adjacent_result()
+    mock_get_adjacent_videos = mocker.patch(
+        "lightly_studio.resolvers.video_resolver.get_adjacent_videos",
+        return_value=expected,
+    )
+    fake_order_by = mocker.MagicMock()
+    mock_translate = mocker.patch(
+        "lightly_studio.models.sort.adjacent_sort_expr_to_order_by",
+        return_value=fake_order_by,
+    )
+
+    sample_id = uuid4()
+    collection_id = uuid4()
+    filters = VideoFilter()
+    sort_by: list[AdjacentSortExpr] = [
+        VideoSortFieldExpr(
+            source=SortFieldSource.video,
+            field_name="duration_s",
+            direction=SortDirection.desc,
+        )
+    ]
+    request = AdjacentRequest(
+        sample_type=SampleType.VIDEO,
+        collection_id=collection_id,
+        filters=filters,
+        sort_by=sort_by,
+    )
+
+    result = get_adjacent_samples(
+        session=db_session,
+        sample_id=sample_id,
+        request=request,
+    )
+
+    assert result == expected
+    mock_translate.assert_called_once_with(sort_by[0])
+    mock_get_adjacent_videos.assert_called_once_with(
+        session=db_session,
+        sample_id=sample_id,
+        collection_id=collection_id,
+        filters=filters,
+        text_embedding=None,
+        order_by=[fake_order_by],
     )
 
 


### PR DESCRIPTION
Open a video from a sorted grid and prev/next in the detail view walks file-path order, not the grid sort. Images already follow their sort. This threads the grid sort into the video adjacency query so prev/next matches.

Behavior-neutral until the frontend PR that sends a video sort. Independent root; the split isolates the backend change.

- `models/sort`: add an `AdjacentSortExpr` union so the shared adjacent-samples request takes an image or video sort. A discriminated union on `source` won't build (both field types allow `metadata`), so it matches left to right.
- `sample_adjacents_service` maps and forwards the sort in the video branch; image and video now share one translator.
- `get_adjacent_videos` takes `order_by` and applies it to the lag/lead/row_number windows, with a file_path_abs tiebreaker. It uses video's own window helper, not a shared builder: the image window has an open TODO to unify adjacency ordering, and building the shared version now would collide.

Window path only; no keyset seek for video yet. The generated TypeScript client is gitignored, and CI regenerates it.

Testing: a resolver test that prev/next follows a non-default order, a service test for the video sort-to-order mapping, plus `make static-checks` (ruff, mypy) and pytest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sorting support for adjacent image and video samples.
  * Added sorting by evaluation metrics and metadata where applicable.
  * Adjacent video results now honor requested sort order with deterministic navigation.

* **Bug Fixes**
  * Prevented incompatible sort fields from being used with the wrong sample type.
  * Improved similarity-based ordering when combined with other sort requests.

* **Tests**
  * Added coverage for metadata sorting, similarity ordering, and invalid cross-type sort fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->