### PR TITLE
Send the grid sort to video prev/next

### DIFF
--- a/lightly_studio_view/src/lib/hooks/useAdjacentSamples/useAdjacentSamples.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentSamples/useAdjacentSamples.ts
@@ -9,7 +9,7 @@ import type {
     VideoFilter,
     VideoFrameAdjacentFilter,
     VideoSortFieldExpr
-} from '$lib/api/lightly_studio_local/types.gen';
+} from '$lib/api/lightly_studio_local';
 import type { ImageSortExpr } from '../useImagesInfinite/types';
 
 export type AdjacentSamplesRequestBody =

--- a/lightly_studio_view/src/lib/hooks/useAdjacentSamples/useAdjacentSamples.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentSamples/useAdjacentSamples.ts
@@ -7,7 +7,8 @@ import type {
     ImageFilter,
     SampleType,
     VideoFilter,
-    VideoFrameAdjacentFilter
+    VideoFrameAdjacentFilter,
+    VideoSortFieldExpr
 } from '$lib/api/lightly_studio_local/types.gen';
 import type { ImageSortExpr } from '../useImagesInfinite/types';
 
@@ -24,6 +25,7 @@ export type AdjacentSamplesRequestBody =
           collection_id: string;
           filters?: ({ filter_type: 'video' } & VideoFilter) | null;
           text_embedding?: number[];
+          sort_by?: VideoSortFieldExpr[] | null;
       }
     | {
           sample_type: Extract<SampleType, 'video_frame'>;

--- a/lightly_studio_view/src/lib/hooks/useAdjacentVideos/useAdjacentVideos.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentVideos/useAdjacentVideos.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { writable } from 'svelte/store';
 import { SampleType } from '$lib/api/lightly_studio_local';
-import type { VideoFilter, VideoSortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
+import type { VideoFilter, VideoSortFieldExpr } from '$lib/api/lightly_studio_local';
 import type { TextEmbedding } from '../useGlobalStorage';
 
 const useAdjacentSamplesMock = vi.fn();

--- a/lightly_studio_view/src/lib/hooks/useAdjacentVideos/useAdjacentVideos.test.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentVideos/useAdjacentVideos.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { writable } from 'svelte/store';
 import { SampleType } from '$lib/api/lightly_studio_local';
-import type { VideoFilter } from '$lib/api/lightly_studio_local/types.gen';
+import type { VideoFilter, VideoSortFieldExpr } from '$lib/api/lightly_studio_local/types.gen';
 import type { TextEmbedding } from '../useGlobalStorage';
 
 const useAdjacentSamplesMock = vi.fn();
 const videoFilterStore = writable<VideoFilter | null>(null);
+const videoSortByStore = writable<VideoSortFieldExpr[] | null>(null);
 const textEmbeddingStore = writable<TextEmbedding | undefined>(undefined);
 
 vi.mock('../useAdjacentSamples/useAdjacentSamples', () => ({
@@ -14,7 +15,8 @@ vi.mock('../useAdjacentSamples/useAdjacentSamples', () => ({
 
 vi.mock('../useVideoFilters/useVideoFilters', () => ({
     useVideoFilters: () => ({
-        videoFilter: videoFilterStore
+        videoFilter: videoFilterStore,
+        videoSortBy: videoSortByStore
     })
 }));
 
@@ -34,6 +36,7 @@ describe('useAdjacentVideos', () => {
             filter_type: 'video',
             sample_filter: { tag_ids: ['t1'] }
         });
+        videoSortByStore.set(null);
         textEmbeddingStore.set({ embedding: [0.11, 0.22], queryText: 'query' });
         useAdjacentSamplesMock.mockReturnValue({ query: 'query-result', refetch: vi.fn() });
     });
@@ -51,7 +54,8 @@ describe('useAdjacentVideos', () => {
                         filter_type: 'video',
                         sample_filter: { tag_ids: ['t1'] }
                     },
-                    text_embedding: [0.11, 0.22]
+                    text_embedding: [0.11, 0.22],
+                    sort_by: undefined
                 }
             }
         });
@@ -73,9 +77,64 @@ describe('useAdjacentVideos', () => {
                     filters: {
                         filter_type: 'video'
                     },
-                    text_embedding: undefined
+                    text_embedding: undefined,
+                    sort_by: undefined
                 }
             }
         });
+    });
+
+    it('passes sort_by to useAdjacentSamples when videoSortBy is set and text embedding is inactive', () => {
+        textEmbeddingStore.set(undefined);
+        const sort: VideoSortFieldExpr[] = [
+            { source: 'video', field_name: 'duration_s', direction: 'desc' }
+        ];
+        videoSortByStore.set(sort);
+
+        useAdjacentVideos({ sampleId: 'video-123', collectionId: 'collection-1' });
+
+        expect(useAdjacentSamplesMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    body: expect.objectContaining({ sort_by: sort })
+                })
+            })
+        );
+    });
+
+    it('passes sort_by as undefined when videoSortBy is null', () => {
+        textEmbeddingStore.set(undefined);
+        videoSortByStore.set(null);
+
+        useAdjacentVideos({ sampleId: 'video-123', collectionId: 'collection-1' });
+
+        expect(useAdjacentSamplesMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    body: expect.objectContaining({ sort_by: undefined })
+                })
+            })
+        );
+    });
+
+    it('passes sort_by as undefined when text embedding is active, even if videoSortBy is set', () => {
+        textEmbeddingStore.set({ embedding: [0.11, 0.22], queryText: 'query' });
+        const sort: VideoSortFieldExpr[] = [
+            { source: 'video', field_name: 'duration_s', direction: 'desc' }
+        ];
+        videoSortByStore.set(sort);
+
+        useAdjacentVideos({ sampleId: 'video-123', collectionId: 'collection-1' });
+
+        expect(useAdjacentSamplesMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    body: expect.objectContaining({
+                        sort_by: undefined,
+                        text_embedding: [0.11, 0.22]
+                    })
+                })
+            })
+        );
     });
 });

--- a/lightly_studio_view/src/lib/hooks/useAdjacentVideos/useAdjacentVideos.ts
+++ b/lightly_studio_view/src/lib/hooks/useAdjacentVideos/useAdjacentVideos.ts
@@ -11,10 +11,12 @@ export const useAdjacentVideos = ({
     sampleId: string;
     collectionId: string;
 }) => {
-    const { videoFilter } = useVideoFilters();
+    const { videoFilter, videoSortBy } = useVideoFilters();
     const { textEmbedding } = useGlobalStorage();
 
     const filter = get(videoFilter);
+    const embedding = get(textEmbedding);
+    const sortBy = embedding ? undefined : (get(videoSortBy) ?? undefined);
     return useAdjacentSamples({
         params: {
             sampleId,
@@ -24,7 +26,8 @@ export const useAdjacentVideos = ({
                 filters: filter
                     ? { filter_type: 'video' as const, ...filter }
                     : { filter_type: 'video' as const },
-                text_embedding: get(textEmbedding)?.embedding
+                text_embedding: embedding?.embedding,
+                sort_by: sortBy
             }
         }
     });

--- a/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideoFilters/useVideoFilters.ts
@@ -7,7 +7,7 @@ import type {
     VideoFilter,
     VideoFieldsBoundsView,
     VideoSortFieldExpr
-} from '$lib/api/lightly_studio_local/types.gen';
+} from '$lib/api/lightly_studio_local';
 import type { CategoricalMetadataValues } from '$lib/services/types';
 type MetadataValues = Record<string, { min: number; max: number }>;
 

--- a/lightly_studio_view/src/lib/hooks/useVideos/useVideos.svelte.ts
+++ b/lightly_studio_view/src/lib/hooks/useVideos/useVideos.svelte.ts
@@ -2,11 +2,7 @@ import { getAllVideosInfiniteOptions } from '$lib/api/lightly_studio_local/@tans
 
 import { createInfiniteQuery, useQueryClient } from '@tanstack/svelte-query';
 import { writable } from 'svelte/store';
-import type {
-    VideoFilter,
-    VideoSortFieldExpr,
-    VideoView
-} from '$lib/api/lightly_studio_local/types.gen';
+import type { VideoFilter, VideoSortFieldExpr, VideoView } from '$lib/api/lightly_studio_local';
 import { GRID_PAGE_SIZE } from '$lib/constants';
 
 export const useVideos = (


### PR DESCRIPTION
Prev/next in the video detail view now follows the grid sort. `useAdjacentVideos` reads the `videoSortBy` store and sends it with the request, so stepping through videos matches the order shown in the grid. It mirrors `useAdjacentImages`, including the guard that drops the sort during a text-embedding similarity search.

The video variant of `useAdjacentSamples` also widens to carry `sort_by`, matching the backend contract.

Draft, stacked on #2075 (the `videoSortBy` store) and #2078 (the widened `AdjacentSortExpr` contract). The branch bundles both, so it builds and CI runs green; the diff carries their commits until they merge, at which point this rebases onto main for a two-file diff (`useAdjacentVideos.ts` and the `useAdjacentSamples.ts` body-type widening).

Testing: unit tests for `useAdjacentVideos` cover the sort being sent when set and dropped under similarity search. Frontend static checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added video sorting support, including ascending file-path sorting by default.
  * Video sorting preferences are now applied when loading adjacent videos and refreshing results.
  * Sorting is automatically disabled while text-embedding search is active.

* **Tests**
  * Added coverage for sorting behavior with active, null, and text-embedding search states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->