### PR TITLE
Handle default_embedding_space in delete and deep copy

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -44,6 +44,7 @@ from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.dataset import DatasetTable
+from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import (
     EvaluationAnnotationMetricTable,
@@ -139,6 +140,7 @@ def deep_copy(
     _copy_sample_tag_links(session=session)
     _copy_sample_group_links(session=session)
     _copy_annotation_collection_coverage(session=session)
+    _copy_default_embedding_spaces(session=session)
 
     # Commit so the ON COMMIT DROP map tables are released and a subsequent deep_copy in
     # the same session can recreate them.
@@ -194,7 +196,8 @@ def _build_id_maps(session: Session, old_dataset_id: UUID) -> None:
         session=session,
         source_table="embedding_model",
         id_column="embedding_model_id",
-        where_sql=in_collection_map,
+        where_sql="dataset_id = :old_dataset_id",
+        params=dataset_params,
     )
     _create_id_map(
         session=session,
@@ -774,6 +777,31 @@ def _copy_annotation_collection_coverage(session: Session) -> None:
     _copy_table(
         session=session,
         target=AnnotationCollectionCoverageTable,
+        source=src,
+        from_clause=from_clause,
+        overrides=overrides,
+    )
+
+
+def _copy_default_embedding_spaces(session: Session) -> None:
+    """Copy default embedding spaces, remapping collection_id and embedding_model_id.
+
+    The inner joins on the collection and embedding-model maps drop any row whose
+    collection or model is not part of the dataset.
+    """
+    src = _table(DefaultEmbeddingSpaceTable).alias("src")
+    map_collection = _map(_MAP_COLLECTION)
+    map_model = _map(_MAP_EMBEDDING_MODEL)
+    from_clause = src.join(map_collection, map_collection.c.old_id == src.c["collection_id"]).join(
+        map_model, map_model.c.old_id == src.c["embedding_model_id"]
+    )
+    overrides = {
+        "collection_id": map_collection.c.new_id,
+        "embedding_model_id": map_model.c.new_id,
+    }
+    _copy_table(
+        session=session,
+        target=DefaultEmbeddingSpaceTable,
         source=src,
         from_clause=from_clause,
         overrides=overrides,

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -37,6 +37,7 @@ from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.dataset import DatasetTable
+from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
@@ -119,6 +120,8 @@ def delete_dataset(
     _delete_samples(session=session, dataset_id=dataset_id)
     _delete_annotation_labels(session=session, dataset_id=dataset_id)
     _delete_tags(session=session, dataset_id=dataset_id)
+    # Must precede embedding_model and collections (FKs to both, deleted below and in step 6).
+    _delete_default_embedding_spaces(session=session, dataset_id=dataset_id)
     _delete_embedding_models(session=session, dataset_id=dataset_id)
     _delete_object_tracks(session=session, dataset_id=dataset_id)
     _delete_evaluation_runs(session=session, dataset_id=dataset_id)
@@ -317,12 +320,20 @@ def _delete_tags(session: Session, dataset_id: UUID) -> None:
     )
 
 
-def _delete_embedding_models(session: Session, dataset_id: UUID) -> None:
-    """Delete embedding models for the dataset's collections."""
+def _delete_default_embedding_spaces(session: Session, dataset_id: UUID) -> None:
+    """Delete default embedding spaces for the dataset's collections."""
     session.exec(
-        delete(EmbeddingModelTable).where(
-            col(EmbeddingModelTable.collection_id).in_(_collection_ids_subquery(dataset_id))
+        delete(DefaultEmbeddingSpaceTable).where(
+            col(DefaultEmbeddingSpaceTable.collection_id).in_(_collection_ids_subquery(dataset_id))
         ),
+        execution_options=_DELETE_EXECUTION_OPTIONS,
+    )
+
+
+def _delete_embedding_models(session: Session, dataset_id: UUID) -> None:
+    """Delete embedding models for the dataset."""
+    session.exec(
+        delete(EmbeddingModelTable).where(col(EmbeddingModelTable.dataset_id) == dataset_id),
         execution_options=_DELETE_EXECUTION_OPTIONS,
     )
 

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/table_coverage_utils.py
@@ -11,17 +11,13 @@ from sqlmodel import SQLModel
 # - export_job is handled by delete_dataset only (its collection_id FK must be cleared
 #   before the collection is deleted); deep_copy intentionally leaves it alone since a job
 #   is a transient download token, not data worth duplicating.
-_HANDLED_TABLES_COUNT = 25
+# - default_embedding_space is handled by both deep_copy and delete_dataset.
+_HANDLED_TABLES_COUNT = 26
 
 # Tables not relevant for collection operations:
 # - setting (application-level, not collection-specific)
 # - two_dim_embeddings (cached projections, regenerated as needed)
-# - default_embedding_space (populated, but not yet handled by deep_copy/delete_dataset — see TODO)
-# TODO(Michal, 08/2026): wire default_embedding_space into deep_copy and delete_dataset,
-# then move it into _HANDLED_TABLES_COUNT. Until then, on Postgres delete_dataset raises an
-# FK error for any dataset with embeddings, and deep_copy silently drops the copied
-# collection's default.
-_EXCLUDED_TABLES_COUNT = 3
+_EXCLUDED_TABLES_COUNT = 2
 
 _TOTAL_TABLES_COUNT = _HANDLED_TABLES_COUNT + _EXCLUDED_TABLES_COUNT
 

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -20,6 +20,7 @@ from lightly_studio.resolvers import (
     annotation_resolver,
     collection_resolver,
     dataset_resolver,
+    default_embedding_space_resolver,
     embedding_model_resolver,
     evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
@@ -353,6 +354,39 @@ def test_deep_copy__with_embeddings(db_session: Session) -> None:
     original_sample_ids = {img1.sample_id, img2.sample_id}
     copied_sample_ids = {emb.sample_id for emb in copied_embeddings}
     assert original_sample_ids.isdisjoint(copied_sample_ids)
+
+
+def test_deep_copy__with_default_embedding_space(db_session: Session) -> None:
+    # Arrange
+    original = create_collection(session=db_session, collection_name="original")
+    embedding_model = create_embedding_model(
+        session=db_session,
+        collection_id=original.collection_id,
+        embedding_model_name="test_model",
+        embedding_dimension=512,
+        set_as_default=True,
+    )
+
+    # Act
+    copied = dataset_resolver.deep_copy(
+        session=db_session,
+        dataset_id=original.dataset_id,
+        copy_name="copied",
+    )
+
+    # Assert - the copied collection's default resolves to the copied model, not the original.
+    copied_models = embedding_model_resolver.get_all_by_collection_id(
+        session=db_session,
+        collection_id=copied.collection_id,
+    )
+    assert len(copied_models) == 1
+    copied_model_id = copied_models[0].embedding_model_id
+    assert copied_model_id != embedding_model.embedding_model_id
+
+    copied_default_id = default_embedding_space_resolver.get_by_collection_id(
+        session=db_session, collection_id=copied.collection_id
+    )
+    assert copied_default_id == copied_model_id
 
 
 def test_deep_copy__can_delete_original_after_copy(db_session: Session) -> None:

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -21,6 +21,7 @@ from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
 from lightly_studio.models.dataset import DatasetTable
+from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
@@ -110,6 +111,10 @@ def _dataset_table_counts(session: Session, dataset_id: UUID) -> dict[str, int]:
         "embedding_model": count(
             EmbeddingModelTable, col(EmbeddingModelTable.collection_id).in_(collection_ids)
         ),
+        "default_embedding_space": count(
+            DefaultEmbeddingSpaceTable,
+            col(DefaultEmbeddingSpaceTable.collection_id).in_(collection_ids),
+        ),
         "annotation_collection_coverage": count(
             AnnotationCollectionCoverageTable,
             col(AnnotationCollectionCoverageTable.annotation_collection_id).in_(collection_ids),
@@ -154,6 +159,7 @@ def _build_full_dataset(session: Session, name: str) -> UUID:
         collection_id=root.collection_id,
         embedding_model_name=f"{name}_model",
         embedding_dimension=3,
+        set_as_default=True,
     )
     create_sample_embedding(
         session=session,
@@ -264,6 +270,7 @@ def test_deep_copy_then_delete_round_trip(db_session: Session) -> None:
         "tag",
         "sample_tag_link",
         "embedding_model",
+        "default_embedding_space",
         "annotation_label",
         "object_track",
         "evaluation_run",

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -16,6 +16,7 @@ from lightly_studio.resolvers import (
     annotation_label_resolver,
     collection_resolver,
     dataset_resolver,
+    default_embedding_space_resolver,
     evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
     evaluation_sample_metric_resolver,
@@ -186,6 +187,34 @@ def test_delete_dataset__with_embeddings(db_session: Session) -> None:
         embedding_model_id=embedding_model_id,
     )
     assert len(embeddings) == 0
+
+
+def test_delete_dataset__with_default_embedding_space(db_session: Session) -> None:
+    # Arrange
+    dataset = create_collection(session=db_session, collection_name="to_delete")
+    collection_id = dataset.collection_id  # Capture before delete
+    create_embedding_model(
+        session=db_session,
+        collection_id=collection_id,
+        embedding_model_name="test_model",
+        embedding_dimension=512,
+        set_as_default=True,
+    )
+
+    # Act
+    dataset_resolver.delete_dataset(
+        session=db_session,
+        dataset_id=dataset.dataset_id,
+    )
+
+    # Assert - collection and its default embedding space deleted
+    assert collection_resolver.get_by_id(session=db_session, collection_id=collection_id) is None
+    assert (
+        default_embedding_space_resolver.get_by_collection_id(
+            session=db_session, collection_id=collection_id
+        )
+        is None
+    )
 
 
 def test_delete_dataset__with_tags(db_session: Session) -> None:


### PR DESCRIPTION
## What has changed and why?

Makes dataset delete and deep copy handle embedding tables consistently, as part of moving embedding models off `collection_id`.

- Delete embedding models by `dataset_id` (was a collection subquery).
- Delete and deep-copy `default_embedding_space` rows, which neither operation handled before.
- Scope the deep-copy embedding-model id map by `dataset_id`.
- Move `default_embedding_space` into the handled-tables coverage count.

Fixes two latent bugs:
- delete_dataset raised an FK error for any dataset with a persisted default.
- deep_copy silently dropped the copied dataset's default.

Out of scope: `embedding_model.collection_id` and the per-collection write path stay; dropping the column and the unique constraint come later in the stack.

Stacked on #2069.

## How has it been tested?

- New regression tests for delete and deep copy with a default embedding space; the delete test fails on the base.
- Extended the copy/delete round-trip to build with a default and assert its counts.
- `make static-checks` clean; affected Postgres tests pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dataset copies now preserve default embedding spaces while correctly remapping associated models and collections.
  * Dataset deletion now removes default embedding-space data and associated embedding models.
  * Records outside the copied dataset are excluded to prevent unintended data carryover.

* **Tests**
  * Added coverage for copying and deleting datasets with default embedding spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->