### PR TITLE
Fix: Parallelise object embedding processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Speed up cloud storage (S3, GCS, Azure blob) indexing by enabling parallel requests.
 - Speed up cloud image indexing by reading image dimensions in small chunks instead of downloading most of each image.
+- Speed up object embeddings by loading input images in parallel.
 - Stepping to the previous or next image now drives an index range scan instead of scanning the
   sort index from the start. On PostgreSQL with 1M images, one neighbour lookup went from 92ms
   to 0.03ms.

--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from functools import partial
 from typing import Any
 
 import fsspec
@@ -19,6 +21,23 @@ from lightly_studio.core.file_outcome_report import (
 from lightly_studio.dataset.embedding_generator import ImageCrop
 from lightly_studio.dataset.embedding_result import EmbeddingResult
 from lightly_studio.dataset.image_embedding import EmbeddingContext
+from lightly_studio.utils import executor, parallelize
+
+
+@dataclass(frozen=True)
+class _SourceImageCrops:
+    """Crops from one source image, with their positions in the input list."""
+
+    filepath: str
+    indexed_crops: list[tuple[int, ImageCrop]]
+
+
+@dataclass(frozen=True)
+class _PreprocessedSourceImageCrops:
+    """Preprocessed crops from one source image, or ``None`` if it was broken."""
+
+    filepath: str
+    indexed_crops: list[tuple[int, torch.Tensor]] | None
 
 
 def embed_image_crops_batched(
@@ -75,24 +94,23 @@ def embed_image_crops_batched(
         ) as progress_bar,
         torch.no_grad(),
     ):
-        for filepath, indexed_crops in crops_by_filepath.items():
-            try:
-                with fsspec.open(filepath, "rb") as file:
-                    image = Image.open(file).convert("RGB")
-            except BROKEN_IMAGE_ERRORS:
-                report.record(path=filepath, outcome=FileOutcome.BROKEN)
+        source_image_crop_groups = (
+            _SourceImageCrops(filepath=filepath, indexed_crops=indexed_crops)
+            for filepath, indexed_crops in crops_by_filepath.items()
+        )
+        workers = executor.get_media_worker_count()
+        preprocessed_crops = parallelize.thread_imap_lazy(
+            function=partial(_load_and_preprocess_crops, context=context),
+            iterable=source_image_crop_groups,
+            max_workers=workers,
+            buffer_size=workers,
+        )
+        for preprocessed_image_crops in preprocessed_crops:
+            if preprocessed_image_crops.indexed_crops is None:
+                report.record(path=preprocessed_image_crops.filepath, outcome=FileOutcome.BROKEN)
                 continue
-            report.record(path=filepath, outcome=FileOutcome.ADDED)
-            for index, image_crop in indexed_crops:
-                cropped = image.crop(
-                    (
-                        image_crop.x,
-                        image_crop.y,
-                        image_crop.x + image_crop.width,
-                        image_crop.y + image_crop.height,
-                    )
-                )
-                preprocessed = context.preprocess(cropped)
+            report.record(path=preprocessed_image_crops.filepath, outcome=FileOutcome.ADDED)
+            for index, preprocessed in preprocessed_image_crops.indexed_crops:
                 if batch_buffer is None:
                     batch_buffer = torch.empty(
                         (context.max_batch_size, *preprocessed.shape),
@@ -124,6 +142,42 @@ def embed_image_crops_batched(
     # kept_indices in input order maps each returned row back to its input crop.
     kept_indices.sort()
     return EmbeddingResult(embeddings=embeddings[kept_indices], kept_indices=kept_indices)
+
+
+def _load_and_preprocess_crops(
+    source_image_crops: _SourceImageCrops,
+    context: EmbeddingContext,
+) -> _PreprocessedSourceImageCrops:
+    """Load one source image and preprocess all of its crops in a worker thread.
+
+    Opening and decoding happen once per source image. The worker then crops and
+    preprocesses every associated annotation, allowing this work to overlap with
+    inference on the caller thread. Broken source images are returned without crops
+    so the caller can record the failure and continue processing other images.
+    """
+    filepath = source_image_crops.filepath
+    try:
+        with fsspec.open(filepath, "rb") as file:
+            image = Image.open(file).convert("RGB")
+    except BROKEN_IMAGE_ERRORS:
+        return _PreprocessedSourceImageCrops(filepath=filepath, indexed_crops=None)
+    indexed_crops = [
+        (
+            index,
+            context.preprocess(
+                image.crop(
+                    (
+                        image_crop.x,
+                        image_crop.y,
+                        image_crop.x + image_crop.width,
+                        image_crop.y + image_crop.height,
+                    )
+                )
+            ),
+        )
+        for index, image_crop in source_image_crops.indexed_crops
+    ]
+    return _PreprocessedSourceImageCrops(filepath=filepath, indexed_crops=indexed_crops)
 
 
 def _flush_crop_batch(

--- a/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_crop_embedding.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import partial
 from typing import Any
 
 import fsspec
@@ -33,11 +32,12 @@ class _SourceImageCrops:
 
 
 @dataclass(frozen=True)
-class _PreprocessedSourceImageCrops:
-    """Preprocessed crops from one source image, or ``None`` if it was broken."""
+class _LoadedSourceImageCrops:
+    """Loaded source image and its crops, or ``None`` for a broken image."""
 
     filepath: str
-    indexed_crops: list[tuple[int, torch.Tensor]] | None
+    indexed_crops: list[tuple[int, ImageCrop]]
+    image: Image.Image | None
 
 
 def embed_image_crops_batched(
@@ -99,34 +99,48 @@ def embed_image_crops_batched(
             for filepath, indexed_crops in crops_by_filepath.items()
         )
         workers = executor.get_media_worker_count()
-        preprocessed_crops = parallelize.thread_imap_lazy(
-            function=partial(_load_and_preprocess_crops, context=context),
+        loaded_source_images = parallelize.thread_imap_lazy(
+            function=_load_source_image,
             iterable=source_image_crop_groups,
             max_workers=workers,
             buffer_size=workers,
         )
-        for preprocessed_image_crops in preprocessed_crops:
-            if preprocessed_image_crops.indexed_crops is None:
-                report.record(path=preprocessed_image_crops.filepath, outcome=FileOutcome.BROKEN)
+        for loaded_source_image_crops in loaded_source_images:
+            image = loaded_source_image_crops.image
+            if image is None:
+                report.record(path=loaded_source_image_crops.filepath, outcome=FileOutcome.BROKEN)
                 continue
-            report.record(path=preprocessed_image_crops.filepath, outcome=FileOutcome.ADDED)
-            for index, preprocessed in preprocessed_image_crops.indexed_crops:
-                if batch_buffer is None:
-                    batch_buffer = torch.empty(
-                        (context.max_batch_size, *preprocessed.shape),
-                        dtype=preprocessed.dtype,
+            report.record(path=loaded_source_image_crops.filepath, outcome=FileOutcome.ADDED)
+            try:
+                for index, image_crop in loaded_source_image_crops.indexed_crops:
+                    preprocessed = context.preprocess(
+                        image.crop(
+                            (
+                                image_crop.x,
+                                image_crop.y,
+                                image_crop.x + image_crop.width,
+                                image_crop.y + image_crop.height,
+                            )
+                        )
                     )
-                batch_buffer[len(batch_indices)] = preprocessed
-                batch_indices.append(index)
-                kept_indices.append(index)
-                if len(batch_indices) >= context.max_batch_size:
-                    _flush_crop_batch(
-                        batch_buffer=batch_buffer,
-                        batch_indices=batch_indices,
-                        embeddings=embeddings,
-                        context=context,
-                        progress_bar=progress_bar,
-                    )
+                    if batch_buffer is None:
+                        batch_buffer = torch.empty(
+                            (context.max_batch_size, *preprocessed.shape),
+                            dtype=preprocessed.dtype,
+                        )
+                    batch_buffer[len(batch_indices)] = preprocessed
+                    batch_indices.append(index)
+                    kept_indices.append(index)
+                    if len(batch_indices) >= context.max_batch_size:
+                        _flush_crop_batch(
+                            batch_buffer=batch_buffer,
+                            batch_indices=batch_indices,
+                            embeddings=embeddings,
+                            context=context,
+                            progress_bar=progress_bar,
+                        )
+            finally:
+                image.close()
 
         _flush_crop_batch(
             batch_buffer=batch_buffer,
@@ -144,40 +158,25 @@ def embed_image_crops_batched(
     return EmbeddingResult(embeddings=embeddings[kept_indices], kept_indices=kept_indices)
 
 
-def _load_and_preprocess_crops(
+def _load_source_image(
     source_image_crops: _SourceImageCrops,
-    context: EmbeddingContext,
-) -> _PreprocessedSourceImageCrops:
-    """Load one source image and preprocess all of its crops in a worker thread.
-
-    Opening and decoding happen once per source image. The worker then crops and
-    preprocesses every associated annotation, allowing this work to overlap with
-    inference on the caller thread. Broken source images are returned without crops
-    so the caller can record the failure and continue processing other images.
-    """
+) -> _LoadedSourceImageCrops:
+    """Open and decode one source image in a worker thread."""
     filepath = source_image_crops.filepath
     try:
-        with fsspec.open(filepath, "rb") as file:
-            image = Image.open(file).convert("RGB")
+        with fsspec.open(filepath, "rb") as file, Image.open(file) as opened_image:
+            image = opened_image.convert("RGB")
     except BROKEN_IMAGE_ERRORS:
-        return _PreprocessedSourceImageCrops(filepath=filepath, indexed_crops=None)
-    indexed_crops = [
-        (
-            index,
-            context.preprocess(
-                image.crop(
-                    (
-                        image_crop.x,
-                        image_crop.y,
-                        image_crop.x + image_crop.width,
-                        image_crop.y + image_crop.height,
-                    )
-                )
-            ),
+        return _LoadedSourceImageCrops(
+            filepath=filepath,
+            indexed_crops=source_image_crops.indexed_crops,
+            image=None,
         )
-        for index, image_crop in source_image_crops.indexed_crops
-    ]
-    return _PreprocessedSourceImageCrops(filepath=filepath, indexed_crops=indexed_crops)
+    return _LoadedSourceImageCrops(
+        filepath=filepath,
+        indexed_crops=source_image_crops.indexed_crops,
+        image=image,
+    )
 
 
 def _flush_crop_batch(

--- a/lightly_studio/src/lightly_studio/dataset/image_embedding.py
+++ b/lightly_studio/src/lightly_studio/dataset/image_embedding.py
@@ -8,7 +8,6 @@ crop-specific path lives in ``image_crop_embedding.py`` and reuses the same
 
 from __future__ import annotations
 
-import os
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import TypeVar
@@ -26,7 +25,7 @@ from lightly_studio.core.file_outcome_report import (
     FileOutcomeReport,
 )
 from lightly_studio.dataset.embedding_result import EmbeddingResult
-from lightly_studio.utils import batching, parallelize
+from lightly_studio.utils import batching, executor, parallelize
 
 _ItemT = TypeVar("_ItemT")
 
@@ -164,7 +163,7 @@ def _embed_items_batched(
     preprocessed_tensors = parallelize.thread_imap_lazy(
         function=preprocess_item,
         iterable=items,
-        max_workers=_preprocess_workers(),
+        max_workers=executor.get_media_worker_count(),
         # Read at most one extra batch ahead so a full next batch is ready during inference
         # while memory stays bounded to a small multiple of the batch size.
         buffer_size=2 * context.max_batch_size,
@@ -234,13 +233,3 @@ def _encode_preprocessed_batches(
 
     # Truncate to the number of tensors actually encoded (``max_items`` was an upper bound).
     return embeddings[:position]
-
-
-def _preprocess_workers() -> int:
-    """Return the thread count for parallel per-item preprocessing.
-
-    Uses available cores - 1 (at least 1), capped at 16, matching the decode-thread and
-    shared-executor conventions elsewhere in the codebase.
-    """
-    cpu_count = os.cpu_count() or 1
-    return max(1, min(cpu_count - 1 or 1, 16))

--- a/lightly_studio/src/lightly_studio/utils/executor.py
+++ b/lightly_studio/src/lightly_studio/utils/executor.py
@@ -8,6 +8,12 @@ from concurrent.futures import ThreadPoolExecutor
 _executors: dict[str, ThreadPoolExecutor] = {}
 
 
+def get_media_worker_count() -> int:
+    """Return the worker count for parallel media processing."""
+    cpu_count = os.cpu_count() or 1
+    return max(1, min(cpu_count - 1 or 1, 16))
+
+
 def get_media_executor(thread_name_prefix: str) -> ThreadPoolExecutor:
     """Return a shared ``ThreadPoolExecutor`` for CPU-intensive media processing.
 
@@ -22,9 +28,7 @@ def get_media_executor(thread_name_prefix: str) -> ThreadPoolExecutor:
         The cached ``ThreadPoolExecutor`` for the given prefix.
     """
     if thread_name_prefix not in _executors:
-        cpu_count = os.cpu_count() or 1
-        max_workers = max(1, min(cpu_count - 1 or 1, 16))
         _executors[thread_name_prefix] = ThreadPoolExecutor(
-            max_workers=max_workers, thread_name_prefix=thread_name_prefix
+            max_workers=get_media_worker_count(), thread_name_prefix=thread_name_prefix
         )
     return _executors[thread_name_prefix]

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -1,15 +1,23 @@
+from __future__ import annotations
+
+import io
+import threading
+import time
 from pathlib import Path
 
+import fsspec
 import numpy as np
 import pytest
 import torch
 from numpy.typing import NDArray
 from PIL import Image
+from pytest_mock import MockerFixture
 
 from lightly_studio.core.file_outcome_report import AllInputFilesFailedError
 from lightly_studio.dataset import image_crop_embedding
 from lightly_studio.dataset.embedding_generator import ImageCrop
 from lightly_studio.dataset.image_embedding import EmbeddingContext
+from lightly_studio.utils import executor
 
 
 def test_embed_image_crops_batched__empty_input_returns_empty_array() -> None:
@@ -73,6 +81,56 @@ def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
     assert result.kept_indices == [0, 1, 2, 3]
     # Each embedding equals its crop width, in input order.
     assert result.embeddings[:, 0].tolist() == [5.0, 6.0, 7.0, 8.0]
+
+
+def test_embed_image_crops_batched__parallelizes_source_image_preprocessing(
+    mocker: MockerFixture,
+) -> None:
+    image_buffer = io.BytesIO()
+    Image.new("RGB", (100, 100)).save(image_buffer, format="PNG")
+    image_bytes = image_buffer.getvalue()
+    in_flight = 0
+    peak_in_flight = 0
+    lock = threading.Lock()
+
+    class RemoteFile(io.BytesIO):
+        def read(self, size: int | None = -1) -> bytes:
+            nonlocal in_flight, peak_in_flight
+            with lock:
+                in_flight += 1
+                peak_in_flight = max(peak_in_flight, in_flight)
+            time.sleep(0.02)
+            contents = super().read(size)
+            with lock:
+                in_flight -= 1
+            return contents
+
+    open_file = mocker.patch.object(
+        fsspec,
+        "open",
+        side_effect=lambda _path, _mode: RemoteFile(image_bytes),
+    )
+    mocker.patch.object(executor, "get_media_worker_count", return_value=3)
+    paths = [f"s3://bucket/image_{index}.png" for index in range(4)]
+    image_crops = [ImageCrop(filepath=path, x=0, y=0, width=5, height=10) for path in paths]
+    image_crops.append(ImageCrop(filepath=paths[0], x=0, y=0, width=7, height=10))
+
+    result = image_crop_embedding.embed_image_crops_batched(
+        image_crops=image_crops,
+        context=EmbeddingContext(
+            embedding_dimension=1,
+            max_batch_size=2,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
+        ),
+        show_progress=False,
+    )
+
+    assert 1 < peak_in_flight <= 3
+    assert open_file.call_count == len(paths)
+    assert result.kept_indices == list(range(len(image_crops)))
+    assert result.embeddings[:, 0].tolist() == [5.0, 5.0, 5.0, 5.0, 7.0]
 
 
 def test_embed_image_crops_batched__skips_broken_file(tmp_path: Path) -> None:

--- a/lightly_studio/tests/dataset/test_image_crop_embedding.py
+++ b/lightly_studio/tests/dataset/test_image_crop_embedding.py
@@ -83,7 +83,38 @@ def test_embed_image_crops_batched__preserves_input_order_across_filepaths(
     assert result.embeddings[:, 0].tolist() == [5.0, 6.0, 7.0, 8.0]
 
 
-def test_embed_image_crops_batched__parallelizes_source_image_preprocessing(
+def test_embed_image_crops_batched__splits_many_crops_into_embedding_batches(
+    tmp_path: Path,
+) -> None:
+    image_path = tmp_path / "image.png"
+    Image.new("RGB", (100, 100)).save(image_path)
+    image_crops = [
+        ImageCrop(filepath=str(image_path), x=0, y=0, width=width, height=10)
+        for width in range(5, 10)
+    ]
+    encode_calls: list[int] = []
+
+    def encode_batch(images_tensor: torch.Tensor) -> NDArray[np.float32]:
+        encode_calls.append(images_tensor.size(0))
+        return images_tensor.numpy().astype(np.float32)
+
+    result = image_crop_embedding.embed_image_crops_batched(
+        image_crops=image_crops,
+        context=EmbeddingContext(
+            embedding_dimension=1,
+            max_batch_size=2,
+            device=torch.device("cpu"),
+            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            encode_batch=encode_batch,
+        ),
+        show_progress=False,
+    )
+
+    assert encode_calls == [2, 2, 1]
+    assert result.embeddings[:, 0].tolist() == [5.0, 6.0, 7.0, 8.0, 9.0]
+
+
+def test_embed_image_crops_batched__parallelizes_source_image_loading(
     mocker: MockerFixture,
 ) -> None:
     image_buffer = io.BytesIO()
@@ -92,6 +123,8 @@ def test_embed_image_crops_batched__parallelizes_source_image_preprocessing(
     in_flight = 0
     peak_in_flight = 0
     lock = threading.Lock()
+    caller_thread = threading.get_ident()
+    preprocess_threads: list[int] = []
 
     class RemoteFile(io.BytesIO):
         def read(self, size: int | None = -1) -> bytes:
@@ -115,13 +148,17 @@ def test_embed_image_crops_batched__parallelizes_source_image_preprocessing(
     image_crops = [ImageCrop(filepath=path, x=0, y=0, width=5, height=10) for path in paths]
     image_crops.append(ImageCrop(filepath=paths[0], x=0, y=0, width=7, height=10))
 
+    def preprocess(image: Image.Image) -> torch.Tensor:
+        preprocess_threads.append(threading.get_ident())
+        return torch.tensor([float(image.size[0])])
+
     result = image_crop_embedding.embed_image_crops_batched(
         image_crops=image_crops,
         context=EmbeddingContext(
             embedding_dimension=1,
             max_batch_size=2,
             device=torch.device("cpu"),
-            preprocess=lambda image: torch.tensor([float(image.size[0])]),
+            preprocess=preprocess,
             encode_batch=lambda images_tensor: images_tensor.numpy().astype(np.float32),
         ),
         show_progress=False,
@@ -129,6 +166,7 @@ def test_embed_image_crops_batched__parallelizes_source_image_preprocessing(
 
     assert 1 < peak_in_flight <= 3
     assert open_file.call_count == len(paths)
+    assert set(preprocess_threads) == {caller_thread}
     assert result.kept_indices == list(range(len(image_crops)))
     assert result.embeddings[:, 0].tolist() == [5.0, 5.0, 5.0, 5.0, 7.0]
 

--- a/lightly_studio/tests/utils/test_executor.py
+++ b/lightly_studio/tests/utils/test_executor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pytest_mock import MockerFixture
+
 import lightly_studio.utils.executor as executor_module
 from lightly_studio.utils.executor import get_media_executor
 
@@ -26,3 +28,9 @@ def test_get_media_executor_isolates_different_prefixes() -> None:
     video_executor = get_media_executor("video_frame")
 
     assert image_executor is not video_executor
+
+
+def test_get_media_worker_count_uses_shared_worker_policy(mocker: MockerFixture) -> None:
+    mocker.patch("lightly_studio.utils.executor.os.cpu_count", return_value=8)
+
+    assert executor_module.get_media_worker_count() == 7


### PR DESCRIPTION
## What has changed and why?

- Process source images and their crops in parallel before generating object embeddings.
- Speeds up object embeddings for images stored locally or in cloud storage. (speedup on a test dataset was 3.5x while using similar memory)
- Keeps the embedding model and output unchanged.

## How has it been tested?

- New tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Object embeddings are generated faster by loading source images in parallel.
  * Processing continues for readable images even when some files are unavailable or damaged.
  * Embeddings retain the correct crop order while using concurrent processing.
  * Large image sets are processed in appropriately sized batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->