### PR TITLE
Resolve similarity embedding model via default_embedding_space

### DIFF
--- a/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
@@ -6,11 +6,11 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import ColumnElement
-from sqlmodel import Session, col, select
+from sqlmodel import Session, col
 
 from lightly_studio.database import db_vector
-from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
+from lightly_studio.resolvers import default_embedding_space_resolver
 from lightly_studio.type_definitions import QueryType
 
 
@@ -22,18 +22,16 @@ def get_distance_expression(
     """Get distance expression for similarity search if text_embedding is provided.
 
     Returns a tuple of (embedding_model_id, distance_expr). Both are None if
-    no text_embedding is provided or no embedding model exists for the collection.
+    no text_embedding is provided or the collection has no default embedding space.
     """
     if not text_embedding:
         return None, None
 
-    embedding_model_id = session.exec(
-        select(EmbeddingModelTable.embedding_model_id)
-        .where(EmbeddingModelTable.collection_id == collection_id)
-        .limit(1)
-    ).first()
+    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+        session=session, collection_id=collection_id
+    )
 
-    if not embedding_model_id:
+    if embedding_model_id is None:
         return None, None
 
     distance_expr = db_vector.cosine_distance(

--- a/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
@@ -22,7 +22,7 @@ def get_distance_expression(
     """Get distance expression for similarity search if text_embedding is provided.
 
     Returns a tuple of (embedding_model_id, distance_expr). Both are None if
-    no text_embedding is provided or the collection has no default embedding space.
+    no text_embedding is provided or the collection has no default embedding model.
     """
     if not text_embedding:
         return None, None

--- a/lightly_studio/tests/resolvers/annotations/test_get_all_with_payload.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_all_with_payload.py
@@ -246,6 +246,7 @@ def test_get_all_with_payload__orders_by_text_embedding_similarity(
         session=db_session,
         collection_id=annotation_collection_id,
         embedding_dimension=2,
+        set_as_default=True,
     )
     create_sample_embedding(
         session=db_session,

--- a/lightly_studio/tests/resolvers/annotations/test_get_all_with_payload_metric_sort.py
+++ b/lightly_studio/tests/resolvers/annotations/test_get_all_with_payload_metric_sort.py
@@ -109,6 +109,7 @@ def test_get_all_with_payload__text_embedding_takes_precedence_over_order_by(
         session=db_session,
         collection_id=fixture.gt_collection_id,
         embedding_dimension=2,
+        set_as_default=True,
     )
     # Similarity orders these differently than the metric does in either direction, so the
     # expected order only holds if similarity wins.

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_adjacent_images.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_adjacent_images.py
@@ -170,6 +170,7 @@ def test_get_adjacent_images__with_similarity(db_session: Session) -> None:
         collection_id=collection_id,
         embedding_model_name="embedding-for-adjacency",
         embedding_dimension=2,
+        set_as_default=True,
     )
 
     image_a = helpers_resolvers.create_image(

--- a/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/image_resolver/test_get_all_by_dataset_id.py
@@ -436,6 +436,7 @@ def test_get_all_by_collection_id_with_embedding_sort(
         collection_id=collection_id,
         embedding_model_name="example_embedding_model",
         embedding_dimension=3,
+        set_as_default=True,
     )
     # create samples
     image1 = create_image(

--- a/lightly_studio/tests/resolvers/test_similarity_utils.py
+++ b/lightly_studio/tests/resolvers/test_similarity_utils.py
@@ -57,6 +57,25 @@ class TestGetDistanceExpression:
         assert embedding_model_id is None
         assert distance_expr is None
 
+    def test_embedding_model_without_default__returns_none(self, db_session: Session) -> None:
+        """When a model exists but no default is set, returns (None, None)."""
+        collection = create_collection(session=db_session)
+        create_embedding_model(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_name="test_model",
+            embedding_dimension=3,
+        )
+
+        embedding_model_id, distance_expr = get_distance_expression(
+            session=db_session,
+            collection_id=collection.collection_id,
+            text_embedding=[1.0, 0.0, 0.0],
+        )
+
+        assert embedding_model_id is None
+        assert distance_expr is None
+
     def test_with_embedding_model__returns_expression(self, db_session: Session) -> None:
         """When embedding model exists, returns the model ID and distance expression."""
         collection = create_collection(session=db_session)
@@ -75,4 +94,32 @@ class TestGetDistanceExpression:
         )
 
         assert embedding_model_id == embedding_model.embedding_model_id
+        assert distance_expr is not None
+
+    def test_multiple_models__returns_default(self, db_session: Session) -> None:
+        """With several models, returns the one marked as the collection's default."""
+        collection = create_collection(session=db_session)
+        create_embedding_model(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_name="other_model",
+            embedding_model_hash="other_hash",
+            embedding_dimension=3,
+        )
+        default_model = create_embedding_model(
+            session=db_session,
+            collection_id=collection.collection_id,
+            embedding_model_name="default_model",
+            embedding_model_hash="default_hash",
+            embedding_dimension=3,
+            set_as_default=True,
+        )
+
+        embedding_model_id, distance_expr = get_distance_expression(
+            session=db_session,
+            collection_id=collection.collection_id,
+            text_embedding=[1.0, 0.0, 0.0],
+        )
+
+        assert embedding_model_id == default_model.embedding_model_id
         assert distance_expr is not None

--- a/lightly_studio/tests/resolvers/test_similarity_utils.py
+++ b/lightly_studio/tests/resolvers/test_similarity_utils.py
@@ -65,6 +65,7 @@ class TestGetDistanceExpression:
             collection_id=collection.collection_id,
             embedding_model_name="test_model",
             embedding_dimension=3,
+            set_as_default=True,
         )
 
         embedding_model_id, distance_expr = get_distance_expression(

--- a/lightly_studio/tests/resolvers/video/video_frame_resolver/test_get_adjacent_video_frames.py
+++ b/lightly_studio/tests/resolvers/video/video_frame_resolver/test_get_adjacent_video_frames.py
@@ -333,6 +333,7 @@ def test_get_adjacent_video_frames__uses_video_text_embedding(db_session: Sessio
         collection_id=collection.collection_id,
         embedding_model_name="video-text-embedding",
         embedding_dimension=2,
+        set_as_default=True,
     )
 
     video_a = video_helpers.create_video_with_frames(

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_get_adjacent_videos.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_get_adjacent_videos.py
@@ -166,6 +166,7 @@ def test_get_adjacent_videos__with_similarity(db_session: Session) -> None:
         collection_id=collection_id,
         embedding_model_name="embedding-for-adjacency",
         embedding_dimension=2,
+        set_as_default=True,
     )
 
     video_a = video_helpers.create_video(

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_get_all_by_collection_id__sort.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_get_all_by_collection_id__sort.py
@@ -28,6 +28,7 @@ def test_get_all_by_collection_id__embedding_sort_overrides_order_by(db_session:
         collection_id=collection_id,
         embedding_model_name="test_embedding_model",
         embedding_dimension=3,
+        set_as_default=True,
     )
 
     video1_data = create_video_with_frames(
@@ -81,6 +82,7 @@ def test_get_all_by_collection_id__similarity_ties_broken_by_file_path(
         collection_id=collection_id,
         embedding_model_name="test_embedding_model",
         embedding_dimension=3,
+        set_as_default=True,
     )
 
     video_ids = create_videos(

--- a/lightly_studio/tests/resolvers/video/video_resolver/test_get_all_by_dataset_id.py
+++ b/lightly_studio/tests/resolvers/video/video_resolver/test_get_all_by_dataset_id.py
@@ -450,6 +450,7 @@ def test_get_all_by_collection_id__with_embedding_sort(db_session: Session) -> N
         collection_id=collection_id,
         embedding_model_name="test_embedding_model",
         embedding_dimension=3,
+        set_as_default=True,
     )
 
     # Create videos with frames.


### PR DESCRIPTION
## What has changed and why?

`get_distance_expression` resolved the similarity embedding model with a custom query on `embedding_model.collection_id`. It now uses `default_embedding_space_resolver.get_by_collection_id`.

- Removes another reader of `embedding_model.collection_id`, ahead of dropping that column.
- Behavior is now explicit: similarity uses the collection's *default* model, not an arbitrary one.

Part of the embedding-model refactor.

## How has it been tested?

- Updated affected resolver/API tests to register a default embedding space (`set_as_default=True`).
- `make static-checks` and the touched test suites pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Similarity-based search and sorting now consistently use the collection’s designated default embedding model.
  - Improved consistency for similarity results across image, video, and text-based content.
  - Updated behavior when no default embedding model is available, preventing similarity calculations when a default model is missing.

- **Tests**
  - Expanded coverage to verify default embedding model selection across similarity, sorting, and adjacent-content workflows.
  - Added validation for collections with multiple models or no designated default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->