### PR TITLE
Rename DefaultEmbeddingSpace to CollectionEmbeddingModel

### DIFF
--- a/lightly_studio/src/lightly_studio/api/db_tables.py
+++ b/lightly_studio/src/lightly_studio/api/db_tables.py
@@ -19,8 +19,8 @@ from lightly_studio.models.collection import (
 from lightly_studio.models.dataset import (
     DatasetTable,  # noqa: F401, required for SQLModel to work properly
 )
-from lightly_studio.models.default_embedding_space import (
-    DefaultEmbeddingSpaceTable,  # noqa: F401, required for SQLModel to work properly
+from lightly_studio.models.collection_embedding_model import (
+    CollectionEmbeddingModelTable,  # noqa: F401, required for SQLModel to work properly
 )
 from lightly_studio.models.embedding_model import (
     EmbeddingModelTable,  # noqa: F401, required for SQLModel to work properly

--- a/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
+++ b/lightly_studio/src/lightly_studio/api/routes/api/embeddings2d.py
@@ -18,7 +18,7 @@ from lightly_studio.database.db_manager import SessionDep
 from lightly_studio.models.collection import CollectionTable, SampleType
 from lightly_studio.resolvers import (
     annotation_resolver,
-    default_embedding_space_resolver,
+    collection_embedding_model_resolver,
     image_resolver,
     twodim_embedding_resolver,
     video_resolver,
@@ -55,7 +55,7 @@ def get_2d_embeddings(
     _validate_filter_type(collection=collection, filters=body.filters)
 
     # TODO(Malte, 09/2025): Support choosing the embedding model via API parameter.
-    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+    embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
         session=session,
         collection_id=collection_id,
     )

--- a/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
+++ b/lightly_studio/src/lightly_studio/dataset/embedding_manager.py
@@ -23,8 +23,8 @@ from lightly_studio.models.embedding_model import EmbeddingModelCreate, Embeddin
 from lightly_studio.models.sample_embedding import SampleEmbeddingCreate
 from lightly_studio.resolvers import (
     annotation_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
-    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -184,17 +184,17 @@ class EmbeddingManager:
 
         # Record the default in two places: the in-memory map caches the loaded generator
         # for this process, and the default_embedding_space table persists the choice for
-        # query-layer callers (default_embedding_space_resolver.get_by_collection_id).
+        # query-layer callers (collection_embedding_model_resolver.get_by_collection_id).
         if set_as_default or collection_id not in self._collection_id_to_default_model_id:
             self._collection_id_to_default_model_id[collection_id] = model_id
         if (
             set_as_default
-            or default_embedding_space_resolver.get_by_collection_id(
+            or collection_embedding_model_resolver.get_by_collection_id(
                 session=session, collection_id=collection_id
             )
             is None
         ):
-            default_embedding_space_resolver.set_default(
+            collection_embedding_model_resolver.set_default(
                 session=session, collection_id=collection_id, embedding_model_id=model_id
             )
 

--- a/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
+++ b/lightly_studio/src/lightly_studio/few_shot_classifier/classifier_manager.py
@@ -33,8 +33,8 @@ from lightly_studio.models.image import ImageTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
-    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -124,7 +124,7 @@ class ClassifierManager:
         Returns:
             The created classifier name and ID.
         """
-        embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+        embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
             session=session,
             collection_id=collection_id,
         )
@@ -626,7 +626,7 @@ def _get_embedding_model_by_hash(
         raise ValueError(f"Collection {collection_id} not found.")
 
     # TODO(Michal, 08/2026): Remove once embedding models are unique per dataset and hash.
-    default_embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+    default_embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
         session=session, collection_id=collection_id
     )
     if default_embedding_model_id is not None:

--- a/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
+++ b/lightly_studio/src/lightly_studio/models/collection_embedding_model.py
@@ -1,4 +1,4 @@
-"""This module defines the DefaultEmbeddingSpace model for the application."""
+"""This module defines the CollectionEmbeddingModel model for the application."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from uuid import UUID
 from sqlmodel import Field, SQLModel
 
 
-class DefaultEmbeddingSpaceTable(SQLModel, table=True):
+class CollectionEmbeddingModelTable(SQLModel, table=True):
     """Link table: the default embedding space of a collection.
 
     One row per collection (the ``collection_id`` primary key enforces this). The

--- a/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/collection_embedding_model_resolver.py
@@ -6,12 +6,12 @@ from uuid import UUID
 
 from sqlmodel import Session, select
 
-from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
+from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 
 
 def set_default(
     session: Session, collection_id: UUID, embedding_model_id: UUID
-) -> DefaultEmbeddingSpaceTable:
+) -> CollectionEmbeddingModelTable:
     """Set (or replace) the default embedding space of a collection.
 
     A collection has at most one default, so an existing row is updated in place rather
@@ -27,7 +27,7 @@ def set_default(
     """
     default = _get_by_collection_id(session=session, collection_id=collection_id)
     if default is None:
-        default = DefaultEmbeddingSpaceTable(
+        default = CollectionEmbeddingModelTable(
             collection_id=collection_id, embedding_model_id=embedding_model_id
         )
     else:
@@ -62,10 +62,10 @@ def delete_by_collection_id(session: Session, collection_id: UUID) -> bool:
 
 def _get_by_collection_id(
     session: Session, collection_id: UUID
-) -> DefaultEmbeddingSpaceTable | None:
+) -> CollectionEmbeddingModelTable | None:
     """Return the collection's default embedding space row, or None if it has none."""
     return session.exec(
-        select(DefaultEmbeddingSpaceTable).where(
-            DefaultEmbeddingSpaceTable.collection_id == collection_id
+        select(CollectionEmbeddingModelTable).where(
+            CollectionEmbeddingModelTable.collection_id == collection_id
         )
     ).one_or_none()

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/deep_copy.py
@@ -43,8 +43,8 @@ from lightly_studio.models.annotation_collection_coverage import (
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import (
     EvaluationAnnotationMetricTable,
@@ -789,7 +789,7 @@ def _copy_default_embedding_spaces(session: Session) -> None:
     The inner joins on the collection and embedding-model maps drop any row whose
     collection or model is not part of the dataset.
     """
-    src = _table(DefaultEmbeddingSpaceTable).alias("src")
+    src = _table(CollectionEmbeddingModelTable).alias("src")
     map_collection = _map(_MAP_COLLECTION)
     map_model = _map(_MAP_EMBEDDING_MODEL)
     from_clause = src.join(map_collection, map_collection.c.old_id == src.c["collection_id"]).join(
@@ -801,7 +801,7 @@ def _copy_default_embedding_spaces(session: Session) -> None:
     }
     _copy_table(
         session=session,
-        target=DefaultEmbeddingSpaceTable,
+        target=CollectionEmbeddingModelTable,
         source=src,
         from_clause=from_clause,
         overrides=overrides,

--- a/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
+++ b/lightly_studio/src/lightly_studio/resolvers/dataset_resolver/delete_dataset.py
@@ -36,8 +36,8 @@ from lightly_studio.models.annotation_collection_coverage import (
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
@@ -323,8 +323,10 @@ def _delete_tags(session: Session, dataset_id: UUID) -> None:
 def _delete_default_embedding_spaces(session: Session, dataset_id: UUID) -> None:
     """Delete default embedding spaces for the dataset's collections."""
     session.exec(
-        delete(DefaultEmbeddingSpaceTable).where(
-            col(DefaultEmbeddingSpaceTable.collection_id).in_(_collection_ids_subquery(dataset_id))
+        delete(CollectionEmbeddingModelTable).where(
+            col(CollectionEmbeddingModelTable.collection_id).in_(
+                _collection_ids_subquery(dataset_id)
+            )
         ),
         execution_options=_DELETE_EXECUTION_OPTIONS,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
+++ b/lightly_studio/src/lightly_studio/resolvers/embedding_region_resolver.py
@@ -15,7 +15,7 @@ from numpy.typing import NDArray
 from sqlmodel import Session
 
 from lightly_studio.models.embedding_region import EmbeddingRegion
-from lightly_studio.resolvers import default_embedding_space_resolver, twodim_embedding_resolver
+from lightly_studio.resolvers import collection_embedding_model_resolver, twodim_embedding_resolver
 
 
 def get_sample_ids_in_region(
@@ -28,7 +28,7 @@ def get_sample_ids_in_region(
     # so the region is tested against the exact projection the user lassoed over.
     # TODO(Kondrat, 07/2026): Select the embedding model via API parameter once supported,
     # matching embeddings2d.get_2d_embeddings.
-    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+    embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
         session=session,
         collection_id=collection_id,
     )

--- a/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
+++ b/lightly_studio/src/lightly_studio/resolvers/similarity_utils.py
@@ -10,7 +10,7 @@ from sqlmodel import Session, col
 
 from lightly_studio.database import db_vector
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
-from lightly_studio.resolvers import default_embedding_space_resolver
+from lightly_studio.resolvers import collection_embedding_model_resolver
 from lightly_studio.type_definitions import QueryType
 
 
@@ -27,7 +27,7 @@ def get_distance_expression(
     if not text_embedding:
         return None, None
 
-    embedding_model_id = default_embedding_space_resolver.get_by_collection_id(
+    embedding_model_id = collection_embedding_model_resolver.get_by_collection_id(
         session=session, collection_id=collection_id
     )
 

--- a/lightly_studio/tests/few_shot_classifier/conftest.py
+++ b/lightly_studio/tests/few_shot_classifier/conftest.py
@@ -22,7 +22,7 @@ from lightly_studio.models.embedding_model import (
 )
 from lightly_studio.models.sample_embedding import SampleEmbeddingTable
 from lightly_studio.resolvers import (
-    default_embedding_space_resolver,
+    collection_embedding_model_resolver,
     embedding_model_resolver,
 )
 
@@ -66,7 +66,7 @@ def embedding_model(db_session: Session, collection: CollectionTable) -> Embeddi
     )
     created = embedding_model_resolver.create(session=db_session, embedding_model=embedding_model)
     # Register it as the collection's default so it resolves as the collection's model.
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=created.embedding_model_id,

--- a/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
+++ b/lightly_studio/tests/few_shot_classifier/test_classifier_manager.py
@@ -30,8 +30,8 @@ from lightly_studio.models.sample_embedding import (
 )
 from lightly_studio.resolvers import (
     annotation_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
-    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -56,7 +56,7 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -84,7 +84,7 @@ class TestClassifierManager:
         """create_classifier raises when the collection has no default embedding model."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=None,
         )
@@ -109,7 +109,7 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -176,7 +176,7 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -231,7 +231,7 @@ class TestClassifierManager:
         """Test dropping a classifier in the finetuning step."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -369,7 +369,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         # Setup: Create a classifier first
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -432,7 +432,7 @@ class TestClassifierManager:
         classifier_manager = ClassifierManager()
         # Setup: Create a classifier with initial samples
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -549,7 +549,7 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -632,7 +632,7 @@ class TestClassifierManager:
             return_value=EmbeddingModelTable(name="test", embedding_dimension=3),
         )
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -721,7 +721,7 @@ class TestClassifierManager:
         """Test creating a new classifier."""
         classifier_manager = ClassifierManager()
         mocker.patch.object(
-            default_embedding_space_resolver,
+            collection_embedding_model_resolver,
             "get_by_collection_id",
             return_value=uuid4(),
         )
@@ -989,7 +989,7 @@ def test_get_embedding_model_by_hash__prefers_default(db_session: Session) -> No
         embedding_model_name="model_in_child",
         embedding_model_hash="same_hash",
     )
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=child.collection_id,
         embedding_model_id=child_model.embedding_model_id,

--- a/lightly_studio/tests/helpers_resolvers.py
+++ b/lightly_studio/tests/helpers_resolvers.py
@@ -37,8 +37,8 @@ from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
     caption_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
-    default_embedding_space_resolver,
     embedding_model_resolver,
     image_resolver,
     sample_embedding_resolver,
@@ -310,7 +310,7 @@ def create_embedding_model(  # noqa: PLR0913
     """Helper function to create a embedding model.
 
     With ``set_as_default`` the model is recorded as the collection's default embedding
-    model, so ``default_embedding_space_resolver.get_by_collection_id`` resolves to it. It
+    model, so ``collection_embedding_model_resolver.get_by_collection_id`` resolves to it. It
     is off by default to avoid the ``default_embedding_space`` foreign key blocking model
     or collection deletes in tests that do not need a default.
     """
@@ -330,7 +330,7 @@ def create_embedding_model(  # noqa: PLR0913
         ),
     )
     if set_as_default:
-        default_embedding_space_resolver.set_default(
+        collection_embedding_model_resolver.set_default(
             session=session,
             collection_id=collection_id,
             embedding_model_id=model.embedding_model_id,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy.py
@@ -18,9 +18,9 @@ from lightly_studio.models.image import ImageCreate
 from lightly_studio.models.temporal_span import TemporalSpanTable
 from lightly_studio.resolvers import (
     annotation_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
     dataset_resolver,
-    default_embedding_space_resolver,
     embedding_model_resolver,
     evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
@@ -383,7 +383,7 @@ def test_deep_copy__with_default_embedding_space(db_session: Session) -> None:
     copied_model_id = copied_models[0].embedding_model_id
     assert copied_model_id != embedding_model.embedding_model_id
 
-    copied_default_id = default_embedding_space_resolver.get_by_collection_id(
+    copied_default_id = collection_embedding_model_resolver.get_by_collection_id(
         session=db_session, collection_id=copied.collection_id
     )
     assert copied_default_id == copied_model_id

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_deep_copy_delete_roundtrip.py
@@ -20,8 +20,8 @@ from lightly_studio.models.annotation_collection_coverage import AnnotationColle
 from lightly_studio.models.annotation_label import AnnotationLabelTable
 from lightly_studio.models.caption import CaptionTable
 from lightly_studio.models.collection import CollectionTable
+from lightly_studio.models.collection_embedding_model import CollectionEmbeddingModelTable
 from lightly_studio.models.dataset import DatasetTable
-from lightly_studio.models.default_embedding_space import DefaultEmbeddingSpaceTable
 from lightly_studio.models.embedding_model import EmbeddingModelTable
 from lightly_studio.models.evaluation_annotation_metric import EvaluationAnnotationMetricTable
 from lightly_studio.models.evaluation_run import EvaluationRunTable
@@ -112,8 +112,8 @@ def _dataset_table_counts(session: Session, dataset_id: UUID) -> dict[str, int]:
             EmbeddingModelTable, col(EmbeddingModelTable.collection_id).in_(collection_ids)
         ),
         "default_embedding_space": count(
-            DefaultEmbeddingSpaceTable,
-            col(DefaultEmbeddingSpaceTable.collection_id).in_(collection_ids),
+            CollectionEmbeddingModelTable,
+            col(CollectionEmbeddingModelTable.collection_id).in_(collection_ids),
         ),
         "annotation_collection_coverage": count(
             AnnotationCollectionCoverageTable,

--- a/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
+++ b/lightly_studio/tests/resolvers/dataset_resolver/test_delete_dataset.py
@@ -14,9 +14,9 @@ from lightly_studio.models.evaluation_run import EvaluationRunCreate, Evaluation
 from lightly_studio.models.evaluation_sample_metric import EvaluationSampleMetricCreate
 from lightly_studio.resolvers import (
     annotation_label_resolver,
+    collection_embedding_model_resolver,
     collection_resolver,
     dataset_resolver,
-    default_embedding_space_resolver,
     evaluation_annotation_metric_resolver,
     evaluation_run_resolver,
     evaluation_sample_metric_resolver,
@@ -210,7 +210,7 @@ def test_delete_dataset__with_default_embedding_space(db_session: Session) -> No
     # Assert - collection and its default embedding space deleted
     assert collection_resolver.get_by_id(session=db_session, collection_id=collection_id) is None
     assert (
-        default_embedding_space_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_by_collection_id(
             session=db_session, collection_id=collection_id
         )
         is None

--- a/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
+++ b/lightly_studio/tests/resolvers/test_collection_embedding_model_resolver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlmodel import Session
 
-from lightly_studio.resolvers import default_embedding_space_resolver
+from lightly_studio.resolvers import collection_embedding_model_resolver
 from tests.helpers_resolvers import (
     create_collection,
     create_embedding_model,
@@ -13,7 +13,7 @@ def test_set_default__inserts(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
 
-    default = default_embedding_space_resolver.set_default(
+    default = collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model.embedding_model_id,
@@ -38,12 +38,12 @@ def test_set_default__replaces_existing(db_session: Session) -> None:
         embedding_model_hash="hash_2",
     )
 
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model_1.embedding_model_id,
     )
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model_2.embedding_model_id,
@@ -51,7 +51,7 @@ def test_set_default__replaces_existing(db_session: Session) -> None:
 
     # The collection still has a single default, now pointing at the second model.
     assert (
-        default_embedding_space_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         == model_2.embedding_model_id
@@ -62,7 +62,7 @@ def test_get_by_collection_id__none_when_unset(db_session: Session) -> None:
     collection = create_collection(session=db_session)
 
     assert (
-        default_embedding_space_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         is None
@@ -72,14 +72,14 @@ def test_get_by_collection_id__none_when_unset(db_session: Session) -> None:
 def test_get_by_collection_id__returns_id(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model.embedding_model_id,
     )
 
     assert (
-        default_embedding_space_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         == model.embedding_model_id
@@ -89,19 +89,19 @@ def test_get_by_collection_id__returns_id(db_session: Session) -> None:
 def test_delete_by_collection_id__deletes(db_session: Session) -> None:
     collection = create_collection(session=db_session)
     model = create_embedding_model(session=db_session, collection_id=collection.collection_id)
-    default_embedding_space_resolver.set_default(
+    collection_embedding_model_resolver.set_default(
         session=db_session,
         collection_id=collection.collection_id,
         embedding_model_id=model.embedding_model_id,
     )
 
-    deleted = default_embedding_space_resolver.delete_by_collection_id(
+    deleted = collection_embedding_model_resolver.delete_by_collection_id(
         session=db_session, collection_id=collection.collection_id
     )
 
     assert deleted is True
     assert (
-        default_embedding_space_resolver.get_by_collection_id(
+        collection_embedding_model_resolver.get_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         is None
@@ -112,7 +112,7 @@ def test_delete_by_collection_id__returns_false_when_absent(db_session: Session)
     collection = create_collection(session=db_session)
 
     assert (
-        default_embedding_space_resolver.delete_by_collection_id(
+        collection_embedding_model_resolver.delete_by_collection_id(
             session=db_session, collection_id=collection.collection_id
         )
         is False


### PR DESCRIPTION
## What has changed and why?

First step of reworking this table. Renames the class `DefaultEmbeddingSpaceTable` -> `CollectionEmbeddingModelTable` and the model, resolver, and test files, plus all references.

- Table name (`default_embedding_space`) and migrations are untouched on purpose.
- Kept for a later PR that also changes the table fields, so the schema change lands in a single migration.
- Table-concept helper/test names and comments stay until that PR.

Pure rename; no behaviour change.

## How has it been tested?

- `make static-checks` (ruff, mypy, format) pass.
- Affected resolver, deep-copy, delete-dataset, similarity, and classifier tests pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the default embedding configuration to collection embedding model terminology.
  * Updated embedding model selection across similarity search, classifiers, embedding regions, dataset copying, and deletion.
  * Preserved existing collection defaults and embedding behavior during dataset operations.

* **Tests**
  * Updated coverage and test fixtures to use the collection embedding model configuration consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->