### PR TITLE
Extract similarity resolution and share the categorical type names

### DIFF
--- a/lightly_studio/src/lightly_studio/models/metadata.py
+++ b/lightly_studio/src/lightly_studio/models/metadata.py
@@ -39,6 +39,9 @@ NAME_TO_TYPE_MAP = {
 # Schema type names whose values are ordered and aggregated numerically.
 NUMERIC_TYPE_NAMES = ("integer", "float")
 
+# Schema type names whose values are discrete and aggregated by exact value.
+CATEGORICAL_TYPE_NAMES = ("string", "boolean")
+
 
 def get_type_name(value: Any) -> str:
     """Get the type name for a value.

--- a/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
+++ b/lightly_studio/src/lightly_studio/resolvers/metadata_resolver/sample/categorical_value_counts.py
@@ -11,6 +11,7 @@ from sqlmodel import Session
 
 from lightly_studio.database import db_json
 from lightly_studio.models.metadata import (
+    CATEGORICAL_TYPE_NAMES,
     MetadataValueCountsView,
     MetadataValueCountView,
     SampleMetadataTable,
@@ -19,7 +20,6 @@ from lightly_studio.models.sample import SampleTable
 from lightly_studio.resolvers.image_filter import ImageFilter
 from lightly_studio.resolvers.metadata_resolver.sample import metadata_helpers
 
-_CATEGORICAL_TYPES = ("string", "boolean")
 _TOP_VALUE_COUNT = 20
 
 
@@ -50,7 +50,7 @@ def get_metadata_value_counts(
     schema = metadata_helpers.get_merged_schema(session=session, collection_id=collection_id)
     result: dict[str, MetadataValueCountsView] = {}
     for key, metadata_type in schema.items():
-        if metadata_type not in _CATEGORICAL_TYPES:
+        if metadata_type not in CATEGORICAL_TYPE_NAMES:
             continue
         if fields is not None and key not in fields:
             continue

--- a/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_helpers.py
@@ -13,6 +13,7 @@ from lightly_studio.resolvers import (
     sample_embedding_resolver,
     tag_resolver,
 )
+from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 
 
 def get_embeddings_by_sample_ids(
@@ -34,6 +35,27 @@ def get_embeddings_by_sample_ids(
         session=session,
         sample_ids=list(sample_ids),
         embedding_model_id=embedding_model_id,
+    )
+    return [embedding.embedding for embedding in embedding_tables]
+
+
+def get_embeddings_by_tag_id(
+    session: Session,
+    collection_id: UUID,
+    tag_id: UUID,
+    embedding_model_name: str | None,
+) -> list[Embedding]:
+    """Resolve sample embeddings for the given model and sample tag."""
+    embedding_model_id = embedding_model_resolver.get_by_name(
+        session=session,
+        collection_id=collection_id,
+        embedding_model_name=embedding_model_name,
+    ).embedding_model_id
+    embedding_tables = sample_embedding_resolver.get_all_by_collection_id(
+        session=session,
+        collection_id=collection_id,
+        embedding_model_id=embedding_model_id,
+        filters=SampleFilter(tag_ids=[tag_id]),
     )
     return [embedding.embedding for embedding in embedding_tables]
 

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -428,41 +428,11 @@ def _add_strategy_to_mundig(
             stopping_condition_minimum_distance=strat.stopping_condition_minimum_distance,
         )
     elif isinstance(strat, EmbeddingSimilarityStrategy):
-        embeddings = sampling_helpers.get_embeddings_by_sample_ids(
+        _add_similarity_to_mundig(
             session=session,
-            collection_id=context.collection_id,
-            sample_ids=context.input_sample_ids,
-            embedding_model_name=strat.embedding_model_name,
-        )
-        embedding_model_id = embedding_model_resolver.get_by_name(
-            session=session,
-            collection_id=context.collection_id,
-            embedding_model_name=strat.embedding_model_name,
-        ).embedding_model_id
-        query_tag = tag_resolver.get_by_name(
-            session=session,
-            tag_name=strat.query_tag_name,
-            collection_id=context.collection_id,
-        )
-        if query_tag is None:
-            raise ValueError(f"Query tag with name {strat.query_tag_name} not found.")
-        query_embedding_tables = sample_embedding_resolver.get_all_by_collection_id(
-            session=session,
-            collection_id=context.collection_id,
-            embedding_model_id=embedding_model_id,
-            filters=SampleFilter(tag_ids=[query_tag.tag_id]),
-        )
-        query_embeddings = [embedding.embedding for embedding in query_embedding_tables]
-        if not query_embeddings:
-            raise ValueError(
-                "Query tag "
-                f"{strat.query_tag_name} does not have embeddings for embedding model "
-                f"{strat.embedding_model_name}."
-            )
-        mundig.add_similarity(
-            embeddings=embeddings,
-            query_embeddings=query_embeddings,
-            strength=strat.strength,
+            context=context,
+            strat=strat,
+            mundig=mundig,
         )
     elif isinstance(strat, MetadataWeightingStrategy):
         weights: list[float] = []
@@ -492,3 +462,52 @@ def _add_strategy_to_mundig(
         )
     else:
         raise ValueError(f"Sampling strategy of type {type(strat)} is unknown.")
+
+
+def _add_similarity_to_mundig(
+    session: Session,
+    context: _SamplingContext,
+    strat: EmbeddingSimilarityStrategy,
+    mundig: Mundig,
+) -> None:
+    """Resolve the embeddings of a similarity strategy and add it to Mundig.
+
+    Raises:
+        ValueError: If the query tag does not exist or has no embeddings for the model.
+    """
+    embeddings = sampling_helpers.get_embeddings_by_sample_ids(
+        session=session,
+        collection_id=context.collection_id,
+        sample_ids=context.input_sample_ids,
+        embedding_model_name=strat.embedding_model_name,
+    )
+    embedding_model_id = embedding_model_resolver.get_by_name(
+        session=session,
+        collection_id=context.collection_id,
+        embedding_model_name=strat.embedding_model_name,
+    ).embedding_model_id
+    query_tag = tag_resolver.get_by_name(
+        session=session,
+        tag_name=strat.query_tag_name,
+        collection_id=context.collection_id,
+    )
+    if query_tag is None:
+        raise ValueError(f"Query tag with name {strat.query_tag_name} not found.")
+    query_embedding_tables = sample_embedding_resolver.get_all_by_collection_id(
+        session=session,
+        collection_id=context.collection_id,
+        embedding_model_id=embedding_model_id,
+        filters=SampleFilter(tag_ids=[query_tag.tag_id]),
+    )
+    query_embeddings = [embedding.embedding for embedding in query_embedding_tables]
+    if not query_embeddings:
+        raise ValueError(
+            "Query tag "
+            f"{strat.query_tag_name} does not have embeddings for embedding model "
+            f"{strat.embedding_model_name}."
+        )
+    mundig.add_similarity(
+        embeddings=embeddings,
+        query_embeddings=query_embeddings,
+        strength=strat.strength,
+    )

--- a/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
+++ b/lightly_studio/src/lightly_studio/sampling/sampling_via_db.py
@@ -13,18 +13,16 @@ import sqlalchemy
 from numpy.typing import NDArray
 from sqlmodel import Session, col, select
 
+from lightly_studio.database.db_vector import Embedding
 from lightly_studio.models.annotation.annotation_base import AnnotationBaseTable
 from lightly_studio.models.sample import SampleTable
 from lightly_studio.resolvers import (
     annotation_label_resolver,
     annotation_resolver,
     collection_resolver,
-    embedding_model_resolver,
     metadata_resolver,
-    sample_embedding_resolver,
     tag_resolver,
 )
-from lightly_studio.resolvers.sample_resolver.sample_filter import SampleFilter
 from lightly_studio.sampling import sampling_helpers, sequence_sampling
 from lightly_studio.sampling.mundig import Mundig
 from lightly_studio.sampling.sampling_config import (
@@ -470,44 +468,50 @@ def _add_similarity_to_mundig(
     strat: EmbeddingSimilarityStrategy,
     mundig: Mundig,
 ) -> None:
-    """Resolve the embeddings of a similarity strategy and add it to Mundig.
+    """Resolve the embeddings of a similarity strategy and add it to Mundig."""
+    mundig.add_similarity(
+        embeddings=sampling_helpers.get_embeddings_by_sample_ids(
+            session=session,
+            collection_id=context.collection_id,
+            sample_ids=context.input_sample_ids,
+            embedding_model_name=strat.embedding_model_name,
+        ),
+        query_embeddings=_get_query_embeddings(
+            session=session,
+            collection_id=context.collection_id,
+            strat=strat,
+        ),
+        strength=strat.strength,
+    )
+
+
+def _get_query_embeddings(
+    session: Session,
+    collection_id: UUID,
+    strat: EmbeddingSimilarityStrategy,
+) -> list[Embedding]:
+    """Resolve the embeddings of the query sample tag of a similarity strategy.
 
     Raises:
         ValueError: If the query tag does not exist or has no embeddings for the model.
     """
-    embeddings = sampling_helpers.get_embeddings_by_sample_ids(
-        session=session,
-        collection_id=context.collection_id,
-        sample_ids=context.input_sample_ids,
-        embedding_model_name=strat.embedding_model_name,
-    )
-    embedding_model_id = embedding_model_resolver.get_by_name(
-        session=session,
-        collection_id=context.collection_id,
-        embedding_model_name=strat.embedding_model_name,
-    ).embedding_model_id
     query_tag = tag_resolver.get_by_name(
         session=session,
         tag_name=strat.query_tag_name,
-        collection_id=context.collection_id,
+        collection_id=collection_id,
     )
     if query_tag is None:
         raise ValueError(f"Query tag with name {strat.query_tag_name} not found.")
-    query_embedding_tables = sample_embedding_resolver.get_all_by_collection_id(
+    query_embeddings = sampling_helpers.get_embeddings_by_tag_id(
         session=session,
-        collection_id=context.collection_id,
-        embedding_model_id=embedding_model_id,
-        filters=SampleFilter(tag_ids=[query_tag.tag_id]),
+        collection_id=collection_id,
+        tag_id=query_tag.tag_id,
+        embedding_model_name=strat.embedding_model_name,
     )
-    query_embeddings = [embedding.embedding for embedding in query_embedding_tables]
     if not query_embeddings:
         raise ValueError(
             "Query tag "
             f"{strat.query_tag_name} does not have embeddings for embedding model "
             f"{strat.embedding_model_name}."
         )
-    mundig.add_similarity(
-        embeddings=embeddings,
-        query_embeddings=query_embeddings,
-        strength=strat.strength,
-    )
+    return query_embeddings


### PR DESCRIPTION
## What has changed and why?

This PR makes two preparatory refactors in the sampling module. Neither one changes behavior.

The `EmbeddingSimilarityStrategy` branch of `_add_strategy_to_mundig` moves into a new `_add_similarity_to_mundig` function. The body is unchanged. `_add_strategy_to_mundig` is already at the function size limit, so a new strategy branch does not fit.

`_CATEGORICAL_TYPES` moves from `categorical_value_counts` to `CATEGORICAL_TYPE_NAMES` in `models.metadata`, next to `NUMERIC_TYPE_NAMES`. Other modules can then use it.

This PR is 1 of 3. It prepares the categorical metadata balancing strategy in #2068. The next PR is stacked on this branch.

## How has it been tested?

The extracted body is byte-identical to the original after the dedent. There are no test changes, so a green run is the proof that the move keeps the behavior:

```bash
cd lightly_studio
uv run pytest tests/sampling/ tests/resolvers/metadata_resolvers/ tests/metadata/
```

Result: 145 passed. `make static-checks` is clean.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved categorical value handling for text and boolean data.
  - Enhanced similarity-based sampling using embeddings associated with tagged samples.
  - Added clearer validation when tags or query embeddings are unavailable.

- **Refactor**
  - Centralized categorical type handling for more consistent results.
  - Streamlined similarity sampling while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->